### PR TITLE
doctor: guard against nil Xcode.version

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -416,7 +416,7 @@ module Homebrew
       end
 
       def check_for_osx_gcc_installer
-        return unless MacOS.version < "10.7" || MacOS::Xcode.version > "4.1"
+        return unless MacOS.version < "10.7" || ((MacOS::Xcode.version || "0") > "4.1")
         return unless MacOS.clang_version == "2.1"
 
         fix_advice = if MacOS.version >= :mavericks
@@ -439,7 +439,7 @@ module Homebrew
         # if the uninstaller script isn't there, it's a good guess neither are
         # any troublesome leftover Xcode files
         uninstaller = Pathname.new("/Developer/Library/uninstall-developer-folder")
-        return unless MacOS::Xcode.version >= "4.3" && uninstaller.exist?
+        return unless ((MacOS::Xcode.version || "0") >= "4.3") && uninstaller.exist?
 
         <<-EOS.undent
           You have leftover files from an older version of Xcode.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

MacOS::Xcode.version may be nil (when neither Xcode nor CLT are installed), so guard against that where it may happen in `brew doctor`.

Fixes Homebrew/legacy-homebrew#50671

This doesn't address the related issue that MacOS::Xcode.version is a string, not a Version, so doing `<` or `>=` comparisons sorts lexicographically, and may give the wrong answer for the semantics of version strings.