### PR TITLE
ARGV: fix 'value' method, make it more predictable

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -87,9 +87,10 @@ module HomebrewArgvExtension
     at(@n+1) || raise(UsageError)
   end
 
-  def value(arg)
-    arg = find { |o| o =~ /--#{arg}=(.+)/ }
-    $1 if arg
+  def value(name)
+    arg_prefix = "--#{name}="
+    flag_with_value = find { |arg| arg.start_with?(arg_prefix) }
+    flag_with_value.strip_prefix(arg_prefix) if flag_with_value
   end
 
   def force?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -538,9 +538,9 @@ class FormulaInstaller
     end
 
     formula.options.each do |opt|
-      name  = opt.name[/\A(.+)=\z$/, 1]
-      value = ARGV.value(name)
-      args << "--#{name}=#{value}" if name && value
+      name = opt.name[/^([^=])+=$/, 1]
+      value = ARGV.value(name) if name
+      args << "--#{name}=#{value}" if value
     end
 
     args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The fix changes behavior in same cases, but those cases were all either broken or showed unexpected behavior. The new behavior is very simple:

- If an argument starts with `--<option-name>=`, return whatever comes after the equals sign. ~~Don't allow for equal signs or hyphens in `<arg>` or an empty `<arg>` to avoid surprising and confusing behavior.~~

Prior to this change, `ARGV.value` showed some unexpected behavior:

- `ARGV.value("foo")` returned `nil` for `--foo=` because at least one character needed to be present after the equals sign. (All other option parser implementations I'm aware of allow for empty values.)

- `ARGV.value("bar")` returned `"baz"` for `--foo=--bar=baz` because the regular expression was not anchored to the start of the argument.

- `ARGV.value("++")` raised an exception because the string wasn't escaped for use in the regular expression. (An unlikely corner case.)

Also fix a somewhat bogus use of `ARGV.value` in `FormulaInstaller` revealed by the change.