### PR TITLE
tests: fix leak in '[un]linkapps' integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -412,24 +412,23 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_linkapps
-    home = mktmpdir
-    apps_dir = Pathname.new(home).join("Applications")
-    apps_dir.mkpath
+    home_dir = Pathname.new(mktmpdir)
+    (home_dir/"Applications").mkpath
 
     setup_test_formula "testball"
 
     source_dir = HOMEBREW_CELLAR/"testball/0.1/TestBall.app"
     source_dir.mkpath
     assert_match "Linking: #{source_dir}",
-      cmd("linkapps", "--local", "HOME" => home)
+      cmd("linkapps", "--local", "HOME" => home_dir)
   ensure
-    FileUtils.rm_rf apps_dir
+    home_dir.rmtree
     (HOMEBREW_CELLAR/"testball").rmtree
   end
 
   def test_unlinkapps
-    home = mktmpdir
-    apps_dir = Pathname.new(home).join("Applications")
+    home_dir = Pathname.new(mktmpdir)
+    apps_dir = home_dir/"Applications"
     apps_dir.mkpath
 
     setup_test_formula "testball"
@@ -440,9 +439,9 @@ class IntegrationCommandTests < Homebrew::TestCase
     FileUtils.ln_s source_app, "#{apps_dir}/TestBall.app"
 
     assert_match "Unlinking: #{apps_dir}/TestBall.app",
-      cmd("unlinkapps", "--local", "HOME" => home)
+      cmd("unlinkapps", "--local", "HOME" => home_dir)
   ensure
-    apps_dir.rmtree
+    home_dir.rmtree
     (HOMEBREW_CELLAR/"testball").rmtree
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Prior to the fix, every run of the test suite would leave behind a pair of empty directories in `$TMPDIR`. (A temporary home directory was created but only its child `Applications` was wiped when done.)

Noticed while inspecting my local temporary directory. We might want to tweak the temporary directory used during our test suite run so that the file leak detection includes it, too.

cc @eirinikos because tests. :wink: