### PR TITLE
test-bot: start running generic tests.

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -654,6 +654,8 @@ module Homebrew
           tests_args << "--coverage" if ENV["TRAVIS"]
         end
         test "brew", "tests", *tests_args
+        test "brew", "tests", "--generic", "--only=integration_cmds", \
+                              *tests_args
         test "brew", "tests", "--no-compat"
         test "brew", "readall", "--syntax"
       else

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -654,7 +654,7 @@ module Homebrew
           tests_args << "--coverage" if ENV["TRAVIS"]
         end
         test "brew", "tests", *tests_args
-        test "brew", "tests", "--generic", "--only=integration_cmds", \
+        test "brew", "tests", "--generic", "--only=integration_cmds",
                               *tests_args
         test "brew", "tests", "--no-compat"
         test "brew", "readall", "--syntax"

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -358,7 +358,7 @@ class IntegrationCommandTests < Homebrew::TestCase
 
   def test_sh
     assert_match "Your shell has been configured",
-                 cmd("sh", "SHELL" => "/usr/bin/true")
+                 cmd("sh", "SHELL" => which("true"))
   end
 
   def test_info
@@ -588,10 +588,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     assert((share/"notpruneable").directory?)
     refute((share/"pruneable_symlink").symlink?)
 
-    # Inexact match because only if ~/Applications exists, will this output one
-    # more line with contents `No apps unlinked from /Users/<user/Applications`.
-    assert_match "Nothing pruned\nNo apps unlinked from /Applications",
-      cmd("prune", "--verbose")
+    assert_match "Nothing pruned", cmd("prune", "--verbose")
   end
 
   def test_custom_command


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Start running the test suite in the "generic" mode i.e. a base layer for non-OS X platforms to be able to use to ensure we don't break the generic code for the parts of the code we've got running.

Currently this just runs the integration tests as that's the only useful suite that's entirely passing but eventually this will be changed to run the full test suite in generic mode.