### PR TITLE
bump-formula-pr: add --version argument

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -9,6 +9,7 @@
 #   --devel:    Bump a `devel` rather than `stable` version.
 #   --url:      The new formula URL.
 #   --sha256:   The new formula SHA-256.
+#   --version:  The new formula version.
 #   --tag:      The new formula's `tag`
 #   --revision: The new formula's `revision`.
 
@@ -66,6 +67,7 @@ module Homebrew
 
     new_url = ARGV.value("url")
     new_hash = ARGV.value(hash_type)
+    new_version = ARGV.value("version")
     new_tag = ARGV.value("tag")
     new_revision = ARGV.value("revision")
     new_url_hash = if new_url && new_hash
@@ -102,7 +104,13 @@ module Homebrew
 
     new_formula_version = formula_version(formula, requested_spec, new_contents)
 
-    if new_formula_version < old_formula_version
+    if !new_version.nil? && new_formula_version != Version.new(new_version)
+      odie <<-EOS.undent
+        You probably need to bump this formula manually since the new version
+        #{new_formula_version} doesn't match the version
+        #{new_version} specified in --version.
+      EOS
+    elsif new_formula_version < old_formula_version
       odie <<-EOS.undent
         You probably need to bump this formula manually since changing the
         version from #{old_formula_version} to #{new_formula_version} would be a downgrade.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----
There are numerous formulae that have a manually specified `version` attribute ([drake](https://github.com/Homebrew/homebrew-core/blob/master/Formula/drake.rb#L5) for example).
This PR adds an optional `--version` argument to `bump-formula-pr` so that the user can declare what they expect the formula version number to be.

Currently, the script gives an error message if `--version` is supplied and doesn't match the new formula version. In the future, perhaps the `version` tag could be updated if the auto-detected version doesn't match the `--version` argument. I have a [script that already does this](https://bitbucket.org/osrf/release-tools/src/38f306b9d7dac02af1f942944f0bfc61e35d46b8/jenkins-scripts/lib/homebrew_formula_pullrequest.bash?at=default&fileviewer=file-view-default#homebrew_formula_pullrequest.bash-44:65) but wanted to see if you are interested in having this upstream.