### PR TITLE
tests: allow brew tests to accept multiple --only args

### DIFF
--- a/Library/Homebrew/cmd/tests.rb
+++ b/Library/Homebrew/cmd/tests.rb
@@ -41,9 +41,14 @@ module Homebrew
       args << "--trace" if ARGV.include? "--trace"
       if ARGV.value("only")
         ENV["HOMEBREW_TESTS_ONLY"] = "1"
-        test_name, test_method = ARGV.value("only").split("/", 2)
-        args << "TEST=test_#{test_name}.rb"
-        args << "TESTOPTS=--name=test_#{test_method}" if test_method
+
+        pairs = ARGV.value("only").split
+        pairs.each do |pair|
+          test_name, test_method = pair.split("/", 2)
+
+          args << "TEST=test_#{test_name}.rb" unless test_name.empty?
+          args << "TESTOPTS=--name=test_#{test_method}" if test_method
+        end
       end
       args += ARGV.named.select { |v| v[/^TEST(OPTS)?=/] }
       system "bundle", "exec", "rake", "test", *args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is one of my attempts to change `brew tests` so that it allows multiple `--only` args (i.e., multiple test files and/or test methods). It doesn't work, though! 😞 

I looked for documentation on the arguments that `rake test` accepts; if I understand correctly, then `rake test` does accept options that are used in `Test::Unit` (as mentioned [here](http://rake.rubyforge.org/classes/Rake/TestTask.html)).

That led me to believe that `rake test` would indeed accept multiple test files or test methods as arguments (as detailed [here](http://scottpatten.ca/2007/10/ruby-unit-test-command-line-options.html)).

Unfortunately, I haven't been able to test my changes with `rake test` (or `bundle exec rake test`) itself, since I receive this esoteric error when trying to do so:

```
/usr/local/Library/Homebrew/os/mac.rb:27:in `full_version': undefined method `chomp' for nil:NilClass (NoMethodError)
	from /usr/local/Library/Homebrew/os.rb:19:in `<module:OS>'
	from /usr/local/Library/Homebrew/os.rb:1:in `<top (required)>'
	from /usr/local/Library/Homebrew/extend/os/emoji.rb:1:in `require'
	from /usr/local/Library/Homebrew/extend/os/emoji.rb:1:in `<top (required)>'
	from /usr/local/Library/Homebrew/emoji.rb:24:in `require'
	from /usr/local/Library/Homebrew/emoji.rb:24:in `<top (required)>'
	from /usr/local/Library/Homebrew/utils.rb:2:in `require'
	from /usr/local/Library/Homebrew/utils.rb:2:in `<top (required)>'
	from /usr/local/Library/Homebrew/extend/pathname.rb:4:in `require'
	from /usr/local/Library/Homebrew/extend/pathname.rb:4:in `<top (required)>'
	from /usr/local/Library/Homebrew/global.rb:3:in `require'
	from /usr/local/Library/Homebrew/global.rb:3:in `<top (required)>'
	from /usr/local/Library/Homebrew/test/testing_env.rb:5:in `require'
	from /usr/local/Library/Homebrew/test/testing_env.rb:5:in `<top (required)>'
	from /usr/local/Library/Homebrew/test/test_cmd_audit.rb:1:in `require'
	from /usr/local/Library/Homebrew/test/test_cmd_audit.rb:1:in `<top (required)>'
	from /usr/local/Library/Homebrew/test/vendor/bundle/ruby/2.2.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:15:in `require'
	from /usr/local/Library/Homebrew/test/vendor/bundle/ruby/2.2.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:15:in `block in <main>'
	from /usr/local/Library/Homebrew/test/vendor/bundle/ruby/2.2.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in `select'
	from /usr/local/Library/Homebrew/test/vendor/bundle/ruby/2.2.0/gems/rake-10.5.0/lib/rake/rake_test_loader.rb:4:in `<main>'
```

Thanks!