### PR TITLE
Fix style inconsistencies in Bash completion

### DIFF
--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -15,7 +15,7 @@ __brewcomp_words_include() {
 __brewcomp_prev() {
   local idx=$((COMP_CWORD - 1))
   local prv="${COMP_WORDS[idx]}"
-  while [[ $prv == -* ]]; do
+  while [[ $prv = -* ]]; do
     idx=$((--idx))
     prv="${COMP_WORDS[idx]}"
   done

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -2,608 +2,608 @@
 
 __brewcomp_words_include ()
 {
-    local i=1
-    while [[ $i -lt $COMP_CWORD ]]; do
-        if [[ "${COMP_WORDS[i]}" = "$1" ]]; then
-            return 0
-        fi
-        i=$((++i))
-    done
-    return 1
+  local i=1
+  while [[ $i -lt $COMP_CWORD ]]; do
+    if [[ "${COMP_WORDS[i]}" = "$1" ]]; then
+      return 0
+    fi
+    i=$((++i))
+  done
+  return 1
 }
 
 # Find the previous non-switch word
 __brewcomp_prev ()
 {
-    local idx=$((COMP_CWORD - 1))
-    local prv="${COMP_WORDS[idx]}"
-    while [[ $prv == -* ]]; do
-        idx=$((--idx))
-        prv="${COMP_WORDS[idx]}"
-    done
-    echo "$prv"
+  local idx=$((COMP_CWORD - 1))
+  local prv="${COMP_WORDS[idx]}"
+  while [[ $prv == -* ]]; do
+    idx=$((--idx))
+    prv="${COMP_WORDS[idx]}"
+  done
+  echo "$prv"
 }
 
 __brewcomp ()
 {
-    # break $1 on space, tab, and newline characters,
-    # and turn it into a newline separated list of words
-    local list s sep=$'\n' IFS=$' '$'\t'$'\n'
-    local cur="${COMP_WORDS[COMP_CWORD]}"
+  # break $1 on space, tab, and newline characters,
+  # and turn it into a newline separated list of words
+  local list s sep=$'\n' IFS=$' '$'\t'$'\n'
+  local cur="${COMP_WORDS[COMP_CWORD]}"
 
-    for s in $1; do
-        __brewcomp_words_include "$s" && continue
-        list="$list$s$sep"
-    done
+  for s in $1; do
+    __brewcomp_words_include "$s" && continue
+    list="$list$s$sep"
+  done
 
-    IFS=$sep
-    COMPREPLY=($(compgen -W "$list" -- "$cur"))
+  IFS=$sep
+  COMPREPLY=($(compgen -W "$list" -- "$cur"))
 }
 
 # Don't use __brewcomp() in any of the __brew_complete_foo functions, as
 # it is too slow and is not worth it just for duplicate elimination.
 __brew_complete_formulae ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local formulas="$(brew search)"
-    local shortnames="$(echo "$formulas" | grep / | cut -d / -f 3)"
-    COMPREPLY=($(compgen -W "$formulas $shortnames" -- "$cur"))
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local formulas="$(brew search)"
+  local shortnames="$(echo "$formulas" | grep / | cut -d / -f 3)"
+  COMPREPLY=($(compgen -W "$formulas $shortnames" -- "$cur"))
 }
 
 __brew_complete_installed ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local inst=$(\ls $(brew --cellar))
-    COMPREPLY=($(compgen -W "$inst" -- "$cur"))
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local inst=$(\ls $(brew --cellar))
+  COMPREPLY=($(compgen -W "$inst" -- "$cur"))
 }
 
 __brew_complete_outdated ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local od=$(brew outdated --quiet)
-    COMPREPLY=($(compgen -W "$od" -- "$cur"))
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local od=$(brew outdated --quiet)
+  COMPREPLY=($(compgen -W "$od" -- "$cur"))
 }
 
 __brew_complete_versions ()
 {
-    local formula="$1"
-    local versions=$(brew list --versions "$formula")
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    COMPREPLY=($(compgen -W "$versions" -X "$formula" -- "$cur"))
+  local formula="$1"
+  local versions=$(brew list --versions "$formula")
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=($(compgen -W "$versions" -X "$formula" -- "$cur"))
 }
 
 __brew_complete_logs ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local logs=$(ls ${HOMEBREW_LOGS:-~/Library/Logs/Homebrew/})
-    COMPREPLY=($(compgen -W "$logs" -- "$cur"))
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local logs=$(ls ${HOMEBREW_LOGS:-~/Library/Logs/Homebrew/})
+  COMPREPLY=($(compgen -W "$logs" -- "$cur"))
 }
 
 _brew_switch ()
 {
-    case "$COMP_CWORD" in
+  case "$COMP_CWORD" in
     2)  __brew_complete_installed ;;
     3)  __brew_complete_versions "${COMP_WORDS[COMP_CWORD-1]}" ;;
     *)  ;;
-    esac
+  esac
 }
 
 __brew_complete_tapped ()
 {
-    local taplib=$(brew --repository)/Library/Taps
-    local dir taps
+  local taplib=$(brew --repository)/Library/Taps
+  local dir taps
 
-    for dir in ${taplib}/*/*; do
-        [ -d "$dir" ] || continue
-        dir=${dir#${taplib}/}
-        dir=${dir/homebrew-/}
-        taps="$taps $dir"
-    done
-    __brewcomp "$taps"
+  for dir in ${taplib}/*/*; do
+    [ -d "$dir" ] || continue
+    dir=${dir#${taplib}/}
+    dir=${dir/homebrew-/}
+    taps="$taps $dir"
+  done
+  __brewcomp "$taps"
 }
 
 _brew_tap_unpin ()
 {
-    __brewcomp "$(brew tap --list-pinned)"
+  __brewcomp "$(brew tap --list-pinned)"
 }
 
 _brew_complete_tap ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--repair --list-official --list-pinned"
-        return
-        ;;
-    esac
-    __brewcomp "$(brew tap --list-official)"
+      __brewcomp "--repair --list-official --list-pinned"
+      return
+      ;;
+  esac
+  __brewcomp "$(brew tap --list-official)"
 }
 
 _brew_analytics ()
 {
-    case "$COMP_CWORD" in
+  case "$COMP_CWORD" in
     2)  __brewcomp "off on regenerate-uuid state" ;;
-    esac
+  esac
 }
 
 _brew_bottle ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--merge --rb --write --root_url="
-        return
-        ;;
-    esac
-    __brew_complete_installed
+      __brewcomp "--merge --rb --write --root_url="
+      return
+      ;;
+  esac
+  __brew_complete_installed
 }
 
 _brew_cleanup ()
 {
-    __brew_complete_installed
+  __brew_complete_installed
 }
 
 _brew_create ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--autotools --cmake --no-fetch --set-name --set-version"
-        return
-        ;;
-    esac
+      __brewcomp "--autotools --cmake --no-fetch --set-name --set-version"
+      return
+      ;;
+  esac
 }
 
 _brew_deps ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--1 --all --tree"
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "--1 --all --tree"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_desc ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--search --name --description"
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "--search --name --description"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_doctor () {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    __brewcomp "$(brew doctor --list-checks)"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __brewcomp "$(brew doctor --list-checks)"
 }
 
 _brew_diy ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--set-name --set-version"
-        return
-        ;;
-    esac
+      __brewcomp "--set-name --set-version"
+      return
+      ;;
+  esac
 }
 
 _brew_fetch ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local prv=$(__brewcomp_prev)
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prv=$(__brewcomp_prev)
+  case "$cur" in
     --*)
-        __brewcomp "
-          --deps --force
-          --devel --HEAD
-          --build-from-source --force-bottle --build-bottle
-          --retry
-          $(brew options --compact "$prv" 2>/dev/null)
-          "
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "
+        --deps --force
+        --devel --HEAD
+        --build-from-source --force-bottle --build-bottle
+        --retry
+        $(brew options --compact "$prv" 2>/dev/null)
+        "
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_gist_logs ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--new-issue"
-        return
-        ;;
-    esac
-    __brew_complete_logs
+      __brewcomp "--new-issue"
+      return
+      ;;
+  esac
+  __brew_complete_logs
 }
 
 _brew_info ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--all --github --installed --json=v1"
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "--all --github --installed --json=v1"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_install ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local prv=$(__brewcomp_prev)
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prv=$(__brewcomp_prev)
 
-    case "$cur" in
+  case "$cur" in
     --*)
-        if __brewcomp_words_include "--interactive"; then
-            __brewcomp "--devel --git --HEAD"
-        else
-            __brewcomp "
-                --build-from-source --build-bottle --force-bottle
-                --debug
-                --devel
-                --HEAD
-                --ignore-dependencies
-                --interactive
-                --only-dependencies
-                --verbose
-                $(brew options --compact "$prv" 2>/dev/null)
-                "
-        fi
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      if __brewcomp_words_include "--interactive"; then
+        __brewcomp "--devel --git --HEAD"
+      else
+        __brewcomp "
+          --build-from-source --build-bottle --force-bottle
+          --debug
+          --devel
+          --HEAD
+          --ignore-dependencies
+          --interactive
+          --only-dependencies
+          --verbose
+          $(brew options --compact "$prv" 2>/dev/null)
+          "
+      fi
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_irb ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--examples"
-        return
-        ;;
-    esac
+      __brewcomp "--examples"
+      return
+      ;;
+  esac
 }
 
 _brew_link ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--dry-run --overwrite --force"
-        return
-        ;;
-    esac
-    __brew_complete_installed
+      __brewcomp "--dry-run --overwrite --force"
+      return
+      ;;
+  esac
+  __brew_complete_installed
 }
 
 _brew_linkapps ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--local"
-        return
-        ;;
-    esac
-    __brew_complete_installed
+      __brewcomp "--local"
+      return
+      ;;
+  esac
+  __brew_complete_installed
 }
 
 _brew_list ()
 {
-    local allopts="--unbrewed --verbose --pinned --versions --multiple"
-    local cur="${COMP_WORDS[COMP_CWORD]}"
+  local allopts="--unbrewed --verbose --pinned --versions --multiple"
+  local cur="${COMP_WORDS[COMP_CWORD]}"
 
-    case "$cur" in
+  case "$cur" in
     --*)
-        # most options to brew-list are mutually exclusive
-        if __brewcomp_words_include "--unbrewed"; then
-            return
-        elif __brewcomp_words_include "--verbose"; then
-            return
-        elif __brewcomp_words_include "--pinned"; then
-            return
-        # --multiple only applies with --versions
-        elif __brewcomp_words_include "--multiple"; then
-            __brewcomp "--versions"
-            return
-        elif __brewcomp_words_include "--versions"; then
-            __brewcomp "--multiple"
-            return
-        else
-            __brewcomp "$allopts"
-            return
-        fi
-        ;;
-    esac
-
-    # --multiple excludes formulae and *implies* --versions...
-    if __brewcomp_words_include "--multiple"; then
+      # most options to brew-list are mutually exclusive
+      if __brewcomp_words_include "--unbrewed"; then
+        return
+      elif __brewcomp_words_include "--verbose"; then
+        return
+      elif __brewcomp_words_include "--pinned"; then
+        return
+      # --multiple only applies with --versions
+      elif __brewcomp_words_include "--multiple"; then
         __brewcomp "--versions"
-    else
-        __brew_complete_installed
-    fi
+        return
+      elif __brewcomp_words_include "--versions"; then
+        __brewcomp "--multiple"
+        return
+      else
+        __brewcomp "$allopts"
+        return
+      fi
+      ;;
+  esac
+
+  # --multiple excludes formulae and *implies* --versions...
+  if __brewcomp_words_include "--multiple"; then
+    __brewcomp "--versions"
+  else
+    __brew_complete_installed
+  fi
 }
 
 _brew_log ()
 {
-    # if git-completion is loaded, then we complete git-log options
-    declare -F _git_log >/dev/null || return
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  # if git-completion is loaded, then we complete git-log options
+  declare -F _git_log >/dev/null || return
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "
-            $__git_log_common_options
-            $__git_log_shortlog_options
-            $__git_log_gitk_options
-            $__git_diff_common_options
-            --walk-reflogs --graph --decorate
-            --abbrev-commit --oneline --reverse
-            "
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "
+        $__git_log_common_options
+        $__git_log_shortlog_options
+        $__git_log_gitk_options
+        $__git_diff_common_options
+        --walk-reflogs --graph --decorate
+        --abbrev-commit --oneline --reverse
+        "
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_man ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--link --server --verbose"
-        return
-        ;;
-    esac
+      __brewcomp "--link --server --verbose"
+      return
+      ;;
+  esac
 }
 
 _brew_options ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--all --compact --installed"
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "--all --compact --installed"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_outdated ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--quiet --json=v1"
-        return
-        ;;
-    esac
+      __brewcomp "--quiet --json=v1"
+      return
+      ;;
+  esac
 }
 
 _brew_postinstall ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--debug --sandbox"
-        return
-        ;;
-    esac
-    __brew_complete_installed
+      __brewcomp "--debug --sandbox"
+      return
+      ;;
+  esac
+  __brew_complete_installed
 }
 
 _brew_prune ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--dry-run --verbose"
-        return
-        ;;
-    esac
+      __brewcomp "--dry-run --verbose"
+      return
+      ;;
+  esac
 }
 
 _brew_pull ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--bottle --bump --clean --ignore-whitespace --install --resolve"
-        return
-        ;;
-    esac
+      __brewcomp "--bottle --bump --clean --ignore-whitespace --install --resolve"
+      return
+      ;;
+  esac
 }
 
 _brew_readall ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--syntax"
-        return
-        ;;
-    esac
-    __brew_complete_tapped
+      __brewcomp "--syntax"
+      return
+      ;;
+  esac
+  __brew_complete_tapped
 }
 
 _brew_search ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--debian --desc --fedora --fink --macports --opensuse --ubuntu"
-        return
-        ;;
-    esac
+      __brewcomp "--debian --desc --fedora --fink --macports --opensuse --ubuntu"
+      return
+      ;;
+  esac
 }
 
 _brew_style ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--fix"
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "--fix"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew_tap_info ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--installed --json=v1"
-        return
-        ;;
-    esac
-    __brew_complete_tapped
+      __brewcomp "--installed --json=v1"
+      return
+      ;;
+  esac
+  __brew_complete_tapped
 }
 
 _brew_tap_readme ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--verbose"
-        return
-        ;;
-    esac
+      __brewcomp "--verbose"
+      return
+      ;;
+  esac
 }
 
 _brew_tests ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--verbose"
-        return
-        ;;
-    esac
+      __brewcomp "--verbose"
+      return
+      ;;
+  esac
 }
 
 _brew_uninstall ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--force"
-        return
-        ;;
-    esac
-    __brew_complete_installed
+      __brewcomp "--force"
+      return
+      ;;
+  esac
+  __brew_complete_installed
 }
 
 _brew_unlinkapps ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--dry-run --local"
-        return
-        ;;
-    esac
-    __brew_complete_installed
+      __brewcomp "--dry-run --local"
+      return
+      ;;
+  esac
+  __brew_complete_installed
 }
 
 _brew_unpack ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--git --patch --destdir="
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "--git --patch --destdir="
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 _brew_update ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--rebase --verbose"
-        return
-        ;;
-    esac
+      __brewcomp "--rebase --verbose"
+      return
+      ;;
+  esac
 }
 
 _brew_upgrade ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    local prv=$(__brewcomp_prev)
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prv=$(__brewcomp_prev)
 
-    case "$cur" in
+  case "$cur" in
     --*)
-        __brewcomp "
-            --all
-            --build-from-source --build-bottle --force-bottle
-            --cleanup
-            --debug
-            --verbose
-            "
-        return
-        ;;
-    esac
-    __brew_complete_outdated
+      __brewcomp "
+        --all
+        --build-from-source --build-bottle --force-bottle
+        --cleanup
+        --debug
+        --verbose
+        "
+      return
+      ;;
+  esac
+  __brew_complete_outdated
 }
 
 _brew_uses ()
 {
-    local cur="${COMP_WORDS[COMP_CWORD]}"
-    case "$cur" in
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
     --*)
-        __brewcomp "--installed --recursive"
-        return
-        ;;
-    esac
-    __brew_complete_formulae
+      __brewcomp "--installed --recursive"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
 }
 
 _brew ()
 {
-    local i=1 cmd
+  local i=1 cmd
 
-    # find the subcommand
-    while [[ $i -lt $COMP_CWORD ]]; do
-        local s="${COMP_WORDS[i]}"
-        case "$s" in
-        --*)
-            cmd="$s"
-            break
-            ;;
-        -*)
-            ;;
-        *)
-            cmd="$s"
-            break
-            ;;
-        esac
-        i=$((++i))
-    done
+  # find the subcommand
+  while [[ $i -lt $COMP_CWORD ]]; do
+    local s="${COMP_WORDS[i]}"
+    case "$s" in
+      --*)
+        cmd="$s"
+        break
+        ;;
+      -*)
+        ;;
+      *)
+        cmd="$s"
+        break
+        ;;
+    esac
+    i=$((++i))
+  done
 
-    if [[ $i -eq $COMP_CWORD ]]; then
-        # Do not auto-complete "instal" abbreviation for "install" command.
-        # Prefix newline to prevent not checking the first command.
-        local cmds=$'\n'"$(brew commands --quiet --include-aliases)"
-        __brewcomp "${cmds/$'\n'instal$'\n'/$'\n'}"
-        return
-    fi
+  if [[ $i -eq $COMP_CWORD ]]; then
+    # Do not auto-complete "instal" abbreviation for "install" command.
+    # Prefix newline to prevent not checking the first command.
+    local cmds=$'\n'"$(brew commands --quiet --include-aliases)"
+    __brewcomp "${cmds/$'\n'instal$'\n'/$'\n'}"
+    return
+  fi
 
-    # subcommands have their own completion functions
-    case "$cmd" in
+  # subcommands have their own completion functions
+  case "$cmd" in
     --cache|--cellar|--prefix)  __brew_complete_formulae ;;
     analytics)                  _brew_analytics ;;
     audit|cat|edit|home)        __brew_complete_formulae ;;
@@ -650,13 +650,13 @@ _brew ()
     upgrade)                    _brew_upgrade ;;
     uses)                       _brew_uses ;;
     *)                          ;;
-    esac
+  esac
 }
 
 # keep around for compatibility
 _brew_to_completion ()
 {
-    _brew
+  _brew
 }
 
 complete -o bashdefault -o default -F _brew brew

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -2,24 +2,24 @@
 
 __brewcomp_words_include() {
   local i=1
-  while [[ $i -lt $COMP_CWORD ]]
+  while [[ "$i" -lt "$COMP_CWORD" ]]
   do
     if [[ "${COMP_WORDS[i]}" = "$1" ]]
     then
       return 0
     fi
-    i=$((++i))
+    i="$((++i))"
   done
   return 1
 }
 
 # Find the previous non-switch word
 __brewcomp_prev() {
-  local idx=$((COMP_CWORD - 1))
+  local idx="$((COMP_CWORD - 1))"
   local prv="${COMP_WORDS[idx]}"
-  while [[ $prv = -* ]]
+  while [[ "$prv" = -* ]]
   do
-    idx=$((--idx))
+    idx="$((--idx))"
     prv="${COMP_WORDS[idx]}"
   done
   echo "$prv"
@@ -37,7 +37,7 @@ __brewcomp() {
     list="$list$s$sep"
   done
 
-  IFS=$sep
+  IFS="$sep"
   COMPREPLY=($(compgen -W "$list" -- "$cur"))
 }
 
@@ -52,26 +52,26 @@ __brew_complete_formulae() {
 
 __brew_complete_installed() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local inst=$(\ls $(brew --cellar))
+  local inst="$(ls "$(brew --cellar)")"
   COMPREPLY=($(compgen -W "$inst" -- "$cur"))
 }
 
 __brew_complete_outdated() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local od=$(brew outdated --quiet)
+  local od="$(brew outdated --quiet)"
   COMPREPLY=($(compgen -W "$od" -- "$cur"))
 }
 
 __brew_complete_versions() {
   local formula="$1"
-  local versions=$(brew list --versions "$formula")
+  local versions="$(brew list --versions "$formula")"
   local cur="${COMP_WORDS[COMP_CWORD]}"
   COMPREPLY=($(compgen -W "$versions" -X "$formula" -- "$cur"))
 }
 
 __brew_complete_logs() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local logs=$(ls ${HOMEBREW_LOGS:-~/Library/Logs/Homebrew/})
+  local logs="$(ls "${HOMEBREW_LOGS:-~/Library/Logs/Homebrew/}")"
   COMPREPLY=($(compgen -W "$logs" -- "$cur"))
 }
 
@@ -84,14 +84,14 @@ _brew_switch() {
 }
 
 __brew_complete_tapped() {
-  local taplib=$(brew --repository)/Library/Taps
+  local taplib="$(brew --repository)/Library/Taps"
   local dir taps
 
-  for dir in ${taplib}/*/*
+  for dir in "$taplib"/*/*
   do
     [[ -d "$dir" ]] || continue
-    dir=${dir#${taplib}/}
-    dir=${dir/homebrew-/}
+    dir="${dir#${taplib}/}"
+    dir="${dir/homebrew-/}"
     taps="$taps $dir"
   done
   __brewcomp "$taps"
@@ -182,7 +182,7 @@ _brew_diy() {
 
 _brew_fetch() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prv=$(__brewcomp_prev)
+  local prv="$(__brewcomp_prev)"
   case "$cur" in
     --*)
       __brewcomp "
@@ -222,7 +222,7 @@ _brew_info() {
 
 _brew_install() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prv=$(__brewcomp_prev)
+  local prv="$(__brewcomp_prev)"
 
   case "$cur" in
     --*)
@@ -510,7 +510,7 @@ _brew_update() {
 
 _brew_upgrade() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local prv=$(__brewcomp_prev)
+  local prv="$(__brewcomp_prev)"
 
   case "$cur" in
     --*)
@@ -542,7 +542,7 @@ _brew() {
   local i=1 cmd
 
   # find the subcommand
-  while [[ $i -lt $COMP_CWORD ]]
+  while [[ "$i" -lt "$COMP_CWORD" ]]
   do
     local s="${COMP_WORDS[i]}"
     case "$s" in
@@ -557,10 +557,10 @@ _brew() {
         break
         ;;
     esac
-    i=$((++i))
+    i="$((++i))"
   done
 
-  if [[ $i -eq $COMP_CWORD ]]
+  if [[ "$i" -eq "$COMP_CWORD" ]]
   then
     # Do not auto-complete "instal" abbreviation for "install" command.
     # Prefix newline to prevent not checking the first command.

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -75,14 +75,6 @@ __brew_complete_logs() {
   COMPREPLY=($(compgen -W "$logs" -- "$cur"))
 }
 
-_brew_switch() {
-  case "$COMP_CWORD" in
-    2)  __brew_complete_installed ;;
-    3)  __brew_complete_versions "${COMP_WORDS[COMP_CWORD-1]}" ;;
-    *)  ;;
-  esac
-}
-
 __brew_complete_tapped() {
   local taplib="$(brew --repository)/Library/Taps"
   local dir taps
@@ -95,21 +87,6 @@ __brew_complete_tapped() {
     taps="$taps $dir"
   done
   __brewcomp "$taps"
-}
-
-_brew_tap_unpin() {
-  __brewcomp "$(brew tap --list-pinned)"
-}
-
-_brew_complete_tap() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  case "$cur" in
-    --*)
-      __brewcomp "--repair --list-official --list-pinned"
-      return
-      ;;
-  esac
-  __brewcomp "$(brew tap --list-official)"
 }
 
 _brew_analytics() {
@@ -165,11 +142,6 @@ _brew_desc() {
   __brew_complete_formulae
 }
 
-_brew_doctor() {
-  local cur="${COMP_WORDS[COMP_CWORD]}"
-  __brewcomp "$(brew doctor --list-checks)"
-}
-
 _brew_diy() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
@@ -178,6 +150,11 @@ _brew_diy() {
       return
       ;;
   esac
+}
+
+_brew_doctor() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  __brewcomp "$(brew doctor --list-checks)"
 }
 
 _brew_fetch() {
@@ -435,6 +412,25 @@ _brew_style() {
   __brew_complete_formulae
 }
 
+_brew_switch() {
+  case "$COMP_CWORD" in
+    2)  __brew_complete_installed ;;
+    3)  __brew_complete_versions "${COMP_WORDS[COMP_CWORD-1]}" ;;
+    *)  ;;
+  esac
+}
+
+_brew_tap() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
+    --*)
+      __brewcomp "--repair --list-official --list-pinned"
+      return
+      ;;
+  esac
+  __brewcomp "$(brew tap --list-official)"
+}
+
 _brew_tap_info() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
@@ -454,6 +450,10 @@ _brew_tap_readme() {
       return
       ;;
   esac
+}
+
+_brew_tap_unpin() {
+  __brewcomp "$(brew tap --list-pinned)"
 }
 
 _brew_tests() {
@@ -608,7 +608,7 @@ _brew() {
     search|-S)                  _brew_search ;;
     style)                      _brew_style ;;
     switch)                     _brew_switch ;;
-    tap)                        _brew_complete_tap ;;
+    tap)                        _brew_tap ;;
     tap-info)                   _brew_tap_info ;;
     tap-pin)                    __brew_complete_tapped ;;
     tap-readme)                 _brew_tap_readme ;;

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -1,7 +1,6 @@
 # Bash completion script for brew(1)
 
-__brewcomp_words_include ()
-{
+__brewcomp_words_include() {
   local i=1
   while [[ $i -lt $COMP_CWORD ]]; do
     if [[ "${COMP_WORDS[i]}" = "$1" ]]; then
@@ -13,8 +12,7 @@ __brewcomp_words_include ()
 }
 
 # Find the previous non-switch word
-__brewcomp_prev ()
-{
+__brewcomp_prev() {
   local idx=$((COMP_CWORD - 1))
   local prv="${COMP_WORDS[idx]}"
   while [[ $prv == -* ]]; do
@@ -24,8 +22,7 @@ __brewcomp_prev ()
   echo "$prv"
 }
 
-__brewcomp ()
-{
+__brewcomp() {
   # break $1 on space, tab, and newline characters,
   # and turn it into a newline separated list of words
   local list s sep=$'\n' IFS=$' '$'\t'$'\n'
@@ -42,45 +39,39 @@ __brewcomp ()
 
 # Don't use __brewcomp() in any of the __brew_complete_foo functions, as
 # it is too slow and is not worth it just for duplicate elimination.
-__brew_complete_formulae ()
-{
+__brew_complete_formulae() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local formulas="$(brew search)"
   local shortnames="$(echo "$formulas" | grep / | cut -d / -f 3)"
   COMPREPLY=($(compgen -W "$formulas $shortnames" -- "$cur"))
 }
 
-__brew_complete_installed ()
-{
+__brew_complete_installed() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local inst=$(\ls $(brew --cellar))
   COMPREPLY=($(compgen -W "$inst" -- "$cur"))
 }
 
-__brew_complete_outdated ()
-{
+__brew_complete_outdated() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local od=$(brew outdated --quiet)
   COMPREPLY=($(compgen -W "$od" -- "$cur"))
 }
 
-__brew_complete_versions ()
-{
+__brew_complete_versions() {
   local formula="$1"
   local versions=$(brew list --versions "$formula")
   local cur="${COMP_WORDS[COMP_CWORD]}"
   COMPREPLY=($(compgen -W "$versions" -X "$formula" -- "$cur"))
 }
 
-__brew_complete_logs ()
-{
+__brew_complete_logs() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local logs=$(ls ${HOMEBREW_LOGS:-~/Library/Logs/Homebrew/})
   COMPREPLY=($(compgen -W "$logs" -- "$cur"))
 }
 
-_brew_switch ()
-{
+_brew_switch() {
   case "$COMP_CWORD" in
     2)  __brew_complete_installed ;;
     3)  __brew_complete_versions "${COMP_WORDS[COMP_CWORD-1]}" ;;
@@ -88,8 +79,7 @@ _brew_switch ()
   esac
 }
 
-__brew_complete_tapped ()
-{
+__brew_complete_tapped() {
   local taplib=$(brew --repository)/Library/Taps
   local dir taps
 
@@ -102,13 +92,11 @@ __brew_complete_tapped ()
   __brewcomp "$taps"
 }
 
-_brew_tap_unpin ()
-{
+_brew_tap_unpin() {
   __brewcomp "$(brew tap --list-pinned)"
 }
 
-_brew_complete_tap ()
-{
+_brew_complete_tap() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -119,15 +107,13 @@ _brew_complete_tap ()
   __brewcomp "$(brew tap --list-official)"
 }
 
-_brew_analytics ()
-{
+_brew_analytics() {
   case "$COMP_CWORD" in
     2)  __brewcomp "off on regenerate-uuid state" ;;
   esac
 }
 
-_brew_bottle ()
-{
+_brew_bottle() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -138,13 +124,11 @@ _brew_bottle ()
   __brew_complete_installed
 }
 
-_brew_cleanup ()
-{
+_brew_cleanup() {
   __brew_complete_installed
 }
 
-_brew_create ()
-{
+_brew_create() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -154,8 +138,7 @@ _brew_create ()
   esac
 }
 
-_brew_deps ()
-{
+_brew_deps() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -166,8 +149,7 @@ _brew_deps ()
   __brew_complete_formulae
 }
 
-_brew_desc ()
-{
+_brew_desc() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -178,13 +160,12 @@ _brew_desc ()
   __brew_complete_formulae
 }
 
-_brew_doctor () {
+_brew_doctor() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   __brewcomp "$(brew doctor --list-checks)"
 }
 
-_brew_diy ()
-{
+_brew_diy() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -194,8 +175,7 @@ _brew_diy ()
   esac
 }
 
-_brew_fetch ()
-{
+_brew_fetch() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local prv=$(__brewcomp_prev)
   case "$cur" in
@@ -213,8 +193,7 @@ _brew_fetch ()
   __brew_complete_formulae
 }
 
-_brew_gist_logs ()
-{
+_brew_gist_logs() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -225,8 +204,7 @@ _brew_gist_logs ()
   __brew_complete_logs
 }
 
-_brew_info ()
-{
+_brew_info() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -237,8 +215,7 @@ _brew_info ()
   __brew_complete_formulae
 }
 
-_brew_install ()
-{
+_brew_install() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local prv=$(__brewcomp_prev)
 
@@ -265,8 +242,7 @@ _brew_install ()
   __brew_complete_formulae
 }
 
-_brew_irb ()
-{
+_brew_irb() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -276,8 +252,7 @@ _brew_irb ()
   esac
 }
 
-_brew_link ()
-{
+_brew_link() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -288,8 +263,7 @@ _brew_link ()
   __brew_complete_installed
 }
 
-_brew_linkapps ()
-{
+_brew_linkapps() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -300,8 +274,7 @@ _brew_linkapps ()
   __brew_complete_installed
 }
 
-_brew_list ()
-{
+_brew_list() {
   local allopts="--unbrewed --verbose --pinned --versions --multiple"
   local cur="${COMP_WORDS[COMP_CWORD]}"
 
@@ -336,8 +309,7 @@ _brew_list ()
   fi
 }
 
-_brew_log ()
-{
+_brew_log() {
   # if git-completion is loaded, then we complete git-log options
   declare -F _git_log >/dev/null || return
   local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -357,8 +329,7 @@ _brew_log ()
   __brew_complete_formulae
 }
 
-_brew_man ()
-{
+_brew_man() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -368,8 +339,7 @@ _brew_man ()
   esac
 }
 
-_brew_options ()
-{
+_brew_options() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -380,8 +350,7 @@ _brew_options ()
   __brew_complete_formulae
 }
 
-_brew_outdated ()
-{
+_brew_outdated() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -391,8 +360,7 @@ _brew_outdated ()
   esac
 }
 
-_brew_postinstall ()
-{
+_brew_postinstall() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -403,8 +371,7 @@ _brew_postinstall ()
   __brew_complete_installed
 }
 
-_brew_prune ()
-{
+_brew_prune() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -414,8 +381,7 @@ _brew_prune ()
   esac
 }
 
-_brew_pull ()
-{
+_brew_pull() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -425,8 +391,7 @@ _brew_pull ()
   esac
 }
 
-_brew_readall ()
-{
+_brew_readall() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -437,8 +402,7 @@ _brew_readall ()
   __brew_complete_tapped
 }
 
-_brew_search ()
-{
+_brew_search() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -448,8 +412,7 @@ _brew_search ()
   esac
 }
 
-_brew_style ()
-{
+_brew_style() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -460,8 +423,7 @@ _brew_style ()
   __brew_complete_formulae
 }
 
-_brew_tap_info ()
-{
+_brew_tap_info() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -472,8 +434,7 @@ _brew_tap_info ()
   __brew_complete_tapped
 }
 
-_brew_tap_readme ()
-{
+_brew_tap_readme() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -483,8 +444,7 @@ _brew_tap_readme ()
   esac
 }
 
-_brew_tests ()
-{
+_brew_tests() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -494,8 +454,7 @@ _brew_tests ()
   esac
 }
 
-_brew_uninstall ()
-{
+_brew_uninstall() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -506,8 +465,7 @@ _brew_uninstall ()
   __brew_complete_installed
 }
 
-_brew_unlinkapps ()
-{
+_brew_unlinkapps() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -518,8 +476,7 @@ _brew_unlinkapps ()
   __brew_complete_installed
 }
 
-_brew_unpack ()
-{
+_brew_unpack() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -529,8 +486,7 @@ _brew_unpack ()
   esac
   __brew_complete_formulae
 }
-_brew_update ()
-{
+_brew_update() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -540,8 +496,7 @@ _brew_update ()
   esac
 }
 
-_brew_upgrade ()
-{
+_brew_upgrade() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local prv=$(__brewcomp_prev)
 
@@ -560,8 +515,7 @@ _brew_upgrade ()
   __brew_complete_outdated
 }
 
-_brew_uses ()
-{
+_brew_uses() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
@@ -572,8 +526,7 @@ _brew_uses ()
   __brew_complete_formulae
 }
 
-_brew ()
-{
+_brew() {
   local i=1 cmd
 
   # find the subcommand
@@ -662,8 +615,7 @@ _brew ()
 }
 
 # keep around for compatibility
-_brew_to_completion ()
-{
+_brew_to_completion() {
   _brew
 }
 

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -620,7 +620,7 @@ _brew ()
     edit)                       __brew_complete_formulae ;;
     fetch)                      _brew_fetch ;;
     gist-logs)                  _brew_gist_logs ;;
-    home)                       __brew_complete_formulae ;;
+    home|homepage)              __brew_complete_formulae ;;
     info|abv)                   _brew_info ;;
     install|instal)             _brew_install ;;
     irb)                        _brew_irb ;;
@@ -654,7 +654,7 @@ _brew ()
     unpack)                     _brew_unpack ;;
     unpin)                      __brew_complete_formulae ;;
     untap)                      __brew_complete_tapped ;;
-    update)                     _brew_update ;;
+    update|up)                  _brew_update ;;
     upgrade)                    _brew_upgrade ;;
     uses)                       _brew_uses ;;
     *)                          ;;

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -84,7 +84,7 @@ __brew_complete_tapped() {
   local dir taps
 
   for dir in ${taplib}/*/*; do
-    [ -d "$dir" ] || continue
+    [[ -d "$dir" ]] || continue
     dir=${dir#${taplib}/}
     dir=${dir/homebrew-/}
     taps="$taps $dir"

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -2,8 +2,10 @@
 
 __brewcomp_words_include() {
   local i=1
-  while [[ $i -lt $COMP_CWORD ]]; do
-    if [[ "${COMP_WORDS[i]}" = "$1" ]]; then
+  while [[ $i -lt $COMP_CWORD ]]
+  do
+    if [[ "${COMP_WORDS[i]}" = "$1" ]]
+    then
       return 0
     fi
     i=$((++i))
@@ -15,7 +17,8 @@ __brewcomp_words_include() {
 __brewcomp_prev() {
   local idx=$((COMP_CWORD - 1))
   local prv="${COMP_WORDS[idx]}"
-  while [[ $prv = -* ]]; do
+  while [[ $prv = -* ]]
+  do
     idx=$((--idx))
     prv="${COMP_WORDS[idx]}"
   done
@@ -28,7 +31,8 @@ __brewcomp() {
   local list s sep=$'\n' IFS=$' '$'\t'$'\n'
   local cur="${COMP_WORDS[COMP_CWORD]}"
 
-  for s in $1; do
+  for s in $1
+  do
     __brewcomp_words_include "$s" && continue
     list="$list$s$sep"
   done
@@ -83,7 +87,8 @@ __brew_complete_tapped() {
   local taplib=$(brew --repository)/Library/Taps
   local dir taps
 
-  for dir in ${taplib}/*/*; do
+  for dir in ${taplib}/*/*
+  do
     [[ -d "$dir" ]] || continue
     dir=${dir#${taplib}/}
     dir=${dir/homebrew-/}
@@ -221,7 +226,8 @@ _brew_install() {
 
   case "$cur" in
     --*)
-      if __brewcomp_words_include "--interactive"; then
+      if __brewcomp_words_include "--interactive"
+      then
         __brewcomp "--devel --git --HEAD"
       else
         __brewcomp "
@@ -281,17 +287,22 @@ _brew_list() {
   case "$cur" in
     --*)
       # most options to brew-list are mutually exclusive
-      if __brewcomp_words_include "--unbrewed"; then
+      if __brewcomp_words_include "--unbrewed"
+      then
         return
-      elif __brewcomp_words_include "--verbose"; then
+      elif __brewcomp_words_include "--verbose"
+      then
         return
-      elif __brewcomp_words_include "--pinned"; then
+      elif __brewcomp_words_include "--pinned"
+      then
         return
       # --multiple only applies with --versions
-      elif __brewcomp_words_include "--multiple"; then
+      elif __brewcomp_words_include "--multiple"
+      then
         __brewcomp "--versions"
         return
-      elif __brewcomp_words_include "--versions"; then
+      elif __brewcomp_words_include "--versions"
+      then
         __brewcomp "--multiple"
         return
       else
@@ -302,7 +313,8 @@ _brew_list() {
   esac
 
   # --multiple excludes formulae and *implies* --versions...
-  if __brewcomp_words_include "--multiple"; then
+  if __brewcomp_words_include "--multiple"
+  then
     __brewcomp "--versions"
   else
     __brew_complete_installed
@@ -530,7 +542,8 @@ _brew() {
   local i=1 cmd
 
   # find the subcommand
-  while [[ $i -lt $COMP_CWORD ]]; do
+  while [[ $i -lt $COMP_CWORD ]]
+  do
     local s="${COMP_WORDS[i]}"
     case "$s" in
       --*)
@@ -547,7 +560,8 @@ _brew() {
     i=$((++i))
   done
 
-  if [[ $i -eq $COMP_CWORD ]]; then
+  if [[ $i -eq $COMP_CWORD ]]
+  then
     # Do not auto-complete "instal" abbreviation for "install" command.
     # Prefix newline to prevent not checking the first command.
     local cmds=$'\n'"$(brew commands --quiet --include-aliases)"

--- a/etc/bash_completion.d/brew
+++ b/etc/bash_completion.d/brew
@@ -604,21 +604,25 @@ _brew ()
 
   # subcommands have their own completion functions
   case "$cmd" in
-    --cache|--cellar|--prefix)  __brew_complete_formulae ;;
+    --cache)                    __brew_complete_formulae ;;
+    --cellar)                   __brew_complete_formulae ;;
+    --prefix)                   __brew_complete_formulae ;;
     analytics)                  _brew_analytics ;;
-    audit|cat|edit|home)        __brew_complete_formulae ;;
-    test|unlink)                __brew_complete_installed ;;
+    audit)                      __brew_complete_formulae ;;
     bottle)                     _brew_bottle ;;
+    cat)                        __brew_complete_formulae ;;
     cleanup)                    _brew_cleanup ;;
     create)                     _brew_create ;;
     deps)                       _brew_deps ;;
     desc)                       _brew_desc ;;
-    doctor|dr)                  _brew_doctor ;;
     diy|configure)              _brew_diy ;;
+    doctor|dr)                  _brew_doctor ;;
+    edit)                       __brew_complete_formulae ;;
     fetch)                      _brew_fetch ;;
     gist-logs)                  _brew_gist_logs ;;
+    home)                       __brew_complete_formulae ;;
     info|abv)                   _brew_info ;;
-    install|instal|reinstall)   _brew_install ;;
+    install|instal)             _brew_install ;;
     irb)                        _brew_irb ;;
     link|ln)                    _brew_link ;;
     linkapps)                   _brew_linkapps ;;
@@ -633,19 +637,23 @@ _brew ()
     prune)                      _brew_prune ;;
     pull)                       _brew_pull ;;
     readall)                    _brew_readall ;;
+    reinstall)                  _brew_install ;;
     search|-S)                  _brew_search ;;
     style)                      _brew_style ;;
     switch)                     _brew_switch ;;
     tap)                        _brew_complete_tap ;;
     tap-info)                   _brew_tap_info ;;
+    tap-pin)                    __brew_complete_tapped ;;
     tap-readme)                 _brew_tap_readme ;;
     tap-unpin)                  _brew_tap_unpin ;;
+    test)                       __brew_complete_installed ;;
     tests)                      _brew_tests ;;
     uninstall|remove|rm)        _brew_uninstall ;;
+    unlink)                     __brew_complete_installed ;;
     unlinkapps)                 _brew_unlinkapps ;;
     unpack)                     _brew_unpack ;;
     unpin)                      __brew_complete_formulae ;;
-    untap|tap-pin)              __brew_complete_tapped ;;
+    untap)                      __brew_complete_tapped ;;
     update)                     _brew_update ;;
     upgrade)                    _brew_upgrade ;;
     uses)                       _brew_uses ;;


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? 👉 **N/A**
- [x] Have you successfully run `brew tests` with your changes locally?

-----

By now we have a pretty clear style for our Bash/shell code, but our Bash completions, that predate all this code, massively diverge from this style, to a point where it's just not fun to edit that file. This starts with the four-space indent, but includes a lot more than that. This is a follow-up to #654 and makes sure to obey all the rules that have been mentioned there.

Like #654 this focuses on style changes and tries to keep functional changes (even seemingly trivial ones) to an absolute minimum. Consequently, a few `shellcheck` warnings remain. They be addressed in a follow-up PR.

*Note:* I made multiple commits, so interested reviewers can pick out some of the finer changes that would be otherwise hidden by the indentation change. I intend to squash them on merge.