### PR TITLE
(un)linkapps: modernize, prune: remove broken app symlinks

### DIFF
--- a/Library/Homebrew/cmd/linkapps.rb
+++ b/Library/Homebrew/cmd/linkapps.rb
@@ -1,12 +1,11 @@
-# Links any Applications (.app) found in installed prefixes to /Applications
 require "keg"
 require "formula"
 
 module Homebrew
   def linkapps
-    target_dir = ARGV.include?("--local") ? File.expand_path("~/Applications") : "/Applications"
+    target_dir = linkapps_target(:local => ARGV.include?("--local"))
 
-    unless File.exist? target_dir
+    unless target_dir.directory?
       opoo "#{target_dir} does not exist, stopping."
       puts "Run `mkdir #{target_dir}` first."
       exit 1
@@ -16,24 +15,41 @@ module Homebrew
       kegs = Formula.racks.map do |rack|
         keg = rack.subdirs.map { |d| Keg.new(d) }
         next if keg.empty?
-        keg.detect(&:linked?) || keg.max { |a, b| a.version <=> b.version }
+        keg.detect(&:linked?) || keg.max_by(&:version)
       end
     else
       kegs = ARGV.kegs
     end
 
+    link_count = 0
     kegs.each do |keg|
       keg.apps.each do |app|
-        puts "Linking #{app} to #{target_dir}."
-        target = "#{target_dir}/#{app.basename}"
+        puts "Linking: #{app}"
+        target_app = target_dir/app.basename
 
-        if File.exist?(target) && !File.symlink?(target)
-          onoe "#{target} already exists, skipping."
+        if target_app.exist? && !target_app.symlink?
+          onoe "#{target_app} already exists, skipping."
           next
         end
 
+        # We prefer system `ln` over `FileUtils.ln_sf` because the latter seems
+        # to have weird failure conditions (that were observed in the past).
         system "ln", "-sf", app, target_dir
+        link_count += 1
       end
     end
+
+    if link_count.zero?
+      puts "No apps linked to #{target_dir}" if ARGV.verbose?
+    else
+      puts "Linked #{link_count} app#{plural(link_count)} to #{target_dir}"
+    end
+  end
+
+  private
+
+  def linkapps_target(opts = {})
+    local = opts.fetch(:local, false)
+    Pathname.new(local ? "~/Applications" : "/Applications").expand_path
   end
 end

--- a/Library/Homebrew/cmd/prune.rb
+++ b/Library/Homebrew/cmd/prune.rb
@@ -1,5 +1,6 @@
 require "keg"
 require "cmd/tap"
+require "cmd/unlinkapps"
 
 module Homebrew
   def prune
@@ -45,5 +46,7 @@ module Homebrew
       print "and #{d} directories " if d > 0
       puts "from #{HOMEBREW_PREFIX}"
     end unless ARGV.dry_run?
+
+    unlinkapps_prune(:dry_run => ARGV.dry_run?, :quiet => true)
   end
 end

--- a/Library/Homebrew/cmd/unlinkapps.rb
+++ b/Library/Homebrew/cmd/unlinkapps.rb
@@ -9,22 +9,30 @@ module Homebrew
 
   private
 
+  def unlinkapps_prune(opts = {})
+    opts = opts.merge(:prune => true)
+    unlinkapps_from_dir(linkapps_target(:local => false), opts)
+    unlinkapps_from_dir(linkapps_target(:local => true), opts)
+  end
+
   def unlinkapps_from_dir(target_dir, opts = {})
     return unless target_dir.directory?
     dry_run = opts.fetch(:dry_run, false)
+    quiet = opts.fetch(:quiet, false)
 
     apps = Pathname.glob("#{target_dir}/*.app").select do |app|
-      unlinkapps_unlink?(app)
+      unlinkapps_unlink?(app, opts)
     end
 
     ObserverPathnameExtension.reset_counts!
 
+    app_kind = opts.fetch(:prune, false) ? " (broken link)" : ""
     apps.each do |app|
       app.extend(ObserverPathnameExtension)
       if dry_run
-        puts "Would unlink: #{app}"
+        puts "Would unlink#{app_kind}: #{app}"
       else
-        puts "Unlinking: #{app}"
+        puts "Unlinking#{app_kind}: #{app}" unless quiet
         app.unlink
       end
     end
@@ -44,12 +52,14 @@ module Homebrew
     #{HOMEBREW_PREFIX}/opt/
   ].freeze
 
-  def unlinkapps_unlink?(target_app)
+  def unlinkapps_unlink?(target_app, opts = {})
     # Skip non-symlinks and symlinks that don't point into the Homebrew prefix.
     app = "#{target_app.readlink}" if target_app.symlink?
     return false unless app && app.start_with?(*UNLINKAPPS_PREFIXES)
 
-    if ARGV.named.empty?
+    if opts.fetch(:prune, false)
+      !File.exist?(app) # Remove only broken symlinks in prune mode.
+    elsif ARGV.named.empty?
       true
     else
       ARGV.kegs.any? { |keg| app.start_with?("#{keg}/", "#{keg.opt_record}/") }

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -267,14 +267,13 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--force` is passed, Homebrew will allow keg-only formulae to be linked.
 
   * `linkapps` [`--local`] [<formulae>]:
-    Find installed formulae that have compiled `.app`-style "application"
-    packages for OS X, and symlink those apps into `/Applications`, allowing
-    for easier access.
+    Find installed formulae that provide `.app`-style OS X apps and symlink them
+    into `/Applications`, allowing for easier access.
 
-    If no <formulae> are provided, all of them will have their .apps symlinked.
+    If no <formulae> are provided, all of them will have their apps symlinked.
 
-    If provided, `--local` will move them into the user's `~/Applications`
-    directory instead of the system directory. It may need to be created, first.
+    If provided, `--local` will symlink them into the user's `~/Applications`
+    directory instead of the system directory.
 
   * `ls`, `list` [`--full-name`]:
     List all installed formulae. If `--full-name` is passed, print formulae with
@@ -451,10 +450,16 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--dry-run` or `-n` is passed, Homebrew will list all files which would
     be unlinked, but will not actually unlink or delete any files.
 
-  * `unlinkapps` [`--local`] [<formulae>]:
-    Removes links created by `brew linkapps`.
+  * `unlinkapps` [`--local`] [`--dry-run`] [<formulae>]:
+    Remove symlinks created by `brew linkapps` from `/Applications`.
 
-    If no <formulae> are provided, all linked app will be removed.
+    If no <formulae> are provided, all linked apps will be removed.
+
+    If provided, `--local` will remove symlinks from the user's `~/Applications`
+    directory instead of the system directory.
+
+    If `--dry-run` or `-n` is passed, Homebrew will list all symlinks which
+    would be removed, but will not actually delete any files.
 
   * `unpack` [`--git`|`--patch`] [`--destdir=`<path>] <formulae>:
     Unpack the source files for <formulae> into subdirectories of the current

--- a/Library/Homebrew/manpages/brew.1.md
+++ b/Library/Homebrew/manpages/brew.1.md
@@ -340,7 +340,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
   * `prune` [`--dry-run`]:
     Remove dead symlinks from the Homebrew prefix. This is generally not
-    needed, but can be useful when doing DIY installations.
+    needed, but can be useful when doing DIY installations. Also remove broken
+    app symlinks from `/Applications` and `~/Applications` that were previously
+    created by `brew linkapps`.
 
     If `--dry-run` or `-n` is passed, show what would be removed, but do not
     actually remove anything.

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -434,7 +434,7 @@ class IntegrationCommandTests < Homebrew::TestCase
 
     source_dir = HOMEBREW_CELLAR/"testball/0.1/TestBall.app"
     source_dir.mkpath
-    assert_match "Linking #{source_dir} to",
+    assert_match "Linking: #{source_dir}",
       cmd("linkapps", "--local", {"HOME" => home})
   ensure
     formula_file.unlink
@@ -459,7 +459,7 @@ class IntegrationCommandTests < Homebrew::TestCase
 
     FileUtils.ln_s source_app, "#{apps_dir}/TestBall.app"
 
-    assert_match "Unlinking #{apps_dir}/TestBall.app",
+    assert_match "Unlinking: #{apps_dir}/TestBall.app",
       cmd("unlinkapps", "--local", {"HOME" => home})
   ensure
     formula_file.unlink

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -694,7 +694,9 @@ class IntegrationCommandTests < Homebrew::TestCase
     assert (share/"notpruneable").directory?
     refute (share/"pruneable_symlink").symlink?
 
-    assert_equal "Nothing pruned",
+    # Inexact match because only if ~/Applications exists, will this output one
+    # more line with contents `No apps unlinked from /Users/<user/Applications`.
+    assert_match "Nothing pruned\nNo apps unlinked from /Applications",
       cmd("prune", "--verbose")
   ensure
     share.rmtree

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -487,6 +487,18 @@ _brew_uninstall ()
     __brew_complete_installed
 }
 
+_brew_unlinkapps ()
+{
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    case "$cur" in
+    --*)
+        __brewcomp "--dry-run --local"
+        return
+        ;;
+    esac
+    __brew_complete_installed
+}
+
 _brew_unpack ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -589,7 +601,7 @@ _brew ()
     install|instal|reinstall)   _brew_install ;;
     irb)                        _brew_irb ;;
     link|ln)                    _brew_link ;;
-    linkapps|unlinkapps)        _brew_linkapps ;;
+    linkapps)                   _brew_linkapps ;;
     list|ls)                    _brew_list ;;
     log)                        _brew_log ;;
     man)                        _brew_man ;;
@@ -609,6 +621,7 @@ _brew ()
     tap-unpin)                  _brew_tap_unpin ;;
     tests)                      _brew_tests ;;
     uninstall|remove|rm)        _brew_uninstall ;;
+    unlinkapps)                 _brew_unlinkapps ;;
     unpack)                     _brew_unpack ;;
     unpin)                      __brew_complete_formulae ;;
     untap|tap-info|tap-pin)     __brew_complete_tapped ;;

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -214,14 +214,13 @@ be linked or which would be deleted by <code>brew link --overwrite</code>, but w
 actually link or delete any files.</p>
 
 <p>If <code>--force</code> is passed, Homebrew will allow keg-only formulae to be linked.</p></dd>
-<dt><code>linkapps</code> [<code>--local</code>] [<var>formulae</var>]</dt><dd><p>Find installed formulae that have compiled <code>.app</code>-style "application"
-packages for OS X, and symlink those apps into <code>/Applications</code>, allowing
-for easier access.</p>
+<dt><code>linkapps</code> [<code>--local</code>] [<var>formulae</var>]</dt><dd><p>Find installed formulae that provide <code>.app</code>-style OS X apps and symlink them
+into <code>/Applications</code>, allowing for easier access.</p>
 
-<p>If no <var>formulae</var> are provided, all of them will have their .apps symlinked.</p>
+<p>If no <var>formulae</var> are provided, all of them will have their apps symlinked.</p>
 
-<p>If provided, <code>--local</code> will move them into the user's <code>~/Applications</code>
-directory instead of the system directory. It may need to be created, first.</p></dd>
+<p>If provided, <code>--local</code> will symlink them into the user's <code>~/Applications</code>
+directory instead of the system directory.</p></dd>
 <dt><code>ls</code>, <code>list</code> [<code>--full-name</code>]</dt><dd><p>List all installed formulae. If <code>--full-name</code> is passed, print formulae with
 full-qualified names.</p></dd>
 <dt><code>ls</code>, <code>list</code> <code>--unbrewed</code></dt><dd><p>List all files in the Homebrew prefix not installed by Homebrew.</p></dd>
@@ -341,9 +340,15 @@ for temporarily disabling a formula:
 
 <p>If <code>--dry-run</code> or <code>-n</code> is passed, Homebrew will list all files which would
 be unlinked, but will not actually unlink or delete any files.</p></dd>
-<dt><code>unlinkapps</code> [<code>--local</code>] [<var>formulae</var>]</dt><dd><p>Removes links created by <code>brew linkapps</code>.</p>
+<dt><code>unlinkapps</code> [<code>--local</code>] [<code>--dry-run</code>] [<var>formulae</var>]</dt><dd><p>Remove symlinks created by <code>brew linkapps</code> from <code>/Applications</code>.</p>
 
-<p>If no <var>formulae</var> are provided, all linked app will be removed.</p></dd>
+<p>If no <var>formulae</var> are provided, all linked apps will be removed.</p>
+
+<p>If provided, <code>--local</code> will remove symlinks from the user's <code>~/Applications</code>
+directory instead of the system directory.</p>
+
+<p>If <code>--dry-run</code> or <code>-n</code> is passed, Homebrew will list all symlinks which
+would be removed, but will not actually delete any files.</p></dd>
 <dt><code>unpack</code> [<code>--git</code>|<code>--patch</code>] [<code>--destdir=</code><var>path</var>] <var>formulae</var></dt><dd><p>Unpack the source files for <var>formulae</var> into subdirectories of the current
 working directory. If <code>--destdir=</code><var>path</var> is given, the subdirectories will
 be created in the directory named by <code>&lt;path></code> instead.</p>

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -267,7 +267,9 @@ valid version is <code>v1</code>.</p></dd>
 <dt><code>pin</code> <var>formulae</var></dt><dd><p>Pin the specified <var>formulae</var>, preventing them from being upgraded when
 issuing the <code>brew upgrade</code> command. See also <code>unpin</code>.</p></dd>
 <dt><code>prune</code> [<code>--dry-run</code>]</dt><dd><p>Remove dead symlinks from the Homebrew prefix. This is generally not
-needed, but can be useful when doing DIY installations.</p>
+needed, but can be useful when doing DIY installations. Also remove broken
+app symlinks from <code>/Applications</code> and <code>~/Applications</code> that were previously
+created by <code>brew linkapps</code>.</p>
 
 <p>If <code>--dry-run</code> or <code>-n</code> is passed, show what would be removed, but do not
 actually remove anything.</p></dd>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -365,7 +365,7 @@ Pin the specified \fIformulae\fR, preventing them from being upgraded when issui
 .
 .TP
 \fBprune\fR [\fB\-\-dry\-run\fR]
-Remove dead symlinks from the Homebrew prefix\. This is generally not needed, but can be useful when doing DIY installations\.
+Remove dead symlinks from the Homebrew prefix\. This is generally not needed, but can be useful when doing DIY installations\. Also remove broken app symlinks from \fB/Applications\fR and \fB~/Applications\fR that were previously created by \fBbrew linkapps\fR\.
 .
 .IP
 If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, show what would be removed, but do not actually remove anything\.

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -286,13 +286,13 @@ If \fB\-\-force\fR is passed, Homebrew will allow keg\-only formulae to be linke
 .
 .TP
 \fBlinkapps\fR [\fB\-\-local\fR] [\fIformulae\fR]
-Find installed formulae that have compiled \fB\.app\fR\-style "application" packages for OS X, and symlink those apps into \fB/Applications\fR, allowing for easier access\.
+Find installed formulae that provide \fB\.app\fR\-style OS X apps and symlink them into \fB/Applications\fR, allowing for easier access\.
 .
 .IP
-If no \fIformulae\fR are provided, all of them will have their \.apps symlinked\.
+If no \fIformulae\fR are provided, all of them will have their apps symlinked\.
 .
 .IP
-If provided, \fB\-\-local\fR will move them into the user\'s \fB~/Applications\fR directory instead of the system directory\. It may need to be created, first\.
+If provided, \fB\-\-local\fR will symlink them into the user\'s \fB~/Applications\fR directory instead of the system directory\.
 .
 .TP
 \fBls\fR, \fBlist\fR [\fB\-\-full\-name\fR]
@@ -476,11 +476,17 @@ Remove symlinks for \fIformula\fR from the Homebrew prefix\. This can be useful 
 If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which would be unlinked, but will not actually unlink or delete any files\.
 .
 .TP
-\fBunlinkapps\fR [\fB\-\-local\fR] [\fIformulae\fR]
-Removes links created by \fBbrew linkapps\fR\.
+\fBunlinkapps\fR [\fB\-\-local\fR] [\fB\-\-dry\-run\fR] [\fIformulae\fR]
+Remove symlinks created by \fBbrew linkapps\fR from \fB/Applications\fR\.
 .
 .IP
-If no \fIformulae\fR are provided, all linked app will be removed\.
+If no \fIformulae\fR are provided, all linked apps will be removed\.
+.
+.IP
+If provided, \fB\-\-local\fR will remove symlinks from the user\'s \fB~/Applications\fR directory instead of the system directory\.
+.
+.IP
+If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all symlinks which would be removed, but will not actually delete any files\.
 .
 .TP
 \fBunpack\fR [\fB\-\-git\fR|\fB\-\-patch\fR] [\fB\-\-destdir=\fR\fIpath\fR] \fIformulae\fR


### PR DESCRIPTION
*— Replaces Homebrew/legacy-homebrew#46549 as it no longer cleanly applies without a rebase.*

Summary of changes:

- Re-implemented `linkapps` and `unlinkapps` to use `Pathname` and other Ruby-native facilities.
- Added `--dry-run` option to `unlinkapps`.
- Extended `prune` to delete stale `.app` symlinks created by `linkapps`.
- Adapted documentation and Bash completion to reflect changes.
- Adjusted tests to account for the slightly changed behavior and output of modified commands.

Out of scope, but planned for a future PR:

- Auto-pruning of stale `.app` symlinks on `uninstall`, `upgrade`, … (see, e.g., Homebrew/legacy-homebrew#46542 and possibly others).
- Additional refactoring of shared functionality to avoid cross-`cmd/` includes.

----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Have you written new tests for your changes?~~
- [x] Have you successfully ran `brew tests` with your changes locally?