### PR TITLE
bump-formula-pr: format documentation for --help

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -1,18 +1,20 @@
-#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] <formula> `--url=`<URL> `--sha256=`<SHA-256>:
-#:    Creates a pull request to update the formula <formula>
-#:    with new url <URL> and SHA-256 <SHA-256>.
+#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] `--url=`<URL> `--sha256=`<SHA-256> <formula>:
+#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] `--tag=`<TAG> `--revision=`<REVISION> <formula>:
 #:
-#:    If `--devel` is passed, bump a devel rather than stable version.
+#:    Creates a pull request to update the formula with a new url or a new tag.
 #:
-#:    If `--dry-run` is passed, print what would be done rather than doing it.
+#:    If a <URL> is specified, the <SHA-256> checksum of the new download must also be specified.
 #:
-#:  * `bump-formula-pr` [`--dry-run`] [`--devel`] <formula> `--tag=`<TAG> `--revision=`<REVISION>:
-#:    Creates a pull request to update the formula <formula>
-#:    with new tag <TAG> and revision <REVISION>.
+#:    If a <TAG> is specified, the git commit <REVISION> corresponding to that tag must also be specified.
 #:
-#:    If `--devel` is passed, bump a devel rather than stable version.
+#:    If `--devel` is passed, bump the development rather than stable version.
+#:    The development spec must already exist.
 #:
 #:    If `--dry-run` is passed, print what would be done rather than doing it.
+#:
+#:    Note that this command cannot be used to transition a formula from a
+#:    url-and-sha256 style specification into a tag-and-revision style specification, nor vice versa.
+#:    It must use whichever style specification the preexisting formula already uses.
 
 require "formula"
 

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -3,7 +3,7 @@
 #:
 #:    Creates a pull request to update the formula with a new url or a new tag.
 #:
-#:    If a <url> is specified, the <SHA-256> checksum of the new download must
+#:    If a <url> is specified, the <sha-256> checksum of the new download must
 #:    also be specified.
 #:
 #:    If a <tag> is specified, the git commit <revision> corresponding to that

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -1,16 +1,18 @@
-# Creates a pull request with the new version of a formula.
-#
-# Usage: brew bump [options...] <formula-name>
-#
-# Requires either `--url` and `--sha256` or `--tag` and `--revision`.
-#
-# Options:
-#   --dry-run:  Print what would be done rather than doing it.
-#   --devel:    Bump a `devel` rather than `stable` version.
-#   --url:      The new formula URL.
-#   --sha256:   The new formula SHA-256.
-#   --tag:      The new formula's `tag`
-#   --revision: The new formula's `revision`.
+#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] <formula> `--url=`<URL> `--sha256=`<SHA-256>:
+#:    Creates a pull request to update the formula <formula>
+#:    with new url <URL> and SHA-256 <SHA-256>.
+#:
+#:    If `--devel` is passed, bump a devel rather than stable version.
+#:
+#:    If `--dry-run` is passed, print what would be done rather than doing it.
+#:
+#:  * `bump-formula-pr` [`--dry-run`] [`--devel`] <formula> `--tag=`<TAG> `--revision=`<REVISION>:
+#:    Creates a pull request to update the formula <formula>
+#:    with new tag <TAG> and revision <REVISION>.
+#:
+#:    If `--devel` is passed, bump a devel rather than stable version.
+#:
+#:    If `--dry-run` is passed, print what would be done rather than doing it.
 
 require "formula"
 

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -1,11 +1,13 @@
-#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] `--url=`<URL> `--sha256=`<SHA-256> <formula>:
-#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] `--tag=`<TAG> `--revision=`<REVISION> <formula>:
+#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] `--url=`<url> `--sha256=`<sha-256> <formula>:
+#:  * `bump-formula-pr` [`--devel`] [`--dry-run`] `--tag=`<tag> `--revision=`<revision> <formula>:
 #:
 #:    Creates a pull request to update the formula with a new url or a new tag.
 #:
-#:    If a <URL> is specified, the <SHA-256> checksum of the new download must also be specified.
+#:    If a <url> is specified, the <SHA-256> checksum of the new download must
+#:    also be specified.
 #:
-#:    If a <TAG> is specified, the git commit <REVISION> corresponding to that tag must also be specified.
+#:    If a <tag> is specified, the git commit <revision> corresponding to that
+#:    tag must also be specified.
 #:
 #:    If `--devel` is passed, bump the development rather than stable version.
 #:    The development spec must already exist.
@@ -13,8 +15,9 @@
 #:    If `--dry-run` is passed, print what would be done rather than doing it.
 #:
 #:    Note that this command cannot be used to transition a formula from a
-#:    url-and-sha256 style specification into a tag-and-revision style specification, nor vice versa.
-#:    It must use whichever style specification the preexisting formula already uses.
+#:    url-and-sha256 style specification into a tag-and-revision style
+#:    specification, nor vice versa. It must use whichever style specification
+#:    the preexisting formula already uses.
 
 require "formula"
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I've been toying with using the `bump-formula-pr` command, but I couldn't remember the command-line arguments, and they weren't showing up when I pass `--help`, so I formatted the comments based on what I saw in some other commands. Suggestions are welcome of course, but I'm on vacation, so I might not have a chance to respond for at least a week.

I'm pasting the output but it loses some of the formatting:
~~~
brew bump-formula-pr --help
brew bump-formula-pr [--devel] [--dry-run] formula --url=URL --sha256=SHA-256:
    Creates a pull request to update the formula formula
    with new url URL and SHA-256 SHA-256.

    If --devel is passed, bump a devel rather than stable version.

    If --dry-run is passed, print what would be done rather than doing it.

brew bump-formula-pr [--dry-run] [--devel] formula --tag=TAG --revision=REVISION:
    Creates a pull request to update the formula formula
    with new tag TAG and revision REVISION.

    If --devel is passed, bump a devel rather than stable version.

    If --dry-run is passed, print what would be done rather than doing it.
~~~