### PR TITLE
Add `--full-name` option to `brew deps`

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -1,4 +1,4 @@
-#:  * `deps` [`--1`] [`-n`] [`--union`] [`--installed`] [`--include-build`] [`--include-optional`] [`--skip-recommended`] <formulae>:
+#:  * `deps` [`--1`] [`-n`] [`--union`] [`--full-name`] [`--installed`] [`--include-build`] [`--include-optional`] [`--skip-recommended`] <formulae>:
 #:    Show dependencies for <formulae>. When given multiple formula arguments,
 #:    show the intersection of dependencies for <formulae>.
 #:
@@ -9,6 +9,8 @@
 #:
 #:    If `--union` is passed, show the union of dependencies for <formulae>,
 #:    instead of the intersection.
+#:
+#:    If `--full-name` is passed, list dependencies by their full name.
 #:
 #:    If `--installed` is passed, only list those dependencies that are
 #:    currently installed.
@@ -62,7 +64,11 @@ module Homebrew
     else
       all_deps = deps_for_formulae(ARGV.formulae, !ARGV.one?, &(mode.union? ? :| : :&))
       all_deps = all_deps.select(&:installed?) if mode.installed?
-      all_deps = all_deps.map(&:name).uniq
+      if ARGV.include? "--full-name"
+        all_deps = all_deps.map(&:to_formula).map(&:full_name).uniq
+      else
+        all_deps = all_deps.map(&:name).uniq
+      end
       all_deps.sort! unless mode.topo_order?
       puts all_deps
     end

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -64,11 +64,11 @@ module Homebrew
     else
       all_deps = deps_for_formulae(ARGV.formulae, !ARGV.one?, &(mode.union? ? :| : :&))
       all_deps = all_deps.select(&:installed?) if mode.installed?
-      if ARGV.include? "--full-name"
-        all_deps = all_deps.map(&:to_formula).map(&:full_name).uniq
+      all_deps = if ARGV.include? "--full-name"
+        all_deps.map(&:to_formula).map(&:full_name)
       else
-        all_deps = all_deps.map(&:name).uniq
-      end
+        all_deps.map(&:name)
+      end.uniq
       all_deps.sort! unless mode.topo_order?
       puts all_deps
     end

--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -753,7 +753,7 @@ module Homebrew
       changed_formulae_dependents = {}
 
       @formulae.each do |formula|
-        formula_dependencies = Utils.popen_read("brew", "deps", "--include-build", formula).split("\n")
+        formula_dependencies = Utils.popen_read("brew", "deps", "--full-name", "--include-build", formula).split("\n")
         unchanged_dependencies = formula_dependencies - @formulae
         changed_dependences = formula_dependencies - unchanged_dependencies
         changed_dependences.each do |changed_formula|

--- a/share/doc/homebrew/brew.1.html
+++ b/share/doc/homebrew/brew.1.html
@@ -100,7 +100,7 @@ you to explicitly set the name and version of the package you are creating.</p>
 
 <p>The option <code>--tap</code> takes a tap as its argument and generates the formula in
 the specified tap.</p></dd>
-<dt><code>deps</code> [<code>--1</code>] [<code>-n</code>] [<code>--union</code>] [<code>--installed</code>] [<code>--include-build</code>] [<code>--include-optional</code>] [<code>--skip-recommended</code>] <var>formulae</var></dt><dd><p>Show dependencies for <var>formulae</var>. When given multiple formula arguments,
+<dt><code>deps</code> [<code>--1</code>] [<code>-n</code>] [<code>--union</code>] [<code>--full-name</code>] [<code>--installed</code>] [<code>--include-build</code>] [<code>--include-optional</code>] [<code>--skip-recommended</code>] <var>formulae</var></dt><dd><p>Show dependencies for <var>formulae</var>. When given multiple formula arguments,
 show the intersection of dependencies for <var>formulae</var>.</p>
 
 <p>If <code>--1</code> is passed, only show dependencies one level down, instead of
@@ -110,6 +110,8 @@ recursing.</p>
 
 <p>If <code>--union</code> is passed, show the union of dependencies for <var>formulae</var>,
 instead of the intersection.</p>
+
+<p>If <code>--full-name</code> is passed, list dependencies by their full name.</p>
 
 <p>If <code>--installed</code> is passed, only list those dependencies that are
 currently installed.</p>

--- a/share/man/man1/brew.1
+++ b/share/man/man1/brew.1
@@ -132,7 +132,7 @@ The options \fB\-\-set\-name\fR and \fB\-\-set\-version\fR each take an argument
 The option \fB\-\-tap\fR takes a tap as its argument and generates the formula in the specified tap\.
 .
 .TP
-\fBdeps\fR [\fB\-\-1\fR] [\fB\-n\fR] [\fB\-\-union\fR] [\fB\-\-installed\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] \fIformulae\fR
+\fBdeps\fR [\fB\-\-1\fR] [\fB\-n\fR] [\fB\-\-union\fR] [\fB\-\-full\-name\fR] [\fB\-\-installed\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] \fIformulae\fR
 Show dependencies for \fIformulae\fR\. When given multiple formula arguments, show the intersection of dependencies for \fIformulae\fR\.
 .
 .IP
@@ -143,6 +143,9 @@ If \fB\-n\fR is passed, show dependencies in topological order\.
 .
 .IP
 If \fB\-\-union\fR is passed, show the union of dependencies for \fIformulae\fR, instead of the intersection\.
+.
+.IP
+If \fB\-\-full\-name\fR is passed, list dependencies by their full name\.
 .
 .IP
 If \fB\-\-installed\fR is passed, only list those dependencies that are currently installed\.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This adds a `--full-name` option to the `brew deps` command so that tapped formulae in the dependencies list will be printed with their full name `owner/tap/formula`. This option is also used when running `brew test-bot` with multiple formulae changed, as described in #738.

For example:

~~~
$ brew deps homebrew/science/ceres-solver
cmake
eigen
gflags
glog
metis
suite-sparse
tbb
~~~

~~~
$ brew deps homebrew/science/ceres-solver --full-name
cmake
eigen
gflags
glog
homebrew/science/metis
homebrew/science/suite-sparse
tbb
~~~