### PR TITLE
various: eliminate the usage of `any?`

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -628,7 +628,8 @@ class FormulaAuditor
 
     fv = FormulaVersions.new(formula, :max_depth => 10)
     revision_map = fv.revision_map("origin/master")
-    if (revisions = revision_map[formula.version]).any?
+    revisions = revision_map[formula.version]
+    if !revisions.empty?
       problem "revision should not decrease" if formula.revision < revisions.max
     elsif formula.revision != 0
       if formula.stable
@@ -644,7 +645,7 @@ class FormulaAuditor
   def audit_legacy_patches
     return unless formula.respond_to?(:patches)
     legacy_patches = Patch.normalize_legacy_patches(formula.patches).grep(LegacyPatch)
-    if legacy_patches.any?
+    unless legacy_patches.empty?
       problem "Use the patch DSL instead of defining a 'patches' method"
       legacy_patches.each { |p| audit_patch(p) }
     end

--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -58,10 +58,10 @@ module Homebrew
       next if Metafiles::EXTENSIONS.include? file.extname
 
       linked_libraries = Keg.file_linked_libraries(file, string)
-      result ||= linked_libraries.any?
+      result ||= !linked_libraries.empty?
 
       if ARGV.verbose?
-        print_filename(string, file) if linked_libraries.any?
+        print_filename(string, file) unless linked_libraries.empty?
         linked_libraries.each do |lib|
           puts " #{Tty.gray}-->#{Tty.reset} links to #{lib}"
         end
@@ -83,7 +83,7 @@ module Homebrew
         end
       end
 
-      if ARGV.verbose? && text_matches.any?
+      if ARGV.verbose? && !text_matches.empty?
         print_filename string, file
         text_matches.first(MAXIMUM_STRING_MATCHES).each do |match, offset|
           puts " #{Tty.gray}-->#{Tty.reset} match '#{match}' at offset #{Tty.em}0x#{offset}#{Tty.reset}"
@@ -157,7 +157,7 @@ module Homebrew
       versions = FormulaVersions.new(f)
       bottle_revisions = versions.bottle_version_map("origin/master")[f.pkg_version]
       bottle_revisions.pop if bottle_revisions.last.to_i > 0
-      bottle_revision = bottle_revisions.any? ? bottle_revisions.max.to_i + 1 : 0
+      bottle_revision = bottle_revisions.empty? ? 0 : bottle_revisions.max.to_i + 1
     end
 
     filename = Bottle::Filename.create(f, Utils::Bottles.tag, bottle_revision)
@@ -287,7 +287,7 @@ module Homebrew
         old_spec.send(field) != bottle.send(field)
       end
       bad_fields.delete(:cellar) if old_spec.cellar == :any && bottle.cellar == :any_skip_relocation
-      if bad_fields.any?
+      unless bad_fields.empty?
         bottle_path.unlink if bottle_path.exist?
         odie "--keep-old is passed but there are changes in: #{bad_fields.join ", "}"
       end
@@ -387,7 +387,7 @@ module Homebrew
                 next if key == "cellar" && old_value == "any" && value == "any_skip_relocation"
                 mismatches << key if old_value.empty? || value != old_value
               end
-              if mismatches.any?
+              unless mismatches.empty?
                 odie "--keep-old was passed but there were changes in #{mismatches.join(", ")}!"
               end
               output = bottle_output bottle

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -118,7 +118,7 @@ module Homebrew
     attrs << "pinned at #{f.pinned_version}" if f.pinned?
     attrs << "keg-only" if f.keg_only?
 
-    puts "#{f.full_name}: #{specs * ", "}#{" [#{attrs * ", "}]" if attrs.any?}"
+    puts "#{f.full_name}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
     puts f.desc if f.desc
     puts "#{Tty.em}#{f.homepage}#{Tty.reset}" if f.homepage
 
@@ -126,14 +126,14 @@ module Homebrew
     puts "Conflicts with: #{conflicts*", "}" unless conflicts.empty?
 
     kegs = f.installed_kegs.sort_by(&:version)
-    if kegs.any?
+    if kegs.empty?
+      puts "Not installed"
+    else
       kegs.each do |keg|
         puts "#{keg} (#{keg.abv})#{" *" if keg.linked?}"
         tab = Tab.for_keg(keg).to_s
         puts "  #{tab}" unless tab.empty?
       end
-    else
-      puts "Not installed"
     end
 
     puts "From: #{Tty.em}#{github_info(f)}#{Tty.reset}"

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -82,7 +82,7 @@ module Homebrew
     begin
       formulae = []
 
-      if ARGV.casks.any?
+      unless ARGV.casks.empty?
         args = []
         args << "--force" if ARGV.force?
         args << "--debug" if ARGV.debug?

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -28,7 +28,7 @@ module Homebrew
     # Unbrewed uses the PREFIX, which will exist
     # Things below use the CELLAR, which doesn't until the first formula is installed.
     unless HOMEBREW_CELLAR.exist?
-      raise NoSuchKegError.new(ARGV.named.first) if ARGV.named.any?
+      raise NoSuchKegError.new(ARGV.named.first) unless ARGV.named.empty?
       return
     end
 

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -17,13 +17,17 @@ require "keg"
 
 module Homebrew
   def outdated
-    formulae = ARGV.resolved_formulae.any? ? ARGV.resolved_formulae : Formula.installed
+    formulae = if ARGV.resolved_formulae.empty?
+      Formula.installed
+    else
+      ARGV.resolved_formulae
+    end
     if ARGV.json == "v1"
       outdated = print_outdated_json(formulae)
     else
       outdated = print_outdated(formulae)
     end
-    Homebrew.failed = ARGV.resolved_formulae.any? && outdated.any?
+    Homebrew.failed = !ARGV.resolved_formulae.empty? && !outdated.empty?
   end
 
   def print_outdated(formulae)

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -22,10 +22,10 @@ module Homebrew
     end
 
     options = { :aliases => ARGV.include?("--aliases") }
-    taps = if ARGV.named.any?
-      [Tap.fetch(ARGV.named.first)]
-    else
+    taps = if ARGV.named.empty?
       Tap
+    else
+      [Tap.fetch(ARGV.named.first)]
     end
     taps.each do |tap|
       Homebrew.failed = true unless Readall.valid_tap?(tap, options)

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -89,7 +89,7 @@ module Homebrew
           arg.include?(char) && !arg.start_with?("/")
         end
       end
-      if ARGV.any? && bad_regex
+      if !ARGV.empty? && bad_regex
         ohai "Did you mean to perform a regular expression search?"
         ohai "Surround your query with /slashes/ to search by regex."
       end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -21,16 +21,16 @@ module Homebrew
     if ARGV.named.empty?
       outdated = Formula.installed.select(&:outdated?)
       exit 0 if outdated.empty?
-    elsif ARGV.named.any?
+    else
       outdated = ARGV.resolved_formulae.select(&:outdated?)
 
       (ARGV.resolved_formulae - outdated).each do |f|
         versions = f.installed_kegs.map { |keg| keg.version }
-        if versions.any?
+        if versions.empty?
+          onoe "#{f.full_name} not installed"
+        else
           version = versions.max
           onoe "#{f.full_name} #{version} already installed"
-        else
-          onoe "#{f.full_name} not installed"
         end
       end
       exit 1 if outdated.empty?

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -25,7 +25,7 @@ module Homebrew
         end
         contents.gsub!(old, new)
       end
-      if contents.errors.any?
+      unless contents.errors.empty?
         raise Utils::InreplaceError, path => contents.errors
       end
       contents

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -342,7 +342,7 @@ module Homebrew
           @name = "#{diff_start_sha1}-#{diff_end_sha1}"
         end
       # Handle formulae arguments being passed on the command-line e.g. `brew test-bot wget fish`.
-      elsif @formulae && @formulae.any?
+      elsif @formulae && !@formulae.empty?
         @name = "#{@formulae.first}-#{diff_end_sha1}"
         diff_start_sha1 = diff_end_sha1
       # Handle a hash being passed on the command-line e.g. `brew test-bot 1a2b3c`.
@@ -602,7 +602,7 @@ module Homebrew
             test "brew", "uninstall", "--force", formula_name
             FileUtils.ln bottle_filename, HOMEBREW_CACHE/bottle_filename, :force => true
             @formulae.delete(formula_name)
-            if unchanged_build_dependencies.any?
+            unless unchanged_build_dependencies.empty?
               test "brew", "uninstall", "--force", *unchanged_build_dependencies
               unchanged_dependencies -= unchanged_build_dependencies
             end
@@ -652,7 +652,7 @@ module Homebrew
           test "brew", "uninstall", "--devel", "--force", formula_name
         end
       end
-      test "brew", "uninstall", "--force", *unchanged_dependencies if unchanged_dependencies.any?
+      test "brew", "uninstall", "--force", *unchanged_dependencies unless unchanged_dependencies.empty?
     end
 
     def homebrew

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -350,7 +350,7 @@ class BuildError < RuntimeError
       end
     end
     puts
-    if RUBY_VERSION >= "1.8.7" && issues && issues.any?
+    if RUBY_VERSION >= "1.8.7" && issues && !issues.empty?
       puts "These open issues may also help:"
       puts issues.map { |i| "#{i["title"]} #{i["html_url"]}" }.join("\n")
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -998,7 +998,7 @@ class Formula
 
   # @private
   def outdated?
-    outdated_versions.any?
+    !outdated_versions.empty?
   rescue Migrator::MigrationNeededError
     true
   end
@@ -1517,7 +1517,7 @@ class Formula
         installed_kegs.select { |k| pkg_version > k.version }
       end
 
-      if eligible_kegs.any?
+      unless eligible_kegs.empty?
         eligible_kegs.each do |keg|
           if keg.linked?
             opoo "Skipping (old) #{keg} due to it being linked"
@@ -1526,7 +1526,7 @@ class Formula
           end
         end
       end
-    elsif installed_prefixes.any? && !pinned?
+    elsif !installed_prefixes.empty? && !pinned?
       # If the cellar only has one version installed, don't complain
       # that we can't tell which one to keep. Don't complain at all if the
       # only installed version is a pinned formula.

--- a/Library/Homebrew/formula_pin.rb
+++ b/Library/Homebrew/formula_pin.rb
@@ -31,7 +31,7 @@ class FormulaPin
   end
 
   def pinnable?
-    @f.installed_prefixes.any?
+    !@f.installed_prefixes.empty?
   end
 
   def pinned_version

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -253,11 +253,11 @@ class Keg
           when :zsh  then path.join("share", "zsh", "site-functions")
           when :fish then path.join("share", "fish", "vendor_completions.d")
           end
-    dir && dir.directory? && dir.children.any?
+    dir && dir.directory? && !dir.children.empty?
   end
 
   def plist_installed?
-    Dir["#{path}/*.plist"].any?
+    !Dir["#{path}/*.plist"].empty?
   end
 
   def python_site_packages_installed?
@@ -265,7 +265,7 @@ class Keg
   end
 
   def python_pth_files_installed?
-    Dir["#{path}/lib/python2.7/site-packages/*.pth"].any?
+    !Dir["#{path}/lib/python2.7/site-packages/*.pth"].empty?
   end
 
   def apps

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -131,8 +131,8 @@ module Language
           dep_site_packages = Formula[d.name].opt_lib/"python#{xy}/site-packages"
           next unless dep_site_packages.exist?
           "import site; site.addsitedir('#{dep_site_packages}')\n"
-        end
-        if pth_contents.any?
+        end.compact
+        unless pth_contents.empty?
           (venv_root/"lib/python#{xy}/site-packages/homebrew_deps.pth").write pth_contents.join
         end
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -77,7 +77,7 @@ class SoftwareSpec
   end
 
   def bottle_defined?
-    bottle_specification.collector.keys.any?
+    !bottle_specification.collector.keys.empty?
   end
 
   def bottled?

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -259,10 +259,10 @@ module GitHub
     open_or_closed_prs = issues_matching(query, :type => "pr")
 
     open_prs = open_or_closed_prs.select { |i| i["state"] == "open" }
-    if open_prs.any?
+    if !open_prs.empty?
       puts "Open pull requests:"
       prs = open_prs
-    elsif open_or_closed_prs.any?
+    elsif !open_or_closed_prs.empty?
       puts "Closed pull requests:"
       prs = open_or_closed_prs
     else

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -28,12 +28,12 @@ module Utils
           s.gsub!(before, after, audit_result)
         end
 
-        errors[path] = s.errors if s.errors.any?
+        errors[path] = s.errors unless s.errors.empty?
 
         Pathname(path).atomic_write(s)
       end
 
-      raise InreplaceError.new(errors) if errors.any?
+      raise InreplaceError.new(errors) unless errors.empty?
     end
     module_function :inreplace
   end


### PR DESCRIPTION
`any?` is not the opposite of `empty?`. Besides the case that
`[false, nil].any?` will return false, `any?`(O(n)) has much worse
performance than `empty?`(O(1)).

cc @UniqMartin 