### PR TITLE
audit.rb: require https for download.savannah.gnu.org

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -1150,6 +1150,8 @@ class ResourceAuditor
       case p
       when %r{^http://ftp\.gnu\.org/},
            %r{^http://ftpmirror\.gnu\.org/},
+           %r{^http://download\.savannah\.gnu\.org/},
+           %r{^http://download-mirror\.savannah\.gnu\.org/},
            %r{^http://[^/]*\.apache\.org/},
            %r{^http://code\.google\.com/},
            %r{^http://fossies\.org/},


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

and download-mirror.savannah.gnu.org

These URLs now do support HTTPS. The first one (`download.savannah.gnu.org`) is a redirector, that may redirect to an insecure URL, the second one (`download-mirror.savannah.gnu.org`) is a direct secure download.