### PR TITLE
update: add --force argument.

### DIFF
--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -440,7 +440,9 @@ source. This is useful for creating patches for the software.</p></dd>
  <code>git</code>(1).</p>
 
 <p>If <code>--merge</code> is specified then <code>git merge</code> is used to include updates
-  (rather than <code>git rebase</code>).</p></dd>
+  (rather than <code>git rebase</code>).
+If <code>--force</code> is specified then always do a slower, full update check even
+  if unnecessary.</p></dd>
 <dt><code>upgrade</code> [<var>install-options</var>] [<code>--cleanup</code>] [<code>--fetch-HEAD</code>] [<var>formulae</var>]</dt><dd><p>Upgrade outdated, unpinned brews.</p>
 
 <p>Options for the <code>install</code> command are also valid here.</p>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -597,7 +597,7 @@ Remove a tapped repository\.
 Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1)\.
 .
 .IP
-If \fB\-\-merge\fR is specified then \fBgit merge\fR is used to include updates (rather than \fBgit rebase\fR)\.
+If \fB\-\-merge\fR is specified then \fBgit merge\fR is used to include updates (rather than \fBgit rebase\fR)\. If \fB\-\-force\fR is specified then always do a slower, full update check even if unnecessary\.
 .
 .TP
 \fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fIformulae\fR]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add a `brew update --force` to side-step all of the clever optimisations we have to detect if an update is unnecessary. That means if those optimisations go wrong in future we can tell people just to run this single command.

This would have been a useful workaround for the issue fixed in 985c672.