### PR TITLE
audit: don't check formula linkage.

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -70,17 +70,6 @@ module FormulaCellarChecks
           #{checker.broken_dylibs.to_a * "\n          "}
       EOS
     end
-
-    # only check undeclared deps for standard installations.
-    return unless formula.build.used_options.empty?
-
-    if checker.undeclared_deps?
-      audit_check_output <<-EOS.undent
-        Formulae are required to declare all linked dependencies.
-        Please add all linked dependencies to the formula with:
-          #{checker.undeclared_deps.map { |d| "depends_on \"#{d}\" => :linked"} * "\n          "}
-      EOS
-    end
   end
 
   def audit_installed


### PR DESCRIPTION
This partly reverts commit 0ed673abdb59e2f75f9b8539cce318607924e87f from #470.

As discussed in #470. CC @DomT4 @UniqMartin @ilovezfs @xu-cheng 