### PR TITLE
audit: tweak devel/head tap check

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -74,9 +74,9 @@ module Homebrew
       problem_count += fa.problems.size
       problem_lines = fa.problems.map { |p| "* #{p.chomp.gsub("\n", "\n    ")}" }
       if ARGV.include? "--display-filename"
-        puts problem_lines.map { |s| "#{f.path}: #{s}"}
+        puts problem_lines.map { |s| "#{f.path}: #{s}" }
       else
-        puts "#{f.full_name}:", problem_lines.map { |s| "  #{s}"}
+        puts "#{f.full_name}:", problem_lines.map { |s| "  #{s}" }
       end
     end
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -552,11 +552,11 @@ class FormulaAuditor
   end
 
   def audit_specs
-    if head_only?(formula) && formula.tap.to_s.downcase !~ /-head-only$/
+    if head_only?(formula) && formula.tap.to_s.downcase !~ %r{[-/]head-only$}
       problem "Head-only (no stable download)"
     end
 
-    if devel_only?(formula) && formula.tap.to_s.downcase !~ /-devel-only$/
+    if devel_only?(formula) && formula.tap.to_s.downcase !~ %r{[-/]devel-only$}
       problem "Devel-only (no stable download)"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

For some reason the existing check seems to have started failing between March and today. I haven't managed to narrow down why yet but the biggest change between then and now was the core separation so perhaps related to that.

Perhaps at some point we started considering purely short tap names, i.e. `homebrew/devel-only` rather than full tap names, i.e. `homebrew/homebrew-devel-only`, in the audit mechanism.

This fixes the current issue whilst retaining the spirit of the original commit: 86d04e9