### PR TITLE
cleaner: fix generic executable handling.

### DIFF
--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -67,7 +67,7 @@ class Cleaner
   end
 
   def executable_path?(path)
-    path.text_executable?
+    path.text_executable? || path.executable?
   end
 
   # Clean a top-level (bin, sbin, lib) directory, recursively, by fixing file


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Don't unset things that are already set as executable for the generic path.

OS X overrides this behaviour and detects if it's an MachO executable but there's no cross-OS generic equivalent so just fall back to whatever the build system has set.