### PR TITLE
respect user's curlrc file

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1324,6 +1324,8 @@ class Formula
   # @private
   def run_test
     old_home = ENV["HOME"]
+    old_curl_home = ENV["CURL_HOME"]
+    ENV["CURL_HOME"] = old_curl_home || old_home
     build, self.build = self.build, Tab.for_formula(self)
     mktemp("#{name}-test") do |staging|
       staging.retain! if ARGV.keep_tmp?
@@ -1341,6 +1343,7 @@ class Formula
     @testpath = nil
     self.build = build
     ENV["HOME"] = old_home
+    ENV["CURL_HOME"] = old_curl_home
   end
 
   # @private
@@ -1555,6 +1558,8 @@ class Formula
       mkdir_p env_home
 
       old_home, ENV["HOME"] = ENV["HOME"], env_home
+      old_curl_home = ENV["CURL_HOME"]
+      ENV["CURL_HOME"] = old_curl_home || old_home
       setup_home env_home
 
       begin
@@ -1562,6 +1567,7 @@ class Formula
       ensure
         @buildpath = nil
         ENV["HOME"] = old_home
+        ENV["CURL_HOME"] = old_curl_home
       end
     end
   end


### PR DESCRIPTION
Users may have ~/.curlrc file to include options like proxies.
However, since we overwrite HOME environment variable during the build
and test, curl won't be able to find it.

This commit solves this issue by using CURL_HOME environment variable,
which will be pointed to the original HOME path.

From `curl(1)`:
> 1) curl tries to find the "home dir": It first  checks  for  the
     CURL_HOME and then the HOME environment variables. Failing that,
     it uses getpwuid() on Unix-like systems (which returns the  home
     dir  given the current user in your system). On Windows, it then
     checks for the APPDATA variable, or as a last resort the '%USER-
     PROFILE%\Application Data'.