### PR TITLE
readall: fail on Ruby syntax warnings, check 'brew.rb'

### DIFF
--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -22,7 +22,8 @@ module Homebrew
           Thread.new do
             begin
               while rb = ruby_files.pop(true)
-                failed = true unless system RUBY_PATH, "-c", "-w", rb
+                # As a side effect, print syntax errors/warnings to `$stderr`.
+                failed = true if syntax_errors_or_warnings?(rb)
               end
             rescue ThreadError # ignore empty queue error
             end
@@ -68,5 +69,18 @@ module Homebrew
         Homebrew.failed = true
       end
     end
+  end
+
+  private
+
+  def syntax_errors_or_warnings?(rb)
+    # Retrieve messages about syntax errors/warnings printed to `$stderr`, but
+    # discard a `Syntax OK` printed to `$stdout` (in absence of syntax errors).
+    messages = Utils.popen_read("#{RUBY_PATH} -c -w #{rb} 2>&1 >/dev/null")
+    $stderr.print messages
+
+    # Only syntax errors result in a non-zero status code. To detect syntax
+    # warnings we also need to inspect the output to `$stderr`.
+    !$?.success? || !messages.chomp.empty?
   end
 end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -17,20 +17,18 @@ module Homebrew
       end
 
       failed = false
-      nostdout do
-        workers = (0...Hardware::CPU.cores).map do
-          Thread.new do
-            begin
-              while rb = ruby_files.pop(true)
-                # As a side effect, print syntax errors/warnings to `$stderr`.
-                failed = true if syntax_errors_or_warnings?(rb)
-              end
-            rescue ThreadError # ignore empty queue error
+      workers = (0...Hardware::CPU.cores).map do
+        Thread.new do
+          begin
+            while rb = ruby_files.pop(true)
+              # As a side effect, print syntax errors/warnings to `$stderr`.
+              failed = true if syntax_errors_or_warnings?(rb)
             end
+          rescue ThreadError # ignore empty queue error
           end
         end
-        workers.map(&:join)
       end
+      workers.each(&:join)
       Homebrew.failed = failed
     end
 

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -11,7 +11,11 @@ module Homebrew
   def readall
     if ARGV.delete("--syntax")
       ruby_files = Queue.new
-      Dir.glob("#{HOMEBREW_LIBRARY}/Homebrew/**/*.rb").each do |rb|
+      scan_files = %W[
+        #{HOMEBREW_LIBRARY}/*.rb
+        #{HOMEBREW_LIBRARY}/Homebrew/**/*.rb
+      ]
+      Dir.glob(scan_files).each do |rb|
         next if rb.include?("/vendor/")
         ruby_files << rb
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully ran `brew tests` with your changes locally?

Should help with code quality and prevent accidental introduction of Ruby syntax warnings, as those will now cause a test bot build to fail. 

cc @xu-cheng