### PR TITLE
update.sh: further speed up `brew update`.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -235,6 +235,9 @@ update-preinstall() {
   then
     brew update --preinstall
   fi
+
+  # If we've checked for updates, we don't need to check again.
+  export HOMEBREW_NO_AUTO_UPDATE="1"
 }
 
 if [[ -n "$HOMEBREW_BASH_COMMAND" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -359,8 +359,6 @@ EOS
 
   # only allow one instance of brew update
   lock update
-  # prevent recursive updates
-  export HOMEBREW_NO_AUTO_UPDATE="1"
 
   git_init_if_necessary
   # rename Taps directories

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -314,6 +314,11 @@ EOS
     set -x
   fi
 
+  if [[ -z "$HOMEBREW_AUTO_UPDATE_SECS" ]]
+  then
+    HOMEBREW_AUTO_UPDATE_SECS="60"
+  fi
+
   # check permissions
   if [[ "$HOMEBREW_PREFIX" = "/usr/local" && ! -w /usr/local ]]
   then
@@ -395,7 +400,7 @@ EOS
       if [[ -n "$HOMEBREW_UPDATE_PREINSTALL" ]]
       then
         # Skip taps checked/fetched recently
-        [[ -n "$(find "$DIR/.git/FETCH_HEAD" -type f -mtime -60s 2>/dev/null)" ]] && exit
+        [[ -n "$(find "$DIR/.git/FETCH_HEAD" -type f -mtime -"${HOMEBREW_AUTO_UPDATE_SECS}"s 2>/dev/null)" ]] && exit
 
         # Skip taps without formulae (but always update Homebrew/brew and Homebrew/homebrew-core)
         if [[ "$DIR" != "$HOMEBREW_REPOSITORY" &&

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -920,7 +920,6 @@ module Homebrew
     end
 
     ENV["HOMEBREW_DEVELOPER"] = "1"
-    ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
     ENV["HOMEBREW_SANDBOX"] = "1"
     ENV["HOMEBREW_RUBY_MACHO"] = "1" if RUBY_TWO
     ENV["HOMEBREW_NO_EMOJI"] = "1"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Tweak the logic further to make the no-op case even faster.

Before:
```
brew update  1.10s user 1.05s system 92% cpu 2.325 total
brew update --preinstall  0.60s user 0.77s system 96% cpu 1.433 total
```

After:
```
brew update  0.60s user 0.34s system 83% cpu 1.132 total
brew update --preinstall  0.18s user 0.20s system 120% cpu 0.318 total
```

These times are now fast enough to avoid any further special-casing for `--preinstall`, roll it out to users by default and not print a message unless we've actually found some updates.