### PR TITLE
diagnostic: prod unsupported OS users to file PRs.

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -18,6 +18,7 @@ module Homebrew
           You are using OS X #{MacOS.version}.
           #{who} do not provide support for this #{what}.
           You may encounter build failures or other breakages.
+          Please create pull-requests instead of filing issues.
         EOS
       end
 


### PR DESCRIPTION
They may not but it's nice to be a bit more explicit.

CC @DomT4 