### PR TITLE
update: Don't report formulae that are moved within a tap but not renamed

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -209,8 +209,12 @@ class Reporter
         end
         @report[:M] << tap.formula_file_to_name(src)
       when /^R\d{0,3}/
-        @report[:D] << tap.formula_file_to_name(src) if tap.formula_file?(src)
-        @report[:A] << tap.formula_file_to_name(dst) if tap.formula_file?(dst)
+        src_full_name = tap.formula_file_to_name(src)
+        dst_full_name = tap.formula_file_to_name(dst)
+        # Don't report formulae that are moved within a tap but not renamed
+        next if src_full_name == dst_full_name
+        @report[:D] << src_full_name if tap.formula_file?(src)
+        @report[:A] << dst_full_name if tap.formula_file?(dst)
       end
     end
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -209,12 +209,13 @@ class Reporter
         end
         @report[:M] << tap.formula_file_to_name(src)
       when /^R\d{0,3}/
+        next unless tap.formula_file?(dst)
         src_full_name = tap.formula_file_to_name(src)
         dst_full_name = tap.formula_file_to_name(dst)
         # Don't report formulae that are moved within a tap but not renamed
         next if src_full_name == dst_full_name
-        @report[:D] << src_full_name if tap.formula_file?(src)
-        @report[:A] << dst_full_name if tap.formula_file?(dst)
+        @report[:D] << src_full_name
+        @report[:A] << dst_full_name
       end
     end
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -209,7 +209,6 @@ class Reporter
         end
         @report[:M] << tap.formula_file_to_name(src)
       when /^R\d{0,3}/
-        next unless tap.formula_file?(dst)
         src_full_name = tap.formula_file_to_name(src)
         dst_full_name = tap.formula_file_to_name(dst)
         # Don't report formulae that are moved within a tap but not renamed

--- a/Library/Homebrew/test/fixtures/updater_fixture.yaml
+++ b/Library/Homebrew/test/fixtures/updater_fixture.yaml
@@ -45,6 +45,8 @@ update_git_diff_output_with_formula_rename: |
 update_git_diff_output_with_restructured_tap: |
   R100	git.rb	Formula/git.rb
   R100	lua.rb	Formula/lua.rb
+update_git_diff_output_with_formula_rename_and_restructuring: |
+  R100	xchat.rb	Formula/xchat2.rb
 update_git_diff_simulate_homebrew_php_restructuring: |
   R100	Formula/git.rb	Abstract/git.rb
   R100	Formula/lua.rb	Abstract/lua.rb

--- a/Library/Homebrew/test/test_update_report.rb
+++ b/Library/Homebrew/test/test_update_report.rb
@@ -87,6 +87,7 @@ class ReportTests < Homebrew::TestCase
     perform_update("update_git_diff_output_with_restructured_tap")
     assert_empty @hub.select_formula(:A)
     assert_empty @hub.select_formula(:D)
+    assert_empty @hub.select_formula(:R)
   ensure
     tap.path.parent.rmtree
   end
@@ -113,6 +114,7 @@ class ReportTests < Homebrew::TestCase
     perform_update("update_git_diff_simulate_homebrew_php_restructuring")
     assert_empty @hub.select_formula(:A)
     assert_empty @hub.select_formula(:D)
+    assert_empty @hub.select_formula(:R)
   ensure
     tap.path.parent.rmtree
   end

--- a/Library/Homebrew/test/test_update_report.rb
+++ b/Library/Homebrew/test/test_update_report.rb
@@ -91,6 +91,20 @@ class ReportTests < Homebrew::TestCase
     tap.path.parent.rmtree
   end
 
+  def test_update_homebrew_with_formula_rename_and_restructuring
+    tap = Tap.new("foo", "bar")
+    @reporter = ReporterMock.new(tap)
+    tap.path.join("Formula").mkpath
+    tap.stubs(:formula_renames).returns("xchat" => "xchat2")
+
+    perform_update("update_git_diff_output_with_formula_rename_and_restructuring")
+    assert_empty @hub.select_formula(:A)
+    assert_empty @hub.select_formula(:D)
+    assert_equal [%w[foo/bar/xchat foo/bar/xchat2]], @hub.select_formula(:R)
+  ensure
+    tap.path.parent.rmtree
+  end
+
   def test_update_homebrew_simulate_homebrew_php_restructuring
     tap = Tap.new("foo", "bar")
     @reporter = ReporterMock.new(tap)

--- a/Library/Homebrew/test/test_update_report.rb
+++ b/Library/Homebrew/test/test_update_report.rb
@@ -85,7 +85,7 @@ class ReportTests < Homebrew::TestCase
     tap.path.join("Formula").mkpath
 
     perform_update("update_git_diff_output_with_restructured_tap")
-    assert_equal %w[foo/bar/git foo/bar/lua], @hub.select_formula(:A)
+    assert_empty @hub.select_formula(:A)
     assert_empty @hub.select_formula(:D)
   ensure
     tap.path.parent.rmtree
@@ -98,7 +98,7 @@ class ReportTests < Homebrew::TestCase
 
     perform_update("update_git_diff_simulate_homebrew_php_restructuring")
     assert_empty @hub.select_formula(:A)
-    assert_equal %w[foo/bar/git foo/bar/lua], @hub.select_formula(:D)
+    assert_empty @hub.select_formula(:D)
   ensure
     tap.path.parent.rmtree
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It's misleading to report a formula as "new" when it's only been moved from one directory to another within the same tap.

Ref: [caskroom/homebrew-cask#22669 (comment)](https://github.com/caskroom/homebrew-cask/pull/22669#issuecomment-231457315)