### PR TITLE
Restrict TMPDIR etc. changes to install, post_install and test

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -103,6 +103,11 @@ class Build
       end
     end
 
+    old_tmpdir = ENV["TMPDIR"]
+    old_temp = ENV["TEMP"]
+    old_tmp = ENV["TMP"]
+    ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
+
     formula.extend(Debrew::Formula) if ARGV.debug?
 
     formula.brew do |_formula, staging|
@@ -139,6 +144,10 @@ class Build
         formula.prefix.install_metafiles formula.libexec if formula.libexec.exist?
       end
     end
+  ensure
+    ENV["TMPDIR"] = old_tmpdir
+    ENV["TEMP"] = old_temp
+    ENV["TMP"] = old_tmp
   end
 
   def detect_stdlibs(compiler)

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -35,11 +35,6 @@ HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/")
 # Must use /tmp instead of $TMPDIR because long paths break Unix domain sockets
 HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp"))
 
-# Set common tmpdir environment variables to HOMEBREW_TEMP
-ENV["TMPDIR"] = HOMEBREW_TEMP
-ENV["TEMP"] = HOMEBREW_TEMP
-ENV["TMP"] = HOMEBREW_TEMP
-
 unless defined? HOMEBREW_LIBRARY_PATH
   # Root of the Homebrew code base
   HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -888,11 +888,18 @@ class Formula
   def run_post_install
     build = self.build
     self.build = Tab.for_formula(self)
+    old_tmpdir = ENV["TMPDIR"]
+    old_temp = ENV["TEMP"]
+    old_tmp = ENV["TMP"]
+    ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
     with_logging("post_install") do
       post_install
     end
   ensure
     self.build = build
+    ENV["TMPDIR"] = old_tmpdir
+    ENV["TEMP"] = old_temp
+    ENV["TMP"] = old_tmp
   end
 
   # Tell the user about any caveats regarding this package.
@@ -1411,7 +1418,11 @@ class Formula
   def run_test
     old_home = ENV["HOME"]
     old_curl_home = ENV["CURL_HOME"]
+    old_tmpdir = ENV["TMPDIR"]
+    old_temp = ENV["TEMP"]
+    old_tmp = ENV["TMP"]
     ENV["CURL_HOME"] = old_curl_home || old_home
+    ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
     mktemp("#{name}-test") do |staging|
       staging.retain! if ARGV.keep_tmp?
       @testpath = staging.tmpdir
@@ -1430,6 +1441,9 @@ class Formula
     @testpath = nil
     ENV["HOME"] = old_home
     ENV["CURL_HOME"] = old_curl_home
+    ENV["TMPDIR"] = old_tmpdir
+    ENV["TEMP"] = old_temp
+    ENV["TMP"] = old_tmp
   end
 
   # @private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

#800 came with a caveat, which despite [my initial confidence](https://github.com/Homebrew/brew/pull/800#issue-172882122), actually [bit others too](https://github.com/Homebrew/brew/pull/800#issuecomment-242592802) (I'm saying "too" because I myself was certainly bitten, but didn't regard it as too big a deal).

In this PR we restrict `TMPDIR`, `TEMP` and `TMP` normalization to `install`, `post_install` and `test` and restore their original values afterwards, thus eliminating the caveat.

There's quite a bit of code duplication here unfortunately. I also have a DRY branch https://github.com/zmwangx/brew/commit/f5cc95c9967793e50a83c675f4e43419fde7e1a6 in case anyone's interested, but it involves a bit of global changes and it seems harder to restore the original values without further global hacks.

CC @xu-cheng (who proposed this) @dunn.