### PR TITLE
Install Cask’s default tap if untapped.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -142,6 +142,7 @@ class Hbc::CLI
     command_string, *rest = *arguments
     rest = process_options(rest)
     command = Hbc.help ? "help" : lookup_command(command_string)
+    Hbc.default_tap.install unless Hbc.default_tap.installed?
     Hbc.init if should_init?(command)
     run_command(command, *rest)
   rescue Hbc::CaskError, Hbc::CaskSha256MismatchError => e

--- a/Library/Homebrew/cask/lib/hbc/locations.rb
+++ b/Library/Homebrew/cask/lib/hbc/locations.rb
@@ -126,7 +126,7 @@ module Hbc::Locations
     attr_writer :default_tap
 
     def default_tap
-      @default_tap ||= Tap.fetch("caskroom/homebrew-cask")
+      @default_tap ||= Tap.fetch("caskroom", "homebrew-cask")
     end
 
     def path(query)

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -17,7 +17,6 @@ OFFICIAL_TAPS = %w[
 ].freeze
 
 OFFICIAL_CMD_TAPS = {
-  "caskroom/cask" => ["cask"],
   "homebrew/bundle" => ["bundle"],
   "homebrew/services" => ["services"],
 }.freeze

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -307,7 +307,7 @@ class Tap
     @formula_dir ||= [path/"Formula", path/"HomebrewFormula", path].detect(&:directory?)
   end
 
-  # path to the directory of all casks for caskroom/cask {Tap}.
+  # path to the directory of all {Cask} files for this {Tap}.
   def cask_dir
     @cask_dir ||= path/"Casks"
   end


### PR DESCRIPTION
`cask` should auto-tap `caskroom/cask` as before if it is untapped.