### PR TITLE
cleaner: kill unnecessary perl elements

### DIFF
--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -1,6 +1,8 @@
 # Cleans a newly installed keg.
 # By default:
 # * removes .la files
+# * removes perllocal.pod files
+# * removes .packlist files
 # * removes empty directories
 # * sets permissions on executables
 # * removes unresolved symlinks
@@ -88,6 +90,14 @@ class Cleaner
       if path.symlink? || path.directory?
         next
       elsif path.extname == ".la"
+        path.unlink
+      elsif path.basename.to_s == "perllocal.pod"
+        # Both this file & the .packlist one below are completely unnecessary
+        # to package & causes pointless conflict with other formulae. They are
+        # removed by Debian, Arch & MacPorts amongst other packagers as well.
+        # The files are created as part of installing any Perl module.
+        path.unlink
+      elsif path.basename.to_s == ".packlist" # Hidden file, not file extension!
         path.unlink
       else
         # Set permissions for executables and non-executables

--- a/Library/Homebrew/test/test_cleaner.rb
+++ b/Library/Homebrew/test/test_cleaner.rb
@@ -151,6 +151,28 @@ class CleanerTests < Homebrew::TestCase
     refute_predicate file, :exist?
   end
 
+  def test_removes_perllocal_files
+    file = @f.lib/"perl5/darwin-thread-multi-2level/perllocal.pod"
+
+    (@f.lib/"perl5/darwin-thread-multi-2level").mkpath
+    touch file
+
+    Cleaner.new(@f).clean
+
+    refute_predicate file, :exist?
+  end
+
+  def test_removes_packlist_files
+    file = @f.lib/"perl5/darwin-thread-multi-2level/auto/test/.packlist"
+
+    (@f.lib/"perl5/darwin-thread-multi-2level/auto/test").mkpath
+    touch file
+
+    Cleaner.new(@f).clean
+
+    refute_predicate file, :exist?
+  end
+
   def test_skip_clean_la
     file = @f.lib/"foo.la"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We shouldn't be packaging either `perllocal.pod` or `.packlist` files. Both are only really useful outside of package management. They get automatically generated whenever you install a Perl module.

Debian, Arch, MacPorts & others remove them and we should have been as well really; keeping them causes completely unnecessary conflicts between formulae.