### PR TITLE
keg_relocate: Fix hardlink behavior for ruby-macho

### DIFF
--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -304,4 +304,35 @@ class LinkTests < Homebrew::TestCase
     keg.unlink
     keg.uninstall
   end
+
+  def test_mach_o_files_skips_hardlinks
+    a = HOMEBREW_CELLAR/"a/1.0"
+    (a/"lib").mkpath
+    FileUtils.cp dylib_path("i386"), a/"lib/i386.dylib"
+    FileUtils.ln a/"lib/i386.dylib", a/"lib/i386_link.dylib"
+
+    keg = Keg.new(a)
+    keg.link
+
+    assert_equal 1, keg.mach_o_files.size
+  ensure
+    keg.unlink
+    keg.uninstall
+  end
+
+  def test_mach_o_files_isnt_confused_by_symlinks
+    a = HOMEBREW_CELLAR/"a/1.0"
+    (a/"lib").mkpath
+    FileUtils.cp dylib_path("i386"), a/"lib/i386.dylib"
+    FileUtils.ln a/"lib/i386.dylib", a/"lib/i386_link.dylib"
+    FileUtils.ln_s a/"lib/i386.dylib", a/"lib/1.dylib"
+
+    keg = Keg.new(a)
+    keg.link
+
+    assert_equal 1, keg.mach_o_files.size
+  ensure
+    keg.unlink
+    keg.uninstall
+  end
 end

--- a/Library/Homebrew/test/test_mach.rb
+++ b/Library/Homebrew/test/test_mach.rb
@@ -1,14 +1,6 @@
 require "testing_env"
 
 class MachOPathnameTests < Homebrew::TestCase
-  def dylib_path(name)
-    Pathname.new("#{TEST_DIRECTORY}/mach/#{name}.dylib")
-  end
-
-  def bundle_path(name)
-    Pathname.new("#{TEST_DIRECTORY}/mach/#{name}.bundle")
-  end
-
   def test_fat_dylib
     pn = dylib_path("fat")
     assert_predicate pn, :universal?

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -112,5 +112,13 @@ module Homebrew
       }
       refute exp.eql?(act), msg
     end
+
+    def dylib_path(name)
+      Pathname.new("#{TEST_DIRECTORY}/mach/#{name}.dylib")
+    end
+
+    def bundle_path(name)
+      Pathname.new("#{TEST_DIRECTORY}/mach/#{name}.bundle")
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This patch should stop the incorrect hardlink behavior noted in https://github.com/Homebrew/brew/issues/399.

Tested locally with the following:

```bash
export HOMEBREW_DEVELOPER=1
export HOMEBREW_RUBY_MACHO=1
brew install --build-bottle --verbose gawk
brew bottle --verbose --json gawk
```

There were some warnings in the output about `/usr/local/opt` and `/usr/local/Cellar` being present in the `gawk` binary - are these relevant?

cc @UniqMartin 

ref https://github.com/Homebrew/brew/issues/399