### PR TITLE
config: expose Git version and path

### DIFF
--- a/Library/ENV/scm/git
+++ b/Library/ENV/scm/git
@@ -23,6 +23,10 @@ def exec(*args)
   # prevent fork-bombs
   arg0 = args.first
   return if arg0 =~ /^#{F}/i || Pathname.new(arg0).realpath == SELF_REAL
+  if ARGV == %w[--homebrew=print-path]
+    puts arg0
+    exit
+  end
   super
 end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -743,15 +743,15 @@ module Homebrew
         EOS
       end
 
-      def __check_git_version
+      def check_git_version
         # https://help.github.com/articles/https-cloning-errors
-        `git --version`.chomp =~ /git version ((?:\d+\.?)+)/
-        return unless $1 && Version.new($1) < Version.new("1.7.10")
+        return unless Utils.git_available?
+        return unless Version.new(Utils.git_version) < Version.new("1.7.10")
 
         git = Formula["git"]
         git_upgrade_cmd = git.any_version_installed? ? "upgrade" : "install"
         <<-EOS.undent
-          An outdated version of Git was detected in your PATH.
+          An outdated version (#{Utils.git_version}) of Git was detected in your PATH.
           Git 1.7.10 or newer is required to perform checkouts over HTTPS from GitHub.
           Please upgrade:
             brew #{git_upgrade_cmd} git
@@ -759,16 +759,14 @@ module Homebrew
       end
 
       def check_for_git
-        if Utils.git_available?
-          __check_git_version
-        else
-          <<-EOS.undent
-            Git could not be found in your PATH.
-            Homebrew uses Git for several internal functions, and some formulae use Git
-            checkouts instead of stable tarballs. You may want to install Git:
-              brew install git
-          EOS
-        end
+        return if Utils.git_available?
+
+        <<-EOS.undent
+          Git could not be found in your PATH.
+          Homebrew uses Git for several internal functions, and some formulae use Git
+          checkouts instead of stable tarballs. You may want to install Git:
+            brew install git
+        EOS
       end
 
       def check_git_newline_settings

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -107,6 +107,11 @@ class SystemConfig
       javas.uniq.join(", ")
     end
 
+    def describe_git
+      return "N/A" unless Utils.git_available?
+      "#{Utils.git_version} => #{Utils.git_path}"
+    end
+
     def dump_verbose_config(f = $stdout)
       f.puts "HOMEBREW_VERSION: #{HOMEBREW_VERSION}"
       f.puts "ORIGIN: #{origin}"
@@ -127,6 +132,7 @@ class SystemConfig
       f.puts "GCC-4.0: build #{gcc_40}" if gcc_40
       f.puts "GCC-4.2: build #{gcc_42}" if gcc_42
       f.puts "Clang: #{clang ? "#{clang} build #{clang_build}" : "N/A"}"
+      f.puts "Git: #{describe_git}"
       f.puts "Perl: #{describe_perl}"
       f.puts "Python: #{describe_python}"
       f.puts "Ruby: #{describe_ruby}"

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -4,6 +4,20 @@ module Utils
     @git = quiet_system HOMEBREW_ENV_PATH/"scm/git", "--version"
   end
 
+  def self.git_path
+    return unless git_available?
+    @git_path ||= Utils.popen_read(
+      HOMEBREW_ENV_PATH/"scm/git", "--homebrew=print-path"
+    ).chuzzle
+  end
+
+  def self.git_version
+    return unless git_available?
+    @git_version ||= Utils.popen_read(
+      HOMEBREW_ENV_PATH/"scm/git", "--version"
+    ).chomp[/git version (\d+(?:\.\d+)*)/, 1]
+  end
+
   def self.ensure_git_installed!
     return if git_available?
 
@@ -25,5 +39,7 @@ module Utils
 
   def self.clear_git_available_cache
     remove_instance_variable(:@git) if instance_variable_defined?(:@git)
+    @git_path = nil
+    @git_version = nil
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A working and somewhat up-to-date Git is central to a working Homebrew installation. This exposes the current Git version and which `git` binary will actually be called by the `Library/ENV/scm/git` wrapper that is used for invoking Git in all of Homebrew. The lookup logic is a bit involved, so this adds a level of transparency difficult to achieve by asking users for their `PATH` and various other information from their environment. The lookup logic is (copied from #330, first match wins):

1. If `HOMEBREW_GIT` is set in the environment, try that.
2. If `GIT` is set in the environment, try that.
3. If the `git` formula is installed, try that.
4. Iterate over all `git` binaries in `PATH`, but exclude `/usr/bin/git` because it might be a non-functional popup stub if neither Xcode nor Command Line Tools are installed.
5. Try locating a `git` binary using `xcrun -find git`.
6. Try using `git` from Xcode if it is installed in `/Applications/Xcode.app`.
7. Try `/usr/bin/git` if all else failed and we're sure it's not a popup stub.
8. Give up.

This PR doesn't change (and doesn't intend to change) the lookup logic as suggested in https://github.com/Homebrew/brew/issues/330#issuecomment-225430965. That's something for a separate PR, though the `brew config` output added here and the supporting code may help make such a PR in the future.

(This would have tremendously helped with debugging the issue in #330 experienced by two users.)