### PR TITLE
os/mac/*_mach: move shared code into 'SharedMachO'

### DIFF
--- a/Library/Homebrew/os/mac/cctools_mach.rb
+++ b/Library/Homebrew/os/mac/cctools_mach.rb
@@ -1,5 +1,3 @@
-require "os/mac/architecture_list"
-
 module CctoolsMachO
   # @private
   OTOOL_RX = /\t(.*) \(compatibility version (?:\d+\.)*\d+, current version (?:\d+\.)*\d+\)/
@@ -52,53 +50,6 @@ module CctoolsMachO
     rescue
       []
     end
-  end
-
-  def archs
-    mach_data.map { |m| m.fetch :arch }.extend(ArchitectureListExtension)
-  end
-
-  def arch
-    case archs.length
-    when 0 then :dunno
-    when 1 then archs.first
-    else :universal
-    end
-  end
-
-  def universal?
-    arch == :universal
-  end
-
-  def i386?
-    arch == :i386
-  end
-
-  def x86_64?
-    arch == :x86_64
-  end
-
-  def ppc7400?
-    arch == :ppc7400
-  end
-
-  def ppc64?
-    arch == :ppc64
-  end
-
-  # @private
-  def dylib?
-    mach_data.any? { |m| m.fetch(:type) == :dylib }
-  end
-
-  # @private
-  def mach_o_executable?
-    mach_data.any? { |m| m.fetch(:type) == :executable }
-  end
-
-  # @private
-  def mach_o_bundle?
-    mach_data.any? { |m| m.fetch(:type) == :bundle }
   end
 
   # @private

--- a/Library/Homebrew/os/mac/pathname.rb
+++ b/Library/Homebrew/os/mac/pathname.rb
@@ -1,3 +1,5 @@
+require "os/mac/shared_mach"
+
 class Pathname
   if ENV["HOMEBREW_RUBY_MACHO"]
     require "os/mac/ruby_mach"
@@ -6,4 +8,6 @@ class Pathname
     require "os/mac/cctools_mach"
     include CctoolsMachO
   end
+
+  include SharedMachO
 end

--- a/Library/Homebrew/os/mac/ruby_mach.rb
+++ b/Library/Homebrew/os/mac/ruby_mach.rb
@@ -1,5 +1,4 @@
 require "vendor/macho/macho"
-require "os/mac/architecture_list"
 
 module RubyMachO
   # @private
@@ -52,53 +51,6 @@ module RubyMachO
       end
       []
     end
-  end
-
-  def archs
-    mach_data.map { |m| m.fetch :arch }.extend(ArchitectureListExtension)
-  end
-
-  def arch
-    case archs.length
-    when 0 then :dunno
-    when 1 then archs.first
-    else :universal
-    end
-  end
-
-  def universal?
-    arch == :universal
-  end
-
-  def i386?
-    arch == :i386
-  end
-
-  def x86_64?
-    arch == :x86_64
-  end
-
-  def ppc7400?
-    arch == :ppc7400
-  end
-
-  def ppc64?
-    arch == :ppc64
-  end
-
-  # @private
-  def dylib?
-    mach_data.any? { |m| m.fetch(:type) == :dylib }
-  end
-
-  # @private
-  def mach_o_executable?
-    mach_data.any? { |m| m.fetch(:type) == :executable }
-  end
-
-  # @private
-  def mach_o_bundle?
-    mach_data.any? { |m| m.fetch(:type) == :bundle }
   end
 
   def dynamically_linked_libraries

--- a/Library/Homebrew/os/mac/shared_mach.rb
+++ b/Library/Homebrew/os/mac/shared_mach.rb
@@ -1,0 +1,50 @@
+require "os/mac/architecture_list"
+
+module SharedMachO
+  def archs
+    mach_data.map { |m| m.fetch :arch }.extend(ArchitectureListExtension)
+  end
+
+  def arch
+    case archs.length
+    when 0 then :dunno
+    when 1 then archs.first
+    else :universal
+    end
+  end
+
+  def universal?
+    arch == :universal
+  end
+
+  def i386?
+    arch == :i386
+  end
+
+  def x86_64?
+    arch == :x86_64
+  end
+
+  def ppc7400?
+    arch == :ppc7400
+  end
+
+  def ppc64?
+    arch == :ppc64
+  end
+
+  # @private
+  def dylib?
+    mach_data.any? { |m| m.fetch(:type) == :dylib }
+  end
+
+  # @private
+  def mach_o_executable?
+    mach_data.any? { |m| m.fetch(:type) == :executable }
+  end
+
+  # @private
+  def mach_o_bundle?
+    mach_data.any? { |m| m.fetch(:type) == :bundle }
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Both the `CctoolsMachO` and `RubyMachO` module implement a common set of methods that simplify querying `mach_data`. Move these into a shared module, that gets included after either of these implementations is loaded and included in `Pathname`.

cc @woodruffw