### PR TITLE
Refactor accessing meta data of Git repositories

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -805,7 +805,7 @@ module Homebrew
       def check_git_origin
         return if !Utils.git_available? || !(HOMEBREW_REPOSITORY/".git").exist?
 
-        origin = Homebrew.git_origin
+        origin = HOMEBREW_REPOSITORY.git_origin
 
         if origin.nil?
           <<-EOS.undent

--- a/Library/Homebrew/extend/git_repository.rb
+++ b/Library/Homebrew/extend/git_repository.rb
@@ -1,0 +1,47 @@
+require "utils/git"
+require "utils/popen"
+
+module GitRepositoryExtension
+  def git?
+    join(".git").exist?
+  end
+
+  def git_origin
+    return unless git? && Utils.git_available?
+    cd do
+      Utils.popen_read("git", "config", "--get", "remote.origin.url").chuzzle
+    end
+  end
+
+  def git_head
+    return unless git? && Utils.git_available?
+    cd do
+      Utils.popen_read("git", "rev-parse", "--verify", "-q", "HEAD").chuzzle
+    end
+  end
+
+  def git_short_head
+    return unless git? && Utils.git_available?
+    cd do
+      Utils.popen_read(
+        "git", "rev-parse", "--short=4", "--verify", "-q", "HEAD"
+      ).chuzzle
+    end
+  end
+
+  def git_last_commit
+    return unless git? && Utils.git_available?
+    cd do
+      Utils.popen_read("git", "show", "-s", "--format=%cr", "HEAD").chuzzle
+    end
+  end
+
+  def git_last_commit_date
+    return unless git? && Utils.git_available?
+    cd do
+      Utils.popen_read(
+        "git", "show", "-s", "--format=%cd", "--date=short", "HEAD"
+      ).chuzzle
+    end
+  end
+end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -761,7 +761,7 @@ class FormulaInstaller
     tab.tap = formula.tap
     tab.poured_from_bottle = true
     tab.time = Time.now.to_i
-    tab.head = Homebrew.git_head
+    tab.head = HOMEBREW_REPOSITORY.git_head
     tab.write
   end
 

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -1,6 +1,7 @@
 require "extend/module"
 require "extend/fileutils"
 require "extend/pathname"
+require "extend/git_repository"
 require "extend/ARGV"
 require "extend/string"
 require "extend/enumerable"

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -20,6 +20,8 @@ HOMEBREW_WWW = "http://brew.sh"
 
 require "config"
 
+HOMEBREW_REPOSITORY.extend(GitRepositoryExtension)
+
 if RbConfig.respond_to?(:ruby)
   RUBY_PATH = Pathname.new(RbConfig.ruby)
 else

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -23,15 +23,15 @@ class SystemConfig
     end
 
     def head
-      Homebrew.git_head || "(none)"
+      HOMEBREW_REPOSITORY.git_head || "(none)"
     end
 
     def last_commit
-      Homebrew.git_last_commit || "never"
+      HOMEBREW_REPOSITORY.git_last_commit || "never"
     end
 
     def origin
-      Homebrew.git_origin || "(none)"
+      HOMEBREW_REPOSITORY.git_origin || "(none)"
     end
 
     def core_tap_head

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -24,7 +24,7 @@ class Tab < OpenStruct
       "poured_from_bottle" => false,
       "time" => Time.now.to_i,
       "source_modified_time" => source_modified_time.to_i,
-      "HEAD" => Homebrew.git_head,
+      "HEAD" => HOMEBREW_REPOSITORY.git_head,
       "compiler" => compiler,
       "stdlib" => stdlib,
       "source" => {

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -62,6 +62,7 @@ class Tap
     @repo = repo
     @name = "#{@user}/#{@repo}".downcase
     @path = TAP_DIRECTORY/"#{@user}/homebrew-#{@repo}".downcase
+    @path.extend(GitRepositoryExtension)
   end
 
   # clear internal cache
@@ -84,15 +85,8 @@ class Tap
   # The remote path to this {Tap}.
   # e.g. `https://github.com/user/homebrew-repo`
   def remote
-    @remote ||= if installed?
-      if git? && Utils.git_available?
-        path.cd do
-          Utils.popen_read("git", "config", "--get", "remote.origin.url").chomp
-        end
-      end
-    else
-      raise TapUnavailableError, name
-    end
+    raise TapUnavailableError, name unless installed?
+    @remote ||= path.git_origin
   end
 
   # The default remote path to this {Tap}.
@@ -102,35 +96,31 @@ class Tap
 
   # True if this {Tap} is a git repository.
   def git?
-    (path/".git").exist?
+    path.git?
   end
 
   # git HEAD for this {Tap}.
   def git_head
     raise TapUnavailableError, name unless installed?
-    return unless git? && Utils.git_available?
-    path.cd { Utils.popen_read("git", "rev-parse", "--verify", "-q", "HEAD").chuzzle }
+    path.git_head
   end
 
   # git HEAD in short format for this {Tap}.
   def git_short_head
     raise TapUnavailableError, name unless installed?
-    return unless git? && Utils.git_available?
-    path.cd { Utils.popen_read("git", "rev-parse", "--short=4", "--verify", "-q", "HEAD").chuzzle }
+    path.git_short_head
   end
 
   # time since git last commit for this {Tap}.
   def git_last_commit
     raise TapUnavailableError, name unless installed?
-    return unless git? && Utils.git_available?
-    path.cd { Utils.popen_read("git", "show", "-s", "--format=%cr", "HEAD").chuzzle }
+    path.git_last_commit
   end
 
   # git last commit date for this {Tap}.
   def git_last_commit_date
     raise TapUnavailableError, name unless installed?
-    return unless git? && Utils.git_available?
-    path.cd { Utils.popen_read("git", "show", "-s", "--format=%cd", "--date=short", "HEAD").chuzzle }
+    path.git_last_commit_date
   end
 
   # The issues URL of this {Tap}.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -198,34 +198,9 @@ module Homebrew
     _system(cmd, *args)
   end
 
-  def self.git_origin
-    return unless Utils.git_available?
-    HOMEBREW_REPOSITORY.cd { `git config --get remote.origin.url 2>/dev/null`.chuzzle }
-  end
-
-  def self.git_head
-    return unless Utils.git_available?
-    HOMEBREW_REPOSITORY.cd { `git rev-parse --verify -q HEAD 2>/dev/null`.chuzzle }
-  end
-
-  def self.git_short_head
-    return unless Utils.git_available?
-    HOMEBREW_REPOSITORY.cd { `git rev-parse --short=4 --verify -q HEAD 2>/dev/null`.chuzzle }
-  end
-
-  def self.git_last_commit
-    return unless Utils.git_available?
-    HOMEBREW_REPOSITORY.cd { `git show -s --format="%cr" HEAD 2>/dev/null`.chuzzle }
-  end
-
-  def self.git_last_commit_date
-    return unless Utils.git_available?
-    HOMEBREW_REPOSITORY.cd { `git show -s --format="%cd" --date=short HEAD 2>/dev/null`.chuzzle }
-  end
-
   def self.homebrew_version_string
-    if pretty_revision = git_short_head
-      last_commit = git_last_commit_date
+    if pretty_revision = HOMEBREW_REPOSITORY.git_short_head
+      last_commit = HOMEBREW_REPOSITORY.git_last_commit_date
       "#{HOMEBREW_VERSION} (git revision #{pretty_revision}; last commit #{last_commit})"
     else
       "#{HOMEBREW_VERSION} (no git repository)"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Introduce `GitRepositoryExtension` that can be mixed-in into a `Pathname` instance that points at a Git repository (the path is the repository root), providing access to various Git-related meta data.

The goal is to avoid unnecessary code duplication across the `Homebrew.git_*` methods (they query the `brew` repository) and `Tap#git_*` methods (they query the repository associated with the given tap).