### PR TITLE
test-bot: purge non-core taps at start/end of job

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -651,6 +651,7 @@ module Homebrew
         safe_system "git", "checkout", "-f", "master"
         # This will uninstall all formulae, as long as
         # HOMEBREW_REPOSITORY == HOMEBREW_PREFIX, which is true on the test bots
+        Tap.names.each { |s| safe_system "brew", "untap", s if s != "homebrew/core" }
         safe_system "git", "clean", "-ffdx", "--exclude=/Library/Taps/" unless ENV["HOMEBREW_RUBY"] == "1.8.7"
       end
       pr_locks = "#{@repository}/.git/refs/remotes/*/pr/*/*.lock"
@@ -675,6 +676,7 @@ module Homebrew
         test "git", "clean", "-ffdx"
         HOMEBREW_REPOSITORY.cd do
           safe_system "git", "reset", "--hard"
+          Tap.names.each { |s| safe_system "brew", "untap", s if s != "homebrew/core" }
           safe_system "git", "clean", "-ffdx", "--exclude=/Library/Taps/"
         end
         if ARGV.include? "--local"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

https://github.com/Homebrew/brew/commit/e70a3552d3faddd0afd2535a03c31b8c50be901a seems to have exacerbated the problem where taps stick around and then `brew uses` gets executed on a whole host of taps, which is currently breaking almost every PR for formulae that would be used cross-tap, as well as causing lengthier CI builds.

Examples from the last week or so include sqlite, V8, protobuf, and so on. Whilst it may be true that cross-tap formulae failing can show problems that need looking at, a lot of the time the failures are unrelated to the build in question and just leave contributors confused on what needs to be done, or why their PR is failing for something that seems entirely unrelated.

You can see the taps failing to vanish locally by doing something like:

```
brew tap homebrew/fuse
brew tap homebrew/versions
cd $(brew --prefix) && git clean -ffdx --exclude=/Library/Taps/
brew tap
...
homebrew/core
homebrew/fuse
homebrew/versions
```

This is a very simple proposal to handle the problem, but there's no real reason I couldn't write this functionality into `untap` itself and then we call that in test-bot. Just didn't necessarily want to jump immediately to expanding the `untap` command to solve what is more-or-less a CI problem.

There are other ways to handle this as well, but this seemed nice and simple, and not over-complicating the fix seemed desirable.