### PR TITLE
formula_installer: option to ignore deps' tabs

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -624,7 +624,7 @@ module Homebrew
               test "brew", "unlink", conflict.name
             end
             unless ARGV.include?("--fast")
-              run_as_not_developer { test "brew", "install", dependent.name }
+              run_as_not_developer { test "brew", "install", "--ignore-tabs", dependent.name }
               next if steps.last.failed?
             end
           end

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -159,6 +159,10 @@ module HomebrewArgvExtension
     include? "--ignore-dependencies"
   end
 
+  def ignore_tabs?
+    include? "--ignore-tabs"
+  end
+
   def only_deps?
     include? "--only-dependencies"
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -427,7 +427,7 @@ class FormulaInstaller
     end
 
     fi = DependencyInstaller.new(df)
-    fi.options           |= tab.used_options
+    fi.options           |= tab.used_options unless ARGV.ignore_tabs?
     fi.options           |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
     fi.options           |= inherited_options
     fi.build_from_source  = ARGV.build_formula_from_source?(df)


### PR DESCRIPTION
This allows test-bot to avoid having to explicitly uninstall a formula
just because a contradictory tab is lingering.