### PR TITLE
`brew` subcommands as objects, with subcommand help [Proof of Concept]

### DIFF
--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -1,28 +1,75 @@
+class CommandsBrewCmd < BrewCmdClass
+  summary "List available brew subcommands"
+  helptext <<EOS
+
+brew commands - #{summary}
+
+  brew commands [--quiet] [--verbose] [--implementation]
+
+Options:
+  --quiet            Do not display section headers
+  --verbose          Include additional descriptive info
+  --include-aliases  Include command aliases (only in --quiet mode)
+  --implementation   Include info on each command's implementation
+EOS
+
+  def run
+    Homebrew.commands
+  end
+end
+
+
 module Homebrew
   def commands
+
+    if ARGV.include?("--implementation") || ARGV.include?("--verbose")
+      require "command"
+    end
+
     if ARGV.include? "--quiet"
       cmds = internal_commands + external_commands
       cmds += internal_development_commands if ARGV.homebrew_developer?
       cmds += HOMEBREW_INTERNAL_COMMAND_ALIASES.keys if ARGV.include? "--include-aliases"
       puts_columns cmds.sort
     else
+
       # Find commands in Homebrew/cmd
       puts "Built-in commands"
-      puts_columns internal_commands
+      display_commands internal_commands
 
       # Find commands in Homebrew/dev-cmd
       if ARGV.homebrew_developer?
         puts
         puts "Built-in development commands"
-        puts_columns internal_development_commands
+        display_commands internal_development_commands
       end
 
       # Find commands in the path
       unless (exts = external_commands).empty?
         puts
         puts "External commands"
-        puts_columns exts
+        display_commands exts
       end
+    end
+  end
+
+  def display_commands(names)
+    max_name_len = names.map { |str| str.size }.max
+    if ARGV.include? "--implementation"
+    format = "%-#{max_name_len}s    %-20s   %s"
+    names.each do |name|
+      cmd = BrewCmd[name]
+      impl_file_display = cmd.internal_cmd? ? "built-in" : cmd.implementation_file
+      puts format % [name, cmd.implementation_type, impl_file_display]
+    end
+    elsif ARGV.include? "--verbose"
+      format = "%-#{max_name_len}s    %s"
+      names.each do |name|
+        cmd = BrewCmd[name]
+        puts format % [name, cmd.summary]
+      end
+    else
+      puts_columns names
     end
   end
 

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -1,5 +1,17 @@
 require "diagnostic"
 
+class DoctorBrewCmd < BrewCmdClass
+  summary "Examine this system for potential problems affecting brew"
+  helptext <<EOS
+
+brew doctor - #{summary}
+
+  brew doctor [--list-checks]
+
+Options:
+  --list-checks  List defined tests instead of running them
+EOS
+end
 module Homebrew
   def doctor
     checks = Diagnostic::Checks.new

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -1,6 +1,29 @@
 require "metafiles"
 require "formula"
 
+class ListBrewCmd < BrewCmdClass
+  summary "List installed formulae, or files in installed formula"
+  helptext <<EOS
+
+brew list, ls - #{summary}
+
+  brew list [--full-name]
+  brew list --unbrewed
+  brew list [--versions [--multiple]] [--verbose] [--pinned] <formulae>
+
+Options:
+  --full-name  Print fully-qualified formula names
+  --unbrewed   List all files in brew prefix not installed by Homebrew
+  --versions   Include formula version numbers
+  --multiple   Only show formulae with multiple versions installed
+  --pinned     Show versions of pinned formulae
+EOS
+
+  def run
+    Homebrew.list
+  end
+end
+
 module Homebrew
   def list
     # Use of exec means we don't explicitly exit

--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -1,25 +1,37 @@
-# Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
-# Optionally, installs the formulae changed by the patch.
-#
-# Usage: brew pull [options...] <patch-source>
-#
-# <patch-source> may be any of:
-#   * The ID number of a pull request in the Homebrew GitHub repo
-#   * The URL of a pull request on GitHub, using either the web page or API URL formats
-#   * The URL of a commit on GitHub
-#   * A "brew.sh/job/..." string specifying a testing job ID
-#
-# Options:
-#   --bottle:    Handle bottles, pulling the bottle-update commit and publishing files on Bintray
-#   --bump:      For one-formula PRs, automatically reword commit message to our preferred format
-#   --clean:     Do not rewrite or otherwise modify the commits found in the pulled PR
-#   --ignore-whitespace: Silently ignore whitespace discrepancies when applying diffs
-#   --install:   Install changed formulae locally after pulling the patch
-#   --resolve:   When a patch fails to apply, leave in progress and allow user to
-#                 resolve, instead of aborting
-#   --branch-okay: Do not warn if pulling to a branch besides master (useful for testing)
-#   --legacy:    Pull legacy formula PR from Homebrew/homebrew
-#                (TODO remove it when it's not longer necessary)
+
+class PullBrewCmd < BrewCmdClass
+  summary "Pull patches and bottles for PRs to local Homebrew repo"
+
+  helptext <<EOS
+
+brew pull [options...] <patch-source>
+
+Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
+Optionally, installs the formulae changed by the patch.
+
+<patch-source> may be any of:
+  * The ID number of a pull request in the Homebrew GitHub repo
+  * The URL of a pull request on GitHub, using either the web page or API URL formats
+  * The URL of a commit on GitHub
+  * A "brew.sh/job/..." string specifying a testing job ID
+
+Options:
+  --bottle:    Handle bottles, pulling the bottle-update commit and publishing files on Bintray
+  --bump:      For one-formula PRs, automatically reword commit message to our preferred format
+  --clean:     Do not rewrite or otherwise modify the commits found in the pulled PR
+  --install:   Install changed formulae locally after pulling the patch
+  --resolve:   When a patch fails to apply, leave in progress and allow user to
+                 resolve, instead of aborting
+  --branch-okay: Do not warn if pulling to a branch besides master (useful for testing)
+  --ignore-whitespace: Silently ignore whitespace discrepancies when applying diffs
+  --legacy:    Pull legacy formula PR from Homebrew/homebrew
+               (TODO remove it when it's not longer necessary)
+EOS
+
+  def run
+    Homebrew.pull
+  end
+end
 
 require "utils"
 require "utils/json"

--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -1,31 +1,3 @@
-# Comprehensively test a formula or pull request.
-#
-# Usage: brew test-bot [options...] <pull-request|formula>
-#
-# Options:
-# --keep-logs:     Write and keep log files under ./brewbot/
-# --cleanup:       Clean the Homebrew directory. Very dangerous. Use with care.
-# --clean-cache:   Remove all cached downloads. Use with care.
-# --skip-setup:    Don't check the local system is setup correctly.
-# --skip-homebrew: Don't check Homebrew's files and tests are all valid.
-# --junit:         Generate a JUnit XML test results file.
-# --no-bottle:     Run brew install without --build-bottle
-# --keep-old:      Run brew bottle --keep-old to build new bottles for a single platform.
-# --legacy         Bulid formula from legacy Homebrew/homebrew repo.
-#                  (TODO remove it when it's not longer necessary)
-# --HEAD:          Run brew install with --HEAD
-# --local:         Ask Homebrew to write verbose logs under ./logs/ and set HOME to ./home/
-# --tap=<tap>:     Use the git repository of the given tap
-# --dry-run:       Just print commands, don't run them.
-# --fail-fast:     Immediately exit on a failing step.
-# --verbose:       Print out all logs in realtime
-# --fast:          Don't install any packages but run e.g. audit anyway.
-#
-# --ci-master:           Shortcut for Homebrew master branch CI options.
-# --ci-pr:               Shortcut for Homebrew pull request CI options.
-# --ci-testing:          Shortcut for Homebrew testing CI options.
-# --ci-upload:           Homebrew CI bottle upload.
-
 require "formula"
 require "utils"
 require "date"
@@ -33,6 +5,45 @@ require "rexml/document"
 require "rexml/xmldecl"
 require "rexml/cdata"
 require "tap"
+
+class TestBotBrewCmd < BrewCmdClass
+  summary "Comprehensively test a formula or PR"
+  helptext <<EOS
+
+brew test-bot - #{summary}
+
+Usage: brew test-bot [options...] <pull-request|formula>
+
+Options:
+  --keep-logs:     Write and keep log files under ./brewbot/.
+  --cleanup:       Clean the Homebrew directory. Very dangerous. Use with care.
+  --clean-cache:   Remove all cached downloads. Use with care.
+  --skip-setup:    Don't check the local system is setup correctly.
+  --skip-homebrew: Don't check Homebrew's files and tests are all valid.
+  --junit:         Generate a JUnit XML test results file.
+  --no-bottle:     Run brew install without --build-bottle.
+  --keep-old:      Run brew bottle --keep-old to build new bottles for a single platform.
+  --legacy         Build formula from legacy Homebrew/homebrew repo.
+                   (TODO remove it when it's not longer necessary)
+  --HEAD:          Run brew install with --HEAD.
+  --local:         Ask Homebrew to write verbose logs under ./logs/ and set HOME to ./home/.
+  --tap=<tap>:     Use the git repository of the given tap.
+  --dry-run:       Just print commands, don't run them.
+  --fail-fast:     Immediately exit on a failing step.
+  --verbose:       Print test step output in realtime. Has the side effect of passing output
+                   as raw bytes instead of re-encoding in UTF-8.
+  --fast:          Don't install any packages but run e.g. audit anyway.
+
+  --ci-master:           Shortcut for Homebrew master branch CI options.
+  --ci-pr:               Shortcut for Homebrew pull request CI options.
+  --ci-testing:          Shortcut for Homebrew testing CI options.
+  --ci-upload:           Homebrew CI bottle upload.
+EOS
+
+  def run
+    Homebrew.test_bot
+  end
+end
 
 module Homebrew
   BYTES_IN_1_MEGABYTE = 1024*1024

--- a/Library/Homebrew/command.rb
+++ b/Library/Homebrew/command.rb
@@ -1,0 +1,341 @@
+
+# A BrewCmd is a `brew` subcommand, such as "update", "info", "tap",
+# or "install". It defines how to run the command, and may provide
+# metadata such as a summary, helptext, and description of its options.
+#
+# Commands may be implemented in different ways; BrewCmd is the common
+# superclass for all of them. Commands may be implemented as:
+#   * Ruby class definitions of BrewCmd subclasses
+#   * As a special case, foo.rb files containing FooBrewCmd definitions
+#     which can be located and loaded automatically.
+#   * Ruby scripts
+#   * Arbitrary executables, such as shell scripts
+# BrewCmd itself is effectively abstract. All the different command implementations
+# are supported by subclasses.
+#
+# In the documentation for this class, "<cmd>" means the name of the command.
+class BrewCmd
+  # The command's name.
+  def name
+  end
+
+  # A short (<60 chars) one-line summary of this command, suitable for
+  # use in lists of multiple commands. Nil if no summary is available.
+  def summary
+  end
+
+  # Multi-line helptext to be displayed for `brew help <cmd>` or
+  # `brew <cmd> --help`. Nil if no helptext is available.
+  def helptext
+  end
+
+  # Description of the command line options this supports, as a CmdOptions
+  # object. Nil if a description is unavailable, in which case it may
+  # support options, but it just doesn't tell you what they are.
+  def options
+  end
+
+  # A symbol indicating the implementation type of this command. May be:
+  #   :ruby_class_file    - a <cmd>.rb file in the new BrewCmd class style
+  #   :ruby_function_file - a <cmd>.rb file in the old single-function
+  #                           internal command style
+  #   :ruby_script        - a <cmd>.rb file that runs as a script
+  #   :external_exe       - an external executable command
+  # The list of implementation types is open-ended, so other symbols may
+  # be returned as well.
+  def implementation_type
+  end
+
+  # Pathname of the file that implements this command (e.g. the <cmd>.rb source file
+  # or the external executable command). Nil if unknown or there is none.
+  def implementation_file
+  end
+
+  # True if this is an internal command shipped with brew itself
+  def internal_cmd?
+  end
+
+  # Whether this command implements its own handling of the "--help" option.
+  # When true, `brew <cmd> --help` should just call run(), passing along "--help"
+  # as one of the arguments, instead of doing the normal display of what
+  # helptext() returns. This is to support the older style of script and
+  # external executable commands, which were expected to do their own --help
+  # handling.
+  def handles_help_itself?
+  end
+
+  # Performs the actions of this command.
+  # It should set Homebrew.failed = true to indicate failure. Raising an
+  # exception is also considered failure, and may cause diagnostics to be printed.
+  # In the case of some external commands, run() never returns because the
+  # external command is exec'ed and takes over the process.
+  def run
+    raise "run() is not implemented for class #{self.class.name}"
+  end
+
+  # Displays the helptext for this command
+  def display_help
+    if helptext.nil?
+      puts "No help is available for command 'brew #{name}'"
+    else
+      puts helptext
+    end
+  end
+
+  # Gets the BrewCmd object for a command, looking it up by name.
+  def self.[](name)
+    BrewCmdLoader.new.lookup(name)
+  end
+end
+
+
+class BrewCmdLoader
+
+  COMMANDS = {}
+
+  # Converts a formula name to the corresponding class name.
+  # This is a copy of Formulary.class_s, duplicated here to avoid having
+  # to require "formulary".
+  def self.class_s(name)
+    class_name = name.capitalize
+    class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }
+    class_name.tr!("+", "x")
+    class_name
+  end
+
+  # Converts a command name to the corresponding <Cmd>BrewCmd class name
+  def self.cmd_class_s(name)
+    class_s(name) + "BrewCmd"
+  end
+
+  # Converts a command name to the corresponding function name used by old-style
+  # internal commands
+  def self.cmd_function_s(name)
+    name.tr("-", "_").downcase
+  end
+
+  # Gets the BrewCmd object for a command, looking it up by name.
+  def lookup(name)
+    if COMMANDS.has_key?(name)
+      COMMANDS[name]
+    else
+      COMMANDS[name] = search_and_load_cmd(name)
+    end
+  end
+
+  # Auto-taps absent taps for well-known commands
+  # Returns the tap it added if it did so, or nil if it did not add
+  # one
+  def self.lookup_well_known_tap_commands(cmd)
+    # Second-chance lookup for well-known commands in non-default taps
+    require "tap"
+    possible_tap = case cmd
+                     when "brewdle", "brewdler", "bundle", "bundler"
+                       Tap.fetch("Homebrew", "bundle")
+                     when "cask"
+                       Tap.fetch("caskroom", "cask")
+                     when "services"
+                       Tap.fetch("Homebrew", "services")
+                   end
+
+    if possible_tap && !possible_tap.installed?
+      brew_uid = HOMEBREW_BREW_FILE.stat.uid
+      tap_commands = []
+      if Process.uid.zero? && !brew_uid.zero?
+        tap_commands += %W[/usr/bin/sudo -u ##{brew_uid}]
+      end
+      tap_commands += %W[#{HOMEBREW_BREW_FILE} tap #{possible_tap}]
+      safe_system *tap_commands
+      possible_tap
+    else
+      nil
+    end
+  end
+
+  private
+
+  def search_and_load_cmd(name)
+    # Locate internal commands
+    internal_cmd_dirs = [HOMEBREW_LIBRARY_PATH.join("cmd")]
+    if ARGV.homebrew_developer?
+      internal_cmd_dirs << HOMEBREW_LIBRARY_PATH.join("dev-cmd")
+    end
+    internal_cmd_dirs.each do |dir|
+      file = dir.join(name+".rb")
+      if File.file?(file)
+        return load_internal_cmd(name, file)
+      end
+    end
+
+    # External commands: arbitrary exes to be exec'ed
+    exe_file = which "brew-#{name}"
+    if exe_file
+      return ExternalExeCmd(exe_file)
+    end
+
+    # External commands: .rb files to be required
+    rb_exe_file = which "brew-#{name}.rb"
+    if rb_exe_file
+      return load_rb_exe_cmd(name, rb_exe_file)
+    end
+    # Well-known commands in non-default taps
+  end
+
+  # Load an "internal" command shipped with Homebrew. Supports the legacy
+  # "function in Homebrew module" and new "BrewCmd class definition" forms
+  def load_internal_cmd(name, file)
+    if looks_like_cmd_class_file?(name, file)
+      load_class_file_cmd(name, file)
+    else
+      load_internal_function_cmd(name, file)
+    end
+  end
+
+  def load_rb_exe_cmd(name, file)
+    if looks_like_cmd_class_file?(name, file)
+      load_class_file_cmd(name, file)
+    else
+      RubyScriptCmd.new(name, file)
+    end
+  end
+
+  # Loads new-style <Cmd>BrewCmd class command definition file
+  def load_class_file_cmd(name, file)
+    require file
+    Object.const_get(BrewCmdLoader.cmd_class_s(name)).new(name)
+  end
+
+  # Loads an old-style Homebrew.<cmd> function file
+  def load_internal_function_cmd(name, file)
+    require file
+    FunctionInternalCmd.new(name, file)
+  end
+
+  # True if the file looks like a <Cmd>BrewCmd class definition. This determines whether
+  # it will be treated as a new BrewCmd class style definition, or an old style function
+  # or script definition. Strictly, it looks for a line with "class <Cmd>BrewCmd" in it.
+  def looks_like_cmd_class_file?(name, file)
+    cmd_class_name = BrewCmdLoader.cmd_class_s(name)
+    File.foreach(file).any? { |line| line =~ /^\s*class\s+#{cmd_class_name}/ }
+  end
+end
+
+# A command that has its own class to define it. This is the kind typically found in
+# new-style command class definition files. It has support for DSL via class-level
+# properties, like Formula.
+class BrewCmdClass < BrewCmd
+
+  # Named cmd_name to avoid conflict with existing Class.name
+  #attr_rw :cmd_name
+  #attr_rw :summary
+  #attr_rw :helptext
+
+  def initialize(name)
+    @name = name
+  end
+
+  attr_reader :name
+
+  class << self
+    attr_rw :cmd_name
+    attr_rw :summary
+    attr_rw :helptext
+  end
+
+  def summary
+    self.class.summary
+  end
+
+  def helptext
+    self.class.helptext
+  end
+end
+
+# Wraps an old-style single-function internal command definition.
+# Does not support summary, helptext, or options.
+# The functions are always defined in the Homebrew module.
+class FunctionInternalCmd < BrewCmd
+  def initialize(name, file)
+    @name = name
+    @implementation_file = file
+    @function_name = BrewCmdLoader.cmd_function_s(name)
+  end
+
+  def name
+    @name
+  end
+
+  def implementation_type
+    :ruby_function_file
+  end
+
+  def implementation_file
+    @implementation_file
+  end
+
+  def internal_cmd?
+    true
+  end
+
+  def handles_help_itself?
+    false
+  end
+
+  def run
+    Homebrew.send @function_name
+  end
+end
+
+class RubyScriptCmd < BrewCmd
+  def initialize(name, file)
+    @name = name
+    @implementation_file = file
+    @implementation_type = :ruby_script
+  end
+
+  attr_reader :name
+  attr_reader :implementation_file
+  attr_reader :implementation_type
+
+  def internal_cmd?
+    false
+  end
+
+  def handles_help_itself?
+    true
+  end
+
+  def run
+    load @implementation_file
+  end
+
+end
+
+class ExternalExeCmd < BrewCmd
+  def initialize(name, file)
+    @name = name
+    @implementation_file = file
+    @implementation_type = :external_exe
+  end
+
+  attr_reader :name
+  attr_reader :implementation_file
+  attr_reader :implementation_type
+
+  def internal_cmd?
+    false
+  end
+
+  def handles_help_itself?
+    true
+  end
+
+  def run
+    %w[CACHE LIBRARY_PATH].each do |e|
+      ENV["HOMEBREW_#{e}"] = Object.const_get("HOMEBREW_#{e}").to_s
+    end
+    exec @implementation_file
+  end
+
+end
+

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -20,6 +20,7 @@ chdir() {
   cd "$@" >/dev/null || odie "Error: failed to cd to $*!"
 }
 
+
 # Force UTF-8 to avoid encoding issues for users with broken locale settings.
 if [[ "$(locale charmap 2> /dev/null)" != "UTF-8" ]]
 then


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully ran `brew tests` with your changes locally?
  - One of the `brew doctor` tests is failing; I'm working on it.

##  Description

This is a proof-of-concept for an approach to representing and defining `brew` subcommands as objects instead of just functions or scripts, in a back-compatible manner.

This allows the commands to be queried for things like a descriptive summary, help text, and options they take. This adds support for per-subcommand `brew --help` output. It also opens up the possibility for programmatically describing subcommand options for better ARGV parsing, but doesn't implement that yet.

The new class-based command definitions go in Ruby files in the same locations as existing commands, and can be used for core commands or "external" user-provided commands. They can optionally use a DSL similar to the `Formula` DSL to supply their metadata. Commands defined using the existing implementation styles (Ruby functions, Ruby scripts, or executable external commands) are represented using adapter classes, so they continue to work as is. Commands can be switched to the new form one at a time.

The major behavior change is that now `brew help foo` for a command that does not define help text will now say `No help available for command 'foo'` instead of displaying the main `brew` help text.

This proof-of-concept code implements per-subcommand help. It does not implement subcommand option definitions.

This is an alternative to #10. But this could be extended to support it, too: you could add additional forms of helptext representations that the command objects know how to read from their implementation files.

##  Examples

You can define a command class in a `<cmd>.rb` or `brew-<cmd>.rb` in the same location as existing `.rb` command files. Use the `summary`, `helptext`, and optionally `name` DSL items to describe it. Implement `run()` to define the command's behavior. (Note that the syntax highlighting is a little wonky; it uses here-documents.)

```ruby
class TestBotBrewCmd < BrewCmdClass
  summary "Comprehensively test a formula or PR"
  helptext <<EOS

brew test-bot - #{summary}

Usage: brew test-bot [options...] <pull-request|formula>

Options:
  --keep-logs:     Write and keep log files under ./brewbot/.
  --cleanup:       Clean the Homebrew directory. Very dangerous. Use with care.
...
```

Note that the `helptext` incorporates `#{summary}` to avoid redundant code. If we come up with an object-based option definition, we could similarly generate the options summary inside `helptext` from the options definition.

For the existing internal commands, you can convert them to the new class form just by sticking a `FooBrewCmd` class at the top, and having `run()` call the existing function.

```ruby
class ListBrewCmd < BrewCmdClass
  summary "List installed formulae, or files in installed formula"
  helptext <<EOS

brew list, ls - #{summary}

  brew list [--full-name]
  brew list --unbrewed
  brew list [--versions [--multiple]] [--verbose] [--pinned] <formulae>

Options:
  --full-name  Print fully-qualified formula names
  --unbrewed   List all files in brew prefix not installed by Homebrew
  --versions   Include formula version numbers
  --multiple   Only show formulae with multiple versions installed
  --pinned     Show versions of pinned formulae
EOS

  def run
    Homebrew.list
  end
end

module Homebrew
  def list
  # ... the rest of the file is the original, unmodified `list` function
```

And then `brew help <foo>` or `brew <foo> --help` will display that helptext.

```
$ brew help list

brew list, ls - List installed formulae, or files in installed formula

  brew list [--full-name]
  brew list --unbrewed
  brew list [--versions [--multiple]] [--verbose] [--pinned] <formulae>

Options:
  --full-name  Print fully-qualified formula names
  --unbrewed   List all files in brew prefix not installed by Homebrew
  --versions   Include formula version numbers
  --multiple   Only show formulae with multiple versions installed
  --pinned     Show versions of pinned formulae
[/usr/local/Library on ⇄ brew-commands-as-objects]
$ brew help create
No help is available for command 'brew create'
[/usr/local/Library on ⇄ brew-commands-as-objects]
$
```

##  Other concerns

This might have a bad interaction with aliases that rely on symlinks, because if you read the symlink directly, it will be inconsistent with the file's internal class name. May have to pull alias resolution up a level.

This keeps the existing behavior where the `--help` implementation for external commands is deferred to them by just passing along the original ARGV, including the help flag. I left this as is to keep changes minimal, but we should consider changing it. It would be easy to add support for auxiliary files that allowed people to define the metadata (summary, helptext, options) for their external commands. And passing along the help flags is inconvenient or possibly destructive: if the external subcommand does not explicitly implement support for all of the help flags, it will just end up doing its normal behavior.

I think when doing `brew help <anything>`, such as `brew help destructive-update`, it's a reasonable expectation that this is a safe command and it'll just show you some helptext. But if `destructive-update` is an external command, that actually ends up running `brew destructive-update help`, and the subcommand might just ignore the `help` argument. Plus, having access to the helptext as data within the `brew` program would be useful; lets you do more things with it.