### PR TITLE
Skip tmux warning if reattached to user namespace

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -196,7 +196,9 @@ class Caveats
         s << "  #{f.plist_manual}"
       end
 
-      s << "" << "WARNING: brew services will fail when run under tmux." if ENV["TMUX"]
+      if ENV["TMUX"] && !quiet_system("/usr/bin/pbpaste")
+        s << "" << "WARNING: brew services will fail when run under tmux."
+      end
     end
     s.join("\n") + "\n" unless s.empty?
   end


### PR DESCRIPTION
The exit status of pbpaste is a proxy for whether the user has set up
reattach-to-user-namespace. It should be 0 if it is set up, 1 otherwise.

This is the same hack as Homebrew/homebrew-services#48.