### PR TITLE
keg_relocate: don't assume .la files are in lib.

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -183,11 +183,10 @@ class Keg
   def libtool_files
     libtool_files = []
 
-    # find .la files, which are stored in lib/
-    lib.find do |pn|
+    path.find do |pn|
       next if pn.symlink? || pn.directory? || pn.extname != ".la"
       libtool_files << pn
-    end if lib.directory?
+    end
     libtool_files
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

Sometimes they are in e.g. libexec but there's no real reason to assume they are anywhere; we want to relocate them regardless.

CC @lucafavatella https://github.com/Homebrew/homebrew-core/pull/577