### PR TITLE
tests: add cmd/test integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -773,4 +773,31 @@ class IntegrationCommandTests < Homebrew::TestCase
     assert_match "testball does not have a version \"0.3\"",
       cmd_fail("switch", "testball", "0.3")
   end
+
+  def test_test_formula
+    assert_match "This command requires a formula argument", cmd_fail("test")
+    assert_match "Testing requires the latest version of testball",
+      cmd_fail("test", testball)
+
+    cmd("install", testball)
+    assert_match "testball defines no test", cmd_fail("test", testball)
+
+    setup_test_formula "testball_copy", <<-EOS.undent
+      head "https://github.com/example/testball2.git"
+
+      devel do
+        url "file://#{File.expand_path("..", __FILE__)}/tarballs/testball-0.1.tbz"
+        sha256 "#{TESTBALL_SHA256}"
+      end
+
+      keg_only "just because"
+
+      test do
+      end
+    EOS
+
+    cmd("install", "testball_copy")
+    assert_match "Testing testball_copy", cmd("test", "--HEAD", "testball_copy")
+    assert_match "Testing testball_copy", cmd("test", "--devel", "testball_copy")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds test coverage for `brew test foo`. It also incorporates @UniqMartin's [suggestion](https://github.com/Homebrew/brew/pull/398/files#r70382703) to use `/^testball/` in the `case` statement. 🎈 

[These lines](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/test.rb#L65-L85) remain untested, though. Is it feasible to test a formula within the test suite? It looks like using Minitest assertions is not an option, because when doing so, I receive this error:

``undefined method `assertions' for #<Formulary::FormulaNamespace[...]::TestballCopy:[...]>``

