### PR TITLE
--env: support more shells, allow explicit shell selection

### DIFF
--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -3,6 +3,7 @@
 
 require "extend/ENV"
 require "build_environment"
+require "utils/shell"
 
 module Homebrew
   def __env
@@ -11,12 +12,25 @@ module Homebrew
     ENV.setup_build_environment
     ENV.universal_binary if ARGV.build_universal?
 
-    if $stdout.tty?
+    shell_value = ARGV.value("shell")
+    has_plain = ARGV.include?("--plain")
+
+    if has_plain
+      shell = nil
+    elsif shell_value.nil?
+      # legacy behavior
+      shell = :bash unless $stdout.tty?
+    elsif shell_value == "auto"
+      shell = Utils::Shell.parent_shell || Utils::Shell.preferred_shell
+    elsif shell_value
+      shell = Utils::Shell.path_to_shell(shell_value)
+    end
+
+    env_keys = build_env_keys(ENV)
+    if shell.nil?
       dump_build_env ENV
     else
-      build_env_keys(ENV).each do |key|
-        puts "export #{key}=\"#{ENV[key]}\""
-      end
+      env_keys.each { |key| puts Utils::Shell.export_value(shell, key, ENV[key]) }
     end
   end
 end

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -13,9 +13,8 @@ module Homebrew
     ENV.universal_binary if ARGV.build_universal?
 
     shell_value = ARGV.value("shell")
-    has_plain = ARGV.include?("--plain")
 
-    if has_plain
+    if ARGV.include?("--plain")
       shell = nil
     elsif shell_value.nil?
       # legacy behavior

--- a/Library/Homebrew/compat/utils.rb
+++ b/Library/Homebrew/compat/utils.rb
@@ -1,0 +1,10 @@
+# return the shell profile file based on users' preference shell
+def shell_profile
+  opoo "shell_profile has been deprecated in favor of Utils::Shell.profile"
+  case ENV["SHELL"]
+  when %r{/(ba)?sh} then "~/.bash_profile"
+  when %r{/zsh} then "~/.zshrc"
+  when %r{/ksh} then "~/.kshrc"
+  else "~/.bash_profile"
+  end
+end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -3,6 +3,7 @@ require "language/python"
 require "formula"
 require "version"
 require "development_tools"
+require "utils/shell"
 
 module Homebrew
   module Diagnostic
@@ -475,7 +476,7 @@ module Homebrew
 
                   Consider setting your PATH so that #{HOMEBREW_PREFIX}/bin
                   occurs before /usr/bin. Here is a one-liner:
-                    echo 'export PATH="#{HOMEBREW_PREFIX}/bin:$PATH"' >> #{shell_profile}
+                    echo 'export PATH="#{HOMEBREW_PREFIX}/bin:$PATH"' >> #{Utils::Shell.shell_profile}
                 EOS
               end
             end
@@ -495,7 +496,7 @@ module Homebrew
         <<-EOS.undent
           Homebrew's bin was not found in your PATH.
           Consider setting the PATH for example like so
-            echo 'export PATH="#{HOMEBREW_PREFIX}/bin:$PATH"' >> #{shell_profile}
+            echo 'export PATH="#{HOMEBREW_PREFIX}/bin:$PATH"' >> #{Utils::Shell.shell_profile}
         EOS
       end
 
@@ -510,7 +511,7 @@ module Homebrew
           Homebrew's sbin was not found in your PATH but you have installed
           formulae that put executables in #{HOMEBREW_PREFIX}/sbin.
           Consider setting the PATH for example like so
-            echo 'export PATH="#{HOMEBREW_PREFIX}/sbin:$PATH"' >> #{shell_profile}
+            echo 'export PATH="#{HOMEBREW_PREFIX}/sbin:$PATH"' >> #{Utils::Shell.shell_profile}
         EOS
       end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -476,7 +476,7 @@ module Homebrew
 
                   Consider setting your PATH so that #{HOMEBREW_PREFIX}/bin
                   occurs before /usr/bin. Here is a one-liner:
-                    echo 'export PATH="#{HOMEBREW_PREFIX}/bin:$PATH"' >> #{Utils::Shell.shell_profile}
+                    #{Utils::Shell.prepend_path_in_shell_profile("#{HOMEBREW_PREFIX}/bin")}
                 EOS
               end
             end
@@ -496,7 +496,7 @@ module Homebrew
         <<-EOS.undent
           Homebrew's bin was not found in your PATH.
           Consider setting the PATH for example like so
-            echo 'export PATH="#{HOMEBREW_PREFIX}/bin:$PATH"' >> #{Utils::Shell.shell_profile}
+            #{Utils::Shell.prepend_path_in_shell_profile("#{HOMEBREW_PREFIX}/bin:$PATH")}
         EOS
       end
 
@@ -511,7 +511,7 @@ module Homebrew
           Homebrew's sbin was not found in your PATH but you have installed
           formulae that put executables in #{HOMEBREW_PREFIX}/sbin.
           Consider setting the PATH for example like so
-            echo 'export PATH="#{HOMEBREW_PREFIX}/sbin:$PATH"' >> #{Utils::Shell.shell_profile}
+            #{Utils::Shell.prepend_path_in_shell_profile("#{HOMEBREW_PREFIX}/sbin:$PATH")}
         EOS
       end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -496,7 +496,7 @@ module Homebrew
         <<-EOS.undent
           Homebrew's bin was not found in your PATH.
           Consider setting the PATH for example like so
-            #{Utils::Shell.prepend_path_in_shell_profile("#{HOMEBREW_PREFIX}/bin:$PATH")}
+            #{Utils::Shell.prepend_path_in_shell_profile("#{HOMEBREW_PREFIX}/bin")}
         EOS
       end
 
@@ -511,7 +511,7 @@ module Homebrew
           Homebrew's sbin was not found in your PATH but you have installed
           formulae that put executables in #{HOMEBREW_PREFIX}/sbin.
           Consider setting the PATH for example like so
-            #{Utils::Shell.prepend_path_in_shell_profile("#{HOMEBREW_PREFIX}/sbin:$PATH")}
+            #{Utils::Shell.prepend_path_in_shell_profile("#{HOMEBREW_PREFIX}/sbin")}
         EOS
       end
 

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -202,7 +202,7 @@ module Homebrew
           SSL_CERT_DIR support was removed from Apple's curl.
           If fetching formulae fails you should:
             unset SSL_CERT_DIR
-          and remove it from #{shell_profile} if present.
+          and remove it from #{Utils::Shell.shell_profile} if present.
         EOS
       end
 

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -1,3 +1,5 @@
+require "utils/shell"
+
 module FormulaCellarChecks
   def check_PATH(bin)
     # warn the user if stuff was installed outside of their PATH
@@ -12,7 +14,7 @@ module FormulaCellarChecks
 
     <<-EOS.undent
       #{prefix_bin} is not in your PATH
-      You can amend this by altering your #{shell_profile} file
+      You can amend this by altering your #{Utils::Shell.shell_profile} file
     EOS
   end
 

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -227,6 +227,26 @@ class IntegrationCommandTests < Homebrew::TestCase
                  cmd("--env"))
   end
 
+  def test_env_bash
+    assert_match %r{export CMAKE_PREFIX_PATH="#{Regexp.quote(HOMEBREW_PREFIX.to_s)}"},
+                 cmd("--env", "--shell=bash")
+  end
+
+  def test_env_fish
+    assert_match %r{set [-]gx CMAKE_PREFIX_PATH "#{Regexp.quote(HOMEBREW_PREFIX.to_s)}"},
+                 cmd("--env", "--shell=fish")
+  end
+
+  def test_env_csh
+    assert_match %r{setenv CMAKE_PREFIX_PATH},
+                 cmd("--env", "--shell=tcsh")
+  end
+
+  def test_env_plain
+    assert_match %r{CMAKE_PREFIX_PATH: #{Regexp.quote(HOMEBREW_PREFIX)}},
+                 cmd("--env", "--plain")
+  end
+
   def test_prefix_formula
     assert_match "#{HOMEBREW_CELLAR}/testball",
                  cmd("--prefix", testball)

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -238,7 +238,7 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_env_csh
-    assert_match %r{setenv CMAKE_PREFIX_PATH},
+    assert_match %r{setenv CMAKE_PREFIX_PATH #{Regexp.quote(HOMEBREW_PREFIX.to_s)}},
                  cmd("--env", "--shell=tcsh")
   end
 

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -238,7 +238,7 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_env_csh
-    assert_match %r{setenv CMAKE_PREFIX_PATH #{Regexp.quote(HOMEBREW_PREFIX.to_s)}},
+    assert_match %r{setenv CMAKE_PREFIX_PATH #{Regexp.quote(HOMEBREW_PREFIX.to_s)};},
                  cmd("--env", "--shell=tcsh")
   end
 

--- a/Library/Homebrew/test/test_shell.rb
+++ b/Library/Homebrew/test/test_shell.rb
@@ -35,4 +35,25 @@ class ShellSmokeTest < Homebrew::TestCase
     assert_equal "\\$", Utils::Shell.csh_quote("$")
     assert_equal "word", Utils::Shell.csh_quote("word")
   end
+
+  def prepend_path_shell(shell, path, fragment)
+    original_shell = ENV["SHELL"]
+    ENV["SHELL"] = shell
+
+    prepend_message = Utils::Shell.prepend_path_in_shell_profile(path)
+    assert(
+      prepend_message.start_with?(fragment),
+      "#{shell}: expected #{prepend_message} to match #{fragment}"
+    )
+
+    ENV["SHELL"] = original_shell
+  end
+
+  def test_prepend_path_in_shell_profile()
+    prepend_path_shell "/bin/tcsh", "/path", "echo 'setenv PATH /path"
+
+    prepend_path_shell "/bin/bash", "/path", "echo 'export PATH=\"/path"
+
+    prepend_path_shell "/usr/local/bin/fish", "/path", "echo 'set -g fish_user_paths \"/path\" $fish_user_paths' >>"
+  end
 end

--- a/Library/Homebrew/test/test_shell.rb
+++ b/Library/Homebrew/test/test_shell.rb
@@ -30,7 +30,7 @@ class ShellSmokeTest < Homebrew::TestCase
   def test_csh_quote()
     assert_equal "''", Utils::Shell.csh_quote("")
     assert_equal "\\\\", Utils::Shell.csh_quote("\\")
-    # note this test is different
+    # note this test is different than for sh
     assert_equal "'\\\n'", Utils::Shell.csh_quote("\n")
     assert_equal "\\$", Utils::Shell.csh_quote("$")
     assert_equal "word", Utils::Shell.csh_quote("word")

--- a/Library/Homebrew/test/test_shell.rb
+++ b/Library/Homebrew/test/test_shell.rb
@@ -1,0 +1,38 @@
+require "testing_env"
+require "utils/shell"
+
+class ShellSmokeTest < Homebrew::TestCase
+  def test_path_to_shell()
+    # raw command name
+    assert_equal :bash, Utils::Shell.path_to_shell("bash")
+    # full path
+    assert_equal :bash, Utils::Shell.path_to_shell("/bin/bash")
+    # versions
+    assert_equal :zsh, Utils::Shell.path_to_shell("zsh-5.2")
+    # strip newline too
+    assert_equal :zsh, Utils::Shell.path_to_shell("zsh-5.2\n")
+  end
+
+  def test_path_to_shell_failure()
+    assert_equal nil, Utils::Shell.path_to_shell("")
+    assert_equal nil, Utils::Shell.path_to_shell("@@@@@@")
+    assert_equal nil, Utils::Shell.path_to_shell("invalid_shell-4.2")
+  end
+
+  def test_sh_quote()
+    assert_equal "''", Utils::Shell.sh_quote("")
+    assert_equal "\\\\", Utils::Shell.sh_quote("\\")
+    assert_equal "'\n'", Utils::Shell.sh_quote("\n")
+    assert_equal "\\$", Utils::Shell.sh_quote("$")
+    assert_equal "word", Utils::Shell.sh_quote("word")
+  end
+
+  def test_csh_quote()
+    assert_equal "''", Utils::Shell.csh_quote("")
+    assert_equal "\\\\", Utils::Shell.csh_quote("\\")
+    # note this test is different
+    assert_equal "'\\\n'", Utils::Shell.csh_quote("\n")
+    assert_equal "\\$", Utils::Shell.csh_quote("$")
+    assert_equal "word", Utils::Shell.csh_quote("word")
+  end
+end

--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -1,6 +1,7 @@
 require "testing_env"
 require "utils"
 require "tempfile"
+require "utils/shell"
 
 class TtyTests < Homebrew::TestCase
   def test_strip_ansi
@@ -157,15 +158,15 @@ class UtilTests < Homebrew::TestCase
 
   def test_shell_profile
     ENV["SHELL"] = "/bin/sh"
-    assert_equal "~/.bash_profile", shell_profile
+    assert_equal "~/.bash_profile", Utils::Shell.shell_profile
     ENV["SHELL"] = "/bin/bash"
-    assert_equal "~/.bash_profile", shell_profile
+    assert_equal "~/.bash_profile", Utils::Shell.shell_profile
     ENV["SHELL"] = "/bin/another_shell"
-    assert_equal "~/.bash_profile", shell_profile
+    assert_equal "~/.bash_profile", Utils::Shell.shell_profile
     ENV["SHELL"] = "/bin/zsh"
-    assert_equal "~/.zshrc", shell_profile
+    assert_equal "~/.zshrc", Utils::Shell.shell_profile
     ENV["SHELL"] = "/bin/ksh"
-    assert_equal "~/.kshrc", shell_profile
+    assert_equal "~/.kshrc", Utils::Shell.shell_profile
   end
 
   def test_popen_read

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -519,16 +519,6 @@ def paths
   end.uniq.compact
 end
 
-# return the shell profile file based on users' preference shell
-def shell_profile
-  case ENV["SHELL"]
-  when %r{/(ba)?sh} then "~/.bash_profile"
-  when %r{/zsh} then "~/.zshrc"
-  when %r{/ksh} then "~/.kshrc"
-  else "~/.bash_profile"
-  end
-end
-
 def disk_usage_readable(size_in_bytes)
   if size_in_bytes >= 1_073_741_824
     size = size_in_bytes.to_f / 1_073_741_824

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -76,7 +76,7 @@ module Utils
     def self.prepend_path_in_shell_profile(path)
       case preferred_shell 
       when :bash, :ksh, :sh, :zsh, nil
-        "echo 'export PATH=\"#{sh_quote(path)}:$PATH'\" >> #{shell_profile}"
+        "echo 'export PATH=\"#{sh_quote(path)}:$PATH\"' >> #{shell_profile}"
       when :csh, :tcsh
         "echo 'setenv PATH #{csh_quote(path)}:$PATH' >> #{shell_profile}"
       when :fish

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -69,5 +69,16 @@ module Utils
     def self.shell_profile
       SHELL_PROFILE_MAP.fetch(preferred_shell, "~/.bash_profile")
     end
+
+    def self.prepend_path_in_shell_profile(path)
+      case preferred_shell 
+      when :bash, :ksh, :sh, :zsh
+        "echo 'export PATH=\"#{sh_quote(path)}:$PATH >> #{shell_profile}"
+      when :csh, :tcsh
+        "echo 'setenv PATH #{csh_quote(path)}:$PATH' >> #{shell_profile}"
+      when :fish
+        "echo 'set -g fish_user_paths $fish_user_paths >> #{sh_quote(path)}' >> #{shell_profile}"
+      end
+    end
   end
 end

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -1,0 +1,73 @@
+module Utils
+  SHELL_PROFILE_MAP = {
+    :bash => "~/.bash_profile",
+    :csh => "~/.cshrc",
+    :fish => "~/.config/fish/config.fish",
+    :ksh => "~/.kshrc",
+    :sh => "~/.bash_profile",
+    :tcsh => "~/.tcshrc",
+    :zsh => "~/.zshrc",
+  }.freeze
+
+  module Shell
+    # take a path and heuristically convert it
+    # to a shell, return nil if there's no match
+    def self.path_to_shell(path)
+      # we only care about the basename
+      shell_name = File.basename(path)
+      # handle possible version suffix like `zsh-5.2`
+      shell_name.sub!(/-.*\z/m, "")
+      shell_name.to_sym if %w[bash csh fish ksh sh tcsh zsh].include?(shell_name)
+    end
+
+    def self.preferred_shell
+      path_to_shell(ENV.fetch("SHELL", ""))
+    end
+
+    def self.parent_shell
+      path_to_shell(`ps -p #{Process.ppid} -o ucomm=`.strip)
+    end
+
+    def self.csh_quote(str)
+      # ruby's implementation of shell_escape
+      str = str.to_s
+      return "''" if str.empty?
+      str = str.dup
+      # anything that isn't a known safe character is padded
+      str.gsub!(/([^A-Za-z0-9_\-.,:\/@\n])/, "\\\\" + "\\1")
+      str.gsub!(/\n/, "'\\\n'")
+      str
+    end
+    
+    def self.sh_quote(str)
+      # ruby's implementation of shell_escape
+      str = str.to_s
+      return "''" if str.empty?
+      str = str.dup
+      # anything that isn't a known safe character is padded
+      str.gsub!(/([^A-Za-z0-9_\-.,:\/@\n])/, "\\\\" + "\\1")
+      str.gsub!(/\n/, "'\n'")
+      str
+    end
+
+    # quote values. quoting keys is overkill
+    def self.export_value(shell, key, value)
+      case shell
+      when :bash, :ksh, :sh, :zsh
+        "export #{key}=\"#{sh_quote(value)}\""
+      when :fish
+        # fish quoting is mostly Bourne compatible except that
+        # a single quote can be included in a single-quoted string via \'
+        # and a literal \ can be included via \\
+        "set -gx #{key} \"#{sh_quote(value)}\""
+      when :csh, :tcsh
+        "setenv #{key} #{csh_quote(value)}"
+      end
+    end
+
+    # return the shell profile file based on users' preferred shell
+    def self.shell_profile
+      SHELL_PROFILE_MAP.fetch(preferred_shell, "~/.bash_profile")
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew --env` can be given an explicit shell argument via shell.
The basename of the path is compared against a known list of
shells.

An explicit argument of `--shell=` or `--shell ''`
with an empty string forces brew --env to dump the environment in
the key: value format that it uses when it detects that
stdout is a tty.

If an explicit shell is not supplied from the command line and
stdout is not a tty, then `brew --env` will check the parent process,
then its parent process etc until it finds a process with an
argv[0] that is either a known shell name or a known shell name with
`-` prepended

When I ran the test suite I encountered one failure in an integration test
if I run the test suite under `tcsh` but none if I run it under `bash`. The integration test
will probably need to be updated to use an explicit shell.

Here's an excerpt of the failing case.

```
  1) Failure:
IntegrationCommandTests#test_env [/Users/greg/opt/brew/brew-dev/Library/Homebrew/test/test_integration_cmds.rb:113]:
```