### PR TITLE
Don't report .pyc file writes in sandbox logs

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -95,6 +95,10 @@ class Sandbox
       -k Sender sandboxd
     ]
     logs = Utils.popen_read("syslog", *syslog_args)
+
+    # These messages are confusing and non-fatal, so don't report them.
+    logs = logs.gsub(/^.*Python(\d+) deny file-write.*pyc$/, "").strip
+
     unless logs.empty?
       if @logfile
         log = open(@logfile, "w")

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -97,7 +97,7 @@ class Sandbox
     logs = Utils.popen_read("syslog", *syslog_args)
 
     # These messages are confusing and non-fatal, so don't report them.
-    logs = logs.lines.reject { |l| l.match /^.*Python\(\d+\) deny file-write.*pyc$/ }.join
+    logs = logs.lines.reject{ |l| l.match(/^.*Python\(\d+\) deny file-write.*pyc$/) }.join
 
     unless logs.empty?
       if @logfile

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -97,7 +97,7 @@ class Sandbox
     logs = Utils.popen_read("syslog", *syslog_args)
 
     # These messages are confusing and non-fatal, so don't report them.
-    logs = logs.gsub(/^.*Python(\d+) deny file-write.*pyc$/, "").strip
+    logs = logs.lines.reject { |l| l.match /^.*Python\(\d+\) deny file-write.*pyc$/ }.join
 
     unless logs.empty?
       if @logfile

--- a/Library/Homebrew/test/test_sandbox.rb
+++ b/Library/Homebrew/test/test_sandbox.rb
@@ -28,18 +28,27 @@ class SandboxTest < Homebrew::TestCase
 
   def test_complains_on_failure
     Utils.expects(:popen_read => "foo")
+    ARGV.stubs(:verbose? => true)
     out, err = capture_io do
       assert_raises(ErrorDuringExecution) { @sandbox.exec "false" }
     end
-    assert_match out, "foo"
+    assert_match "foo", out
   end
 
   def test_ignores_bogus_python_error
-    bogus_error = "Mar 17 02:55:06 sandboxd[342]: Python(49765) deny file-write-unlink /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/errors.pyc\n"
-    Utils.expects(:popen_read => bogus_error)
+    with_bogus_error = <<-EOS.undent
+      foo
+      Mar 17 02:55:06 sandboxd[342]: Python(49765) deny file-write-unlink /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/errors.pyc
+      bar
+    EOS
+    Utils.expects(:popen_read => with_bogus_error)
+    ARGV.stubs(:verbose? => true)
     out, err = capture_io do
       assert_raises(ErrorDuringExecution) { @sandbox.exec "false" }
     end
-    assert_predicate out, :empty?
+    refute_predicate out, :empty?
+    assert_match "foo", out
+    assert_match "bar", out
+    refute_match "Python", out
   end
 end

--- a/Library/Homebrew/test/test_sandbox.rb
+++ b/Library/Homebrew/test/test_sandbox.rb
@@ -29,7 +29,7 @@ class SandboxTest < Homebrew::TestCase
   def test_complains_on_failure
     Utils.expects(:popen_read => "foo")
     ARGV.stubs(:verbose? => true)
-    out, err = capture_io do
+    out, _err = capture_io do
       assert_raises(ErrorDuringExecution) { @sandbox.exec "false" }
     end
     assert_match "foo", out
@@ -43,7 +43,7 @@ class SandboxTest < Homebrew::TestCase
     EOS
     Utils.expects(:popen_read => with_bogus_error)
     ARGV.stubs(:verbose? => true)
-    out, err = capture_io do
+    out, _err = capture_io do
       assert_raises(ErrorDuringExecution) { @sandbox.exec "false" }
     end
     refute_predicate out, :empty?

--- a/Library/Homebrew/test/test_sandbox.rb
+++ b/Library/Homebrew/test/test_sandbox.rb
@@ -25,4 +25,12 @@ class SandboxTest < Homebrew::TestCase
     end
     refute_predicate @file, :exist?
   end
+
+  def test_complains_on_failure
+    Utils.expects(:popen_read => "foo")
+    out, err = capture_io do
+      assert_raises(ErrorDuringExecution) { @sandbox.exec "false" }
+    end
+    assert_match out, "foo"
+  end
 end

--- a/Library/Homebrew/test/test_sandbox.rb
+++ b/Library/Homebrew/test/test_sandbox.rb
@@ -33,4 +33,13 @@ class SandboxTest < Homebrew::TestCase
     end
     assert_match out, "foo"
   end
+
+  def test_ignores_bogus_python_error
+    bogus_error = "Mar 17 02:55:06 sandboxd[342]: Python(49765) deny file-write-unlink /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/errors.pyc\n"
+    Utils.expects(:popen_read => bogus_error)
+    out, err = capture_io do
+      assert_raises(ErrorDuringExecution) { @sandbox.exec "false" }
+    end
+    assert_predicate out, :empty?
+  end
 end


### PR DESCRIPTION
These are never fatal and often confusing.

Fixes #683.