### PR TITLE
Make -no_weak_imports opt-in.

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -79,11 +79,6 @@ class Build
 
     ENV.activate_extensions!
 
-    # Go makes extensive use of weak imports.
-    if formula_deps.any? { |f| f.name == "go" }
-      ENV.permit_weak_imports
-    end
-
     if superenv?
       ENV.keg_only_deps = keg_only_deps
       ENV.deps = formula_deps

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -293,6 +293,7 @@ module SharedEnvExtension
 
   def permit_arch_flags; end
 
+  # A no-op until we enable this by default again (which we may never do).
   def permit_weak_imports; end
 
   private

--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -1,5 +1,5 @@
 module SharedEnvExtension
-  def no_weak_imports?
+  def no_weak_import_support?
     return false unless compiler == :clang
 
     if MacOS::Xcode.version && MacOS::Xcode.version < "8.0"

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -28,11 +28,6 @@ module Stdenv
       # depend on it already being installed to build itself.
       ld64 if Formula["ld64"].installed?
     end
-
-    # Xcode 8 should be told to fail to link against weak links
-    # Issue from Apple engineer:
-    # https://github.com/Homebrew/homebrew-core/issues/3727
-    append "LDFLAGS", "-Wl,-no_weak_imports" if no_weak_imports?
   end
 
   def homebrew_extra_pkg_config_paths
@@ -147,7 +142,7 @@ module Stdenv
     append "CFLAGS", "-I#{MacOS::X11.include}" unless MacOS::CLT.installed?
   end
 
-  def permit_weak_imports
-    remove "LDFLAGS", "-Wl,-no_weak_imports"
+  def no_weak_imports
+    append "LDFLAGS", "-Wl,-no_weak_imports"
   end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -81,10 +81,6 @@ module Superenv
     s << "s" if MacOS.version >= :mountain_lion
     # Fix issue with >= 10.8 apr-1-config having broken paths
     s << "a" if MacOS.version >= :mountain_lion
-    # Xcode 8 should be told to fail to link against weak links
-    # Issue from Apple engineer:
-    # https://github.com/Homebrew/homebrew-core/issues/3727
-    s << "w" if no_weak_imports?
     s
   end
 
@@ -107,8 +103,8 @@ module Superenv
     ENV.x11 = MacOS::X11.installed?
   end
 
-  def permit_weak_imports
-    remove "HOMEBREW_CCCFG", "w"
+  def no_weak_imports
+    add "HOMEBREW_CCCFG", "w"
   end
 
   # These methods are no longer necessary under superenv, but are needed to


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The experiment to add `-no_weak_imports` unconditionally has been a bit of a failure. It's broken more than it's fixed and I don't think we can have this as a default for Xcode 8.

Add `ENV.no_weak_imports` to be used by formulae authors and make `ENV.permit_weak_imports a no-op (for now). 

We may reconsider this behaviour in future.

CC @domt4 @ilovezfs for thoughts and @achivetta and @mcphailtom FYI.

Previous issues for reference: https://github.com/Homebrew/homebrew-core/issues/3727 https://github.com/Homebrew/brew/pull/721 https://github.com/Homebrew/homebrew-core/issues/3727 https://github.com/Homebrew/homebrew-core/issues/2674  https://github.com/Homebrew/brew/pull/741 https://github.com/Homebrew/homebrew-core/issues/4015 https://github.com/derekparker/delve/issues/616

Fixes https://github.com/Homebrew/homebrew-core/issues/4128