### PR TITLE
bottle: fix --keep-old JSON generation.

### DIFF
--- a/Library/Homebrew/cmd/bottle.rb
+++ b/Library/Homebrew/cmd/bottle.rb
@@ -279,10 +279,9 @@ module Homebrew
     end
     bottle.rebuild rebuild
     sha256 = bottle_path.sha256
-    bottle.sha256 sha256 => Utils::Bottles.tag
 
-    old_spec = f.bottle_specification
-    if ARGV.include?("--keep-old") && !old_spec.checksums.empty?
+    if ARGV.include?("--keep-old") && !f.bottle_specification.checksums.empty?
+      old_spec = f.bottle_specification
       bad_fields = [:root_url, :prefix, :cellar, :rebuild].select do |field|
         old_spec.send(field) != bottle.send(field)
       end
@@ -291,7 +290,10 @@ module Homebrew
         bottle_path.unlink if bottle_path.exist?
         odie "--keep-old is passed but there are changes in: #{bad_fields.join ", "}"
       end
+      bottle = old_spec
     end
+
+    bottle.sha256 sha256 => Utils::Bottles.tag
 
     output = bottle_output bottle
 
@@ -323,6 +325,19 @@ module Homebrew
           },
         },
       }
+      if ARGV.include?("--keep-old")
+        bottle.checksums.each do |hash_type, checksums|
+          checksums.each do |checksum_hash|
+            checksum_hash.each do |checksum, tag|
+              tag_hash = {}
+              tag_hash["filename"] ||= Bottle::Filename.create(f, tag, rebuild).to_s
+              tag_hash[hash_type.to_s] ||= checksum.hexdigest
+              json[f.full_name]["bottle"]["tags"][tag.to_s] ||= tag_hash
+            end
+          end
+        end
+      end
+
       File.open("#{filename.prefix}.bottle.json", "w") do |file|
         file.write Utils::JSON.dump json
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Ensure that the JSON file contains all the bottle checksums when using `--keep-old`. This avoids having to use the formula DSL when merging and relies on existing integrity checks.

This change does nothing differently if `--keep-old` is not passed.

Will merge this shortly after it's 💚 so I can get `--keep-old` working on @BrewTestBot. Please feel free to review and leave comments anyway, though, so I can address them in a future PR.