### PR TITLE
formulary: fix to_rack for fully-scoped references

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -256,12 +256,15 @@ class Formulary
   end
 
   def self.to_rack(ref)
-    # First, check whether the rack with the given name exists.
+    # If using a fully-scoped reference, check if the formula can be resolved.
+    factory(ref) if ref.include? "/"
+
+    # Check whether the rack with the given name exists.
     if (rack = HOMEBREW_CELLAR/File.basename(ref, ".rb")).directory?
       return rack.resolved_path
     end
 
-    # Second, use canonical name to locate rack.
+    # Use canonical name to locate rack.
     (HOMEBREW_CELLAR/canonical_name(ref)).resolved_path
   end
 

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -111,6 +111,15 @@ class FormularyFactoryTest < Homebrew::TestCase
   def test_load_from_contents
     assert_kind_of Formula, Formulary.from_contents(@name, @path, @path.read)
   end
+
+  def test_to_rack
+    assert_equal HOMEBREW_CELLAR/@name, Formulary.to_rack(@name)
+    (HOMEBREW_CELLAR/@name).mkpath
+    assert_equal HOMEBREW_CELLAR/@name, Formulary.to_rack(@name)
+    assert_raises(TapFormulaUnavailableError) { Formulary.to_rack("a/b/#{@name}") }
+  ensure
+    FileUtils.rm_rf HOMEBREW_CELLAR/@name
+  end
 end
 
 class FormularyTapFactoryTest < Homebrew::TestCase


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes the case where I have `mysql56` installed but do `brew uninstall foo/bar/mysql56` which isn't a valid formula.

Fixes https://github.com/Homebrew/legacy-homebrew/issues/39883.