### PR TITLE
ARGV#resolved_formulae: also load build options

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -27,9 +27,11 @@ module HomebrewArgvExtension
     @resolved_formulae ||= (downcased_unique_named - casks).map do |name|
       if name.include?("/")
         f = Formulary.factory(name, spec)
-        if spec(default=nil).nil? && f.any_version_installed?
-          installed_spec = Tab.for_formula(f).spec
-          f.set_active_spec(installed_spec) if f.send(installed_spec)
+        if f.any_version_installed?
+          tab = Tab.for_formula(f)
+          resolved_spec = spec(default=nil) || tab.spec
+          f.set_active_spec(resolved_spec) if f.send(resolved_spec)
+          f.build = tab
         end
         f
       else

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -227,7 +227,7 @@ class Formulary
     tap = tab.tap
     spec ||= tab.spec
 
-    if tap.nil?
+    f = if tap.nil?
       factory(rack.basename.to_s, spec)
     else
       begin
@@ -237,6 +237,8 @@ class Formulary
         factory(rack.basename.to_s, spec)
       end
     end
+    f.build = tab
+    f
   end
 
   # Return a Formula instance directly from contents

--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -129,9 +129,7 @@ class LinkageChecker
   end
 
   def resolve_formula(keg)
-    f = Formulary.from_rack(keg.rack)
-    f.build = Tab.for_keg(keg)
-    f
+    Formulary.from_keg(keg)
   rescue FormulaUnavailableError
     opoo "Formula unavailable: #{keg.name}"
   end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -179,6 +179,18 @@ class Tab < OpenStruct
     include?("32-bit")
   end
 
+  def head?
+    spec == :head
+  end
+
+  def devel?
+    spec == :devel
+  end
+
+  def stable?
+    spec == :stable
+  end
+
   def used_options
     Options.create(super)
   end

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -90,12 +90,17 @@ class FormularyFactoryTest < Homebrew::TestCase
     alias_dir.rmtree
   end
 
-  def test_factory_from_rack
+  def test_factory_from_rack_and_from_keg
     formula = Formulary.factory(@path)
     installer = FormulaInstaller.new(formula)
     shutup { installer.install }
     keg = Keg.new(formula.prefix)
-    assert_kind_of Formula, Formulary.from_rack(formula.rack)
+    f = Formulary.from_rack(formula.rack)
+    assert_kind_of Formula, f
+    assert_kind_of Tab, f.build
+    f = Formulary.from_keg(keg)
+    assert_kind_of Formula, f
+    assert_kind_of Tab, f.build
   ensure
     keg.unlink
     keg.uninstall

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -29,6 +29,9 @@ class TabTests < Homebrew::TestCase
     assert_empty tab.used_options
     refute_predicate tab, :built_as_bottle
     refute_predicate tab, :poured_from_bottle
+    assert_predicate tab, :stable?
+    refute_predicate tab, :devel?
+    refute_predicate tab, :head?
     assert_nil tab.tap
     assert_nil tab.time
     assert_nil tab.HEAD
@@ -74,6 +77,9 @@ class TabTests < Homebrew::TestCase
     assert_equal @unused.sort, tab.unused_options.sort
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
+    assert_predicate tab, :stable?
+    refute_predicate tab, :devel?
+    refute_predicate tab, :head?
     assert_equal "homebrew/core", tab.tap.name
     assert_equal :stable, tab.spec
     refute_nil tab.time
@@ -90,6 +96,9 @@ class TabTests < Homebrew::TestCase
     assert_equal @unused.sort, tab.unused_options.sort
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
+    assert_predicate tab, :stable?
+    refute_predicate tab, :devel?
+    refute_predicate tab, :head?
     assert_equal "homebrew/core", tab.tap.name
     assert_equal :stable, tab.spec
     refute_nil tab.time


### PR DESCRIPTION
This fixes the problem that `brew audit foo` complains that
an optional dependency is undeclared.