### PR TITLE
tests: add cmd/pull integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -706,4 +706,35 @@ class IntegrationCommandTests < Homebrew::TestCase
 
     assert_match "Interactive Homebrew Shell", cmd("irb", irb_test)
   end
+
+  def test_pull_offline
+    assert_match "You meant `git pull --rebase`.", cmd_fail("pull", "--rebase")
+    assert_match "This command requires at least one argument", cmd_fail("pull")
+    assert_match "Not a GitHub pull request or commit",
+      cmd_fail("pull", "0")
+  end
+
+  def test_pull
+    skip "Requires network connection" if ENV["HOMEBREW_NO_GITHUB_API"]
+
+    core_tap = CoreTap.new
+    core_tap.path.cd do
+      shutup do
+        system "git", "init"
+        system "git", "checkout", "-b", "new-branch"
+      end
+    end
+
+    assert_match "Testing URLs require `--bottle`!",
+      cmd_fail("pull", "http://bot.brew.sh/job/Homebrew\%20Testing/1028/")
+    assert_match "Current branch is new-branch",
+      cmd_fail("pull", "1")
+    assert_match "No changed formulae found to bump",
+      cmd_fail("pull", "--bump", "8")
+    assert_match "Can only bump one changed formula",
+      cmd_fail("pull", "--bump",
+        "https://api.github.com/repos/Homebrew/homebrew-core/pulls/122")
+    assert_match "Patch failed to apply",
+      cmd_fail("pull", "https://github.com/Homebrew/homebrew-core/pull/1")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds some test coverage for `brew pull` (40-41% coverage). As you can see, every assertion involves a `cmd_fail`, and a network connection would probably be needed.

Until it came up in conversation with @MikeMcQuaid 😁 , I actually hadn't yet pieced together the fact that with [this change](https://github.com/Homebrew/brew/commit/3e982b97202c3a7be5838d736a70bef495e08466#diff-841108270ac7faea0c3a1e1a291246d4), the `--online` flag needs to be passed to `brew tests` to include tests that require a network connection.

Apparently only `test_search` falls in that category (at the moment)?... whenever I run `brew tests` (without any flags), I do see that three tests are always skipped; however, the SimpleCov report always shows coverage for assertions that involve a network connection (e.g., `test_search` and `test_pull` assertions, which one would expect to be skipped).