### PR TITLE
update-report: also link `brew*.1` manpages.

### DIFF
--- a/Library/Homebrew/cmd/man.rb
+++ b/Library/Homebrew/cmd/man.rb
@@ -11,25 +11,13 @@ module Homebrew
     raise UsageError unless ARGV.named.empty?
 
     if ARGV.flag? "--link"
-      link_man_pages
+      odie "`brew man --link` is now done automatically by `brew update`."
     else
       regenerate_man_pages
     end
   end
 
   private
-
-  def link_man_pages
-    linked_path = HOMEBREW_PREFIX/"share/man/man1"
-
-    if TARGET_MAN_PATH == linked_path
-      odie "The target path is the same as the linked one."
-    end
-
-    Dir["#{TARGET_MAN_PATH}/*.1"].each do |page|
-      FileUtils.ln_s page, linked_path
-    end
-  end
 
   def regenerate_man_pages
     Homebrew.install_gem_setup_path! "ronn"

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -85,6 +85,7 @@ module Homebrew
       Descriptions.update_cache(hub)
     end
 
+    link_manpages
     Tap.each(&:link_manpages)
 
     Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
@@ -157,6 +158,11 @@ module Homebrew
         EOS
       end
     end
+  end
+
+  def link_manpages
+    return if HOMEBREW_PREFIX.to_s == HOMEBREW_REPOSITORY.to_s
+    link_path_manpages(HOMEBREW_REPOSITORY/"share", "brew update")
   end
 end
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -248,26 +248,7 @@ class Tap
   end
 
   def link_manpages
-    return unless (path/"man").exist?
-    conflicts = []
-    (path/"man").find do |src|
-      next if src.directory?
-      dst = HOMEBREW_PREFIX/"share"/src.relative_path_from(path)
-      next if dst.symlink? && src == dst.resolved_path
-      if dst.exist?
-        conflicts << dst
-        next
-      end
-      dst.make_relative_symlink(src)
-    end
-    unless conflicts.empty?
-      onoe <<-EOS.undent
-        Could not link #{name} manpages to:
-          #{conflicts.join("\n")}
-
-        Please delete these files and run `brew tap --repair`.
-      EOS
-    end
+    link_path_manpages(path, "brew tap --repair")
   end
 
   # uninstall this {Tap}.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -594,3 +594,26 @@ def truncate_text_to_approximate_size(s, max_bytes, options = {})
   out.encode!("UTF-8")
   out
 end
+
+def link_path_manpages(path, command)
+  return unless (path/"man").exist?
+  conflicts = []
+  (path/"man").find do |src|
+    next if src.directory?
+    dst = HOMEBREW_PREFIX/"share"/src.relative_path_from(path)
+    next if dst.symlink? && src == dst.resolved_path
+    if dst.exist?
+      conflicts << dst
+      next
+    end
+    dst.make_relative_symlink(src)
+  end
+  unless conflicts.empty?
+    onoe <<-EOS.undent
+      Could not link #{name} manpages to:
+        #{conflicts.join("\n")}
+
+      Please delete these files and run `#{command}`.
+    EOS
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise if your `HOMEBREW_PREFIX` and `HOMEBREW_REPOSITORY` are not equal then your tap manpages will be linked but your `brew*` ones will not.

CC @chdiza as this removes a step of your mentioned `/usr/local/homebrew` installation instructions.