### PR TITLE
download_strategy: check if commit nil

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -821,6 +821,7 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
     if !@last_commit
       super
     else
+      return true unless commit
       return true unless @last_commit.start_with?(commit)
       multiple_short_commits_exist?(commit)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix handlink `brew outdated` for old-style `HEAD` pathnames.

```
$ mkdir -p $(brew —prefix)/Cellar/archey/HEAD
$ brew outdated --fetch-HEAD archey
Error: no implicit conversion of nil into String
Please report this bug:
    https://git.io/brew-troubleshooting
/Users/xucheng/dev/git/brew/Library/Homebrew/download_strategy.rb:824:in `start_with?'
/Users/xucheng/dev/git/brew/Library/Homebrew/download_strategy.rb:824:in `commit_outdated?'
/Users/xucheng/dev/git/brew/Library/Homebrew/formula.rb:442:in `head_version_outdated?'
/Users/xucheng/dev/git/brew/Library/Homebrew/formula.rb:1022:in `_outdated_versions'
/Users/xucheng/dev/git/brew/Library/Homebrew/formula.rb:1006:in `block in outdated_versions'
/Users/xucheng/dev/git/brew/Library/Homebrew/formula.rb:1008:in `yield'
/Users/xucheng/dev/git/brew/Library/Homebrew/formula.rb:1008:in `outdated_versions'
/Users/xucheng/dev/git/brew/Library/Homebrew/formula.rb:1031:in `outdated?'
/Users/xucheng/dev/git/brew/Library/Homebrew/cmd/outdated.rb:42:in `block in print_outdated'
/Users/xucheng/dev/git/brew/Library/Homebrew/cmd/outdated.rb:42:in `select'
/Users/xucheng/dev/git/brew/Library/Homebrew/cmd/outdated.rb:42:in `print_outdated'
/Users/xucheng/dev/git/brew/Library/Homebrew/cmd/outdated.rb:33:in `outdated'
/Users/xucheng/dev/git/brew/Library/Homebrew/brew.rb:84:in `<main>'
```

CC @xu-cheng 