### PR TITLE
Revert "diagnostic: ignore duplicated `brew-cask` commands"

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1090,8 +1090,6 @@ module Homebrew
           cmd_map[cmd_name] << cmd
         end
         cmd_map.reject! { |_cmd_name, cmd_paths| cmd_paths.size == 1 }
-        # TODO: remove when Cask migration is complete.
-        cmd_map.reject! { |cmd_name, _cmd_paths| cmd_name.include? "brew-cask" }
         return if cmd_map.empty?
 
         message = "You have external commands with conflicting names.\n"


### PR DESCRIPTION
Reverts Homebrew/brew#752

This is no longer needed as Homebrew Cask has removed their `cmd` directory and we should complain about this now as it would be a sign that the two repositories are out of sync.

CC @reitermarkus for a sanity check.