### PR TITLE
brew.{rb,sh}: move to Library/Homebrew.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -1,7 +1,7 @@
 std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 
 require "pathname"
-HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent.join("Homebrew")
+HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
 $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -245,5 +245,5 @@ else
 
   # Unshift command back into argument list (unless argument list was empty).
   [[ "$HOMEBREW_ARG_COUNT" -gt 0 ]] && set -- "$HOMEBREW_COMMAND" "$@"
-  { update-preinstall; exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/brew.rb" "$@"; }
+  { update-preinstall; exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/Homebrew/brew.rb" "$@"; }
 fi

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -9,7 +9,7 @@
 # shellcheck source=/dev/null
 source "$HOMEBREW_LIBRARY/Homebrew/utils/lock.sh"
 
-# Replaces the function in Library/brew.sh to cache the Git executable to
+# Replaces the function in Library/Homebrew/brew.sh to cache the Git executable to
 # provide speedup when using Git repeatedly (as update.sh does).
 git() {
   if [[ -z "$GIT_EXECUTABLE" ]]

--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -34,7 +34,7 @@ SimpleCov.start do
   add_group "OS", "/Homebrew/os/"
   add_group "Requirements", "/Homebrew/requirements/"
   add_group "Scripts", %w[
-    /brew.rb
+    /Homebrew/brew.rb
     /Homebrew/build.rb
     /Homebrew/postinstall.rb
     /Homebrew/test.rb

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -64,7 +64,7 @@ class IntegrationCommandTests < Homebrew::TestCase
       cmd_args << "-rsimplecov"
     end
     cmd_args << "-rintegration_mocks"
-    cmd_args << (HOMEBREW_LIBRARY_PATH/"../brew.rb").resolved_path.to_s
+    cmd_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
     cmd_args += args
     Bundler.with_original_env do
       ENV["HOMEBREW_BREW_FILE"] = HOMEBREW_PREFIX/"bin/brew"

--- a/bin/brew
+++ b/bin/brew
@@ -25,4 +25,4 @@ fi
 
 HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 
-source "$HOMEBREW_LIBRARY/brew.sh"
+source "$HOMEBREW_LIBRARY/Homebrew/brew.sh"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This has bugged me for ages so I figured: why not do something about it? It's irritating to work on Homebrew by doing e.g. `mate /usr/local/Library/Homebrew` and have it not include these files that have non-trivial amounts of logic in them. Instead, put them in `Library/Homebrew` where they belong.

A random thought as a result of this was: what if we managed to make everything we need installed outside `Library/Homebrew` a symlink (or hard link) instead of requiring all of `/usr/local` to be a Git repository? It feels like this may address some `/usr/local` complaints as well as avoiding e.g. `README.md` in that location.
