### PR TITLE
test-bot: check all dependents for broken dylibs

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -1,0 +1,125 @@
+#
+# Description: check linkage of installed keg
+# Usage:
+#   brew linkage <formulae>
+#
+# Only works on installed formulae. An error is raised if it is run on uninstalled
+# formulae.
+#
+# Options:
+#  --test      - testing version: only display broken libs; exit non-zero if any
+#                breakage was found.
+
+require "set"
+require "keg"
+require "formula"
+
+module Homebrew
+
+  def linkage
+    found_broken_dylibs = false
+    ARGV.kegs.each do |keg|
+      ohai "Checking #{keg.name} linkage" if ARGV.kegs.size > 1
+      result = LinkageChecker.new(keg)
+      if ARGV.include?("--test")
+        result.display_test_output
+      else
+        result.display_normal_output
+      end
+      found_broken_dylibs = true if !result.broken_dylibs.empty?
+    end
+    if ARGV.include?("--test") && found_broken_dylibs
+      exit 1
+    end
+  end
+
+  class LinkageChecker
+    attr_reader :keg
+    attr_reader :broken_dylibs
+
+    def initialize(keg)
+      @keg = keg
+      @brewed_dylibs = Hash.new { |h, k| h[k] = Set.new }
+      @system_dylibs = Set.new
+      @broken_dylibs = Set.new
+      @variable_dylibs = Set.new
+      check_dylibs
+    end
+
+    def check_dylibs
+      @keg.find do |file|
+        next unless file.dylib? || file.mach_o_executable? || file.mach_o_bundle?
+        file.dynamically_linked_libraries.each do |dylib|
+          if dylib.start_with? "@"
+            @variable_dylibs << dylib
+          else
+            begin
+              owner = Keg.for Pathname.new(dylib)
+            rescue NotAKegError
+              @system_dylibs << dylib
+            rescue Errno::ENOENT
+              @broken_dylibs << dylib
+            else
+              @brewed_dylibs[owner.name] << dylib
+            end
+          end
+        end
+      end
+
+      begin
+        f = Formula[keg.name]
+        @undeclared_deps = @brewed_dylibs.keys - f.deps.map(&:name)
+        @undeclared_deps -= [f.name]
+      rescue FormulaUnavailableError
+        opoo "Formula unavailable: #{keg.name}"
+        @undeclared_deps = []
+      end
+
+    end
+
+    def display_normal_output
+      unless @system_dylibs.empty?
+        display_items "System libraries", @system_dylibs
+      end
+      unless @brewed_dylibs.empty?
+        display_items "Homebrew libraries", @brewed_dylibs
+      end
+      unless @variable_dylibs.empty?
+        display_items "Variable-referenced libraries", @variable_dylibs
+      end
+      unless @broken_dylibs.empty?
+        display_items "Missing libraries", @broken_dylibs
+      end
+      unless @undeclared_deps.empty?
+        display_items "Possible undeclared dependencies", @undeclared_deps
+      end
+    end
+
+    def display_test_output
+      if @broken_dylibs.empty?
+        puts "No broken dylib links"
+      else
+        display_items "Missing libraries", @broken_dylibs
+      end
+    end
+
+    private
+
+    # Display a list of things.
+    # Things may either be an array, or a hash of (label -> array)
+    def display_items(label, things)
+      puts "#{label}:"
+      if things.is_a? Hash
+        things.sort.each do |label, list|
+          list.sort.each do |item|
+            puts "  #{item} (#{label})"
+          end
+        end
+      else
+        things.sort.each do |item|
+          puts "  #{item}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). **Answer:** *No. This is mostly in test-bot so we don't have a harness to test it. And `brew linkage` depends on having a formula installed, so we can't test that reproducibly without interacting with the Homebrew installation.*
- [X] Have you successfully ran `brew tests` with your changes locally?

Goes with Homebrew/homebrew-dev-tools/pull/5.
Addresses #60 

##  Description  ##

Has `test-bot` check all dependents of changed formulae for dylib link breakage, independent of whether they have a `test do` block.

Pulls 'brew linkage' in to main brew repo as a dev-cmd, and has test-bot use it to detect dylib breakage, which usually means a revision bump is needed. Checks all dependents, not just those with a 'test do' block defined, since we can do this without formula support.

This follows up #60 ("Preventing formulae updates from breaking their dependencies") and partially addresses its concerns. Doesn't fully fix them, because the decoupling between repos means that test-bot still won't be able to validate cross-repo library dependencies. It will take manual work on the PR author's part to make sure separate PRs are made for revision bumps dependent repos and that all formulae are included.

##   Testing  ##

You can see an example of the new output at https://gist.github.com/apjanke/77f7e593c922a58408bdc1f92964bcec.

This was produced with `brew test-bot --keep-logs --junit --local --verbose --skip-homebrew --skip-setup icu4c  | tee test-bot-with-linkage.txt` run against the current repo states.

You can see it catching dylib breakage that's still in some of `icu4c`'s dependents. Some of these were not caught by the existing tests, because they don't define a `test do` block, so they're not "testable". This would show up in Jenkins as a failed test step.

```

==> brew linkage --test gptfdisk
No broken dylib links
==> brew linkage --test libfolia
Broken dylib links:
  /usr/local/opt/icu4c/lib/libicudata.56.1.dylib
  /usr/local/opt/icu4c/lib/libicui18n.56.dylib
  /usr/local/opt/icu4c/lib/libicuio.56.dylib
  /usr/local/opt/icu4c/lib/libicuuc.56.dylib
==> FAILED
==> brew linkage --test ucto
Broken dylib links:
  /usr/local/opt/icu4c/lib/libicudata.56.1.dylib
  /usr/local/opt/icu4c/lib/libicui18n.56.dylib
  /usr/local/opt/icu4c/lib/libicuio.56.dylib
  /usr/local/opt/icu4c/lib/libicuuc.56.dylib
==> FAILED
==> brew linkage --test vislcg3
Broken dylib links:
  /usr/local/opt/icu4c/lib/libicui18n.56.dylib
  /usr/local/opt/icu4c/lib/libicuio.56.dylib
  /usr/local/opt/icu4c/lib/libicuuc.56.dylib
  @rpath/libcg3.0.dylib
```

##  Changes and Compatibility  ##

With this, `brew linkage` is now a dev-cmd inside main `brew`, instead of a regular cmd in `homebrew/dev-tools`. Users will need to have `HOMEBREW_DEVELOPER` enabled to make it visible. Users who had `homebrew/dev-tools` tapped but didn't have `HOMEBREW_DEVELOPER` set will lose it.

I chose to put it in `dev-cmd` because the move was done for `test-bot`'s use, and it was originally a "dev" tool. I think it'd be fine to just have in `cmd`, too, to avoid breaking things for anybody, if other maintainers think that would be more appropriate.

Any other taps which define a `linkage` command will now have it masked when `HOMEBREW_DEVELOPER` is enabled. (Or always, if we choose to make it a regular `cmd`.)