### PR TITLE
Add tagging to formula tests

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1348,6 +1348,10 @@ class Formula
     false
   end
 
+  def test_trivial?
+    test_defined? && @test_tag == :trivial
+  end
+
   # @private
   def test
   end
@@ -2043,7 +2047,8 @@ class Formula
     #
     # The test will fail if it returns false, or if an exception is raised.
     # Failed assertions and failed `system` commands will raise exceptions.
-    def test(&block)
+    def test(tag = :nontrivial, &block)
+      @test_tag = tag
       define_method(:test, &block)
     end
 

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -309,6 +309,27 @@ class FormulaTests < Homebrew::TestCase
     refute f2.test_defined?
   end
 
+  def test_test_trivial
+    f1 = formula do
+      url "foo-1.0"
+
+      test :trivial do
+        true
+      end
+    end
+
+    f2 = formula do
+      url "foo-1.0"
+
+      test do
+        true
+      end
+    end
+
+    assert f1.test_trivial?
+    refute f2.test_trivial?
+  end
+
   def test_test_fixtures
     f1 = formula do
       url "foo-1.0"


### PR DESCRIPTION
Instead of the normal `test do`, tests that only perform trivial behavior
(like checking `--version` or `--help`) should use `test :trivial do`.

This allows coverage of formula to be improved while properly distinguishing
nontrivial checks from trivial ones (`Formula#test_trivial?`).