### PR TITLE
brew.rb: allow 10.5.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -11,13 +11,6 @@ if ARGV == %w[--version] || ARGV == %w[-v]
   exit 0
 end
 
-if OS.mac? && MacOS.version < "10.6"
-  abort <<-EOABORT.undent
-    Homebrew requires Snow Leopard or higher. For Tiger and Leopard support, see:
-    https://github.com/mistydemeo/tigerbrew
-  EOABORT
-end
-
 def require?(path)
   require path
 rescue LoadError => e


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We'll keep the Homebrew installer pointing to Tigerbrew for now but as Homebrew/brew technically has no reason to not work on 10.5 let's remove this check CC @xu-cheng 