### PR TITLE
[WIP] Allow HEAD-formula upgrades

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -28,10 +28,18 @@ module Homebrew
 
   def print_outdated(formulae)
     verbose = ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
+    fetch_head = ARGV.fetch_head?
 
-    formulae.select(&:outdated?).each do |f|
+    formulae.select do |f|
+      f.outdated?(:fetch_head => fetch_head)
+    end.each do |f|
       if verbose
-        puts "#{f.full_name} (#{f.outdated_versions*", "} < #{f.pkg_version})"
+        outdated_versions = f.outdated_versions(:fetch_head => fetch_head)
+        if outdated_versions.any? && f.head? && !fetch_head
+          puts "#{f.full_name} (#{outdated_versions*", "}) HEAD update available"
+        else
+          puts "#{f.full_name} (#{outdated_versions*", "}) < #{f.pkg_version}"
+        end
       else
         puts f.full_name
       end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -18,10 +18,15 @@ module Homebrew
     Homebrew.perform_preinstall_checks
 
     if ARGV.named.empty?
-      outdated = Formula.installed.select(&:outdated?)
+      outdated = Formula.installed.select do |f|
+        f.outdated?(:fetch_head => ARGV.fetch_head?)
+      end
+
       exit 0 if outdated.empty?
     elsif ARGV.named.any?
-      outdated = ARGV.resolved_formulae.select(&:outdated?)
+      outdated = ARGV.resolved_formulae.select do |f|
+        f.outdated?(:fetch_head => ARGV.fetch_head?)
+      end
 
       (ARGV.resolved_formulae - outdated).each do |f|
         versions = f.installed_kegs.map { |keg| keg.version }

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -6,6 +6,7 @@ class AbstractDownloadStrategy
   include FileUtils
 
   attr_reader :meta, :name, :version, :resource
+  attr_reader :shutup
 
   def initialize(name, resource)
     @name = name
@@ -17,6 +18,19 @@ class AbstractDownloadStrategy
 
   # Download and cache the resource as {#cached_location}.
   def fetch
+  end
+
+  # Supress output
+  def shutup!
+    @shutup = true
+  end
+
+  def puts(*args)
+    super(*args) unless shutup
+  end
+
+  def ohai(*args)
+    super(*args) unless shutup
   end
 
   # Unpack {#cached_location} into the current working directory, and possibly
@@ -57,6 +71,14 @@ class AbstractDownloadStrategy
     # 2 as default because commands are eg. svn up, git pull
     args.insert(2, "-q") unless ARGV.verbose?
     args
+  end
+
+  def safe_system(*args)
+    if @shutup
+      quiet_system(*args) || raise(ErrorDuringExecution.new(args.shift, *args))
+    else
+      super(*args)
+    end
   end
 
   def quiet_safe_system(*args)

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -601,7 +601,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
   end
 
   def last_commit
-    Utils.popen_read("git", "--git-dir", git_dir, "rev-parse", "--short=7", "HEAD").chomp
+    Utils.popen_read("git", "--git-dir", git_dir, "rev-parse", "HEAD").chomp
   end
 
   private

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -223,6 +223,10 @@ module HomebrewArgvExtension
     include? "--force-bottle"
   end
 
+  def fetch_head?
+    include? "--fetch-HEAD"
+  end
+
   # eg. `foo -ns -i --bar` has three switches, n, s and i
   def switch?(char)
     return false if char.length > 1

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -413,16 +413,34 @@ class Formula
     Pathname.new("#{HOMEBREW_LIBRARY}/LinkedKegs/#{name}")
   end
 
-  def latest_head_prefix
+  def latest_head_version
     head_versions = installed_prefixes.map do |pn|
       pn_pkgversion = PkgVersion.parse(pn.basename.to_s)
       pn_pkgversion if pn_pkgversion.head?
     end.compact
 
-    latest_head_version = head_versions.max_by do |pn_pkgversion|
+    head_versions.max_by do |pn_pkgversion|
       [Tab.for_keg(prefix(pn_pkgversion)).source_modified_time, pn_pkgversion.revision]
     end
-    prefix(latest_head_version) if latest_head_version
+  end
+
+  def latest_head_prefix
+    head_version = latest_head_version
+    prefix(head_version) if head_version
+  end
+
+  def head_version_outdated?(version, options={})
+    tab = Tab.for_keg(prefix(version))
+
+    return true if stable && tab.stable_version && tab.stable_version < stable.version
+    return true if devel && tab.devel_version && tab.devel_version < devel.version
+
+    if options[:fetch_head]
+      return false unless head && head.downloader.is_a?(VCSDownloadStrategy)
+      downloader = head.downloader
+      downloader.shutup! unless ARGV.verbose?
+      version.version.commit != downloader.fetch_last_commit
+    end
   end
 
   # The latest prefix for this formula. Checks for {#head}, then {#devel}

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -998,7 +998,7 @@ class Formula
   end
 
   # @private
-  def outdated_versions
+  def outdated_versions(options={})
     @outdated_versions ||= begin
       all_versions = []
 
@@ -1007,16 +1007,22 @@ class Formula
       installed_kegs.each do |keg|
         version = keg.version
         all_versions << version
-        return [] if pkg_version <= version
+
+        return [] if pkg_version <= version && !version.head?
       end
 
-      all_versions.sort!
+      head_version = latest_head_version
+      if head_version
+        head_version_outdated?(head_version, options) ? all_versions.sort! : []
+      else
+        all_versions.sort!
+      end
     end
   end
 
   # @private
-  def outdated?
-    outdated_versions.any?
+  def outdated?(options={})
+    outdated_versions(options).any?
   rescue Migrator::MigrationNeededError
     true
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -447,8 +447,8 @@ class Formula
   # and then {#stable}'s {#prefix}
   # @private
   def installed_prefix
-    if head && (head_prefix = latest_head_prefix) && head_prefix.directory?
-      head_prefix
+    if head && (head_version = latest_head_version) && !head_version_outdated?(head_version)
+      latest_head_prefix
     elsif devel && (devel_prefix = prefix(PkgVersion.new(devel.version, revision))).directory?
       devel_prefix
     elsif stable && (stable_prefix = prefix(PkgVersion.new(stable.version, revision))).directory?

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -31,7 +31,12 @@ class Tab < OpenStruct
       "source" => {
         "path" => formula.path.to_s,
         "tap" => formula.tap ? formula.tap.name : nil,
-        "spec" => formula.active_spec_sym.to_s
+        "spec" => formula.active_spec_sym.to_s,
+        "versions" => {
+          "stable" => formula.stable ? formula.stable.version.to_s : nil,
+          "devel" => formula.devel ? formula.devel.version.to_s : nil,
+          "head" => formula.head ? formula.head.version.to_s : nil
+        }
       }
     }
 
@@ -144,7 +149,12 @@ class Tab < OpenStruct
       "source" => {
         "path" => nil,
         "tap" => nil,
-        "spec" => "stable"
+        "spec" => "stable",
+        "versions" => {
+          "stable" => nil,
+          "devel" => nil,
+          "head" => nil
+        }
       }
     }
 
@@ -229,6 +239,18 @@ class Tab < OpenStruct
 
   def spec
     source["spec"].to_sym
+  end
+
+  def versions
+    source["versions"]
+  end
+
+  def stable_version
+    Version.create(versions["stable"]) if versions["stable"]
+  end
+
+  def devel_version
+    Version.create(versions["devel"]) if versions["devel"]
   end
 
   def source_modified_time

--- a/Library/Homebrew/test/test_download_strategies.rb
+++ b/Library/Homebrew/test/test_download_strategies.rb
@@ -119,7 +119,7 @@ class GitDownloadStrategyTests < Homebrew::TestCase
       touch "LICENSE"
       git_commit_all
     end
-    assert_equal "c50c79b", @strategy.last_commit
+    assert_equal "c50c79b9573c9482b9178a1882695fbbcd36fe7d", @strategy.last_commit
   end
 end
 

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -134,6 +134,47 @@ class FormulaTests < Homebrew::TestCase
     f.rack.rmtree
   end
 
+  def test_installed_prefix_outdated_stable_head_installed
+    f = formula do
+      url "foo"
+      version "1.9"
+      head "foo"
+    end
+
+    head_prefix = HOMEBREW_CELLAR/"#{f.name}/HEAD"
+    head_prefix.mkpath
+    tab = Tab.empty
+    tab.tabfile = head_prefix.join("INSTALL_RECEIPT.json")
+    tab.source["versions"] = { "stable" => "1.0" }
+    tab.write
+
+    assert_equal HOMEBREW_CELLAR/"#{f.name}/#{f.version}", f.installed_prefix
+  ensure
+    f.rack.rmtree
+  end
+
+  def test_installed_prefix_outdated_devel_head_installed
+    f = formula do
+      url "foo"
+      version "1.9"
+      devel do
+        url "foo"
+        version "2.1"
+      end
+    end
+
+    head_prefix = HOMEBREW_CELLAR/"#{f.name}/HEAD"
+    head_prefix.mkpath
+    tab = Tab.empty
+    tab.tabfile = head_prefix.join("INSTALL_RECEIPT.json")
+    tab.source["versions"] = { "stable" => "1.9", "devel" => "2.0" }
+    tab.write
+
+    assert_equal HOMEBREW_CELLAR/"#{f.name}/#{f.version}", f.installed_prefix
+  ensure
+    f.rack.rmtree
+  end
+
   def test_installed_prefix_head
     f = formula("test", Pathname.new(__FILE__).expand_path, :head) do
       head "foo"
@@ -527,60 +568,67 @@ class OutdatedVersionsTests < Homebrew::TestCase
   end
 
   def teardown
-    @f.rack.rmtree
+    @f.rack.rmtree if @f.rack.exist?
   end
 
-  def setup_tab_for_prefix(prefix, tap_string=nil)
+  def setup_tab_for_prefix(prefix, options={})
     prefix.mkpath
     tab = Tab.empty
     tab.tabfile = prefix.join("INSTALL_RECEIPT.json")
-    tab.source["tap"] = tap_string if tap_string
-    tab.write
+    tab.source["tap"] = options[:tap] if options[:tap]
+    tab.source["versions"] = options[:versions] if options[:versions]
+    tab.source_modified_time = options[:source_modified_time].to_i
+    tab.write unless options[:no_write]
     tab
   end
 
+  def reset_outdated_versions
+    f.instance_variable_set(:@outdated_versions, nil)
+  end
+
   def test_greater_different_tap_installed
-    setup_tab_for_prefix(greater_prefix, "user/repo")
+    setup_tab_for_prefix(greater_prefix, :tap => "user/repo")
     assert_predicate f.outdated_versions, :empty?
   end
 
   def test_greater_same_tap_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
-    setup_tab_for_prefix(greater_prefix, "homebrew/core")
+    setup_tab_for_prefix(greater_prefix, :tap => "homebrew/core")
     assert_predicate f.outdated_versions, :empty?
   end
 
   def test_outdated_different_tap_installed
-    setup_tab_for_prefix(outdated_prefix, "user/repo")
+    setup_tab_for_prefix(outdated_prefix, :tap => "user/repo")
     refute_predicate f.outdated_versions, :empty?
   end
 
   def test_outdated_same_tap_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
-    setup_tab_for_prefix(outdated_prefix, "homebrew/core")
+    setup_tab_for_prefix(outdated_prefix, :tap => "homebrew/core")
     refute_predicate f.outdated_versions, :empty?
   end
 
   def test_same_head_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
-    setup_tab_for_prefix(head_prefix, "homebrew/core")
+    setup_tab_for_prefix(head_prefix, :tap => "homebrew/core")
     assert_predicate f.outdated_versions, :empty?
   end
 
   def test_different_head_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
-    setup_tab_for_prefix(head_prefix, "user/repo")
+    setup_tab_for_prefix(head_prefix, :tap => "user/repo")
     assert_predicate f.outdated_versions, :empty?
   end
 
   def test_mixed_taps_greater_version_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
-    setup_tab_for_prefix(outdated_prefix, "homebrew/core")
-    setup_tab_for_prefix(greater_prefix, "user/repo")
+    setup_tab_for_prefix(outdated_prefix, :tap => "homebrew/core")
+    setup_tab_for_prefix(greater_prefix, :tap => "user/repo")
 
     assert_predicate f.outdated_versions, :empty?
 
-    setup_tab_for_prefix(greater_prefix, "homebrew/core")
+    setup_tab_for_prefix(greater_prefix, :tap => "homebrew/core")
+    reset_outdated_versions
 
     assert_predicate f.outdated_versions, :empty?
   end
@@ -591,23 +639,97 @@ class OutdatedVersionsTests < Homebrew::TestCase
     extra_outdated_prefix = HOMEBREW_CELLAR/"#{f.name}/1.0"
 
     setup_tab_for_prefix(outdated_prefix)
-    setup_tab_for_prefix(extra_outdated_prefix, "homebrew/core")
+    setup_tab_for_prefix(extra_outdated_prefix, :tap => "homebrew/core")
+    reset_outdated_versions
 
     refute_predicate f.outdated_versions, :empty?
 
-    setup_tab_for_prefix(outdated_prefix, "user/repo")
+    setup_tab_for_prefix(outdated_prefix, :tap => "user/repo")
+    reset_outdated_versions
 
     refute_predicate f.outdated_versions, :empty?
   end
 
   def test_same_version_tap_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
-    setup_tab_for_prefix(same_prefix, "homebrew/core")
+    setup_tab_for_prefix(same_prefix, :tap => "homebrew/core")
 
     assert_predicate f.outdated_versions, :empty?
 
-    setup_tab_for_prefix(same_prefix, "user/repo")
+    setup_tab_for_prefix(same_prefix, :tap => "user/repo")
+    reset_outdated_versions
 
     assert_predicate f.outdated_versions, :empty?
+  end
+
+  def test_outdated_installed_head_less_than_stable
+    tab = setup_tab_for_prefix(head_prefix, :versions => { "stable" => "1.0" })
+    refute_predicate f.outdated_versions, :empty?
+
+    # Tab.for_keg(head_prefix) will be fetched from CACHE but we write it anyway
+    tab.source["versions"] = { "stable" => f.version.to_s }
+    tab.write
+    reset_outdated_versions
+
+    assert_predicate f.outdated_versions, :empty?
+  end
+
+  def test_outdated_fetch_head
+    outdated_stable_prefix = HOMEBREW_CELLAR.join("testball/1.0")
+    head_prefix_a = HOMEBREW_CELLAR.join("testball/HEAD")
+    head_prefix_b = HOMEBREW_CELLAR.join("testball/HEAD-aaaaaaa_1")
+    head_prefix_c = HOMEBREW_CELLAR.join("testball/HEAD-56589463e5d9942a19d8e80975034ebf8886bba4")
+
+    setup_tab_for_prefix(outdated_stable_prefix)
+    tab_a = setup_tab_for_prefix(head_prefix_a, :versions => { "stable" => "1.0" })
+    tab_b = setup_tab_for_prefix(head_prefix_b)
+
+    initial_env = ENV.to_hash
+    testball_repo = HOMEBREW_PREFIX.join("testball_repo")
+    testball_repo.mkdir
+
+    @f = formula("testball") do
+      url "foo"
+      version "2.10"
+      head "file://#{testball_repo}", :using => :git
+    end
+
+    %w[AUTHOR COMMITTER].each do |role|
+      ENV["GIT_#{role}_NAME"] = "brew tests"
+      ENV["GIT_#{role}_EMAIL"] = "brew-tests@localhost"
+      ENV["GIT_#{role}_DATE"] = "Thu May 21 00:04:11 2009 +0100"
+    end
+
+    testball_repo.cd do |d|
+      FileUtils.touch "LICENSE"
+      shutup do
+        system "git", "init"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "Initial commit"
+      end
+    end
+
+    refute_predicate f.outdated_versions(:fetch_head => true), :empty?
+
+    tab_a["versions"] = { "stable" => f.version }
+    tab_a.write
+    reset_outdated_versions
+    refute_predicate f.outdated_versions(:fetch_head => true), :empty?
+
+    head_prefix_a.rmtree
+    reset_outdated_versions
+    refute_predicate f.outdated_versions(:fetch_head => true), :empty?
+
+    setup_tab_for_prefix(head_prefix_c, :source_modified_time => 1)
+    reset_outdated_versions
+    assert_predicate f.outdated_versions(:fetch_head => true), :empty?
+  ensure
+    ENV.replace(initial_env)
+    testball_repo.rmtree if testball_repo.exist?
+    outdated_stable_prefix.rmtree if outdated_stable_prefix.exist?
+    head_prefix_b.rmtree if head_prefix.exist?
+    head_prefix_c.rmtree if head_prefix_c.exist?
+    FileUtils.rm_rf HOMEBREW_CACHE/"testball--git"
+    FileUtils.rm_rf HOMEBREW_CELLAR/"testball"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

# Description

This is a GSoC PR for "Better support HEAD formulae" project.

- [x] Implement and override `VCSDownloadStrategy#last_commit` to determine unique identifier for the last commit in the repository.
- [x] Tests for GetDownloadStrategy
- [x] Implement `HeadVersion`
- [x] Add `HeadVersion` tests
- [x] Make `install/reinstall` work for HEAD versions
- [x] Midterm (June 20 - 27)
- [x] Implement `Formula#outdated_versions` (to be reviewed)
- [x] Establish `upgrade/outdated` behaviour  (to be reviewed)
- [ ] Update `print_outdated_json`
- [x] Allow to suppress download strategies output
- [x] Add outdated tests for HEAD versions
- [x] Use GitHub API to fetch last commit hash for github repositories (to be reviewed) 
- [ ] Fix edge cases (WIP)

cc @xu-cheng 