### PR TITLE
utils: fix link_path_manpages message indentation.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -615,7 +615,7 @@ def link_path_manpages(path, command)
   unless conflicts.empty?
     onoe <<-EOS.undent
       Could not link #{name} manpages to:
-        #{conflicts.join("\n")}
+      #{conflicts.join("\n")}
 
       Please delete these files and run `#{command}`.
     EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise looks weird with multiple items.