### PR TITLE
brew.sh: don't require /usr/local/Cellar creation.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -38,13 +38,13 @@ then
   export LC_ALL="en_US.UTF-8"
 fi
 
-# Where we store built products; /usr/local/Cellar if it exists,
-# otherwise a Cellar relative to the Repository.
-if [[ -d "$HOMEBREW_PREFIX/Cellar" ]]
+# Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
+# for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.
+if [[ -d "$HOMEBREW_REPOSITORY/Cellar" ]]
 then
-  HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar"
-else
   HOMEBREW_CELLAR="$HOMEBREW_REPOSITORY/Cellar"
+else
+  HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar"
 fi
 
 case "$*" in


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If you're using e.g. a `/usr/local/homebrew` prefix then don't require the `/usr/local/Cellar` to be manually created to avoid e.g. `/usr/local/homebrew/Cellar` being used. Let's do all we can to let
people use this `Cellar` location as it means they can put their repository wherever they like and still use all our bottles.

CC @Homebrew/maintainers for thoughts as it's a pretty big change and @chdiza as this was part of your neat `/usr/local/homebrew` installation hack that I'm enjoying.