### PR TITLE
tests: fix external command test and code style

### DIFF
--- a/Library/Homebrew/test/test_commands.rb
+++ b/Library/Homebrew/test/test_commands.rb
@@ -19,7 +19,7 @@ class CommandsTests < Homebrew::TestCase
   end
 
   def teardown
-    @cmds.each { |f| f.unlink }
+    @cmds.each(&:unlink)
   end
 
   def test_internal_commands
@@ -43,12 +43,12 @@ class CommandsTests < Homebrew::TestCase
       %w[brew-t1 brew-t2.rb brew-t3.py].each do |file|
         path = "#{dir}/#{file}"
         FileUtils.touch path
-        FileUtils.chmod 0744, path
+        FileUtils.chmod 0755, path
       end
 
-      FileUtils.touch "#{dir}/t4"
+      FileUtils.touch "#{dir}/brew-t4"
 
-      ENV["PATH"] = "#{ENV["PATH"]}#{File::PATH_SEPARATOR}#{dir}"
+      ENV["PATH"] += "#{File::PATH_SEPARATOR}#{dir}"
       cmds = Homebrew.external_commands
 
       assert cmds.include?("t1"), "Executable files should be included"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? 👉 **N/A**
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The check that `t4` is not an external command would always succeed, but not because the file wasn't executable, but because it wasn't even found due to the missing `brew-` prefix.

Also change the valid but atypical file mode from 0744 to 0755 and apply minor code style fixes.