### PR TITLE
style: use RuboCop 0.40, fix RuboCop configuration

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -5,111 +5,111 @@ AllCops:
 
 # 1.8-style hash keys
 Style/HashSyntax:
-    EnforcedStyle: hash_rockets
+  EnforcedStyle: hash_rockets
 
 # ruby style guide favorite
 Style/StringLiterals:
-    EnforcedStyle: double_quotes
+  EnforcedStyle: double_quotes
 
 # consistency with above
 Style/StringLiteralsInInterpolation:
-    EnforcedStyle: double_quotes
+  EnforcedStyle: double_quotes
 
 # percent-x is allowed for multiline
 Style/CommandLiteral:
-    EnforcedStyle: mixed
+  EnforcedStyle: mixed
 
 # paths abound, easy escape
 Style/RegexpLiteral:
-    EnforcedStyle: slashes
+  EnforcedStyle: slashes
 
 # our current conditional style is established, clear and
 # requiring users to change that now would be confusing.
 Style/ConditionalAssignment:
-    Enabled: false
+  Enabled: false
 
 # no metrics for formulas
 Metrics/AbcSize:
-    Enabled: false
+  Enabled: false
 Metrics/CyclomaticComplexity:
-    Enabled: false
+  Enabled: false
 Metrics/MethodLength:
-    Enabled: false
+  Enabled: false
 Metrics/ClassLength:
-    Enabled: false
+  Enabled: false
 Metrics/PerceivedComplexity:
-    Enabled: false
+  Enabled: false
 
 # we often need very long lines
 Metrics/LineLength:
-    Enabled: false
+  Enabled: false
 
 # formulas have no mandatory doc
 Style/Documentation:
-    Enabled: false
+  Enabled: false
 
 # favor parens-less DSL-style arguments
 Lint/AmbiguousOperator:
-    Enabled: false
+  Enabled: false
 Lint/AmbiguousRegexpLiteral:
-    Enabled: false
+  Enabled: false
 Lint/AssignmentInCondition:
-    Enabled: false
+  Enabled: false
 Lint/ParenthesesAsGroupedExpression:
-    Enabled: false
+  Enabled: false
 
 # compact style
 Style/EmptyLineBetweenDefs:
-    AllowAdjacentOneLineDefs: true
+  AllowAdjacentOneLineDefs: true
 
 # port numbers and such tech stuff
 Style/NumericLiterals:
-    Enabled: false
+  Enabled: false
 
 # consistency and readability when faced with string interpolation
 Style/PercentLiteralDelimiters:
-    PreferredDelimiters:
-        '%':  '()'
-        '%i': '()'
-        '%q': '()'
-        '%Q': '()'
-        '%r': '{}'
-        '%s': '()'
-        '%w': '[]'
-        '%W': '[]'
-        '%x': '()'
+  PreferredDelimiters:
+    '%':  '()'
+    '%i': '()'
+    '%q': '()'
+    '%Q': '()'
+    '%r': '{}'
+    '%s': '()'
+    '%w': '[]'
+    '%W': '[]'
+    '%x': '()'
 
 # conflicts with DSL-style path concatenation with `/`
 Style/SpaceAroundOperators:
-    Enabled: false
+  Enabled: false
 
 # not a problem for typical shell users
 Style/SpecialGlobalVars:
-    Enabled: false
+  Enabled: false
 
 # `system` is a special case and aligns on second argument
 Style/AlignParameters:
-    Enabled: false
+  Enabled: false
 
 # counterproductive in formulas, notably within the install method
 Style/GuardClause:
-    Enabled: false
+  Enabled: false
 Style/IfUnlessModifier:
-    Enabled: false
+  Enabled: false
 
 # dashes in filenames are typical
 # TODO: enforce when rubocop has fixed this
 # https://github.com/bbatsov/rubocop/issues/1545
 Style/FileName:
-    Enabled: false
+  Enabled: false
 
 # no percent word array, being friendly to non-ruby users
 # TODO: enforce when rubocop has fixed this
 # https://github.com/bbatsov/rubocop/issues/1543
 Style/WordArray:
-    Enabled: false
+  Enabled: false
 Style/UnneededCapitalW:
-    Enabled: false
+  Enabled: false
 
 # we use raise, not fail
 Style/SignalException:

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -47,7 +47,7 @@ module Homebrew
 
   def check_style_impl(files, output_type, options = {})
     fix = options[:fix]
-    Homebrew.install_gem_setup_path! "rubocop", "0.39"
+    Homebrew.install_gem_setup_path! "rubocop", "0.40"
 
     args = %W[
       --force-exclusion


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Aside from bumping the RuboCop version this also unifies indentation in `.rubocop.yml` to two spaces (a bigger chunk was inconsistently indented with four spaces).

When comparing the output of `brew style` for all core formulae, the major difference between 0.39 and 0.40 is the now default-enabled `Style/MultilineArrayBraceLayout` cop. It will complain about, e.g.:

```ruby
args = ["--disable-debug",
        "--disable-dependency-tracking",
        "--prefix=#{prefix}",
        "--mandir=#{man}",
       ]
```

It will stop complaining once this is transformed to (IMO a good idea and worth keeping enabled):

```ruby
args = [
  "--disable-debug",
  "--disable-dependency-tracking",
  "--prefix=#{prefix}",
  "--mandir=#{man}",
]
```