### PR TITLE
gist-logs: truncate log files to be gist-friendly

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -91,6 +91,9 @@ module Homebrew
     logs = {}
     dir.children.sort.each do |file|
       contents = file.size? ? file.read : "empty log"
+      # small enough to avoid GitHub "unicorn" page-load-timeout errors
+      max_file_size = 1_000_000
+      contents = truncate_text_to_approximate_size(contents, max_file_size, :front_weight => 0.2)
       logs[file.basename.to_s] = { :content => contents }
     end if dir.exist?
     raise "No logs." if logs.empty?

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -40,10 +40,6 @@ module Homebrew
 
   HOMEBREW_TAP_REGEX = %r{^([\w-]+)/homebrew-([\w-]+)$}
 
-  def ruby_has_encoding?
-    String.method_defined?(:force_encoding)
-  end
-
   if ruby_has_encoding?
     def fix_encoding!(str)
       # Assume we are starting from a "mostly" UTF-8 string
@@ -1012,13 +1008,7 @@ module Homebrew
 
       # Truncate to 1MB to avoid hitting CI limits
       if output.bytesize > MAX_STEP_OUTPUT_SIZE
-        if ruby_has_encoding?
-          binary_output = output.force_encoding("BINARY")
-          output = binary_output.slice(-MAX_STEP_OUTPUT_SIZE, MAX_STEP_OUTPUT_SIZE)
-          fix_encoding!(output)
-        else
-          output = output.slice(-MAX_STEP_OUTPUT_SIZE, MAX_STEP_OUTPUT_SIZE)
-        end
+        output = truncate_text_to_approximate_size(output, MAX_STEP_OUTPUT_SIZE, :front_weight => 0.0)
         output = "truncated output to 1MB:\n" + output
       end
     end

--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -210,4 +210,17 @@ class UtilTests < Homebrew::TestCase
     assert_equal "1,000", number_readable(1_000)
     assert_equal "1,000,000", number_readable(1_000_000)
   end
+
+  def test_truncate_text_to_approximate_size
+    glue = "\n[...snip...]\n" # hard-coded copy from truncate_text_to_approximate_size
+    n = 20
+    long_s = "x" * 40
+    s = truncate_text_to_approximate_size(long_s, n)
+    assert_equal n, s.length
+    assert_match(/^x+#{Regexp.escape(glue)}x+$/, s)
+    s = truncate_text_to_approximate_size(long_s, n, :front_weight => 0.0)
+    assert_equal glue + ("x" * (n - glue.length)), s
+    s = truncate_text_to_approximate_size(long_s, n, :front_weight => 1.0)
+    assert_equal(("x" * (n - glue.length)) + glue, s)
+  end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -533,3 +533,49 @@ def number_readable(number)
   (numstr.size - 3).step(1, -3) { |i| numstr.insert(i, ",") }
   numstr
 end
+
+# True if this version of Ruby supports text encodings in its strings
+def ruby_has_encoding?
+  String.method_defined?(:force_encoding)
+end
+
+# Truncates a text string to fit within a byte size constraint,
+# preserving character encoding validity. The returned string will
+# be not much longer than the specified max_bytes, though the exact
+# shortfall or overrun may vary.
+def truncate_text_to_approximate_size(s, max_bytes, options = {})
+  front_weight = options.fetch(:front_weight, 0.5)
+  if front_weight < 0.0 || front_weight > 1.0
+    raise "opts[:front_weight] must be between 0.0 and 1.0"
+  end
+  return s if s.bytesize <= max_bytes
+
+  glue = "\n[...snip...]\n"
+  max_bytes_in = [max_bytes - glue.bytesize, 1].max
+  if ruby_has_encoding?
+    bytes = s.dup.force_encoding("BINARY")
+    glue_bytes = glue.encode("BINARY")
+  else
+    bytes = s
+    glue_bytes = glue
+  end
+  n_front_bytes = (max_bytes_in * front_weight).floor
+  n_back_bytes = max_bytes_in - n_front_bytes
+  if n_front_bytes == 0
+    front = bytes[1..0]
+    back = bytes[-max_bytes_in..-1]
+  elsif n_back_bytes == 0
+    front = bytes[0..(max_bytes_in - 1)]
+    back = bytes[1..0]
+  else
+    front = bytes[0..(n_front_bytes - 1)]
+    back = bytes[-n_back_bytes..-1]
+  end
+  out = front + glue_bytes + back
+  if ruby_has_encoding?
+    out.force_encoding("UTF-8")
+    out.encode!("UTF-16", :invalid => :replace)
+    out.encode!("UTF-8")
+  end
+  out
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Fixes homebrew/legacy-homebrew#44706

Changes `brew gist-logs` to truncate each individual log file to be under 1 MB. This avoids upload and download errors with the gists, and respects GitHub's suggested size limits.

###   Discussion   ###

If you try to upload a Gist that's larger than 10 MB or so, you'll get a 405 error. The upload will still succeed, but per GitHub support, this is an accident, and can't be relied on. And then you don't get the URL of the uploaded gist.

Also, if a Gist is large, you may get a "unicorn" error page saying "this page is taking too long to load" when trying to view it on github.com.

The 1 MB per file size limit is conservative. I chose it experimentally: at 2 MB per file, uploads would succeed, but I was still getting unicorn download errors when trying to view them on GitHub. I think we should size the log files to work with the Gist web interface. That's the file size this mechanism was built to support, and working within it makes these log files a lot easier for users & maintainers to work with, and respects the intent of GitHub in providing the Gist service.

In terms of diagnostic usefulness, I think the 1 MB per file size limit will be fine. For large log files, usually the bulk of the output isn't useful anyway, because the build errors happen at the end (almost by definition), and it's usually the output right around the errors, and at the beginning during the configuration and launch steps, which matters. So I don't think this somewhat-aggressive truncation is losing us anything useful. 

This is also a win because uploads of large log file sets will not be so slow, because JSON validation (which seems to be one of the bottlenecks) will be done on the smaller post-truncation data set.

###  Notes   ###

a) Strictly speaking, the build logs may not be UTF-8, so the truncation may still have encoding errors in its output if the build logs are not valid UTF-8 (and haven't been re-encoded). But I think the `gist-logs` code is already assuming that the log files are in UTF-8 (because the JSON upload requires Unicode), so this wouldn't be a regression.

b) It would be possible to refactor the `brew test-bot` code to use this new function for its truncation, but I found doing so to be less readable, and no more concise, so I didn't do it.