### PR TITLE
Silence auditing formula revisions deprecations

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -34,6 +34,7 @@ class FormulaVersions
     contents = file_contents_at_revision(rev)
 
     begin
+      Homebrew.raise_deprecation_exceptions = true
       nostdout { yield Formulary.from_contents(name, path, contents) }
     rescue *IGNORED_EXCEPTIONS => e
       # We rescue these so that we can skip bad versions and
@@ -41,6 +42,8 @@ class FormulaVersions
       ohai "#{e} in #{name} at revision #{rev}", e.backtrace if ARGV.debug?
     rescue FormulaUnavailableError
       # Suppress this error
+    ensure
+      Homebrew.raise_deprecation_exceptions = false
     end
   end
 

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -51,6 +51,9 @@ module Homebrew
 
   attr_accessor :failed
   alias_method :failed?, :failed
+
+  attr_accessor :raise_deprecation_exceptions
+  alias_method :raise_deprecation_exceptions?, :raise_deprecation_exceptions
 end
 
 HOMEBREW_PULL_API_REGEX = %r{https://api\.github\.com/repos/([\w-]+)/([\w-]+)?/pulls/(\d+)}

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -149,7 +149,8 @@ def odeprecated(method, replacement = nil, options = {})
     #{caller_message}#{tap_message}
   EOS
 
-  if ARGV.homebrew_developer? || options[:die]
+  if ARGV.homebrew_developer? || options[:die] ||
+     Homebrew.raise_deprecation_exceptions?
     raise FormulaMethodDeprecatedError, message
   else
     opoo "#{message}\n"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add a `Homebrew.raise_deprecation_exceptions` method as a global setting to allow raising exceptions on `odeprecated` even for non-developers.

Fixes #681.
Checked that this doesn't reproduce #696 

CC @DomT4 