### PR TITLE
tests: fix fluctuations in test coverage

### DIFF
--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -7,6 +7,11 @@ SimpleCov.start do
   coverage_dir File.expand_path("#{tests_path}/coverage")
   root File.expand_path("#{tests_path}/..")
 
+  # We manage the result cache ourselves and the default of 10 minutes can be
+  # too low (particularly on Travis CI), causing results from some integration
+  # tests to be dropped. This causes random fluctuations in test coverage.
+  merge_timeout 86400
+
   add_filter "/Homebrew/compat/"
   add_filter "/Homebrew/test/"
   add_filter "/Homebrew/vendor/"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Thanks @eirinikos for noticing and raising this issue! This behavior basically started once our integration tests caused the overall test time to raise above 10 minutes, causing some coverage data to be dropped because SimpleCov believed it to be stale.

This PR returns our test coverage to (glorious) ~56.76%<sup>(1)</sup> and, more more importantly, fixes the fluctuations that would result in different coverage on every run, causing changes of coverage to be completely disconnected from changes in PRs and commits to `master`, ultimately making them more confusing than useful.

**Notes:**

- This doesn't address the problem that our test times for runs with `--coverage` have increased massively and are unacceptably long. I'm plan to address this in a future PR (very soon).

- Unhelpfully, a bug in `test-bot` temporarily caused the coverage results reported to Coveralls to be way too low, masking the introduction of these fluctuations. Because test run time can vary widely on Travis CI and locally on different machines, this was a bit tricky to identify.

<sup>(1)</sup>Coveralls results slightly differ due to different environment.