### PR TITLE
Haskell::Cabal: fix overquoting of flags

### DIFF
--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -81,7 +81,7 @@ module Language
           # dependencies, and call cabal configure afterwards to set the flags again for compile
           flags = ""
           if options[:flags]
-            flags = "--flags='#{options[:flags].join(" ")}'"
+            flags = "--flags=#{options[:flags].join(" ")}"
           end
 
           args_and_flags = args


### PR DESCRIPTION
Since `system` escapes its own spaces, cabal was interpreting
`--flags='webapp s3'` as `+'webapp +s3'` rather than `+webapp +s3`.