### PR TITLE
Rename 'chdir' shell functions to avoid confusion

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -311,7 +311,7 @@ EOS
   # only allow one instance of brew update
   lock update
 
-  chdir "$HOMEBREW_REPOSITORY"
+  safe_cd "$HOMEBREW_REPOSITORY"
   git_init_if_necessary
   # rename Taps directories
   # this procedure will be removed in the future if it seems unnecessary
@@ -382,7 +382,7 @@ EOS
     pull "$DIR"
   done
 
-  chdir "$HOMEBREW_REPOSITORY"
+  safe_cd "$HOMEBREW_REPOSITORY"
 
   if [[ -n "$HOMEBREW_UPDATED" ||
         -n "$HOMEBREW_UPDATE_FAILED" ||

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -20,7 +20,7 @@ odie() {
   exit 1
 }
 
-chdir() {
+safe_cd() {
   cd "$@" >/dev/null || odie "Error: failed to cd to $*!"
 }
 

--- a/bin/brew
+++ b/bin/brew
@@ -1,11 +1,11 @@
 #!/bin/bash
 set +o posix
 
-chdir() {
+quiet_cd() {
   cd "$@" >/dev/null
 }
 
-BREW_FILE_DIRECTORY="$(chdir "${0%/*}" && pwd -P)"
+BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}" && pwd -P)"
 HOMEBREW_BREW_FILE="$BREW_FILE_DIRECTORY/${0##*/}"
 
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
@@ -15,8 +15,8 @@ if [[ -L "$HOMEBREW_BREW_FILE" ]]
 then
   BREW_SYMLINK="$(readlink "$HOMEBREW_BREW_FILE")"
   BREW_SYMLINK_DIRECTORY="$(dirname "$BREW_SYMLINK")"
-  BREW_FILE_DIRECTORY="$(chdir "$BREW_FILE_DIRECTORY" &&
-                         chdir "$BREW_SYMLINK_DIRECTORY" && pwd -P)"
+  BREW_FILE_DIRECTORY="$(quiet_cd "$BREW_FILE_DIRECTORY" &&
+                         quiet_cd "$BREW_SYMLINK_DIRECTORY" && pwd -P)"
   HOMEBREW_REPOSITORY="${BREW_FILE_DIRECTORY%/*}"
 fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The new names (`quiet_cd` and `safe_cd`, inspired by `quiet_system` and `safe_system`) are both much clearer and avoid some of the confusion caused by `chdir` meaning two different things in `bin/brew` and `Library/brew.sh` (not to mention that overriding the former implementation with the latter is surprising).