### PR TITLE
Ship analytics for Homebrew.

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -169,8 +169,6 @@ can take several different forms:
   * `HOMEBREW_NO_ANALYTICS`:
     If set, Homebrew will not send analytics. See: <https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md#analytics>
 
-    *Note:* Homebrew currently disables analytics by default.
-
   * `HOMEBREW_NO_EMOJI`:
     If set, Homebrew will not print the `HOMEBREW_INSTALL_BADGE` on a
     successful build.

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -8,7 +8,6 @@ def analytics_label
 end
 
 def report_analytics(type, metadata = {})
-  return unless ENV["HOMEBREW_ANALYTICS"]
   return if ENV["HOMEBREW_NO_ANALYTICS"]
 
   args = %W[

--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -1,5 +1,4 @@
 setup-analytics() {
-  [[ -z "$HOMEBREW_ANALYTICS" ]] && return
   [[ -n "$HOMEBREW_NO_ANALYTICS" ]] && return
 
   # User UUID file. Used for Homebrew user counting. Can be deleted and
@@ -27,7 +26,6 @@ setup-analytics() {
 }
 
 report-analytics-screenview-command() {
-  [[ -z "$HOMEBREW_ANALYTICS" ]] && return
   [[ -n "$HOMEBREW_NO_ANALYTICS" ]] && return
 
   # Don't report non-official commands.

--- a/share/doc/homebrew/Analytics.md
+++ b/share/doc/homebrew/Analytics.md
@@ -1,5 +1,5 @@
 # Homebrew's Anonymous Aggregate User Behaviour Analytics
-Homebrew will shortly begin gathering anonymous aggregate user behaviour analytics and reporting these to Google Analytics.
+Homebrew has begun gathering anonymous aggregate user behaviour analytics and reporting these to Google Analytics.
 
 ## Why?
 Homebrew is provided free of charge and run entirely by volunteers in their spare time. As a result, we do not have the resources to do detailed user studies of Homebrew users to decide on how best to design future features and prioritise current work. Anonymous aggregate user analytics allow us to prioritise fixes and features based on how, where and when people use Homebrew. For example:

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -516,9 +516,7 @@ Homebrew uses the GitHub API for features such as <code>brew search</code>.</p>
 the number of parallel jobs to run when building with <code>make</code>(1).</p>
 
 <p><em>Default:</em> the number of available CPU cores.</p></dd>
-<dt><code>HOMEBREW_NO_ANALYTICS</code></dt><dd><p>If set, Homebrew will not send analytics. See: <a href="https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md#analytics" data-bare-link="true">https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md#analytics</a></p>
-
-<p><em>Note:</em> Homebrew currently disables analytics by default.</p></dd>
+<dt><code>HOMEBREW_NO_ANALYTICS</code></dt><dd><p>If set, Homebrew will not send analytics. See: <a href="https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md#analytics" data-bare-link="true">https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md#analytics</a></p></dd>
 <dt><code>HOMEBREW_NO_EMOJI</code></dt><dd><p>If set, Homebrew will not print the <code>HOMEBREW_INSTALL_BADGE</code> on a
 successful build.</p>
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -723,9 +723,6 @@ If set, instructs Homebrew to use the value of \fBHOMEBREW_MAKE_JOBS\fR as the n
 \fBHOMEBREW_NO_ANALYTICS\fR
 If set, Homebrew will not send analytics\. See: \fIhttps://github\.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics\.md#analytics\fR
 .
-.IP
-\fINote:\fR Homebrew currently disables analytics by default\.
-.
 .TP
 \fBHOMEBREW_NO_EMOJI\fR
 If set, Homebrew will not print the \fBHOMEBREW_INSTALL_BADGE\fR on a successful build\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

I believe Homebrew's Analytics are ready to :ship:. This makes them opt-out by default. They will be accompanied by a tweet and mailing list post announcing this to people and pointing them towards the 
https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md#analytics documentation.

@Homebrew/maintainers If there's any **blockers** in releasing analytics to everyone (i.e. we **cannot** ship analytics until this is fixed): please let me know in this issue. Feel free to suggest "nice to haves" but please be explicit about whether a comment is a suggestion/idea for something in the future or you consider it a hard blocker on releasing this feature.

I'll leave this open for at least a few days to solicit feedback.

Thanks!

--

Commit message:
For more information and opt-out instructions please read:
https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Analytics.md#analytics