### PR TITLE
Don't reject -L/usr/local/lib when SDKROOT is defined

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -279,7 +279,9 @@ class Cmd
   end
 
   def system_library_paths
-    %W[#{sysroot}/usr/lib /usr/local/lib]
+    paths = ["#{sysroot}/usr/lib"]
+    paths << "/usr/local/lib" unless sysroot || ENV["SDKROOT"]
+    paths
   end
 
   def configure?


### PR DESCRIPTION
/usr/local/lib is removed from the default linker search path when
SDKROOT is defined or sysroot is specified.

Homebrew sometimes sets SDKROOT without setting a sysroot as of 45e138f.

This is the simplest possible change, but there are some other options:
* Modify effective_sysroot so that HOMEBREW_SDKROOT gets set identically; maybe @ilovezfs knows why this wasn't done originally?
* Add an additional accessor for SDKROOT
* ?

Fixes #844.