### PR TITLE
style: use RuboCop 0.41.1

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -66,6 +66,10 @@ Style/EmptyLineBetweenDefs:
 Style/NumericLiterals:
   Enabled: false
 
+# zero-prefixed octal literals are just too widely used (and mostly understood)
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
 # consistency and readability when faced with string interpolation
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -47,7 +47,7 @@ module Homebrew
 
   def check_style_impl(files, output_type, options = {})
     fix = options[:fix]
-    Homebrew.install_gem_setup_path! "rubocop", "0.40"
+    Homebrew.install_gem_setup_path! "rubocop", "0.41.1"
 
     args = %W[
       --force-exclusion


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As usual, there are some new cops. The one that is most relevant to our code base (both the package manager and formulae) is the one for octal number literals, e.g.:

```console
$ brew style --display-cop-names ack
== Library/Taps/homebrew/homebrew-core/Formula/ack.rb ==
C: 41: 13: Style/NumericLiteralPrefix: Use 0o for octal literals.
```

I personally agree with this suggestion. It's a lot more friendly to newcomers without a background with C/C++ that probably find the effect of a leading zero more than surprising, but if the majority of us would prefer to suppress this advice and not change the existing code (as changes to the code trickle in), there's an option to disable this cop and I'm happy to adjust our `.rubocop` accordingly in this PR.