### PR TITLE
--insecure arg added back

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -9,6 +9,8 @@ def curl_args(extra_args=[])
   flags -= ["--progress-bar"] if ARGV.verbose?
 
   args = ["#{curl}"] + flags + extra_args
+  # needed for cask support
+  args << "--insecure" if MacOS.release < "10.6"
   args << "--verbose" if ENV["HOMEBREW_CURL_VERBOSE"]
   args << "--silent" if !$stdout.tty? || ENV["TRAVIS"]
   args

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -10,7 +10,7 @@ def curl_args(extra_args=[])
 
   args = ["#{curl}"] + flags + extra_args
   # needed for cask support
-  args << "--insecure" if MacOS.release < "10.6"
+  args << "--insecure" if MacOS.version < "10.6"
   args << "--verbose" if ENV["HOMEBREW_CURL_VERBOSE"]
   args << "--silent" if !$stdout.tty? || ENV["TRAVIS"]
   args


### PR DESCRIPTION

Adding this since Homebrew core and Cask are being merged and cask supports <10.6 OS versions.