### PR TITLE
Add permit_weak_imports directive

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -293,6 +293,8 @@ module SharedEnvExtension
 
   def permit_arch_flags; end
 
+  def permit_weak_imports; end
+
   private
 
   def cc=(val)

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -78,6 +78,7 @@ module Superenv
     # g - Enable "-stdlib=libc++" for clang.
     # h - Enable "-stdlib=libstdc++" for clang.
     # K - Don't strip -arch <arch>, -m32, or -m64
+    # w - Pass -no_weak_imports to the linker
     #
     # On 10.8 and newer, these flags will also be present:
     # s - apply fix for sed's Unicode support

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -146,4 +146,8 @@ module Stdenv
 
     append "CFLAGS", "-I#{MacOS::X11.include}" unless MacOS::CLT.installed?
   end
+
+  def permit_weak_imports
+    remove "LDFLAGS", "-Wl,-no_weak_imports"
+  end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -107,6 +107,10 @@ module Superenv
     ENV.x11 = MacOS::X11.installed?
   end
 
+  def permit_weak_imports
+    remove "HOMEBREW_CCCFG", "w"
+  end
+
   # These methods are no longer necessary under superenv, but are needed to
   # maintain an interface compatible with stdenv.
   alias_method :macosxsdk, :noop


### PR DESCRIPTION
Issue Homebrew/homebrew-core#3727 suggested we set -no_weak_imports for new versions of Xcode to ensure that e.g. building on 10.11 against the 10.12 SDK doesn't result in a situation where autotools thinks symbols exist that don't actually exist on the current platform.

Further discussion in golang/go#16770 revealed that some packages require weak imports to build normally.

This PR allows formulas to opt out of -no_weak_imports.