### PR TITLE
desc: use short name when possible

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -409,11 +409,12 @@ class FormulaAuditor
     end
 
     # Make sure the formula name plus description is no longer than 80 characters
-    linelength = formula.full_name.length + ": ".length + desc.length
+    # Note full_name includes the name of the tap, while name does not
+    linelength = formula.name.length + ": ".length + desc.length
     if linelength > 80
       problem <<-EOS.undent
         Description is too long. \"name: desc\" should be less than 80 characters.
-        Length is calculated as #{formula.full_name} + desc. (currently #{linelength})
+        Length is calculated as #{formula.name} + desc. (currently #{linelength})
       EOS
     end
 

--- a/Library/Homebrew/descriptions.rb
+++ b/Library/Homebrew/descriptions.rb
@@ -1,3 +1,4 @@
+require "set"
 require "formula"
 require "formula_versions"
 
@@ -123,9 +124,22 @@ class Descriptions
   # print them.
   def print
     blank = "#{Tty.yellow}[no description]#{Tty.reset}"
-    @descriptions.keys.sort.each do |name|
-      description = @descriptions[name] || blank
-      puts "#{Tty.white}#{name}:#{Tty.reset} #{description}"
+    @descriptions.keys.sort.each do |full_name|
+      short_name = short_names[full_name]
+      printed_name = short_name_counts[short_name] == 1 ? short_name : full_name
+      description = @descriptions[full_name] || blank
+      puts "#{Tty.white}#{printed_name}:#{Tty.reset} #{description}"
     end
+  end
+
+  private
+
+  def short_names
+    @short_names ||= Hash[@descriptions.keys.map { |k| [k, k.split("/").last] }]
+  end
+
+  def short_name_counts
+    @short_name_counts ||=
+      short_names.values.reduce(Hash.new(0)) { |counts, name| counts[name] += 1; counts }
   end
 end

--- a/Library/Homebrew/test/test_descriptions.rb
+++ b/Library/Homebrew/test/test_descriptions.rb
@@ -1,0 +1,45 @@
+require "testing_env"
+require "descriptions"
+
+class DescriptionsTest < Homebrew::TestCase
+  def setup
+    @descriptions_hash = {}
+    @descriptions = Descriptions.new(@descriptions_hash)
+
+    @old_stdout = $stdout
+    $stdout = StringIO.new
+  end
+
+  def teardown
+    $stdout = @old_stdout
+  end
+
+  def test_single_core_formula
+    @descriptions_hash["homebrew/core/foo"] = "Core foo"
+    @descriptions.print
+    assert_equal "foo: Core foo", $stdout.string.chomp
+  end
+
+  def test_single_external_formula
+    @descriptions_hash["somedev/external/foo"] = "External foo"
+    @descriptions.print
+    assert_equal "foo: External foo", $stdout.string.chomp
+  end
+
+  def test_even_dupes
+    @descriptions_hash["homebrew/core/foo"] = "Core foo"
+    @descriptions_hash["somedev/external/foo"] = "External foo"
+    @descriptions.print
+    assert_equal "homebrew/core/foo: Core foo\nsomedev/external/foo: External foo",
+                 $stdout.string.chomp
+  end
+
+  def test_odd_dupes
+    @descriptions_hash["homebrew/core/foo"] = "Core foo"
+    @descriptions_hash["somedev/external/foo"] = "External foo"
+    @descriptions_hash["otherdev/external/foo"] = "Other external foo"
+    @descriptions.print
+    assert_equal "homebrew/core/foo: Core foo\notherdev/external/foo: Other external foo\nsomedev/external/foo: External foo",
+                 $stdout.string.chomp
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

This is a follow-up to Homebrew/legacy-homebrew#47296, addressing comments from @mikemcquaid and @bfontaine and incorporating @crd's original changes. `audit --strict` considers only the formula's short name when calculating description length (e.g. `suite-sparse` rather than `homebrew/science/suite-sparse`), and `desc` prints the short name unless another formula has the same short name.