### PR TITLE
brew.1: correct documentation of install --keep-tmp

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -40,8 +40,8 @@
 #:    If `--HEAD` is passed, and <formula> defines it, install the HEAD version,
 #:    aka master, trunk, unstable.
 #:
-#:    If `--keep-tmp` is passed, the temporary files created for the test are
-#:    not deleted.
+#:    If `--keep-tmp` is passed, the temporary files created during installation
+#:    are not deleted.
 #:
 #:    To install a newer version of HEAD use
 #:    `brew rm <foo> && brew install --HEAD <foo>`.

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -227,8 +227,8 @@ for the current version of OS X, even if custom options are given.</p>
 <p>If <code>--HEAD</code> is passed, and <var>formula</var> defines it, install the HEAD version,
 aka master, trunk, unstable.</p>
 
-<p>If <code>--keep-tmp</code> is passed, the temporary files created for the test are
-not deleted.</p>
+<p>If <code>--keep-tmp</code> is passed, the temporary files created during installation
+are not deleted.</p>
 
 <p>To install a newer version of HEAD use
 <code>brew rm &lt;foo> &amp;&amp; brew install --HEAD &lt;foo></code>.</p></dd>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -299,7 +299,7 @@ If \fB\-\-devel\fR is passed, and \fIformula\fR defines it, install the developm
 If \fB\-\-HEAD\fR is passed, and \fIformula\fR defines it, install the HEAD version, aka master, trunk, unstable\.
 .
 .IP
-If \fB\-\-keep\-tmp\fR is passed, the temporary files created for the test are not deleted\.
+If \fB\-\-keep\-tmp\fR is passed, the temporary files created during installation are not deleted\.
 .
 .IP
 To install a newer version of HEAD use \fBbrew rm <foo> && brew install \-\-HEAD <foo>\fR\.


### PR DESCRIPTION
Obvious copy/paste failure in acc9a7c.