### PR TITLE
tests: add cmd/irb integration test

### DIFF
--- a/Library/Homebrew/test/lib/config.rb
+++ b/Library/Homebrew/test/lib/config.rb
@@ -2,10 +2,9 @@ require "tmpdir"
 require "pathname"
 
 HOMEBREW_BREW_FILE = Pathname.new(ENV["HOMEBREW_BREW_FILE"])
-HOMEBREW_TEMP = Pathname.new(ENV["HOMEBREW_TEMP"] || Dir.tmpdir)
 
 TEST_TMPDIR = ENV.fetch("HOMEBREW_TEST_TMPDIR") { |k|
-  dir = Dir.mktmpdir("homebrew_tests", HOMEBREW_TEMP)
+  dir = Dir.mktmpdir("homebrew-tests-", ENV["HOMEBREW_TEMP"] || "/tmp")
   at_exit { FileUtils.remove_entry(dir) }
   ENV[k] = dir
 }
@@ -24,6 +23,7 @@ HOMEBREW_CACHE_FORMULA = HOMEBREW_PREFIX.parent+"formula_cache"
 HOMEBREW_LOCK_DIR      = HOMEBREW_PREFIX.parent+"locks"
 HOMEBREW_CELLAR        = HOMEBREW_PREFIX.parent+"cellar"
 HOMEBREW_LOGS          = HOMEBREW_PREFIX.parent+"logs"
+HOMEBREW_TEMP          = HOMEBREW_PREFIX.parent+"temp"
 
 TESTBALL_SHA1 = "be478fd8a80fe7f29196d6400326ac91dad68c37"
 TESTBALL_SHA256 = "91e3f7930c98d7ccfb288e115ed52d06b0e5bc16fec7dce8bdda86530027067b"

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -18,6 +18,7 @@ class IntegrationCommandTests < Homebrew::TestCase
       HOMEBREW_CACHE.children,
       HOMEBREW_LOCK_DIR.children,
       HOMEBREW_LOGS.children,
+      HOMEBREW_TEMP.children,
       HOMEBREW_PREFIX/"bin",
       HOMEBREW_PREFIX/"share",
       HOMEBREW_PREFIX/"opt",
@@ -688,5 +689,21 @@ class IntegrationCommandTests < Homebrew::TestCase
 
     cmd("install", "testball")
     assert_match "Would remove", cmd("unlink", "--dry-run", "testball")
+  end
+
+  def test_irb
+    assert_match "'v8'.f # => instance of the v8 formula",
+      cmd("irb", "--examples")
+
+    setup_test_formula "testball"
+
+    irb_test = HOMEBREW_TEMP/"irb-test.rb"
+    irb_test.write <<-EOS.undent
+      "testball".f
+      :testball.f
+      exit
+    EOS
+
+    assert_match "Interactive Homebrew Shell", cmd("irb", irb_test)
   end
 end

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -7,7 +7,7 @@ require "formulary"
 
 # Test environment setup
 (HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-core/Formula").mkpath
-%w[cache formula_cache locks cellar logs].each { |d| HOMEBREW_PREFIX.parent.join(d).mkpath }
+%w[cache formula_cache locks cellar logs temp].each { |d| HOMEBREW_PREFIX.parent.join(d).mkpath }
 
 # Test fixtures and files can be found relative to this path
 TEST_DIRECTORY = File.dirname(File.expand_path(__FILE__))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds testing for `brew irb`. Several lines remain untested, though. I haven't yet figured out a way to quit the `IRB` shell from within the test... 😞 