### PR TITLE
tests: fix code style issues

### DIFF
--- a/Library/Homebrew/test/.rubocop.yml
+++ b/Library/Homebrew/test/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from: ../../.rubocop.yml
+
+# `formula do` uses nested method definitions
+Style/NestedMethodDefinition:
+  Enabled: false

--- a/Library/Homebrew/test/lib/config.rb
+++ b/Library/Homebrew/test/lib/config.rb
@@ -3,11 +3,11 @@ require "pathname"
 
 HOMEBREW_BREW_FILE = Pathname.new(ENV["HOMEBREW_BREW_FILE"])
 
-TEST_TMPDIR = ENV.fetch("HOMEBREW_TEST_TMPDIR") { |k|
+TEST_TMPDIR = ENV.fetch("HOMEBREW_TEST_TMPDIR") do |k|
   dir = Dir.mktmpdir("homebrew-tests-", ENV["HOMEBREW_TEMP"] || "/tmp")
   at_exit { FileUtils.remove_entry(dir) }
   ENV[k] = dir
-}
+end
 
 # Paths pointing into the Homebrew code base that persist across test runs
 HOMEBREW_LIBRARY_PATH  = Pathname.new(File.expand_path("../../..", __FILE__))
@@ -25,8 +25,8 @@ HOMEBREW_CELLAR        = HOMEBREW_PREFIX.parent+"cellar"
 HOMEBREW_LOGS          = HOMEBREW_PREFIX.parent+"logs"
 HOMEBREW_TEMP          = HOMEBREW_PREFIX.parent+"temp"
 
-TESTBALL_SHA1 = "be478fd8a80fe7f29196d6400326ac91dad68c37"
-TESTBALL_SHA256 = "91e3f7930c98d7ccfb288e115ed52d06b0e5bc16fec7dce8bdda86530027067b"
-TESTBALL_PATCHES_SHA256 = "799c2d551ac5c3a5759bea7796631a7906a6a24435b52261a317133a0bfb34d9"
-PATCH_A_SHA256 = "83404f4936d3257e65f176c4ffb5a5b8d6edd644a21c8d8dcc73e22a6d28fcfa"
-PATCH_B_SHA256 = "57958271bb802a59452d0816e0670d16c8b70bdf6530bcf6f78726489ad89b90"
+TESTBALL_SHA1 = "be478fd8a80fe7f29196d6400326ac91dad68c37".freeze
+TESTBALL_SHA256 = "91e3f7930c98d7ccfb288e115ed52d06b0e5bc16fec7dce8bdda86530027067b".freeze
+TESTBALL_PATCHES_SHA256 = "799c2d551ac5c3a5759bea7796631a7906a6a24435b52261a317133a0bfb34d9".freeze
+PATCH_A_SHA256 = "83404f4936d3257e65f176c4ffb5a5b8d6edd644a21c8d8dcc73e22a6d28fcfa".freeze
+PATCH_B_SHA256 = "57958271bb802a59452d0816e0670d16c8b70bdf6530bcf6f78726489ad89b90".freeze

--- a/Library/Homebrew/test/test_bottle_hooks.rb
+++ b/Library/Homebrew/test/test_bottle_hooks.rb
@@ -6,7 +6,10 @@ class BottleHookTests < Homebrew::TestCase
   class FormulaDouble
     def bottle; end
     def local_bottle_path; end
-    def bottle_disabled?; false end
+
+    def bottle_disabled?
+      false
+    end
 
     def some_random_method
       true

--- a/Library/Homebrew/test/test_checksum.rb
+++ b/Library/Homebrew/test/test_checksum.rb
@@ -20,4 +20,3 @@ class ChecksumTests < Homebrew::TestCase
     refute_equal a, b
   end
 end
-

--- a/Library/Homebrew/test/test_dependency.rb
+++ b/Library/Homebrew/test/test_dependency.rb
@@ -47,12 +47,12 @@ class DependencyTests < Homebrew::TestCase
     assert_equal 2, merged.length
     assert_equal Dependency, merged.first.class
 
-    foo_named_dep = merged.find {|d| d.name == "foo"}
+    foo_named_dep = merged.find { |d| d.name == "foo" }
     assert_equal ["bar"], foo_named_dep.tags
     assert_includes foo_named_dep.option_names, "foo"
     assert_includes foo_named_dep.option_names, "foo2"
 
-    xyz_named_dep = merged.find {|d| d.name == "xyz"}
+    xyz_named_dep = merged.find { |d| d.name == "xyz" }
     assert_equal ["abc"], xyz_named_dep.tags
     assert_includes xyz_named_dep.option_names, "foo"
     refute_includes xyz_named_dep.option_names, "foo2"

--- a/Library/Homebrew/test/test_dependency_expansion.rb
+++ b/Library/Homebrew/test/test_dependency_expansion.rb
@@ -87,10 +87,13 @@ class DependencyExpansionTests < Homebrew::TestCase
   end
 
   def test_skip_skips_parent_but_yields_children
-    f = stub(:name => "f", :deps => [
-      build_dep(:foo, [], [@bar, @baz]),
-      build_dep(:foo, [], [@baz])
-    ])
+    f = stub(
+      :name => "f",
+      :deps => [
+        build_dep(:foo, [], [@bar, @baz]),
+        build_dep(:foo, [], [@baz]),
+      ]
+    )
 
     deps = Dependency.expand(f) do |_dependent, dep|
       Dependency.skip if %w[foo qux].include? dep.name

--- a/Library/Homebrew/test/test_diagnostic.rb
+++ b/Library/Homebrew/test/test_diagnostic.rb
@@ -105,11 +105,11 @@ class DiagnosticChecksTest < Homebrew::TestCase
     sep = File::PATH_SEPARATOR
     # ensure /usr/bin is before HOMEBREW_PREFIX/bin in the PATH
     ENV["PATH"] = "/usr/bin#{sep}#{bin}#{sep}" +
-      ENV["PATH"].gsub(%r{(?:^|#{sep})(?:/usr/bin|#{bin})}, "")
+                  ENV["PATH"].gsub(%r{(?:^|#{sep})(?:/usr/bin|#{bin})}, "")
 
     # ensure there's at least one file with the same name in both /usr/bin/ and
     # HOMEBREW_PREFIX/bin/
-    (bin/"#{File.basename Dir["/usr/bin/*"].first}").mkpath
+    (bin/File.basename(Dir["/usr/bin/*"].first)).mkpath
 
     assert_match "/usr/bin occurs before #{HOMEBREW_PREFIX}/bin",
       @checks.check_user_path_1
@@ -129,7 +129,7 @@ class DiagnosticChecksTest < Homebrew::TestCase
   def test_check_user_path_sbin
     sbin = HOMEBREW_PREFIX/"sbin"
     ENV["PATH"] = "#{HOMEBREW_PREFIX}/bin#{File::PATH_SEPARATOR}" +
-      ENV["PATH"].gsub(%r{(?:^|#{File::PATH_SEPARATOR})#{sbin}}, "")
+                  ENV["PATH"].gsub(/(?:^|#{Regexp.escape(File::PATH_SEPARATOR)})#{Regexp.escape(sbin)}/, "")
     (sbin/"something").mkpath
 
     assert_nil @checks.check_user_path_1
@@ -162,7 +162,7 @@ class DiagnosticChecksTest < Homebrew::TestCase
     end
   end
 
-  def test_check_DYLD_vars
+  def test_check_dyld_vars
     ENV["DYLD_INSERT_LIBRARIES"] = "foo"
     assert_match "Setting DYLD_INSERT_LIBRARIES",
       @checks.check_DYLD_vars

--- a/Library/Homebrew/test/test_exceptions.rb
+++ b/Library/Homebrew/test/test_exceptions.rb
@@ -32,7 +32,7 @@ class ExceptionsTest < Homebrew::TestCase
   end
 
   def test_tap_formula_unavailable_error
-    t = stub({:user => "u", :repo => "r", :to_s => "u/r", :installed? => false})
+    t = stub(:user => "u", :repo => "r", :to_s => "u/r", :installed? => false)
     assert_match "Please tap it and then try again: brew tap u/r",
       TapFormulaUnavailableError.new(t, "foo").to_s
   end
@@ -73,7 +73,7 @@ class ExceptionsTest < Homebrew::TestCase
   end
 
   def test_build_error
-    f = stub({:name => "foo"})
+    f = stub(:name => "foo")
     assert_equal "Failed executing: badprg arg1 arg2",
       BuildError.new(f, "badprg", %w[arg1 arg2], {}).to_s
   end
@@ -84,20 +84,20 @@ class ExceptionsTest < Homebrew::TestCase
   end
 
   def test_formula_installation_already_attempted_error
-    f = stub({:full_name => "foo/bar"})
+    f = stub(:full_name => "foo/bar")
     assert_equal "Formula installation already attempted: foo/bar",
       FormulaInstallationAlreadyAttemptedError.new(f).to_s
   end
 
   def test_formula_conflict_error
-    f = stub({:full_name => "foo/qux"})
-    c = stub({:name => "bar", :reason => "I decided to"})
+    f = stub(:full_name => "foo/qux")
+    c = stub(:name => "bar", :reason => "I decided to")
     assert_match "Please `brew unlink bar` before continuing.",
       FormulaConflictError.new(f, [c]).to_s
   end
 
   def test_compiler_selection_error
-    f = stub({:full_name => "foo"})
+    f = stub(:full_name => "foo")
     assert_match "foo cannot be built with any available compilers.",
       CompilerSelectionError.new(f).to_s
   end
@@ -115,27 +115,27 @@ class ExceptionsTest < Homebrew::TestCase
   end
 
   def test_checksum_mismatch_error
-    h1 = stub({:hash_type => "sha256", :to_s => "deadbeef"})
-    h2 = stub({:hash_type => "sha256", :to_s => "deadcafe"})
+    h1 = stub(:hash_type => "sha256", :to_s => "deadbeef")
+    h2 = stub(:hash_type => "sha256", :to_s => "deadcafe")
     assert_match "SHA256 mismatch",
       ChecksumMismatchError.new("/file.tar.gz", h1, h2).to_s
   end
 
   def test_resource_missing_error
-    f = stub({:full_name => "bar"})
-    r = stub({:inspect => "<resource foo>"})
+    f = stub(:full_name => "bar")
+    r = stub(:inspect => "<resource foo>")
     assert_match "bar does not define resource <resource foo>",
       ResourceMissingError.new(f, r).to_s
   end
 
   def test_duplicate_resource_error
-    r = stub({:inspect => "<resource foo>"})
+    r = stub(:inspect => "<resource foo>")
     assert_equal "Resource <resource foo> is defined more than once",
       DuplicateResourceError.new(r).to_s
   end
 
   def test_bottle_version_mismatch_error
-    f = stub({:full_name => "foo"})
+    f = stub(:full_name => "foo")
     assert_match "Bottle version mismatch",
       BottleVersionMismatchError.new("/foo.bottle.tar.gz", "1.0", f, "1.1").to_s
   end

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -529,7 +529,7 @@ class OutdatedVersionsTests < Homebrew::TestCase
     @f.rack.rmtree
   end
 
-  def setup_tab_for_prefix(prefix, tap_string=nil)
+  def setup_tab_for_prefix(prefix, tap_string = nil)
     prefix.mkpath
     tab = Tab.empty
     tab.tabfile = prefix.join("INSTALL_RECEIPT.json")

--- a/Library/Homebrew/test/test_formula_spec_selection.rb
+++ b/Library/Homebrew/test/test_formula_spec_selection.rb
@@ -3,11 +3,11 @@ require "formula"
 
 class FormulaSpecSelectionTests < Homebrew::TestCase
   def test_selects_stable_by_default
-    f = formula {
+    f = formula do
       url "foo-1.0"
       devel { url "foo-1.1a" }
       head "foo"
-    }
+    end
 
     assert_predicate f, :stable?
   end
@@ -18,10 +18,10 @@ class FormulaSpecSelectionTests < Homebrew::TestCase
   end
 
   def test_selects_devel_before_head
-    f = formula {
+    f = formula do
       devel { url "foo-1.1a" }
       head "foo"
-    }
+    end
 
     assert_predicate f, :devel?
   end
@@ -37,62 +37,62 @@ class FormulaSpecSelectionTests < Homebrew::TestCase
   end
 
   def test_incomplete_spec_not_selected
-    f = formula {
+    f = formula do
       sha256 TEST_SHA256
       version "1.0"
       head "foo"
-    }
+    end
 
     assert_predicate f, :head?
   end
 
   def test_incomplete_stable_not_set
-    f = formula {
+    f = formula do
       sha256 TEST_SHA256
       devel { url "foo-1.1a" }
       head "foo"
-    }
+    end
 
     assert_nil f.stable
     assert_predicate f, :devel?
   end
 
   def test_selects_head_when_requested
-    f = formula("test", Pathname.new(__FILE__).expand_path, :head) {
+    f = formula("test", Pathname.new(__FILE__).expand_path, :head) do
       url "foo-1.0"
       devel { url "foo-1.1a" }
       head "foo"
-    }
+    end
 
     assert_predicate f, :head?
   end
 
   def test_selects_devel_when_requested
-    f = formula("test", Pathname.new(__FILE__).expand_path, :devel) {
+    f = formula("test", Pathname.new(__FILE__).expand_path, :devel) do
       url "foo-1.0"
       devel { url "foo-1.1a" }
       head "foo"
-    }
+    end
 
     assert_predicate f, :devel?
   end
 
   def test_incomplete_devel_not_set
-    f = formula {
+    f = formula do
       url "foo-1.0"
       devel { version "1.1a" }
       head "foo"
-    }
+    end
 
     assert_nil f.devel
     assert_predicate f, :stable?
   end
 
   def test_does_not_raise_for_missing_spec
-    f = formula("test", Pathname.new(__FILE__).expand_path, :devel) {
+    f = formula("test", Pathname.new(__FILE__).expand_path, :devel) do
       url "foo-1.0"
       head "foo"
-    }
+    end
 
     assert_predicate f, :stable?
   end

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -131,7 +131,7 @@ class FormularyTapFactoryTest < Homebrew::TestCase
   end
 
   def test_factory_tap_formula
-    assert_kind_of Formula, Formulary.factory("#{@name}")
+    assert_kind_of Formula, Formulary.factory(@name)
   end
 
   def test_factory_tap_alias

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -194,8 +194,8 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_env
-    assert_match %r{CMAKE_PREFIX_PATH="#{HOMEBREW_PREFIX}[:"]},
-                 cmd("--env")
+    assert_match(/CMAKE_PREFIX_PATH="#{Regexp.escape(HOMEBREW_PREFIX)}[:"]/,
+                 cmd("--env"))
   end
 
   def test_prefix_formula

--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -154,7 +154,7 @@ class LinkTests < Homebrew::TestCase
     refute_predicate HOMEBREW_PREFIX/"lib/foo", :directory?
   end
 
-  def test_unlink_ignores_DS_Store_when_pruning_empty_dirs
+  def test_unlink_ignores_ds_store_when_pruning_empty_dirs
     mkpath HOMEBREW_PREFIX/"lib/foo/bar"
     touch HOMEBREW_PREFIX/"lib/foo/.DS_Store"
     mkpath @keg/"lib/foo/bar"

--- a/Library/Homebrew/test/test_migrator.rb
+++ b/Library/Homebrew/test/test_migrator.rb
@@ -5,15 +5,13 @@ require "tab"
 require "keg"
 
 class Formula
-  def set_oldname(oldname)
-    @oldname = oldname
-  end
+  attr_writer :oldname
 end
 
 class MigratorErrorsTests < Homebrew::TestCase
   def setup
     @new_f = Testball.new("newname")
-    @new_f.set_oldname "oldname"
+    @new_f.oldname = "oldname"
     @old_f = Testball.new("oldname")
   end
 
@@ -43,7 +41,7 @@ class MigratorTests < Homebrew::TestCase
 
   def setup
     @new_f = Testball.new("newname")
-    @new_f.set_oldname "oldname"
+    @new_f.oldname = "oldname"
 
     @old_f = Testball.new("oldname")
 

--- a/Library/Homebrew/test/test_patch.rb
+++ b/Library/Homebrew/test/test_patch.rb
@@ -21,13 +21,13 @@ class PatchTests < Homebrew::TestCase
     assert_equal :p1, patch.strip
   end
 
-  def test_create_DATA
+  def test_create_data
     patch = Patch.create(:p0, :DATA)
     assert_kind_of DATAPatch, patch
     assert_equal :p0, patch.strip
   end
 
-  def test_create_DATA_without_strip
+  def test_create_data_without_strip
     patch = Patch.create(:DATA, nil)
     assert_kind_of DATAPatch, patch
     assert_equal :p1, patch.strip
@@ -112,7 +112,6 @@ end
 class ExternalPatchTests < Homebrew::TestCase
   def setup
     @p = ExternalPatch.new(:p1) { url "file:///my.patch" }
-
   end
 
   def test_url

--- a/Library/Homebrew/test/test_patching.rb
+++ b/Library/Homebrew/test/test_patching.rb
@@ -2,15 +2,15 @@ require "testing_env"
 require "formula"
 
 class PatchingTests < Homebrew::TestCase
-  TESTBALL_URL = "file://#{TEST_DIRECTORY}/tarballs/testball-0.1.tbz"
-  TESTBALL_PATCHES_URL = "file://#{TEST_DIRECTORY}/tarballs/testball-0.1-patches.tgz"
-  PATCH_URL_A = "file://#{TEST_DIRECTORY}/patches/noop-a.diff"
-  PATCH_URL_B = "file://#{TEST_DIRECTORY}/patches/noop-b.diff"
+  TESTBALL_URL = "file://#{TEST_DIRECTORY}/tarballs/testball-0.1.tbz".freeze
+  TESTBALL_PATCHES_URL = "file://#{TEST_DIRECTORY}/tarballs/testball-0.1-patches.tgz".freeze
+  PATCH_URL_A = "file://#{TEST_DIRECTORY}/patches/noop-a.diff".freeze
+  PATCH_URL_B = "file://#{TEST_DIRECTORY}/patches/noop-b.diff".freeze
   PATCH_A_CONTENTS = File.read "#{TEST_DIRECTORY}/patches/noop-a.diff"
   PATCH_B_CONTENTS = File.read "#{TEST_DIRECTORY}/patches/noop-b.diff"
-  APPLY_A = "noop-a.diff"
-  APPLY_B = "noop-b.diff"
-  APPLY_C = "noop-c.diff"
+  APPLY_A = "noop-a.diff".freeze
+  APPLY_B = "noop-b.diff".freeze
+  APPLY_C = "noop-c.diff".freeze
 
   def formula(*args, &block)
     super do
@@ -157,7 +157,7 @@ class PatchingTests < Homebrew::TestCase
         sha256 TESTBALL_PATCHES_SHA256
         apply APPLY_B
       end
-   }
+    }
   end
 
   def test_patch_p0
@@ -200,7 +200,7 @@ class PatchingTests < Homebrew::TestCase
     assert_patched formula { patch :p0, PATCH_B_CONTENTS }
   end
 
-  def test_patch_DATA_constant
+  def test_patch_data_constant
     assert_patched formula("test", Pathname.new(__FILE__).expand_path) {
       def patches
         :DATA

--- a/Library/Homebrew/test/test_pathname.rb
+++ b/Library/Homebrew/test/test_pathname.rb
@@ -46,7 +46,7 @@ class PathnameTests < Homebrew::TestCase
     refute_predicate @dir, :exist?
   end
 
-  def test_rmdir_if_possible_ignore_DS_Store
+  def test_rmdir_if_possible_ignore_ds_store
     mkdir_p @dir
     touch @dir/".DS_Store"
     assert @dir.rmdir_if_possible

--- a/Library/Homebrew/test/test_software_spec.rb
+++ b/Library/Homebrew/test/test_software_spec.rb
@@ -158,7 +158,7 @@ class BottleSpecificationTests < Homebrew::TestCase
       :snow_leopard_32 => "deadbeef"*8,
       :snow_leopard    => "faceb00c"*8,
       :lion            => "baadf00d"*8,
-      :mountain_lion   => "8badf00d"*8
+      :mountain_lion   => "8badf00d"*8,
     }
 
     checksums.each_pair do |cat, digest|

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -19,7 +19,7 @@ class TabTests < Homebrew::TestCase
                    "source"               => {
                      "tap" => "homebrew/core",
                      "path" => nil,
-                     "spec" => "stable"
+                     "spec" => "stable",
                    })
   end
 

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -161,7 +161,7 @@ class TapTest < Homebrew::TestCase
 
     assert_equal "e1893a6bd191ba895c71b652ff8376a6114c7fa7", @tap.git_head
     assert_equal "e189", @tap.git_short_head
-    assert_match %r{years ago}, @tap.git_last_commit
+    assert_match "years ago", @tap.git_last_commit
     assert_equal "2009-05-21", @tap.git_last_commit_date
   end
 
@@ -181,7 +181,7 @@ class TapTest < Homebrew::TestCase
     setup_git_repo
     already_tapped_tap = Tap.new("Homebrew", "foo")
     assert_equal true, already_tapped_tap.installed?
-    right_remote = "#{@tap.remote}"
+    right_remote = @tap.remote
     assert_raises(TapAlreadyTappedError) { already_tapped_tap.install :clone_target => right_remote }
   end
 

--- a/Library/Homebrew/test/test_update_report.rb
+++ b/Library/Homebrew/test/test_update_report.rb
@@ -37,7 +37,7 @@ class ReportTests < Homebrew::TestCase
   end
 
   def test_update_report_without_revision_var
-    ENV.delete_if { |k,v| k.start_with? "HOMEBREW_UPDATE" }
+    ENV.delete_if { |k, _v| k.start_with? "HOMEBREW_UPDATE" }
     assert_raises(Reporter::ReporterRevisionUnsetError) { Reporter.new(@tap) }
   end
 

--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -53,7 +53,7 @@ class VersionComparisonTests < Homebrew::TestCase
     assert_operator version("1.2.3"), :<, version("1.2.3-p34")
   end
 
-  def test_HEAD
+  def test_head
     assert_operator version("HEAD"), :>, version("1.2.3")
     assert_operator version("HEAD-abcdef"), :>, version("1.2.3")
     assert_operator version("1.2.3"), :<, version("HEAD")
@@ -448,7 +448,7 @@ class VersionParsingTests < Homebrew::TestCase
 
   def test_from_url
     assert_version_detected "1.2.3",
-      "http://github.com/foo/bar.git", {:tag => "v1.2.3"}
+      "http://github.com/foo/bar.git", :tag => "v1.2.3"
   end
 end
 

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -30,7 +30,7 @@ module Homebrew
       assert_equal Version.create(expected), actual
     end
 
-    def assert_version_detected(expected, url, specs={})
+    def assert_version_detected(expected, url, specs = {})
       assert_equal expected, Version.detect(url, specs).to_s
     end
 
@@ -111,9 +111,9 @@ module Homebrew
     end
 
     def refute_eql(exp, act, msg = nil)
-      msg = message(msg) {
+      msg = message(msg) do
         "Expected #{mu_pp(act)} to not be eql to #{mu_pp(exp)}"
-      }
+      end
       refute exp.eql?(act), msg
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change fixes many of the existing bugs reported by `brew style` for `Homebrew/test`.

33 bugs remain; many of them are one of the following:
- `Method definitions must not be nested. Use lambda instead.`
  - these method definitions all (or mostly) seem to be enclosed within `formula do` blocks; does it make sense to convert these to lambdas? (I haven't yet figured out a way to do so that passes `brew tests`.)

- `Use snake_case for method names.`
  - examples of these methods include `test_check_DYLD_vars` and `test_create_DATA`; it seems like these acronyms are best kept as-is.

- `Prefer to_s over string interpolation.`
  - these bugs are easy to fix, but many instances of string interpolation seem to be tolerated by `brew style` (e.g., in `test_integration_cmds`; why is that?

I'm sensing that Rubocop's opinions are meant to be guidelines (rather than gospel), but maybe I'm wrong!

🎈 