### PR TITLE
Fix missing `magenta` in Tty.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/utils.rb
+++ b/Library/Homebrew/cask/lib/hbc/utils.rb
@@ -37,7 +37,7 @@ def odebug(title, *sput)
     if $stdout.tty? && title.to_s.length > width
       title = title.to_s[0, width - 3] + "..."
     end
-    puts "#{Tty.magenta}==> #{title}#{Tty.reset}"
+    puts "#{Tty.magenta}==>#{Tty.reset} #{Tty.white}#{title}#{Tty.reset}"
     puts sput unless sput.empty?
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -25,6 +25,10 @@ class Tty
       bold 39
     end
 
+    def magenta
+      bold 35
+    end
+
     def red
       underline 31
     end


### PR DESCRIPTION
This was overlooked in https://github.com/Homebrew/brew/pull/794.