### PR TITLE
update: don't recheck taps checked in the last 1m.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -386,6 +386,8 @@ EOS
     (
       if [[ -n "$HOMEBREW_UPDATE_PREINSTALL" ]]
       then
+        # Skip taps checked/fetched recently
+        [[ -n "$(find "$DIR/.git/FETCH_HEAD" -type f -mmin -1)" ]] && exit
         # Skip taps without formulae.
         FORMULAE="$(find "$DIR" -maxdepth 1 \( -name "*.rb" -or -name Formula -or -name HomebrewFormula \) -print -quit)"
         [[ -z "$FORMULAE" ]] && exit
@@ -405,6 +407,8 @@ EOS
            --header "Accept: application/vnd.github.v3.sha" \
            --header "If-None-Match: \"$UPSTREAM_BRANCH_LOCAL_SHA\"" \
            "https://api.github.com/repos/$UPSTREAM_REPOSITORY/commits/$UPSTREAM_BRANCH")"
+        # Touch FETCH_HEAD to confirm we've checked for an update.
+        [[ -f "$DIR/.git/FETCH_HEAD" ]] && touch "$DIR/.git/FETCH_HEAD"
         [[ "$UPSTREAM_SHA_HTTP_CODE" = "304" ]] && exit
       elif [[ -n "$HOMEBREW_UPDATE_PREINSTALL" ]]
       then


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is less than ideal but it gets the time on my machine down from ~6s to ~2s when checking no taps. It still shows that we're doing way more in `update.sh` than we need to be doing but that's a future PR.

CC @ilovezfs and @UniqMartin who suggested this.