### PR TITLE
Auto-update when running brew install/upgrade.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -4,6 +4,13 @@ require "formulary"
 require "descriptions"
 
 module Homebrew
+  def update_preinstall_header
+    @header_already_printed ||= begin
+      ohai "Auto-updated Homebrew!" if ARGV.include?("--preinstall")
+      true
+    end
+  end
+
   def update_report
     install_core_tap_if_necessary
 
@@ -17,6 +24,7 @@ module Homebrew
     end
 
     if initial_revision != current_revision
+      update_preinstall_header
       puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
       updated = true
     end
@@ -37,13 +45,14 @@ module Homebrew
     end
 
     unless updated_taps.empty?
+      update_preinstall_header
       puts "Updated #{updated_taps.size} tap#{plural(updated_taps.size)} " \
            "(#{updated_taps.join(", ")})."
       updated = true
     end
 
     if !updated
-      puts "Already up-to-date."
+      puts "Already up-to-date." unless ARGV.include?("--preinstall")
     elsif hub.empty?
       puts "No changes to formulae."
     else

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -207,7 +207,14 @@ pull() {
 
   trap '' SIGINT
 
-  pop_stash_message
+  if [[ -n "$HOMEBREW_DEVELOPER" ]] &&
+     [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" ]]
+  then
+    git checkout "${QUIET_ARGS[@]}" "$INITIAL_BRANCH"
+    pop_stash
+  else
+    pop_stash_message
+  fi
 
   trap - SIGINT
 }
@@ -226,6 +233,7 @@ homebrew-update() {
       --debug) HOMEBREW_DEBUG=1;;
       --rebase) HOMEBREW_REBASE=1 ;;
       --simulate-from-current-branch) HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH=1 ;;
+      --preinstall) HOMEBREW_UPDATE_PREINSTALL=1 ;;
       --*) ;;
       -*)
         [[ "$option" = *v* ]] && HOMEBREW_VERBOSE=1;
@@ -311,11 +319,21 @@ EOS
            --header "If-None-Match: \"$UPSTREAM_BRANCH_LOCAL_SHA\"" \
            "https://api.github.com/repos/$UPSTREAM_REPOSITORY/commits/$UPSTREAM_BRANCH")"
         [[ "$UPSTREAM_SHA_HTTP_CODE" = "304" ]] && exit
+      elif [[ -n "$HOMEBREW_UPDATE_PREINSTALL" ]]
+      then
+        # Don't try to do a `git fetch` that may take longer than expected.
+        exit
       fi
 
-      git fetch --force "${QUIET_ARGS[@]}" origin \
-        "refs/heads/$UPSTREAM_BRANCH:refs/remotes/origin/$UPSTREAM_BRANCH" || \
-          odie "Fetching $DIR failed!"
+      if [[ -n "$HOMEBREW_UPDATE_PREINSTALL" ]]
+      then
+        git fetch --force "${QUIET_ARGS[@]}" origin \
+          "refs/heads/$UPSTREAM_BRANCH:refs/remotes/origin/$UPSTREAM_BRANCH" 2>/dev/null
+      else
+        git fetch --force "${QUIET_ARGS[@]}" origin \
+          "refs/heads/$UPSTREAM_BRANCH:refs/remotes/origin/$UPSTREAM_BRANCH" || \
+            odie "Fetching $DIR failed!"
+      fi
     ) &
   done
 

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -230,6 +230,19 @@ then
     & disown
 fi
 
+update-preinstall() {
+  [[ -n "$HOMEBREW_AUTO_UPDATE" ]] || return
+  [[ -z "$HOMEBREW_NO_AUTO_UPDATE" ]] || return
+
+  if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" ]]
+  then
+    # Hide shellcheck complaint:
+    # shellcheck source=/dev/null
+    source "$HOMEBREW_LIBRARY/Homebrew/cmd/update.sh"
+    homebrew-update --preinstall
+  fi
+}
+
 if [[ -n "$HOMEBREW_BASH_COMMAND" ]]
 then
   # source rather than executing directly to ensure the entire file is read into
@@ -240,9 +253,9 @@ then
   # Hide shellcheck complaint:
   # shellcheck source=/dev/null
   source "$HOMEBREW_BASH_COMMAND"
-  { "homebrew-$HOMEBREW_COMMAND" "$@"; exit $?; }
+  { update-preinstall; "homebrew-$HOMEBREW_COMMAND" "$@"; exit $?; }
 else
   # Unshift command back into argument list (unless argument list was empty).
   [[ "$HOMEBREW_ARG_COUNT" -gt 0 ]] && set -- "$HOMEBREW_COMMAND" "$@"
-  exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/brew.rb" "$@"
+  { update-preinstall; exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/brew.rb" "$@"; }
 fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

Follows on from https://github.com/Homebrew/legacy-homebrew/pull/50192.

The main changes from there:
- I've fixed the issue if `brew.sh` was updated while running
- I've fixed the `brew edit` workflow for when `HOMEBREW_DEVELOPER` is set
- Only enable this behaviour if `HOMEBREW_AUTO_UPDATE` is set (so I can test it locally and see how annoying it is to e.g. run on every command).

CC @UniqMartin @xu-cheng @bfontaine @apjanke on what would be required for this to be merged as-is (disabled by default).