### PR TITLE
tap: default to full clones for developers.

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -48,7 +48,7 @@ module Homebrew
       tap = Tap.fetch(ARGV.named[0])
       begin
         tap.install :clone_target => ARGV.named[1],
-                    :full_clone   => ARGV.include?("--full"),
+                    :full_clone   => full_clone?,
                     :quiet        => ARGV.quieter?
       rescue TapRemoteMismatchError => e
         odie e
@@ -58,12 +58,16 @@ module Homebrew
     end
   end
 
+  def full_clone?
+    ARGV.include?("--full") || ARGV.homebrew_developer?
+  end
+
   # @deprecated this method will be removed in the future, if no external commands use it.
   def install_tap(user, repo, clone_target = nil)
     opoo "Homebrew.install_tap is deprecated, use Tap#install."
     tap = Tap.fetch(user, repo)
     begin
-      tap.install(:clone_target => clone_target, :full_clone => ARGV.include?("--full"))
+      tap.install(:clone_target => clone_target, :full_clone => full_clone?)
     rescue TapAlreadyTappedError
       false
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

You need a non-shallow clone to push branches upstream so if you often tap and untap taps (e.g. `homebrew/boneyard`) then you need to remember to manually `fetch --unshallow`.