### PR TITLE
brew audit: add --display-filename option for easy grepping of output

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1,4 +1,4 @@
-#:  * `audit` [`--strict`] [`--online`] [`--display-cop-names`] [<formulae>]:
+#:  * `audit` [`--strict`] [`--online`] [`--display-cop-names`] [`--display-filename`] [<formulae>]:
 #:    Check <formulae> for Homebrew coding style violations. This should be
 #:    run before submitting a new formula.
 #:
@@ -12,6 +12,9 @@
 #:
 #:    If `--display-cop-names` is passed, the RuboCop cop name for each violation
 #:    is included in the output.
+#:
+#:    If `--display-filename` is passed, every line of output is prefixed with the
+#:    name of the file or formula being audited, to make the output easy to grep.
 #:
 #:    `audit` exits with a non-zero status if any errors are found. This is useful,
 #:    for instance, for implementing pre-commit hooks.
@@ -69,8 +72,12 @@ module Homebrew
 
       formula_count += 1
       problem_count += fa.problems.size
-      problem_lines = fa.problems.map { |p| "  * #{p.chomp.gsub("\n", "\n    ")}" }
-      puts "#{f.full_name}:", problem_lines
+      problem_lines = fa.problems.map { |p| "* #{p.chomp.gsub("\n", "\n    ")}" }
+      if ARGV.include? "--display-filename"
+        puts problem_lines.map { |s| "#{f.path}: #{s}"}
+      else
+        puts "#{f.full_name}:", problem_lines.map { |s| "  #{s}"}
+      end
     end
 
     unless problem_count.zero?

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -39,7 +39,7 @@ If no search term is given, all locally available formulae are listed.</p></dd>
 Read more at <a href="https://git.io/brew-analytics" data-bare-link="true">https://git.io/brew-analytics</a>.</p></dd>
 <dt><code>analytics</code> (<code>on</code>|<code>off</code>)</dt><dd><p>Turn on/off Homebrew's analytics.</p></dd>
 <dt><code>analytics</code> <code>regenerate-uuid</code></dt><dd><p>Regenerate UUID used in Homebrew's analytics.</p></dd>
-<dt><code>audit</code> [<code>--strict</code>] [<code>--online</code>] [<code>--display-cop-names</code>] [<var>formulae</var>]</dt><dd><p>Check <var>formulae</var> for Homebrew coding style violations. This should be
+<dt><code>audit</code> [<code>--strict</code>] [<code>--online</code>] [<code>--display-cop-names</code>] [<code>--display-filename</code>] [<var>formulae</var>]</dt><dd><p>Check <var>formulae</var> for Homebrew coding style violations. This should be
 run before submitting a new formula.</p>
 
 <p>If no <var>formulae</var> are provided, all of them are checked.</p>
@@ -52,6 +52,9 @@ connection are run. This should be used when creating for new formulae.</p>
 
 <p>If <code>--display-cop-names</code> is passed, the RuboCop cop name for each violation
 is included in the output.</p>
+
+<p>If <code>--display-filename</code> is passed, every line of output is prefixed with the
+name of the file or formula being audited, to make the output easy to grep.</p>
 
 <p><code>audit</code> exits with a non-zero status if any errors are found. This is useful,
 for instance, for implementing pre-commit hooks.</p></dd>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -56,7 +56,7 @@ Turn on/off Homebrew\'s analytics\.
 Regenerate UUID used in Homebrew\'s analytics\.
 .
 .TP
-\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-online\fR] [\fB\-\-display\-cop\-names\fR] [\fIformulae\fR]
+\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-online\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-display\-filename\fR] [\fIformulae\fR]
 Check \fIformulae\fR for Homebrew coding style violations\. This should be run before submitting a new formula\.
 .
 .IP
@@ -70,6 +70,9 @@ If \fB\-\-online\fR is passed, additional slower checks that require a network c
 .
 .IP
 If \fB\-\-display\-cop\-names\fR is passed, the RuboCop cop name for each violation is included in the output\.
+.
+.IP
+If \fB\-\-display\-filename\fR is passed, every line of output is prefixed with the name of the file or formula being audited, to make the output easy to grep\.
 .
 .IP
 \fBaudit\fR exits with a non\-zero status if any errors are found\. This is useful, for instance, for implementing pre\-commit hooks\.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Alters `brew audit` to add a `--display-filename` option which uses an alternate display format that prefixes every single violation line with the name of the file or formula it occurs in. This makes it easy to grep the output for particular violations. For example, this "low-hanging fruit" check to find formulae which lack tests but ignore other violations you don't care about as much.

```
[/usr/local/Library/Taps/homebrew/homebrew-science on ⇄ audit-work-A-01]
$ brew audit --strict --display-filename [ab]*.rb | grep 'test do'
homebrew/science/alembic: * A `test do` test block should be added
homebrew/science/arow++: * A `test do` test block should be added
homebrew/science/atomic-pseudopotential-engine: * A `test do` test block should be added
```

Could be an easier way of extracting some of the information that #208 ("Add tagging to formula tests") would have provided, but without introducing any new DSL or requiring work by users.

And at some point, if one wanted to, one could add an `audit` check for "trivial" tests (possibly off by default and enabled by `--strict` or another option, and maybe escapable by an explicit `#trivial test okay` comment in formulae which have Reasons for using trivial tests) and grep for that too.

###  Considerations

This "`--display-filename`" might not be the best wording of the option name, since it actually displays formula names instead of file paths. But it corresponds to the inverse of `grep`'s `--no-filename` option, so I think it's intuitive. And I think we might want to add it to `brew style` at some point and use the same option name, and there it might be actual file names.