### PR TITLE
.rubocop.yml: bring back hash_rockets.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -3,6 +3,10 @@ AllCops:
     - 'Homebrew/vendor/**/*'
     - 'Homebrew/test/vendor/**/*'
 
+# until we want to make a mass-change to Ruby 2 style
+Style/HashSyntax:
+ -  EnforcedStyle: hash_rockets
+
 # ruby style guide favorite
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Enforce Ruby 1.8 style until we want to make a mass change.