### PR TITLE
update: pop the stash more quietly

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -95,11 +95,13 @@ read_current_revision() {
 
 pop_stash() {
   [[ -z "$STASHED" ]] && return
-  git stash pop "${QUIET_ARGS[@]}"
   if [[ -n "$HOMEBREW_VERBOSE" ]]
   then
+    git stash pop
     echo "Restoring your stashed changes to $DIR:"
     git status --short --untracked-files
+  else
+    git stash pop "${QUIET_ARGS[@]}" 1>/dev/null
   fi
   unset STASHED
 }


### PR DESCRIPTION
git stash pop -q will print "Already up-to-date!" if untracked changes
are being poppped. This quiets it down unless verbose is set.