### PR TITLE
Remove duplicate "a" in "must be built from source" error

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -400,7 +400,7 @@ class BuildToolsError < RuntimeError
     super <<-EOS.undent
       The following #{formula_text}:
         #{formulae.join(", ")}
-      cannot be installed as a #{package_text} and must be built from source.
+      cannot be installed as #{package_text} and must be built from source.
       #{xcode_text}
     EOS
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). -- No, are there tests for error messages?
- [ ] Have you successfully run `brew tests` with your changes locally? -- No, I'm making this PR from the github web interface.

-----

otherwise would get "cannot be installed as a a binary package"
since `package_text` contains "a binary package" in the singular case