### PR TITLE
brew: sanitize BASH_ENV

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -64,6 +64,10 @@ fi
 unset GEM_HOME
 unset GEM_PATH
 
+# Users may have this set, injecting arbitrary environment changes into
+# bash processes inside builds
+unset BASH_ENV
+
 HOMEBREW_SYSTEM="$(uname -s)"
 case "$HOMEBREW_SYSTEM" in
   Darwin) HOMEBREW_OSX="1" ;;


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Should we sanitize `BASH_ENV` out of the environment for `brew`?

If it's set, then child `bash` processes can end up making arbitrary changes to their environment, in ways that may not be obvious when debugging `brew` stuff.

Fixes Homebrew/homebrew-dupes#627

There were also two older problems that were tracked down to `BASH_ENV` being set:

https://github.com/Homebrew/legacy-homebrew/issues/36479
https://github.com/Homebrew/legacy-homebrew/issues/24363

When `BASH_ENV` is set, this causes *non-interactive* bash shells to source the given file. Which would apply to bash instances spawned by `brew` or a package's build scripts.

I can't immediately think of any use cases for `BASH_ENV` that couldn't be handled by just exporting variables from the original bash invocation's `.bashrc` or `.profile` files. And it seems to go against Homebrew's approach of tightly controlling the environment to support uniform builds.

###  Alternatives

If not sanitizing it outright, we could just check for it in `brew doctor`.