### PR TITLE
Synchronize counts for link and unlink

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -530,9 +530,8 @@ module ObserverPathnameExtension
   end
 
   def mkpath
-    return if exist?
     super
-    puts "mkdir #{self}" if ObserverPathnameExtension.verbose?
+    puts "mkdir -p #{self}" if ObserverPathnameExtension.verbose?
   end
 
   def rmdir

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -529,6 +529,12 @@ module ObserverPathnameExtension
     ObserverPathnameExtension.n += 1
   end
 
+  def mkpath
+    return if exist?
+    super
+    puts "mkdir #{self}" if ObserverPathnameExtension.verbose?
+  end
+
   def rmdir
     super
     puts "rmdir #{self}" if ObserverPathnameExtension.verbose?

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -234,7 +234,7 @@ class Keg
       dirs.reverse_each(&:rmdir_if_possible)
     end
 
-    ObserverPathnameExtension.total
+    ObserverPathnameExtension.n
   end
 
   def lock
@@ -374,7 +374,7 @@ class Keg
     unlink
     raise
   else
-    ObserverPathnameExtension.total
+    ObserverPathnameExtension.n
   end
 
   def remove_oldname_opt_record

--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -56,7 +56,7 @@ class LinkTests < Homebrew::TestCase
   def test_unlinking_keg
     @keg.link
     assert_predicate @dst, :symlink?
-    assert_equal 4, @keg.unlink
+    assert_equal 3, @keg.unlink
     refute_predicate @dst, :symlink?
   end
 
@@ -239,7 +239,7 @@ class LinkTests < Homebrew::TestCase
   def test_unlink_ignores_nonexistent_file
     @keg.link
     @dst.delete
-    assert_equal 3, @keg.unlink
+    assert_equal 2, @keg.unlink
   end
 
   def test_pkgconfig_is_mkpathed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The output of linking and unlinking a formula can give different counts in some cases, as mentioned in #239:
```
$ brew link neovim
Linking /usr/local/Cellar/neovim/0.1.4... 40 symlinks created
$ brew unlink neovim
Unlinking /usr/local/Cellar/neovim/0.1.4... 66 symlinks removed
```

Investigation confirms that the links created and removed are the same, but `unlink` counts also directories among symlinks removed. This PR improves the situation to synchronize `link` and `unlink`, getting both to talk about 40 symlinks. Verbose logs confirm this is the amount of links created/removed (see below). This PR also takes care to not affect statistics used by other commands, which specifically mention directories.
If desired, one could also log the count of created and removed directories in `link/unlink`'s output.

Furthermore, this PR restores logging of mkdir operation during verbose linking, which was removed in https://github.com/Homebrew/legacy-homebrew/commit/f899878220668c7c7f0fcf43c6d294a52b7e79ed without a specific rationale. Logging both creations and removals appears more symmetric.

In previous discussion in #239, @mikemcquaid explained the issue was known and low-priority, while @xu-cheng claimed this was not an issue and offered an alternative explanation. I investigated the alternative explanation in more detail, and was unable to find confirming evidence, at least in this instance.

```
$ brew -v unlink neovim
Unlinking /usr/local/Cellar/neovim/0.1.4...
rm /usr/local/bin/nvim
rm /usr/local/share/locale/af/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ca/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/cs/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/cs.cp1250/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/de/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/en_GB/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/eo/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/es/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/fi/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/fr/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ga/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/it/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ja/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ja.euc-jp/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ja.sjis/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ko/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ko.UTF-8/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/nb/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/nl/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/no/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/pl/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/pl.UTF-8/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/pl.cp1250/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/pt_BR/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ru/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/ru.cp1251/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/sk/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/sk.cp1250/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/sv/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/uk/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/uk.cp1251/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/vi/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/zh_CN/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/zh_CN.UTF-8/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/zh_CN.cp936/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/zh_TW/LC_MESSAGES/nvim.mo
rm /usr/local/share/locale/zh_TW.UTF-8/LC_MESSAGES/nvim.mo
rm /usr/local/share/man/man1/nvim.1
rm /usr/local/share/nvim
rmdir /usr/local/share/locale/zh_TW.UTF-8/LC_MESSAGES
rmdir /usr/local/share/locale/zh_TW.UTF-8
rmdir /usr/local/share/locale/zh_CN.cp936/LC_MESSAGES
rmdir /usr/local/share/locale/zh_CN.cp936
rmdir /usr/local/share/locale/zh_CN.UTF-8/LC_MESSAGES
rmdir /usr/local/share/locale/zh_CN.UTF-8
rmdir /usr/local/share/locale/uk.cp1251/LC_MESSAGES
rmdir /usr/local/share/locale/uk.cp1251
rmdir /usr/local/share/locale/sk.cp1250/LC_MESSAGES
rmdir /usr/local/share/locale/sk.cp1250
rmdir /usr/local/share/locale/ru.cp1251/LC_MESSAGES
rmdir /usr/local/share/locale/ru.cp1251
rmdir /usr/local/share/locale/pl.cp1250/LC_MESSAGES
rmdir /usr/local/share/locale/pl.cp1250
rmdir /usr/local/share/locale/pl.UTF-8/LC_MESSAGES
rmdir /usr/local/share/locale/pl.UTF-8
rmdir /usr/local/share/locale/no/LC_MESSAGES
rmdir /usr/local/share/locale/no
rmdir /usr/local/share/locale/ko.UTF-8/LC_MESSAGES
rmdir /usr/local/share/locale/ko.UTF-8
rmdir /usr/local/share/locale/ja.sjis/LC_MESSAGES
rmdir /usr/local/share/locale/ja.sjis
rmdir /usr/local/share/locale/ja.euc-jp/LC_MESSAGES
rmdir /usr/local/share/locale/ja.euc-jp
rmdir /usr/local/share/locale/cs.cp1250/LC_MESSAGES
rmdir /usr/local/share/locale/cs.cp1250
40 symlinks removed
$ brew -v link neovim
Linking /usr/local/Cellar/neovim/0.1.4...
ln -s ../Cellar/neovim/0.1.4/bin/nvim nvim
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/af/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ca/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/cs/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/cs.cp1250
mkdir /usr/local/share/locale/cs.cp1250/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/cs.cp1250/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/de/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/en_GB/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/eo/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/es/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/fi/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/fr/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ga/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/it/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ja/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/ja.euc-jp
mkdir /usr/local/share/locale/ja.euc-jp/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ja.euc-jp/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/ja.sjis
mkdir /usr/local/share/locale/ja.sjis/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ja.sjis/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ko/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/ko.UTF-8
mkdir /usr/local/share/locale/ko.UTF-8/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ko.UTF-8/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/nb/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/nl/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/no
mkdir /usr/local/share/locale/no/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/no/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/pl/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/pl.UTF-8
mkdir /usr/local/share/locale/pl.UTF-8/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/pl.UTF-8/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/pl.cp1250
mkdir /usr/local/share/locale/pl.cp1250/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/pl.cp1250/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/pt_BR/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ru/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/ru.cp1251
mkdir /usr/local/share/locale/ru.cp1251/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/ru.cp1251/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/sk/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/sk.cp1250
mkdir /usr/local/share/locale/sk.cp1250/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/sk.cp1250/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/sv/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/uk/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/uk.cp1251
mkdir /usr/local/share/locale/uk.cp1251/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/uk.cp1251/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/vi/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/zh_CN/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/zh_CN.UTF-8
mkdir /usr/local/share/locale/zh_CN.UTF-8/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/zh_CN.UTF-8/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/zh_CN.cp936
mkdir /usr/local/share/locale/zh_CN.cp936/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/zh_CN.cp936/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/zh_TW/LC_MESSAGES/nvim.mo nvim.mo
mkdir /usr/local/share/locale/zh_TW.UTF-8
mkdir /usr/local/share/locale/zh_TW.UTF-8/LC_MESSAGES
ln -s ../../../../Cellar/neovim/0.1.4/share/locale/zh_TW.UTF-8/LC_MESSAGES/nvim.mo nvim.mo
ln -s ../../../Cellar/neovim/0.1.4/share/man/man1/nvim.1 nvim.1
ln -s ../Cellar/neovim/0.1.4/share/nvim nvim
40 symlinks created
```

Saving this output to `~/foo` and counting link creations and removal with `grep` confirms they're both indeed 40, and that both directory creations and removals are here 26. This fits the explanation that "66 symlinks removed" counted both symlinks and directories.
```
$ grep '^ln ' ~/foo|wc -l
      40
$ grep '^rm ' ~/foo|wc -l
      40
$ grep '^rmdir ' ~/foo|wc -l
      26
$ grep '^mkdir ' ~/foo|wc -l
      26
```
