### PR TITLE
ENV: fix homebrew_extra_pkg_config_paths

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -31,7 +31,7 @@ module Stdenv
   end
 
   def homebrew_extra_pkg_config_paths
-    ["#{HOMEBREW_LIBRARY_PATH}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
+    ["#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
   end
 
   # Sets architecture-specific flags for every environment variable

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -26,7 +26,7 @@ module Superenv
   # @private
   def homebrew_extra_pkg_config_paths
     paths = \
-      ["#{HOMEBREW_LIBRARY_PATH}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
+      ["#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
     paths << "#{MacOS::X11.lib}/pkgconfig" << "#{MacOS::X11.share}/pkgconfig" if x11?
     paths
   end


### PR DESCRIPTION
Switch to HOMEBREW_LIBRARY since HOMEBREW_LIBRARY_PATH already includes
"/Homebrew" and HOMEBREW_LIBRARY is less confusing.

Closes https://github.com/Homebrew/homebrew-core/issues/3038.