### PR TITLE
brew.sh: make analytics 'curl' fully asynchronous

### DIFF
--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -228,7 +228,8 @@ then
     -d av="$HOMEBREW_VERSION" \
     -d t=screenview \
     -d cd="$HOMEBREW_COMMAND" \
-    &
+    &> /dev/null \
+    & disown
 fi
 
 if [[ -n "$HOMEBREW_BASH_COMMAND" ]]


### PR DESCRIPTION
If analytics are enabled and `brew` is used in a command substitution context, e.g. `brew search` for tab completion, the result is that even though the Google Analytics `curl` process runs in the background it still is attached to the captured `stdout`, thus could theoretically contribute to the result of the command substitution and consequently makes the command substitution block on the completion of this process. Redirecting `stdout` (and `stderr` for good measure) to `/dev/null` makes this process truly asynchronous in these contexts.

Furthermore, even if the process is in the background, it is still included in the shell's job list and thus shell internals like `wait` (used in `cmd/update.sh`) have to wait on this process, even if they never intended to do so. Removing the analytics process from the job list via `disown` avoids this unintended effect.

The result of all this is that enabling analytics no longer causes any measurable latency, no matter how slow a user's network connection is. A downside may be that running multiple `brew` commands in rapid succession has the potential to spawn a lot of `curl` processes.

Fixes #29.

----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Have you written new tests for your changes?~~
- [x] Have you successfully ran `brew tests` with your changes locally?