### PR TITLE
brew.sh: allow cask to be run as root.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -203,6 +203,7 @@ check-run-command-as-root() {
   [[ "$(id -u)" = 0 ]] || return
   export HOMEBREW_NO_SANDBOX="1"
 
+  [[ "$HOMEBREW_COMMAND" = "cask" ]] && return
   [[ "$HOMEBREW_COMMAND" = "services" ]] && return
 
   onoe <<EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It also uses `sudo` for legitimate things e.g. installing `.pkg`s systemwide.