### PR TITLE
tests: extend cmd/desc integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -323,6 +323,17 @@ class IntegrationCommandTests < Homebrew::TestCase
     EOS
 
     assert_equal "testball: Some test", cmd("desc", "testball")
+    assert_match "Pick one, and only one", cmd_fail("desc", "--search", "--name")
+    assert_match "You must provide a search term", cmd_fail("desc", "--search")
+
+    refute_predicate HOMEBREW_CACHE.join("desc_cache.json"),
+                     :exist?, "Cached file should not exist"
+
+    cmd("desc", "--description", "testball")
+    assert_predicate HOMEBREW_CACHE.join("desc_cache.json"),
+                     :exist?, "Cached file should exist"
+
+    FileUtils.rm HOMEBREW_CACHE.join("desc_cache.json")
   ensure
     formula_file.unlink
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds tests asserting that `brew desc` returns the expected output when run with one flag, with more than one flag, and without an argument.

If anyone has suggestions for improving the code or the formatting, let me know, thanks!