### PR TITLE
tap-info: expose whether a tap is private, tweaks

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -1,5 +1,10 @@
-#:  * `tap-info` <tap>:
-#:    Display information about <tap>.
+#:  * `tap-info`:
+#:    Display a brief summary of all installed taps.
+#:
+#:  * `tap-info` (`--installed`|<taps>):
+#:    Display detailed information about one or more <taps>.
+#:
+#:    Pass `--installed` to display information on all installed taps.
 #:
 #:  * `tap-info` `--json=`<version> (`--installed`|<taps>):
 #:    Print a JSON representation of <taps>. Currently the only accepted value

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -42,14 +42,17 @@ module Homebrew
       formula_count = 0
       command_count = 0
       pinned_count = 0
+      private_count = 0
       Tap.each do |tap|
         tap_count += 1
         formula_count += tap.formula_files.size
         command_count += tap.command_files.size
         pinned_count += 1 if tap.pinned?
+        private_count += 1 if tap.private?
       end
       info = "#{tap_count} tap#{plural(tap_count)}"
       info += ", #{pinned_count} pinned"
+      info += ", #{private_count} private"
       info += ", #{formula_count} formula#{plural(formula_count, "e")}"
       info += ", #{command_count} command#{plural(command_count)}"
       info += ", #{Tap::TAP_DIRECTORY.abv}" if Tap::TAP_DIRECTORY.directory?
@@ -60,6 +63,7 @@ module Homebrew
         info = "#{tap}: "
         if tap.installed?
           info += tap.pinned? ? "pinned" : "unpinned"
+          info += ", private" if tap.private?
           if (formula_count = tap.formula_files.size) > 0
             info += ", #{formula_count} formula#{plural(formula_count, "e")}"
           end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -418,6 +418,7 @@ class Tap
     if installed?
       hash["remote"] = remote
       hash["custom_remote"] = custom_remote?
+      hash["private"] = private?
     end
 
     hash

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -460,6 +460,18 @@ _brew_style ()
     __brew_complete_formulae
 }
 
+_brew_tap_info ()
+{
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    case "$cur" in
+    --*)
+        __brewcomp "--installed --json=v1"
+        return
+        ;;
+    esac
+    __brew_complete_tapped
+}
+
 _brew_tap_readme ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -625,6 +637,7 @@ _brew ()
     style)                      _brew_style ;;
     switch)                     _brew_switch ;;
     tap)                        _brew_complete_tap ;;
+    tap-info)                   _brew_tap_info ;;
     tap-readme)                 _brew_tap_readme ;;
     tap-unpin)                  _brew_tap_unpin ;;
     tests)                      _brew_tests ;;
@@ -632,7 +645,7 @@ _brew ()
     unlinkapps)                 _brew_unlinkapps ;;
     unpack)                     _brew_unpack ;;
     unpin)                      __brew_complete_formulae ;;
-    untap|tap-info|tap-pin)     __brew_complete_tapped ;;
+    untap|tap-pin)              __brew_complete_tapped ;;
     update)                     _brew_update ;;
     upgrade)                    _brew_upgrade ;;
     uses)                       _brew_uses ;;

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -369,7 +369,10 @@ However, retapping with a different <var>URL</var> will cause an exception, so f
 <dt><code>tap</code> <code>--repair</code></dt><dd><p>Migrate tapped formulae from symlink-based to directory-based structure.</p></dd>
 <dt><code>tap</code> <code>--list-official</code></dt><dd><p>List all official taps.</p></dd>
 <dt><code>tap</code> <code>--list-pinned</code></dt><dd><p>List all pinned taps.</p></dd>
-<dt><code>tap-info</code> <var>tap</var></dt><dd><p>Display information about <var>tap</var>.</p></dd>
+<dt><code>tap-info</code></dt><dd><p>Display a brief summary of all installed taps.</p></dd>
+<dt><code>tap-info</code> (<code>--installed</code>|<var>taps</var>)</dt><dd><p>Display detailed information about one or more <var>taps</var>.</p>
+
+<p>Pass <code>--installed</code> to display information on all installed taps.</p></dd>
 <dt><code>tap-info</code> <code>--json=</code><var>version</var> (<code>--installed</code>|<var>taps</var>)</dt><dd><p>Print a JSON representation of <var>taps</var>. Currently the only accepted value
 for <var>version</var> is <code>v1</code>.</p>
 

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -503,8 +503,15 @@ List all official taps\.
 List all pinned taps\.
 .
 .TP
-\fBtap\-info\fR \fItap\fR
-Display information about \fItap\fR\.
+\fBtap\-info\fR
+Display a brief summary of all installed taps\.
+.
+.TP
+\fBtap\-info\fR (\fB\-\-installed\fR|\fItaps\fR)
+Display detailed information about one or more \fItaps\fR\.
+.
+.IP
+Pass \fB\-\-installed\fR to display information on all installed taps\.
 .
 .TP
 \fBtap\-info\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-installed\fR|\fItaps\fR)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Additionally:

- Expand and correct help text.
- Improve Bash completion.

Before:

```console
$ brew tap-info
9 taps, 0 pinned, 4493 formulae, 25 commands, 11,133 files, 193.7M
$ brew tap-info uniqmartin/tools
uniqmartin/tools: unpinned, 10 commands
/opt/homebrew/Library/Taps/uniqmartin/homebrew-tools (39B)
From: https://github.com/UniqMartin/homebrew-tools.git
$ brew tap-info --json=v1 uniqmartin/tools | jq .[].private
null
```

After:

```console
$ brew tap-info
9 taps, 0 pinned, 9 private, 4493 formulae, 25 commands, 11,133 files, 193.7M
$ brew tap-info uniqmartin/tools
uniqmartin/tools: unpinned, private, 10 commands
/opt/homebrew/Library/Taps/uniqmartin/homebrew-tools (39B)
From: https://github.com/UniqMartin/homebrew-tools.git
$ brew tap-info --json=v1 uniqmartin/tools | jq .[].private
true
```