### PR TITLE
Keg#link: run optlink first

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -304,6 +304,8 @@ class Keg
 
     ObserverPathnameExtension.reset_counts!
 
+    optlink(mode) unless mode.dry_run
+
     # yeah indeed, you have to force anything you need in the main tree into
     # these dirs REMEMBER that *NOT* everything needs to be in the main tree
     link_dir("etc", mode) { :mkpath }
@@ -366,10 +368,7 @@ class Keg
       end
     end
 
-    unless mode.dry_run
-      make_relative_symlink(linked_keg_record, path, mode)
-      optlink(mode)
-    end
+    make_relative_symlink(linked_keg_record, path, mode) unless mode.dry_run
   rescue LinkError
     unlink
     raise


### PR DESCRIPTION
This prevents a link conflict during `brew upgrade` causing opt link
stuck to old version. At this point, users will have to run `brew switch`
to fix it.