### PR TITLE
tap: allow Homebrew developers to tap broken taps.

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -215,7 +215,9 @@ class Tap
     begin
       safe_system "git", *args
       unless Readall.valid_tap?(self, :aliases => true)
-        raise "Cannot tap #{name}: invalid syntax in tap!"
+        unless ARGV.homebrew_developer?
+          raise "Cannot tap #{name}: invalid syntax in tap!"
+        end
       end
     rescue Interrupt, ErrorDuringExecution, RuntimeError
       ignore_interrupts do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Instead of allowing certain taps to be tapped even if broken, allow Homebrew developers to tap those taps so we can fix them.

Closes #615. CC @apjanke 