### PR TITLE
Fix style inconsistencies in Bash code

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -33,7 +33,7 @@ git() {
 }
 
 # Force UTF-8 to avoid encoding issues for users with broken locale settings.
-if [[ "$(locale charmap 2> /dev/null)" != "UTF-8" ]]
+if [[ "$(locale charmap 2>/dev/null)" != "UTF-8" ]]
 then
   export LC_ALL="en_US.UTF-8"
 fi
@@ -48,8 +48,8 @@ else
 fi
 
 case "$*" in
-  --prefix) echo "$HOMEBREW_PREFIX"; exit 0 ;;
-  --cellar) echo "$HOMEBREW_CELLAR"; exit 0 ;;
+  --prefix)            echo "$HOMEBREW_PREFIX"; exit 0 ;;
+  --cellar)            echo "$HOMEBREW_CELLAR"; exit 0 ;;
   --repository|--repo) echo "$HOMEBREW_REPOSITORY"; exit 0 ;;
 esac
 
@@ -66,8 +66,8 @@ unset GEM_PATH
 
 HOMEBREW_SYSTEM="$(uname -s)"
 case "$HOMEBREW_SYSTEM" in
-  Darwin) HOMEBREW_OSX="1";;
-  Linux) HOMEBREW_LINUX="1";;
+  Darwin) HOMEBREW_OSX="1" ;;
+  Linux)  HOMEBREW_LINUX="1" ;;
 esac
 
 HOMEBREW_CURL="/usr/bin/curl"
@@ -171,20 +171,20 @@ HOMEBREW_ARG_COUNT="$#"
 HOMEBREW_COMMAND="$1"
 shift
 case "$HOMEBREW_COMMAND" in
-  ls)          HOMEBREW_COMMAND="list";;
-  homepage)    HOMEBREW_COMMAND="home";;
-  -S)          HOMEBREW_COMMAND="search";;
-  up)          HOMEBREW_COMMAND="update";;
-  ln)          HOMEBREW_COMMAND="link";;
-  instal)      HOMEBREW_COMMAND="install";; # gem does the same
-  rm)          HOMEBREW_COMMAND="uninstall";;
-  remove)      HOMEBREW_COMMAND="uninstall";;
-  configure)   HOMEBREW_COMMAND="diy";;
-  abv)         HOMEBREW_COMMAND="info";;
-  dr)          HOMEBREW_COMMAND="doctor";;
-  --repo)      HOMEBREW_COMMAND="--repository";;
-  environment) HOMEBREW_COMMAND="--env";;
-  --config)    HOMEBREW_COMMAND="config";;
+  ls)          HOMEBREW_COMMAND="list" ;;
+  homepage)    HOMEBREW_COMMAND="home" ;;
+  -S)          HOMEBREW_COMMAND="search" ;;
+  up)          HOMEBREW_COMMAND="update" ;;
+  ln)          HOMEBREW_COMMAND="link" ;;
+  instal)      HOMEBREW_COMMAND="install" ;; # gem does the same
+  rm)          HOMEBREW_COMMAND="uninstall" ;;
+  remove)      HOMEBREW_COMMAND="uninstall" ;;
+  configure)   HOMEBREW_COMMAND="diy" ;;
+  abv)         HOMEBREW_COMMAND="info" ;;
+  dr)          HOMEBREW_COMMAND="doctor" ;;
+  --repo)      HOMEBREW_COMMAND="--repository" ;;
+  environment) HOMEBREW_COMMAND="--env" ;;
+  --config)    HOMEBREW_COMMAND="config" ;;
 esac
 
 if [[ -f "$HOMEBREW_LIBRARY/Homebrew/cmd/$HOMEBREW_COMMAND.sh" ]]
@@ -197,8 +197,8 @@ fi
 
 check-run-command-as-root() {
   case "$HOMEBREW_COMMAND" in
-      analytics|create|install|link|migrate|pin|postinstall|reinstall|switch|tap|tap-pin|\
-      update|upgrade|vendor-install)
+    analytics|create|install|link|migrate|pin|postinstall|reinstall|switch|tap|\
+    tap-pin|update|upgrade|vendor-install)
       ;;
     *)
       return
@@ -210,7 +210,7 @@ check-run-command-as-root() {
   local brew_file_ls_info=($(ls -nd "$HOMEBREW_BREW_FILE"))
   if [[ "${brew_file_ls_info[2]}" != 0 ]]
   then
-      odie <<EOS
+    odie <<EOS
 Cowardly refusing to 'sudo brew $HOMEBREW_COMMAND'
 You can use brew with sudo, but only if the brew executable is owned by root.
 However, this is both not recommended and completely unsupported so do so at

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -284,19 +284,19 @@ homebrew-update() {
   for option in "$@"
   do
     case "$option" in
-      -\?|-h|--help|--usage) brew help update; exit $? ;;
-      --verbose) HOMEBREW_VERBOSE=1 ;;
-      --debug) HOMEBREW_DEBUG=1;;
-      --merge) HOMEBREW_MERGE=1 ;;
+      -\?|-h|--help|--usage)          brew help update; exit $? ;;
+      --verbose)                      HOMEBREW_VERBOSE=1 ;;
+      --debug)                        HOMEBREW_DEBUG=1 ;;
+      --merge)                        HOMEBREW_MERGE=1 ;;
       --simulate-from-current-branch) HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH=1 ;;
-      --preinstall) export HOMEBREW_UPDATE_PREINSTALL=1 ;;
-      --*) ;;
+      --preinstall)                   export HOMEBREW_UPDATE_PREINSTALL=1 ;;
+      --*)                            ;;
       -*)
-        [[ "$option" = *v* ]] && HOMEBREW_VERBOSE=1;
-        [[ "$option" = *d* ]] && HOMEBREW_DEBUG=1;
+        [[ "$option" = *v* ]] && HOMEBREW_VERBOSE=1
+        [[ "$option" = *d* ]] && HOMEBREW_DEBUG=1
         ;;
       *)
-        odie <<-EOS
+        odie <<EOS
 This command updates brew itself, and does not take formula names.
 Use 'brew upgrade <formula>'.
 EOS
@@ -312,7 +312,7 @@ EOS
   # check permissions
   if [[ "$HOMEBREW_PREFIX" = "/usr/local" && ! -w /usr/local ]]
   then
-    odie <<-EOS
+    odie <<EOS
 /usr/local is not writable. You should change the ownership
 and permissions of /usr/local back to your user account:
   sudo chown -R \$(whoami) /usr/local
@@ -321,7 +321,7 @@ EOS
 
   if [[ ! -w "$HOMEBREW_REPOSITORY" ]]
   then
-    odie <<-EOS
+    odie <<EOS
 $HOMEBREW_REPOSITORY is not writable. You should change the
 ownership and permissions of $HOMEBREW_REPOSITORY back to your
 user account:
@@ -387,7 +387,7 @@ EOS
       if [[ -n "$HOMEBREW_UPDATE_PREINSTALL" ]]
       then
         # Skip taps without formulae.
-        FORMULAE="$(find "$DIR" -maxdepth 1 \( -name '*.rb' -or -name 'Formula' -or -name 'HomebrewFormula' \) -print -quit)"
+        FORMULAE="$(find "$DIR" -maxdepth 1 \( -name "*.rb" -or -name Formula -or -name HomebrewFormula \) -print -quit)"
         [[ -z "$FORMULAE" ]] && exit
       fi
 
@@ -399,7 +399,7 @@ EOS
         UPSTREAM_BRANCH_LOCAL_SHA="$(git rev-parse "refs/remotes/origin/$UPSTREAM_BRANCH")"
         # Only try to `git fetch` when the upstream branch is at a different SHA
         # (so the API does not return 304: unmodified).
-        UPSTREAM_SHA_HTTP_CODE="$("$HOMEBREW_CURL" --silent '--max-time' 3 \
+        UPSTREAM_SHA_HTTP_CODE="$("$HOMEBREW_CURL" --silent --max-time 3 \
            --output /dev/null --write-out "%{http_code}" \
            --user-agent "$HOMEBREW_USER_AGENT_CURL" \
            --header "Accept: application/vnd.github.v3.sha" \
@@ -425,7 +425,7 @@ EOS
         if ! git fetch --force "${QUIET_ARGS[@]}" origin \
           "refs/heads/$UPSTREAM_BRANCH:refs/remotes/origin/$UPSTREAM_BRANCH"
         then
-          echo "Fetching $DIR failed!" >> "$update_failed_file"
+          echo "Fetching $DIR failed!" >>"$update_failed_file"
         fi
       fi
     ) &
@@ -436,7 +436,7 @@ EOS
 
   if [[ -f "$update_failed_file" ]]
   then
-    onoe < "$update_failed_file"
+    onoe <"$update_failed_file"
     rm -f "$update_failed_file"
     export HOMEBREW_UPDATE_FAILED="1"
   fi

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -30,10 +30,10 @@ fetch() {
   local temporary_path
 
   curl_args=(
-    --fail \
-    --remote-time \
-    --location \
-    --user-agent "$HOMEBREW_USER_AGENT_CURL" \
+    --fail
+    --remote-time
+    --location
+    --user-agent "$HOMEBREW_USER_AGENT_CURL"
   )
 
   if [[ -n "$HOMEBREW_QUIET" ]]
@@ -44,7 +44,7 @@ fetch() {
     curl_args+=(--progress-bar)
   fi
 
-  temporary_path="${CACHED_LOCATION}.incomplete"
+  temporary_path="$CACHED_LOCATION.incomplete"
 
   mkdir -p "$HOMEBREW_CACHE"
   [[ -n "$HOMEBREW_QUIET" ]] || echo "==> Downloading $VENDOR_URL"
@@ -67,7 +67,7 @@ fetch() {
 
     if [[ ! -f "$temporary_path" ]]
     then
-      odie "Download failed: ${VENDOR_URL}"
+      odie "Download failed: $VENDOR_URL"
     fi
 
     trap '' SIGINT
@@ -159,10 +159,10 @@ homebrew-vendor-install() {
   do
     case "$option" in
       -\?|-h|--help|--usage) brew help vendor-install; exit $? ;;
-      --verbose) HOMEBREW_VERBOSE=1 ;;
-      --quiet) HOMEBREW_QUIET=1 ;;
-      --debug) HOMEBREW_DEBUG=1 ;;
-      --*) ;;
+      --verbose)             HOMEBREW_VERBOSE=1 ;;
+      --quiet)               HOMEBREW_QUIET=1 ;;
+      --debug)               HOMEBREW_DEBUG=1 ;;
+      --*)                   ;;
       -*)
         [[ "$option" = *v* ]] && HOMEBREW_VERBOSE=1
         [[ "$option" = *q* ]] && HOMEBREW_QUIET=1
@@ -188,7 +188,7 @@ homebrew-vendor-install() {
     odie "Cannot find a vendored version of $VENDOR_NAME."
   fi
 
-  VENDOR_VERSION="$(<"$VENDOR_DIR/portable-${VENDOR_NAME}-version")"
+  VENDOR_VERSION="$(<"$VENDOR_DIR/portable-$VENDOR_NAME-version")"
   CACHED_LOCATION="$HOMEBREW_CACHE/$(basename "$VENDOR_URL")"
 
   lock "vendor-install-$VENDOR_NAME"

--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -42,7 +42,7 @@ executable() {
 }
 
 lowercase() {
-  echo "$1" | tr '[:upper:]' '[:lower:]'
+  echo "$1" | tr "[:upper:]" "[:lower:]"
 }
 
 safe_exec() {

--- a/Library/Homebrew/shims/super/ant
+++ b/Library/Homebrew/shims/super/ant
@@ -1,5 +1,7 @@
 #!/bin/bash
+
 export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
+
 ant=/usr/bin/ant
-[ -x "$ant" ] || ant="$(${HOMEBREW_BREW_FILE} --prefix ant)/bin/ant"
+[[ -x "$ant" ]] || ant="$("$HOMEBREW_BREW_FILE" --prefix ant)/bin/ant"
 exec "$ant" "$@"

--- a/Library/Homebrew/shims/super/apr-1-config
+++ b/Library/Homebrew/shims/super/apr-1-config
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-if [[ "$HOMEBREW_CCCFG" == *a* ]]; then
+if [[ "$HOMEBREW_CCCFG" = *a* ]]
+then
   case "$1" in
-  --cc) echo "cc";;
-  --cpp) echo "cpp";;
-  --includedir) echo "$HOMEBREW_SDKROOT/usr/include/apr-1";;
-  --includes) echo "-isystem$HOMEBREW_SDKROOT/usr/include/apr-1";;
-  --apr-libtool) echo "glibtool";;
-  *)
-    exec xcrun apr-1-config "$@";;
+    --cc)          echo "cc" ;;
+    --cpp)         echo "cpp" ;;
+    --includedir)  echo "$HOMEBREW_SDKROOT/usr/include/apr-1" ;;
+    --includes)    echo "-isystem$HOMEBREW_SDKROOT/usr/include/apr-1" ;;
+    --apr-libtool) echo "glibtool" ;;
+    *)
+      exec xcrun apr-1-config "$@"
+      ;;
   esac
 else
   exec /usr/bin/apr-1-config "$@"

--- a/Library/Homebrew/shims/super/bsdmake
+++ b/Library/Homebrew/shims/super/bsdmake
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
 exec xcrun bsdmake "$@"

--- a/Library/Homebrew/shims/super/make
+++ b/Library/Homebrew/shims/super/make
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
 exec xcrun make "$@"

--- a/Library/Homebrew/shims/super/mig
+++ b/Library/Homebrew/shims/super/mig
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 pwd="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec xcrun mig -cc $pwd/cc "$@"
+exec xcrun mig -cc "$pwd/cc" "$@"

--- a/Library/Homebrew/shims/super/pod2man
+++ b/Library/Homebrew/shims/super/pod2man
@@ -1,3 +1,8 @@
 #!/bin/bash
-POD2MAN=$(/usr/bin/which pod2man5.18 || /usr/bin/which pod2man5.16 || /usr/bin/which pod2man5.12 || /usr/bin/which $HOMEBREW_PREFIX/opt/pod2man/bin/pod2man || echo /usr/bin/pod2man)
-exec $POD2MAN "$@"
+
+POD2MAN="$(/usr/bin/which pod2man5.18 ||
+           /usr/bin/which pod2man5.16 ||
+           /usr/bin/which pod2man5.12 ||
+           /usr/bin/which "$HOMEBREW_PREFIX/opt/pod2man/bin/pod2man" ||
+           echo /usr/bin/pod2man)"
+exec "$POD2MAN" "$@"

--- a/Library/Homebrew/shims/super/sed
+++ b/Library/Homebrew/shims/super/sed
@@ -1,7 +1,9 @@
 #!/bin/bash
-if [[ $HOMEBREW_CCCFG == *s* ]]; then
+
+if [[ "$HOMEBREW_CCCFG" = *s* ]]
+then
   # Fix issue with sed barfing on unicode characters on Mountain Lion
   unset LC_ALL
-  export LC_CTYPE='C'
+  export LC_CTYPE="C"
 fi
 exec /usr/bin/sed "$@"

--- a/Library/Homebrew/test/test_bash.rb
+++ b/Library/Homebrew/test/test_bash.rb
@@ -1,20 +1,34 @@
 require "testing_env"
 
 class BashTests < Homebrew::TestCase
-  def assert_valid_bash_syntax(files)
-    output = Utils.popen_read("/bin/bash -n #{files} 2>&1")
+  def assert_valid_bash_syntax(file)
+    output = Utils.popen_read("/bin/bash -n #{file} 2>&1")
     assert $?.success?, output
   end
 
   def test_bin_brew
-    assert_valid_bash_syntax "#{HOMEBREW_LIBRARY_PATH.parent.parent}/bin/brew"
+    assert_valid_bash_syntax HOMEBREW_LIBRARY_PATH.parent.parent/"bin/brew"
   end
 
-  def test_bash_cmds
-    %w[cmd dev-cmd].each do |dir|
-      Dir["#{HOMEBREW_LIBRARY_PATH}/#{dir}/*.sh"].each do |cmd|
-        assert_valid_bash_syntax cmd
-      end
+  def test_bash_code
+    Pathname.glob("#{HOMEBREW_LIBRARY_PATH}/**/*.sh").each do |pn|
+      pn_relative = pn.relative_path_from(HOMEBREW_LIBRARY_PATH)
+      next if pn_relative.to_s.start_with?("shims/", "test/", "vendor/")
+      assert_valid_bash_syntax pn
+    end
+  end
+
+  def test_bash_completion
+    script = HOMEBREW_LIBRARY_PATH.parent.parent/"etc/bash_completion.d/brew"
+    assert_valid_bash_syntax script
+  end
+
+  def test_bash_shims
+    # These have no file extension, but can be identified by their shebang.
+    (HOMEBREW_LIBRARY_PATH/"shims").find do |pn|
+      next if pn.directory? || pn.symlink?
+      next unless pn.executable? && pn.read(12) == "#!/bin/bash\n"
+      assert_valid_bash_syntax pn
     end
   end
 end

--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -37,7 +37,7 @@ setup-analytics() {
   then
     if [[ -n "$HOMEBREW_LINUX" ]]
     then
-      HOMEBREW_ANALYTICS_USER_UUID="$(tr a-f A-F < /proc/sys/kernel/random/uuid)"
+      HOMEBREW_ANALYTICS_USER_UUID="$(tr a-f A-F </proc/sys/kernel/random/uuid)"
     elif [[ -n "$HOMEBREW_OSX" ]]
     then
       HOMEBREW_ANALYTICS_USER_UUID="$(/usr/bin/uuidgen)"
@@ -91,16 +91,16 @@ report-analytics-screenview-command() {
   esac
 
   local args=(
-    --max-time 3 \
-    --user-agent "$HOMEBREW_USER_AGENT_CURL" \
-    -d v=1 \
-    -d tid="$HOMEBREW_ANALYTICS_ID" \
-    -d cid="$HOMEBREW_ANALYTICS_USER_UUID" \
-    -d aip=1 \
-    -d an="$HOMEBREW_PRODUCT" \
-    -d av="$HOMEBREW_VERSION" \
-    -d t=screenview \
-    -d cd="$HOMEBREW_COMMAND" \
+    --max-time 3
+    --user-agent "$HOMEBREW_USER_AGENT_CURL"
+    -d v=1
+    -d tid="$HOMEBREW_ANALYTICS_ID"
+    -d cid="$HOMEBREW_ANALYTICS_USER_UUID"
+    -d aip=1
+    -d an="$HOMEBREW_PRODUCT"
+    -d av="$HOMEBREW_VERSION"
+    -d t=screenview
+    -d cd="$HOMEBREW_COMMAND"
   )
 
   # Send analytics. Don't send or store any personally identifiable information.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We have accumulated quite a few style inconsistencies in our Bash code. I fixed all of them following the rules below that I inferred them from what I believe to be our preferred and/or predominant style. (Of course all of those rules are up for debate.)

- **Whitespace**
  - Indent by two spaces.
  - Align single-line items in `case` statements.
  - Put one space between single-line items in `case` and terminating `;;`.
  - Indent items in `case` statements one step (unlike in Ruby code).
  - Use multi-line `if`/`elsif`-`then` and `for`/`while`-`do` statements.
  - Omit space between function name and `()`.
  - Put function “signature” and opening curly brace on same line, e.g. `foo() {`.
  - Put a newline between shebang and shell code.
  - Omit space after redirection operators (`>`, `>>`, `<`), e.g. `>/dev/null`.
- **Redundant Stuff**
  - Omit unneeded trailing `;`.
  - Omit unneeded `-` in `<<-EOS` (we don't tab-indent our here documents).
  - Omit unneeded line continuation (`\`) in arrays.
- **Miscellaneous**
  - Prefer double-quoted strings over single-quoted strings if equally clear. (Continue to use single-quoted string if double-quoted string requires heinous escaping.)
  - Prefer `[[` over `[` and `test`.
  - Prefer `=` over `==` in `[[`.
  - Always quote variable usage and shell substitution unless word-splitting behavior is intended. (For consistency, do this also in assignments where special rules apply.)