### PR TITLE
tests: add cmd/style integration test

### DIFF
--- a/Library/Homebrew/test/Gemfile
+++ b/Library/Homebrew/test/Gemfile
@@ -16,3 +16,4 @@ gem "coveralls", "0.8.10", :require => false
 # Remove these lines when we've stopped supporting it.
 gem "mime-types", "~> 1.16"
 gem "rest-client", "1.6.9"
+gem "rubocop", "0.40"

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -11,6 +11,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.3.0)
     coveralls (0.8.10)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
@@ -25,14 +26,26 @@ GEM
     minitest (5.8.4)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
+    parser (2.3.1.2)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    rainbow (2.1.0)
     rake (10.5.0)
     rest-client (1.6.9)
       mime-types (~> 1.16)
+    rubocop (0.40.0)
+      parser (>= 2.3.1.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
     simplecov-html (0.10.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
     tins (1.6.0)
+    unicode-display_width (1.0.5)
 
 PLATFORMS
   ruby
@@ -44,6 +57,7 @@ DEPENDENCIES
   mocha (~> 1.1)
   rake (~> 10.3)
   rest-client (= 1.6.9)
+  rubocop (= 0.40)
   simplecov (= 0.11.2)!
 
 BUNDLED WITH

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -834,4 +834,29 @@ class IntegrationCommandTests < Homebrew::TestCase
     desc_cache.unlink
     formula_file.unlink
   end
+
+  def test_style
+    foo_file = CoreTap.new.formula_dir/"foo.rb"
+    foo_file.write <<-EOS.undent
+      class Foo < Formula
+        url 'https://example.com/foo-1.0'
+      end
+    EOS
+
+    rubocop_yml = HOMEBREW_LIBRARY/".rubocop.yml"
+    rubocop_yml.write <<-EOS.undent
+      Style/Documentation:
+        Enabled: false
+
+      Style/StringLiterals:
+        EnforcedStyle: double_quotes
+    EOS
+
+    assert_match "Prefer double-quoted strings", cmd_fail("style")
+    assert_match "1 file inspected, 1 offense detected", cmd_fail("style", "#{foo_file}")
+    assert_match "1 file inspected, 1 offense detected", cmd_fail("style", "foo")
+  ensure
+    foo_file.unlink
+    rubocop_yml.unlink
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds *some* test coverage for `brew style`. It looks like the parts concerning JSON output (including the `RubocopResults` `RubocopOffense`, and `RubocopLineLocation` classes) would be served by adding test coverage for `brew audit --strict` (which I'll add to my to-do list).

It seemed necessary to add `rubocop` to the `Gemfile`, but if that's incorrect, I look forward to finding out!

I'll be sure to update the creation and unlinking of the `foo` formula once [this pull request](https://github.com/Homebrew/brew/pull/370) is finalized/merged.

Thanks!