### PR TITLE
tests: add test bottle for Sierra

### DIFF
--- a/Library/Homebrew/test/bottles/testball_bottle-0.1.sierra.bottle.tar.gz
+++ b/Library/Homebrew/test/bottles/testball_bottle-0.1.sierra.bottle.tar.gz
@@ -1,0 +1,1 @@
+testball_bottle-0.1.yosemite.bottle.tar.gz


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes:

```
  1) Error:
FormularyFactoryTest#test_factory_from_bottle:
Errno::ENOENT: No such file or directory - /usr/local/Library/Homebrew/test/bottles/testball_bottle-0.1.sierra.bottle.tar.gz
    /usr/local/Library/Homebrew/formulary.rb:98:in `realpath'
    /usr/local/Library/Homebrew/formulary.rb:98:in `realpath'
    /usr/local/Library/Homebrew/formulary.rb:98:in `initialize'
    /usr/local/Library/Homebrew/formulary.rb:274:in `new'
    /usr/local/Library/Homebrew/formulary.rb:274:in `loader_for'
    /usr/local/Library/Homebrew/formulary.rb:215:in `factory'
    /usr/local/Library/Homebrew/test/test_formulary.rb:79:in `test_factory_from_bottle'
```