### PR TITLE
stage: fix block signature back-compatibility under Ruby 1.8.7

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -179,7 +179,7 @@ end
 unless File.respond_to?(:write)
   class File
     def self.write(filename, contents)
-      File.open(filename, 'w') do |file|
+      File.open(filename, "w") do |file|
         file.write contents
       end
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1548,7 +1548,7 @@ class Formula
   end
 
   def stage
-    active_spec.stage do |_resource, staging|
+    active_spec.stage do |staging|
       @source_modified_time = active_spec.source_modified_time
       @buildpath = Pathname.pwd
       env_home = buildpath/".brew_home"

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -1,6 +1,7 @@
 require "download_strategy"
 require "checksum"
 require "version"
+require "forwardable"
 
 # Resource is the fundamental representation of an external resource. The
 # primary formula download, along with other declared resources, are instances
@@ -86,15 +87,15 @@ class Resource
   end
 
   # If a target is given, unpack there; else unpack to a temp folder.
-  # If block is given, yield to that block with |self, staging|, where staging
-  # is a staging context that responds to retain!().
+  # If block is given, yield to that block with |stage|, where stage
+  # is a ResourceStagingContext.
   # A target or a block must be given, but not both.
   def unpack(target = nil)
     mktemp(download_name) do |staging|
       downloader.stage
       @source_modified_time = downloader.source_modified_time
       if block_given?
-        yield self, staging
+        yield ResourceStageContext.new(self, staging)
       elsif target
         target = Pathname.new(target) unless target.is_a? Pathname
         target.install Dir["*"]
@@ -184,5 +185,29 @@ class Resource
       @patch_files.concat(paths)
       @patch_files.uniq!
     end
+  end
+end
+
+# The context in which a Resource.stage() occurs. Supports access to both
+# the Resource and associated Mktemp in a single block argument. The interface
+# is back-compatible with Resource itself as used in that context.
+class ResourceStageContext
+  extend Forwardable
+
+  # The Resource that is being staged
+  attr_reader :resource
+  # The Mktemp in which @resource is staged
+  attr_reader :staging
+
+  def_delegators :@resource, :version, :url, :mirrors, :specs, :using, :source_modified_time
+  def_delegators :@staging, :retain!
+
+  def initialize(resource, staging)
+    @resource = resource
+    @staging = staging
+  end
+
+  def to_s
+    "<#{self.class}: resource=#{resource} staging=#{staging}>"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully ran `brew tests` with your changes locally?

### Description

The new stage() signature introduced by #66 breaks back-compatibility under Ruby 1.8.7. This fixes it by switching back to a one-argument block signature and using a new class to wrap both the `Resource` and `Mktemp` info for the staging context. It's done in a signature-back-compatible way, using duck typing to be compatible with `Resource` for where `Formula` DSL was using it.

I think the block-argument design is much better than using globals. This lets us keep the block design but switch to a fully back-compatible signature for Formula API purposes.

Tested under Ruby 2.0 and 1.8.7 on OS X 10.9.5. Testing log [here](https://gist.github.com/apjanke/95abf25a7972b7b78185c041b224f768). Worked fine for me, and I verified that it fixes the breakage with `docbook`, `cracklib`, `dcadec`, and `odt2txt`.

Closes homebrew/homebrew-core#529
Fixes Homebrew/homebrew-core#524