### PR TITLE
scm/git: make --homebrew=print-path use realpath.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -17,10 +17,7 @@ source "$HOMEBREW_LIBRARY/Homebrew/utils/lock.sh"
 git() {
   if [[ -z "$GIT_EXECUTABLE" ]]
   then
-    GIT_EXECUTABLE_RELATIVE="$("$HOMEBREW_LIBRARY/Homebrew/shims/scm/git" --homebrew=print-path)"
-    GIT_EXECUTABLE_BASE="$(basename "$GIT_EXECUTABLE_RELATIVE")"
-    GIT_EXECUTABLE_DIR="$(cd "$(dirname "$GIT_EXECUTABLE_RELATIVE")" && pwd)"
-    GIT_EXECUTABLE="$GIT_EXECUTABLE_DIR/$GIT_EXECUTABLE_BASE"
+    GIT_EXECUTABLE="$("$HOMEBREW_LIBRARY/Homebrew/shims/scm/git" --homebrew=print-path)"
   fi
   "$GIT_EXECUTABLE" "$@"
 }

--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -9,15 +9,23 @@ quiet_safe_cd() {
   cd "$1" >/dev/null || { echo "Error: failed to cd to $1" >&2; exit 1; }
 }
 
+absdir() {
+  quiet_safe_cd "${1%/*}/" && pwd -P
+}
+
+dirbasepath() {
+  local dir="$1"
+  local base="${2##*/}"
+  echo "$dir/$base"
+}
+
 realpath() {
   local path="$1"
   local dir
-  local base
   local dest
 
-  dir="$(quiet_safe_cd "${path%/*}/" && pwd -P)"
-  base="${path##*/}"
-  path="$dir/$base"
+  dir="$(absdir "$path")"
+  path="$(dirbasepath "$dir" "$path")"
 
   while [[ -L "$path" ]]
   do
@@ -28,9 +36,8 @@ realpath() {
     else
       path="$dir/$dest"
     fi
-    dir="$(quiet_safe_cd "${path%/*}/" && pwd -P)"
-    base="${path##*/}"
-    path="$dir/$base"
+    dir="$(absdir "$path")"
+    path="$(dirbasepath "$dir" "$path")"
   done
 
   echo "$path"
@@ -58,7 +65,9 @@ safe_exec() {
   fi
   if [[ "$HOMEBREW" = "print-path" ]]
   then
-    echo "$arg0"
+    local dir="$(quiet_safe_cd "${arg0%/*}/" && pwd)"
+    local path="$(dirbasepath "$dir" "$arg0")"
+    echo "$path"
     exit
   fi
   exec "$@"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This ensures that the output is always a fully-resolved path.

Requested by @UniqMartin in https://github.com/Homebrew/brew/pull/778 but I'm uncertain if this is what we actually want given it will return e.g. `/usr/local/Cellar/git/2.9.3/bin/git` and not `/usr/local/bin/git` and the prior may not be consistently well-cacheable. Opening for discussion more than thinking this is a better solution than https://github.com/Homebrew/brew/pull/778.