### PR TITLE
check_linkage: print full name for other taps only

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -72,10 +72,11 @@ module FormulaCellarChecks
     end
 
     if checker.undeclared_deps?
+      undeclared_deps = checker.undeclared_deps.map { |d| d.strip_prefix("#{formula.tap}/") }
       audit_check_output <<-EOS.undent
         Formulae are required to declare all linked dependencies.
         Please add all linked dependencies to the formula with:
-          #{checker.undeclared_deps.map { |d| "depends_on \"#{d}\" => :linked"} * "\n          "}
+          #{undeclared_deps.map { |d| "depends_on \"#{d}\" => :linked"} * "\n          "}
       EOS
     end
   end


### PR DESCRIPTION
`depends_on` only requires full name when the dependency is a member of
some other tap. Even though redundant full names work, they are rarely
used in practice, so to avoid confusion, it would be best for
`brew audit` to follow the use-non-full-name-when-possible convention
when it prints undeclared linkage failures.

For example, if the formula being audited is in homebrew/science, print

```
      depends_on "homebrew/dupes/ncurses" => :linked
      depends_on "htslib" => :linked
```

not

```
      depends_on "homebrew/dupes/ncurses" => :linked
      depends_on "homebrew/science/htslib" => :linked
```

Note that this change is irrelevant with respect to core formulae since
their full names are not prefixed with "homebrew/core" anyway.

Thanks to Xu Cheng for contributing the code in this commit.

Closes https://github.com/Homebrew/brew/issues/540.