### PR TITLE
audit: check plist placement

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -187,6 +187,7 @@ class FormulaAuditor
       [/^  (go_)?resource/,                "resource"],
       [/^  def install/,                   "install method"],
       [/^  def caveats/,                   "caveats method"],
+      [/^  (plist_options|def plist)/,     "plist block"],
       [/^  test do/,                       "test block"],
     ]
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -638,6 +638,10 @@ class FormulaAuditor
       problem "\"Formula.factory(name)\" is deprecated in favor of \"Formula[name]\""
     end
 
+    if text =~ /def plist/ && text !~ /plist_options/
+      problem "Please set plist_options when using a formula-defined plist."
+    end
+
     if text =~ /system "npm", "install"/ && text !~ %r[opt_libexec\}/npm/bin] && formula.name !~ /^kibana(\d{2})?$/
       need_npm = "\#{Formula[\"node\"].opt_libexec\}/npm/bin"
       problem <<-EOS.undent

--- a/Library/Homebrew/test/test_cmd_audit.rb
+++ b/Library/Homebrew/test/test_cmd_audit.rb
@@ -173,6 +173,24 @@ class FormulaAuditorTests < Homebrew::TestCase
       fa.problems
   end
 
+  def test_audit_file_strict_plist_placement
+    fa = formula_auditor "foo", <<-EOS.undent, :strict => true
+      class Foo < Formula
+        url "https://example.com/foo-1.0.tgz"
+
+        test do
+          assert_match "Dogs are terrific", shell_output("./dogs")
+        end
+
+        def plist
+        end
+      end
+    EOS
+    fa.audit_file
+    assert_equal ["`plist block` (line 8) should be put before `test block` (line 4)"],
+      fa.problems
+  end
+
   def test_audit_file_strict_url_outside_of_stable_block
     fa = formula_auditor "foo", <<-EOS.undent, :strict => true
       class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

Migrated over from https://github.com/Homebrew/legacy-homebrew/pull/49733, with the additional change requested by @mikemcquaid.

From the prior thread:
>  Was highlighted to me that our audit currently completely ignores `plist`s despite checking for almost everything else possible written into a formula. Makes sense to add that check. It doesn't cover 100% but it covers the most common two cases and preferred names for those blocks.