### PR TITLE
brew search: fix `--desc` regression

### DIFF
--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -37,6 +37,7 @@ class Descriptions
   # repos were updated more recently than it was.
   def self.cache_fresh?
     return false unless CACHE_FILE.exist?
+    cache_mtime = File.mtime(CACHE_FILE)
 
     Tap.each do |tap|
       next unless tap.git?


### PR DESCRIPTION
Fixes homebrew/homebrew-core#22. Issue was introduced by e9886cac6cd7cffbd39f812d02e9f4c5f308e470.