### PR TITLE
brew-create: add --tap option for creating formula in a specified tap

### DIFF
--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -78,7 +78,7 @@ With <code>--include-aliases</code>, the aliases of internal commands will be in
 <dt class="flush"><code>config</code></dt><dd><p>Show Homebrew and system configuration useful for debugging. If you file
 a bug report, you will likely be asked for this information if you do not
 provide it.</p></dd>
-<dt><code>create</code> <var>URL</var> [<code>--autotools</code>|<code>--cmake</code>] [<code>--no-fetch</code>] [<code>--set-name</code> <var>name</var>] [<code>--set-version</code> <var>version</var>]</dt><dd><p>Generate a formula for the downloadable file at <var>URL</var> and open it in the editor.
+<dt><code>create</code> <var>URL</var> [<code>--autotools</code>|<code>--cmake</code>] [<code>--no-fetch</code>] [<code>--set-name</code> <var>name</var>] [<code>--set-version</code> <var>version</var>] [<code>--tap</code> <var>user</var><code>/</code><var>repo</var>]</dt><dd><p>Generate a formula for the downloadable file at <var>URL</var> and open it in the editor.
 Homebrew will attempt to automatically derive the formula name
 and version, but if it fails, you'll have to make your own template. The <code>wget</code>
 formula serves as a simple example. For the complete API have a look at</p>
@@ -92,7 +92,10 @@ If <code>--cmake</code> is passed, create a basic template for a CMake-style bui
 will thus not add the SHA256 to the formula for you.</p>
 
 <p>The options <code>--set-name</code> and <code>--set-version</code> each take an argument and allow
-you to explicitly set the name and version of the package you are creating.</p></dd>
+you to explicitly set the name and version of the package you are creating.</p>
+
+<p>The option <code>--tap</code> takes a tap as its argument and generates the formula in
+the specified tap.</p></dd>
 <dt><code>deps</code> [<code>--1</code>] [<code>-n</code>] [<code>--union</code>] [<code>--installed</code>] [<code>--include-build</code>] [<code>--include-optional</code>] [<code>--skip-recommended</code>] <var>formulae</var></dt><dd><p>Show dependencies for <var>formulae</var>. When given multiple formula arguments,
 show the intersection of dependencies for <var>formulae</var>.</p>
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -110,7 +110,7 @@ If \fB\-\-quiet\fR is passed, list only the names of commands without the header
 Show Homebrew and system configuration useful for debugging\. If you file a bug report, you will likely be asked for this information if you do not provide it\.
 .
 .TP
-\fBcreate\fR \fIURL\fR [\fB\-\-autotools\fR|\fB\-\-cmake\fR] [\fB\-\-no\-fetch\fR] [\fB\-\-set\-name\fR \fIname\fR] [\fB\-\-set\-version\fR \fIversion\fR]
+\fBcreate\fR \fIURL\fR [\fB\-\-autotools\fR|\fB\-\-cmake\fR] [\fB\-\-no\-fetch\fR] [\fB\-\-set\-name\fR \fIname\fR] [\fB\-\-set\-version\fR \fIversion\fR] [\fB\-\-tap\fR \fIuser\fR\fB/\fR\fIrepo\fR]
 Generate a formula for the downloadable file at \fIURL\fR and open it in the editor\. Homebrew will attempt to automatically derive the formula name and version, but if it fails, you\'ll have to make your own template\. The \fBwget\fR formula serves as a simple example\. For the complete API have a look at
 .
 .IP
@@ -124,6 +124,9 @@ If \fB\-\-no\-fetch\fR is passed, Homebrew will not download \fIURL\fR to the ca
 .
 .IP
 The options \fB\-\-set\-name\fR and \fB\-\-set\-version\fR each take an argument and allow you to explicitly set the name and version of the package you are creating\.
+.
+.IP
+The option \fB\-\-tap\fR takes a tap as its argument and generates the formula in the specified tap\.
 .
 .TP
 \fBdeps\fR [\fB\-\-1\fR] [\fB\-n\fR] [\fB\-\-union\fR] [\fB\-\-installed\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] \fIformulae\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Often enough I need to create a formula in a personal tap (usually because it's not notable enough and/or a personal project), and I love the convenience of `brew-create`, but it is only capable of creating formulae in the core tap, which means manually moving the formula around post-creation.

This commit adds a `--tap` option to the `create` command such that a user could create a formula in a specified tap instead of the core.

<s>To facilitate this, a helper method `tap_path` has been added to the `Formulary` class (which is very different from the existing method `tap_paths`).</s>

Note that I did not write new tests because

- `cmd/create.rb` has no associated tests;
- <s>`formulary.rb` does have tests, but not for the peers of `Formulary.tap_path` (`Formulary.core_path`, `Formulary.tap_paths`, etc.).</s>