### PR TITLE
curl: fall back to /usr/bin/curl when HOMEBREW_CURL doesn't exist

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -311,6 +311,7 @@ end
 
 def curl(*args)
   curl = Pathname.new ENV["HOMEBREW_CURL"]
+  curl = Pathname.new "/usr/bin/curl" unless curl.exist?
   raise "#{curl} is not executable" unless curl.exist? && curl.executable?
 
   flags = HOMEBREW_CURL_ARGS


### PR DESCRIPTION
This can happen when `HOMEBREW_CURL` is set to brewed curl, but during
`brew resinstall curl`, brewed curl's symlink is temporary
unlinked.

So let's fallback to /usr/bin/curl in this case.