### PR TITLE
tests: extend cmd/install integration test

### DIFF
--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -265,9 +265,24 @@ class IntegrationCommandTests < Homebrew::TestCase
   end
 
   def test_install
-    setup_test_formula "testball"
+    setup_test_formula "testball1"
+    assert_match "Specify `--HEAD`", cmd_fail("install", "testball1", "--head")
+    assert_match "No head is defined", cmd_fail("install", "testball1", "--HEAD")
+    assert_match "No devel block", cmd_fail("install", "testball1", "--devel")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/0.1", cmd("install", "testball1")
+    assert_match "testball1-0.1 already installed", cmd("install", "testball1")
+    assert_match "MacRuby is not packaged", cmd_fail("install", "macruby")
+    assert_match "No available formula", cmd_fail("install", "formula")
+    assert_match "This similarly named formula was found",
+      cmd_fail("install", "testball")
 
-    assert_match "#{HOMEBREW_CELLAR}/testball/0.1", cmd("install", "testball")
+    setup_test_formula "testball2"
+    assert_match "These similarly named formulae were found",
+      cmd_fail("install", "testball")
+
+    install_and_rename_coretap_formula "testball1", "testball2"
+    assert_match "testball1 already installed, it's just not migrated",
+      cmd("install", "testball2")
   end
 
   def test_bottle


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change adds more test coverage for `brew install`.

There is some overlap between this new `test_install` and `test_migrate` (in #601); this is so that [these lines](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/install.rb#L137-L142) in `cmd/install.rb` can be covered. 😬 

There are ~25 lines that are duplicated between the two tests; perhaps there's a way to shorten them and/or it would be OK to refactor them into their own method?