### PR TITLE
test-bot: check for conflicts in dependencies

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -593,6 +593,9 @@ module Homebrew
             test "brew", "fetch", "--retry", dependent.name
             next if steps.last.failed?
             conflicts = dependent.conflicts.map { |c| Formulary.factory(c.name) }.select(&:installed?)
+            dependent.recursive_dependencies.each do |dependency|
+              conflicts += dependency.to_formula.conflicts.map { |c| Formulary.factory(c.name) }.select(&:installed?)
+            end
             conflicts.each do |conflict|
               test "brew", "unlink", conflict.name
             end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The `test-bot` checks the formula under test and its recursive dependencies for installed conflicts before installing dependencies and building a bottle ([lines 474-485](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/test-bot.rb#L474-L485)). However, when checking that the bottled dependents work with the new bottle, conflicts in recursive dependencies are not checked ([lines 592-603](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/test-bot.rb#L592-L603)). This caused a [bottle build failure](http://build.osrfoundation.org/view/os_homebrew/job/generic-release-homebrew_bottle_builder/42) for software that I maintain. This branch checks dependents for conflicts in recursive dependencies and [fixed the bottle build](http://build.osrfoundation.org/view/os_homebrew/job/generic-release-homebrew_bottle_builder/45/).