### PR TITLE
Improve error handling for misnamed formula class

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -139,6 +139,11 @@ module Homebrew
       perform_preinstall_checks
 
       formulae.each { |f| install_formula(f) }
+    rescue FormulaClassUnavailableError => e
+      # Need to rescue before `FormulaUnavailableError` (superclass of this)
+      # is handled, as searching for a formula doesn't make sense here (the
+      # formula was found, but there's a problem with its implementation).
+      ofail e.message
     rescue FormulaUnavailableError => e
       if (blacklist = blacklisted?(e.name))
         ofail "#{e.message}\n#{blacklist}"

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -68,6 +68,43 @@ class TapFormulaUnavailableError < FormulaUnavailableError
   end
 end
 
+class FormulaClassUnavailableError < FormulaUnavailableError
+  attr_reader :path
+  attr_reader :class_name
+  attr_reader :class_list
+
+  def initialize(name, path, class_name, class_list)
+    @path = path
+    @class_name = class_name
+    @class_list = class_list
+    super name
+  end
+
+  def to_s
+    s = super
+    s += "\nIn formula file: #{path}"
+    s += "\nExpected to find class #{class_name}, but #{class_list_s}."
+    s
+  end
+
+  private
+
+  def class_list_s
+    formula_class_list = class_list.select { |klass| klass < Formula }
+    if class_list.empty?
+      "found no classes"
+    elsif formula_class_list.empty?
+      "only found: #{format_list(class_list)} (not derived from Formula!)"
+    else
+      "only found: #{format_list(formula_class_list)}"
+    end
+  end
+
+  def format_list(class_list)
+    class_list.map { |klass| klass.name.split("::")[-1] }.join(", ")
+  end
+end
+
 class TapFormulaAmbiguityError < RuntimeError
   attr_reader :name, :paths, :formulae
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -23,8 +23,12 @@ class Formulary
 
     begin
       mod.const_get(class_name)
-    rescue NameError => e
-      raise FormulaUnavailableError, name, e.backtrace
+    rescue NameError => original_exception
+      class_list = mod.constants.
+        map { |const_name| mod.const_get(const_name) }.
+        select { |const| const.is_a?(Class) }
+      e = FormulaClassUnavailableError.new(name, path, class_name, class_list)
+      raise e, "", original_exception.backtrace
     end
   end
 

--- a/Library/Homebrew/test/test_exceptions.rb
+++ b/Library/Homebrew/test/test_exceptions.rb
@@ -37,6 +37,25 @@ class ExceptionsTest < Homebrew::TestCase
       TapFormulaUnavailableError.new(t, "foo").to_s
   end
 
+  def test_formula_class_unavailable_error
+    mod = Module.new
+    mod.module_eval <<-EOS.undent
+      class Bar < Requirement; end
+      class Baz < Formula; end
+    EOS
+
+    assert_match "Expected to find class Foo, but found no classes.",
+      FormulaClassUnavailableError.new("foo", "foo.rb", "Foo", []).to_s
+
+    list = [mod.const_get(:Bar)]
+    assert_match "Expected to find class Foo, but only found: Bar (not derived from Formula!).",
+      FormulaClassUnavailableError.new("foo", "foo.rb", "Foo", list).to_s
+
+    list = [mod.const_get(:Baz)]
+    assert_match "Expected to find class Foo, but only found: Baz.",
+      FormulaClassUnavailableError.new("foo", "foo.rb", "Foo", list).to_s
+  end
+
   def test_tap_unavailable_error
     assert_equal "No available tap foo.\n", TapUnavailableError.new("foo").to_s
   end

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -54,6 +54,16 @@ class FormularyFactoryTest < Homebrew::TestCase
     assert_raises(FormulaUnavailableError) { Formulary.factory("not_existed_formula") }
   end
 
+  def test_formula_class_unavailable_error
+    name = "giraffe"
+    path = CoreTap.new.formula_dir/"#{name}.rb"
+    path.write "class Wrong#{Formulary.class_s(name)} < Formula\nend\n"
+
+    assert_raises(FormulaClassUnavailableError) { Formulary.factory(name) }
+  ensure
+    path.unlink
+  end
+
   def test_factory_from_path
     assert_kind_of Formula, Formulary.factory(@path)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully ran `brew tests` with your changes locally?

----

Improve on the confusing error behavior observed in #82, i.e. for the case where there is a mismatch between the expected and actual class name in a formula file and adapt `brew install` to suppress the confusing search in this case. (The new exception class is a subclass of `FormulaUnavailableError`, thus the change is transparent to other users of `Formulary` that haven't been adapted.)

Old behavior:

```
$ brew info qt5-webkit
Error: No available formula with the name "qt5-webkit"

$ brew install qt5-webkit
Error: No available formula with the name "qt5-webkit"
==> Searching for similarly named formulae...
This similarly named formula was found:
qt5-webkit
To install it, run:
  brew install qt5-webkit
==> Searching taps...
Error: No formulae found in taps.
```

New behavior:

```
$ brew info qt5-webkit
Error: No available formula with the name "qt5-webkit"
In formula file: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5-webkit.rb
Expected to find class Qt5Webkit, but only found: Qt5WebKit.

$ brew install qt5-webkit
Error: No available formula with the name "qt5-webkit"
In formula file: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5-webkit.rb
Expected to find class Qt5Webkit, but only found: Qt5WebKit.
```

New behavior when there's no class derived from `Formula`:

```
$ brew info qt5-webkit
Error: No available formula with the name "qt5-webkit"
In formula file: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5-webkit.rb
Expected to find class Qt5Webkit, but only found: SomeUnrelatedClass (not derived from Formula!).
```

New behavior when there are no classes in the formula file:

```
$ brew info qt5-webkit
Error: No available formula with the name "qt5-webkit"
In formula file: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5-webkit.rb
Expected to find class Qt5Webkit, but found no classes.
```

cc @xu-cheng