### PR TITLE
Haskell::Cabal: add cabal_get method

### DIFF
--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -99,6 +99,11 @@ module Language
           yield if block_given?
         end
       end
+
+      # download and extract a package(s) source code
+      def cabal_get(*args)
+        system "cabal", "get", *args
+      end
     end
   end
 end


### PR DESCRIPTION
`cabal get "foo"` is the simplest way to grab a dependency's source code
if patching is needed during `cabal install`.

`cabal_get` should usually be followed up by a call to
`cabal_sandbox_add_source` so that the patched version will be used.