### PR TITLE
Revert "Switch to bbatsov's Style Guide since GitHub's is 404"

### DIFF
--- a/Library/Homebrew/README.md
+++ b/Library/Homebrew/README.md
@@ -3,6 +3,6 @@ This is the (partially) documented public API for Homebrew.
 
 The main class you should look at is the {Formula} class (and classes linked from there). That's the class that's used to create Homebrew formulae (i.e. package descriptions). Assume anything else you stumble upon is private.
 
-You may also find the [Formula Cookbook](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Formula-Cookbook.md) and bbatsov's [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide) helpful in creating formulae.
+You may also find the [Formula Cookbook](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Formula-Cookbook.md) and [Ruby Style Guide](https://github.com/styleguide/ruby) helpful in creating formulae.
 
 Good luck!

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -26,7 +26,7 @@ require "migrator"
 # @see FileUtils
 # @see Pathname
 # @see http://www.rubydoc.info/github/Homebrew/brew/file/share/doc/homebrew/Formula-Cookbook.md Formula Cookbook
-# @see https://github.com/bbatsov/ruby-style-guide Ruby Style Guide
+# @see https://github.com/styleguide/ruby Ruby Style Guide
 #
 # <pre>class Wget < Formula
 #   homepage "https://www.gnu.org/software/wget/"


### PR DESCRIPTION
Reverts Homebrew/brew#189

GitHub's style guide is back. CC @apjanke.