### PR TITLE
brew test, install, test-bot: add --keep-tmp option to retain staged files

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -105,7 +105,8 @@ class Build
 
     formula.extend(Debrew::Formula) if ARGV.debug?
 
-    formula.brew do
+    formula.brew do |_formula, staging|
+      staging.retain! if ARGV.keep_tmp?
       formula.patch
 
       if ARGV.git?

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -1,4 +1,4 @@
-#:  * `install` [`--debug`] [`--env=`<std>|<super>] [`--ignore-dependencies`] [`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] <formula>:
+#:  * `install` [`--debug`] [`--env=`<std>|<super>] [`--ignore-dependencies`] [`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] <formula>:
 #:    Install <formula>.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
@@ -34,6 +34,9 @@
 #:
 #:    If `--HEAD` is passed, and <formula> defines it, install the HEAD version,
 #:    aka master, trunk, unstable.
+#:
+#:    If `--keep-tmp` is passed, the temporary files created for the test are
+#:    not deleted.
 #:
 #:    To install a newer version of HEAD use
 #:    `brew rm <foo> && brew install --HEAD <foo>`.

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -22,15 +22,11 @@ module Homebrew
     end
 
     if Sandbox.available? && ARGV.sandbox?
-      if Sandbox.auto_disable?
-        Sandbox.print_autodisable_warning
-      else
-        Sandbox.print_sandbox_message
-      end
+      Sandbox.print_sandbox_message
     end
 
     Utils.safe_fork do
-      if Sandbox.available? && ARGV.sandbox? && !Sandbox.auto_disable?
+      if Sandbox.available? && ARGV.sandbox?
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"sandbox.postinstall.log")

--- a/Library/Homebrew/cmd/test.rb
+++ b/Library/Homebrew/cmd/test.rb
@@ -1,4 +1,4 @@
-#:  * `test` [`--devel`|`--HEAD`] [`--debug`] <formula>:
+#:  * `test` [`--devel`|`--HEAD`] [`--debug`] [`--keep-tmp`] <formula>:
 #:    A few formulae provide a test method. `brew test` <formula> runs this
 #:    test method. There is no standard output or return code, but it should
 #:    generally indicate to the user if something is wrong with the installed
@@ -9,6 +9,9 @@
 #:
 #:    If `--debug` is passed and the test fails, an interactive debugger will be
 #:    launched with access to IRB or a shell inside the temporary test directory.
+#:
+#:    If `--keep-tmp` is passed, the temporary files created for the test are
+#:    not deleted.
 #:
 #:    Example: `brew install jruby && brew test jruby`
 
@@ -55,15 +58,11 @@ module Homebrew
         end
 
         if Sandbox.available? && !ARGV.no_sandbox?
-          if Sandbox.auto_disable?
-            Sandbox.print_autodisable_warning
-          else
-            Sandbox.print_sandbox_message
-          end
+          Sandbox.print_sandbox_message
         end
 
         Utils.safe_fork do
-          if Sandbox.available? && !ARGV.no_sandbox? && !Sandbox.auto_disable?
+          if Sandbox.available? && !ARGV.no_sandbox?
             sandbox = Sandbox.new
             f.logs.mkpath
             sandbox.record_log(f.logs/"sandbox.test.log")

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -5,6 +5,8 @@ module Homebrew
   #    brew update-test --commit=<sha1> # using <sha1> as start commit
   #    brew update-test --before=<date> # using commit at <date> as start commit
   #
+  # Options:
+  #   --keep-tmp      Retain temporary directory containing the new clone
   def update_test
     cd HOMEBREW_REPOSITORY
     start_sha1 = if commit = ARGV.value("commit")
@@ -19,7 +21,8 @@ module Homebrew
     puts "Start commit: #{start_sha1}"
     puts "End   commit: #{end_sha1}"
 
-    mktemp do
+    mktemp("update-test") do |staging|
+      staging.retain! if ARGV.keep_tmp?
       curdir = Pathname.new(Dir.pwd)
 
       oh1 "Setup test environment..."

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -17,7 +17,9 @@ class AbstractDownloadStrategy
   def fetch
   end
 
-  # Unpack {#cached_location} into the current working directory.
+  # Unpack {#cached_location} into the current working directory, and possibly
+  # chdir into the newly-unpacked directory.
+  # Unlike {Resource#stage}, this does not take a block.
   def stage
   end
 

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -120,6 +120,10 @@ module HomebrewArgvExtension
     include?("--dry-run") || switch?("n")
   end
 
+  def keep_tmp?
+    include? "--keep-tmp"
+  end
+
   def git?
     flag? "--git"
   end

--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -6,42 +6,83 @@ require "etc"
 # @see http://ruby-doc.org/stdlib-1.8.7/libdoc/fileutils/rdoc/FileUtils.html Ruby's FileUtils API
 module FileUtils
   # Create a temporary directory then yield. When the block returns,
-  # recursively delete the temporary directory.
-  def mktemp(prefix = name)
-    prev = pwd
-    tmp  = Dir.mktmpdir(prefix, HOMEBREW_TEMP)
-
-    # Make sure files inside the temporary directory have the same group as the
-    # brew instance.
-    #
-    # Reference from `man 2 open`
-    # > When a new file is created, it is given the group of the directory which
-    # contains it.
-    group_id = if HOMEBREW_BREW_FILE.grpowned?
-      HOMEBREW_BREW_FILE.stat.gid
-    else
-      Process.gid
-    end
-    begin
-      # group_id.to_s makes OS X 10.6.7 (ruby-1.8.7-p174) and earlier happy.
-      chown(nil, group_id.to_s, tmp)
-    rescue Errno::EPERM
-      opoo "Failed setting group \"#{Etc.getgrgid(group_id).name}\" on #{tmp}"
-    end
-
-    begin
-      cd(tmp)
-
-      begin
-        yield
-      ensure
-        cd(prev)
-      end
-    ensure
-      ignore_interrupts { rm_rf(tmp) }
+  # recursively delete the temporary directory. Passing opts[:retain]
+  # or calling `do |staging| ... staging.retain!` in the block will skip
+  # the deletion and retain the temporary directory's contents.
+  def mktemp(prefix = name, opts = {})
+    Mktemp.new(prefix, opts).run do |staging|
+      yield staging
     end
   end
+
   module_function :mktemp
+
+  # Performs mktemp's functionality, and tracks the results.
+  # Each instance is only intended to be used once.
+  class Mktemp
+    include FileUtils
+
+    # Path to the tmpdir used in this run, as a Pathname.
+    attr_reader :tmpdir
+
+    def initialize(prefix = name, opts = {})
+      @prefix = prefix
+      @retain = opts[:retain]
+      @quiet = false
+    end
+
+    # Instructs this Mktemp to retain the staged files
+    def retain!
+      @retain = true
+    end
+
+    # True if the staged temporary files should be retained
+    def retain?
+      @retain
+    end
+
+    # Instructs this Mktemp to not emit messages when retention is triggered
+    def quiet!
+      @quiet = true
+    end
+
+    def to_s
+      "[Mktemp: #{tmpdir} retain=#{@retain} quiet=#{@quiet}]"
+    end
+
+    def run
+      @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix}-", HOMEBREW_TEMP))
+
+      # Make sure files inside the temporary directory have the same group as the
+      # brew instance.
+      #
+      # Reference from `man 2 open`
+      # > When a new file is created, it is given the group of the directory which
+      # contains it.
+      group_id = if HOMEBREW_BREW_FILE.grpowned?
+                   HOMEBREW_BREW_FILE.stat.gid
+                 else
+                   Process.gid
+                 end
+      begin
+        # group_id.to_s makes OS X 10.6.7 (ruby-1.8.7-p174) and earlier happy.
+        chown(nil, group_id.to_s, tmpdir)
+      rescue Errno::EPERM
+        opoo "Failed setting group \"#{Etc.getgrgid(group_id).name}\" on #{tmp}"
+      end
+
+      begin
+        Dir.chdir(tmpdir) { yield self }
+      ensure
+        ignore_interrupts { rm_rf(tmpdir) } unless retain?
+      end
+    ensure
+      if retain? && !@tmpdir.nil? && !@quiet
+        ohai "Kept temporary files"
+        puts "Temporary files retained at #{@tmpdir}"
+      end
+    end
+  end
 
   # @private
   alias_method :old_mkdir, :mkdir

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -523,6 +523,7 @@ class FormulaInstaller
     args << "--debug" if debug?
     args << "--cc=#{ARGV.cc}" if ARGV.cc
     args << "--default-fortran-flags" if ARGV.include? "--default-fortran-flags"
+    args << "--keep-tmp" if ARGV.keep_tmp?
 
     if ARGV.env
       args << "--env=#{ARGV.env}"
@@ -567,18 +568,14 @@ class FormulaInstaller
     ].concat(build_argv)
 
     if Sandbox.available? && ARGV.sandbox?
-      if Sandbox.auto_disable?
-        Sandbox.print_autodisable_warning
-      else
-        Sandbox.print_sandbox_message
-      end
+      Sandbox.print_sandbox_message
     end
 
     Utils.safe_fork do
       # Invalidate the current sudo timestamp in case a build script calls sudo
       system "/usr/bin/sudo", "-k"
 
-      if Sandbox.available? && ARGV.sandbox? && !Sandbox.auto_disable?
+      if Sandbox.available? && ARGV.sandbox?
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"sandbox.build.log")

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -8,18 +8,6 @@ class Sandbox
     OS.mac? && File.executable?(SANDBOX_EXEC)
   end
 
-  # there are times the sandbox cannot be used.
-  def self.auto_disable?
-    @auto_disable ||= ARGV.interactive? || ARGV.debug?
-  end
-
-  def self.print_autodisable_warning
-    unless @printed_autodisable_warning
-      opoo "The sandbox cannot be used in debug or interactive mode."
-      @printed_autodisable_warning = true
-    end
-  end
-
   def self.print_sandbox_message
     unless @printed_sandbox_message
       ohai "Using the sandbox"

--- a/Library/Homebrew/test/test_patching.rb
+++ b/Library/Homebrew/test/test_patching.rb
@@ -122,7 +122,7 @@ class PatchingTests < Homebrew::TestCase
             url PATCH_URL_A
             sha256 PATCH_A_SHA256
           end
-        end.brew(&:patch)
+        end.brew { |f, _staging| f.patch }
       end
     end
   end
@@ -136,7 +136,7 @@ class PatchingTests < Homebrew::TestCase
             sha256 TESTBALL_PATCHES_SHA256
             apply APPLY_A
           end
-        end.brew(&:patch)
+        end.brew { |f, _staging| f.patch }
       end
     end
   end
@@ -234,7 +234,7 @@ class PatchingTests < Homebrew::TestCase
             sha256 TESTBALL_PATCHES_SHA256
             apply "patches/#{APPLY_A}"
           end
-        end.brew(&:patch)
+        end.brew { |f, _staging| f.patch }
       end
     end
   end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -172,8 +172,7 @@ def interactive_shell(f = nil)
   if $?.success?
     return
   elsif $?.exited?
-    puts "Aborting due to non-zero exit status"
-    exit $?.exitstatus
+    raise "Aborted due to non-zero exit status (#{$?.exitstatus})"
   else
     raise $?.inspect
   end

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -155,7 +155,7 @@ information on all installed formulae.</p>
 
 <p>See the docs for examples of using the JSON:
 <a href="https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Querying-Brew.md" data-bare-link="true">https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Querying-Brew.md</a></p></dd>
-<dt><code>install</code> [<code>--debug</code>] [<code>--env=</code><var>std</var>|<var>super</var>] [<code>--ignore-dependencies</code>] [<code>--only-dependencies</code>] [<code>--cc=</code><var>compiler</var>] [<code>--build-from-source</code>|<code>--force-bottle</code>] [<code>--devel</code>|<code>--HEAD</code>] <var>formula</var></dt><dd><p>Install <var>formula</var>.</p>
+<dt><code>install</code> [<code>--debug</code>] [<code>--env=</code><var>std</var>|<var>super</var>] [<code>--ignore-dependencies</code>] [<code>--only-dependencies</code>] [<code>--cc=</code><var>compiler</var>] [<code>--build-from-source</code>|<code>--force-bottle</code>] [<code>--devel</code>|<code>--HEAD</code>] [<code>--keep-tmp</code>] <var>formula</var></dt><dd><p>Install <var>formula</var>.</p>
 
 <p><var>formula</var> is usually the name of the formula to install, but it can be specified
 several different ways. See <a href="#SPECIFYING-FORMULAE" title="SPECIFYING FORMULAE" data-bare-link="true">SPECIFYING FORMULAE</a>.</p>
@@ -190,6 +190,9 @@ for the current version of OS X, even if custom options are given.</p>
 
 <p>If <code>--HEAD</code> is passed, and <var>formula</var> defines it, install the HEAD version,
 aka master, trunk, unstable.</p>
+
+<p>If <code>--keep-tmp</code> is passed, the temporary files created for the test are
+not deleted.</p>
 
 <p>To install a newer version of HEAD use
 <code>brew rm &lt;foo> &amp;&amp; brew install --HEAD &lt;foo></code>.</p></dd>
@@ -321,7 +324,7 @@ for <var>version</var> is <code>v1</code>.</p>
 <dt><code>tap-pin</code> <var>tap</var></dt><dd><p>Pin <var>tap</var>, prioritizing its formulae over core when formula names are supplied
 by the user. See also <code>tap-unpin</code>.</p></dd>
 <dt><code>tap-unpin</code> <var>tap</var></dt><dd><p>Unpin <var>tap</var> so its formulae are no longer prioritized. See also <code>tap-pin</code>.</p></dd>
-<dt><code>test</code> [<code>--devel</code>|<code>--HEAD</code>] [<code>--debug</code>] <var>formula</var></dt><dd><p>A few formulae provide a test method. <code>brew test</code> <var>formula</var> runs this
+<dt><code>test</code> [<code>--devel</code>|<code>--HEAD</code>] [<code>--debug</code>] [<code>--keep-tmp</code>] <var>formula</var></dt><dd><p>A few formulae provide a test method. <code>brew test</code> <var>formula</var> runs this
 test method. There is no standard output or return code, but it should
 generally indicate to the user if something is wrong with the installed
 formula.</p>
@@ -331,6 +334,9 @@ formula.</p>
 
 <p>If <code>--debug</code> is passed and the test fails, an interactive debugger will be
 launched with access to IRB or a shell inside the temporary test directory.</p>
+
+<p>If <code>--keep-tmp</code> is passed, the temporary files created for the test are
+not deleted.</p>
 
 <p>Example: <code>brew install jruby &amp;&amp; brew test jruby</code></p></dd>
 <dt><code>uninstall</code>, <code>rm</code>, <code>remove</code> [<code>--force</code>] <var>formula</var></dt><dd><p>Uninstall <var>formula</var>.</p>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -214,7 +214,7 @@ Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to
 See the docs for examples of using the JSON: \fIhttps://github\.com/Homebrew/brew/blob/master/share/doc/homebrew/Querying\-Brew\.md\fR
 .
 .TP
-\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR\fIstd\fR|\fIsuper\fR] [\fB\-\-ignore\-dependencies\fR] [\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformula\fR
+\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR\fIstd\fR|\fIsuper\fR] [\fB\-\-ignore\-dependencies\fR] [\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] \fIformula\fR
 Install \fIformula\fR\.
 .
 .IP
@@ -249,6 +249,9 @@ If \fB\-\-devel\fR is passed, and \fIformula\fR defines it, install the developm
 .
 .IP
 If \fB\-\-HEAD\fR is passed, and \fIformula\fR defines it, install the HEAD version, aka master, trunk, unstable\.
+.
+.IP
+If \fB\-\-keep\-tmp\fR is passed, the temporary files created for the test are not deleted\.
 .
 .IP
 To install a newer version of HEAD use \fBbrew rm <foo> && brew install \-\-HEAD <foo>\fR\.
@@ -449,7 +452,7 @@ Pin \fItap\fR, prioritizing its formulae over core when formula names are suppli
 Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
 .
 .TP
-\fBtest\fR [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-debug\fR] \fIformula\fR
+\fBtest\fR [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-debug\fR] [\fB\-\-keep\-tmp\fR] \fIformula\fR
 A few formulae provide a test method\. \fBbrew test\fR \fIformula\fR runs this test method\. There is no standard output or return code, but it should generally indicate to the user if something is wrong with the installed formula\.
 .
 .IP
@@ -457,6 +460,9 @@ To test the development or head version of a formula, use \fB\-\-devel\fR or \fB
 .
 .IP
 If \fB\-\-debug\fR is passed and the test fails, an interactive debugger will be launched with access to IRB or a shell inside the temporary test directory\.
+.
+.IP
+If \fB\-\-keep\-tmp\fR is passed, the temporary files created for the test are not deleted\.
 .
 .IP
 Example: \fBbrew install jruby && brew test jruby\fR


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully ran `brew tests` with your changes locally?

This adds a `--keep-tmp` option to `brew test`, `brew install`, and `brew update-test` which lets you preserve the files for inspection after a failed test or install. It applies to the test dir for `brew test` and the build dir (with staged distribution) for `brew install`. Also adds it to `brew test-bot`, where it is propagated to the main `brew install` and `brew test` runs that test-bot does.

When `--interactive` or `--debug` are supplied, the temp file retention is done automatically if there is a build or test failure, even if `--keep-tmp` was not provided.

Enables the sandbox for interactive and debug use, now that we have a way of retaining those files for subsequent inspection. (The main reason the sandbox was disabled here is that it would prevent you from copying the staged temp files out to a new location, right? Though it seems like one could have just copied it to another location under Homebrew's cache, which was whitelisted.)