### PR TITLE
PR template: separate checklist from issue body

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,6 @@
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
 - [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
 - [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
-- [ ] Have you successfully ran `brew tests` with your changes locally?
+- [ ] Have you successfully run `brew tests` with your changes locally?
+
+-----


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). **N/A**
- [x] Have you successfully ran `brew tests` with your changes locally? **N/A**

###  Description

Adds a ~~"### Description" header~~ horizontal rule separating the template's checklist from the user's comments.

Also a minor grammar fix.

~~Changes "have you checked for open PRs" to just "have you checked for PRs", changing the link to search for all PRs, not just open ones. I think submitters should look for similar PRs in the closed and merged ones as well, to see if their change has already been proposed and rejected, or if it's already been merged and they just haven't noticed or updated recently.~~
