### PR TITLE
tests: update cmd/analytics integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -745,16 +745,20 @@ class IntegrationCommandTests < Homebrew::TestCase
       end
     end
 
-    assert_match "Invalid usage", cmd_fail("analytics", "on", "off")
-    assert_match "Invalid usage", cmd_fail("analytics", "testball")
-    assert_match "Analytics is enabled", cmd("analytics")
-    assert_match "Analytics is disabled",
+    assert_match "Analytics is disabled (by HOMEBREW_NO_ANALYTICS)",
       cmd("analytics", "HOMEBREW_NO_ANALYTICS" => "1")
 
-    cmd("analytics", "regenerate-uuid")
-    cmd("analytics", "on")
     cmd("analytics", "off")
-    assert_match "Analytics is disabled", cmd("analytics")
+    assert_match "Analytics is disabled",
+      cmd("analytics", "HOMEBREW_NO_ANALYTICS" => nil)
+
+    cmd("analytics", "on")
+    assert_match "Analytics is enabled", cmd("analytics",
+      "HOMEBREW_NO_ANALYTICS" => nil)
+
+    assert_match "Invalid usage", cmd_fail("analytics", "on", "off")
+    assert_match "Invalid usage", cmd_fail("analytics", "testball")
+    cmd("analytics", "regenerate-uuid")
   end
 
   def test_switch


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change updates `test_analytics` to allow for the possibility that the user has set a value for `ENV["HOMEBREW_NO_ANALYTICS"]`, which was previously overlooked in #558. Thanks to @DomT4 for pointing this out. I also updated the relevant `assert_match` to clarify that `"Analytics is disabled (by HOMEBREW_NO_ANALYTICS)"`.

Is there no way to simply delete `ENV["HOMEBREW_NO_ANALYTICS"]` from within the test? I tried adding `ENV.delete` and `ENV["HOMEBREW_NO_ANALYTICS"] = nil` to the beginning of the test (to no avail).

Thanks.