### PR TITLE
cleanup: remove older versions when reasonable

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -466,10 +466,10 @@ class Formula
     rack.directory? ? rack.subdirs : []
   end
 
-  # All of current installed kegs.
+  # All of current installed kegs, sorted by version.
   # @private
   def installed_kegs
-    installed_prefixes.map { |dir| Keg.new(dir) }
+    installed_prefixes.map { |dir| Keg.new(dir) }.sort_by(&:version)
   end
 
   # The directory where the formula's binaries should be installed.
@@ -1318,8 +1318,6 @@ class Formula
       }
     end
 
-    hsh["installed"] = hsh["installed"].sort_by { |i| Version.create(i["version"]) }
-
     hsh
   end
 
@@ -1526,7 +1524,20 @@ class Formula
           end
         end
       end
-    elsif installed_prefixes.any? && !pinned?
+    elsif installed_prefixes.length > 1
+      if linked_keg.exist?
+        # If the most recent available version is not installed, cleanup
+        # only those older than the currently-linked one.
+        linked_version = PkgVersion.parse(linked_keg.resolved_path.basename.to_s)
+        eligible_for_cleanup = installed_kegs.select { |k| linked_version > k.version }
+        opoo "Skipping (old) #{linked_keg.resolved_path} due to it being linked"
+      else
+        # If no version is linked, keep only the newest one.
+        eligible_for_cleanup = installed_kegs
+        last_keg = eligible_for_cleanup.pop
+        opoo "Skipping (old, unlinked) #{last_keg} due to it being the latest version installed"
+      end
+    elsif !pinned?
       # If the cellar only has one version installed, don't complain
       # that we can't tell which one to keep. Don't complain at all if the
       # only installed version is a pinned formula.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change updates the eligibility criteria for removing older kegs to be a bit more inclusive, thus better aligning the command with its documented behavior from `brew help cleanup`:
> For all installed or specific formulae, remove any older versions from the cellar. [...]

Today, the `cleanup` command is a bit overly conservative in
that it doesn't even try to remove older kegs when the most
recent version isn't installed. This means "slow adopters" are
often left with many older kegs that have no use, even after
using the command. (*Update:* e.g. #412.)

- Unchanged: if the most recent available version is installed, all
  older, non-linked versions are eligible for cleanup.
- New: if any version is linked, all versions older than it are eligible
  for cleanup.
- New: if no installed version is linked, all but the latest installed
  version are eligible for cleanup.

Please note that I didn't modify or add to the existing cleanup test, but it's not immediately clear to me the proper way to do this, or if it's even necessary in this case.

Also, there are one or two points in the code where I made choices that may or may not be the accepted way to do things. I'll try to comment on these lines, but I'm sure someone will point out anything that should be changed. Thanks for considering this!