### PR TITLE
ENV: mark gcc-6 as supporting C++11

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -322,4 +322,9 @@ module SharedEnvExtension
       raise "Non-Apple GCC can't build universal binaries"
     end
   end
+
+  def gcc_with_cxx11_support?(cc)
+    version = cc[/^gcc-(\d+(?:\.\d+)?)$/, 1]
+    version && Version.new(version) >= Version.new("4.8")
+  end
 end

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -287,7 +287,7 @@ module Stdenv
     if compiler == :clang
       append "CXX", "-std=c++11"
       append "CXX", "-stdlib=libc++"
-    elsif compiler =~ /gcc-(4\.(8|9)|5)/
+    elsif gcc_with_cxx11_support?(compiler)
       append "CXX", "-std=c++11"
     else
       raise "The selected compiler doesn't support C++11: #{compiler}"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -303,11 +303,10 @@ module Superenv
   end
 
   def cxx11
-    case homebrew_cc
-    when "clang"
+    if homebrew_cc == "clang"
       append "HOMEBREW_CCCFG", "x", ""
       append "HOMEBREW_CCCFG", "g", ""
-    when /gcc-(4\.(8|9)|5)/
+    elsif gcc_with_cxx11_support?(homebrew_cc)
       append "HOMEBREW_CCCFG", "x", ""
     else
       raise "The selected compiler doesn't support C++11: #{homebrew_cc}"

--- a/Library/Homebrew/test/test_ENV.rb
+++ b/Library/Homebrew/test/test_ENV.rb
@@ -141,4 +141,33 @@ class SuperenvTests < Homebrew::TestCase
     assert_equal [], @env.deps
     assert_equal [], @env.keg_only_deps
   end
+
+  def test_unsupported_cxx11
+    %w[gcc gcc-4.7].each do |compiler|
+      @env["HOMEBREW_CC"] = compiler
+      assert_raises do
+        @env.cxx11
+      end
+      refute_match "x", @env["HOMEBREW_CCCFG"]
+    end
+  end
+
+  def test_supported_cxx11_gcc_5
+    @env["HOMEBREW_CC"] = "gcc-5"
+    @env.cxx11
+    assert_match "x", @env["HOMEBREW_CCCFG"]
+  end
+
+  def test_supported_cxx11_gcc_6
+    @env["HOMEBREW_CC"] = "gcc-6"
+    @env.cxx11
+    assert_match "x", @env["HOMEBREW_CCCFG"]
+  end
+
+  def test_supported_cxx11_clang
+    @env["HOMEBREW_CC"] = "clang"
+    @env.cxx11
+    assert_match "x", @env["HOMEBREW_CCCFG"]
+    assert_match "g", @env["HOMEBREW_CCCFG"]
+  end
 end


### PR DESCRIPTION
- [✓] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [✓] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [✓] Have you added an explanation of what your changes do and why you'd like us to include them?
- [✕] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [✕] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds gcc-6 (installed via `brew`) to the list of C++11 supporting compilers. Addresses https://github.com/Homebrew/brew/issues/346 and adds to the work done as part of https://github.com/Homebrew/brew/pull/163.

I'll put together tests once I've had a look at where it would be best to integrate - any suggestions helpful! :D