### PR TITLE
Tap remote related tweak

### DIFF
--- a/Library/Homebrew/cmd/test-bot.rb
+++ b/Library/Homebrew/cmd/test-bot.rb
@@ -906,20 +906,13 @@ module Homebrew
 
   def test_bot
     sanitize_ARGV_and_ENV
-    p ARGV
 
     tap = resolve_test_tap
-    if tap.installed?
-      # make sure Tap is not a shallow clone.
-      # bottle revision and bottle upload rely on full clone.
-      if (tap.path/".git/shallow").exist?
-        safe_system "git", "-C", tap.path, "fetch", "--unshallow"
-      end
-    else
-      # Tap repository if required, this is done before everything else
-      # because Formula parsing and/or git commit hash lookup depends on it.
-      safe_system "brew", "tap", tap.name, "--full"
-    end
+    # Tap repository if required, this is done before everything else
+    # because Formula parsing and/or git commit hash lookup depends on it.
+    # At the same time, make sure Tap is not a shallow clone.
+    # bottle revision and bottle upload rely on full clone.
+    safe_system "brew", "tap", tap.name, "--full"
 
     if ARGV.include? "--ci-upload"
       return test_ci_upload(tap)

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -95,6 +95,11 @@ class Tap
     end
   end
 
+  # The default remote path to this {Tap}.
+  def default_remote
+    "https://github.com/#{user}/homebrew-#{repo}"
+  end
+
   # True if this {Tap} is a git repository.
   def git?
     (path/".git").exist?
@@ -185,7 +190,7 @@ class Tap
 
     full_clone = options.fetch(:full_clone, false)
     quiet = options.fetch(:quiet, false)
-    requested_remote = options[:clone_target] || "https://github.com/#{user}/homebrew-#{repo}"
+    requested_remote = options[:clone_target] || default_remote
 
     if installed?
       raise TapAlreadyTappedError, name unless full_clone
@@ -293,7 +298,7 @@ class Tap
   # True if the {#remote} of {Tap} is customized.
   def custom_remote?
     return true unless remote
-    remote.casecmp("https://github.com/#{user}/homebrew-#{repo}") != 0
+    remote.casecmp(default_remote) != 0
   end
 
   # path to the directory of all {Formula} files for this {Tap}.
@@ -500,9 +505,13 @@ end
 # A specialized {Tap} class for the core formulae
 class CoreTap < Tap
   if OS.mac?
-    OFFICIAL_REMOTE = "https://github.com/Homebrew/homebrew-core"
+    def default_remote
+      "https://github.com/Homebrew/homebrew-core"
+    end
   else
-    OFFICIAL_REMOTE = "https://github.com/Linuxbrew/homebrew-core"
+    def default_remote
+      "https://github.com/Linuxbrew/homebrew-core"
+    end
   end
 
   # @private
@@ -519,11 +528,6 @@ class CoreTap < Tap
     args = ["tap", instance.name]
     args << "-q" if options.fetch(:quiet, true)
     safe_system HOMEBREW_BREW_FILE, *args
-  end
-
-  def install(options = {})
-    options[:clone_target] ||= OFFICIAL_REMOTE
-    super options
   end
 
   # @private
@@ -544,11 +548,6 @@ class CoreTap < Tap
   # @private
   def pinned?
     false
-  end
-
-  # @private
-  def custom_remote?
-    remote != OFFICIAL_REMOTE
   end
 
   # @private

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -188,7 +188,6 @@ class Tap
     requested_remote = options[:clone_target] || "https://github.com/#{user}/homebrew-#{repo}"
 
     if installed?
-      raise TapRemoteMismatchError.new(name, @remote, requested_remote) unless remote == requested_remote
       raise TapAlreadyTappedError, name unless full_clone
       raise TapAlreadyUnshallowError, name unless shallow?
     end
@@ -197,6 +196,10 @@ class Tap
     Utils.ensure_git_installed!
 
     if installed?
+      if options[:clone_target] && requested_remote != remote
+        raise TapRemoteMismatchError.new(name, @remote, requested_remote)
+      end
+
       ohai "Unshallowing #{name}" unless quiet
       args = %W[fetch --unshallow]
       args << "-q" if quiet

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -181,9 +181,10 @@ class TapTest < Homebrew::TestCase
   def test_install_tap_remote_mismatch_error
     setup_git_repo
     already_tapped_tap = Tap.new("Homebrew", "foo")
+    touch @tap.path/".git/shallow"
     assert_equal true, already_tapped_tap.installed?
     wrong_remote = "#{@tap.remote}-oops"
-    assert_raises(TapRemoteMismatchError) { already_tapped_tap.install :clone_target => wrong_remote }
+    assert_raises(TapRemoteMismatchError) { already_tapped_tap.install :clone_target => wrong_remote, :full_clone => true }
   end
 
   def test_install_tap_already_unshallow_error


### PR DESCRIPTION
* Tap#install: better TapRemoteMismatchError check
 * remote check requires `git` installed.
 * Do not perform check if user does not passing remote explicitly.
 * Fixes #108
* add Tap#default_remote
 * without `default_remote`, `CoreTap#install` won't be able to tell
   whether user has passed to custom remote to it.
 * simplify some part of logics