### PR TITLE
formula_versions: ignore FormulaMethodDeprecatedError

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -4,7 +4,7 @@ class FormulaVersions
   IGNORED_EXCEPTIONS = [
     ArgumentError, NameError, SyntaxError, TypeError,
     FormulaSpecificationError, FormulaValidationError,
-    ErrorDuringExecution, LoadError
+    ErrorDuringExecution, LoadError, FormulaMethodDeprecatedError
   ]
 
   attr_reader :name, :path, :repository, :entry_name


### PR DESCRIPTION
old formula revisions have deprecated elements such as sha1 checksums