### PR TITLE
superenv: fix formula prefix path to consider revisions

### DIFF
--- a/Library/ENV/4.3/cc
+++ b/Library/ENV/4.3/cc
@@ -15,7 +15,7 @@ require "set"
 
 class Cmd
   attr_reader :config, :prefix, :cellar, :opt, :tmpdir, :sysroot, :deps
-  attr_reader :archflags, :optflags, :keg_regex, :formula, :formula_version
+  attr_reader :archflags, :optflags, :keg_regex, :formula_prefix
 
   def initialize(arg0, args)
     @arg0 = arg0
@@ -29,8 +29,7 @@ class Cmd
     @archflags = ENV.fetch("HOMEBREW_ARCHFLAGS") { "" }.split(" ")
     @optflags = ENV.fetch("HOMEBREW_OPTFLAGS") { "" }.split(" ")
     @deps = Set.new(ENV.fetch("HOMEBREW_DEPENDENCIES") { "" }.split(","))
-    @formula = ENV["HOMEBREW_FORMULA"]
-    @formula_version = ENV["HOMEBREW_FORMULA_VERSION"]
+    @formula_prefix = ENV["HOMEBREW_FORMULA_PREFIX"]
     # matches opt or cellar prefix and formula name
     @keg_regex = %r[(#{Regexp.escape(opt)}|#{Regexp.escape(cellar)})/([\w\-_\+]+)]
   end
@@ -208,7 +207,7 @@ class Cmd
     return keep_orig?(path) unless ENV["HOMEBREW_EXPERIMENTAL_FILTER_FLAGS_ON_DEPS"]
 
     # Allow references to self
-    if keg_path && path.start_with?(keg_path)
+    if formula_prefix && path.start_with?("#{formula_prefix}/")
       true
     # first two paths: reject references to Cellar or opt paths
     # for unspecified dependencies
@@ -279,11 +278,6 @@ class Cmd
 
   def system_library_paths
     %W[#{sysroot}/usr/lib /usr/local/lib]
-  end
-
-  def keg_path
-    return nil if formula.nil?
-    "#{cellar}/#{formula}/#{formula_version}"
   end
 
   def configure?

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -69,8 +69,7 @@ module Superenv
     self["HOMEBREW_LIBRARY_PATHS"] = determine_library_paths
     self["HOMEBREW_DEPENDENCIES"] = determine_dependencies
     unless formula.nil?
-      self["HOMEBREW_FORMULA"] = formula.name
-      self["HOMEBREW_FORMULA_VERSION"] = formula.version
+      self["HOMEBREW_FORMULA_PREFIX"] = formula.prefix
     end
 
     if MacOS::Xcode.without_clt? || (MacOS::Xcode.installed? && MacOS::Xcode.version.to_i >= 7)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully ran `brew tests` with your changes locally?

Fixes a bug in #63. It's formula prefix path calculation logic didn't include the revision in the package version, so would be wrong for formulae with revision > 0.

Switches to passing the whole prefix path from the parent `brew` process to avoid duplicating path calculation logic.