### PR TITLE
deps.rb: list only unique dependencies

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -125,7 +125,7 @@ module Homebrew
       chr = i == max ? "└──" : "├──"
       puts prefix + "#{chr} :#{req.to_dependency.name}"
     end
-    deps = f.deps.default
+    deps = f.deps.default.uniq
     max = deps.length - 1
     deps.each_with_index do |dep, i|
       chr = i == max ? "└──" : "├──"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [N/A] Have you successfully run `brew tests` with your changes locally?

-----
List only unique dependencies for a package. From [here](https://github.com/Linuxbrew/brew/pull/45)
The example below makes the effect of the patch clear:

Before the patch:
```sh
$ brew deps --tree xapian
xapian (required dependencies)
└── :python
├── xz
└── xz
```
After the patch:
```sh
$ brew deps --tree xapian
xapian (required dependencies)
└── :python
└── xz
```
