### PR TITLE
Don't ask `xcrun` for output if no CLT is installed

### DIFF
--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -137,7 +137,8 @@ export HOMEBREW_USER_AGENT_CURL
 
 if [[ -n "$HOMEBREW_OSX" ]]
 then
-  if [[ "$('/usr/bin/xcode-select' --print-path)" = "/" ]]
+  XCODE_SELECT_PATH=$('/usr/bin/xcode-select' --print-path 2>/dev/null)
+  if [[ "$XCODE_SELECT_PATH" = "/" ]]
   then
     odie <<EOS
 Your xcode-select path is currently set to '/'.
@@ -149,15 +150,20 @@ Otherwise, you should:
 EOS
   fi
 
-  XCRUN_OUTPUT="$(/usr/bin/xcrun clang 2>&1)"
-  XCRUN_STATUS="$?"
-
-  if [[ "$XCRUN_STATUS" -ne 0 && "$XCRUN_OUTPUT" = *license* ]]
+  # Don't check xcrun if Xcode and the CLT aren't installed, as that opens
+  # a popup window asking the user to install the CLT
+  if [[ -n "$XCODE_SELECT_PATH" ]]
   then
-    odie <<EOS
+    XCRUN_OUTPUT="$(/usr/bin/xcrun clang 2>&1)"
+    XCRUN_STATUS="$?"
+
+    if [[ "$XCRUN_STATUS" -ne 0 && "$XCRUN_OUTPUT" = *license* ]]
+    then
+      odie <<EOS
 You have not agreed to the Xcode license. Please resolve this by running:
   sudo xcodebuild -license
 EOS
+    fi
   fi
 fi
 


### PR DESCRIPTION
This change checks for empty output from `xcode-select --print-path`, (and redirects `STDERR` to `/dev/null`), forgoing any `xcrun` invocations in `brew.sh` if the output is empty.

Empty output from `xcode-select --print-path` is due to no CLT or Xcode being installed on the users machine, as seen in [this analogous ruby code](https://github.com/Homebrew/brew/blob/master/Library/ENV/scm/git#L49-L54).  Running `xcrun` when no CLT is installed causes the following popup window to appear:

<img width="317" alt="xcrun" src="https://cloud.githubusercontent.com/assets/130920/15876331/bb7893ee-2cc1-11e6-8dba-056fd38087cb.png">

`STDERR` is redirected to `/dev/null` to avoid the following message being output to the console during `brew` operations:

```
xcode-select: error: unable to get active developer directory, use `xcode-select --switch` to set one (or see `man xcode-select`)
```

