### PR TITLE
update: tweak stash/checkout behavior.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -124,7 +124,7 @@ reset_on_interrupt() {
     git reset --hard "$INITIAL_REVISION" "${QUIET_ARGS[@]}"
   fi
 
-  if [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" ]]
+  if [[ -n "$HOMEBREW_DEVELOPER" ]]
   then
     pop_stash
   else
@@ -225,10 +225,13 @@ pull() {
 
   trap '' SIGINT
 
-  if [[ -n "$HOMEBREW_DEVELOPER" ]] &&
-     [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" ]]
+  if [[ -n "$HOMEBREW_DEVELOPER" ]]
   then
-    git checkout "${QUIET_ARGS[@]}" "$INITIAL_BRANCH"
+    if [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" ]]
+    then
+      git checkout "$INITIAL_BRANCH"
+    fi
+
     pop_stash
   else
     pop_stash_message


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Always pop stashed changes for Homebrew developers and only checkout original branches for them (to avoid users who don't understand Git ending up "stuck" on branches).

I've been dog fooding `HOMEBREW_AUTO_UPDATE` and this was the last thing that was making it a bit annoying. Other maintainers: after this is merged in some form I suggest setting that variable so you too can try the autoupdate feature and see if there's anything else you think we need to change before 🚢ing it.