### PR TITLE
sha1: undeprecate

### DIFF
--- a/Library/Homebrew/compat/sha1.rb
+++ b/Library/Homebrew/compat/sha1.rb
@@ -1,6 +1,5 @@
 class Formula
   def self.sha1(val)
-    odeprecated "Formula.sha1", "Formula.sha256"
     stable.sha1(val)
   end
 end


### PR DESCRIPTION
This particular deprecation is causing an inordinate amount of noise
and adding very marginal value now since all sha1 has been removed from
the official Homebrew repositories.