### PR TITLE
diagnostic: remove MacGPG2 check

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -114,25 +114,6 @@ module Homebrew
         EOS
       end
 
-      # Installing MacGPG2 interferes with Homebrew in a big way
-      # https://github.com/GPGTools/MacGPG2
-      def check_for_macgpg2
-        return if File.exist? "/usr/local/MacGPG2/share/gnupg/VERSION"
-
-        suspects = %w[
-          /Applications/start-gpg-agent.app
-          /Library/Receipts/libiconv1.pkg
-          /usr/local/MacGPG2
-        ]
-        return unless suspects.any? { |f| File.exist? f }
-
-        <<-EOS.undent
-          You may have installed MacGPG2 via the package installer.
-          Several other checks in this script will turn up problems, such as stray
-          dylibs in /usr/local and permissions issues with share and man in /usr/local/.
-        EOS
-      end
-
       # Anaconda installs multiple system & brew dupes, including OpenSSL, Python,
       # sqlite, libpng, Qt, etc. Regularly breaks compile on Vim, MacVim and others.
       # Is flagged as part of the *-config script checks below, but people seem


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

++++
Split out of https://github.com/Homebrew/brew/pull/386 because trying to bundle everything together in one huge PR to submit like a block of 🍰 was turning up some pretty significant problems & simultaneously making me unhappy and making others think I've been sat here smoking a cigar this whole time.
++++

This hasn't been an issue for upstream stable releases for 3 years, since March 2013, and hasn't been an issue for pre-release versions for 4 years.

That release, and indeed the latest modern GPGTools releases, support 10.6 and above so there's no reason to suspect people are actually encountering the old versions in the wild with enough regularity to merit this being a permanent part of our codebase any more.

In the last two years Homebrew has seen one Issue where MacGPG2 was the problem, and that wasn't reproducible at the time (and still isn't), and the `doctor` check likely wasn't even raised there. There has only been one Issue where the MacGPG2 `doctor` check was raised in that two year period.

I think it's fair to treat this as an user configuration outlier now rather than an issue we need to be constantly on guard for.

Ref: Homebrew/legacy-homebrew@dfb171b
Ref: Homebrew/legacy-homebrew#12238
Ref: Homebrew/legacy-homebrew@046498b