### PR TITLE
brew.rb: uninstall old Homebrew Cask.

### DIFF
--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -78,6 +78,11 @@ begin
     # `Homebrew.help` never returns, except for external/unknown commands.
   end
 
+  # Uninstall old brew-cask if it's still around; we just use the tap now.
+  if cmd == "cask" && (HOMEBREW_CELLAR/"brew-cask").exist?
+    system(HOMEBREW_BREW_FILE, "uninstall", "--force", "brew-cask")
+  end
+
   if internal_cmd
     Homebrew.send cmd.to_s.tr("-", "_").downcase
   elsif which "brew-#{cmd}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran `brew tests` with your changes locally?

This version is never wanted at this point and it will help Homebrew Cask deal with the annoying errors that result from having this version still around (some which I've already help users debug).

CC @jawshooah 