### PR TITLE
add integration test for cmd/home

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -552,6 +552,20 @@ class IntegrationCommandTests < Homebrew::TestCase
   def test_home
     assert_equal HOMEBREW_WWW,
                  cmd("home", {"HOMEBREW_BROWSER" => "echo"})
+
+    formula_file = CoreTap.new.formula_dir/"testball.rb"
+    formula_file.write <<-EOS.undent
+      class Testball < Formula
+        desc "Some test"
+        homepage "https://example.com/testball"
+        url "https://example.com/testball-0.1.tar.gz"
+      end
+    EOS
+
+    assert_equal Formula["testball"].homepage,
+                 cmd("home", "testball", {"HOMEBREW_BROWSER" => "echo"})
+  ensure
+    formula_file.unlink
   end
 
   def test_list


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew
![simplecov-home](https://cloud.githubusercontent.com/assets/9170701/15685932/d9b658f4-2722-11e6-8787-a8f96d8fdc57.png)
/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally? **see below**

-----

This change adds a test to assert that a formula's homepage is opened with `brew home foo`. Here's the SimpleCov report showing which line was missed:

![simplecov-home](https://cloud.githubusercontent.com/assets/9170701/15685945/e2934cac-2722-11e6-90ba-804540f961db.png)

`brew tests` passes, but `brew tests --only=integration_cmds/home` raises an error. Rake also aborts (possibly whenever `--only` is used). Error messages are copied below.

I `brew update` regularly and `brew doctor` shows that everything's tip-top. Does anyone have an idea of what the problem may be? Thanks!

```
IntegrationCommandTests#test_home:
NoMethodError: undefined method `[]' for Formula:Class
    /usr/local/Library/Homebrew/test/test_integration_cmds.rb:565:in `test_home'

1 runs, 2 assertions, 0 failures, 1 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -I"lib:/usr/local/Library/Homebrew/test" -
I"/usr/local/Library/Homebrew/test/vendor/bundle/ruby/2.0.0/gems/rake-10.5.0/lib" 
"/usr/local/Library/Homebrew/test/vendor/bundle/ruby/2.0.0/gems/rake-
10.5.0/lib/rake/rake_test_loader.rb" "test_integration_cmds.rb" --name=test_home]
```