### PR TITLE
Enable sandbox by default for homebrew/core

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -21,12 +21,10 @@ module Homebrew
       args << "--devel"
     end
 
-    if Sandbox.available? && ARGV.sandbox?
-      Sandbox.print_sandbox_message
-    end
+    Sandbox.print_sandbox_message if Sandbox.formula?(formula)
 
     Utils.safe_fork do
-      if Sandbox.available? && ARGV.sandbox?
+      if Sandbox.formula?(formula)
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"sandbox.postinstall.log")

--- a/Library/Homebrew/cmd/test.rb
+++ b/Library/Homebrew/cmd/test.rb
@@ -57,12 +57,10 @@ module Homebrew
           args << "--devel"
         end
 
-        if Sandbox.available? && !ARGV.no_sandbox?
-          Sandbox.print_sandbox_message
-        end
+        Sandbox.print_sandbox_message if Sandbox.test?
 
         Utils.safe_fork do
-          if Sandbox.available? && !ARGV.no_sandbox?
+          if Sandbox.test?
             sandbox = Sandbox.new
             f.logs.mkpath
             sandbox.record_log(f.logs/"sandbox.test.log")

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -588,15 +588,13 @@ class FormulaInstaller
       #{formula.path}
     ].concat(build_argv)
 
-    if Sandbox.available? && ARGV.sandbox?
-      Sandbox.print_sandbox_message
-    end
+    Sandbox.print_sandbox_message if Sandbox.formula?(formula)
 
     Utils.safe_fork do
       # Invalidate the current sudo timestamp in case a build script calls sudo
       system "/usr/bin/sudo", "-k"
 
-      if Sandbox.available? && ARGV.sandbox?
+      if Sandbox.formula?(formula)
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"sandbox.build.log")

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -8,6 +8,11 @@ class Sandbox
     OS.mac? && File.executable?(SANDBOX_EXEC)
   end
 
+  def self.test?
+    return false unless available?
+    !ARGV.no_sandbox?
+  end
+
   def self.print_sandbox_message
     unless @printed_sandbox_message
       ohai "Using the sandbox"

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -3,9 +3,17 @@ require "tempfile"
 
 class Sandbox
   SANDBOX_EXEC = "/usr/bin/sandbox-exec".freeze
+  SANDBOXED_TAPS = [
+    "homebrew/core",
+  ].freeze
 
   def self.available?
     OS.mac? && File.executable?(SANDBOX_EXEC)
+  end
+
+  def self.formula?(formula)
+    return false unless available?
+    ARGV.sandbox? || SANDBOXED_TAPS.include?(formula.tap.to_s)
   end
 
   def self.test?

--- a/Library/Homebrew/test/test_sandbox.rb
+++ b/Library/Homebrew/test/test_sandbox.rb
@@ -13,6 +13,22 @@ class SandboxTest < Homebrew::TestCase
     @dir.rmtree
   end
 
+  def test_formula?
+    f = formula { url "foo-1.0" }
+    f2 = formula { url "bar-1.0" }
+    f2.stubs(:tap).returns(Tap.fetch("test/tap"))
+
+    ARGV.stubs(:sandbox?).returns true
+    assert Sandbox.formula?(f),
+      "Formulae should be sandboxed if --sandbox was passed."
+
+    ARGV.stubs(:sandbox?).returns false
+    assert Sandbox.formula?(f),
+      "Formulae should be sandboxed if in a sandboxed tap."
+    refute Sandbox.formula?(f2),
+        "Formulae should not be sandboxed if not in a sandboxed tap."
+  end
+
   def test_test?
     ARGV.stubs(:no_sandbox?).returns false
     assert Sandbox.test?,

--- a/Library/Homebrew/test/test_sandbox.rb
+++ b/Library/Homebrew/test/test_sandbox.rb
@@ -13,6 +13,12 @@ class SandboxTest < Homebrew::TestCase
     @dir.rmtree
   end
 
+  def test_test?
+    ARGV.stubs(:no_sandbox?).returns false
+    assert Sandbox.test?,
+      "Tests should be sandboxed unless --no-sandbox was passed."
+  end
+
   def test_allow_write
     @sandbox.allow_write @file
     @sandbox.exec "touch", @file


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Now that https://github.com/Homebrew/homebrew-core/issues/342 is finished we can now enable the sandbox by default for all users using the homebrew/core tap. This whitelist system should give users of the most widely used tap better security without breaking other taps that are working without the sandbox. We can aim to get all the Homebrew/homebrew-* taps supported in here eventually and allow the community to submit PRs if they want their tap protected by the sandbox. Eventually we may turn this on for all taps (but not for a while).