### PR TITLE
brew install: make `-s` apply only to given formula, not deps

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -64,7 +64,7 @@ module Homebrew
   def fetch_bottle?(f)
     return true if ARGV.force_bottle? && f.bottle
     return false unless f.bottle && f.pour_bottle?
-    return false if ARGV.build_from_source? || ARGV.build_bottle?
+    return false if ARGV.build_formula_from_source?(f)
     return false unless f.bottle.compatible_cellar?
     true
   end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -24,8 +24,13 @@
 #:    `gcc-4.2` for Apple's GCC 4.2, or `gcc-4.9` for a Homebrew-provided GCC
 #:    4.9.
 #:
-#:    If `--build-from-source` is passed, compile from source even if a bottle
-#:    is provided for <formula>.
+#:    If `--build-from-source` or `-s` is passed, compile the specified <formula> from
+#:    source even if a bottle is provided. Dependencies will still be installed
+#:    from bottles if they are available.
+#:
+#:    If `HOMEBREW_BUILD_FROM_SOURCE` is set, regardless of whether `--build-from-source` was
+#:    passed, then both <formula> and the dependencies installed as part of this process
+#:    are built from source even if bottles are available.
 #:
 #:    If `--force-bottle` is passed, install from a bottle if it exists
 #:    for the current version of OS X, even if custom options are given.
@@ -259,7 +264,7 @@ module Homebrew
     fi.ignore_deps         = ARGV.ignore_deps?
     fi.only_deps           = ARGV.only_deps?
     fi.build_bottle        = ARGV.build_bottle?
-    fi.build_from_source   = ARGV.build_from_source?
+    fi.build_from_source   = ARGV.build_from_source? || ARGV.build_all_from_source?
     fi.force_bottle        = ARGV.force_bottle?
     fi.interactive         = ARGV.interactive?
     fi.git                 = ARGV.git?

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -26,7 +26,7 @@ module Homebrew
     fi = FormulaInstaller.new(f)
     fi.options             = options
     fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && tab.build_bottle?)
-    fi.build_from_source   = ARGV.build_from_source?
+    fi.build_from_source   = ARGV.build_from_source? || ARGV.build_all_from_source?
     fi.force_bottle        = ARGV.force_bottle?
     fi.interactive         = ARGV.interactive?
     fi.git                 = ARGV.git?

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -71,7 +71,7 @@ module Homebrew
     fi = FormulaInstaller.new(f)
     fi.options             = tab.used_options
     fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && tab.build_bottle?)
-    fi.build_from_source   = ARGV.build_from_source?
+    fi.build_from_source   = ARGV.build_from_source? || ARGV.build_all_from_source?
     fi.verbose             = ARGV.verbose?
     fi.quieter             = ARGV.quieter?
     fi.debug               = ARGV.debug?

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -185,7 +185,19 @@ module HomebrewArgvExtension
   end
 
   def build_from_source?
-    switch?("s") || include?("--build-from-source") || !!ENV["HOMEBREW_BUILD_FROM_SOURCE"]
+    switch?("s") || include?("--build-from-source")
+  end
+
+  def build_all_from_source?
+    !!ENV["HOMEBREW_BUILD_FROM_SOURCE"]
+  end
+
+  # Whether a given formula should be built from source during the current
+  # installation run.
+  def build_formula_from_source?(f)
+    return true if build_all_from_source?
+    return false unless (build_from_source? || build_bottle?)
+    formulae.any? { |argv_f| argv_f.full_name == f.full_name }
   end
 
   def flag?(flag)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -794,6 +794,8 @@ class Formula
     opt_prefix+"Frameworks"
   end
 
+  # Indicates that this formula supports bottles. (Not necessarily that one
+  # should be used in the current installation run.)
   # Can be overridden to selectively disable bottles from formulae.
   # Defaults to true so overridden version does not have to check if bottles
   # are supported.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -428,7 +428,7 @@ class FormulaInstaller
     fi.options           |= tab.used_options
     fi.options           |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
     fi.options           |= inherited_options
-    fi.build_from_source  = build_from_source?
+    fi.build_from_source  = ARGV.build_formula_from_source?(df)
     fi.verbose            = verbose? && !quieter?
     fi.debug              = debug?
     fi.prelude

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -145,7 +145,7 @@ For tarballs, also print SHA-256 checksums.</p>
 <p>If <code>--HEAD</code> or <code>--devel</code> is passed, fetch that version instead of the
 stable version.</p>
 
-<p>If <code>-v</code> is passed, do a verbose VCS checkout, if the URL represents a CVS.
+<p>If <code>-v</code> is passed, do a verbose VCS checkout, if the URL represents a VCS.
 This is useful for seeing if an existing VCS cache has been updated.</p>
 
 <p>If <code>--force</code> is passed, remove a previously cached version and re-fetch.</p>
@@ -196,8 +196,13 @@ options but do not install the specified formula.</p>
 <code>gcc-4.2</code> for Apple's GCC 4.2, or <code>gcc-4.9</code> for a Homebrew-provided GCC
 4.9.</p>
 
-<p>If <code>--build-from-source</code> is passed, compile from source even if a bottle
-is provided for <var>formula</var>.</p>
+<p>If <code>--build-from-source</code> or <code>-s</code> is passed, compile the specified <var>formula</var> from
+source even if a bottle is provided. Dependencies will still be installed
+from bottles if they are available.</p>
+
+<p>If HOMEBREW_BUILD_FROM_SOURCE is set, regardless of whether <code>--build-from-source</code> was
+passed, then both <var>formula</var> and the dependencies installed as part of this process
+are built from source even if bottles are available.</p>
 
 <p>If <code>--force-bottle</code> is passed, install from a bottle if it exists
 for the current version of OS X, even if custom options are given.</p>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -196,7 +196,7 @@ Download the source packages for the given \fIformulae\fR\. For tarballs, also p
 If \fB\-\-HEAD\fR or \fB\-\-devel\fR is passed, fetch that version instead of the stable version\.
 .
 .IP
-If \fB\-v\fR is passed, do a verbose VCS checkout, if the URL represents a CVS\. This is useful for seeing if an existing VCS cache has been updated\.
+If \fB\-v\fR is passed, do a verbose VCS checkout, if the URL represents a VCS\. This is useful for seeing if an existing VCS cache has been updated\.
 .
 .IP
 If \fB\-\-force\fR is passed, remove a previously cached version and re\-fetch\.
@@ -265,7 +265,10 @@ If \fB\-\-only\-dependencies\fR is passed, install the dependencies with specifi
 If \fB\-\-cc=\fR\fIcompiler\fR is passed, attempt to compile using \fIcompiler\fR\. \fIcompiler\fR should be the name of the compiler\'s executable, for instance \fBgcc\-4\.2\fR for Apple\'s GCC 4\.2, or \fBgcc\-4\.9\fR for a Homebrew\-provided GCC 4\.9\.
 .
 .IP
-If \fB\-\-build\-from\-source\fR is passed, compile from source even if a bottle is provided for \fIformula\fR\.
+If \fB\-\-build\-from\-source\fR or \fB\-s\fR is passed, compile the specified \fIformula\fR from source even if a bottle is provided\. Dependencies will still be installed from bottles if they are available\.
+.
+.IP
+If HOMEBREW_BUILD_FROM_SOURCE is set, regardless of whether \fB\-\-build\-from\-source\fR was passed, then both \fIformula\fR and the dependencies installed as part of this process are built from source even if bottles are available\.
 .
 .IP
 If \fB\-\-force\-bottle\fR is passed, install from a bottle if it exists for the current version of OS X, even if custom options are given\.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Changes our `--build-from-source`/`-s` behavior to build only the explicitly requested formulae from source. Dependencies pulled in implicitly are poured from bottle by default. Addresses discussion in https://github.com/Homebrew/homebrew-core/pull/841#issuecomment-217442862.

The implementation is written to handle the case where there are dependencies between the specified formulae, possibly indirect ones (with intermediate dependencies not included on the command line), and they are specified out of the required installation order.

Adds `--build-all-from-source`/`-S` if you want to have the old behavior (`HOMEBREW_BUILD_FROM_SOURCE` does the same thing, but users might want a command-line switch that they can use tab completion on, or the really short `-S`.)

###   Testing

I tested this manually, using these clusters of formulae which have dependency chains.

```
abook -> readline
afflib -> expat :optional, openssl
augeas -> readline

aspcud -> gringo, clasp
gringo -> re2c, scons ( build )

analog -> jpeg, libpng
libpng -> xz
dpkg -> xz
```