### PR TITLE
Analytics: Separate user-supplied and internal-use DISABLE_ANALYTICS

### DIFF
--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -3,7 +3,7 @@ require "fileutils"
 module Homebrew
   def tests
     (HOMEBREW_LIBRARY/"Homebrew/test").cd do
-      ENV["HOMEBREW_NO_ANALYTICS"] = "1"
+      ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
       ENV["TESTOPTS"] = "-v" if ARGV.verbose?
       ENV["HOMEBREW_NO_COMPAT"] = "1" if ARGV.include? "--no-compat"
       if ARGV.include? "--coverage"

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -18,7 +18,7 @@ module Homebrew
       analytics_disabled = \
         Utils.popen_read("git", "config", "--local", "--get", "homebrew.analyticsdisabled").chuzzle
       if analytics_message_displayed != "true" && analytics_disabled != "true"
-        ENV["HOMEBREW_NO_ANALYTICS"] = "1"
+        ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
         ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
         puts "Read the analytics documentation (and how to opt-out) here:"
         puts "  https://git.io/brew-analytics"

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -8,7 +8,7 @@ def analytics_label
 end
 
 def report_analytics(type, metadata = {})
-  return if ENV["HOMEBREW_NO_ANALYTICS"]
+  return if ENV["HOMEBREW_NO_ANALYTICS"] || ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"]
 
   args = %W[
     --max-time 3

--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -3,12 +3,19 @@ setup-analytics() {
   # recreated with no adverse effect (beyond our user counts being inflated).
   HOMEBREW_ANALYTICS_USER_UUID_FILE="$HOME/.homebrew_analytics_user_uuid"
 
-  if [[ -n "$HOMEBREW_NO_ANALYTICS" ||
-        "$(git config --file="$HOMEBREW_REPOSITORY/.git/config" --get homebrew.analyticsmessage)" != "true" ||
+  # Make disabling anlytics sticky
+  if [[ -n "$HOMEBREW_NO_ANALYTICS" ]]
+  then
+    git config --file="$HOMEBREW_REPOSITORY/.git/config" --replace-all homebrew.analyticsdisabled true
+    # Internal variable for brew's use, to differentiate from user-supplied setting
+    export HOMEBREW_NO_ANALYTICS_THIS_RUN="1"
+  fi
+
+  if [[ "$(git config --file="$HOMEBREW_REPOSITORY/.git/config" --get homebrew.analyticsmessage)" != "true" ||
         "$(git config --file="$HOMEBREW_REPOSITORY/.git/config" --get homebrew.analyticsdisabled)" = "true" ]]
   then
     [[ -f "$HOMEBREW_ANALYTICS_USER_UUID_FILE" ]] && rm -f "$HOMEBREW_ANALYTICS_USER_UUID_FILE"
-    export HOMEBREW_NO_ANALYTICS="1"
+    export HOMEBREW_NO_ANALYTICS_THIS_RUN="1"
     return
   fi
 
@@ -34,7 +41,7 @@ setup-analytics() {
 }
 
 report-analytics-screenview-command() {
-  [[ -n "$HOMEBREW_NO_ANALYTICS" ]] && return
+  [[ -n "$HOMEBREW_NO_ANALYTICS" || -n "$HOMEBREW_NO_ANALYTICS_THIS_RUN" ]] && return
 
   # Don't report non-official commands.
   if ! [[ "$HOMEBREW_COMMAND" = "bundle"   ||


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

-----------

This prevents `brew` self-calls from interacting with the stickiness of
HOMEBREW_NO_ANALYTICS being persisted to the brew repo and accidentally
disabling analytics permanently when it should have been for just one run,
while restoring the stickiness of an explicit user-supplied
HOMEBREW_NO_ANALYTICS.

In [this comment](https://github.com/Homebrew/brew/issues/142#issuecomment-214564476), we stated that HOMEBREW_NO_ANALYTICS would be "sticky".

The change in #154 removed the stickiness as a side effect.

This restores it - I don't think we should do that behavior change until we have a chance to get maintainer consensus and communicate it to the user community.

Splitting HOMEBREW_NO_ANALYTICS and HOMEBREW_NO_ANALYTICS_THIS_RUN will make the implementation easier because we can distinguish between user-supplied imperatives, and the state it should be in for one run.

Also, in the old code when it was still sticky, running `brew tests` would have the side effect of permanently disabling analytics (I think) because it set `HOMEBREW_NO_ANALYTICS=1`, and `brew tests` includes some `brew` self-calls, which would do `setup-analytics` and make it sticky.