### PR TITLE
Go Language Tweaks.

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -676,6 +676,10 @@ class FormulaAuditor
     if text =~ /def plist/ && text !~ /plist_options/
       problem "Please set plist_options when using a formula-defined plist."
     end
+
+    if text =~ %r{require "language/go"} && text !~ /go_resource/
+      problem "require \"language/go\" is unnecessary unless using `go_resource`s"
+    end
   end
 
   def audit_line(line, lineno)

--- a/Library/Homebrew/language/go.rb
+++ b/Library/Homebrew/language/go.rb
@@ -7,7 +7,13 @@ module Language
     # The resource names should be the import name of the package,
     # e.g. `resource "github.com/foo/bar"`
     def self.stage_deps(resources, target)
-      opoo "tried to stage empty resources array" if resources.empty?
+      if resources.empty?
+        if ARGV.homebrew_developer?
+          odie "tried to stage empty Language::Go resources array"
+        else
+          opoo "tried to stage empty Language::Go resources array"
+        end
+      end
       resources.grep(Resource::Go) { |resource| resource.stage(target) }
     end
   end

--- a/Library/Homebrew/test/test_language_go.rb
+++ b/Library/Homebrew/test/test_language_go.rb
@@ -5,7 +5,11 @@ require "language/go"
 
 class LanguageGoTests < Homebrew::TestCase
   def test_stage_deps_empty
-    Language::Go.expects(:opoo).once
+    if ARGV.homebrew_developer?
+      Language::Go.expects(:odie).once
+    else
+      Language::Go.expects(:opoo).once
+    end
     mktmpdir do |path|
       shutup { Language::Go.stage_deps [], path }
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I'm so tired of having to catch this stuff in post or us leaving it there forever because nobody sees or bothers to not ignore the existing `oppo` warning.

Let's punch harder on the empty arrays when `HOMEBREW_DEVELOPER` is set so we can start killing code that isn't necessary. User impact should be limited given the `HOMEBREW_DEVELOPER` couching, mostly means we can catch this with CI more than anything.

You only need to use `require "language/go` if you're using `go_resource`s, which we'll be doing less & less over time as upstream pressure to adopt the vendor system comes to bear. That is the _only_ purpose of the Go language module in Homebrew. Let's insert an `audit` warning about using `require "language/go` unnecessarily.