### PR TITLE
scm/git: prevent exec bomb with 'env :userpaths'

### DIFF
--- a/Library/ENV/scm/git
+++ b/Library/ENV/scm/git
@@ -13,13 +13,16 @@ exec "$HOMEBREW_RUBY_PATH" -x "$0" "$@"
 # This script because we support $GIT, $HOMEBREW_SVN, etc., Xcode-only and
 # no Xcode/CLT configurations. Order is careful to be what the user would want.
 
+require "pathname"
+
+SELF_REAL = Pathname.new(__FILE__).realpath
 F = File.basename(__FILE__).freeze
 D = File.expand_path(File.dirname(__FILE__)).freeze
 
 def exec(*args)
   # prevent fork-bombs
   arg0 = args.first
-  return if arg0 =~ /^#{F}/i || File.expand_path(arg0) == File.expand_path(__FILE__)
+  return if arg0 =~ /^#{F}/i || Pathname.new(arg0).realpath == SELF_REAL
   super
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Have you written new tests for your changes?~~
- [x] Have you successfully ran `brew tests` with your changes locally?

----

Using `git` from `Formula#install` can cause ~~a fork~~ an exec bomb if used in a formula with `env :userpaths` because that causes both `Library/ENV/4.3` and `Library/ENV/scm` to be in PATH, both of which contain a `git` binary that is the same SCM wrapper. Those will mutually ~~fork~~ exec each other indefinitely as they fail to detect that they are the same wrapper.

Extend the ~~fork-bomb~~ exec-bomb protection to check the paths after all symbolic links have been expanded to prevent this situation. (This incurs a small performance penalty because we need to rely on `Pathname` for Ruby 1.8.7 compatibility, but this wrapper isn't performance critical at all.)

*Note:* This must have happened in the past occasionally. Commit 8ca79a6df59a7d02ee379e5a766e9170bb26c797 just made it much more likely to happen due to a subtle change. (And `boost` happens to be a formula that triggers this behavior.)

Fixes #43.
Fixes Homebrew/homebrew-core#133.