### PR TITLE
bump-formula-pr: return to starting branch

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -147,6 +147,7 @@ module Homebrew
         ohai "hub fork (to read $HUB_REMOTE)"
         ohai "git push $HUB_REMOTE #{branch}:#{branch}"
         ohai "hub pull-request --browse -m '#{formula.name} #{new_formula_version}#{devel_message}'"
+        ohai "git checkout -"
       else
         safe_system "git", "checkout", "-b", branch, "origin/master"
         safe_system "git", "commit", "--no-edit", "--verbose",
@@ -159,6 +160,7 @@ module Homebrew
         safe_system "git", "push", remote, "#{branch}:#{branch}"
         safe_system "hub", "pull-request", "--browse", "-m",
           "#{formula.name} #{new_formula_version}#{devel_message}\n\nCreated with `brew bump-formula-pr`."
+        safe_system "git", "checkout", "-"
       end
     end
   end


### PR DESCRIPTION
After branching, bumping, pushing, and pr-ing; return to whatever branch
was originally checked out.

In most cases, I'd imagine users to want to continue receiving tap
updates from master. However, after using bump-formula-pr, the tap in
which the formula was bumped is left on the working branch that was
doing the bumping and pull-request. After opening the PR, we should
return to whatever branch the user originally had checked out – most
likely master. (But git allows us to just say "previous branch" by using
`-`)