### PR TITLE
Vendored Ruby tweaks

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,4 +1,4 @@
-origin-setup-ruby-path() {
+original-setup-ruby-path() {
   if [[ -z "$HOMEBREW_DEVELOPER" ]]
   then
     unset HOMEBREW_RUBY_PATH
@@ -24,7 +24,7 @@ origin-setup-ruby-path() {
 setup-ruby-path() {
   if [[ -z "$HOMEBREW_USE_VENDOR_RUBY" ]]
   then
-    origin-setup-ruby-path
+    original-setup-ruby-path
     return
   fi
 

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -22,7 +22,7 @@ original-setup-ruby-path() {
 }
 
 setup-ruby-path() {
-  if [[ -z "$HOMEBREW_USE_VENDOR_RUBY" ]]
+  if [[ -z "$HOMEBREW_USE_VENDOR_RUBY" && -z "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
   then
     original-setup-ruby-path
     return
@@ -70,7 +70,7 @@ setup-ruby-path() {
         ruby_version_major="${ruby_version_major%%.*}"
       fi
 
-      if [[ "$ruby_version_major" != "2" ]]
+      if [[ "$ruby_version_major" != "2" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
       then
         brew vendor-install ruby --quiet
         if [[ ! -x "$vendor_ruby_path" ]]

--- a/Library/brew.sh
+++ b/Library/brew.sh
@@ -211,11 +211,6 @@ fi
 
 # Hide shellcheck complaint:
 # shellcheck source=/dev/null
-source "$HOMEBREW_LIBRARY/Homebrew/utils/ruby.sh"
-setup-ruby-path
-
-# Hide shellcheck complaint:
-# shellcheck source=/dev/null
 source "$HOMEBREW_LIBRARY/Homebrew/utils/analytics.sh"
 setup-analytics
 report-analytics-screenview-command
@@ -243,6 +238,11 @@ then
   source "$HOMEBREW_BASH_COMMAND"
   { update-preinstall; "homebrew-$HOMEBREW_COMMAND" "$@"; exit $?; }
 else
+  # Hide shellcheck complaint:
+  # shellcheck source=/dev/null
+  source "$HOMEBREW_LIBRARY/Homebrew/utils/ruby.sh"
+  setup-ruby-path
+
   # Unshift command back into argument list (unless argument list was empty).
   [[ "$HOMEBREW_ARG_COUNT" -gt 0 ]] && set -- "$HOMEBREW_COMMAND" "$@"
   { update-preinstall; exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/brew.rb" "$@"; }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- fix original setup ruby path name.
- allow forcing the usage of the vendored Ruby.
- brew.sh: only setup/install Ruby when running Ruby.

CC @xu-cheng 