### PR TITLE
tests: add cmd/link, cmd/unlink integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -110,11 +110,11 @@ class IntegrationCommandTests < Homebrew::TestCase
     formula_path = CoreTap.new.formula_dir/"#{name}.rb"
 
     case name
-    when "testball"
+    when /^testball/
       content = <<-EOS.undent
         desc "Some test"
         homepage "https://example.com/#{name}"
-        url "file://#{File.expand_path("..", __FILE__)}/tarballs/#{name}-0.1.tbz"
+        url "file://#{File.expand_path("..", __FILE__)}/tarballs/testball-0.1.tbz"
         sha256 "#{TESTBALL_SHA256}"
 
         option "with-foo", "Build with foo"
@@ -664,5 +664,32 @@ class IntegrationCommandTests < Homebrew::TestCase
     setup_remote_tap("homebrew/services")
     assert_equal "Warning: No services available to control with `brew services`",
       cmd("services", "list")
+  end
+
+  def test_link
+    assert_match "This command requires a keg argument", cmd_fail("link")
+
+    setup_test_formula "testball1"
+    cmd("install", "testball1")
+    cmd("link", "testball1")
+
+    cmd("unlink", "testball1")
+    assert_match "Would link", cmd("link", "--dry-run", "testball1")
+    assert_match "Would remove",
+      cmd("link", "--dry-run", "--overwrite", "testball1")
+    assert_match "Linking", cmd("link", "testball1")
+
+    setup_test_formula "testball2", <<-EOS.undent
+      keg_only "just because"
+    EOS
+    cmd("install", "testball2")
+    assert_match "testball2 is keg-only", cmd("link", "testball2")
+  end
+
+  def test_unlink
+    setup_test_formula "testball"
+
+    cmd("install", "testball")
+    assert_match "Would remove", cmd("unlink", "--dry-run", "testball")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds test coverage for `brew link` and `brew unlink`, though [these lines of `cmd/link.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/link.rb#L53-L55) still lack coverage (I haven't yet figured out how the `LinkError` gets raised).

[These lines](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/link.rb#L53-L55) also lack coverage, though somehow they *were* tested when I tried using a combination of `test/testball.rb`+ `setup_test_formula "baz"` (instead of only `setup_test_formula "testball"`). Since there are three other `ensure` blocks that do the following, I was hoping that the `cmd`s could be refactored into their own method):
```
cmd("uninstall", "--force", testball)
cmd("cleanup", "--force", "--prune=all")
```

But I wanted to test a `keg_only` formula and I'm not sure if there's a way to modify the existing `test/testball` file to make it such.


