### PR TITLE
build: permit weak imports in Go reverse deps.

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -79,6 +79,11 @@ class Build
 
     ENV.activate_extensions!
 
+    # Go makes extensive use of weak imports.
+    if formula_deps.any? { |f| f.name == "go" }
+      ENV.permit_weak_imports
+    end
+
     if superenv?
       ENV.keg_only_deps = keg_only_deps
       ENV.deps = formula_deps


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Go makes extensive use of weak imports so we need to allow them when building Go-using software.

Closes https://github.com/Homebrew/homebrew-core/issues/4047.