### PR TITLE
tests: refactor FormulaTextTests in test_cmd_audit, add assertion to test_simple_valid_formula

### DIFF
--- a/Library/Homebrew/test/test_cmd_audit.rb
+++ b/Library/Homebrew/test/test_cmd_audit.rb
@@ -36,6 +36,7 @@ class FormulaTextTests < Homebrew::TestCase
     assert ft =~ /\burl\b/, "The formula should match 'url'"
     assert_nil ft.line_number(/desc/), "The formula should not match 'desc'"
     assert_equal 2, ft.line_number(/\burl\b/)
+    assert ft.include?("Valid"), "The formula should include \"Valid\""
   end
 
   def test_trailing_newline


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In the process of going through `test_cmd_audit.rb` (with the intention of adding some unit tests), I figured I'd try to refactor `formula_text`. I also added an assertion to `test_simple_valid_formula` (wasn't sure if it belonged in the same commit as the refactoring).

Do the assertions' `msg`s need to be corrected? I left them mostly as-is. But even though they're not of critical importance, I was under the impression that they should be worded to address a situation where the assertion fails, e.g.:

`assert ft.has_trailing_newline?, "The formula should have a trailing newline"`

rather than

`assert ft.has_trailing_newline?, "The formula has a trailing newline"`