### PR TITLE
More analytics tweaks.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -13,10 +13,11 @@ module Homebrew
 
   def update_report
     HOMEBREW_REPOSITORY.cd do
-      key = "homebrew.analyticsmessage"
       analytics_message_displayed = \
-        Utils.popen_read("git", "config", "--local", "--get", key).chuzzle
-      unless analytics_message_displayed == "true"
+        Utils.popen_read("git", "config", "--local", "--get", "homebrew.analyticsmessage").chuzzle
+      analytics_disabled = \
+        Utils.popen_read("git", "config", "--local", "--get", "homebrew.analyticsdisabled").chuzzle
+      if analytics_message_displayed != "true" && analytics_disabled != "true"
         ENV["HOMEBREW_NO_ANALYTICS"] = "1"
         ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
         puts "Read the analytics documentation (and how to opt-out) here:"
@@ -24,7 +25,7 @@ module Homebrew
 
         # Consider the message possibly missed if not a TTY.
         if $stdout.tty?
-          safe_system "git", "config", "--local", "--replace-all", key, "true"
+          safe_system "git", "config", "--local", "--replace-all", "homebrew.analyticsmessage", "true"
         end
       end
     end

--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -1,9 +1,26 @@
 setup-analytics() {
-  [[ -n "$HOMEBREW_NO_ANALYTICS" ]] && return
-
   # User UUID file. Used for Homebrew user counting. Can be deleted and
   # recreated with no adverse effect (beyond our user counts being inflated).
   HOMEBREW_ANALYTICS_USER_UUID_FILE="$HOME/.homebrew_analytics_user_uuid"
+
+  if [[ -n "$HOMEBREW_NO_ANALYTICS" ]]
+  then
+    rm -f "$HOMEBREW_ANALYTICS_USER_UUID_FILE"
+    git config --file="$HOMEBREW_REPOSITORY/.git/config" --replace-all homebrew.analyticsdisabled true
+  fi
+
+  if [[ "$(git config --file="$HOMEBREW_REPOSITORY/.git/config" --get homebrew.analyticsmessage)" != "true" ]]
+  then
+    export HOMEBREW_NO_ANALYTICS="1"
+    return
+  fi
+
+  if [[ "$(git config --file="$HOMEBREW_REPOSITORY/.git/config" --get homebrew.analyticsdisabled)" = "true" ]]
+  then
+    export HOMEBREW_NO_ANALYTICS="1"
+    return
+  fi
+
   if [[ -r "$HOMEBREW_ANALYTICS_USER_UUID_FILE" ]]
   then
     HOMEBREW_ANALYTICS_USER_UUID="$(<"$HOMEBREW_ANALYTICS_USER_UUID_FILE")"

--- a/share/doc/homebrew/Analytics.md
+++ b/share/doc/homebrew/Analytics.md
@@ -44,4 +44,4 @@ Homebrew's analytics are accessible to Homebrew's current maintainers. Contact @
 The code is viewable in https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/analytics.rb and https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/analytics.sh. They are done in a separate background process and fail fast to avoid delaying any execution. They will fail immediately and silently if you have no network connection.
 
 ## Opting-out
-If after everything you've read you still wish to opt-out of Homebrew's analytics you may set `HOMEBREW_NO_ANALYTICS=1` in your environment which will prevent analytics from ever being sent when it is set.
+If after everything you've read you still wish to opt-out of Homebrew's analytics you may set `HOMEBREW_NO_ANALYTICS=1` in your environment or run `git config --file="$(brew --repository)/.git/config" --replace-all homebrew.analyticsdisabled true` which will prevent analytics from ever being sent when either or them have been set.


### PR DESCRIPTION
Provide a single command that can be run to disable analytics, run it if `HOMEBREW_NO_ANALYTICS` is ever set and remove the user UUID file in that case too.

References https://github.com/Homebrew/brew/issues/142.