### PR TITLE
Prefer $stderr over STDERR for consistency

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -86,7 +86,7 @@ class Formulary
     private
 
     def load_file
-      STDERR.puts "#{$0} (#{self.class.name}): loading #{path}" if ARGV.debug?
+      $stderr.puts "#{$0} (#{self.class.name}): loading #{path}" if ARGV.debug?
       raise FormulaUnavailableError.new(name) unless path.file?
       Formulary.load_formula_from_path(name, path)
     end
@@ -199,7 +199,7 @@ class Formulary
     end
 
     def klass
-      STDERR.puts "#{$0} (#{self.class.name}): loading #{path}" if ARGV.debug?
+      $stderr.puts "#{$0} (#{self.class.name}): loading #{path}" if ARGV.debug?
       namespace = "FormulaNamespace#{Digest::MD5.hexdigest(contents)}"
       Formulary.load_formula(name, path, contents, namespace)
     end

--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -20,7 +20,7 @@ module Utils
           return pipe.read
         end
       else
-        STDERR.reopen("/dev/null", "w")
+        $stderr.reopen("/dev/null", "w")
         exec(*args)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Prior to this change there were only 3 instances of `STD(IN|OUT|ERR)` versus 74 instances of `$std(in|out|err)` in the Homebrew code base. The latter variant is also strongly suggested by bbatsov's [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide#global-stdout). In `Library/Homebrew/`:

```
$ ack --nogroup -w 'STD(?:IN|OUT|ERR)' | wc -l
       3
$ ack --nogroup -w '\$std(?:in|out|err)' | wc -l
      74
```

cc @MikeMcQuaid who was sympathetic to this style adjustment a few weeks ago.