### PR TITLE
Override VCSDownloadStrategy#source_modified_time

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -765,6 +765,10 @@ class MercurialDownloadStrategy < VCSDownloadStrategy
     end
   end
 
+  def source_modified_time
+    Time.parse Utils.popen_read("hg", "tip", "--template", "{date|isodate}", "-R", cached_location.to_s)
+  end
+
   private
 
   def cache_tag

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -801,6 +801,10 @@ class BazaarDownloadStrategy < VCSDownloadStrategy
     rm_r ".bzr"
   end
 
+  def source_modified_time
+    Time.parse Utils.popen_read("bzr", "log", "-l", "1", "--timezone=utc", cached_location.to_s)[/^timestamp: (.+)$/, 1]
+  end
+
   private
 
   def cache_tag

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -838,6 +838,10 @@ class FossilDownloadStrategy < VCSDownloadStrategy
     safe_system(*args)
   end
 
+  def source_modified_time
+    Time.parse Utils.popen_read("fossil", "info", "tip", "-R", cached_location.to_s)[/^uuid: +\h+ (.+)$/, 1]
+  end
+
   private
 
   def cache_tag


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully ran `brew tests` with your changes locally?

## Detaills

Implement

* `MercurialDownloadStrategy#source_modified_time`
* `BazaarDownloadStrategy#source_modified_time`
* `FossilDownloadStrategy#source_modified_time`

from #81

Bazaar
======

`bzr log -l 1` has the following format:
```
➜ vlad:bazimport$ bzr log -l 1
------------------------------------------------------------
revno: 663
committer: Aaron Bentley <aaron@aaronbentley.com>
branch nick: bazimport
timestamp: Thu 2008-10-23 18:04:00 +0100
message:
  Fix import with existing revisions
```
Mercurial
=======

`hg tip` has the following format:
```
➜ vlad:SDL_rtf$ hg tip
changeset:   66:c0f87ece5d47
tag:         tip
user:        Sam Lantinga <slouken@libsdl.org>
date:        Sat Jan 02 10:54:19 2016 -0800
summary:     Updated copyright to 2016

```
`hg log -l 1` also possible, but `hg tip` seems to be better.

Fossil
=====
`fossil info tip -R <repo>` has the following format:
```
➜ vlad:fossil$ fossil info tip -R fossil
uuid:         7c4628a568c01a11642e18c119c93aa1d85632ed 2016-04-29 10:28:21 UTC
parent:       6f35075ad72b8608bd5ce2fccf093495331d1187 2016-04-29 08:28:27 UTC
tags:         trunk
comment:      Make options --repolist and --baseurl work together, if the original URL doesn't end with '/'. (user: jan.nijtmans)
```
