### PR TITLE
Switch to bbatsov's Style Guide since GitHub's is 404

### DIFF
--- a/Library/Homebrew/README.md
+++ b/Library/Homebrew/README.md
@@ -3,6 +3,6 @@ This is the (partially) documented public API for Homebrew.
 
 The main class you should look at is the {Formula} class (and classes linked from there). That's the class that's used to create Homebrew formulae (i.e. package descriptions). Assume anything else you stumble upon is private.
 
-You may also find the [Formula Cookbook](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Formula-Cookbook.md) and [Ruby Style Guide](https://github.com/styleguide/ruby) helpful in creating formulae.
+You may also find the [Formula Cookbook](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Formula-Cookbook.md) and bbatsov's [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) helpful in creating formulae.
 
 Good luck!

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -26,7 +26,7 @@ require "migrator"
 # @see FileUtils
 # @see Pathname
 # @see http://www.rubydoc.info/github/Homebrew/brew/file/share/doc/homebrew/Formula-Cookbook.md Formula Cookbook
-# @see https://github.com/styleguide/ruby Ruby Style Guide
+# @see https://github.com/bbatsov/ruby-style-guide Ruby Style Guide
 #
 # <pre>class Wget < Formula
 #   homepage "https://www.gnu.org/software/wget/"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #106

GitHub's Ruby Style Guide is 404, and though it's supposed to come back in a revised form some time, we don't know when.

This switches our references to [bbatsov's Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide), which GitHub's was based on.