### PR TITLE
formula_installer: better handle missing conflict.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -251,9 +251,22 @@ class FormulaInstaller
       begin
         f = Formulary.factory(c.name)
       rescue TapFormulaUnavailableError
-        # If the formula name is in full-qualified name. Let's silently
+        # If the formula name is a fully-qualified name let's silently
         # ignore it as we don't care about things used in taps that aren't
         # currently tapped.
+        false
+      rescue FormulaUnavailableError => e
+        # If the formula name doesn't exist any more then complain but don't
+        # stop installation from continuing.
+        opoo <<-EOS.undent
+          #{formula}: #{e.message}
+          'conflicts_with \"#{c.name}\"' should be removed from #{formula.path.basename}.
+        EOS
+        if ARGV.homebrew_developer?
+          raise
+        else
+          $stderr.puts "Please report this to the #{formula.tap} tap!"
+        end
         false
       else
         f.linked_keg.exist? && f.opt_prefix.exist?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Doesn't feel like a good reason to abort installation for users if the formula author has specified a conflict that doesn't exist. Instead, behave more like the `TapFormulaUnavailableError` but print a message telling people to report to the formula authors.

Closes https://github.com/Homebrew/homebrew-versions/issues/1327