### PR TITLE
tab: include installation date in string representation

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -246,12 +246,15 @@ class Tab < OpenStruct
 
   def to_s
     s = []
-    case poured_from_bottle
-    when true  then s << "Poured from bottle"
-    when false then s << "Built from source"
+    if poured_from_bottle
+      s << "Poured from bottle"
+    else
+      s << "Built from source"
+    end
+    if time
+      s << Time.at(time).strftime("on %Y-%m-%d at %H:%M:%S")
     end
     unless used_options.empty?
-      s << "Installed" if s.empty?
       s << "with:"
       s << used_options.to_a.join(" ")
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] N/A (no `to_s` test so far). Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I often wonder when a formula was upgraded, but despite showing each installed version, `brew info` does not show dates. I have to dig into `INSTALL_RECEIPT.json` or log/blame a formula to find out the date.

With this patch, `brew info` will include the installation date for each installed version, e.g.,

```
> brew info git
git: stable 2.8.2 (bottled), HEAD
Distributed revision control system
https://git-scm.com
...
/usr/local/Cellar/git/2.8.0 (1,416 files, 30.5M)
  Poured from bottle on 2016-03-29
/usr/local/Cellar/git/2.8.1 (1,416 files, 30.4M)
  Built from source on 2016-04-10 with: --without-completions
/usr/local/Cellar/git/2.8.2 (1,417 files, 30.4M) *
  Built from source on 2016-04-30 with: --without-completions
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/git.rb
...
```

I'm using ISO 8601 date format here because it's most widely accepted across the world (hopefully), but this is debatable.

---

**Update.** Time is also included now:

```
> brew info git
git: stable 2.8.2 (bottled), HEAD
Distributed revision control system
https://git-scm.com
...
/usr/local/Cellar/git/2.7.4 (1,415 files, 30.5M)
  Poured from bottle on 2016-03-18 at 04:00:26
/usr/local/Cellar/git/2.8.0 (1,416 files, 30.5M)
  Poured from bottle on 2016-03-29 at 04:00:22
/usr/local/Cellar/git/2.8.1 (1,416 files, 30.4M)
  Built from source on 2016-04-10 at 22:58:14 with: --without-completions
/usr/local/Cellar/git/2.8.2 (1,417 files, 30.4M) *
  Built from source on 2016-04-30 at 09:16:56 with: --without-completions
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/git.rb
...
```