### PR TITLE
tests: avoid compat code in --no-compat mode

### DIFF
--- a/Library/Homebrew/test/test_formula_installer.rb
+++ b/Library/Homebrew/test/test_formula_installer.rb
@@ -1,6 +1,5 @@
 require "testing_env"
 require "formula"
-require "compat/formula_specialties"
 require "formula_installer"
 require "keg"
 require "tab"

--- a/Library/Homebrew/test/test_formula_installer_bottle.rb
+++ b/Library/Homebrew/test/test_formula_installer_bottle.rb
@@ -1,6 +1,5 @@
 require "testing_env"
 require "formula"
-require "compat/formula_specialties"
 require "formula_installer"
 require "keg"
 require "tab"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Simply drop because the `require`s are not actually used by the tests and no file from `compat/` should be loaded unconditionally. (This can otherwise lead to incorrect results for `brew tests --no-compat`.)

cc @eirinikos because you might be interested in PRs that touch test-related code.