### PR TITLE
remove unnecessary build options manipulation

### DIFF
--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -12,11 +12,10 @@ module Homebrew
 
     installed.each do |f|
       deps = []
-      tab = Tab.for_formula(f)
 
       f.deps.each do |dep|
         if dep.optional? || dep.recommended?
-          deps << dep.to_formula.full_name if tab.with?(dep)
+          deps << dep.to_formula.full_name if f.build.with?(dep)
         else
           deps << dep.to_formula.full_name
         end

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -11,7 +11,8 @@ module Homebrew
   end
 
   def reinstall_formula(f)
-    options = f.build.used_options
+    options = BuildOptions.new(Options.create(ARGV.flags_only), f.options).used_options
+    options |= f.build.used_options
 
     notice  = "Reinstalling #{f.full_name}"
     notice += " with #{options * ", "}" unless options.empty?

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -11,8 +11,7 @@ module Homebrew
   end
 
   def reinstall_formula(f)
-    tab = Tab.for_formula(f)
-    options = tab.used_options | f.build.used_options
+    options = f.build.used_options
 
     notice  = "Reinstalling #{f.full_name}"
     notice += " with #{options * ", "}" unless options.empty?
@@ -25,7 +24,7 @@ module Homebrew
 
     fi = FormulaInstaller.new(f)
     fi.options             = options
-    fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && tab.build_bottle?)
+    fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
     fi.build_from_source   = ARGV.build_from_source? || ARGV.build_all_from_source?
     fi.force_bottle        = ARGV.force_bottle?
     fi.interactive         = ARGV.interactive?

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -66,11 +66,10 @@ module Homebrew
 
   def upgrade_formula(f)
     outdated_keg = Keg.new(f.linked_keg.resolved_path) if f.linked_keg.directory?
-    tab = Tab.for_formula(f)
 
     fi = FormulaInstaller.new(f)
-    fi.options             = tab.used_options
-    fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && tab.build_bottle?)
+    fi.options             = f.build.used_options
+    fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
     fi.build_from_source   = ARGV.build_from_source? || ARGV.build_all_from_source?
     fi.verbose             = ARGV.verbose?
     fi.quieter             = ARGV.quieter?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -836,14 +836,6 @@ class Formula
     method(:post_install).owner == self.class
   end
 
-  # @private
-  def run_post_install
-    build, self.build = self.build, Tab.for_formula(self)
-    post_install
-  ensure
-    self.build = build
-  end
-
   # Tell the user about any caveats regarding this package.
   # @return [String]
   # <pre>def caveats
@@ -1346,7 +1338,6 @@ class Formula
     old_home = ENV["HOME"]
     old_curl_home = ENV["CURL_HOME"]
     ENV["CURL_HOME"] = old_curl_home || old_home
-    build, self.build = self.build, Tab.for_formula(self)
     mktemp("#{name}-test") do |staging|
       staging.retain! if ARGV.keep_tmp?
       @testpath = staging.tmpdir
@@ -1361,7 +1352,6 @@ class Formula
     end
   ensure
     @testpath = nil
-    self.build = build
     ENV["HOME"] = old_home
     ENV["CURL_HOME"] = old_curl_home
   end

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -13,7 +13,7 @@ begin
 
   formula = ARGV.resolved_formulae.first
   formula.extend(Debrew::Formula) if ARGV.debug?
-  formula.run_post_install
+  formula.post_install
 rescue Exception => e
   Marshal.dump(e, error_pipe)
   error_pipe.close


### PR DESCRIPTION
* We already loaded build options in ARGV.resolved_formulae for test and
postinstall
* remove unnecessary `Tab.for_formula`