### PR TITLE
bump-formula-pr now creates non-tracking branches

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -140,15 +140,15 @@ module Homebrew
     formula.path.parent.cd do
       branch = "#{formula.name}-#{new_formula_version}"
       if ARGV.dry_run?
-        ohai "git checkout -b #{branch} origin/master"
+        ohai "git checkout --no-track -b #{branch} origin/master"
         ohai "git commit --no-edit --verbose --message='#{formula.name} #{new_formula_version}#{devel_message}' -- #{formula.path}"
         ohai "hub fork --no-remote"
         ohai "hub fork"
         ohai "hub fork (to read $HUB_REMOTE)"
-        ohai "git push $HUB_REMOTE #{branch}:#{branch}"
+        ohai "git push --set-upstream $HUB_REMOTE #{branch}:#{branch}"
         ohai "hub pull-request --browse -m '#{formula.name} #{new_formula_version}#{devel_message}'"
       else
-        safe_system "git", "checkout", "-b", branch, "origin/master"
+        safe_system "git", "checkout", "--no-track", "-b", branch, "origin/master"
         safe_system "git", "commit", "--no-edit", "--verbose",
           "--message=#{formula.name} #{new_formula_version}#{devel_message}",
           "--", formula.path
@@ -156,7 +156,7 @@ module Homebrew
         quiet_system "hub", "fork"
         remote = Utils.popen_read("hub fork 2>&1")[/fatal: remote (.+) already exists\./, 1]
         odie "cannot get remote from 'hub'!" if remote.to_s.empty?
-        safe_system "git", "push", remote, "#{branch}:#{branch}"
+        safe_system "git", "push", "--set-upstream", remote, "#{branch}:#{branch}"
         safe_system "hub", "pull-request", "--browse", "-m",
           "#{formula.name} #{new_formula_version}#{devel_message}\n\nCreated with `brew bump-formula-pr`."
       end


### PR DESCRIPTION
Without `--no-track`, some git setups may automatically set
`origin/master` as the tracked upstream for the newly created branch.
This upstream is what hub defaults as --head when opening PRs. By not
allowing git to set `origin/master` as upstream, hub can then use the
proper --head for the PR.

Since hub still needs to know what --head is intended to be, we can set
the branch's upstream when pushing: with the --set-upstream option.

Fixes #755