### PR TITLE
formula_installer: install deps of dep before dep

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -219,7 +219,8 @@ class FormulaInstaller
 
     @@attempted << formula
 
-    if pour_bottle?(:warn => true)
+    pour_bottle = pour_bottle?(:warn => true)
+    if pour_bottle
       begin
         install_relocation_tools unless formula.bottle_specification.skip_relocation?
         pour
@@ -242,7 +243,10 @@ class FormulaInstaller
     build_bottle_preinstall if build_bottle?
 
     unless @poured_bottle
-      compute_and_install_dependencies if @pour_failed && !ignore_deps?
+      not_pouring = !pour_bottle || @pour_failed
+      if not_pouring && !ignore_deps?
+        compute_and_install_dependencies
+      end
       build
       clean
     end


### PR DESCRIPTION
Dependencies/requirements of a dependency need to be installed/satisfied
before the dependency. The fact that @pour_failed may be false is
irrelevant to that imperative.

See https://github.com/Homebrew/homebrew-core/pull/4258 where python3
wasn't being installed before sip despite the "with-python3" option
coming from qscintilla's `depends_on "sip" => "with-python3"`, causing
the sip build to fail as soon as it tried to invoke python3.