### PR TITLE
update.sh: reset pre-stash, die if stash fails.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -226,9 +226,18 @@ merge_or_rebase() {
     fi
     git merge --abort &>/dev/null
     git rebase --abort &>/dev/null
-    git -c "user.email=brew-update@localhost" \
-        -c "user.name=brew update" \
-        stash save --include-untracked "${QUIET_ARGS[@]}"
+    git reset --mixed "${QUIET_ARGS[@]}"
+    if ! git -c "user.email=brew-update@localhost" \
+             -c "user.name=brew update" \
+             stash save --include-untracked "${QUIET_ARGS[@]}"
+    then
+      odie <<EOS
+Could not `git stash` in $DIR!
+Please stash/commit manually if you need to keep your changes or, if not, run:
+  cd $DIR
+  git reset --hard origin/master
+EOS
+    fi
     git reset --hard "${QUIET_ARGS[@]}"
     STASHED="1"
   fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A `git reset --hard` without stashing first risks nuking in-progress work. A `git reset --mixed` should allow stashing to occur more often on e.g. merge conflicts.

CC @ilovezfs 

Fixes #766.