### PR TITLE
brew.rb: Use odie instead of onoe+exit

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -107,8 +107,7 @@ begin
       safe_system(*tap_commands)
       exec HOMEBREW_BREW_FILE, cmd, *ARGV
     else
-      onoe "Unknown command: #{cmd}"
-      exit 1
+      odie "Unknown command: #{cmd}"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

