### PR TITLE
bintray "package" should be name not full_name

### DIFF
--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -321,7 +321,7 @@ module Homebrew
             }
           },
           "bintray" => {
-            "package" => Utils::Bottles::Bintray.package(f.full_name),
+            "package" => Utils::Bottles::Bintray.package(f.name),
             "repository" => Utils::Bottles::Bintray.repository(f.tap),
           },
         },


### PR DESCRIPTION
Based on how it's used to construct URLs, the bintray "package" should
be the formula name not the formula full_name. For core formulae, there
is no difference, but that's not the case in other taps.

See https://github.com/Homebrew/homebrew-gui/pull/10