### PR TITLE
Point to analytics documentation on brew update.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -12,6 +12,23 @@ module Homebrew
   end
 
   def update_report
+    HOMEBREW_REPOSITORY.cd do
+      key = "homebrew.analyticsmessage"
+      analytics_message_displayed = \
+        Utils.popen_read("git", "config", "--local", "--get", key).chuzzle
+      unless analytics_message_displayed == "true"
+        ENV["HOMEBREW_NO_ANALYTICS"] = "1"
+        ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
+        puts "Read the analytics documentation (and how to opt-out) here:"
+        puts "  https://git.io/brew-analytics"
+
+        # Consider the message possibly missed if not a TTY.
+        if $stdout.tty?
+          safe_system "git", "config", "--local", "--replace-all", key, "true"
+        end
+      end
+    end
+
     install_core_tap_if_necessary
 
     hub = ReporterHub.new

--- a/share/doc/homebrew/Analytics.md
+++ b/share/doc/homebrew/Analytics.md
@@ -1,5 +1,5 @@
 # Homebrew's Anonymous Aggregate User Behaviour Analytics
-Homebrew has begun gathering anonymous aggregate user behaviour analytics and reporting these to Google Analytics.
+Homebrew has begun gathering anonymous aggregate user behaviour analytics and reporting these to Google Analytics. You will be notified the first time you run `brew update` or install Homebrew.
 
 ## Why?
 Homebrew is provided free of charge and run entirely by volunteers in their spare time. As a result, we do not have the resources to do detailed user studies of Homebrew users to decide on how best to design future features and prioritise current work. Anonymous aggregate user analytics allow us to prioritise fixes and features based on how, where and when people use Homebrew. For example:


### PR DESCRIPTION
Make sure that users are notified on the first run of `brew update` after we enabled analytics about how it works and how to opt-out. This will be shown to all users who have not already seen this message from `brew update` or through a new Homebrew installation.

References https://github.com/Homebrew/install/pull/42
References https://github.com/Homebrew/brew/issues/142