### PR TITLE
download_strategy: cvs source_modified_time

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -713,6 +713,21 @@ class CVSDownloadStrategy < VCSDownloadStrategy
     end
   end
 
+  def source_modified_time
+    # Look for the file timestamps under {#cached_location} because
+    # newly-unpacked directory can have timestamps of the moment of copying.
+    # Filter CVS's files because the timestamp for each of them is the moment
+    # of clone.
+    max_mtime = Time.at(0)
+    cached_location.find do |f|
+      Find.prune if f.directory? && f.basename.to_s == "CVS"
+      next unless f.file?
+      mtime = f.mtime
+      max_mtime = mtime if mtime > max_mtime
+    end
+    max_mtime
+  end
+
   def stage
     cp_r File.join(cached_location, "."), Dir.pwd
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Implement `CVSDownloadStrategy#source_modified_time` from #81 

### Description

* CVS stores its system data under `CVS` directories in each directory of the repository, so if we ignore CVS's data timestamps and inspect all the files timestamp except CVS's files, we can get source modified time.
```
➜ vlad:global$ tree
.
├── 1
├── AUTHORS
├── BOKIN_MODEL
├── BOKIN_MODEL_FAQ
├── COPYING
├── COPYING.LIB
├── CVS
│   ├── Entries
│   ├── Repository
│   └── Root
├── ChangeLog
├── DONORS
├── Doxyfile.in
├── FAQ
├── INSTALL
├── LICENSE
├── Makefile.am
├── NEWS
├── README
├── README.PATCHES
├── THANKS
├── acinclude.m4
├── btreeop
│   └── CVS
│       ├── Entries
│       ├── Repository
│       └── Root
:
```


* We cannot rely on `Pathname.pwd.to_enum(:find).select(&:file?).map(&:mtime).max` from `AbstractDownloadStrategy#source_modified_time` because in case of `CVSDownloadStrategy` `Pathname.pwd` will be called inside **copied** clone of the repository (it's created at the moment of `stage`ing), so the timestamps will show the moment of copying. The workaround here is to inspect timestamps inside `cached_directory`.