### PR TITLE
utils: avoid using 'gem' as an identifier

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -242,7 +242,7 @@ module Homebrew
     end
   end
 
-  def self.install_gem_setup_path!(gem, version = nil, executable = gem)
+  def self.install_gem_setup_path!(name, version = nil, executable = name)
     require "rubygems"
 
     # Add Gem binary directory and (if missing) Ruby binary directory to PATH.
@@ -251,9 +251,9 @@ module Homebrew
     path.unshift("#{Gem.user_dir}/bin")
     ENV["PATH"] = path.join(File::PATH_SEPARATOR)
 
-    if Gem::Specification.find_all_by_name(gem, version).empty?
-      ohai "Installing or updating '#{gem}' gem"
-      install_args = %W[--no-ri --no-rdoc --user-install #{gem}]
+    if Gem::Specification.find_all_by_name(name, version).empty?
+      ohai "Installing or updating '#{name}' gem"
+      install_args = %W[--no-ri --no-rdoc --user-install #{name}]
       install_args << "--version" << version if version
 
       # Do `gem install [...]` without having to spawn a separate process or
@@ -267,12 +267,12 @@ module Homebrew
       rescue Gem::SystemExitException => e
         exit_code = e.exit_code
       end
-      odie "Failed to install/update the '#{gem}' gem." if exit_code != 0
+      odie "Failed to install/update the '#{name}' gem." if exit_code != 0
     end
 
     unless which executable
       odie <<-EOS.undent
-        The '#{gem}' gem is installed but couldn't find '#{executable}' in the PATH:
+        The '#{name}' gem is installed but couldn't find '#{executable}' in the PATH:
         #{ENV["PATH"]}
       EOS
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Avoid breaking code highlighting of some editors (e.g. Sublime Text) when `gem` is used as an identifier. This messes up the highlighting below the first use and makes working with the file rather annoying.

*This is a bit of a self-serving PR, but I hope it is acceptable nonetheless. I believe TextMate users might be affected, too, as they rely on the same syntax definition files for code highlighting.*