### PR TITLE
Remove legacy Aliases/Formula symlink from Library

### DIFF
--- a/Library/Aliases
+++ b/Library/Aliases
@@ -1,1 +1,0 @@
-Taps/homebrew/homebrew-core/Aliases

--- a/Library/Formula
+++ b/Library/Formula
@@ -1,1 +1,0 @@
-Taps/homebrew/homebrew-core/Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This has been working flawlessly for me for the past three months, thus basically since we have made the split. Enough time for active projects to catch up with these developments and drop the legacy symlinks that just mask broken behavior in software/scripts that are still relying on those locations. (It also helps to further tidy up the repository outside of `Library/Homebrew/` and avoids symlinks that point nowhere when only this repository is checked out, i.e. when not immediately installing the homebrew/core tap, too.)