### PR TITLE
tab: eliminate redundant 'Tab.create' arguments

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -131,7 +131,8 @@ class Build
         formula.install
 
         stdlibs = detect_stdlibs(ENV.compiler)
-        Tab.create(formula, ENV.compiler, stdlibs.first, formula.build, formula.source_modified_time).write
+        tab = Tab.create(formula, ENV.compiler, stdlibs.first)
+        tab.write
 
         # Find and link metafiles
         formula.prefix.install_metafiles formula.buildpath

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -15,7 +15,8 @@ class Tab < OpenStruct
     CACHE.clear
   end
 
-  def self.create(formula, compiler, stdlib, build, source_modified_time)
+  def self.create(formula, compiler, stdlib)
+    build = formula.build
     attributes = {
       "used_options" => build.used_options.as_flags,
       "unused_options" => build.unused_options.as_flags,
@@ -23,7 +24,7 @@ class Tab < OpenStruct
       "built_as_bottle" => build.bottle?,
       "poured_from_bottle" => false,
       "time" => Time.now.to_i,
-      "source_modified_time" => source_modified_time.to_i,
+      "source_modified_time" => formula.source_modified_time.to_i,
       "HEAD" => HOMEBREW_REPOSITORY.git_head,
       "compiler" => compiler,
       "stdlib" => stdlib,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `build` and `source_modified_time` arguments are always coming from the matching attributes of the `Formula` instance. Thus query `formula` for them instead of passing them individually.