### PR TITLE
Fixes https://github.com/Homebrew/brew/issues/796

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -154,6 +154,8 @@ class Sandbox
           (literal "/dev/dtracehelper")
           (literal "/dev/null")
           (literal "/dev/zero")
+          ; required by curl for accessing SSL certs when running under root user
+          (literal "/private/var/db/mds/system/mds.lock")
           (regex #"^/dev/fd/[0-9]+$")
           (regex #"^/dev/ttys?[0-9]*$")
           )


### PR DESCRIPTION
Curl will request to write /private/var/db/mds/system/mds.lock in order
to access system SSL certs when running Homebrew under root user.