### PR TITLE
config: set TMPDIR, TEMP and TMP to HOMEBREW_TEMP

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -35,6 +35,11 @@ HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/")
 # Must use /tmp instead of $TMPDIR because long paths break Unix domain sockets
 HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp"))
 
+# Set common tmpdir environment variables to HOMEBREW_TEMP
+ENV["TMPDIR"] = HOMEBREW_TEMP
+ENV["TEMP"] = HOMEBREW_TEMP
+ENV["TMP"] = HOMEBREW_TEMP
+
 unless defined? HOMEBREW_LIBRARY_PATH
   # Root of the Homebrew code base
   HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`TMPDIR`, `TEMP` and `TMP` (when set) are not whitelisted for writing in `sandbox.rb`, which could result in sandbox violations when programs attempt to write to these locations.

Setting `TMPDIR`, `TEMP` and `TMP` to `HOMEBREW_TEMP` (which defaults to `/tmp` when not set) works around the aforementioned problem and also improves uniformity in the locations of tempfiles created during Homebrew operations.

Caveat: Non-matching `HOMEBREW_TEMP` and `TMPDIR` could lead to undesirable side effects in certain cases, e.g., emacsclient not being able to find an existing server (whose socket lives in `$TMPDIR/emacs$UID/`) when launched through brew edit.

---

See #787 for an alternative approach and discussions.