### PR TITLE
Don't show help for 'brew <command> help', help-related improvements

### DIFF
--- a/Library/Homebrew/cmd/help.rb
+++ b/Library/Homebrew/cmd/help.rb
@@ -32,13 +32,37 @@ EOS
 # NOTE The reason the string is at the top is so 25 lines is easy to measure!
 
 module Homebrew
-  def help
-    puts HOMEBREW_HELP
+  def help(cmd = nil, empty_argv = false)
+    # Handle `brew` (no arguments).
+    if empty_argv
+      $stderr.puts HOMEBREW_HELP
+      exit 1
+    end
+
+    # Handle `brew (-h|--help|--usage|-?|help)` (no other arguments).
+    if cmd.nil?
+      puts HOMEBREW_HELP
+      exit 0
+    end
+
+    # Get help text and if `nil` (external commands), resume in `brew.rb`.
+    help_text = help_for_command(cmd)
+    return if help_text.nil?
+
+    # Display help for internal command (or generic help if undocumented).
+    if help_text.empty?
+      opoo "No help available for '#{cmd}' command."
+      help_text = HOMEBREW_HELP
+    end
+    puts help_text
+    exit 0
   end
 
   def help_s
     HOMEBREW_HELP
   end
+
+  private
 
   def help_for_command(cmd)
     cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)

--- a/Library/Homebrew/cmd/help.rb
+++ b/Library/Homebrew/cmd/help.rb
@@ -58,10 +58,6 @@ module Homebrew
     exit 0
   end
 
-  def help_s
-    HOMEBREW_HELP
-  end
-
   private
 
   def help_for_command(cmd)

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -198,11 +198,6 @@ module HomebrewArgvExtension
     options_only.any? { |arg| arg.scan("-").size == 1 && arg.include?(char) }
   end
 
-  def usage
-    require "cmd/help"
-    Homebrew.help_s
-  end
-
   def cc
     value "cc"
   end

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -30,7 +30,7 @@ begin
   trap("INT", std_trap) # restore default CTRL-C handler
 
   empty_argv = ARGV.empty?
-  help_flag_list = %w[-h --help --usage -? help]
+  help_flag_list = %w[-h --help --usage -?]
   help_flag = false
   internal_cmd = true
   cmd = nil
@@ -38,7 +38,11 @@ begin
   ARGV.dup.each_with_index do |arg, i|
     if help_flag && cmd
       break
-    elsif help_flag_list.include? arg
+    elsif help_flag_list.include?(arg)
+      # Option-style help: Both `--help <cmd>` and `<cmd> --help` are fine.
+      help_flag = true
+    elsif arg == "help" && !cmd
+      # Command-style help: `help <cmd>` is fine, but `<cmd> help` is not.
       help_flag = true
     elsif !cmd
       cmd = ARGV.delete_at(i)

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -68,29 +68,9 @@ begin
   #
   # It should never affect external commands so they can handle usage
   # arguments themselves.
-
-  if empty_argv
-    $stderr.puts ARGV.usage
-    exit 1
-  elsif help_flag
-    if cmd.nil?
-      puts ARGV.usage
-      exit 0
-    else
-      # Handle both internal ruby and shell commands
-      require "cmd/help"
-      help_text = Homebrew.help_for_command(cmd)
-      if help_text.nil?
-        # External command, let it handle help by itself
-      elsif help_text.empty?
-        opoo "No help available for '#{cmd}' command."
-        puts ARGV.usage
-        exit 0
-      else
-        puts help_text
-        exit 0
-      end
-    end
+  if empty_argv || help_flag
+    require "cmd/help"
+    Homebrew.help cmd, empty_argv # Never returns, except for external command.
   end
 
   if internal_cmd


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully ran `brew tests` with your changes locally?

----

Summary:

- Let the `help` command handle most of the help display logic (previously in `brew.rb`).
  - Eliminate now unused helper methods `ARGV.usage` and `Homebrew.help_s`.
- Stop interpreting `brew <command> [<arguments>] help` as a request for help. This is hardly useful and prevents commands from receiving a literal `help` as a named argument. (`brew help <command>` and option-style help flags like `--help` continue to be interpreted as usual.)