### PR TITLE
FileUtils::mktemp pass gid to Etc.getgrgid as int

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -22,10 +22,9 @@ module FileUtils
     else
       Process.gid
     end
-    # Make OS X 10.6.7 (ruby-1.8.7-p174) and earlier happy.
-    group_id = group_id.to_s
     begin
-      chown(nil, group_id, tmp)
+      # group_id.to_s makes OS X 10.6.7 (ruby-1.8.7-p174) and earlier happy.
+      chown(nil, group_id.to_s, tmp)
     rescue Errno::EPERM
       opoo "Failed setting group \"#{Etc.getgrgid(group_id).name}\" on #{tmp}"
     end


### PR DESCRIPTION
We need to move the Snow Leopard fix down since Etc.getgrgid can't
handle a string.