### PR TITLE
bin/brew: improve $HOMEBREW_REPOSITORY/bin/brew handling.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -31,6 +31,17 @@ then
   HOMEBREW_REPOSITORY="${BREW_FILE_DIRECTORY%/*}"
 fi
 
+# Try to find a /usr/local HOMEBREW_PREFIX where possible (for bottles)
+if [[ -L "/usr/local/bin/brew" ]]
+then
+  USR_LOCAL_BREW_FILE_DIRECTORY="$(symlink_target_directory "/usr/local/bin/brew" "/usr/local/bin")"
+  USR_LOCAL_HOMEBREW_REPOSITORY="${USR_LOCAL_BREW_FILE_DIRECTORY%/*}"
+  if [[ "$HOMEBREW_REPOSITORY" = "$USR_LOCAL_HOMEBREW_REPOSITORY" ]]
+  then
+    HOMEBREW_PREFIX="/usr/local"
+  fi
+fi
+
 HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 
 source "$HOMEBREW_LIBRARY/Homebrew/brew.sh"

--- a/bin/brew
+++ b/bin/brew
@@ -7,10 +7,13 @@ quiet_cd() {
 
 BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
-
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
-[[ -n "$HOMEBREW_PREFIX" && "$HOMEBREW_PREFIX" != "$HOMEBREW_BREW_FILE" ]] \
-  || HOMEBREW_PREFIX="/"
+
+# Default to / prefix if unset or the bin/brew file.
+if [[ -z "$HOMEBREW_PREFIX" || "$HOMEBREW_PREFIX" = "$HOMEBREW_BREW_FILE" ]]
+then
+  HOMEBREW_PREFIX="/"
+fi
 
 HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX"
 

--- a/bin/brew
+++ b/bin/brew
@@ -5,6 +5,13 @@ quiet_cd() {
   cd "$@" >/dev/null
 }
 
+symlink_target_directory() {
+  local target="$(readlink "$1")"
+  local target_dirname="$(dirname "$target")"
+  local directory="$2"
+  quiet_cd "$directory" && quiet_cd "$target_dirname" && pwd -P
+}
+
 BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
@@ -17,12 +24,10 @@ fi
 
 HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX"
 
+# Resolve the bin/brew symlink to find Homebrew's repository
 if [[ -L "$HOMEBREW_BREW_FILE" ]]
 then
-  BREW_SYMLINK="$(readlink "$HOMEBREW_BREW_FILE")"
-  BREW_SYMLINK_DIRECTORY="$(dirname "$BREW_SYMLINK")"
-  BREW_FILE_DIRECTORY="$(quiet_cd "$BREW_FILE_DIRECTORY" &&
-                         quiet_cd "$BREW_SYMLINK_DIRECTORY" && pwd -P)"
+  BREW_FILE_DIRECTORY="$(symlink_target_directory "$HOMEBREW_BREW_FILE" "$BREW_FILE_DIRECTORY")"
   HOMEBREW_REPOSITORY="${BREW_FILE_DIRECTORY%/*}"
 fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If `/usr/local` is the prefix but not the repository (so bottles can be used) then running `/usr/local/bin/brew` works great but `$HOMEBREW_REPOSITORY/bin/brew` assumes the prefix is
`$HOMEBREW_REPOSITORY`. This is a pain when doing work on the Homebrew repository and having e.g. `bin` in your `$PATH`. Improve this behaviour so `bin/brew` knows how to handle this situation.

There was some refactoring necessary so this has been split into three commits.

CC @UniqMartin for Bash review and @chdiza for `/usr/local/homebrew` thoughts.