### PR TITLE
gist-logs: close temp file before passing to curl, to ensure output availability

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -140,6 +140,7 @@ module GitHub
     begin
       if data
         data_tmpfile.write data
+        data_tmpfile.close
         args += ["--data", "@#{data_tmpfile.path}"]
       end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #417 

Looks like there's a race condition with I/O buffering when `gist-logs` is passing a temporary data file to `curl`. `close` is not called on the tempfile handle, so the data isn't guaranteed to be flushed to the filesystem and visible to external processes. This appears to be behind the intermittent JSON parsing errors during gist creations on one of my machines: adding the earlier `close` made them go away.

This adds a close, ensuring that the data gets written to disk so curl can see it, avoiding intermittent JSON parsing errors in gist creation.

Strictly speaking, there may be a similar race condition with the reading of the header temp file, which is opened in the `brew` Ruby process before `curl` writes out to it. But I don't think it'll ever get hit, because no `read` is done before `curl` runs, so it probably doesn't have a chance to buffer any output from the "before" state of the file.