### PR TITLE
tap: more thoroughly validate tap names

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -25,7 +25,9 @@ class Tap
       repo = args[1]
     end
 
-    raise "Invalid tap name" unless user && repo
+    if [user, repo].any? { |part| part.nil? || part.include?("/") }
+      raise "Invalid tap name '#{args.join("/")}'"
+    end
 
     # we special case homebrew so users don't have to shift in a terminal
     user = "Homebrew" if user == "homebrew"

--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -63,6 +63,13 @@ class TapTest < Homebrew::TestCase
     tap = Tap.fetch("Homebrew", "foo")
     assert_kind_of Tap, tap
     assert_equal "homebrew/foo", tap.name
+
+    assert_match "Invalid tap name",
+                 assert_raises { Tap.fetch("foo") }.message
+    assert_match "Invalid tap name",
+                 assert_raises { Tap.fetch("homebrew/homebrew/bar") }.message
+    assert_match "Invalid tap name",
+                 assert_raises { Tap.fetch("homebrew", "homebrew/baz") }.message
   ensure
     Tap.clear_cache
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Tap.fetch` and commands building on top of it accepted tap names like `homebrew/homebrew/bogus` causing some misbehavior. Ensure neither `user` nor `repo` include slashes and print a more helpful error message that additionally includes the problematic tap name.

Before:

```console
$ brew tap homebrew/homebrew/completions/apm-bash-completion
==> Tapping homebrew/homebrew/completions/apm-bash-completion
Cloning into '/opt/brewery/dummy/Library/Taps/homebrew/homebrew-homebrew/completions/apm-bash-completion'...
fatal: repository 'https://github.com/Homebrew/homebrew-homebrew/completions/apm-bash-completion/' not found
Error: Failure while executing: git clone https://github.com/Homebrew/homebrew-homebrew/completions/apm-bash-completion /opt/brewery/dummy/Library/Taps/homebrew/homebrew-homebrew/completions/apm-bash-completion
```

After:

```console
$ brew tap homebrew/homebrew/completions/apm-bash-completion
Error: Invalid tap name 'homebrew/homebrew/completions/apm-bash-completion'
```

Closes #585.