### PR TITLE
Test officially supported cmd taps.

### DIFF
--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -1,13 +1,23 @@
 #: @hide_from_man_page
-#:  * `tests` [`-v`] [`--coverage`] [`--generic`] [`--no-compat`] [`--only=`<test_script/test_method>] [`--seed` <seed>] [`--trace`] [`--online`]:
+#:  * `tests` [`-v`] [`--coverage`] [`--generic`] [`--no-compat`] [`--only=`<test_script/test_method>] [`--seed` <seed>] [`--trace`] [`--online`] [`--official-cmd-taps`]:
 #:    Run Homebrew's unit and integration tests.
 
 require "fileutils"
+require "tap"
 
 module Homebrew
   def tests
+    ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
+
+    if ARGV.include? "--official-cmd-taps"
+      ENV["HOMEBREW_TEST_OFFICIAL_CMD_TAPS"] = "1"
+      OFFICIAL_CMD_TAPS.each do |tap, _|
+        tap = Tap.fetch tap
+        tap.install unless tap.installed?
+      end
+    end
+
     (HOMEBREW_LIBRARY/"Homebrew/test").cd do
-      ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
       ENV["TESTOPTS"] = "-v" if ARGV.verbose?
       ENV["HOMEBREW_NO_COMPAT"] = "1" if ARGV.include? "--no-compat"
       ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if ARGV.include? "--generic"

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -659,6 +659,7 @@ module Homebrew
         test "brew", "tests", *tests_args
         test "brew", "tests", "--no-compat"
         test "brew", "readall", "--syntax"
+        test "brew", "tests", "--official-cmd-taps"
       else
         test "brew", "readall", "--aliases", @tap.name
       end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -9,6 +9,7 @@ require "utils"
 require "exceptions"
 require "set"
 require "rbconfig"
+require "official_taps"
 
 ARGV.extend(HomebrewArgvExtension)
 

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -15,4 +15,10 @@ OFFICIAL_TAPS = %w[
   tex
   versions
   x11
-]
+].freeze
+
+OFFICIAL_CMD_TAPS = {
+  "caskroom/cask" => ["cask"],
+  "homebrew/bundle" => ["bundle"],
+  "homebrew/services" => ["services"],
+}.freeze

--- a/Library/brew.rb
+++ b/Library/brew.rb
@@ -94,14 +94,8 @@ begin
     exit Homebrew.failed? ? 1 : 0
   else
     require "tap"
-    possible_tap = case cmd
-    when "brewdle", "brewdler", "bundle", "bundler"
-      Tap.fetch("Homebrew", "bundle")
-    when "cask"
-      Tap.fetch("caskroom", "cask")
-    when "services"
-      Tap.fetch("Homebrew", "services")
-    end
+    possible_tap = OFFICIAL_CMD_TAPS.find { |_, cmds| cmds.include?(cmd) }
+    possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
     if possible_tap && !possible_tap.installed?
       brew_uid = HOMEBREW_BREW_FILE.stat.uid


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

All of these taps use Homebrew internal APIs (or will shortly) and we autoinstall them all from `brew $CMD`. We should adjust our CI to ensure that we never accidentally break these taps when making changes to core code so that these taps can rely more on this core code rather than having to e.g. vendor equivalent code that never changes on our end.

CI may well by wrong here as I've not tested this on the actual bot and it won't run `brew tests --official-cmd-taps` (although I should fix that so we can test new `brew test-bot` changes here).

The approach may well be terrible; we could perhaps get away with a simpler integration tests or a subset of their tests. Alternatively, we may also want to consider running these tests in parallel with something like https://github.com/grosser/parallel_tests.

This (in some form) will be a requirement for @anastasiasulyagina's GSoC project to be able to remove duplicated/vendored core code from Caskroom/cask and eventually move it into Homebrew itself and it's something we should have done for Homebrew/bundle a while ago. This also perhaps overlaps with @eirinikos's integration testing work.

CC @Homebrew/maintainers for thoughts as this is a fairly big change in how we do CI for this repository but it's something we'll have to do in some form.