### PR TITLE
Refurbish args in virtualenv

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -119,6 +119,7 @@ module Language
       # @param formula [Formula] the active Formula
       # @return [Virtualenv] a {Virtualenv} instance
       def virtualenv_create(venv_root, python = "python", formula = self)
+        ENV.refurbish_args
         venv = Virtualenv.new formula, venv_root, python
         venv.create
         venv


### PR DESCRIPTION
Instead of adding additional lines to formula.rb:
  https://git.io/vKxxh
just turn on argument refurbishment for any formula that creates a
virtualenv.

cf Homebrew/ruby-macho#50, Homebrew/homebrew-core#1663