### PR TITLE
brew-tap: allow boneyards to include invalid formulae

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -214,7 +214,7 @@ class Tap
 
     begin
       safe_system "git", *args
-      unless Readall.valid_tap?(self, :aliases => true)
+      unless repo.include?("boneyard") || Readall.valid_tap?(self, :aliases => true)
         raise "Cannot tap #{name}: invalid syntax in tap!"
       end
     rescue Interrupt, ErrorDuringExecution, RuntimeError


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR allows `*boneyard*` taps to be tapped even if their formulae have errors in them.

Now that `brew tap` does a `readall` on taps and balks at adding ones with errors, I can't tap `homebrew/boneyard` any more. The old formulae with `sha1` checksums are considered invalid.

```
$ brew tap homebrew/boneyard
==> Tapping homebrew/boneyard
Cloning into '/usr/local/Library/Taps/homebrew/homebrew-boneyard'...
remote: Counting objects: 1346, done.
remote: Total 1346 (delta 0), reused 0 (delta 0), pack-reused 1346
Receiving objects: 100% (1346/1346), 373.64 KiB | 0 bytes/s, done.
Resolving deltas: 100% (655/655), done.
Checking connectivity... done.
Error: Invalid formula: /usr/local/Library/Taps/homebrew/homebrew-boneyard/attica.rb
Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/homebrew/homebrew-boneyard/attica.rb:6:in `<class:Attica>'
Please report this to the homebrew/boneyard tap!
Error: Invalid formula: /usr/local/Library/Taps/homebrew/homebrew-boneyard/cdf.rb
Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
...
Error: Invalid formula: /usr/local/Library/Taps/homebrew/homebrew-boneyard/sparseassembler.rb
Calling Formula.sha1 is deprecated!
Use Formula.sha256 instead.
/usr/local/Library/Taps/homebrew/homebrew-boneyard/sparseassembler.rb:7:in `<class:Sparseassembler>'
Please report this to the homebrew/boneyard tap!
Error: Cannot tap homebrew/boneyard: invalid syntax in tap!
[✘ /usr/local/Library/Taps/homebrew on ⇄ master]
```

The boneyard is where formulae with problems go to die, and we do not maintain boneyarded formulae to our current standards, so it seems like this should be allowed.

Unless someone wants to go through and update the `sha1`s in the boneyard. There's a script to do that, right? I think we should allow it in the mean time. I need to tap the boneyard so I can boneyard a formula.