### PR TITLE
tests: bypass local GPG signing defaults

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -236,7 +236,7 @@ class IntegrationCommandTests < Homebrew::TestCase
         system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
         FileUtils.touch "readme"
         system "git", "add", "--all"
-        system "git", "commit", "-m", "init"
+        system "git", "commit", "--no-gpg-sign", "-m", "init"
       end
     end
 
@@ -692,7 +692,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     FileUtils.cd HOMEBREW_REPOSITORY do
       shutup do
         system "git", "init"
-        system "git", "commit", "--allow-empty", "-m", "This is a test commit"
+        system "git", "commit", "--allow-empty", "--no-gpg-sign", "-m", "This is a test commit"
       end
     end
     assert_match "This is a test commit", cmd("log")

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -47,7 +47,7 @@ class TapTest < Homebrew::TestCase
         system "git", "init"
         system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
         system "git", "add", "--all"
-        system "git", "commit", "-m", "init"
+        system "git", "commit", "--no-gpg-sign", "-m", "init"
       end
     end
   ensure


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](httxps://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This might be a mildly controversial change, but here's a PR. Explained in the commit summaries, but if you have:

```
[commit]
	gpgsign = true
```

Set in your `.gitconfig` either `brew tests` will hang waiting for your key password, or if you leave `gpg-agent` running with a timeout it'll sign the commits automatically, which isn't particularly desired behaviour.

It's a minor edge case but since it's easy enough to stamp out the change seems harmless. This flag has been supported since 2011, git 1.7.9, so should be safe to adopt unconditionally.

`test_tap` actually fails hard with that config setting in place due to the actual hash deviating from the expected hash.