### PR TITLE
tests: add cmd/switch integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -756,4 +756,21 @@ class IntegrationCommandTests < Homebrew::TestCase
     cmd("analytics", "off")
     assert_match "Analytics is disabled", cmd("analytics")
   end
+
+  def test_switch
+    assert_match "Usage: brew switch <name> <version>", cmd_fail("switch")
+    assert_match "testball not found", cmd_fail("switch", "testball", "0.1")
+
+    setup_test_formula "testball", <<-EOS.undent
+      keg_only "just because"
+    EOS
+
+    cmd("install", "testball")
+    testball_rack = HOMEBREW_CELLAR/"testball"
+    FileUtils.cp_r testball_rack/"0.1", testball_rack/"0.2"
+
+    cmd("switch", "testball", "0.2")
+    assert_match "testball does not have a version \"0.3\"",
+      cmd_fail("switch", "testball", "0.3")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds test coverage for `brew switch`.

Since [these lines](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/switch.rb#L20-L33) return exit codes that fall outside the purview of `cmd_fail`, would it be OK to add another helper method to address them?
