### PR TITLE
Simplify Formula#outdated_versions logic.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -132,8 +132,7 @@ module Homebrew
           msg = "#{f.full_name}-#{f.installed_version} already installed"
           msg << ", it's just not linked" unless f.linked_keg.symlink? || f.keg_only?
           opoo msg
-        elsif f.oldname && (dir = HOMEBREW_CELLAR/f.oldname).directory? && !dir.subdirs.empty? \
-            && f.tap == Tab.for_keg(dir.subdirs.first).tap && !ARGV.force?
+        elsif f.migration_needed? && !ARGV.force?
           # Check if the formula we try to install is the same as installed
           # but not migrated one. If --force passed then install anyway.
           opoo "#{f.oldname} already installed, it's just not migrated"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -956,33 +956,25 @@ class Formula
     @oldname_lock.unlock unless @oldname_lock.nil?
   end
 
+  def migration_needed?
+    oldname && !rack.exist? && (dir = HOMEBREW_CELLAR/oldname).directory? &&
+      !dir.subdirs.empty? && tap == Tab.for_keg(dir.subdirs.first).tap
+  end
+
   # @private
   def outdated_versions
     @outdated_versions ||= begin
       all_versions = []
-      older_or_same_tap_versions = []
 
-      if oldname && !rack.exist? && (dir = HOMEBREW_CELLAR/oldname).directory? &&
-        !dir.subdirs.empty? && tap == Tab.for_keg(dir.subdirs.first).tap
-        raise Migrator::MigrationNeededError.new(self)
-      end
+      raise Migrator::MigrationNeededError.new(self) if migration_needed?
 
       installed_kegs.each do |keg|
         version = keg.version
         all_versions << version
-        older_version = pkg_version <= version
-
-        tab_tap = Tab.for_keg(keg).tap
-        if tab_tap.nil? || tab_tap == tap || older_version
-          older_or_same_tap_versions << version
-        end
+        return [] if pkg_version <= version
       end
 
-      if older_or_same_tap_versions.all? { |v| pkg_version > v }
-        all_versions.sort!
-      else
-        []
-      end
+      all_versions.sort!
     end
   end
 

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -40,6 +40,28 @@ class FormulaTests < Homebrew::TestCase
     f.rack.rmtree
   end
 
+  def test_migration_needed
+    f = Testball.new("newname")
+    f.instance_variable_set(:@oldname, "oldname")
+    f.instance_variable_set(:@tap, CoreTap.instance)
+
+    oldname_prefix = HOMEBREW_CELLAR/"oldname/2.20"
+    oldname_prefix.mkpath
+    oldname_tab = Tab.empty
+    oldname_tab.tabfile = oldname_prefix.join("INSTALL_RECEIPT.json")
+    oldname_tab.write
+
+    refute_predicate f, :migration_needed?
+
+    oldname_tab.tabfile.unlink
+    oldname_tab.source["tap"] = "homebrew/core"
+    oldname_tab.write
+
+    assert_predicate f, :migration_needed?
+  ensure
+    oldname_prefix.parent.rmtree
+  end
+
   def test_installed?
     f = Testball.new
     f.stubs(:installed_prefix).returns(stub(:directory? => false))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

# Description

Replace complicated logic from `Formula#outdated_versions` with simpler equivalent and add tests.

What `outdated_versions` used to do:

```ruby
     1	all_versions = []
     2	older_or_same_tap_versions = []
     3	
     4	installed_kegs.each do |keg|
     5	  version = keg.version
     6	  all_versions << version
     7	  older_version = pkg_version <= version
     8	
     9	  tab_tap = Tab.for_keg(keg).tap
    10	  if tab_tap.nil? || tab_tap == tap || older_version
    11	    older_or_same_tap_versions << version
    12	  end
    13	end
    14	
    15	if older_or_same_tap_versions.all? { |v| pkg_version > v }
    16	  all_versions.sort!
    17	else
    18	  []
    19	end

```


Suppose we have `f` -- an instance of `Formula`.
1. Go through all the _keg_s of installed under the `f.name` (line 4)
2. (line 10)

   * If _keg_'s tap was `nil` and if `f.pkg_version` was less or equal _keg_'s  version then at the end of `outdated_versions` [] used to be returned.

   * If _keg_'s was same as `f.tap`, then if `pkg_version` was less or equal _keg_'s  version then at the end of `outdated_versions` [] used to be returned.

   * If _keg_'s tap was not the same as `f.tap` we checked if `f.pkg_version` was less or equal to _keg's_ version (line 7)  and then after `older_or_same_tap_versions` was formed `f.pkg_version` was never greater than _keg_'s version (line 15), so we returned `[]`.

   *  (no conditions from line 10 satisfied) If _keg_'s tap was not the same as `f.tap` we checked if `f.pkg_version` was greater then _keg's_ version we didn't add _keg_'s version to  `older_or_same_tap_versions`.

So, [] was returned if and only if `f.pkg_version` less or equal for at least one of the kegs **or** `f.rack` was empty.

The PR suggests that we return `[]` as soon as we are sure the previously used `older_or_same_tap_versions` cannot satisfy `older_or_same_tap_versions.all? { |v| pkg_version > v }`.

Old `Formula#outdated_versions` implementation passes all the added `outdated_versions` tests.
