### PR TITLE
add .editorconfig

### DIFF
--- a/Library/.editorconfig
+++ b/Library/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+[Homebrew/**.rb]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Taps/homebrew/**.rb]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+# trailing whitespace is crucial for patches
+trim_trailing_whitespace = false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

This adds a `.editorconfig` file to automatically configure users' editors to match up with Homebrew's preferred style guidelines.

It is a tweaked version of @xu-cheng's PR https://github.com/Homebrew/legacy-homebrew/pull/45855 with the following changes:

* It was moved into `Library` as opposed to the top level (by explicit maintainer request). For this reason, rules for .travis.yml and the Markdown documentation were dropped - not a big deal, IMO, since I expect the vast majority of PR's to be against Ruby files.
* The original PR was made before the homebrew-core/brew split. It's been adapted accordingly.