### PR TITLE
superenv: allow paths under self's keg

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -15,7 +15,7 @@ require "set"
 
 class Cmd
   attr_reader :config, :prefix, :cellar, :opt, :tmpdir, :sysroot, :deps
-  attr_reader :archflags, :optflags, :keg_regex
+  attr_reader :archflags, :optflags, :keg_regex, :formula, :formula_version
 
   def initialize(arg0, args)
     @arg0 = arg0
@@ -29,6 +29,8 @@ class Cmd
     @archflags = ENV.fetch("HOMEBREW_ARCHFLAGS") { "" }.split(" ")
     @optflags = ENV.fetch("HOMEBREW_OPTFLAGS") { "" }.split(" ")
     @deps = Set.new(ENV.fetch("HOMEBREW_DEPENDENCIES") { "" }.split(","))
+    @formula = ENV["HOMEBREW_FORMULA"]
+    @formula_version = ENV["HOMEBREW_FORMULA_VERSION"]
     # matches opt or cellar prefix and formula name
     @keg_regex = %r[(#{Regexp.escape(opt)}|#{Regexp.escape(cellar)})/([\w\-_\+]+)]
   end
@@ -205,9 +207,12 @@ class Cmd
     # but is currently opt-in.
     return keep_orig?(path) unless ENV["HOMEBREW_EXPERIMENTAL_FILTER_FLAGS_ON_DEPS"]
 
+    # Allow references to self
+    if keg_path && path.start_with?(keg_path)
+      true
     # first two paths: reject references to Cellar or opt paths
     # for unspecified dependencies
-    if path.start_with?(cellar) || path.start_with?(opt)
+    elsif path.start_with?(cellar) || path.start_with?(opt)
       dep = path[keg_regex, 2]
       dep && @deps.include?(dep)
     elsif path.start_with?(prefix)
@@ -274,6 +279,11 @@ class Cmd
 
   def system_library_paths
     %W[#{sysroot}/usr/lib /usr/local/lib]
+  end
+
+  def keg_path
+    return nil if formula.nil?
+    "#{cellar}/#{formula}/#{formula_version}"
   end
 
   def configure?

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -68,6 +68,10 @@ module Superenv
     self["HOMEBREW_INCLUDE_PATHS"] = determine_include_paths
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
     self["HOMEBREW_DEPENDENCIES"] = determine_dependencies
+    unless formula.nil?
+      self["HOMEBREW_FORMULA"] = formula.name
+      self["HOMEBREW_FORMULA_VERSION"] = formula.version
+    end
 
     if MacOS::Xcode.without_clt? || (MacOS::Xcode.installed? && MacOS::Xcode.version.to_i >= 7)
       self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully ran `brew tests` with your changes locally?

Fixes build error in Homebrew/homebrew-core#100.
Fixes build error in Homebrew/homebrew-core#137.
Fixes build error in Homebrew/homebrew-core#262.
Will probably prevent build error next time `elm` is updated.

The new path-filtering logic in `superenv` will reject paths under the cellar which are not in the formula's declared dependencies. This rejects references to the formula currently being built, too, which can break multi-stage builds. This typically only shows up under `brew test-bot`, because that's the only place that currently enables `HOMEBREW_EXPERIMENTAL_FILTER_FLAGS_ON_DEPS=1`, which activates the new path-filtering logic.

This modifies superenv to allow paths under the keg for the formula currently being built.