### PR TITLE
help: handle usage errors, more refactoring, tests

### DIFF
--- a/Library/Homebrew/cmd/help.rb
+++ b/Library/Homebrew/cmd/help.rb
@@ -39,6 +39,14 @@ module Homebrew
       path = command_path(cmd)
     end
 
+    # Display command-specific (or generic) help in response to `UsageError`.
+    if (error_message = flags[:usage_error])
+      $stderr.puts path ? command_help(path) : HOMEBREW_HELP
+      $stderr.puts
+      onoe error_message
+      exit 1
+    end
+
     # Handle `brew` (no arguments).
     if flags[:empty_argv]
       $stderr.puts HOMEBREW_HELP

--- a/Library/Homebrew/cmd/help.rb
+++ b/Library/Homebrew/cmd/help.rb
@@ -32,9 +32,15 @@ EOS
 # NOTE The reason the string is at the top is so 25 lines is easy to measure!
 
 module Homebrew
-  def help(cmd = nil, empty_argv = false)
+  def help(cmd = nil, flags = {})
+    # Resolve command aliases and find file containing the implementation.
+    if cmd
+      cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
+      path = command_path(cmd)
+    end
+
     # Handle `brew` (no arguments).
-    if empty_argv
+    if flags[:empty_argv]
       $stderr.puts HOMEBREW_HELP
       exit 1
     end
@@ -45,24 +51,18 @@ module Homebrew
       exit 0
     end
 
-    # Get help text and if `nil` (external commands), resume in `brew.rb`.
-    help_text = help_for_command(cmd)
-    return if help_text.nil?
+    # Resume execution in `brew.rb` for external/unknown commands.
+    return if path.nil?
 
     # Display help for internal command (or generic help if undocumented).
-    if help_text.empty?
-      opoo "No help available for '#{cmd}' command."
-      help_text = HOMEBREW_HELP
-    end
-    puts help_text
+    puts command_help(path)
     exit 0
   end
 
   private
 
-  def help_for_command(cmd)
-    cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
-    cmd_path = if File.exist?(HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.sh")
+  def command_path(cmd)
+    if File.exist?(HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.sh")
       HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.sh"
     elsif ARGV.homebrew_developer? && File.exist?(HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.sh")
       HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.sh"
@@ -71,15 +71,20 @@ module Homebrew
     elsif ARGV.homebrew_developer? && File.exist?(HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.rb")
       HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.rb"
     end
-    return if cmd_path.nil?
+  end
 
-    cmd_path.read.
-      split("\n").
-      grep(/^#:/).
-      map do |line|
-        line.slice(2..-1).sub(/^  \* /, "#{Tty.highlight}brew#{Tty.reset} ").
-        gsub(/`(.*?)`/, "#{Tty.highlight}\\1#{Tty.reset}").
-        gsub(/<(.*?)>/, "#{Tty.em}\\1#{Tty.reset}")
-      end.join("\n")
+  def command_help(path)
+    help_lines = path.read.lines.grep(/^#:/)
+    if help_lines.empty?
+      opoo "No help text in: #{path}" if ARGV.homebrew_developer?
+      HOMEBREW_HELP
+    else
+      help_lines.map do |line|
+        line.slice(2..-1).
+          sub(/^  \* /, "#{Tty.highlight}brew#{Tty.reset} ").
+          gsub(/`(.*?)`/, "#{Tty.highlight}\\1#{Tty.reset}").
+          gsub(/<(.*?)>/, "#{Tty.em}\\1#{Tty.reset}")
+      end.join
+    end
   end
 end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -1,6 +1,28 @@
-class UsageError < RuntimeError; end
-class FormulaUnspecifiedError < UsageError; end
-class KegUnspecifiedError < UsageError; end
+class UsageError < RuntimeError
+  attr_reader :reason
+
+  def initialize(reason = nil)
+    @reason = reason
+  end
+
+  def to_s
+    s = "Invalid usage"
+    s += ": #{reason}" if reason
+    s
+  end
+end
+
+class FormulaUnspecifiedError < UsageError
+  def initialize
+    super "This command requires a formula argument"
+  end
+end
+
+class KegUnspecifiedError < UsageError
+  def initialize
+    super "This command requires a keg argument"
+  end
+end
 
 class MultipleVersionsInstalledError < RuntimeError
   attr_reader :name

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -130,8 +130,21 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_help
-    assert_match "Example usage:",
-                 cmd("help")
+    assert_match "Example usage:\n",
+                 cmd_fail # Generic help (empty argument list).
+    assert_match "Unknown command: command-that-does-not-exist",
+                 cmd_fail("help", "command-that-does-not-exist")
+    assert_match(/^brew cat /,
+                 cmd_fail("cat")) # Missing formula argument triggers help.
+
+    assert_match "Example usage:\n",
+                 cmd("help") # Generic help.
+    assert_match(/^brew cat /,
+                 cmd("help", "cat")) # Internal command (documented, Ruby).
+    assert_match(/^brew update /,
+                 cmd("help", "update")) # Internal command (documented, Shell).
+    assert_match "Example usage:\n",
+                 cmd("help", "test-bot") # Internal command (undocumented).
   end
 
   def test_config

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -74,7 +74,8 @@ begin
   # arguments themselves.
   if empty_argv || help_flag
     require "cmd/help"
-    Homebrew.help cmd, empty_argv # Never returns, except for external command.
+    Homebrew.help cmd, :empty_argv => empty_argv
+    # `Homebrew.help` never returns, except for external/unknown commands.
   end
 
   if internal_cmd

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -113,13 +113,9 @@ begin
     end
   end
 
-rescue FormulaUnspecifiedError
-  abort "This command requires a formula argument"
-rescue KegUnspecifiedError
-  abort "This command requires a keg argument"
-rescue UsageError
+rescue UsageError => e
   require "cmd/help"
-  Homebrew.help cmd, :usage_error => "Invalid usage"
+  Homebrew.help cmd, :usage_error => e.message
 rescue SystemExit => e
   onoe "Kernel.exit" if ARGV.verbose? && !e.success?
   $stderr.puts e.backtrace if ARGV.debug?

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -118,8 +118,8 @@ rescue FormulaUnspecifiedError
 rescue KegUnspecifiedError
   abort "This command requires a keg argument"
 rescue UsageError
-  onoe "Invalid usage"
-  abort ARGV.usage
+  require "cmd/help"
+  Homebrew.help cmd, :usage_error => "Invalid usage"
 rescue SystemExit => e
   onoe "Kernel.exit" if ARGV.verbose? && !e.success?
   $stderr.puts e.backtrace if ARGV.debug?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully ran `brew tests` with your changes locally?

----

User-visible changes:

- Improved and unified handling of `UsageError` and its subclasses `FormulaUnspecifiedError` and `KegUnspecifiedError`:
  - Print command-specific help (if available) or generic help text otherwise (previous behavior).
  - Print error message below help text (was above) to prevent it from scrolling off the screen.
- Restricts printing warnings about missing help texts (e.g. when issuing `brew help style`) to users with `HOMEBREW_DEVELOPER=1` set.
- Fixes a regression introduced in c6536066dc39da653d265640c6ba6046bb5def98 where something like `brew create`, that raises `UsageError`, would fail to print the generic help text.

----

Old behavior (for some select commands):

```
$ brew cat
This command requires a formula argument

$ brew unlink
This command requires a keg argument

$ brew create
Error: Invalid usage
Example usage:
  brew [info | home | options ] [FORMULA...]
  brew install FORMULA...
  brew uninstall FORMULA...
  brew search [foo]
  brew list [FORMULA...]
  brew update
  brew upgrade [FORMULA...]
  brew pin/unpin [FORMULA...]

Troubleshooting:
  brew doctor
  brew install -vd FORMULA
  brew [--env | config]

Brewing:
  brew create [URL [--no-fetch]]
  brew edit [FORMULA...]
  https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Formula-Cookbook.md

Further help:
  man brew
  brew home
```

New behavior:

```
$ brew cat
brew cat formula:
    Display the source to formula.

Error: Invalid usage: This command requires a formula argument

$ brew unlink
brew unlink [--dry-run] formula:
    Remove symlinks for formula from the Homebrew prefix. This can be useful
    for temporarily disabling a formula:
    brew unlink foo && commands && brew link foo.

    If --dry-run or -n is passed, Homebrew will list all files which would
    be unlinked, but will not actually unlink or delete any files.

Error: Invalid usage: This command requires a keg argument

$ brew create
brew create URL [--autotools|--cmake] [--no-fetch] [--set-name name] [--set-version version]:
    Generate a formula for the downloadable file at URL and open it in the editor.
    Homebrew will attempt to automatically derive the formula name
    and version, but if it fails, you'll have to make your own template. The wget
    formula serves as a simple example. For the complete API have a look at

    http://www.rubydoc.info/github/Homebrew/brew/master/Formula

    If --autotools is passed, create a basic template for an Autotools-style build.
    If --cmake is passed, create a basic template for a CMake-style build.

    If --no-fetch is passed, Homebrew will not download URL to the cache and
    will thus not add the SHA256 to the formula for you.

    The options --set-name and --set-version each take an argument and allow
    you to explicitly set the name and version of the package you are creating.

Error: Invalid usage
```