### PR TITLE
inreplace: support for audit arg in non-block form

### DIFF
--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -15,7 +15,7 @@ module Utils
     # HOMEBREW_PREFIX is available in the embedded patch.
     # inreplace supports regular expressions.
     # <pre>inreplace "somefile.cfg", /look[for]what?/, "replace by #{bin}/tool"</pre>
-    def inreplace(paths, before = nil, after = nil)
+    def inreplace(paths, before = nil, after = nil, audit_result = true)
       errors = {}
 
       Array(paths).each do |path|
@@ -25,7 +25,7 @@ module Utils
           yield s
         else
           after = after.to_s if Symbol === after
-          s.gsub!(before, after)
+          s.gsub!(before, after, audit_result)
         end
 
         errors[path] = s.errors if s.errors.any?


### PR DESCRIPTION
Provides feature parity between the block and non-block forms of
inreplace by creating a four-argument version of the non-block form,
where the fourth argument is an optional Boolean value, defaulting to
true, which specifies whether a failed inreplace should cause an
InreplaceError error to be raised. The fourth argument is passed along
to StringInreplaceExtension#gsub!, which already supports an optional
audit_result argument.

This resolves the Catch-22 that single replacements aren't permissible
in the block form (in that they now cause `brew audit` to complain), but
the audit_result argument is not available in the non-block form.