### PR TITLE
boneyard-formula-pr: add local-only mode

### DIFF
--- a/Library/Homebrew/dev-cmd/boneyard-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/boneyard-formula-pr.rb
@@ -70,7 +70,7 @@ module Homebrew
     branch = "#{formula.name}-boneyard"
     if ARGV.dry_run?
       puts "cd #{formula.tap.path}"
-      puts "git checkout -b #{branch} origin/master"
+      puts "git checkout --no-track -b #{branch} origin/master"
       puts "git commit --no-edit --verbose --message=\"#{formula.name}: migrate to boneyard\" -- #{formula_relpath} #{tap_migrations_path.basename}"
 
       unless local_only
@@ -82,7 +82,7 @@ module Homebrew
       end
     else
       cd formula.tap.path
-      safe_system "git", "checkout", "-b", branch, "origin/master"
+      safe_system "git", "checkout", "--no-track", "-b", branch, "origin/master"
       safe_system "git", "commit", "--no-edit", "--verbose",
         "--message=#{formula.name}: migrate to boneyard",
         "--", formula_relpath, tap_migrations_path.basename
@@ -104,7 +104,7 @@ module Homebrew
 
     if ARGV.dry_run?
       puts "cd #{boneyard_tap.path}"
-      puts "git checkout -b #{branch} origin/master"
+      puts "git checkout --no-track -b #{branch} origin/master"
       if bottle_block
         puts "Removing bottle block"
       else
@@ -122,7 +122,7 @@ module Homebrew
       end
     else
       cd boneyard_tap.formula_dir
-      safe_system "git", "checkout", "-b", branch, "origin/master"
+      safe_system "git", "checkout", "--no-track", "-b", branch, "origin/master"
       if bottle_block
         Utils::Inreplace.inreplace formula_file, /  bottle do.+?end\n\n/m, ""
       end

--- a/Library/Homebrew/dev-cmd/boneyard-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/boneyard-formula-pr.rb
@@ -60,7 +60,7 @@ module Homebrew
       tap_migrations = tap_migrations.sort.inject({}) { |a, e| a.merge!(e[0] => e[1]) }
       tap_migrations_path.atomic_write(JSON.pretty_generate(tap_migrations) + "\n")
     end
-    unless Formula["hub"].any_version_installed? || local_only
+    unless which("hub") || local_only
       if ARGV.dry_run?
         puts "brew install hub"
       else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Allow boneyarding a formula locally, i.e. make all the necessary changes in the local repositories but don't push them to a remote and don't open a pull request automatically.

This is helpful when further customizations to the commit messages and/or PR bodies are desired or when boneyarding multiple related formulae in a single PR. Tested with Homebrew/homebrew-core#2195 and Homebrew/homebrew-boneyard#131.

cc @ilovezfs