### PR TITLE
pull: non-core tap support for Homebrew Testing jobs

### DIFF
--- a/Library/Homebrew/cmd/pull.rb
+++ b/Library/Homebrew/cmd/pull.rb
@@ -52,9 +52,16 @@ module Homebrew
         url = "https://github.com/Homebrew/homebrew-core/pull/#{arg}"
         tap = CoreTap.instance
       elsif (testing_match = arg.match %r{brew\.sh/job/Homebrew.*Testing/(\d+)/})
+        tap = ARGV.value("tap")
+        tap = if tap && tap.start_with?("homebrew/")
+          Tap.fetch("homebrew", tap.strip_prefix("homebrew/"))
+        elsif tap
+          odie "Tap option did not start with \"homebrew/\": #{tap}"
+        else
+          CoreTap.instance
+        end
         _, testing_job = *testing_match
-        url = "https://github.com/Homebrew/homebrew-core/compare/master...BrewTestBot:testing-#{testing_job}"
-        tap = CoreTap.instance
+        url = "https://github.com/Homebrew/homebrew-#{tap.repo}/compare/master...BrewTestBot:testing-#{testing_job}"
         odie "Testing URLs require `--bottle`!" unless ARGV.include?("--bottle")
       elsif (api_match = arg.match HOMEBREW_PULL_API_REGEX)
         _, user, repo, issue = *api_match


### PR DESCRIPTION
`test-bot --ci-testing` supports a `--tap` option for non-core taps, so
`brew pull` should too when pulling Homebrew Testing jobs.