### PR TITLE
audit: tweaks

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -303,7 +303,7 @@ class FormulaAuditor
 
     same_name_tap_formulae.delete(full_name)
 
-    if same_name_tap_formulae.size > 0
+    unless same_name_tap_formulae.empty?
       problem "Formula name conflicts with #{same_name_tap_formulae.join ", "}"
     end
   end
@@ -415,7 +415,7 @@ class FormulaAuditor
 
     desc = formula.desc
 
-    unless desc && desc.length > 0
+    unless desc && !desc.empty?
       problem "Formula should have a desc (Description)."
       return
     end
@@ -1198,7 +1198,7 @@ class ResourceAuditor
         problem "Don't use #{$1}use_mirror in SourceForge urls (url is #{p})."
       end
 
-      if p =~ /\/download$/
+      if p.end_with?("/download")
         problem "Don't use /download in SourceForge urls (url is #{p})."
       end
 

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1167,7 +1167,7 @@ class ResourceAuditor
            %r{^http://(?:[^/]*\.)?archive\.org},
            %r{^http://(?:[^/]*\.)?freedesktop\.org}
         problem "Please use https:// for #{p}"
-      when %r{^http://search\.(mcpan|cpan)\.org/CPAN/(.*)}i
+      when %r{^http://search\.mcpan\.org/CPAN/(.*)}i
         problem "#{p} should be `https://cpan.metacpan.org/#{$1}`"
       when %r{^(http|ftp)://ftp\.gnome\.org/pub/gnome/(.*)}i
         problem "#{p} should be `https://download.gnome.org/#{$2}`"

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1163,6 +1163,7 @@ class ResourceAuditor
            %r{^http://www\.mirrorservice\.org/},
            %r{^http://launchpad\.net/},
            %r{^http://bitbucket\.org/},
+           %r{^http://cpan\.metacpan\.org/},
            %r{^http://hackage\.haskell\.org/},
            %r{^http://(?:[^/]*\.)?archive\.org},
            %r{^http://(?:[^/]*\.)?freedesktop\.org}

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1175,6 +1175,16 @@ class ResourceAuditor
       end
     end
 
+    # Prefer HTTP/S when possible over FTP protocol due to possible firewalls.
+    urls.each do |p|
+      case p
+      when %r{^ftp://ftp\.mirrorservice\.org}
+        problem "Please use https:// for #{p}"
+      when %r{^ftp://ftp\.cpan\.org/pub/CPAN(.*)}i
+        problem "#{p} should be `http://search.cpan.org/CPAN#{$1}`"
+      end
+    end
+
     # Check SourceForge urls
     urls.each do |p|
       # Skip if the URL looks like a SVN repo

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1160,13 +1160,13 @@ class ResourceAuditor
            %r{^http://mirrors\.kernel\.org/},
            %r{^http://(?:[^/]*\.)?bintray\.com/},
            %r{^http://tools\.ietf\.org/},
-           %r{^http://www\.mirrorservice\.org/},
            %r{^http://launchpad\.net/},
            %r{^http://bitbucket\.org/},
            %r{^http://cpan\.metacpan\.org/},
            %r{^http://hackage\.haskell\.org/},
            %r{^http://(?:[^/]*\.)?archive\.org},
-           %r{^http://(?:[^/]*\.)?freedesktop\.org}
+           %r{^http://(?:[^/]*\.)?freedesktop\.org},
+           %r{^http://(?:[^/]*\.)?mirrorservice\.org/}
         problem "Please use https:// for #{p}"
       when %r{^http://search\.mcpan\.org/CPAN/(.*)}i
         problem "#{p} should be `https://cpan.metacpan.org/#{$1}`"

--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1168,7 +1168,7 @@ class ResourceAuditor
            %r{^http://(?:[^/]*\.)?freedesktop\.org}
         problem "Please use https:// for #{p}"
       when %r{^http://search\.(mcpan|cpan)\.org/CPAN/(.*)}i
-        problem "#{p} should be `https://cpan.metacpan.org/#{$2}`"
+        problem "#{p} should be `https://cpan.metacpan.org/#{$1}`"
       when %r{^(http|ftp)://ftp\.gnome\.org/pub/gnome/(.*)}i
         problem "#{p} should be `https://download.gnome.org/#{$2}`"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Explained in the commit messages, but in summary:

* Update `mirrorservice` checks to account for all of `http://*`, `ftp://*` and `http://ftp.*` being accepted there when we universally want to use `https://*`.

* Add a short block to kick people to use HTTP/S over FTP when we know for sure it's available, because FTP is prone to being firewalled to death.

* Minor style tweaks to stop Rubocop yelling at me.

* The rewrote Perl URL checks the other day are causing false positives like:
```
percona-xtrabackup:
  * Stable resource "DBD::mysql": http://search.cpan.org/CPAN/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.033.tar.gz should be `https://cpan.metacpan.org/authors/id/C/CA/CAPTTOFU/DBD-mysql-4.033.tar.gz`
```
Which isn't correct. We don't want to move every single `search.cpan.org` URL onto `metacpan` because  1) Doing so breaks the audit on a chunk of formulae right now, 2) `search.cpan.org` is an intended mirror to the secure `metacpan` URLs.