### PR TITLE
Formula: include bad value in invalid-option error message

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -122,9 +122,12 @@ class SoftwareSpec
         puts "Symbols are reserved for future use, please pass a string instead"
         name = name.to_s
       end
+      unless String === name
+        raise ArgumentError, "option name must be string or symbol; got a #{name.class}: #{name}"
+      end
       raise ArgumentError, "option name is required" if name.empty?
-      raise ArgumentError, "option name must be longer than one character" unless name.length > 1
-      raise ArgumentError, "option name must not start with dashes" if name.start_with?("-")
+      raise ArgumentError, "option name must be longer than one character: #{name}" unless name.length > 1
+      raise ArgumentError, "option name must not start with dashes: #{name}" if name.start_with?("-")
       Option.new(name, description)
     end
     options << opt


### PR DESCRIPTION
###  Checklist

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully ran `brew tests` with your changes locally?

##  Description

###   The issue

When you have an invalid `option` call like the following in a formula, it'll give you an error message saying what's wrong ("can't be a single character", "can't be a symbol", "can't start with dashes") but it won't give you an indication of which line was wrong.

```
  option "f"
  option :my_symbol
  option "foo" => "enables foo localization"
```

```
$ brew info cowsay
Error: option name must be longer than one character
Please report this bug:
    https://git.io/brew-troubleshooting
```

In particular, if you use an arrow (`option "foo" => "include foo"`) instead of a comma (`option "foo", "include foo"`), it'll also give you a misleading message saying that the name must be longer than one character, because what you end up passing is a one-valued hash instead of a string, and it happens to support the duck-typed calls the testing is making on `name`.

###  This PR's fix

This PR adds the invalid "name" passed to `option` to the error message to make the error location and reason easier to identify. It also adds a couple more checks: non-string/symbol options get their own error message, and symbols converted to strings are checked for validity after conversion.

Now the error messages look like this:

```
option "x"

$ brew info cowsay
Error: option name must be longer than one character: x
```
```
option :f

$ brew info cowsay$ brew info cowsay
Warning: Passing arbitrary symbols to `option` is deprecated: :f
Symbols are reserved for future use, please pass a string instead
Error: option name must be longer than one character: f
```
```
option "foo" => "bar"

$ brew info cowsay
Error: option name must be string or symbol; got a Hash: {"foo"=>"bar"}
```

###   Considerations

This is mostly a cosmetic change affecting the messages when errors occur. However, it also prohibits single-character symbol option names, which previously would have passed through. (Unintentionally, I believe.) And it will prohibit other types which look like strings.

If we really want to support other types for the `name` argument to `option`, we could just `to_s` any non-`String` that gets passed in, and then evaluate it as a normal string option. I suspect that usage would usually be a mistake, though.

