### PR TITLE
Option: also store value

### DIFF
--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -93,7 +93,7 @@ class BuildOptions
 
   # @private
   def used_options
-    @options & @args
+    @args & @options
   end
 
   # @private

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -37,7 +37,7 @@ class SoftwareSpec
     @dependency_collector = DependencyCollector.new
     @bottle_specification = BottleSpecification.new
     @patches = []
-    @options = Options.new
+    @options = Options.create
     @flags = ARGV.flags_only
     @deprecated_flags = []
     @deprecated_options = []

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -89,7 +89,7 @@ class Tab < OpenStruct
     deprecated_options.each do |deprecated_option|
       option = options.find { |o| o.name == deprecated_option.old }
       next unless option
-      options -= [option]
+      options -= Options.create([option])
       options << Option.new(deprecated_option.current, option.description)
     end
     options

--- a/Library/Homebrew/test/test_options.rb
+++ b/Library/Homebrew/test/test_options.rb
@@ -56,7 +56,7 @@ end
 
 class OptionsTests < Homebrew::TestCase
   def setup
-    @options = Options.new
+    @options = Options.create
   end
 
   def test_no_duplicate_options
@@ -83,11 +83,11 @@ class OptionsTests < Homebrew::TestCase
   end
 
   def test_union_returns_options
-    assert_instance_of Options, @options + Options.new
+    assert_instance_of Options, @options + Options.create
   end
 
   def test_difference_returns_options
-    assert_instance_of Options, @options - Options.new
+    assert_instance_of Options, @options - Options.create
   end
 
   def test_shovel_returns_self
@@ -113,14 +113,14 @@ class OptionsTests < Homebrew::TestCase
 
   def test_intersection
     foo, bar, baz = %w[foo bar baz].map { |o| Option.new(o) }
-    options = Options.new << foo << bar
+    options = Options.create [foo, bar]
     @options << foo << baz
     assert_equal [foo], (@options & options).to_a
   end
 
   def test_set_union
     foo, bar, baz = %w[foo bar baz].map { |o| Option.new(o) }
-    options = Options.new << foo << bar
+    options = Options.create [foo, bar]
     @options << foo << baz
     assert_equal [foo, bar, baz].sort, (@options | options).sort
   end


### PR DESCRIPTION
This fixes long term problem that `brew install` fails to remember the
value part of args like `--with-foo=bar` passed by users. As result,
such value will not be preserved when invoking `brew reinstall` or
`brew upgrade`.

A real formula example can be `homebrew/science/abyss`.

Since there may have two options sharing the same name but different
values. We will have to use Hash instead of set for `Options` object.
The Hash will be a map between option name to option object. When
merging options under the same name, we choose to keep old option if
possible unless the new option has a value while the old one doesn't.