### PR TITLE
tests: add cmd/search integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -797,4 +797,41 @@ class IntegrationCommandTests < Homebrew::TestCase
         cmd(cmd, {"PATH" => "#{path}#{File::PATH_SEPARATOR}#{ENV["PATH"]}"})
     end
   end
+
+  def test_search
+    formula_file = CoreTap.new.formula_dir/"testball.rb"
+    formula_file.write <<-EOS.undent
+      class Testball < Formula
+        desc "Some test"
+        url "https://example.com/testball-0.1.tar.gz"
+      end
+    EOS
+
+    desc_cache = HOMEBREW_CACHE/"desc_cache.json"
+    refute_predicate desc_cache, :exist?, "Cached file should not exist"
+
+    assert_match "testball", cmd("search")
+    assert_match "testball", cmd("search", "testball")
+    assert_match "testball", cmd("search", "homebrew/homebrew-core/testball")
+    assert_match "testball", cmd("search", "--desc", "Some test")
+
+    flags = {
+      "macports" => "https://www.macports.org/ports.php?by=name&substr=testball",
+      "fink" => "http://pdb.finkproject.org/pdb/browse.php?summary=testball",
+      "debian" => "https://packages.debian.org/search?keywords=testball&searchon=names&suite=all&section=all",
+      "opensuse" => "https://software.opensuse.org/search?q=testball",
+      "fedora" => "https://admin.fedoraproject.org/pkgdb/packages/%2Atestball%2A/",
+      "ubuntu" => "http://packages.ubuntu.com/search?keywords=testball&searchon=names&suite=all&section=all",
+    }
+
+    flags.each do |flag, url|
+      assert_equal url, cmd("search", "--#{flag}",
+        "testball", "HOMEBREW_BROWSER" => "echo")
+    end
+
+    assert_predicate desc_cache, :exist?, "Cached file should exist"
+  ensure
+    desc_cache.unlink
+    formula_file.unlink
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds test coverage to `cmd/search.rb` (though coverage isn't yet complete).

I'm having trouble understanding how to test [these lines](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/search.rb#L64-L96) in `search.rb`... not as straightforward as I'd assumed, but I'll try again tomorrow.

**Re: testing for the `--macports`, `--fink`, etc. flags**
The URLs are long enough to need wrapping. But separating strings with `\` and a newline seems to raise an error (due to the indentation on the newline). String concatenation doesn't seem ideal, either. Is there a better way? And would it be better to bypass the hash iteration and just have an assertion for each flag?