### PR TITLE
Add helper class for Python virtualenvs

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -1,4 +1,5 @@
 require "utils"
+require "language/python_virtualenv_constants"
 
 module Language
   module Python
@@ -96,5 +97,135 @@ module Language
     def self.package_available?(python, module_name)
       quiet_system python, "-c", "import #{module_name}"
     end
-  end
-end
+
+    # Mixin module for {Formula} adding virtualenv support features.
+    module Virtualenv
+      def self.included(base)
+        base.class_eval do
+          resource "homebrew-virtualenv" do
+            url PYTHON_VIRTUALENV_URL
+            sha256 PYTHON_VIRTUALENV_SHA256
+          end
+        end
+      end
+
+      # Instantiates, creates, and yields a {Virtualenv} object for use from
+      # Formula#install, which provides helper methods for instantiating and
+      # installing packages into a Python virtualenv.
+      # @param venv_root [Pathname, String] the path to the root of the virtualenv
+      #   (often `libexec/"venv"`)
+      # @param python [String] which interpreter to use (e.g. "python"
+      #   or "python3")
+      # @param formula [Formula] the active Formula
+      # @return [Virtualenv] a {Virtualenv} instance
+      def virtualenv_create(venv_root, python = "python", formula = self)
+        venv = Virtualenv.new formula, venv_root, python
+        venv.create
+        venv
+      end
+
+      # Helper method for the common case of installing a Python application.
+      # Creates a virtualenv in `libexec`, installs all `resource`s defined
+      # on the formula, and then installs the formula.
+      def virtualenv_install_with_resources
+        venv = virtualenv_create(libexec)
+        venv.pip_install resources
+        venv.link_scripts(bin) { venv.pip_install buildpath }
+        venv
+      end
+
+      # Convenience wrapper for creating and installing packages into Python
+      # virtualenvs.
+      class Virtualenv
+        # Initializes a Virtualenv instance. This does not create the virtualenv
+        # on disk; {#create} does that.
+        # @param formula [Formula] the active Formula
+        # @param venv_root [Pathname, String] the path to the root of the
+        #   virtualenv
+        # @param python [String] which interpreter to use; i.e. "python" or
+        #   "python3"
+        def initialize(formula, venv_root, python)
+          @formula = formula
+          @venv_root = Pathname.new(venv_root)
+          @python = python
+        end
+
+        # Obtains a copy of the virtualenv library and creates a new virtualenv
+        # on disk.
+        # @return [void]
+        def create
+          return if (@venv_root/"bin/python").exist?
+
+          @formula.resource("homebrew-virtualenv").stage do |stage|
+            old_pythonpath = ENV.delete "PYTHONPATH"
+            begin
+              xy = Language::Python.major_minor_version(@python)
+              staging = Pathname.new(stage.staging.tmpdir)
+              ENV.prepend_create_path "PYTHONPATH", staging/"target/lib/python#{xy}/site-packages"
+              @formula.system @python, *Language::Python.setup_install_args(staging/"target")
+              @formula.system @python, "-s", staging/"target/bin/virtualenv", "-p", @python, @venv_root
+            ensure
+              ENV["PYTHONPATH"] = old_pythonpath
+            end
+          end
+
+          # Robustify symlinks to survive python3 patch upgrades
+          @venv_root.find do |f|
+            next unless f.symlink?
+            if (rp = f.realpath.to_s).start_with? HOMEBREW_CELLAR
+              python = rp.include?("python3") ? "python3" : "python"
+              new_target = rp.sub %r{#{HOMEBREW_CELLAR}/#{python}/[^/]+}, Formula[python].opt_prefix
+              f.unlink
+              f.make_symlink new_target
+            end
+          end
+        end
+
+        # Installs packages represented by `targets` into the virtualenv.
+        # @param targets [String, Pathname, Resource,
+        #   Array<String, Pathname, Resource>] (A) token(s) passed to pip
+        #   representing the object to be installed. This can be a directory
+        #   containing a setup.py, a {Resource} which will be staged and
+        #   installed, or a package identifier to be fetched from PyPI.
+        #   Multiline strings are allowed and treated as though they represent
+        #   the contents of a `requirements.txt`.
+        # @return [void]
+        def pip_install(targets)
+          targets = [targets] unless targets.is_a? Array
+          targets.each do |t|
+            if t.respond_to? :stage
+              next if t.name == "homebrew-virtualenv"
+              t.stage { do_install Pathname.pwd }
+            else
+              t = t.lines.map(&:strip) if t.respond_to?(:lines) && t =~ /\n/
+              do_install t
+            end
+          end
+        end
+
+        # Compares the venv bin directory before and after executing a block,
+        # and symlinks any new scripts into `destination`.
+        # Use like: venv.link_scripts(bin) { venv.pip_install my_package }
+        # @param destination [Pathname, String] Destination into which new
+        #   scripts should be linked.
+        # @return [void]
+        def link_scripts(destination)
+          bin_before = Dir[@venv_root/"bin/*"].to_set
+          yield
+          bin_after = Dir[@venv_root/"bin/*"].to_set
+          destination = Pathname.new(destination)
+          destination.install_symlink((bin_after - bin_before).to_a)
+        end
+
+        private
+
+        def do_install(targets)
+          targets = [targets] unless targets.is_a? Array
+          @formula.system @venv_root/"bin/pip", "install",
+                 "-v", "--no-deps", "--no-binary", ":all:",
+                 *targets
+        end
+      end # class Virtualenv
+    end # module Virtualenv
+  end # module Python
+end # module Language

--- a/Library/Homebrew/language/python_virtualenv_constants.rb
+++ b/Library/Homebrew/language/python_virtualenv_constants.rb
@@ -1,0 +1,2 @@
+PYTHON_VIRTUALENV_URL = "https://files.pythonhosted.org/packages/5c/79/5dae7494b9f5ed061cff9a8ab8d6e1f02db352f3facf907d9eb614fb80e9/virtualenv-15.0.2.tar.gz"
+PYTHON_VIRTUALENV_SHA256 = "fab40f32d9ad298fba04a260f3073505a16d52539a84843cf8c8369d4fd17167"

--- a/Library/Homebrew/test/test_language_python.rb
+++ b/Library/Homebrew/test/test_language_python.rb
@@ -1,0 +1,88 @@
+require "testing_env"
+require "language/python"
+require "resource"
+
+class LanguagePythonTests < Homebrew::TestCase
+  def setup
+    @dir = Pathname.new(mktmpdir)
+    resource = stub("resource", :stage => true)
+    @formula = mock("formula") do
+      stubs(:resource).returns(resource)
+    end
+    @venv = Language::Python::Virtualenv::Virtualenv.new(@formula, @dir, "python")
+  end
+
+  def teardown
+    FileUtils.rm_rf @dir
+  end
+
+  def test_virtualenv_creation
+    @formula.expects(:resource).with("homebrew-virtualenv").returns(
+      mock("resource", :stage => true)
+    )
+    @venv.create
+  end
+
+  # or at least doesn't crash the second time
+  def test_virtualenv_creation_is_idempotent
+    @formula.expects(:resource).with("homebrew-virtualenv").returns(
+      mock("resource", :stage => true)
+    )
+    @venv.create
+    FileUtils.mkdir_p @dir/"bin"
+    FileUtils.touch @dir/"bin/python"
+    @venv.create
+    FileUtils.rm @dir/"bin/python"
+  end
+
+  def test_pip_install_accepts_string
+    @formula.expects(:system).returns(true).with do |*params|
+      params.first == @dir/"bin/pip" && params.last == "foo"
+    end
+    @venv.pip_install "foo"
+  end
+
+  def test_pip_install_accepts_multiline_string
+    @formula.expects(:system).returns(true).with do |*params|
+      params.first == @dir/"bin/pip" && params[-2..-1] == ["foo", "bar"]
+    end
+    @venv.pip_install <<-EOS.undent
+      foo
+      bar
+    EOS
+  end
+
+  def test_pip_install_accepts_array
+    @formula.expects(:system).returns(true).with do |*params|
+      params.first == @dir/"bin/pip" && params.last == "foo"
+    end
+    @formula.expects(:system).returns(true).with do |*params|
+      params.first == @dir/"bin/pip" && params.last == "bar"
+    end
+    @venv.pip_install ["foo", "bar"]
+  end
+
+  def test_pip_install_accepts_resource
+    res = Resource.new "test"
+    res.expects(:stage).yields(nil)
+    @formula.expects(:system).returns(true).with do |*params|
+      params.first == @dir/"bin/pip" && params.last == Pathname.pwd
+    end
+    @venv.pip_install res
+  end
+
+  def test_link_scripts_links_scripts
+    bin = (@dir/"bin")
+    dest = (@dir/"dest")
+    bin.mkpath
+    refute((bin/"kilroy").exist?)
+    refute((dest/"kilroy").exist?)
+    FileUtils.touch bin/"irrelevant"
+    @venv.link_scripts(dest) { FileUtils.touch bin/"kilroy" }
+    assert((bin/"kilroy").exist?)
+    assert((dest/"kilroy").exist?)
+    assert((dest/"kilroy").symlink?)
+    assert_equal((bin/"kilroy").realpath, (dest/"kilroy").realpath)
+    refute((dest/"irrelevant").exist?)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR proposes a new class for interacting with Python virtualenvs which enables a new way to write formulas for Python applications. 

This approach resolves a few problems with the existing approach:
* UX: Installing applications with this method yields [clearer and much less code](https://gist.github.com/tdsmith/cf2ef71adae2718075fef17bd9f6d938) than [the current method](https://github.com/Homebrew/homebrew-core/blob/master/Formula/jrnl.rb#L52-L65). If we trust pip to talk to pypi, we can pass a list of requirements instead of using resources, which means [even less code](https://gist.github.com/f9e83e9ce66fa19349ac711b1c170462).
* Functional: In order that installing an application which uses Python packages does not disturb the global Python environment, we presently install packages and their dependencies into a Cellar-only prefix and write wrapper scripts that set PYTHONPATH to help Python find the installed tools. This generally works, with caveats. One is that namespace packages don't work very well, requiring formula authors to add `touch foo/"__init__.py"` manually. Another is PYTHONPATH propagates to child processes, which makes it difficult for a script installed with python2 to launch another script written in python3, since the Python 2 packages in PYTHONPATH may be incompatible. This has been a problem for e.g. Ansible. Virtualenvs do not have either problem.

This is functionally similar to [pipsi](https://github.com/mitsuhiko/pipsi). I expect this approach to work in general but I'll plan to ask some people in the Python packaging community for review.

Some highlights for review:
* Where is the right place to store the virtualenv package's URL and hash? Should we just package a tarball in the Homebrew repository?
* Is the hack I'm using to make sure that pip is invoked with `Formula#system` appropriate? I don't really like separating Virtualenv#create! from Virtualenv#initialize but we need an opportunity to monkeypatch the singleton class. :p I think I like this better than teaching the Virtualenv class about formula objects because they don't otherwise interact. Should this happen in Language::Python or is it more logical to write a `Formula#python_virtualenv` method that handles the hackery?
* Can we usefully define tests for this class? (An example would be helpful!)
* Does this belong in the evolution process?

Some work to do:
* Make sure we do what we can to ensure that these don't break on revision or patch-level bumps for python3 virtualenvs -- python2 virtualenvs should be created against system Python and should be rock-solid

Thoughts welcome!