### PR TITLE
test-bot: add safety margin to output truncation size

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -37,6 +37,8 @@ require "tap"
 
 module Homebrew
   BYTES_IN_1_MEGABYTE = 1024*1024
+  MAX_STEP_OUTPUT_SIZE = BYTES_IN_1_MEGABYTE - (200*1024) # margin of safety
+
   HOMEBREW_TAP_REGEX = %r{^([\w-]+)/homebrew-([\w-]+)$}
 
   def ruby_has_encoding?
@@ -997,14 +999,14 @@ module Homebrew
         output = output.delete("\000\a\b\e\f\x2\x1f")
       end
 
-      # Truncate to 1MB
-      if output.bytesize > BYTES_IN_1_MEGABYTE
+      # Truncate to 1MB to avoid hitting CI limits
+      if output.bytesize > MAX_STEP_OUTPUT_SIZE
         if ruby_has_encoding?
           binary_output = output.force_encoding("BINARY")
-          output = binary_output.slice(-BYTES_IN_1_MEGABYTE, BYTES_IN_1_MEGABYTE)
+          output = binary_output.slice(-MAX_STEP_OUTPUT_SIZE, MAX_STEP_OUTPUT_SIZE)
           fix_encoding!(output)
         else
-          output = output.slice(-BYTES_IN_1_MEGABYTE, BYTES_IN_1_MEGABYTE)
+          output = output.slice(-MAX_STEP_OUTPUT_SIZE, MAX_STEP_OUTPUT_SIZE)
         end
         output = "truncated output to 1MB:\n" + output
       end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully ran `brew tests` with your changes locally?

Follows up on #27. Lowers the truncation threshold for `test-bot`'s Step output from 1 MB to about 800K, to ensure we're well under the 1 MB limit that CI might be sensitive to, even after the "output truncated to 1 MB:" string is added to the result.