### PR TITLE
certs: add certificates update cmd

### DIFF
--- a/Library/Homebrew/cmd/certs.rb
+++ b/Library/Homebrew/cmd/certs.rb
@@ -1,0 +1,50 @@
+#:  * `certs` [`--force-curl`]:
+#:    You should really write more documentation up here Dom.
+
+module Homebrew
+  BREWED_CURL = Pathname.new(HOMEBREW_PREFIX/"opt/curl")
+  BREWED_OPENSSL = Pathname.new(HOMEBREW_PREFIX/"opt/openssl")
+  BREWED_LIBRESSL = Pathname.new(HOMEBREW_PREFIX/"opt/libressl")
+  BREWED_GNUTLS = Pathname.new(HOMEBREW_PREFIX/"opt/gnutls")
+
+  def certs
+    # Needs further investigation, just a rough guess currently that Apple
+    # isn't regularly updating certificates for Mountain Lion or less now.
+    if OS.mac? && MacOS.version <= :mountain_lion || OS.linux? || ARGV.include?("--force-curl")
+      use_brew_curl
+    elsif OS.mac? && MacOS.version >= :mavericks
+      use_postinstall
+    else
+      raise UsageError
+    end
+  end
+
+  def use_brew_curl
+    if BREWED_CURL.exist?
+      HOMEBREW_CACHE.mkpath
+      Dir.chdir HOMEBREW_CACHE
+      quiet_system BREWED_CURL/"libexec/mk-ca-bundle.pl", "-q", "-f", "cert.pem"
+
+      if BREWED_OPENSSL.exist? || BREWED_GNUTLS.exist?
+        Pathname.new(HOMEBREW_PREFIX/"etc/openssl").mkpath
+        FileUtils.cp "cert.pem", Pathname.new(HOMEBREW_PREFIX/"etc/openssl")
+      end
+      if BREWED_LIBRESSL.exist?
+        Pathname.new(HOMEBREW_PREFIX/"etc/libressl").mkpath
+        FileUtils.cp "cert.pem", Pathname.new(HOMEBREW_PREFIX/"etc/libressl")
+      end
+    else
+      odie <<-EOS.undent
+        This command requires Homebrew's curl to be installed for this operating
+        system. Please install it with:
+          `brew install curl`
+      EOS
+    end
+  end
+
+  def use_postinstall
+    quiet_system "brew", "postinstall", "openssl" if BREWED_OPENSSL.exist?
+    quiet_system "brew", "postinstall", "libressl" if BREWED_LIBRESSL.exist?
+    quiet_system "brew", "postinstall", "gnutls" if BREWED_GNUTLS.exist?
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Adds a relatively simple command to update the certificates Homebrew uses for OpenSSL/LibreSSL/GnuTLS installations.

Currently we just update the certs on upgrade/reinstall of those formulae but Apple themselves sometimes push certificate changes on OS X update or doesn't update certs at all for certain OS X releases. This provides a way for people to update out-of-band, and might save Shaun & Misty some work on Linuxbrew/Tigerbrew respectively.

For the three most recent OS X releases that can still claim to be kind of to completely supported by Apple it leans on the existing post_install logic in OpenSSL/LibreSSL/GnuTLS but could just as easily be flipped around so the core logic behind that resides in this command and those formulae call this command in `postinstall`, if that's preferred.

For the older OS X releases and Linux it uses Homebrew's curl to retrieve Mozilla certs and wraps them into a nice PEM, which is similar to what Misty and Shaun already do.

Reviving a three year old idea. Ref: https://github.com/Homebrew/legacy-homebrew/pull/21065
More discussion over in https://github.com/Homebrew/homebrew-core/pull/971.