### PR TITLE
Xcode: track/warn prerelease versions

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -4,6 +4,7 @@ module Homebrew
       def all_development_tools_checks
         %w[
           check_for_unsupported_osx
+          check_for_prerelease_xcode
           check_for_bad_install_name_tool
           check_for_installed_developer_tools
           check_xcode_license_approved
@@ -27,6 +28,21 @@ module Homebrew
         <<-EOS.undent
           You are using OS X #{MacOS.version}.
           #{who} do not provide support for this #{what}.
+          You may encounter build failures or other breakages.
+          Please create pull-requests instead of filing issues.
+        EOS
+      end
+
+      def check_for_prerelease_xcode
+        return if ARGV.homebrew_developer?
+        # Running a pre-release Xcode on a pre-release OS is expected
+        # and likely to cause less problems than a stable Xcode will.
+        return if OS::Mac.prerelease?
+        return unless MacOS::Xcode.installed?
+        return unless MacOS::Xcode.prerelease?
+
+        <<-EOS.undent
+          You are using a pre-release version of Xcode.
           You may encounter build failures or other breakages.
           Please create pull-requests instead of filing issues.
         EOS

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -27,6 +27,11 @@ module OS
         end
       end
 
+      def prerelease?
+        # TODO: bump to version >= "8.1" after Xcode 8.0 is stable.
+        version > "7.3.1"
+      end
+
       def outdated?
         version < latest_version
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A number of users have switched over to Xcode 8 on 10.11, which is somehow even more of a breaky decision than running Xcode 8 on the pre-release 10.12. Since we warn about the latter, it makes sense to warn about the former.