### PR TITLE
update: improve some edge cases.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -70,7 +70,9 @@ module Homebrew
     end
 
     if !updated
-      puts "Already up-to-date." unless ARGV.include?("--preinstall")
+      if !ARGV.include?("--preinstall") && !ENV["HOMEBREW_UPDATE_FAILED"]
+        puts "Already up-to-date."
+      end
     elsif hub.empty?
       puts "No changes to formulae."
     else
@@ -81,6 +83,8 @@ module Homebrew
     end
 
     Tap.each(&:link_manpages)
+
+    Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
   end
 
   private

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -1,6 +1,6 @@
 HOMEBREW_VERSION="0.9.9"
 
-odie() {
+onoe() {
   if [[ -t 2 ]] # check whether stderr is a tty.
   then
     echo -ne "\033[4;31mError\033[0m: " >&2 # highlight Error with underline and red color
@@ -13,6 +13,10 @@ odie() {
   else
     echo "$*" >&2
   fi
+}
+
+odie() {
+  onoe "$@"
   exit 1
 }
 


### PR DESCRIPTION
- When running `brew update` and there’s been no changes from upstream on any repositories there’s no need to call the (relatively) slow `brew update-report` when we already know what it will say (“Already up-to date.”).
- When any`git fetch`es fail then throw out an error at the end of the output and produce a failing exit code (closes #65).