### PR TITLE
introduce global lock directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /Library/Homebrew/test/coverage
 /Library/Homebrew/test/fs_leak_log
 /Library/LinkedKegs
+/Library/Locks
 /Library/PinnedKegs
 /Library/PinnedTaps
 /Library/Taps

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -106,9 +106,9 @@ module Homebrew
     end
 
     def self.cleanup_lockfiles
-      return unless HOMEBREW_CACHE_FORMULA.directory?
-      candidates = HOMEBREW_CACHE_FORMULA.children
-      lockfiles  = candidates.select { |f| f.file? && f.extname == ".brewing" }
+      return unless HOMEBREW_LOCK_DIR.directory?
+      candidates = HOMEBREW_LOCK_DIR.children
+      lockfiles  = candidates.select(&:file?)
       lockfiles.each do |file|
         next unless file.readable?
         file.open.flock(File::LOCK_EX | File::LOCK_NB) && file.unlink

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -1,7 +1,7 @@
 HOMEBREW_CACHE = Pathname.new(ENV["HOMEBREW_CACHE"] || "~/Library/Caches/Homebrew").expand_path
 
 # Where brews installed via URL are cached
-HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE+"Formula"
+HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE/"Formula"
 
 if ENV["HOMEBREW_BREW_FILE"]
   HOMEBREW_BREW_FILE = Pathname.new(ENV["HOMEBREW_BREW_FILE"])
@@ -18,6 +18,9 @@ HOMEBREW_REPOSITORY = Pathname.new(ENV["HOMEBREW_REPOSITORY"])
 HOMEBREW_LIBRARY = Pathname.new(ENV["HOMEBREW_LIBRARY"])
 HOMEBREW_ENV_PATH = HOMEBREW_LIBRARY/"ENV"
 HOMEBREW_CONTRIB = HOMEBREW_REPOSITORY/"Library/Contributions"
+
+# Where we store lock files
+HOMEBREW_LOCK_DIR = HOMEBREW_LIBRARY/"Locks"
 
 # Where we store built products
 HOMEBREW_CELLAR = Pathname.new(ENV["HOMEBREW_CELLAR"])

--- a/Library/Homebrew/formula_lock.rb
+++ b/Library/Homebrew/formula_lock.rb
@@ -1,7 +1,7 @@
 require "fcntl"
 
 class FormulaLock
-  LOCKDIR = HOMEBREW_CACHE_FORMULA
+  LOCKDIR = HOMEBREW_LOCK_DIR
 
   def initialize(name)
     @name = name

--- a/Library/Homebrew/test/lib/config.rb
+++ b/Library/Homebrew/test/lib/config.rb
@@ -18,6 +18,7 @@ HOMEBREW_ENV_PATH      = HOMEBREW_LIBRARY_PATH.parent+"ENV"
 HOMEBREW_LOAD_PATH     = [File.expand_path("..", __FILE__), HOMEBREW_LIBRARY_PATH].join(":")
 HOMEBREW_CACHE         = HOMEBREW_PREFIX.parent+"cache"
 HOMEBREW_CACHE_FORMULA = HOMEBREW_PREFIX.parent+"formula_cache"
+HOMEBREW_LOCK_DIR      = HOMEBREW_PREFIX.parent+"locks"
 HOMEBREW_CELLAR        = HOMEBREW_PREFIX.parent+"cellar"
 HOMEBREW_LOGS          = HOMEBREW_PREFIX.parent+"logs"
 

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -7,7 +7,7 @@ require "formulary"
 
 # Test environment setup
 (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-core/Formula").mkpath
-%w[cache formula_cache cellar logs].each { |d| HOMEBREW_PREFIX.parent.join(d).mkpath }
+%w[cache formula_cache locks cellar logs].each { |d| HOMEBREW_PREFIX.parent.join(d).mkpath }
 
 # Test fixtures and files can be found relative to this path
 TEST_DIRECTORY = File.dirname(File.expand_path(__FILE__))

--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -3,7 +3,9 @@
 # Noted due to the fixed FD, a shell process can only create one lock.
 lock() {
   local name="$1"
-  local lock_file="/tmp/homebrew${HOMEBREW_REPOSITORY//\//-}-${name}.lock"
+  local lock_dir="$HOMEBREW_LIBRARY/Locks"
+  local lock_file="$lock_dir/$name"
+  [[ -d "$lock_dir" ]] || mkdir -p "$lock_dir"
   # 200 is the file descriptor used in the lock.
   # This FD should be used exclusively for lock purpose.
   # Any value except 0(stdin), 1(stdout) and 2(stderr) can do the job.


### PR DESCRIPTION
Since #292, HOMEBREW_CACHE was moved to a per-user directory. This makes
it unsuitable to store global lock files on multiple users environment.

Therefore, introducing a global lock directory `/Library/Lock.d` to
store lock files from formula lockers as well as `brew update`.