### PR TITLE
linkage: avoid checking symlinks/directories

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -48,6 +48,7 @@ module Homebrew
 
     def check_dylibs
       @keg.find do |file|
+        next if file.symlink? || file.directory?
         next unless file.dylib? || file.mach_o_executable? || file.mach_o_bundle?
         file.dynamically_linked_libraries.each do |dylib|
           if dylib.start_with? "@"

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -15,7 +15,6 @@ require "keg"
 require "formula"
 
 module Homebrew
-
   def linkage
     found_broken_dylibs = false
     ARGV.kegs.each do |keg|
@@ -26,7 +25,7 @@ module Homebrew
       else
         result.display_normal_output
       end
-      found_broken_dylibs = true if !result.broken_dylibs.empty?
+      found_broken_dylibs = true unless result.broken_dylibs.empty?
     end
     if ARGV.include?("--test") && found_broken_dylibs
       exit 1
@@ -75,7 +74,6 @@ module Homebrew
         opoo "Formula unavailable: #{keg.name}"
         @undeclared_deps = []
       end
-
     end
 
     def display_normal_output

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -77,29 +77,16 @@ module Homebrew
     end
 
     def display_normal_output
-      unless @system_dylibs.empty?
-        display_items "System libraries", @system_dylibs
-      end
-      unless @brewed_dylibs.empty?
-        display_items "Homebrew libraries", @brewed_dylibs
-      end
-      unless @variable_dylibs.empty?
-        display_items "Variable-referenced libraries", @variable_dylibs
-      end
-      unless @broken_dylibs.empty?
-        display_items "Missing libraries", @broken_dylibs
-      end
-      unless @undeclared_deps.empty?
-        display_items "Possible undeclared dependencies", @undeclared_deps
-      end
+      display_items "System libraries", @system_dylibs
+      display_items "Homebrew libraries", @brewed_dylibs
+      display_items "Variable-referenced libraries", @variable_dylibs
+      display_items "Missing libraries", @broken_dylibs
+      display_items "Possible undeclared dependencies", @undeclared_deps
     end
 
     def display_test_output
-      if @broken_dylibs.empty?
-        puts "No broken dylib links"
-      else
-        display_items "Missing libraries", @broken_dylibs
-      end
+      display_items "Missing libraries", @broken_dylibs
+      puts "No broken dylib links" if @broken_dylibs.empty?
     end
 
     private
@@ -107,6 +94,7 @@ module Homebrew
     # Display a list of things.
     # Things may either be an array, or a hash of (label -> array)
     def display_items(label, things)
+      return if things.empty?
       puts "#{label}:"
       if things.is_a? Hash
         things.sort.each do |list_label, list|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Prevent raising an error when `HOMEBREW_RUBY_MACHO=1` is set. Skipping symlinks and directories while iterating over a directory structure to find Mach-O binaries makes sense and similar logic is applied elsewhere. (This would have immediately impacted `brew test-bot` with `HOMEBREW_RUBY_MACHO=1` set.)

Also fix some minor code style issues and simplify the display logic for good measure, but in separate commits to avoid conflating them with the bug fix.

Without this fix, `HOMEBREW_RUBY_MACHO=1` will cause `brew linkage` to fail with either of the following outputs, depending on whether #378 has been already applied or not:

```
$ brew linkage webp
Error: Failed to read Mach-O binary: /usr/local/Cellar/webp/0.5.0
Error: Is a directory - /usr/local/Cellar/webp/0.5.0

$ brew linkage webp
Error: Failed to read Mach-O binary: /usr/local/Cellar/webp/0.5.0
Error: /usr/local/Cellar/webp/0.5.0: no such file
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/vendor/macho/macho/open.rb:10:in `open'
/usr/local/Library/Homebrew/os/mac/ruby_mach.rb:7:in `macho'
/usr/local/Library/Homebrew/os/mac/ruby_mach.rb:17:in `mach_data'
/usr/local/Library/Homebrew/os/mac/shared_mach.rb:38:in `dylib?'
/usr/local/Library/Homebrew/dev-cmd/linkage.rb:51:in `block in check_dylibs'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/pathname.rb:546:in `block in find'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/find.rb:43:in `block in find'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/find.rb:42:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/find.rb:42:in `find'
/System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/pathname.rb:546:in `find'
/usr/local/Library/Homebrew/keg.rb:291:in `find'
/usr/local/Library/Homebrew/dev-cmd/linkage.rb:50:in `check_dylibs'
/usr/local/Library/Homebrew/dev-cmd/linkage.rb:46:in `initialize'
/usr/local/Library/Homebrew/dev-cmd/linkage.rb:23:in `new'
/usr/local/Library/Homebrew/dev-cmd/linkage.rb:23:in `block in linkage'
/usr/local/Library/Homebrew/dev-cmd/linkage.rb:21:in `each'
/usr/local/Library/Homebrew/dev-cmd/linkage.rb:21:in `linkage'
/usr/local/Library/brew.rb:87:in `<main>'
```

cc @woodruffw