### PR TITLE
formula: pinned keg is not eligible for cleanup

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1611,6 +1611,8 @@ class Formula
         eligible_kegs.each do |keg|
           if keg.linked?
             opoo "Skipping (old) #{keg} due to it being linked"
+          elsif pinned? && keg == Keg.new(@pin.path.resolved_path)
+            opoo "Skipping (old) #{keg} due to it being pinned"
           else
             eligible_for_cleanup << keg
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [WIP] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If formula is pinned it shouldn't be eligible for cleanup.
Otherwise we can encounter the following behaviour:

1. Install <formula>
2. Pin <formula>
3. <formula> gets outdated
4. Install <other_formula> that depends on <formula>, which requires
up-to-date installation of <formula>. Thus, <formula> gets updated.
5. Now, if we cleanup <formula> we don't remove pin, so it points to
the keg which doesn't exist any longer. The right behaviour is not
to cleanup pinned kegs, which is done in this commit.

Also see #831 for further info.

=======

How does this look?
Also, I can come up with different behaviour.

E.g. we can _warn and not allow to install formula_ if it depends on outdated formula that is pinned. Or we can repin pinned formula if it eventually gets upgraded by its dependent.

CC @ilovezfs.