### PR TITLE
gpg: syntax additions

### DIFF
--- a/Library/Homebrew/cmd/audit.rb
+++ b/Library/Homebrew/cmd/audit.rb
@@ -208,6 +208,7 @@ class FormulaAuditor
       [/^  mirror ["'][\S\ ]+["']/,        "mirror"],
       [/^  version ["'][\S\ ]+["']/,       "version"],
       [/^  (sha1|sha256) ["'][\S\ ]+["']/, "checksum"],
+      [/^  gpg ["'][\S\ ]+["']/,           "gpg verification"],
       [/^  revision/,                      "revision"],
       [/^  version_scheme/,                "version_scheme"],
       [/^  head ["'][\S\ ]+["']/,          "head"],

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -29,9 +29,11 @@ require "migrator"
 # @see https://github.com/styleguide/ruby Ruby Style Guide
 #
 # <pre>class Wget < Formula
+#   desc "Internet file retriever"
 #   homepage "https://www.gnu.org/software/wget/"
-#   url "https://ftp.gnu.org/gnu/wget/wget-1.15.tar.gz"
-#   sha256 "52126be8cf1bddd7536886e74c053ad7d0ed2aa89b4b630f76785bac21695fcd"
+#   url "https://ftpmirror.gnu.org/wget/wget-1.18.tar.xz"
+#   mirror "https://ftp.gnu.org/gnu/wget/wget-1.18.tar.xz"
+#   sha256 "b5b55b75726c04c06fe253daec9329a6f1a3c0c1878e3ea76ebfebc139ea9cc1"
 #
 #   def install
 #     system "./configure", "--prefix=#{prefix}"
@@ -294,6 +296,12 @@ class Formula
   # @see .version
   def version
     active_spec.version
+  end
+
+  # GPG verification for current spec.
+  # @see .gpg
+  def gpg
+    active_spec.gpg
   end
 
   def update_head_version
@@ -1808,6 +1816,17 @@ class Formula
     # <pre>sha256 "2a2ba417eebaadcb4418ee7b12fe2998f26d6e6f7fda7983412ff66a741ab6f7"</pre>
     Checksum::TYPES.each do |type|
       define_method(type) { |val| stable.send(type, val) }
+    end
+
+    # @!attribute [w] gpg
+    # An optional mechanism to verify the download with GnuPG as well as the
+    # standard checksum verification. Upstream must publish signature files
+    # for us to be able to use this mechanism. Those signature files often
+    # have either a ".gpg" or ".sig" file extension.
+    #
+    # <pre>gpg "https://ftpmirror.gnu.org/wget/wget-1.18.tar.xz.sig"</pre>
+    def gpg(val)
+      stable.gpg(val)
     end
 
     # @!attribute [w] bottle

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -12,6 +12,7 @@ class Resource
   attr_reader :mirrors, :specs, :using, :source_modified_time
   attr_writer :version
   attr_accessor :download_strategy, :checksum
+  attr_rw :gpg
 
   # Formula name must be set after the DSL, as we have no access to the
   # formula name before initialization of the formula
@@ -37,6 +38,10 @@ class Resource
     def mirrors
       @resource.mirrors
     end
+
+    def gpg
+      @resource.gpg
+    end
   end
 
   def initialize(name = nil, &block)
@@ -46,6 +51,7 @@ class Resource
     @mirrors = []
     @specs = {}
     @checksum = nil
+    @gpg = nil
     @using = nil
     instance_eval(&block) if block_given?
   end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -3,6 +3,7 @@ require "resource"
 require "checksum"
 require "version"
 require "options"
+require "gpg"
 require "build_options"
 require "dependency_collector"
 require "utils/bottles"
@@ -29,6 +30,7 @@ class SoftwareSpec
   def_delegators :@resource, :cached_download, :clear_cache
   def_delegators :@resource, :checksum, :mirrors, :specs, :using
   def_delegators :@resource, :version, :mirror, *Checksum::TYPES
+  def_delegators :@resource, :gpg
   def_delegators :@resource, :downloader
 
   def initialize

--- a/Library/Homebrew/test/test_gpg.rb
+++ b/Library/Homebrew/test/test_gpg.rb
@@ -27,4 +27,16 @@ class GpgTest < Homebrew::TestCase
     end
     assert_equal "https://ftpmirror.gnu.org/wget/wget-1.18.tar.xz.sig", f.gpg
   end
+
+  def test_formula_resource_syntax_valid
+    f = formula do
+      url "https://ftpmirror.gnu.org/wget/wget-1.18.tar.xz"
+
+      resource("doom") do
+        url "https://test.doom/doomed-1.2.3.tar.gz"
+        gpg "https://test.doom/doomed-1.2.3.tar.gz.sig"
+      end
+    end
+    assert_equal "https://test.doom/doomed-1.2.3.tar.gz.sig", f.resource("doom").gpg
+  end
 end

--- a/Library/Homebrew/test/test_gpg.rb
+++ b/Library/Homebrew/test/test_gpg.rb
@@ -7,6 +7,10 @@ class GpgTest < Homebrew::TestCase
     @dir = Pathname.new(mktmpdir)
   end
 
+  def teardown
+    FileUtils.rm_rf(@dir)
+  end
+
   def test_create_test_key
     Dir.chdir(@dir) do
       with_environment("HOME" => @dir) do
@@ -14,7 +18,13 @@ class GpgTest < Homebrew::TestCase
         assert_predicate @dir/".gnupg/secring.gpg", :exist?
       end
     end
-  ensure
-    @dir.rmtree
+  end
+
+  def test_formula_syntax_valid
+    f = formula do
+      url "https://ftpmirror.gnu.org/wget/wget-1.18.tar.xz"
+      gpg "https://ftpmirror.gnu.org/wget/wget-1.18.tar.xz.sig"
+    end
+    assert_equal "https://ftpmirror.gnu.org/wget/wget-1.18.tar.xz.sig", f.gpg
   end
 end

--- a/Library/Homebrew/test/test_gpg.rb
+++ b/Library/Homebrew/test/test_gpg.rb
@@ -3,7 +3,6 @@ require "gpg"
 
 class GpgTest < Homebrew::TestCase
   def setup
-    skip "GPG Unavailable" unless Gpg.available?
     @dir = Pathname.new(mktmpdir)
   end
 
@@ -12,6 +11,7 @@ class GpgTest < Homebrew::TestCase
   end
 
   def test_create_test_key
+    skip "GPG Unavailable" unless Gpg.available?
     Dir.chdir(@dir) do
       with_environment("HOME" => @dir) do
         shutup { Gpg.create_test_key(@dir) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is split out of yet another in-progress branch, which was split out of another in-progress branch _(yeah, I know I'm making life complicated for myself)_, because I've been having an absolute nightmare with getting the broader fetch/verify mechanism to work consistently for quite some time now 😭, despite trying multiple ways to get that done, so here's _some_ progress to review.

This is obviously a WIP rather than the whole deal, designed to be enough for things like:
```ruby
Formula["wget"].gpg
Formula["wget"].devel.gpg
Formula["wget"].resource("test").gpg
```
to return the correct variables, and for `brew` to be able to load the changed `wget` with `info`, `install`, etc without going _"I don't know what that gpg thing is"_.