### PR TITLE
tests: sanitize env more for consistency

### DIFF
--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -12,18 +12,6 @@ module Homebrew
         FileUtils.rm_f "coverage/.resultset.json"
       end
 
-      # Override author/committer as global settings might be invalid and thus
-      # will cause silent failure during the setup of dummy Git repositories.
-      %w[AUTHOR COMMITTER].each do |role|
-        ENV["GIT_#{role}_NAME"] = "brew tests"
-        ENV["GIT_#{role}_EMAIL"] = "brew-tests@localhost"
-      end
-
-      Homebrew.install_gem_setup_path! "bundler"
-      unless quiet_system("bundle", "check")
-        system "bundle", "install", "--path", "vendor/bundle"
-      end
-
       # Make it easier to reproduce test runs.
       ENV["SEED"] = ARGV.next if ARGV.include? "--seed"
 
@@ -36,18 +24,55 @@ module Homebrew
         args << "TESTOPTS=--name=test_#{test_method}" if test_method
       end
       args += ARGV.named.select { |v| v[/^TEST(OPTS)?=/] }
-      system "bundle", "exec", "rake", "test", *args
 
-      Homebrew.failed = !$?.success?
+      begin
+        sanitize_env!
 
-      if (fs_leak_log = HOMEBREW_LIBRARY/"Homebrew/test/fs_leak_log").file?
-        fs_leak_log_content = fs_leak_log.read
-        unless fs_leak_log_content.empty?
-          opoo "File leak is detected"
-          puts fs_leak_log_content
-          Homebrew.failed = true
+        # Since we "borrow" HOME for duration of tests bundler
+        # needs fetching/installing every run.
+        Homebrew.install_gem_setup_path! "bundler"
+        unless quiet_system("bundle", "check")
+          system "bundle", "install", "--path", "vendor/bundle"
         end
+
+        system "bundle", "exec", "rake", "test", *args
+        Homebrew.failed = !$?.success?
+
+        if (fs_leak_log = HOMEBREW_LIBRARY/"Homebrew/test/fs_leak_log").file?
+          fs_leak_log_content = fs_leak_log.read
+          unless fs_leak_log_content.empty?
+            opoo "File leak is detected"
+            puts fs_leak_log_content
+            Homebrew.failed = true
+          end
+        end
+      ensure
+        ENV["HOME"] = @old_home
+        # For the sake of safety, ensure @env_home actually resides in
+        # HOMEBREW_TEMP before trying to remove this directory.
+        FileUtils.rm_r @env_home if @env_home.dirname == HOMEBREW_TEMP
       end
     end
+  end
+
+  def sanitize_env!
+    # Override author/committer as global settings might be invalid and thus
+    # will cause silent failure during the setup of dummy Git repositories.
+    %w[AUTHOR COMMITTER].each do |role|
+      ENV["GIT_#{role}_NAME"] = "brew tests"
+      ENV["GIT_#{role}_EMAIL"] = "brew-tests@localhost"
+    end
+
+    # Variables possibly set in git configuration files can cause deviations
+    # from expected hashes of tests & cause them to fail. To ensure
+    # predictability ignore those.
+    ENV.delete("GITCONFIG")
+    ENV["GIT_CONFIG_NOSYSTEM"] = "1"
+
+    # Ensure tests are run from a temporary HOME so user configuration
+    # files, such as ~/.gitconfig, are ignored for consistency.
+    @old_home = ENV["HOME"]
+    @env_home = ENV["HOME"] = Pathname.new(Dir.mktmpdir("tests", HOMEBREW_TEMP))
+    ENV["HOME"] = @env_home
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Ensures that like we do for formulae install & test processes we "borrow" the `$HOME` env to ensure consistency for the duration of `tests`. Comments above the changes in the file explain the rest, really.

Testing with `puts` shows things are being set as expected:

```
BEFORE_TESTS = /Users/Dominyk

==> Installing or updating 'bundler' gem
Fetching: bundler-1.12.5.gem (100%)
Successfully installed bundler-1.12.5
1 gem installed

DURING_TESTS = /tmp/tests20160607-26482-1w5ubie

Finished in 46.985927s, 18.1969 runs/s, 44.3750 assertions/s.

855 runs, 2085 assertions, 0 failures, 0 errors, 0 skips
AFTER_ENSURE = /Users/Dominyk
```

Checked with a deliberate failure to ensure it still fails as expected, which it does:
```
  1) Failure:
TapTest#test_git_variant [/usr/local/Library/Homebrew/test/test_tap.rb:155]:
--- expected
+++ actual
@@ -1 +1 @@
-"e1893a6bd191ba895c71b652ff8376a6114c7fa6"
+"e1893a6bd191ba895c71b652ff8376a6114c7fa7"
```

Alternative to https://github.com/Homebrew/brew/pull/324.