### PR TITLE
style: use RuboCop 0.41.2, adjust defaults

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -3,9 +3,13 @@ AllCops:
     - 'Homebrew/vendor/**/*'
     - 'Homebrew/test/vendor/**/*'
 
-# 1.8-style hash keys
+# Ruby 1.8 compatibility
+Style/DotPosition:
+  EnforcedStyle: trailing
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: no_comma
 
 # ruby style guide favorite
 Style/StringLiterals:
@@ -22,6 +26,10 @@ Style/CommandLiteral:
 # paths abound, easy escape
 Style/RegexpLiteral:
   EnforcedStyle: slashes
+
+# too prevalent to change this now, but might be discussed/changed later
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
 
 # our current conditional style is established, clear and
 # requiring users to change that now would be confusing.
@@ -115,10 +123,6 @@ Style/WordArray:
 Style/UnneededCapitalW:
   Enabled: false
 
-# we use raise, not fail
-Style/SignalException:
-  EnforcedStyle: only_raise
-
 # we prefer compact if-else-end/case-when-end alignment
 Lint/EndAlignment:
   AlignWith: variable
@@ -129,12 +133,6 @@ Style/CaseIndentation:
 Style/PerlBackrefs:
   Enabled: false
 
-# this is required for Ruby 1.8
-Style/DotPosition:
-  EnforcedStyle: trailing
-
 # makes diffs nicer
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: no_comma
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -47,7 +47,7 @@ module Homebrew
 
   def check_style_impl(files, output_type, options = {})
     fix = options[:fix]
-    Homebrew.install_gem_setup_path! "rubocop", "0.41.1"
+    Homebrew.install_gem_setup_path! "rubocop", "0.41.2"
 
     args = %W[
       --force-exclusion


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Changes to our style configuration:

- Consolidate all rules related to Ruby 1.8 compatibility in one place.
- Codify our de-facto preference for `alias_method` over `alias` (drops offense count by 54 after turning this on).
- Drop `Style/SignalException` as `only_raise` has been the new default for quite a while (since RuboCop 0.37.0).