### PR TITLE
Move HOMEBREW_CACHE to ~/Library/Caches

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -43,9 +43,9 @@ module Homebrew
       end
     end
 
-    def self.cleanup_cache
-      return unless HOMEBREW_CACHE.directory?
-      HOMEBREW_CACHE.children.each do |path|
+    def self.cleanup_cache(cache=HOMEBREW_CACHE)
+      return unless cache.directory?
+      cache.children.each do |path|
         if path.to_s.end_with? ".incomplete"
           cleanup_path(path) { path.unlink }
           next

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -2,6 +2,7 @@ require "formula_versions"
 require "migrator"
 require "formulary"
 require "descriptions"
+require "cleanup"
 
 module Homebrew
   def update_preinstall_header
@@ -69,6 +70,8 @@ module Homebrew
       updated = true
     end
 
+    migrate_legacy_cache_if_necessary
+
     if !updated
       if !ARGV.include?("--preinstall") && !ENV["HOMEBREW_UPDATE_FAILED"]
         puts "Already up-to-date."
@@ -100,6 +103,52 @@ module Homebrew
     revision = core_tap.git_head
     ENV["HOMEBREW_UPDATE_BEFORE_HOMEBREW_HOMEBREW_CORE"] = revision
     ENV["HOMEBREW_UPDATE_AFTER_HOMEBREW_HOMEBREW_CORE"] = revision
+  end
+
+  def migrate_legacy_cache_if_necessary
+    legacy_cache = Pathname.new "/Library/Caches/Homebrew"
+    return if HOMEBREW_CACHE.to_s == legacy_cache.to_s
+    return unless legacy_cache.directory?
+    return unless legacy_cache.readable_real?
+
+    migration_attempted_file = legacy_cache/".migration_attempted"
+    return if migration_attempted_file.exist?
+
+    return unless legacy_cache.writable_real?
+    FileUtils.touch migration_attempted_file
+
+    # Cleanup to avoid copying files unnecessarily
+    ohai "Cleaning up #{legacy_cache}..."
+    Cleanup.cleanup_cache legacy_cache
+
+    # This directory could have been compromised if it's world-writable/
+    # a symlink/owned by another user so don't copy files in those cases.
+    return if legacy_cache.world_writable?
+    return if legacy_cache.symlink?
+    return if !legacy_cache.owned? && legacy_cache.lstat.uid != 0
+
+    ohai "Migrating #{legacy_cache} to #{HOMEBREW_CACHE}..."
+    HOMEBREW_CACHE.mkpath
+    legacy_cache.cd do
+      legacy_cache.entries.each do |f|
+        next if [".", "..", ".migration_attempted"].include? "#{f}"
+        begin
+          FileUtils.cp_r f, HOMEBREW_CACHE
+        rescue
+          @migration_failed ||= true
+        end
+      end
+    end
+
+    if @migration_failed
+      opoo <<-EOS.undent
+        Failed to migrate #{legacy_cache} to
+        #{HOMEBREW_CACHE}. Please do so manually.
+      EOS
+    else
+      ohai "Deleting #{legacy_cache}..."
+      FileUtils.rm_rf legacy_cache
+    end
   end
 end
 

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -1,27 +1,4 @@
-def cache
-  if ENV["HOMEBREW_CACHE"]
-    Pathname.new(ENV["HOMEBREW_CACHE"]).expand_path
-  else
-    # we do this for historic reasons, however the cache *should* be the same
-    # directory whichever user is used and whatever instance of brew is executed
-    home_cache = Pathname.new("~/Library/Caches/Homebrew").expand_path
-    if home_cache.directory? && home_cache.writable_real?
-      home_cache
-    else
-      Pathname.new("/Library/Caches/Homebrew").extend Module.new {
-        def mkpath
-          unless exist?
-            super
-            chmod 0775
-          end
-        end
-      }
-    end
-  end
-end
-
-HOMEBREW_CACHE = cache
-undef cache
+HOMEBREW_CACHE = Pathname.new(ENV["HOMEBREW_CACHE"] || "~/Library/Caches/Homebrew").expand_path
 
 # Where brews installed via URL are cached
 HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE+"Formula"

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -118,8 +118,7 @@ can take several different forms:
   * `HOMEBREW_CACHE`:
     If set, instructs Homebrew to use the given directory as the download cache.
 
-    *Default:* `~/Library/Caches/Homebrew` if it exists; otherwise,
-    `/Library/Caches/Homebrew`.
+    *Default:* `~/Library/Caches/Homebrew`.
 
   * `HOMEBREW_CURL_VERBOSE`:
     If set, Homebrew will pass `--verbose` when invoking `curl`(1).

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -523,8 +523,7 @@ Homebrew developers. Please do not file issues if you encounter errors when
 using this environment variable.</p></dd>
 <dt><code>HOMEBREW_CACHE</code></dt><dd><p>If set, instructs Homebrew to use the given directory as the download cache.</p>
 
-<p><em>Default:</em> <code>~/Library/Caches/Homebrew</code> if it exists; otherwise,
-<code>/Library/Caches/Homebrew</code>.</p></dd>
+<p><em>Default:</em> <code>~/Library/Caches/Homebrew</code>.</p></dd>
 <dt><code>HOMEBREW_CURL_VERBOSE</code></dt><dd><p>If set, Homebrew will pass <code>--verbose</code> when invoking <code>curl</code>(1).</p></dd>
 <dt><code>HOMEBREW_DEBUG</code></dt><dd><p>If set, any commands that can emit debugging information will do so.</p></dd>
 <dt><code>HOMEBREW_DEBUG_INSTALL</code></dt><dd><p>When <code>brew install -d</code> or <code>brew install -i</code> drops into a shell,

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -720,7 +720,7 @@ If set, instructs Homebrew to compile from source even when a formula provides a
 If set, instructs Homebrew to use the given directory as the download cache\.
 .
 .IP
-\fIDefault:\fR \fB~/Library/Caches/Homebrew\fR if it exists; otherwise, \fB/Library/Caches/Homebrew\fR\.
+\fIDefault:\fR \fB~/Library/Caches/Homebrew\fR\.
 .
 .TP
 \fBHOMEBREW_CURL_VERBOSE\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Thanks to @dlitz for the initial PR, the security checks and sorry for the massive delay in getting this to a 🚢able state. 

I decided on `~/Library/Caches` as it's a user-specific cache directory that OS X already knows how to handle sensibly and avoids any permission issues. For people who already had that directory around it'll also be a no-op for them and for those who wish to keep using `/Library/Caches` they can set the `HOMEBREW_CACHE` environment variable.