### PR TITLE
utils: avoid caching in 'paths' method

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -499,7 +499,7 @@ def nostdout
 end
 
 def paths
-  @paths ||= ENV["PATH"].split(File::PATH_SEPARATOR).collect do |p|
+  ENV["PATH"].split(File::PATH_SEPARATOR).collect do |p|
     begin
       File.expand_path(p).chomp("/")
     rescue ArgumentError


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

### Description

Because `paths` is a global method, the instance variable used for the cache gets attached to whatever happens to be the receiver at the call site. This causes the creation of multiple caches and can additionally lead to inconsistent results if the environment is modified between calls to `paths`.

Fix by eliminating the cache as `paths` is not performance critical and is used in only two places throughout Homebrew:

- `Homebrew.external_commands`
- `Homebrew::Diagnostic::Checks` (by multiple methods of this class)

### Discussion

To my knowledge, the issue addressed here doesn't currently affect any Homebrew code. However, it revealed itself while working on some yet-to-be-published improvements to Homebrew. The selected fix is the simplest and most effective while also giving what I believe to be the desired behavior.

An alternative is sketched in UniqMartin/brew@1e82bbf4982de2fa32327402614f5614c6b7a86c ([`paths-fix-cache`](https://github.com/UniqMartin/brew/tree/paths-fix-cache) branch). By moving `paths` to a module we get consistent behavior, but the cache is never invalidated, which breaks the test suite as it currently relies on the broken caching behavior. (**Addendum:** Getting this right will require some form of cache invalidation, either manually or by checking whether `ENV["PATH"]` has changed.)

### Demonstration

The current (undesired) behavior as well as the behavior of the proposed fix and the alternative sketched above can be demonstrated with a short external command `brew-paths.rb`:

```ruby
class Paths
  def dump; paths; end
  def self.dump; paths; end
end

ENV["PATH"] = "/usr/bin:/bin"
puts "PATH = #{ENV["PATH"]}"
puts "  fun: #{paths.inspect}"

ENV["PATH"] += "#{File::PATH_SEPARATOR}/usr/local/bin"
puts "PATH = #{ENV["PATH"]}"
puts "  fun: #{paths.inspect}"
puts "  cls: #{Paths.dump.inspect}"
puts "  obj: #{Paths.new.dump.inspect}"

ENV["PATH"] += "#{File::PATH_SEPARATOR}/sbin"
puts "PATH = #{ENV["PATH"]}"
puts "  fun: #{paths.inspect}"
puts "  cls: #{Paths.dump.inspect}"
puts "  obj: #{Paths.new.dump.inspect}"
```

Current situation (inconsistent and partially stale):

```
$ brew paths
PATH = /usr/bin:/bin
  fun: ["/usr/bin", "/bin"]
PATH = /usr/bin:/bin:/usr/local/bin
  fun: ["/usr/bin", "/bin"]
  cls: ["/usr/bin", "/bin", "/usr/local/bin"]
  obj: ["/usr/bin", "/bin", "/usr/local/bin"]
PATH = /usr/bin:/bin:/usr/local/bin:/sbin
  fun: ["/usr/bin", "/bin"]
  cls: ["/usr/bin", "/bin", "/usr/local/bin"]
  obj: ["/usr/bin", "/bin", "/usr/local/bin", "/sbin"]
```

Proposed fix (no caching, consistent and always up-to-date):

```
$ brew paths
PATH = /usr/bin:/bin
  fun: ["/usr/bin", "/bin"]
PATH = /usr/bin:/bin:/usr/local/bin
  fun: ["/usr/bin", "/bin", "/usr/local/bin"]
  cls: ["/usr/bin", "/bin", "/usr/local/bin"]
  obj: ["/usr/bin", "/bin", "/usr/local/bin"]
PATH = /usr/bin:/bin:/usr/local/bin:/sbin
  fun: ["/usr/bin", "/bin", "/usr/local/bin", "/sbin"]
  cls: ["/usr/bin", "/bin", "/usr/local/bin", "/sbin"]
  obj: ["/usr/bin", "/bin", "/usr/local/bin", "/sbin"]
```

Alternative fix (fixed caching, consistent but almost always stale):

```
$ brew paths
PATH = /usr/bin:/bin
  fun: ["/usr/bin", "/bin"]
PATH = /usr/bin:/bin:/usr/local/bin
  fun: ["/usr/bin", "/bin"]
  cls: ["/usr/bin", "/bin"]
  obj: ["/usr/bin", "/bin"]
PATH = /usr/bin:/bin:/usr/local/bin:/sbin
  fun: ["/usr/bin", "/bin"]
  cls: ["/usr/bin", "/bin"]
  obj: ["/usr/bin", "/bin"]
```