### PR TITLE
More Tigerbrew patches

### DIFF
--- a/Library/Homebrew/cmd/config.rb
+++ b/Library/Homebrew/cmd/config.rb
@@ -148,6 +148,9 @@ module Homebrew
   end
 
   def describe_java
+    # java_home doesn't exist on all OS Xs; it might be missing on older versions.
+    return "N/A" unless File.executable? "/usr/libexec/java_home"
+
     java_xml = Utils.popen_read("/usr/libexec/java_home", "--xml", "--failfast")
     return "N/A" unless $?.success?
     javas = []

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -117,6 +117,8 @@ class DependencyCollector
     when :emacs      then EmacsRequirement.new(tags)
     # Tiger's ld is too old to properly link some software
     when :ld64       then LD64Dependency.new if MacOS.version < :leopard
+    # Tiger doesn't ship expat in /usr/lib
+    when :expat      then Dependency.new("expat", tag) if MacOS.version < :leopard
     when :python2
       PythonRequirement.new(tags)
     else

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -192,7 +192,14 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
       with_system_path { buffered_write("bunzip2") }
     when :gzip, :bzip2, :compress, :tar
       # Assume these are also tarred
-      tar_flags = (ARGV.verbose? && ENV["TRAVIS"].nil?) ? "xvf" : "xf"
+      tar_flags = (ARGV.verbose? && ENV["TRAVIS"].nil?) ? "xv" : "x"
+      # Older versions of tar require an explicit format flag
+      if cached_location.compression_type == :gzip
+        tar_flags << "z"
+      elsif cached_location.compression_type == :bzip2
+        tar_flags << "j"
+      end
+      tar_flags << "f"
       with_system_path { safe_system "tar", tar_flags, cached_location }
       chdir
     when :xz

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -457,11 +457,23 @@ end
 # the compilers available on the user's system
 class CompilerSelectionError < RuntimeError
   def initialize(formula)
-    super <<-EOS.undent
-      #{formula.full_name} cannot be built with any available compilers.
-      To install this formula, you may need to:
-        brew install gcc
-      EOS
+    if MacOS.version > :tiger
+      super <<-EOS.undent
+        #{formula.full_name} cannot be built with any available compilers.
+        To install this formula, you may need to:
+          brew install gcc
+        EOS
+    # Tiger doesn't ship with apple-gcc42, and this is required to build
+    # some software that doesn't build properly with FSF GCC.
+    else
+      super <<-EOS.undent
+        #{formula.full_name} cannot be built with any available compilers.
+        To install this formula, you may need to either:
+          brew install apple-gcc42
+        or:
+          brew install gcc
+        EOS
+    end
   end
 end
 

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -70,6 +70,17 @@ module Stdenv
       append_path "PATH", "#{MacOS::Xcode.prefix}/usr/bin"
       append_path "PATH", "#{MacOS::Xcode.toolchain_path}/usr/bin"
     end
+
+    # Leopard's ld needs some convincing that it's building 64-bit
+    # See: https://github.com/mistydemeo/tigerbrew/issues/59
+    if MacOS.version == :leopard && MacOS.prefer_64_bit?
+      append "LDFLAGS", "-arch #{Hardware::CPU.arch_64_bit}"
+
+      # Many, many builds are broken thanks to Leopard's buggy ld.
+      # Our ld64 fixes many of those builds, though of course we can't
+      # depend on it already being installed to build itself.
+      ld64 if Formula["ld64"].installed?
+    end
   end
 
   # @private

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -327,6 +327,9 @@ module Stdenv
     remove flags, /-msse4(\.\d)?/
     append flags, xarch unless xarch.empty?
     append flags, map.fetch(effective_arch, default)
+
+    # Works around a buggy system header on Tiger
+    append flags, "-faltivec" if MacOS.version == :tiger
   end
 
   # @private

--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -156,6 +156,19 @@ module FileUtils
     system RUBY_BIN/"rake", *args
   end
 
+  # Run `make` 3.81 or newer.
+  # Uses the system make on Leopard and newer, and the
+  # path to the actually-installed make on Tiger or older.
+  def make(*args)
+    if Utils.popen_read("/usr/bin/make", "--version").match(/Make (\d\.\d+)/)[1] > "3.80"
+      system "/usr/bin/make", *args
+    else
+      make = Formula["make"].opt_bin/"make"
+      make_path = make.exist? ? make.to_s : (Formula["make"].opt_bin/"gmake").to_s
+      system make_path, *args
+    end
+  end
+
   if method_defined?(:ruby)
     # @private
     alias_method :old_ruby, :ruby

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -48,7 +48,8 @@ module OS
         # Homebrew GCCs most frequently; much faster to check this before xcrun
         elsif (path = HOMEBREW_PREFIX/"bin/#{tool}").executable?
           path
-        else
+        # xcrun was introduced in Xcode 3 on Leopard
+        elsif MacOS.version > :tiger
           path = Utils.popen_read("/usr/bin/xcrun", "-no-cache", "-find", tool).chomp
           Pathname.new(path) if File.executable?(path)
         end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -248,6 +248,7 @@ module OS
     end
 
     STANDARD_COMPILERS = {
+      "2.0"   => { :gcc_40_build => 4061 },
       "2.5"   => { :gcc_40_build => 5370 },
       "3.1.4" => { :gcc_40_build => 5493, :gcc_42_build => 5577 },
       "3.2.6" => { :gcc_40_build => 5494, :gcc_42_build => 5666, :llvm_build => 2335, :clang => "1.7", :clang_build => 77 },

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -131,7 +131,9 @@ module OS
 
     def default_compiler
       case default_cc
-      when /^gcc-4.0/ then :gcc_4_0
+      # if GCC 4.2 is installed, e.g. via Tigerbrew, prefer it
+      # over the system's GCC 4.0
+      when /^gcc-4.0/ then gcc_42_build_version ? :gcc : :gcc_4_0
       when /^gcc/ then :gcc
       when /^llvm/ then :llvm
       when "clang" then :clang

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -238,7 +238,11 @@ module OS
     end
 
     def prefer_64_bit?
-      Hardware::CPU.is_64_bit? && version > :leopard
+      if ENV["HOMEBREW_PREFER_64_BIT"] && version == :leopard
+        Hardware::CPU.is_64_bit?
+      else
+        Hardware::CPU.is_64_bit? && version > :leopard
+      end
     end
 
     def preferred_arch

--- a/Library/Homebrew/os/mac/hardware.rb
+++ b/Library/Homebrew/os/mac/hardware.rb
@@ -8,7 +8,8 @@ module MacCPUs
     :g3 => "-mcpu=750",
     :g4 => "-mcpu=7400",
     :g4e => "-mcpu=7450",
-    :g5 => "-mcpu=970"
+    :g5 => "-mcpu=970",
+    :g5_64 => "-mcpu=970 -arch ppc64"
   }.freeze
   def optimization_flags
     OPTIMIZATION_FLAGS

--- a/Library/Homebrew/requirements/apr_requirement.rb
+++ b/Library/Homebrew/requirements/apr_requirement.rb
@@ -4,7 +4,8 @@ class AprRequirement < Requirement
   fatal true
   default_formula "apr-util"
 
-  satisfy(:build_env => false) { MacOS::CLT.installed? }
+  # APR shipped in Tiger is too old, but Leopard+ is usable
+  satisfy(:build_env => false) { MacOS.version > :leopard && MacOS::CLT.installed? }
 
   env do
     unless MacOS::CLT.installed?

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -6,6 +6,8 @@ class JavaRequirement < Requirement
   download "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
   satisfy :build_env => false do
+    return false unless File.executable? "/usr/libexec/java_home"
+
     args = %w[--failfast]
     args << "--version" << "#{@version}" if @version
     @java_home = Utils.popen_read("/usr/libexec/java_home", *args).chomp


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

Following up on #110, this brings in more non-Ruby backport patches from Tigerbrew. Changes include:

* Adds support for CFLAGS for more CPU types, and OS-specific CFLAGS
* Adds an `:expat` special dependency
* Skip using system APR and autotools on older OS Xs
* Fix Java detection if `java_home` is missing (should also help Linux)
* Don't call xcrun when it's not installed
* Improve some messaging for specific OS versions
* Update `tar` flags to work with older `tar`s
* Add a new helper to Formula to locate the path to `make` depending on OS version and install options
* Prioritize picking `gcc-4.2` over `gcc-4.0`, regardless of what `/usr/bin/cc` is