### PR TITLE
test-bot: Install dependencies for Cask container tests.

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -659,7 +659,13 @@ module Homebrew
         test "brew", "readall", "--syntax"
         if OS.mac? &&
            (HOMEBREW_REPOSITORY/"Library/Homebrew/cask/cmd/brew-cask-tests.rb").exist?
-          run_as_not_developer { test "brew", "tap", "caskroom/cask" }
+          run_as_not_developer do
+            test "brew", "tap", "caskroom/cask"
+            test "brew", "cask", "install", "https://raw.githubusercontent.com/caskroom/homebrew-cask/master/Casks/adobe-air.rb"
+            test "brew", "install", "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/cabextract.rb"
+            test "brew", "install", "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/unar.rb"
+            test "brew", "install", "https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/xz.rb"
+          end
           test "brew", "cask-tests"
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In preparation of https://github.com/Homebrew/brew/pull/725, 

- `adobe-air`
- `cabextract`
- `unar` and
- `xz`

have to be installed before running `brew cask-tests`, otherwise some of the container tests will be skipped.