### PR TITLE
gist-logs: add proper documentation, improve error handling

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -1,4 +1,13 @@
-#: usage: brew gist-logs [--new-issue|-n] <formula>
+#:  * `gist-logs` [`--new-issue`|`-n`] <formula>:
+#:     Upload logs for a failed build of <formula> to a new Gist.
+#:
+#:     <formula> is usually the name of the formula to install, but it can be specified
+#:     in several different ways. See [SPECIFYING FORMULAE][].
+#:
+#:     If `--new-issue` is passed, automatically create a new issue in the appropriate
+#:     GitHub repository as well as creating the Gist.
+#:
+#:     If no logs are found, an error message is presented.      
 
 require "formula"
 require "cmd/config"

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -1,3 +1,5 @@
+#: usage: brew gist-logs [--new-issue|-n] <formula>
+
 require "formula"
 require "cmd/config"
 require "net/http"
@@ -161,11 +163,7 @@ module Homebrew
   end
 
   def gist_logs
-    if ARGV.resolved_formulae.length != 1
-      puts "usage: brew gist-logs [--new-issue|-n] <formula>"
-      Homebrew.failed = true
-      return
-    end
+    raise FormulaUnspecifiedError if ARGV.resolved_formulae.length != 1
 
     gistify_logs(ARGV.resolved_formulae[0])
   end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -2,7 +2,7 @@
 #:    Install <formula>.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
-#:    several different ways. See [SPECIFYING FORMULAE][].
+#:    in several different ways. See [SPECIFYING FORMULAE][].
 #:
 #:    If `--debug` is passed and brewing fails, open an interactive debugging
 #:    session with access to IRB or a shell inside the temporary build directory.

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -157,6 +157,15 @@ bottle.</p>
 
 <p>If <code>--force-bottle</code> is passed, download a bottle if it exists for the current
 version of OS X, even if it would not be used during installation.</p></dd>
+<dt><code>gist-logs</code> [<code>--new-issue</code>|<code>-n</code>] <var>formula</var></dt><dd><p> Upload logs for a failed build of <var>formula</var> to a new Gist.</p>
+
+<p> <var>formula</var> is usually the name of the formula to install, but it can be specified
+ in several different ways. See <a href="#SPECIFYING-FORMULAE" title="SPECIFYING FORMULAE" data-bare-link="true">SPECIFYING FORMULAE</a>.</p>
+
+<p> If <code>--new-issue</code> is passed, automatically create a new issue in the appropriate
+ GitHub repository as well as creating the Gist.</p>
+
+<p> If no logs are found, an error message is presented.</p></dd>
 <dt class="flush"><code>home</code></dt><dd><p>Open Homebrew's own homepage in a browser.</p></dd>
 <dt><code>home</code> <var>formula</var></dt><dd><p>Open <var>formula</var>'s homepage in a browser.</p></dd>
 <dt><code>info</code> <var>formula</var></dt><dd><p>Display information about <var>formula</var>.</p></dd>
@@ -174,7 +183,7 @@ information on all installed formulae.</p>
 <dt><code>install</code> [<code>--debug</code>] [<code>--env=</code><var>std</var>|<var>super</var>] [<code>--ignore-dependencies</code>] [<code>--only-dependencies</code>] [<code>--cc=</code><var>compiler</var>] [<code>--build-from-source</code>|<code>--force-bottle</code>] [<code>--devel</code>|<code>--HEAD</code>] [<code>--keep-tmp</code>] <var>formula</var></dt><dd><p>Install <var>formula</var>.</p>
 
 <p><var>formula</var> is usually the name of the formula to install, but it can be specified
-several different ways. See <a href="#SPECIFYING-FORMULAE" title="SPECIFYING FORMULAE" data-bare-link="true">SPECIFYING FORMULAE</a>.</p>
+in several different ways. See <a href="#SPECIFYING-FORMULAE" title="SPECIFYING FORMULAE" data-bare-link="true">SPECIFYING FORMULAE</a>.</p>
 
 <p>If <code>--debug</code> is passed and brewing fails, open an interactive debugging
 session with access to IRB or a shell inside the temporary build directory.</p>
@@ -200,7 +209,7 @@ options but do not install the specified formula.</p>
 source even if a bottle is provided. Dependencies will still be installed
 from bottles if they are available.</p>
 
-<p>If HOMEBREW_BUILD_FROM_SOURCE is set, regardless of whether <code>--build-from-source</code> was
+<p>If <code>HOMEBREW_BUILD_FROM_SOURCE</code> is set, regardless of whether <code>--build-from-source</code> was
 passed, then both <var>formula</var> and the dependencies installed as part of this process
 are built from source even if bottles are available.</p>
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -211,6 +211,19 @@ If \fB\-\-build\-from\-source\fR is passed, download the source rather than a bo
 If \fB\-\-force\-bottle\fR is passed, download a bottle if it exists for the current version of OS X, even if it would not be used during installation\.
 .
 .TP
+\fBgist\-logs\fR [\fB\-\-new\-issue\fR|\fB\-n\fR] \fIformula\fR
+Upload logs for a failed build of \fIformula\fR to a new Gist\.
+.
+.IP
+\fIformula\fR is usually the name of the formula to install, but it can be specified in several different ways\. See \fISPECIFYING FORMULAE\fR\.
+.
+.IP
+If \fB\-\-new\-issue\fR is passed, automatically create a new issue in the appropriate GitHub repository as well as creating the Gist\.
+.
+.IP
+If no logs are found, an error message is presented\.
+.
+.TP
 \fBhome\fR
 Open Homebrew\'s own homepage in a browser\.
 .
@@ -244,7 +257,7 @@ See the docs for examples of using the JSON: \fIhttps://github\.com/Homebrew/bre
 Install \fIformula\fR\.
 .
 .IP
-\fIformula\fR is usually the name of the formula to install, but it can be specified several different ways\. See \fISPECIFYING FORMULAE\fR\.
+\fIformula\fR is usually the name of the formula to install, but it can be specified in several different ways\. See \fISPECIFYING FORMULAE\fR\.
 .
 .IP
 If \fB\-\-debug\fR is passed and brewing fails, open an interactive debugging session with access to IRB or a shell inside the temporary build directory\.
@@ -268,7 +281,7 @@ If \fB\-\-cc=\fR\fIcompiler\fR is passed, attempt to compile using \fIcompiler\f
 If \fB\-\-build\-from\-source\fR or \fB\-s\fR is passed, compile the specified \fIformula\fR from source even if a bottle is provided\. Dependencies will still be installed from bottles if they are available\.
 .
 .IP
-If HOMEBREW_BUILD_FROM_SOURCE is set, regardless of whether \fB\-\-build\-from\-source\fR was passed, then both \fIformula\fR and the dependencies installed as part of this process are built from source even if bottles are available\.
+If \fBHOMEBREW_BUILD_FROM_SOURCE\fR is set, regardless of whether \fB\-\-build\-from\-source\fR was passed, then both \fIformula\fR and the dependencies installed as part of this process are built from source even if bottles are available\.
 .
 .IP
 If \fB\-\-force\-bottle\fR is passed, install from a bottle if it exists for the current version of OS X, even if custom options are given\.


### PR DESCRIPTION
The gist-logs help behaved differently when called in the following ways:

brew gist-logs
brew gist-logs --help

The former displayed a help message, the latter did _not_. I looked at the homebrew help system and saw that the gist-logs developer had implemented his own help, not using the system that other subcommands use. 

This pull request changes "brew gist-logs" to behave like "brew install". The only questionable part of the change is that I no longer set Homebrew.failed = 1, but I believe this is a side-effectless change.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
No real way to test this.
- [x] Have you successfully run `brew tests` with your changes locally?
