### PR TITLE
superenv: make SDKROOT opt-in

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -72,10 +72,7 @@ module Superenv
       self["HOMEBREW_FORMULA_PREFIX"] = formula.prefix
     end
 
-    if MacOS::Xcode.without_clt? || (MacOS::Xcode.installed? && MacOS::Xcode.version.to_i >= 7)
-      self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
-      self["SDKROOT"] = MacOS.sdk_path
-    end
+    self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s if MacOS::Xcode.installed?
 
     # On 10.9, the tools in /usr/bin proxy to the active developer directory.
     # This means we can use them for any combination of CLT and Xcode.


### PR DESCRIPTION
Also, always set MACOSX_DEPLOYMENT_TARGET rather than just when you
don't have the CLT or you have >= Xcode 7.