### PR TITLE
audit: fix false-positive for '--with-check' from 'depends_on "check"…

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -391,7 +391,9 @@ class FormulaAuditor
       end
 
       if o.name =~ /^with(out)?-(?:checks?|tests)$/
-        problem "Use '--with#{$1}-test' instead of '--#{o.name}'. Migrate '--#{o.name}' with `deprecated_option`."
+        unless formula.deps.any? { |d| d.name == "check" && (d.optional? || d.recommended?) }
+          problem "Use '--with#{$1}-test' instead of '--#{o.name}'. Migrate '--#{o.name}' with `deprecated_option`."
+        end
       end
     end
   end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #170

`audit` always complains about `--with-check`, but that's legit if it is referring to an optional dependency on a formula named "check".
