### PR TITLE
brew.sh: error out if no Ruby found.

### DIFF
--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -70,6 +70,10 @@ then
     HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
   else
     HOMEBREW_RUBY_PATH="$(which ruby)"
+    if [[ -z "$HOMEBREW_RUBY_PATH" ]]
+    then
+      odie "No Ruby found, cannot proceed."
+    fi
   fi
 fi
 


### PR DESCRIPTION
This is a nicer error message than the `exec` failing at a later stage. CC @sjackman as I noticed this doing testing on Linux.