### PR TITLE
Prevent brew audit crash from nil exitstatus

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -63,8 +63,10 @@ module Homebrew
       !$?.success?
     when :json
       json = Utils.popen_read_text("rubocop", "--format", "json", *args)
-      # exit status of 1 just means violations were found; others are errors
-      raise "Error while running rubocop" if $?.exitstatus > 1
+      # exit status of 1 just means violations were found; other numbers mean execution errors
+      # exitstatus can also be nil if RuboCop process crashes, e.g. due to
+      # native extension problems
+      raise "Error while running RuboCop" if $?.exitstatus.nil? || $?.exitstatus > 1
       RubocopResults.new(Utils::JSON.load(json))
     else
       raise "Invalid output_type for check_style_impl: #{output_type}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

While working on some new formulae I realized that any attempts to audit a formula (any formula, not just my new creations) resulted in:
```
$ brew audit --strict --online libhivex
Error: undefined method `>' for nil:NilClass
Please report this bug:
    https://git.io/brew-troubleshooting
/usr/local/Library/Homebrew/cmd/style.rb:67:in `check_style_impl'
/usr/local/Library/Homebrew/cmd/style.rb:45:in `check_style_json'
/usr/local/Library/Homebrew/cmd/audit.rb:62:in `audit'
/usr/local/Library/Homebrew/brew.rb:87:in `<main>'
```

I've yet to figure out why `$?.exitstatus` is nil (I'm betting my money on ruby version clash, I have several rubies managed with chruby), but regardless it'd probably be prudent to check for nil before doing the comparison.

I'm afraid that adding tests for this behaviour exceeds my capabilites.