### PR TITLE
Resource.unpack: install invisible files and dirs

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -98,7 +98,7 @@ class Resource
         yield ResourceStageContext.new(self, staging)
       elsif target
         target = Pathname.new(target) unless target.is_a? Pathname
-        target.install Dir["*"]
+        target.install Pathname.pwd.children
       end
     end
   end


### PR DESCRIPTION
Since patches sometimes change .gitignore and .travis.yml, it's desirable to install them along with everything else if a resource needs patching. Also, for resources that are git respositories, this allows install to interact with git objects other than the commit specifically checked out. More generally, this may help to avoid subtle issues by preserving the fidelity of resources in cases where invisible dot files play a functional role.