### PR TITLE
Refactor bootstrap and test coverage setup

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -1,8 +1,6 @@
 std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 
 require "pathname"
-HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
-$:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 
 if ARGV == %w[--version] || ARGV == %w[-v]

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -247,7 +247,11 @@ then
   # Hide shellcheck complaint:
   # shellcheck source=/dev/null
   source "$HOMEBREW_BASH_COMMAND"
-  { update-preinstall; "homebrew-$HOMEBREW_COMMAND" "$@"; exit $?; }
+  {
+    update-preinstall
+    "homebrew-$HOMEBREW_COMMAND" "$@"
+    exit $?
+  }
 else
   # Hide shellcheck complaint:
   # shellcheck source=/dev/null
@@ -256,5 +260,10 @@ else
 
   # Unshift command back into argument list (unless argument list was empty).
   [[ "$HOMEBREW_ARG_COUNT" -gt 0 ]] && set -- "$HOMEBREW_COMMAND" "$@"
-  { update-preinstall; exec "$HOMEBREW_RUBY_PATH" -W0 "$HOMEBREW_LIBRARY/Homebrew/brew.rb" "$@"; }
+  {
+    update-preinstall
+    exec "$HOMEBREW_RUBY_PATH" -W0 \
+      -I "$HOMEBREW_LIBRARY/Homebrew" \
+      -- "$HOMEBREW_LIBRARY/Homebrew/brew.rb" "$@"
+  }
 fi

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -39,4 +39,4 @@ HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp"))
 HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
 
 # Load path used by standalone scripts to access the Homebrew code base
-HOMEBREW_LOAD_PATH = HOMEBREW_LIBRARY_PATH
+HOMEBREW_LOAD_PATH = HOMEBREW_LIBRARY_PATH.to_s

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -35,10 +35,8 @@ HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/")
 # Must use /tmp instead of $TMPDIR because long paths break Unix domain sockets
 HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp"))
 
-unless defined? HOMEBREW_LIBRARY_PATH
-  # Root of the Homebrew code base
-  HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
-end
+# Root of the Homebrew code base
+HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
 
 # Load path used by standalone scripts to access the Homebrew code base
 HOMEBREW_LOAD_PATH = HOMEBREW_LIBRARY_PATH

--- a/Library/Homebrew/test/.simplecov
+++ b/Library/Homebrew/test/.simplecov
@@ -21,7 +21,7 @@ SimpleCov.start do
     at_exit do
       exit_code = $!.nil? ? 0 : $!.status
       $stdout.reopen("/dev/null")
-      SimpleCov.result # Just save result, but don't write formatted output.
+      Homebrew::CoverageHelper.save_coverage
       exit! exit_code
     end
   else
@@ -44,9 +44,4 @@ SimpleCov.start do
   ]
 end
 
-# Don't use Coveralls outside of CI, as it will override SimpleCov's default
-# formatter causing the `index.html` not to be written once all tests finish.
-if RUBY_VERSION.split(".").first.to_i >= 2 && !ENV["HOMEBREW_INTEGRATION_TEST"] && ENV["CI"]
-  require "coveralls"
-  Coveralls.wear!
-end
+Homebrew::CoverageHelper.setup_coveralls

--- a/Library/Homebrew/test/lib/bootstrap_brew.rb
+++ b/Library/Homebrew/test/lib/bootstrap_brew.rb
@@ -1,0 +1,5 @@
+require "bootstrap_coverage"
+require "integration_mocks"
+
+# We load `brew.rb` indirectly, as otherwise we won't get coverage data.
+require File.expand_path("../../../brew.rb", __FILE__)

--- a/Library/Homebrew/test/lib/bootstrap_coverage.rb
+++ b/Library/Homebrew/test/lib/bootstrap_coverage.rb
@@ -1,0 +1,36 @@
+module Homebrew
+  module CoverageHelper
+    def self.save_coverage
+      return unless ENV["HOMEBREW_TESTS_COVERAGE"]
+      return unless ENV["HOMEBREW_INTEGRATION_TEST"]
+
+      SimpleCov.result
+    end
+
+    def self.setup_coveralls
+      # Don't use Coveralls outside of CI. It will override SimpleCov's default
+      # formatter causing no `index.html` to be written once all tests finish.
+      return unless ENV["CI"]
+      return unless ENV["HOMEBREW_TESTS_COVERAGE"]
+      return if ENV["HOMEBREW_INTEGRATION_TEST"]
+      return unless RUBY_VERSION.split(".").first.to_i >= 2
+
+      require "coveralls"
+      Coveralls.wear!
+    end
+  end
+end
+
+if ENV["HOMEBREW_TESTS_COVERAGE"]
+  # This is needed only because we currently use a patched version of SimpleCov,
+  # and Gems installed through Git are not available without requiring
+  # `bundler/setup` first. (See also the comment in `test/Gemfile`.)
+  # Remove the next line when we switch back to a stable SimpleCov release.
+  require "bundler/setup"
+
+  # For SimpleCov to find `.simplecov`, we need to make sure it's in the current
+  # working directory, no matter where this bootstrap code is loaded from.
+  Dir.chdir(File.expand_path("../..", __FILE__)) do
+    require "simplecov"
+  end
+end

--- a/Library/Homebrew/test/lib/integration_mocks.rb
+++ b/Library/Homebrew/test/lib/integration_mocks.rb
@@ -8,10 +8,8 @@ module Homebrew
   end
 
   def exec(*args)
-    if ENV["HOMEBREW_TESTS_COVERAGE"] && ENV["HOMEBREW_INTEGRATION_TEST"]
-      # Ensure we get coverage results before replacing the current process.
-      SimpleCov.result
-    end
+    # Ensure we retain coverage results before replacing the current process.
+    Homebrew::CoverageHelper.save_coverage
     Kernel.exec(*args)
   end
 end

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -56,16 +56,10 @@ class IntegrationCommandTests < Homebrew::TestCase
       -W0
       -I#{HOMEBREW_LIBRARY_PATH}/test/lib
       -I#{HOMEBREW_LIBRARY_PATH}
+      -rbootstrap_coverage
+      -rintegration_mocks
+      --
     ]
-    if ENV["HOMEBREW_TESTS_COVERAGE"]
-      # This is needed only because we currently use a patched version of
-      # simplecov, and gems installed through git are not available without
-      # requiring bundler/setup first. See also the comment in test/Gemfile.
-      # Remove this line when we'll switch back to a stable simplecov release.
-      cmd_args << "-rbundler/setup"
-      cmd_args << "-rsimplecov"
-    end
-    cmd_args << "-rintegration_mocks"
     cmd_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
     cmd_args += args
     Bundler.with_original_env do

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -55,7 +55,7 @@ class IntegrationCommandTests < Homebrew::TestCase
     cmd_args = %W[
       -W0
       -I#{HOMEBREW_LIBRARY_PATH}/test/lib
-      -rconfig
+      -I#{HOMEBREW_LIBRARY_PATH}
     ]
     if ENV["HOMEBREW_TESTS_COVERAGE"]
       # This is needed only because we currently use a patched version of

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -52,15 +52,15 @@ class IntegrationCommandTests < Homebrew::TestCase
   def cmd_output(*args)
     # 1.8-compatible way of writing def cmd_output(*args, **env)
     env = args.last.is_a?(Hash) ? args.pop : {}
+
+    brew_shim = HOMEBREW_LIBRARY_PATH/"test/lib/bootstrap_brew.rb"
     cmd_args = %W[
       -W0
       -I#{HOMEBREW_LIBRARY_PATH}/test/lib
       -I#{HOMEBREW_LIBRARY_PATH}
-      -rbootstrap_coverage
-      -rintegration_mocks
       --
+      #{brew_shim.resolved_path}
     ]
-    cmd_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
     cmd_args += args
     Bundler.with_original_env do
       ENV["HOMEBREW_BREW_FILE"] = HOMEBREW_PREFIX/"bin/brew"

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -1,7 +1,7 @@
 $:.unshift File.expand_path("../..", __FILE__)
 $:.unshift File.expand_path("../lib", __FILE__)
 
-require "simplecov" if ENV["HOMEBREW_TESTS_COVERAGE"]
+require "bootstrap_coverage"
 require "global"
 require "formulary"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The changes are best viewed commit by commit. The goal is to eliminate some discrepancies between the regular Homebrew bootstrap and the bootstrap performed in the test code for integration command testing. The latter was unnecessarily complex because `brew.rb` still has remnants of the time when it was an executable script with a shebang (and thus needed to initialize itself) which is no longer the case.

Aside from a refactoring, there are two major benefits resulting from this PR:

- `brew.rb` is finally included in the coverage reports. This was previously not possible due to the inflexible bootstrap behavior. (It showed up with zero relevant lines.)
- Coverage initialization and helpers are consolidated in `bootstrap_coverage.rb`, making it much easier to bring much needed performance improvements to `brew tests --coverage`.

cc @eirinikos