### PR TITLE
formula_versions: also silence stderr.

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -34,7 +34,7 @@ class FormulaVersions
     contents = file_contents_at_revision(rev)
 
     begin
-      nostdout { yield Formulary.from_contents(name, path, contents) }
+      shutup { yield Formulary.from_contents(name, path, contents) }
     rescue *IGNORED_EXCEPTIONS => e
       # We rescue these so that we can skip bad versions and
       # continue walking the history


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We already stop old formula versions printing stdout but this also stops them printing on stderr for e.g. old deprecation warnings.

CC @ilovezfs 

Closes #691 
Fixes #681 