### PR TITLE
Brew-Test-Bot-For-Core-Contributors: fix broken link

### DIFF
--- a/share/doc/homebrew/Brew-Test-Bot-For-Core-Contributors.md
+++ b/share/doc/homebrew/Brew-Test-Bot-For-Core-Contributors.md
@@ -9,7 +9,7 @@ This job automatically builds any pull requests submitted to Homebrew/homebrew-c
 ## [Homebrew Testing](https://bot.brew.sh/job/Homebrew%20Testing/)
 This job is manually triggered to run [`brew test-bot`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/test-bot.rb) with user-specified parameters. On a successful build it automatically uploads bottles.
 
-You can manually start this job with parameters to run [`brew test-bot`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/test-bot.rb) with the same parameters. It's often useful to pass a pull request URL, a commit URL, a commit SHA-1 and/or formula names to have `brew-test-bot` test them, report the results and produce bottles.
+You can manually start this job with parameters to run [`brew test-bot`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/test-bot.rb) with the same parameters. It's often useful to pass a pull request URL, a commit URL, a commit SHA-1 and/or formula names to have `brew-test-bot` test them, report the results and produce bottles.
 
 ## Bottling
 To pull and bottle a pull request with `brew pull`:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? (N/A)
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Seems like one of the links to `cmd/test-bot` that should have been moved to `dev-cmd/test-bot` left unnoticed.