### PR TITLE
Separate build and test logs

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -27,7 +27,7 @@ module Homebrew
       if Sandbox.formula?(formula)
         sandbox = Sandbox.new
         formula.logs.mkpath
-        sandbox.record_log(formula.logs/"sandbox.postinstall.log")
+        sandbox.record_log(formula.logs/"postinstall.sandbox.log")
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_write_cellar(formula)

--- a/Library/Homebrew/cmd/test.rb
+++ b/Library/Homebrew/cmd/test.rb
@@ -63,7 +63,7 @@ module Homebrew
           if Sandbox.test?
             sandbox = Sandbox.new
             f.logs.mkpath
-            sandbox.record_log(f.logs/"sandbox.test.log")
+            sandbox.record_log(f.logs/"test.sandbox.log")
             sandbox.allow_write_temp_and_cache
             sandbox.allow_write_log(f)
             sandbox.allow_write_xcode

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -127,6 +127,11 @@ class Formula
   # @private
   attr_accessor :local_bottle_path
 
+  # When performing a build, test, or other loggable action, indicates which
+  # log file location to use.
+  # @private
+  attr_reader :active_log_type
+
   # The {BuildOptions} for this {Formula}. Lists the arguments passed and any
   # {#options} in the {Formula}. Note that these may differ at different times
   # during the installation of a {Formula}. This is annoying but the result of
@@ -730,10 +735,28 @@ class Formula
     prefix+".bottle"
   end
 
-  # The directory where the formula's installation logs will be written.
+  # The directory where the formula's installation or test logs will be written.
   # @private
   def logs
     HOMEBREW_LOGS+name
+  end
+
+  # The prefix, if any, to use in filenames for logging current activity
+  def active_log_prefix
+    if active_log_type
+      "#{active_log_type}."
+    else
+      ""
+    end
+  end
+
+  # Runs a block with the given log type in effect for its duration
+  def with_logging(log_type)
+    old_log_type = @active_log_type
+    @active_log_type = log_type
+    yield
+  ensure
+    @active_log_type = old_log_type
   end
 
   # This method can be overridden to provide a plist.
@@ -854,6 +877,17 @@ class Formula
   # @private
   def post_install_defined?
     method(:post_install).owner == self.class
+  end
+
+  # @private
+  def run_post_install
+    build = self.build
+    self.build = Tab.for_formula(self)
+    with_logging("post_install") do
+      post_install
+    end
+  ensure
+    self.build = build
   end
 
   # Tell the user about any caveats regarding this package.
@@ -1374,7 +1408,9 @@ class Formula
       ENV["HOME"] = @testpath
       setup_home @testpath
       begin
-        test
+        with_logging("test") do
+          test
+        end
       rescue Exception
         staging.retain! if ARGV.debug?
         raise
@@ -1466,7 +1502,7 @@ class Formula
 
     @exec_count ||= 0
     @exec_count += 1
-    logfn = "#{logs}/%02d.%s" % [@exec_count, File.basename(cmd).split(" ").first]
+    logfn = "#{logs}/#{active_log_prefix}%02d.%s" % [@exec_count, File.basename(cmd).split(" ").first]
     logs.mkpath
 
     File.open(logfn, "w") do |log|

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -597,7 +597,7 @@ class FormulaInstaller
       if Sandbox.formula?(formula)
         sandbox = Sandbox.new
         formula.logs.mkpath
-        sandbox.record_log(formula.logs/"sandbox.build.log")
+        sandbox.record_log(formula.logs/"build.sandbox.log")
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_write_xcode

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -13,7 +13,7 @@ begin
 
   formula = ARGV.resolved_formulae.first
   formula.extend(Debrew::Formula) if ARGV.debug?
-  formula.post_install
+  formula.run_post_install
 rescue Exception => e
   Marshal.dump(e, error_pipe)
   error_pipe.close


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally? _No; I'm getting a warning that needs to be cleaned up.

-----

Any objections to splitting the build and test logs in to separate subdirectories?

Currently, `brew install` and `brew test` both drop their log files in the same `.../Logs/Homebrew/<formula_name>` directory. This means that if you do a `brew install foo` and then  `brew test foo` on a formula that includes `system()` calls in its `def test`, its test logs will contaminate the installation logs. This happens with `postgresql`, for example.

I suspect this was unintentional, and just wasn't noticed because we seldom use Homebrew logs except for immediately after a failed `brew install`, in which case a `brew test` will not have been run.

This PR adds new `build/` and `test/` subdirs to separate the logs for the two stages, and adjusts `brew gist-logs` and other things using logs to account for it. `brew cleanup` will handle migrating logs in the old directory structure to the new one, so users won't lose existing logs.

This has the additional advantage of opening up logical space in the `brew` logs directory to allow for logging of other things, if that becomes useful in the future.

###   Failing tests   ###

The `brew tests` run isn't failing outright, but it is complaining about leaked files. I haven't been able to fix this yet, because I can't figure out where the whitelist for "okay to appear" files or log structure skeleton is, or if it's complaining about this for some other reason. Help on this is welcome.

Marking this as "in progress" because of this, and won't ask to merge until it's clean.

(The exact test that appears to leak will vary across `brew tests` runs, I think because the random seed shuffles the order tests are run in, but `test_cleanup_logs` is always involved.)

```
[✘ /usr/local/Library/Homebrew on ⇄ separate-build-and-test-logs]
$ brew tests
Run options: --seed 5148

# Running:

.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 51.091141s, 16.7348 runs/s, 40.5941 assertions/s.

855 runs, 2074 assertions, 0 failures, 0 errors, 0 skips
Warning: File leak is detected
InstallTests#test_a_basic_install
--- expected
+++ actual
@@ -3,6 +3,7 @@
  "/cellar",
  "/formula_cache",
  "/logs",
+ "/logs/build",
  "/prefix",
  "/prefix/Library",
  "/prefix/Library/Taps",
CleanupTests#test_cleanup_logs
--- expected
+++ actual
@@ -3,7 +3,6 @@
  "/cellar",
  "/formula_cache",
  "/logs",
- "/logs/build",
  "/prefix",
  "/prefix/Library",
  "/prefix/Library/Taps",
```

###   Considerations   ###

This will be a breaking change for any external commands or other code that relies on the current directory structure of the log files.