### PR TITLE
audit.rb: require https for ftpmirror.gnu.org

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1135,12 +1135,7 @@ class ResourceAuditor
   def audit_urls
     # Check GNU urls; doesn't apply to mirrors
     if url =~ %r{^(?:https?|ftp)://(?!alpha).+/gnu/}
-      problem "Please use \"http://ftpmirror.gnu.org\" instead of #{url}."
-    end
-
-    # GNU's ftpmirror does NOT support SSL/TLS.
-    if url =~ %r{^https://ftpmirror\.gnu\.org/}
-      problem "Please use http:// for #{url}"
+      problem "Please use \"https://ftpmirror.gnu.org\" instead of #{url}."
     end
 
     if mirrors.include?(url)
@@ -1154,6 +1149,7 @@ class ResourceAuditor
     urls.each do |p|
       case p
       when %r{^http://ftp\.gnu\.org/},
+           %r{^http://ftpmirror\.gnu\.org/},
            %r{^http://[^/]*\.apache\.org/},
            %r{^http://code\.google\.com/},
            %r{^http://fossies\.org/},

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -180,8 +180,8 @@ can take several different forms:
     to insecure HTTP.
 
     While ensuring your downloads are fully secure, this is likely
-    to cause from-source Sourceforge & GNOME based formulae
-    to fail to download.
+    to cause from-source Sourceforge, some GNU & GNOME based
+    formulae to fail to download.
 
   * `HOMEBREW_NO_GITHUB_API`:
     If set, Homebrew will not use the GitHub API for e.g searches or

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -561,7 +561,7 @@ successful build.</p>
 to insecure HTTP.</p>
 
 <p>While ensuring your downloads are fully secure, this is likely
-to cause from-source Sourceforge &amp; GNOME based formulae
+to cause from-source Sourceforge, some GNU &amp; GNOME based formulae
 to fail to download.</p></dd>
 <dt><code>HOMEBREW_NO_GITHUB_API</code></dt><dd><p>If set, Homebrew will not use the GitHub API for e.g searches or
 fetching relevant issues on a failed install.</p></dd>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -783,7 +783,7 @@ If set, Homebrew will not print the \fBHOMEBREW_INSTALL_BADGE\fR on a successful
 If set, Homebrew will not permit redirects from secure HTTPS to insecure HTTP\.
 .
 .IP
-While ensuring your downloads are fully secure, this is likely to cause from\-source Sourceforge & GNOME based formulae to fail to download\.
+While ensuring your downloads are fully secure, this is likely to cause from\-source Sourceforge, some GNU & GNOME based formulae to fail to download\.
 .
 .TP
 \fBHOMEBREW_NO_GITHUB_API\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The situation is similar to other mirror redirectors: the server
may subsequently redirect to an insecure url. But it's a step.