### PR TITLE
Do not recommend pip install --prefix=<empty> hack, this breaks default pip command

### DIFF
--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -33,15 +33,6 @@ Similarly, Pip can be used to upgrade itself via:
 
 The normal `pip install --user` is disabled for brewed Python. This is because of a bug in distutils, because Homebrew writes a `distutils.cfg` which sets the package `prefix`.
 
-A possible workaround (which puts executable scripts in `~/Library/Python/<X>.<Y>/bin`) is:
-
-    pip install --user --install-option="--prefix=" <package-name>
-
-You can make this "empty prefix" the default by adding a `~/.pydistutils.cfg` file with the following contents:
-
-    [install]
-    prefix=
-
 ## `site-packages` and the `PYTHONPATH`
 
 The `site-packages` is a directory that contains Python modules (especially bindings installed by other formulae). Homebrew creates it here:

--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -33,6 +33,10 @@ Similarly, Pip can be used to upgrade itself via:
 
 The normal `pip install --user` is disabled for brewed Python. This is because of a bug in distutils, because Homebrew writes a `distutils.cfg` which sets the package `prefix`.
 
+A possible workaround (which puts executable scripts in `~/Library/Python/<X>.<Y>/bin`) is:
+
+    pip install --user --install-option="--prefix=" <package-name>
+
 ## `site-packages` and the `PYTHONPATH`
 
 The `site-packages` is a directory that contains Python modules (especially bindings installed by other formulae). Homebrew creates it here:


### PR DESCRIPTION
Hi,

Please do not recommend `pip install --prefix=<empty>`

This works with `--target`or `--user` option, but breaks normal/default pip operations.

`pip install package` won't work anymore. Tested on OSX. Because of this recommendation, people are getting weird errors like here https://github.com/Homebrew/legacy-homebrew/issues/44836

That recommendation is also top recommendation on this answer http://stackoverflow.com/questions/24257803/distutilsoptionerror-must-supply-either-home-or-prefix-exec-prefix-not-both

But see the user comments on first answer.
