### PR TITLE
virtualenv_install_with_resources: select correct python

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -294,6 +294,17 @@ class FormulaConflictError < RuntimeError
   end
 end
 
+class FormulaAmbiguousPythonError < RuntimeError
+  def initialize(formula)
+    super <<-EOS.undent
+      The version of python to use with the virtualenv in the `#{formula.full_name}` formula
+      cannot be guessed automatically. If the simultaneous use of python and python3
+      is intentional, please add `:using => "python"` or `:using => "python3"` to
+      `virtualenv_install_with_resources` to resolve the ambiguity manually.
+    EOS
+  end
+end
+
 class BuildError < RuntimeError
   attr_reader :formula, :env
 


### PR DESCRIPTION
`virtualenv_install_with_resources` will now attempt to guess the
desired Python based on the active build options and based on the
dependencies and requirements. When the situation is ambiguous (e.g.,
`depends_on :python3` and `build.with? "python"` is true) raise
`FormulaAmbiguousPythonError` unless `:using => "python"` or
`:using => "python3"` has been passed to resolve the ambiguity.

In most cases, this will allow

```
    virtualenv_create(libexec, "python3")
    virtualenv_install_with_resources
```

to be changed to just

```
    virtualenv_install_with_resources
```