### PR TITLE
Include a donation link in the Analytics readme

### DIFF
--- a/share/doc/homebrew/Analytics.md
+++ b/share/doc/homebrew/Analytics.md
@@ -44,4 +44,6 @@ Homebrew's analytics are accessible to Homebrew's current maintainers. Contact @
 The code is viewable in https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/analytics.rb and https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/analytics.sh. They are done in a separate background process and fail fast to avoid delaying any execution. They will fail immediately and silently if you have no network connection.
 
 ## Opting-out
-If after everything you've read you still wish to opt-out of Homebrew's analytics you may set `HOMEBREW_NO_ANALYTICS=1` in your environment which will prevent analytics from ever being sent when it is set.
+If after everything you've read you still wish to opt-out of Homebrew's analytics you may set `HOMEBREW_NO_ANALYTICS=1` in your environment which will prevent analytics from ever being sent when it is set. Please consider making a [donation][donation] to continue supporting the Homebrew project.
+
+[donation]: https://github.com/Homebrew/brew#donations


### PR DESCRIPTION
It's reasonable to ask users who benefit from a project being free, but also
value their privacy, to make a donation to the project. It also helps people
who would like to make a donation figure out how to do so.