### PR TITLE
Add `"build_dependencies"` key to JSON output

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1256,6 +1256,7 @@ class Formula
       "dependencies" => deps.map(&:name).uniq,
       "recommended_dependencies" => deps.select(&:recommended?).map(&:name).uniq,
       "optional_dependencies" => deps.select(&:optional?).map(&:name).uniq,
+      "build_dependencies" => deps.select(&:build?).map(&:name).uniq,
       "conflicts_with" => conflicts.map(&:name),
       "caveats" => caveats
     }


### PR DESCRIPTION
This gives the JSON output the same type of information as `recommended_dependencies` or `optional_dependencies`, but for those marked `:build` in the formula.

Example output before this change:
```
$ brew info --json=v1 mbedtls | jq '.[0].build_dependencies'
null
```

Example output after this change:
```
$ brew info --json=v1 mbedtls | jq '.[0].build_dependencies'
[
  "cmake"
]
```

As an example usecase, this is useful for [`Homebrew.jl`](https://github.com/JuliaLang/Homebrew.jl) when traversing dependency trees to tell the difference between something that must be installed for runtime needs vs. something that can be ignored when installing only bottles.