### PR TITLE
audit: only check undeclared deps for standard installations.

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -71,6 +71,9 @@ module FormulaCellarChecks
       EOS
     end
 
+    # only check undeclared deps for standard installations.
+    return unless formula.build.used_options.empty?
+
     if checker.undeclared_deps?
       audit_check_output <<-EOS.undent
         Formulae are required to declare all linked dependencies.


### PR DESCRIPTION
In fact, we don't really care about undeclared dependencies for optional
installations. Because, this is mainly used to help us to detect breakage
for bottles so we can do a revision bump.

cc @DomT4