### PR TITLE
test-bot: fix coverage on Travis CI, related improvements

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -659,14 +659,15 @@ module Homebrew
 
       if @tap.nil?
         tests_args = []
+        tests_args_coverage = []
         if RUBY_TWO
           tests_args << "--official-cmd-taps"
-          tests_args << "--coverage" if ENV["TRAVIS"]
+          tests_args_coverage << "--coverage" if ENV["TRAVIS"]
         end
         test "brew", "tests", *tests_args
         test "brew", "tests", "--generic", "--only=integration_cmds",
                               *tests_args
-        test "brew", "tests", "--no-compat"
+        test "brew", "tests", "--no-compat", *tests_args_coverage
         test "brew", "readall", "--syntax"
         # test update from origin/master to current commit.
         test "brew", "update-test"

--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -5,13 +5,11 @@ SimpleCov.start do
 
   minimum_coverage 40 unless ENV["HOMEBREW_TESTS_ONLY"]
   coverage_dir File.expand_path("#{tests_path}/coverage")
-  root File.expand_path("#{tests_path}/../../")
+  root File.expand_path("#{tests_path}/..")
 
-  add_filter "Formula/"
-  add_filter "Homebrew/compat/"
-  add_filter "Homebrew/test/"
-  add_filter "Homebrew/vendor/"
-  add_filter "Taps/"
+  add_filter "/Homebrew/compat/"
+  add_filter "/Homebrew/test/"
+  add_filter "/Homebrew/vendor/"
 
   if ENV["HOMEBREW_INTEGRATION_TEST"]
     command_name ENV["HOMEBREW_INTEGRATION_TEST"]
@@ -31,7 +29,7 @@ SimpleCov.start do
   project_name "Homebrew"
   add_group "Commands", %w[/Homebrew/cmd/ /Homebrew/dev-cmd/]
   add_group "Extensions", "/Homebrew/extend/"
-  add_group "OS", "/Homebrew/os/"
+  add_group "OS", %w[/Homebrew/extend/os/ /Homebrew/os/]
   add_group "Requirements", "/Homebrew/requirements/"
   add_group "Scripts", %w[
     /Homebrew/brew.rb

--- a/Library/Homebrew/test/Gemfile
+++ b/Library/Homebrew/test/Gemfile
@@ -3,16 +3,19 @@ source "https://rubygems.org"
 gem "mocha", "~> 1.1"
 gem "minitest", "~> 5.3"
 gem "rake", "~> 10.3"
-# This is a patched version of the v0.11.2. Switch back to the stable version
-# when #436 has been merged upstream.
-# https://github.com/colszowka/simplecov/pull/436
-# See also https://github.com/Homebrew/legacy-homebrew/pull/48250#issuecomment-173171990
-gem "simplecov", "0.11.2",
-  :git => "https://github.com/Homebrew/simplecov.git",
-  :branch => "tracked-files-root-fix",
-  :require => false
-gem "coveralls", "0.8.10", :require => false
-# We need to pin these versions because those are the last supporting Ruby 1.8.
-# Remove these lines when we've stopped supporting it.
-gem "mime-types", "~> 1.16"
-gem "rest-client", "1.6.9"
+
+group :coverage do
+  # This is SimpleCov v0.12.0 with one PR merged on top, that finally resolves
+  # all issues with parallel tests, uncovered files, and tracked files. Switch
+  # back to stable as soon as v0.12.1 or v0.13.0 is released. See pull request
+  # <https://github.com/Homebrew/legacy-homebrew/pull/48250> for full details.
+  gem "simplecov", "0.12.0",
+    :git => "https://github.com/colszowka/simplecov.git",
+    :branch => "master", # commit 257e26394c464c4ab388631b4eff1aa98c37d3f1
+    :require => false
+  gem "coveralls", "0.8.14", :require => false
+
+  # We need to pin the version of this Coveralls dependency because it is the
+  # last one to support Ruby 1.8. Remove as soon as we stop using Ruby 1.8.
+  gem "json", "~> 1.8", :require => false
+end

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -1,33 +1,29 @@
 GIT
-  remote: https://github.com/Homebrew/simplecov.git
-  revision: 4c7642496e902ba9028a74500971e40b3e3aaa29
-  branch: tracked-files-root-fix
+  remote: https://github.com/colszowka/simplecov.git
+  revision: 257e26394c464c4ab388631b4eff1aa98c37d3f1
+  branch: master
   specs:
-    simplecov (0.11.2)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coveralls (0.8.10)
-      json (~> 1.8)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.11.0)
+    coveralls (0.8.14)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
       term-ansicolor (~> 1.3)
       thor (~> 0.19.1)
       tins (~> 1.6.0)
     docile (1.1.5)
     json (1.8.3)
     metaclass (0.0.4)
-    mime-types (1.25.1)
-    minitest (5.8.4)
+    minitest (5.9.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     rake (10.5.0)
-    rest-client (1.6.9)
-      mime-types (~> 1.16)
     simplecov-html (0.10.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
@@ -38,13 +34,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  coveralls (= 0.8.10)
-  mime-types (~> 1.16)
+  coveralls (= 0.8.14)
+  json (~> 1.8)
   minitest (~> 5.3)
   mocha (~> 1.1)
   rake (~> 10.3)
-  rest-client (= 1.6.9)
-  simplecov (= 0.11.2)!
+  simplecov (= 0.12.0)!
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The primary aim is to fix a regression caused by #505, namely that `brew tests --coverage` runs twice and the second run (with `--generic`) replaces the results of the previous run, leading to a low coverage of just 33% on <https://coveralls.io/github/Homebrew/brew>.

To make this PR less dull, I allowed myself to include an update of the SimpleCov and Coveralls gems and to tweak the coverage settings a bit, now that *all* Ruby code relevant to the coverage report lives in `Library/Homebrew/`. (See commit messages for even more detail.)

This has been extensively tested locally, with Ruby 1.8.7/2.0 and with various combinations of command line options. (*Fun fact:* At the time of testing we were covering exactly 8,000 lines.)

cc @MikeMcQuaid