### PR TITLE
gpg: split out into unique requirement

### DIFF
--- a/Library/Homebrew/compat/requirements.rb
+++ b/Library/Homebrew/compat/requirements.rb
@@ -3,7 +3,8 @@ require "requirements"
 XcodeDependency            = XcodeRequirement
 MysqlDependency            = MysqlRequirement
 PostgresqlDependency       = PostgresqlRequirement
-GPGDependency              = GPGRequirement
+GPGDependency              = GPG2Requirement
+GPGRequirement             = GPG2Requirement
 TeXDependency              = TeXRequirement
 MercurialDependency        = MercurialRequirement
 GitDependency              = GitRequirement

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -99,7 +99,7 @@ class DependencyCollector
     when :macos      then MinimumMacOSRequirement.new(tags)
     when :mysql      then MysqlRequirement.new(tags)
     when :postgresql then PostgresqlRequirement.new(tags)
-    when :gpg        then GPGRequirement.new(tags)
+    when :gpg        then GPG2Requirement.new(tags)
     when :fortran    then FortranRequirement.new(tags)
     when :mpi        then MPIRequirement.new(*tags)
     when :tex        then TeXRequirement.new(tags)

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -1,6 +1,7 @@
 require "requirement"
 require "requirements/apr_requirement"
 require "requirements/fortran_requirement"
+require "requirements/gpg_requirement"
 require "requirements/language_module_requirement"
 require "requirements/minimum_macos_requirement"
 require "requirements/maximum_macos_requirement"

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -74,13 +74,6 @@ class RbenvRequirement < Requirement
   satisfy { which "rbenv" }
 end
 
-class GPGRequirement < Requirement
-  fatal true
-  default_formula "gpg"
-
-  satisfy { which("gpg") || which("gpg2") }
-end
-
 class TeXRequirement < Requirement
   fatal true
   cask "mactex"

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -1,7 +1,7 @@
 require "requirement"
 require "requirements/apr_requirement"
 require "requirements/fortran_requirement"
-require "requirements/gpg_requirement"
+require "requirements/gpg2_requirement"
 require "requirements/language_module_requirement"
 require "requirements/minimum_macos_requirement"
 require "requirements/maximum_macos_requirement"

--- a/Library/Homebrew/requirements/gpg2_requirement.rb
+++ b/Library/Homebrew/requirements/gpg2_requirement.rb
@@ -1,7 +1,7 @@
 require "requirement"
 require "gpg"
 
-class GPGRequirement < Requirement
+class GPG2Requirement < Requirement
   fatal true
   default_formula "gnupg2"
 

--- a/Library/Homebrew/requirements/gpg_requirement.rb
+++ b/Library/Homebrew/requirements/gpg_requirement.rb
@@ -1,0 +1,27 @@
+require "requirement"
+
+class GPGRequirement < Requirement
+  fatal true
+  default_formula "gnupg2"
+
+  satisfy(:build_env => false) { gpg2 || gpg }
+
+  # MacGPG2/GPGTools installs GnuPG 2.0.x as a vanilla `gpg` symlink
+  # pointing to `gpg2`, as do we. Ensure we're actually using a 2.0 `gpg`.
+  # Temporarily, only support 2.0.x rather than the 2.1.x "modern" series.
+  def gpg
+    which_all("gpg").detect do |gpg|
+      gpg_short_version = Utils.popen_read(gpg, "--version")[/\d\.\d/, 0]
+      next unless gpg_short_version
+      Version.create(gpg_short_version.to_s) == Version.create("2.0")
+    end
+  end
+
+  def gpg2
+    which_all("gpg2").detect do |gpg2|
+      gpg2_short_version = Utils.popen_read(gpg2, "--version")[/\d\.\d/, 0]
+      next unless gpg2_short_version
+      Version.create(gpg2_short_version.to_s) == Version.create("2.0")
+    end
+  end
+end

--- a/Library/Homebrew/requirements/gpg_requirement.rb
+++ b/Library/Homebrew/requirements/gpg_requirement.rb
@@ -1,27 +1,12 @@
 require "requirement"
+require "gpg"
 
 class GPGRequirement < Requirement
   fatal true
   default_formula "gnupg2"
 
-  satisfy(:build_env => false) { gpg2 || gpg }
-
   # MacGPG2/GPGTools installs GnuPG 2.0.x as a vanilla `gpg` symlink
   # pointing to `gpg2`, as do we. Ensure we're actually using a 2.0 `gpg`.
   # Temporarily, only support 2.0.x rather than the 2.1.x "modern" series.
-  def gpg
-    which_all("gpg").detect do |gpg|
-      gpg_short_version = Utils.popen_read(gpg, "--version")[/\d\.\d/, 0]
-      next unless gpg_short_version
-      Version.create(gpg_short_version.to_s) == Version.create("2.0")
-    end
-  end
-
-  def gpg2
-    which_all("gpg2").detect do |gpg2|
-      gpg2_short_version = Utils.popen_read(gpg2, "--version")[/\d\.\d/, 0]
-      next unless gpg2_short_version
-      Version.create(gpg2_short_version.to_s) == Version.create("2.0")
-    end
-  end
+  satisfy(:build_env => false) { Gpg.gpg2 || Gpg.gpg }
 end

--- a/Library/Homebrew/test/test_gpg.rb
+++ b/Library/Homebrew/test/test_gpg.rb
@@ -7,10 +7,6 @@ class GpgTest < Homebrew::TestCase
     @dir = Pathname.new(mktmpdir)
   end
 
-  def teardown
-    @dir.rmtree
-  end
-
   def test_create_test_key
     Dir.chdir(@dir) do
       with_environment("HOME" => @dir) do
@@ -18,5 +14,7 @@ class GpgTest < Homebrew::TestCase
         assert_predicate @dir/".gnupg/secring.gpg", :exist?
       end
     end
+  ensure
+    @dir.rmtree
   end
 end

--- a/Library/Homebrew/test/test_gpg2_requirement.rb
+++ b/Library/Homebrew/test/test_gpg2_requirement.rb
@@ -1,0 +1,24 @@
+require "testing_env"
+require "requirements/gpg2_requirement"
+require "fileutils"
+
+class GPG2RequirementTests < Homebrew::TestCase
+  def setup
+    @dir = Pathname.new(mktmpdir)
+    (@dir/"bin/gpg").write <<-EOS.undent
+      #!/bin/bash
+      echo 2.0.30
+    EOS
+    FileUtils.chmod 0755, @dir/"bin/gpg"
+  end
+
+  def teardown
+    FileUtils.rm_rf @dir
+  end
+
+  def test_satisfied
+    with_environment("PATH" => @dir/"bin") do
+      assert_predicate GPG2Requirement.new, :satisfied?
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

++++
Split out of https://github.com/Homebrew/brew/pull/386 because trying to bundle everything together in one huge PR to submit like a block of 🍰 was turning up some pretty significant problems & simultaneously making me unhappy and making others think I've been sat here smoking a cigar this whole time.
++++

GPG 1.x has stopped receiving new features, some of which we may well want to take advantage of sooner or later in Homebrew. Upstream has also been attempting to work out for a while how well used it still is which suggests it may "go away" at some point in the future.

Debian is also in the process of migrating GnuPG 1.x to a `gpg1` executable whilst GnuPG 2.1.x assumes the `gpg` executable. There's a detailed video discussion of this from DebConf 2015 [here](http://meetings-archive.debian.net/pub/debian-meetings/2015/debconf15/GnuPG_in_Debian_report.webm).

It's unsafe to assume every `gpg` executable is going to forever equal 1.x and every `gpg2` executable is going to forever equal 2.x. MacGPG2 has been symlinking 2.x as a vanilla `gpg` for a while, for example, and we will be soon as well.

You'll still be able to plonk the `libexec/bin` path of `gpg` in your PATH to access a vanilla `gpg` 1.x executable if you want to, but we're not going to actively keep adding gpg1 support to formulae going forwards. There's really no reason why 99.9% of projects should not or cannot use `gpg2` these days.

This uses detection methods to determine regardless of what the executable is called we're always hitting a 2.0 GnuPG or nothing.