### PR TITLE
version: fix parsing of URLs ending with version

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -438,8 +438,12 @@ class VersionParsingTests < Homebrew::TestCase
       "https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz"
   end
 
-  def test_waf_version
+  def test_no_extension_version
     assert_version_detected "1.8.12", "https://waf.io/waf-1.8.12"
+    assert_version_detected "0.7.1", "https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1"
+    assert_version_detected "0.9.1234", "https://my.datomic.com/downloads/free/0.9.1234"
+    assert_version_detected "0.9", "https://my.datomic.com/downloads/free/0.9.1t34"
+    assert_version_detected "1.2.3", "https://my.datomic.com/downloads/free/1.2.3"
   end
 
   def test_dash_separated_version

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -294,6 +294,8 @@ class Version
       spec.basename.to_s
     elsif %r{((?:sourceforge\.net|sf\.net)/.*)/download$}.match(spec_s)
       Pathname.new(spec.dirname).stem
+    elsif %r{\.[^a-zA-Z]+$}.match(spec_s)
+      Pathname.new(spec_s).basename
     else
       spec.stem
     end


### PR DESCRIPTION
https://github.com/lihaoyi/Ammonite/releases/download/0.7.4/0.7.4

was parsing as "0.7" not "0.7.4" since ".4" was being treated as a
legitimate file extension. At minimum, let's insist that a valid file
extension include at least one letter to avoid lopping off part of the
correct version string.

CC @DomT4 @UniqMartin