### PR TITLE
Allow deprecated hash syntax in Cask headers

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/source/path_base.rb
+++ b/Library/Homebrew/cask/lib/hbc/source/path_base.rb
@@ -55,6 +55,10 @@ class Hbc::Source::PathBase
   end
 
   def build_cask(cask_class, header_token, &block)
+    if header_token.is_a?(Hash)
+      # Cask file is using old `cask :v1 => 'token'` syntax
+      header_token = header_token.values.first
+    end
     raise Hbc::CaskTokenDoesNotMatchError.new(cask_token, header_token) unless cask_token == header_token
     cask_class.new(cask_token, sourcefile_path: path, &block)
   end

--- a/Library/Homebrew/cask/test/cask/dsl_test.rb
+++ b/Library/Homebrew/cask/test/cask/dsl_test.rb
@@ -62,6 +62,15 @@ describe Hbc::DSL do
 
     it "does not require a DSL version in the header" do
       test_cask = Hbc.load("no-dsl-version")
+      test_cask.token.must_equal "no-dsl-version"
+      test_cask.url.to_s.must_equal "http://example.com/TestCask.dmg"
+      test_cask.homepage.must_equal "http://example.com/"
+      test_cask.version.to_s.must_equal "1.2.3"
+    end
+
+    it "may use deprecated DSL version hash syntax" do
+      test_cask = Hbc.load("with-dsl-version")
+      test_cask.token.must_equal "with-dsl-version"
       test_cask.url.to_s.must_equal "http://example.com/TestCask.dmg"
       test_cask.homepage.must_equal "http://example.com/"
       test_cask.version.to_s.must_equal "1.2.3"

--- a/Library/Homebrew/cask/test/support/Casks/with-dsl-version.rb
+++ b/Library/Homebrew/cask/test/support/Casks/with-dsl-version.rb
@@ -1,0 +1,9 @@
+test_cask :v1 => 'with-dsl-version' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url 'http://example.com/TestCask.dmg'
+  homepage 'http://example.com/'
+
+  app 'TestCask.app'
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Closes https://github.com/caskroom/homebrew-cask/issues/23879.

Now that `brew cask uninstall` uses the Cask definition that was saved upon installation of the Cask rather than the latest version of the definition, we've seen issues like https://github.com/caskroom/homebrew-cask/issues/23869 and https://github.com/caskroom/homebrew-cask/issues/24174 where a user attempts to uninstall a Cask that was installed before the header syntax changed, and we spit out an error. This PR simply allows us to parse the old syntax without complaining to the user that we've changed our internals since they last installed a particular Cask.