### PR TITLE
Call subcommands from zsh completion

### DIFF
--- a/share/zsh/site-functions/_brew
+++ b/share/zsh/site-functions/_brew
@@ -2,8 +2,6 @@
 #autoload
 
 # Brew ZSH completion function
-#
-# altered from _fink
 
 _brew_all_formulae() {
   formulae=(`brew search`)
@@ -27,6 +25,12 @@ _brew_pinned_taps() {
 
 _brew_outdated_formulae() {
   outdated_formulae=(`brew outdated`)
+}
+
+__brew_command() {
+  local command="$1"
+  local completion_func="_brew_${command//-/_}"
+  declare -f "$completion_func" >/dev/null && "$completion_func" && return
 }
 
 local -a _1st_arguments
@@ -95,7 +99,8 @@ if (( CURRENT == 1 )); then
   return
 fi
 
-case "$words[1]" in
+local command="$words[1]"
+case "$command" in
   analytics) compadd on off state regenerate-uuid ;;
   install|reinstall|audit|home|homepage|log|info|abv|uses|cat|deps|desc|edit|options|switch)
     _brew_all_formulae
@@ -145,4 +150,6 @@ case "$words[1]" in
       _brew_outdated_formulae
       _wanted outdated_formulae expl 'outdated formulae' compadd -a outdated_formulae
     fi ;;
+  *)
+    __brew_command "$command" ;;
 esac


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

(I'm not sure that these changes require tests so much as a code review and
a look at the other related changes.)

-----

This change is inspired by the way that the git zsh completions work by foisting
the responsibility for sub commands onto the command themselves.
It is paired with another change that takes the oh-my-zsh brew cask plugin and
makes it into a first class completion rather than it overriding this.

This change requires fixes in brew, oh-my-zsh and the zsh-completions, and will
likely cause the `brew cask` completions to break until these have been fully
accepted into each project. I'd anticipate doing brew first and the others after.

See related PRs:
https://github.com/zsh-users/zsh-completions/pull/430
https://github.com/robbyrussell/oh-my-zsh/pull/5191