### PR TITLE
keg_relocate: work around `file` bug

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -64,12 +64,14 @@ class Keg
     text_files = []
     return text_files unless File.exist?("/usr/bin/file")
 
-    path.find do |pn|
-      next if pn.symlink? || pn.directory?
-      next if Metafiles::EXTENSIONS.include? pn.extname
-      # File has known issues with reading files on other locales.
-      # http://bugs.gw.com/view.php?id=292
-      with_custom_locale("C") do
+    # file has known issues with reading files on other locales. Has
+    # been fixed upstream for some time, but a sufficiently new enough
+    # file with that fix is only available in macOS Sierra.
+    # http://bugs.gw.com/view.php?id=292
+    with_custom_locale("C") do
+      path.find do |pn|
+        next if pn.symlink? || pn.directory?
+        next if Metafiles::EXTENSIONS.include? pn.extname
         if Utils.popen_read("/usr/bin/file", "--brief", pn).include?("text") ||
            pn.text_executable?
           text_files << pn

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -67,9 +67,13 @@ class Keg
     path.find do |pn|
       next if pn.symlink? || pn.directory?
       next if Metafiles::EXTENSIONS.include? pn.extname
-      if Utils.popen_read("/usr/bin/file", "--brief", pn).include?("text") ||
-         pn.text_executable?
-        text_files << pn
+      # File has known issues with reading files on other locales.
+      # http://bugs.gw.com/view.php?id=292
+      with_custom_locale("C") do
+        if Utils.popen_read("/usr/bin/file", "--brief", pn).include?("text") ||
+           pn.text_executable?
+          text_files << pn
+        end
       end
     end
 

--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -78,6 +78,14 @@ class UtilTests < Homebrew::TestCase
     end
   end
 
+  def test_with_custom_locale
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    with_custom_locale("C") do
+      assert_equal "C", ENV["LC_ALL"]
+    end
+    assert_equal "en_US.UTF-8", ENV["LC_ALL"]
+  end
+
   def test_run_as_not_developer
     ENV["HOMEBREW_DEVELOPER"] = "foo"
     run_as_not_developer do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -337,6 +337,14 @@ ensure
   ENV["PATH"] = old_path
 end
 
+def with_custom_locale(locale)
+  old_locale = ENV["LC_ALL"]
+  ENV["LC_ALL"] = locale
+  yield
+ensure
+  ENV["LC_ALL"] = old_locale
+end
+
 def run_as_not_developer(&_block)
   old = ENV.delete "HOMEBREW_DEVELOPER"
   yield


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

There's an old bug in `file` which means it can't read certain files under a non-C locale. This has been fixed upstream for some time, but Apple hasn't picked that fix up & even on OS X El Capitan the `file` is ancient.

This is currently causing a lot of false positives in our bottle code around relocating things like manpages translated into non-English languages, because currently the test does:

```
pn = "/usr/local/Cellar/vim/7.4.2109/share/man/fr/man1/vim.1"
Utils.popen_read("/usr/bin/file", "--brief", pn).include?("text")
```
Which returns `false`. But it isn't returning `false` because the actual result is false, but because `file` panics & fails, which for us equals a `false`. The actual output when accessed is:
```
pn = "/usr/local/Cellar/vim/7.4.2109/share/man/fr/man1/vim.1"
Utils.popen_read("/usr/bin/file", "--brief", pn)
"ERROR: line 22: regexec error 17, (illegal byte sequence)\n"
```
Forcing this check to be done under a "C" locale eliminates this particular false positive for strings we can't relocate & consequently things such as NLS may prove to be more portable in some formulae than is currently the case.

Using `vim` again for the example:
```
pn = "/usr/local/Cellar/vim/7.4.2109/share/man/fr/man1/vim.1"
Utils.popen_read("/usr/bin/file", "--brief", pn).include?("text")
true
```
This reduces the flagged strings from `vim` from 4 issues to 2, the remaining two with the `vim` executable itself which "remembers" the full path to perl, python, ruby, etc during build & vomits that information out when requested by the user. Both the manpages flagged before this change are no longer flagged as unrelocatable.

This won't entirely resolve the NLS problem because some things hardcode in a locale path, which will be stored in the executable, but at the very least it should reduce the number of false positives & may enable relocation where that locale path hasn't been burnt in.