### PR TITLE
test-bot: strip additional invalid XML chars under Ruby 1.8.7

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -1001,7 +1001,9 @@ module Homebrew
         invalid_xml_pat = /[\x00-\x08\x0B\x0C\x0E-\x1F\uFFFE\uFFFF]/
         output = output.gsub(invalid_xml_pat, "\uFFFD")
       else
-        output = output.delete("\000\a\b\e\f\x2\x1f")
+        # Invalid XML chars, as far as single-byte chars go
+        output = output.delete("\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f" \
+          "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f")
       end
 
       # Truncate to 1MB to avoid hitting CI limits


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Works some additional rare characters in build/test output which may break the JSON encapsulation of `test-bot`.

Fixes breakage encountered by Homebrew/homebrew-core#1700

I've replaced all the original `\a`, `\b`, `\e`, and similar escape codes with hex ASCII escapes, which I think makes this makes more readable in the context of a longer sequence of character codes.