### PR TITLE
superenv: don't filter out all /opt paths, just /opt/local

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -213,6 +213,7 @@ class Cmd
     elsif path.start_with?(prefix)
       true
     else
+      # ignore MacPorts, Boxen's Homebrew, X11, fink
       !path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")
     end
   end

--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -213,13 +213,13 @@ class Cmd
     elsif path.start_with?(prefix)
       true
     else
-      !path.start_with?("/opt", "/sw", "/usr/X11")
+      !path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")
     end
   end
 
   # The original less-smart version of keep_orig; will eventually be removed
   def keep_orig?(path)
-    path.start_with?(prefix, cellar, tmpdir) || !path.start_with?("/opt", "/sw", "/usr/X11")
+    path.start_with?(prefix, cellar, tmpdir) || !path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")
   end
 
   def cflags


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

This filter was intended to filter out Macports paths, but the user may have valid reasons to have other things here that might get linked against. For example, the user may store their rbenv rubies under `/opt` and expect something building under superenv to have access to them.