### PR TITLE
python: tweak script linking in virtualenv

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -213,20 +213,6 @@ module Language
           link_scripts_finalize(link_scripts_data, link_scripts) if link_scripts
         end
 
-        # Compares the venv bin directory before and after executing a block,
-        # and symlinks any new scripts into `destination`.
-        # Use like: venv.link_scripts(bin) { venv.pip_install my_package }
-        # @param destination [Pathname, String] Destination into which new
-        #   scripts should be linked.
-        # @return [void]
-        def link_scripts(destination)
-          bin_before = Dir[@venv_root/"bin/*"].to_set
-          yield
-          bin_after = Dir[@venv_root/"bin/*"].to_set
-          destination = Pathname.new(destination)
-          destination.install_symlink((bin_after - bin_before).to_a)
-        end
-
         private
 
         def link_scripts_prepare

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -131,7 +131,7 @@ module Language
       def virtualenv_install_with_resources
         venv = virtualenv_create(libexec)
         venv.pip_install resources
-        venv.link_scripts(bin) { venv.pip_install buildpath }
+        venv.pip_install buildpath, :link_scripts => bin
         venv
       end
 
@@ -191,7 +191,12 @@ module Language
         #   Multiline strings are allowed and treated as though they represent
         #   the contents of a `requirements.txt`.
         # @return [void]
-        def pip_install(targets)
+        def pip_install(targets, options = {})
+          if options[:link_scripts]
+            link_scripts(options[:link_scripts]) { pip_install(targets) }
+            return
+          end
+
           targets = [targets] unless targets.is_a? Array
           targets.each do |t|
             if t.respond_to? :stage

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -190,6 +190,10 @@ module Language
         #   installed, or a package identifier to be fetched from PyPI.
         #   Multiline strings are allowed and treated as though they represent
         #   the contents of a `requirements.txt`.
+        # @param options [Hash]
+        # @option options [false, Pathname, String] :link_scripts (false)
+        #   Destination into which new scripts installed by `targets` should be
+        #   linked, typically {Formula#bin}. If `false`, skip this step.
         # @return [void]
         def pip_install(targets, options = {})
           link_scripts = options[:link_scripts]

--- a/Library/Homebrew/test/test_language_python.rb
+++ b/Library/Homebrew/test/test_language_python.rb
@@ -85,7 +85,7 @@ class LanguagePythonTests < Homebrew::TestCase
     bin_before = Dir[bin/"*"]
     FileUtils.touch bin/"kilroy"
     bin_after = Dir[bin/"*"]
-    @venv.expects(:pip_install).with { |*params| params == ["foo"] }
+    @venv.expects(:pip_install).with("foo")
     Dir.expects(:[]).twice.returns(bin_before, bin_after)
 
     @venv.pip_install_and_link "foo"

--- a/Library/Homebrew/test/test_language_python.rb
+++ b/Library/Homebrew/test/test_language_python.rb
@@ -88,7 +88,7 @@ class LanguagePythonTests < Homebrew::TestCase
     assert_predicate bin/"kilroy", :exist?
     assert_predicate dest/"kilroy", :exist?
     assert_predicate dest/"kilroy", :symlink?
-    assert_equal (bin/"kilroy").realpath, (dest/"kilroy").realpath
+    assert_equal((bin/"kilroy").realpath, (dest/"kilroy").realpath)
     refute_predicate dest/"irrelevant", :exist?
   end
 end

--- a/Library/Homebrew/test/test_language_python.rb
+++ b/Library/Homebrew/test/test_language_python.rb
@@ -74,8 +74,9 @@ class LanguagePythonTests < Homebrew::TestCase
   end
 
   def test_pip_install_and_link_links_scripts
-    bin = (@dir/"bin").tap(&:mkpath)
-    dest = @formula.dest
+    bin = @dir/"bin"
+    bin.mkpath
+    dest = @formula.bin
 
     refute_predicate bin/"kilroy", :exist?
     refute_predicate dest/"kilroy", :exist?

--- a/Library/Homebrew/test/test_language_python.rb
+++ b/Library/Homebrew/test/test_language_python.rb
@@ -6,8 +6,10 @@ class LanguagePythonTests < Homebrew::TestCase
   def setup
     @dir = Pathname.new(mktmpdir)
     resource = stub("resource", :stage => true)
+    formula_bin = @dir/"formula_bin"
     @formula = mock("formula") do
       stubs(:resource).returns(resource)
+      stubs(:bin).returns(formula_bin)
     end
     @venv = Language::Python::Virtualenv::Virtualenv.new(@formula, @dir, "python")
   end
@@ -71,9 +73,9 @@ class LanguagePythonTests < Homebrew::TestCase
     @venv.pip_install res
   end
 
-  def test_pip_install_links_scripts
+  def test_pip_install_and_link_links_scripts
     bin = (@dir/"bin").tap(&:mkpath)
-    dest = @dir/"dest"
+    dest = @formula.dest
 
     refute_predicate bin/"kilroy", :exist?
     refute_predicate dest/"kilroy", :exist?
@@ -83,7 +85,7 @@ class LanguagePythonTests < Homebrew::TestCase
       FileUtils.touch bin/"kilroy"
       params.first == @dir/"bin/pip" && params.last == "foo"
     end
-    @venv.pip_install "foo", :link_scripts => dest
+    @venv.pip_install_and_link "foo"
 
     assert_predicate bin/"kilroy", :exist?
     assert_predicate dest/"kilroy", :exist?

--- a/Library/Homebrew/test/test_language_python.rb
+++ b/Library/Homebrew/test/test_language_python.rb
@@ -82,10 +82,12 @@ class LanguagePythonTests < Homebrew::TestCase
     refute_predicate dest/"kilroy", :exist?
 
     FileUtils.touch bin/"irrelevant"
-    @formula.expects(:system).returns(true).with do |*params|
-      FileUtils.touch bin/"kilroy"
-      params.first == @dir/"bin/pip" && params.last == "foo"
-    end
+    bin_before = Dir[bin/"*"]
+    FileUtils.touch bin/"kilroy"
+    bin_after = Dir[bin/"*"]
+    @venv.expects(:pip_install).with { |*params| params == ["foo"] }
+    Dir.expects(:[]).twice.returns(bin_before, bin_after)
+
     @venv.pip_install_and_link "foo"
 
     assert_predicate bin/"kilroy", :exist?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

----

**Remaining steps/tasks (see below for context):**

- [ ] Agree on the preferred interface for the non-block form.
- [x] Replace minimal implementation with proper one without block/recursion.
- [x] Update documentation in code (YARD).
- [ ] Update documentation in `share/doc/homebrew/`.
- [x] Update tests.

-----

This is an attempt to refine #344, to address https://github.com/Homebrew/brew/pull/344#issuecomment-232577429 by @MikeMcQuaid:

> > `venv.link_scripts(bin) { venv.pip_install "." }`
>
> Don't understand why `venv.link_scripts` is a block rather than a following command.

@ilovezfs expressed similar concerns in https://github.com/Homebrew/brew/pull/344#issuecomment-234242676:

> Also, it does still seem awkward to have `venv.link_scripts` taking the block that does ` venv.pip_install buildpath`. Could the virtualenv accumulate before and after state without needing to resort to nesting?

----

Instead of making the formula author use a slightly awkward block construct and expose this implementation detail (diffing of `@venv_root/"bin"`), offer a more familiar:

```ruby
venv.pip_install buildpath, :link_scripts => bin
```

The default will be not to link any scripts, but this can be of course reversed if that's a useful default behavior (in this case, the opt-out would be `:link_scripts => false`).

*Note:* The current state of the PR is primarily to solicit feedback whether this is a reasonable change to make to the user-facing API of the `virtualenv` support, assuming my proposal doesn't come a bit late (as far as I'm aware this part of the interface hasn't been used yet in formulae).

cc @tdsmith 