### PR TITLE
doc: remove outdated documentation for completion

### DIFF
--- a/share/doc/homebrew/Tips-N'-Tricks.md
+++ b/share/doc/homebrew/Tips-N'-Tricks.md
@@ -42,22 +42,6 @@ Use `brew info $FORMULA` to check what versions are installed but not currently 
 ./configure --prefix=/usr/local/Cellar/foo/1.2 && make && make install && brew link foo
 ```
 
-## Command tab-completion
-
-### Bash
-Add to your `~/.bashrc` or `~/.bash_profile` (whichever you have configured to run on shell startup):
-
-```bash
-source $(brew --repository)/Library/Contributions/brew_bash_completion.sh
-```
-
-### Zsh
-Run in terminal (may require `sudo`):
-
-```zsh
-ln -s "$(brew --prefix)/Library/Contributions/brew_zsh_completion.zsh" /usr/local/share/zsh/site-functions/_brew
-```
-
 ## Pre-downloading a file for a formula
 
 Sometimes it's faster to download a file via means other than those


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

By the commit edf000e4cd30c3626ccc28c52ed32f2d84a200dd, bash and zsh completion scripts have been moved to `etc/bash_completion.d/brew` and `share/zsh/site-functions/_brew`, respectively. Now completion will be done automatically without any trick.