### PR TITLE
test-bot: do nott diff tree recursively

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -273,7 +273,7 @@ module Homebrew
       def diff_formulae(start_revision, end_revision, path, filter)
         return unless @tap
         git(
-          "diff-tree", "-r", "--name-only", "--diff-filter=#{filter}",
+          "diff-tree", "--name-only", "--diff-filter=#{filter}",
           start_revision, end_revision, "--", path
         ).lines.map do |line|
           file = Pathname.new line.chomp


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Changes in subfolders, such as [requirements](https://travis-ci.org/Homebrew/homebrew-science/jobs/138505000#L167) are treated as formulas, which causes the bot to report failure.