### PR TITLE
pull: skip non-ruby files when collecting formulae names

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -113,13 +113,9 @@ module Homebrew
           "git", "diff-tree", "-r", "--name-only",
           "--diff-filter=AM", orig_revision, "HEAD", "--", tap.formula_dir.to_s
         ).each_line do |line|
+          next unless line.end_with? ".rb\n"
           name = "#{tap.name}/#{File.basename(line.chomp, ".rb")}"
-          begin
-            changed_formulae_names << name
-          # Make sure we catch syntax errors.
-          rescue Exception
-            next
-          end
+          changed_formulae_names << name
         end
       end
 
@@ -127,7 +123,13 @@ module Homebrew
       changed_formulae_names.each do |name|
         next if ENV["HOMEBREW_DISABLE_LOAD_FORMULA"]
 
-        f = Formula[name]
+        begin
+          f = Formula[name]
+        # Make sure we catch syntax errors.
+        rescue Exception
+          next
+        end
+
         if ARGV.include? "--bottle"
           if f.bottle_unneeded?
             ohai "#{f}: skipping unneeded bottle."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes an issue in taps where formulae are at top-level and you run e.g. `brew pull <PR URL>` on a PR that changes a non-formula file.
It detects some changes in the formulae directory, but because it’s the same than other files like `README.md` if you change those it’ll try to interpret them as formulae.

[See here](http://bot.brew.sh/job/Homebrew%20Completions%20Pull%20Requests/154/version=yosemite/testReport/junit/brew-test-bot/yosemite/pull___clean_https___github_com_Homebrew_homebrew_completions_pull_123/) for an example.

Before:

```
$ brew pull https://github.com/Homebrew/homebrew-completions/pull/123
==> Fetching patch
Patch: https://github.com/Homebrew/homebrew-completions/pull/123.patch
==> Applying patch
Applying: Update CONTRIBUTING.md
Error: No available formula with the name "homebrew/completions/contributing.md"
```

After:

```
$ brew pull https://github.com/Homebrew/homebrew-completions/pull/123
==> Fetching patch
Patch: https://github.com/Homebrew/homebrew-completions/pull/123.patch
==> Applying patch
Applying: Update CONTRIBUTING.md
==> Patch closes issue #123
==> Patch changed:
 CONTRIBUTING.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```