### PR TITLE
add Language::Node.npm_install_args helper method 

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -50,7 +50,7 @@ module Homebrew
           cleanup_path(path) { path.unlink }
           next
         end
-        if path.basename.to_s == "java_cache" && path.directory?
+        if %w[java_cache npm_cache].include?(path.basename.to_s) && path.directory?
           cleanup_path(path) { FileUtils.rm_rf path }
           next
         end

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -656,13 +656,6 @@ class FormulaAuditor
     if text =~ /def plist/ && text !~ /plist_options/
       problem "Please set plist_options when using a formula-defined plist."
     end
-
-    if text =~ /system "npm", "install"/ && text !~ %r[opt_libexec\}/npm/bin] && formula.name !~ /^kibana(\d{2})?$/
-      need_npm = "\#{Formula[\"node\"].opt_libexec\}/npm/bin"
-      problem <<-EOS.undent
-       Please add ENV.prepend_path \"PATH\", \"#{need_npm}"\ to def install
-      EOS
-    end
   end
 
   def audit_line(line, lineno)
@@ -883,6 +876,10 @@ class FormulaAuditor
 
     if line =~ /assert [^!]+\.include?/
       problem "Use `assert_match` instead of `assert ...include?`"
+    end
+
+    if line =~ /system "npm", "install"/ && line !~ /Language::Node/
+      problem "Use Language::Node for npm install args"
     end
 
     if @strict

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -1,0 +1,35 @@
+module Language
+  module Node
+    def self.npm_cache_config
+      "cache=#{HOMEBREW_CACHE}/npm_cache\n"
+    end
+
+    def self.setup_npm_environment
+      npmrc = Pathname.new("#{ENV["HOME"]}/.npmrc")
+      # only run setup_npm_environment once per formula
+      return if npmrc.exist?
+      # explicitly set npm's cache path to HOMEBREW_CACHE/npm_cache to fix
+      # issues caused by overriding $HOME (long build times, high disk usage)
+      # https://github.com/Homebrew/brew/pull/37#issuecomment-208840366
+      npmrc.write npm_cache_config
+      # explicitly use our npm and node-gyp executables instead of the user
+      # managed ones in HOMEBREW_PREFIX/lib/node_modules which might be broken
+      ENV.prepend_path "PATH", Formula["node"].opt_libexec/"npm/bin"
+    end
+
+    def self.std_npm_install_args(libexec)
+      setup_npm_environment
+      # tell npm to not install .brew_home by adding it to the .npmignore file
+      # (or creating a new one if no .npmignore file already exists)
+      open(".npmignore", "a") { |f| f.write( "\n.brew_home\n") }
+      # npm install args for global style module format installed into libexec
+      ["--verbose", "--global", "--prefix=#{libexec}", "."]
+    end
+
+    def self.local_npm_install_args
+      setup_npm_environment
+      # npm install args for local style module format
+      ["--verbose"]
+    end
+  end
+end

--- a/Library/Homebrew/test/test_cleanup.rb
+++ b/Library/Homebrew/test/test_cleanup.rb
@@ -73,4 +73,11 @@ class CleanupTests < Homebrew::TestCase
     shutup { Homebrew::Cleanup.cleanup_cache }
     refute_predicate java_cache, :exist?
   end
+
+  def test_cleanup_cache_npm_cache
+    npm_cache = (HOMEBREW_CACHE/"npm_cache")
+    npm_cache.mkpath
+    shutup { Homebrew::Cleanup.cleanup_cache }
+    refute_predicate npm_cache, :exist?
+  end
 end

--- a/share/doc/homebrew/Node-for-Formula-Authors.md
+++ b/share/doc/homebrew/Node-for-Formula-Authors.md
@@ -1,0 +1,115 @@
+# Node for formula authors
+
+This document explains how to successfully use Node and npm in a Node module based Homebrew formula.
+
+# Running `npm install`
+
+Homebrew provides two helper methods in a `Language::Node` module, `std_npm_install_args` and `local_npm_install_args`. They both set up the correct environment for npm and return arguments for `npm install` for their specific use cases. Please use them instead of invoking `npm install` explicitly. The syntax for a standard Node module installation is:
+
+```ruby
+system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+```
+
+where `libexec` is the destination prefix (usually the `libexec` variable).
+
+# Download URL
+
+If the Node module is also available on the npm registry, we prefer npm hosted release tarballs over GitHub (or elsewhere) hosted source tarballs. The advantages of these tarballs are that they doesn't include the files from the `.npmignore` (such as tests) resulting in a smaller download size and that a possibly transpilation step is already done (e.g. no need to compile CoffeeScript files as a build step).
+
+The npm registry URLs have usually the format of:
+
+```
+https://registry.npmjs.org/<name>/-/<name>-<version>.tgz
+```
+
+Alternatively you could curl the JSON at `https://registry.npmjs.org/<name>` and look for the value of `versions[<version>].dist.tarball` for the correct tarball URL.
+
+# Dependencies
+
+Node modules, which are compatible with the latest Node version should declare a dependencies on the `node` formula.
+
+```ruby
+depends_on "node"
+```
+
+If your formula requires to be executed with an older Node version you must vendor this older Node version as done in the [`kibana` formula](https://github.com/Homebrew/homebrew-core/blob/c6202f91a129e2f994d904f299a308cc6fbd58e5/Formula/kibana.rb).
+
+### Special requirements for native addons
+
+If your node module is a native addon or has a native addon somewhere in it's dependency tree you have to declare an additional dependency. Since the compilation of the native addon results in a invocation of `node-gyp` we need an additional build time dependency on `:python` (because gyp depends on Python 2.7).
+
+```ruby
+depends_on :python => :build
+```
+
+Please also note, that such a formula would only be compatible with the same Node major version it originally was compiled with. This means that we need to revision every formula with a Node native addon with every major version bump of the `node` formula. To make sure we don't overlook your formula on a Node major version bump, write a meaningful test which would fail in such a case (invoked with an ABI incompatible Node version).
+
+# Installation
+
+Node modules should be installed to `libexec`. This prevents the Node modules from contaminating the global `node_modules`, which is important so that npm doesn't try to manage Homebrew-installed Node modules.
+
+In the following we distinguish between 2 type of Node module using formulae:
+* formulae for standard Node modules compatible with npm's global module format which should use [`std_npm_install_args`](#installing-global-style-modules-with-std_npm_install_args-to-libexec) (like [`azure-cli`](https://github.com/Homebrew/homebrew-core/blob/d93fe9ba3bcc9071b699c8da4e7d733518d3337e/Formula/azure-cli.rb) or [`autocode`](https://github.com/Homebrew/homebrew-core/blob/1a670a6269e1e07f86683c2d164977c9bd8a3fb6/Formula/autocode.rb)) and
+* formulae were the `npm install` step is only one of multiple not exclusively Node related install steps (not compatible with npm's global module format) which have to use [`local_npm_install_args`](#installing-module-dependencies-locally-with-local_npm_install_args) (like [`elixirscript`](https://github.com/Homebrew/homebrew-core/blob/ec1e40d37e81af63122a354f0101c377f6a4e66d/Formula/elixirscript.rb) or [`kibana`](https://github.com/Homebrew/homebrew-core/blob/c6202f91a129e2f994d904f299a308cc6fbd58e5/Formula/kibana.rb))
+
+Both methods have in common, that they are setting the correct environment for using npm inside Homebrew up and returning the arguments for invoking `npm install` for their specific use cases. This includes fixing an important edge case with the npm cache (Caused by Homebrew's redirection of `$HOME` during the build and test process) by using our own custom `npm_cache` inside `HOMEBREW_CACHE`, which would otherwise result in very long build times and high disk space usage.
+
+To use them you have to require the Node language module at the beginning of your formula file with:
+
+```ruby
+require "language/node"
+```
+
+### Installing global style modules with `std_npm_install_args` to libexec
+
+In your formula's `install` method, simply cd to the top level of your Node module if necessary and than use `system` to invoke `npm install` with `Language::Node.std_npm_install_args` like:
+
+```ruby
+system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+```
+
+This will install your Node module in npm's global module style with a custom prefix to `libexec`. All your modules executable will be automatically resolved by npm into `libexec/"bin"` for you, which is not symlinked into Homebrew's prefix. We need to make sure these are installed. Do this with we need to symlink all executables to `bin` with:
+
+```ruby
+bin.install_symlink Dir["#{libexec}/bin/*"]
+```
+
+### Installing module dependencies locally with `local_npm_install_args`
+
+In your formula's `install` method, do any installation steps which need to be done before the `npm install` step and than cd to the top level of the included Node module. Then, use `system` with `Language::Node.local_npm_install_args` to invoke `npm install` like:
+
+```ruby
+system "npm", "install", *Language::Node.local_npm_install_args
+```
+
+This will install all of your Node modules dependencies to your local build path. You can now continue with your build steps and take care of the installation into the Homebrew `prefix` by your own, following the [general Homebrew formula instructions](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Formula-Cookbook.md).
+
+# Example
+
+Installing a standard Node module based formula would look like this:
+
+```ruby
+require "language/node"
+
+class Foo < Formula
+  desc "..."
+  homepage "..."
+  url "https://registry.npmjs.org/foo/-/foo-1.4.2.tgz"
+  sha256 "..."
+
+  depends_on "node"
+  # uncomment if there is a native addon inside the dependency tree
+  # depends_on :python => :build
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    # add a meaningful test here
+  end
+end
+```
+
+For examples using the `local_npm_install_args` method look at the  [`elixirscript`](https://github.com/Homebrew/homebrew-core/blob/ec1e40d37e81af63122a354f0101c377f6a4e66d/Formula/elixirscript.rb) or [`kibana`](https://github.com/Homebrew/homebrew-core/blob/c6202f91a129e2f994d904f299a308cc6fbd58e5/Formula/kibana.rb) formula.


### PR DESCRIPTION
**Update: This PR is now ready for review. The first initial design (described below) was discarded because it was to resource heavy. The discussion about all current issues with node module based formulas can be found from this https://github.com/Homebrew/brew/pull/37#issuecomment-208381710 and the discussion about the current approve starts with this https://github.com/Homebrew/brew/pull/37#issuecomment-208882330.**

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

### About handling node module formulas

Inspired by the discussion in legacy-homebrew#50167 I started to work on a prototype of a `Language::Node` for supporting formulas for node modules (with cmd line tools) were all dependencies are managed by homebrew resources and not by npm as it's done now. Especially because I've believed that most of the concerns mentioned by @DomT4 in [this comment](https://github.com/Homebrew/legacy-homebrew/issues/50167#issuecomment-198751313) are no longer an issue now. As it turned out that is the case for all points except the fact that the node community is taking the unix philosophy literally resulting in a high average count of dependencies / resources (which I have underestimated a little I have to admit). So please let's start the discussion if we want to have such a support, where we want to have it (core vs tap) and who we want to realize it!

### How to try it out

I've created a tap for it over at [`chrmoritz/node`](https://github.com/chrmoritz/homebrew-node) so that you can easier try it out (I think this is now the best way to go for testing changes affecting both `brew` and `homebrew-core`).
`brew tap chrmoritz/node`
It also comes with a node based [cmd line tool](https://github.com/chrmoritz/homebrew-node-formulator) for generating homebrew node formulas in the proposed style. It will install the module globally with npm@3 to a /tmp folder and parses the dep tree output from `npm ls --long --json` to generate the formula. You can install with `brew install chrmoritz/node/node-formulator --HEAD`. Then type `node-formulator -h` for usage instruction (btw: sry for the name). Currently it only fully supports npm registry hosted dependencies and has no support for / is not tested with optional and bundled dependencies yet.

It works really great for small tools like [generate-json-schema](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/generate-json-schema.rb) (currently in homebrew-core), [rimraf](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/rimraf.rb), [coffee-script](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/coffee-script.rb) and [coffeelint](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/coffeelint.rb) or the [node-formulator](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/node-formulator.rb) itself.
It still works fine for tools with a about average amount of dependencies like [less](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/less.rb) and [node-sass](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/node-sass.rb).
But is sadly currently hits homebrew limitation (e.g. no concurrent resource fetching) on very dependency heavy modules like [azure-cli](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/azure-cli.rb) or [autocode](https://github.com/chrmoritz/homebrew-node/blob/master/Formula/autocode.rb) (both currently in homebrew-core).

### How does it work

The proposed changes consist of 2 parts.
1. Adding a new `Language::Node` which include all the module installation logic and some other helper function (e.g. major node version helper for checking bottle compatibility of native addons).
2. Adding a new `Resource::Node` which extends the classic `resource` by two new fields: `parent` (used to map the dependency tree structure) and `install` (which is used to patch to install instruction for native addons to not use precompiled binaries, and yes we may should consider renaming it to avoid confusions).

*As you might have seen: I'm not a ruby developer. I'd appreciate it if someone could point me into the right direction to get rid of the helper getters in the `Resource::Node` or give any other feedback to improve to code style.*

##### How it installs the node modules

The actual installation is done by the `Language::Node.node_modules_install resources, libexec/"node_modules"` method. Just to say it at the beginning: The final structure of the `node_modules` folder is only partly npm compatible but fully node module spec compliant. I've taken the time to optimize it for our 'one time installation and never updating a dependency without reinstalling everything'-use case. It was slightly inspired by the flat dependency structure of npm@3, but I've gone further to be 100% flat (yes no nested modules for version conflicts) by using versioned dependencies and symlinks to their parents slightly inspired by [pnpm](https://github.com/rstacruz/pnpm) (yes we don't have multiple copies of the same nested dependency, we just have multiple symlinks from our versioned dependency at the root level to them).

If you look at the generated formulas over at [chrmoritz/homebrew-node/Formula](https://github.com/chrmoritz/homebrew-node/tree/master/Formula) you will see that there are to types of node `resources`. The first block of alphabetically sorted `resources` consists of modules simply named by their name, which should get installed at the root level the same way npm@3 would do it. The second block consist of the versioned modules (in npm@3 they would be nested modules) which are named like `name@version`, which we install in a versioned style at the root level to (similar to the way pnpm handles their modules). Don't worry they can't get accidentally get picked up because every not url safe character (including `@`) is a reserved character for module names in the npm ecosystem. Now that we have them there at one place (without unnecessary copies) we can create symlinks to their parents `node_modules` folder with only their names so they get picked up everywhere where they are needed. The information about their parents is read from the new `resource` metadata field which is filed by my formula generator tool with right information generated from the dependency tree. (Please note: In some very rare cases root dependency can also have parents, namely if a modules X dep in the dependency tree requires the version of module A from the root level, but somewhere in the dep tree branch between X and the root a other version of A is requested by another module and symlinked. Without the symlink from the root version of A this other version would be picked up by X.)

**Handling native addons:** This is still quite some work in progress in the current version. But the idea is that we have to patch most install scrips to not download prebuild binaries and build them always from source instead to be morw aligned with homebrews philosophy of building everything from source. This is done by adding an override field to the `resource` metadata describing how to compile the native addon, which should be used instead of the default one found in the `scripts.install` section of the `package.json`.
These fields are automatically generated by my tool from a patched version of the default install script in case of [node-pre-gyp](https://www.npmjs.com/package/node-pre-gyp) or [prebuild](https://www.npmjs.com/package/prebuild) usage, but they need to be edited by hand for native addons using a custom solution for providing binaries (but most native addons should use one of the 2 supported solutions or not provide any binaries at all).

### Advantages over the current system
*(All italic points could be backborted to the current system without homebrew manged resources)*

* installing doesn't rely on network access at install time (assuming you did a fetch earlier) as all dependencies are managed as npm resources
* *installing the same version of a formula with `--build-from-source` will always result in the same dependency versions to be installed. Currently the dependency are only locked to semver ranges and reinstalling the same version of a formula a week later will result in newer dependency release to be picked up (can bew fixed within the current system by applying a homebrew provided `npm_shrinkwrap.json`)*
* better handling for native addons inside the dependency chain:
  * I've a system in place for patching the install instructions to tell tools like [node-pre-gyp](https://www.npmjs.com/package/node-pre-gyp) or [prebuild](https://www.npmjs.com/package/prebuild) to always build them from source instead of downloading a prebuild binary (which is currently done for `fibers` in `azure-cli`).
  * *I'm also adding a `pour_bottle?` requirement for a specific node major version for formulas with a native addon in it's dependency chain, because the bottle won't be compatible with a node version which doesn't match the major version number with the node version used to build the bottle. (Don't forget the revision `azure-cli` with the upgrade to node v5.)*
  * the native addon compilation is independent of npm, so that it will work for users with a broken npm too (Why are still so many people playing russian roulett with their npm installation by running `npm -g update npm` instead of `npm -g install npm@latest`?). 
* *I'm reading the `package.json`s `bin` section for generating the `bin.install_symlink` code because the command name does not have to match the js file name (Just installing symlinks for everything in bin will not always do the correct thing. They don't even have to be located in the bin folder.)*
* a node module spec compliant 100% flat dependency structure with no duplication: I use versioned dependency (inspired by pnpm) instead of nested dependency to resolve version conflicts and symlink them to their parents `node_modules` folder instead of copying then multiple times over there. (We can do this more efficient than npm here because we don't need to support the 'updating only a specific dependency'-scenario, because every time we want to update a `resource` we have to reinstall the complete formula, which should happen only in a few exceptional cases outside of a formula version upgrade anyway.)
* Formula generation can be done fully automated with a simple command line tool which fills everything out except for the test. (You may have to edit some fields read from the `package.json` like `desc` by hand through if they doesn't match homebrews style.)

### Disadvantages of the proposed system
*these are caused by the high amount of dependencies / resources for which homebrew wasn't really designed for*

* long homebrew formulas (over 1000 lines for very dependency heavy modules)
* if building from source: long resources fetch time for dependency heavy modules (until homebrew implements concurrent resource fetching)

### Summary

As I've sad before: Don't see this as a finished PR. See it more like an prototype, which should start a discussion about how we can improve support for node module based formulas in homebrew.
I would appreciate any feedback about how the current approve can be evolved and how this can / should be supported by homebrew before I invest more time in it. 
I'm also prepared that you might say that the amount of resources is a show stopper for you (I wouldn't be disappointed if thats the case at this point, but I would like to get some feedback saying that this has a change before continuing working on it.). 
And sorry for writing such a long text ;-).