### PR TITLE
test: Select the appropriate compiler for ENV.cc

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -14,12 +14,12 @@ begin
   error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
   error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
 
+  formula = ARGV.formulae.first
   ENV.extend(Stdenv)
-  ENV.setup_build_environment
+  ENV.setup_build_environment(formula)
 
   trap("INT", old_trap)
 
-  formula = ARGV.formulae.first
   formula.extend(Homebrew::Assertions)
   formula.extend(Debrew::Formula) if ARGV.debug?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

Pass the formula to `ENV.setup_build_environment` to select the appropriate compiler for `ENV.cc`.

I've seen build failures on Linuxbrew when the default compiler `/usr/bin/gcc` is used for the `test do` block, when it should be using `$HOMEBREW_PREFIX/bin/gcc-5`. This could in principle affect Mac if the formula `fails_with :clang` or `needs :openmp`. I haven't found such a case with which to test. Perhaps…

```sh
brew install fftw --with-openmp
brew test fftw
```

@xu-cheng