### PR TITLE
bottles: translate foo@1.2 to fooAT1.2

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -57,7 +57,7 @@ class Formulary
     class_name = name.capitalize
     class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }
     class_name.tr!("+", "x")
-    class_name.gsub!(/\b@\b/, "AT")
+    class_name.sub!(/(.)@(\d)/, "\\1AT\\2")
     class_name
   end
 

--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -244,4 +244,13 @@ class UtilTests < Homebrew::TestCase
     assert_match "homebrew/homebrew-core", e.message
     assert_match "homebrew/core", e.message
   end
+
+  def test_bottles_bintray
+    assert_equal "openssl:1.1", Utils::Bottles::Bintray.package("openssl@1.1")
+    assert_equal "gtkx", Utils::Bottles::Bintray.package("gtk+")
+    assert_equal "llvm", Utils::Bottles::Bintray.package("llvm")
+
+    tap = Tap.new("homebrew", "bintray-test")
+    assert_equal "bottles-bintray-test", Utils::Bottles::Bintray.repository(tap)
+  end
 end

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -56,7 +56,10 @@ module Utils
 
     class Bintray
       def self.package(formula_name)
-        formula_name.to_s.tr("+", "x")
+        package_name = formula_name.to_s.dup
+        package_name.tr!("+", "x")
+        package_name.sub!(/(.)@(\d)/, "\\1:\\2") # Handle foo@1.2 style formulae.
+        package_name
       end
 
       def self.repository(tap = nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Guess who hates special characters? Bintray hates special characters! Need to do the translation here as well so things like `openssl@1.1` don't cause Bintray to reject our upload.

Follow up to https://github.com/Homebrew/brew/pull/812.