### PR TITLE
languages: flag missing dependency requirement

### DIFF
--- a/Library/Homebrew/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/requirements/language_module_requirement.rb
@@ -12,11 +12,22 @@ class LanguageModuleRequirement < Requirement
 
   satisfy(:build_env => false) { quiet_system(*the_test) }
 
-  def message; <<-EOS.undent
-    Unsatisfied dependency: #{@module_name}
-    Homebrew does not provide #{@language.to_s.capitalize} dependencies; install with:
-      #{command_line} #{@module_name}
+  def message
+    s = <<-EOS.undent
+      Unsatisfied dependency: #{@module_name}
+      Homebrew does not provide special #{@language.to_s.capitalize} dependencies; install with:
+        `#{command_line} #{@module_name}`
     EOS
+
+    unless [:python, :perl, :ruby].include? @language
+      s += <<-EOS.undent
+
+      You may need to: `brew install #{@language}`
+
+      EOS
+    end
+
+    s
   end
 
   def the_test


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is in part designed to handle situations described in https://github.com/Homebrew/legacy-homebrew/issues/42273 where we tell someone to install a special dependency, but because we (rightly, IMO) resolve special dependencies first users can end up being told to execute a command on a tool that isn't yet installed and isn't immediately obvious how to install it.

In the situation raised there, with the `sile` formula people are being told to `luarocks install xyz` but we hadn't installed Lua for them first, so they just get a `command not found: luarocks` message. Perhaps it should be obvious enough how to install said tools by looking at the formula's dependencies, but it's not a huge burden on us to make life easier than that.

Shuffled over from https://github.com/Homebrew/legacy-homebrew/pull/42576.