### PR TITLE
Fix update commit for non-HEAD kegs with head spec

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -34,7 +34,7 @@ module HomebrewArgvExtension
           f.build = tab
           if f.head? && tab.tabfile
             k = Keg.new(tab.tabfile.parent)
-            f.version.update_commit(k.version.version.commit)
+            f.version.update_commit(k.version.version.commit) if k.version.head?
           end
         end
         f

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -246,7 +246,7 @@ class Formulary
       end
     end
     f.build = tab
-    f.version.update_commit(keg.version.version.commit) if f.head?
+    f.version.update_commit(keg.version.version.commit) if f.head? && keg.version.head?
     f
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If we try to call `Formulary.from_keg(f, :head)` on the keg that
is not HEAD-keg itself, we don't need to update commit of
returned formula and should use just HEAD version with nil commit.

Same is true for `ARGV.resolved_formulae`

See https://github.com/Homebrew/brew/pull/500#issuecomment-237886252 and https://github.com/Homebrew/brew/pull/500#issuecomment-237900703

CC @UniqMartin @xu-cheng @MikeMcQuaid @eirinikos 