### PR TITLE
tests: extend cmd/log integration test

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -919,8 +919,8 @@ class FormulaAuditor
         problem "Use \#{pkgshare} instead of \#{share}/#{formula.name}"
       end
 
-      if line =~ %r{share/"#{Regexp.escape(formula.name)}[/'"]}
-        problem "Use pkgshare instead of (share/\"#{formula.name}\")"
+      if line =~ %r{share(\s*[/+]\s*)(['"])#{Regexp.escape(formula.name)}(?:\2|/)}
+        problem "Use pkgshare instead of (share#{$1}\"#{formula.name}\")"
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds test coverage for [`brew log foo`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/log.rb#L12-L15).

I still haven't figured out how to test [these lines of `cmd/log.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/log.rb#L23-L25). Would it actually be OK to write a `/.git/shallow` file to both `HOMEBREW_REPOSITORY` and the `homebrew-core` tap and then test that the message is output?
