### PR TITLE
audit: check Maven Central URLs, prefer redirector

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1269,6 +1269,12 @@ class ResourceAuditor
           #{u}
       EOS
     end
+
+    # Check for Maven Central urls, prefer HTTPS redirector over specific host
+    urls.each do |u|
+      next unless u =~ %r{https?://(?:central|repo\d+)\.maven\.org/maven2/(.+)$}
+      problem "#{u} should be `https://search.maven.org/remotecontent?filepath=#{$1}`"
+    end
   end
 
   def problem(text)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Should help with being more consistent and makes sure to suggest the HTTPS redirector even if equally valid HTTP URLs for specific hosts or `central.maven.org` are used.

This has been prompted by the (brief) discussion in Homebrew/homebrew-core#1610. The majority of our core formulae that are downloaded from maven.org already adhere to this adit check. Assuming this is accepted, would it be prudent of me to file a follow-up PR in core that changes the URLs in those formulae that don't adhere to this audit check yet?

cc @DomT4 as the master of `brew audit` checks. :wink: