### PR TITLE
Formula-Cookbook: document head branch default.

### DIFF
--- a/share/doc/homebrew/Formula-Cookbook.md
+++ b/share/doc/homebrew/Formula-Cookbook.md
@@ -524,7 +524,7 @@ To use a specific commit, tag, or branch from a repository, specify [`head`](htt
 ```ruby
 class Foo < Formula
   head "https://github.com/some/package.git", :revision => "090930930295adslfknsdfsdaffnasd13"
-                                         # or :branch => "develop"
+                                         # or :branch => "develop" (the default is "master")
                                          # or :tag => "1_0_release",
                                          #    :revision => "090930930295adslfknsdfsdaffnasd13"
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`--HEAD` defaults to `:branch => "master"` so document that.

Closes #722.