### PR TITLE
brew pull: portable bottle downloads, more concise output, faster polling

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -183,7 +183,7 @@ class Version
     if val.respond_to?(:to_str)
       @version = val.to_str
     else
-      raise TypeError, "Version value must be a string"
+      raise TypeError, "Version value must be a string; got a #{val.class} (#{val})"
     end
   end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully ran `brew tests` with your changes locally?

###  Summary

Do the bottle check using any platform's bottle, so `brew pull` works on bottled formulae which don't include a bottle for the current system.

Make output more concise and informative
     * Remove expected download error messages when waiting for Bintray publishing
     * Replace patch download progress bars with patch file name
     * Silence git output about switching to and from bottle-pulling branch
     * Include formula name and patch type in some progress messages

Polls Bintray every 2 seconds instead of doing an exponential backoff, to minimize user waiting time.

Adds a `Formula` class cache clearing method.

###  Discussion

This is a rewrite of homebrew/legacy-homebrew#50070. I think it addresses most of the concerns expressed there.

The self-calls and "internal" commands are all replaced with use of `brew info --json`, so the `brew` command's observable behavior isn't cluttered by this. Makes the code simpler, too.

I'm convinced now that a simple clearing of the `Formulary.FORMULAE` cache is enough to correctly pick up fresh class definitions from updated files: the `Formula` subclass definitions are all wrapped in random module namespaces so they're effectively anonymous, and we don't have to worry about pollution of the global class definition set affecting newly-loaded formulae.

Sorry, @xu-cheng, I couldn't figure out a way to implement the polling purely in terms of `curl`. I wanted it to do a) a single-line progress bar that indicates polling passes, not content downloaded, b) can retry based on exact HTTP error status, so we can restrict it to retrying only on 401 Not Authorized if needed, and c) reuses the same HTTP connection for each poll of a given file, to minimize Bintray resource usage with the faster polling cycle.

###  Testing

I've been using a variant of this ([`pull2` in [my homebrew-custom tap](https://github.com/apjanke/homebrew-custom/blob/master/cmd/brew-pull2.rb)) for the past few days and it's been working well. I don't see a way to write unit tests for it, as all its behavior depends on transient external GitHub state.