### PR TITLE
hardware: prettify config output on 6/8-core CPUs

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -55,6 +55,8 @@ module Hardware
     when 1 then "single"
     when 2 then "dual"
     when 4 then "quad"
+    when 6 then "hexa"
+    when 8 then "octa"
     else
       Hardware::CPU.cores
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Sadly, some of our users (and even maintainers) have to live with a less beautiful `brew config` output:

```
CPU: 8-core 64-bit skylake
```

Others (like me) can enjoy the beauty of transforming the number of cores into a word:

```
CPU: quad-core 64-bit ivybridge
```

This PR fixes this discrepancy for the majority of our users for the foreseeable future.