### PR TITLE
tab: fix Tab.for_formula versions

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -138,6 +138,11 @@ class Tab < OpenStruct
         "path" => f.path.to_s,
         "tap" => f.tap ? f.tap.name : f.tap,
         "spec" => f.active_spec_sym.to_s,
+        "versions" => {
+          "stable" => f.stable ? f.stable.version.to_s : nil,
+          "devel" => f.devel ? f.devel.version.to_s : nil,
+          "head" => f.head ? f.head.version.to_s : nil,
+        }
       }
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Possible bug.

Description:
versions should be initialized even if formula is not installed.

CC @xu-cheng 