### PR TITLE
formula_installer: accumulate inherited options

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -341,10 +341,10 @@ class FormulaInstaller
   end
 
   def expand_dependencies(deps)
-    inherited_options = {}
+    inherited_options = Hash.new { |hash, key| hash[key] = Options.new }
 
     expanded_deps = Dependency.expand(formula, deps) do |dependent, dep|
-      options = inherited_options[dep.name] = inherited_options_for(dep)
+      inherited_options[dep.name] |= inherited_options_for(dep)
       build = effective_build_options_for(
         dependent,
         inherited_options.fetch(dependent.name, [])
@@ -354,7 +354,7 @@ class FormulaInstaller
         Dependency.prune
       elsif dep.build? && install_bottle_for?(dependent, build)
         Dependency.prune
-      elsif dep.satisfied?(options)
+      elsif dep.satisfied?(inherited_options[dep.name])
         Dependency.skip
       end
     end


### PR DESCRIPTION
When a given dependency appears multiple times in a formula's dependency
tree, the inherited options for that dependency should accumulate rather
than being overwritten each time that dependency is considered by
expand_dependencies. In particular, this impacts "universal" since the
dependency should be built with universal unless all of its instances in
the dependency tree don't have "universal" as opposed to only if the last
instance considered has "universal."

See https://github.com/Homebrew/homebrew-core/issues/1604 for an example
of how the current code can cause build failure.