### PR TITLE
utils/github: fix broken pipe error

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -50,7 +50,7 @@ module GitHub
       if ENV["HOMEBREW_GITHUB_API_TOKEN"]
         ENV["HOMEBREW_GITHUB_API_TOKEN"]
       elsif ENV["HOMEBREW_GITHUB_API_USERNAME"] && ENV["HOMEBREW_GITHUB_API_PASSWORD"]
-        [ENV["HOMEBREW_GITHUB_API_USERNAME"], ENV["HOMEBREW_GITHUB_API_PASSWORD"]]
+        [ENV["HOMEBREW_GITHUB_API_PASSWORD"], ENV["HOMEBREW_GITHUB_API_USERNAME"]]
       else
         github_credentials = api_credentials_from_keychain
         github_username = github_credentials[/username=(.+)/, 1]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Steps to reproduce:

- Unset any possibly set `HOMEBREW_GITHUB_*` environment variables.
- Switch to a Git without `git-credential-osxkeychain` or temporarily rename this binary.

Before:

```console
$ brew search php
Error: Broken pipe
```

After:

```console
$ brew search php
No formula found for "php".
==> Searching pull requests...
Closed pull requests:
n98-magerun: migrate to php (https://github.com/Homebrew/homebrew-core/pull/1534)
Error: GitHub API Error: API rate limit exceeded for A.B.C.D. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
Try again in 25 minutes and 34 seconds, or create a personal access token:
  https://github.com/settings/tokens/new?scopes=&description=Homebrew
and then set the token as: export HOMEBREW_GITHUB_API_TOKEN="your_new_token"
```

Closes #573.

**Update:** Slightly expanded the scope of the PR [as mentioned in a comment below](https://github.com/Homebrew/brew/pull/581#issuecomment-234932442).