### PR TITLE
Brew-Test-Bot.md: fix broken link

### DIFF
--- a/share/doc/homebrew/Brew-Test-Bot.md
+++ b/share/doc/homebrew/Brew-Test-Bot.md
@@ -4,7 +4,7 @@ by [our Kickstarter in 2013](https://www.kickstarter.com/projects/homebrew/brew-
 
 It comprises of four Mac Minis running in a data centre in England which host
 [a Jenkins instance at http://bot.brew.sh](http://bot.brew.sh) and run the
-[`brew-test-bot.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/test-bot.rb)
+[`brew test-bot.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/test-bot.rb)
 Ruby script to perform automated testing of commits to the master branch, pull
 requests and custom builds requested by maintainers.
 


### PR DESCRIPTION
Fixes a broken link. Also I changed the link text from `brew-test-bot.rb` to `brew test-bot.rb`. Let me know if it should rather be just `test-bot.rb`.