### PR TITLE
Save aliases in INSTALL_RECEIPT

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -226,6 +226,11 @@ class Formula
 
   public
 
+  # The path that was specified to find/install this formula.
+  def specified_path
+    alias_path || path
+  end
+
   # Is the currently active {SoftwareSpec} a {#stable} build?
   # @private
   def stable?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -58,6 +58,11 @@ class Formula
   # e.g. `this-formula`
   attr_reader :name
 
+  # The name specified when installing this {Formula}.
+  # Could be the name of the {Formula}, or an alias.
+  # e.g. `another-name-for-this-formula`
+  attr_reader :install_name
+
   # The fully-qualified name of this {Formula}.
   # For core formula it's the same as {#name}.
   # e.g. `homebrew/tap-name/this-formula`
@@ -143,9 +148,10 @@ class Formula
   attr_accessor :build
 
   # @private
-  def initialize(name, path, spec)
+  def initialize(name, path, spec, install_name: name)
     @name = name
     @path = path
+    @install_name = install_name
     @revision = self.class.revision || 0
     @version_scheme = self.class.version_scheme || 0
 
@@ -500,6 +506,21 @@ class Formula
   # @private
   def installed_kegs
     installed_prefixes.map { |dir| Keg.new(dir) }
+  end
+
+  # Formula reference to use to get an identical installation of the formula.
+  #
+  # Usually, the formula's path is a good canonical identifier for the formula.
+  # Just using whatever was passed to `brew install` isn't a good idea, because
+  # if it was e.g. a URL, it could end up being downloaded twice.
+  #
+  # However, if the formula was installed with an alias (i.e. `install_name` is
+  # different from `name`), that should be used instead so that information is
+  # preserved. Aliases are looked up in repositories that have already been
+  # tapped, so we don't have to worry about doing extra HTTP requests, or other
+  # expensive operations, when looking them up again.
+  def install_ref
+    install_name == name ? path : install_name
   end
 
   # The directory where the formula's binaries should be installed.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -61,7 +61,7 @@ class Formula
   # The name specified when installing this {Formula}.
   # Could be the name of the {Formula}, or an alias.
   # e.g. `another-name-for-this-formula`
-  attr_reader :install_name
+  attr_reader :alias_path
 
   # The fully-qualified name of this {Formula}.
   # For core formula it's the same as {#name}.
@@ -148,10 +148,10 @@ class Formula
   attr_accessor :build
 
   # @private
-  def initialize(name, path, spec, install_name: name)
+  def initialize(name, path, spec, alias_path: nil)
     @name = name
     @path = path
-    @install_name = install_name
+    @alias_path = alias_path
     @revision = self.class.revision || 0
     @version_scheme = self.class.version_scheme || 0
 
@@ -506,21 +506,6 @@ class Formula
   # @private
   def installed_kegs
     installed_prefixes.map { |dir| Keg.new(dir) }
-  end
-
-  # Formula reference to use to get an identical installation of the formula.
-  #
-  # Usually, the formula's path is a good canonical identifier for the formula.
-  # Just using whatever was passed to `brew install` isn't a good idea, because
-  # if it was e.g. a URL, it could end up being downloaded twice.
-  #
-  # However, if the formula was installed with an alias (i.e. `install_name` is
-  # different from `name`), that should be used instead so that information is
-  # preserved. Aliases are looked up in repositories that have already been
-  # tapped, so we don't have to worry about doing extra HTTP requests, or other
-  # expensive operations, when looking them up again.
-  def install_ref
-    install_name == name ? path : install_name
   end
 
   # The directory where the formula's binaries should be installed.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -589,7 +589,7 @@ class FormulaInstaller
       -I #{HOMEBREW_LOAD_PATH}
       --
       #{HOMEBREW_LIBRARY_PATH}/build.rb
-      #{formula.path}
+      #{formula.install_ref}
     ].concat(build_argv)
 
     Sandbox.print_sandbox_message if Sandbox.formula?(formula)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -589,7 +589,7 @@ class FormulaInstaller
       -I #{HOMEBREW_LOAD_PATH}
       --
       #{HOMEBREW_LIBRARY_PATH}/build.rb
-      #{formula.alias_path || formula.path}
+      #{formula.specified_path}
     ].concat(build_argv)
 
     Sandbox.print_sandbox_message if Sandbox.formula?(formula)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -589,7 +589,7 @@ class FormulaInstaller
       -I #{HOMEBREW_LOAD_PATH}
       --
       #{HOMEBREW_LIBRARY_PATH}/build.rb
-      #{formula.install_ref}
+      #{formula.alias_path || formula.path}
     ].concat(build_argv)
 
     Sandbox.print_sandbox_message if Sandbox.formula?(formula)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -79,7 +79,7 @@ class Formulary
 
     # Gets the formula instance.
     def get_formula(spec)
-      klass.new(name, path, spec, install_name: install_name)
+      klass.new(name, path, spec, :install_name => install_name)
     end
 
     def klass

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -69,17 +69,16 @@ class Formulary
     # The formula's ruby file's path or filename
     attr_reader :path
     # The name used to install the formula
-    attr_reader :install_name
+    attr_reader :alias_path
 
     def initialize(name, path)
       @name = name
       @path = path.resolved_path
-      @install_name = name
     end
 
     # Gets the formula instance.
     def get_formula(spec)
-      klass.new(name, path, spec, :install_name => install_name)
+      klass.new(name, path, spec, :alias_path => alias_path)
     end
 
     def klass
@@ -121,7 +120,7 @@ class Formulary
       path = alias_path.resolved_path
       name = path.basename(".rb").to_s
       super name, path
-      @install_name = alias_path.basename.to_s
+      @alias_path = alias_path
     end
   end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -68,15 +68,18 @@ class Formulary
     attr_reader :name
     # The formula's ruby file's path or filename
     attr_reader :path
+    # The name used to install the formula
+    attr_reader :install_name
 
     def initialize(name, path)
       @name = name
       @path = path.resolved_path
+      @install_name = name
     end
 
     # Gets the formula instance.
     def get_formula(spec)
-      klass.new(name, path, spec)
+      klass.new(name, path, spec, install_name: install_name)
     end
 
     def klass
@@ -118,6 +121,7 @@ class Formulary
       path = alias_path.resolved_path
       name = path.basename(".rb").to_s
       super name, path
+      @install_name = alias_path.basename.to_s
     end
   end
 

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -298,7 +298,7 @@ class Tab < OpenStruct
       "time" => time,
       "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,
-      "alias_path" => alias_path && alias_path.to_s,
+      "alias_path" => (alias_path.to_s if alias_path),
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),
       "source" => source

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -27,7 +27,7 @@ class Tab < OpenStruct
       "time" => Time.now.to_i,
       "source_modified_time" => formula.source_modified_time.to_i,
       "HEAD" => HOMEBREW_REPOSITORY.git_head,
-      "install_name" => formula.install_name,
+      "alias_path" => formula.alias_path.to_s,
       "compiler" => compiler,
       "stdlib" => stdlib,
       "source" => {
@@ -162,7 +162,7 @@ class Tab < OpenStruct
       "time" => nil,
       "source_modified_time" => 0,
       "HEAD" => nil,
-      "install_name" => nil,
+      "alias_path" => nil,
       "stdlib" => nil,
       "compiler" => DevelopmentTools.default_compiler,
       "source" => {
@@ -294,7 +294,7 @@ class Tab < OpenStruct
       "time" => time,
       "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,
-      "install_name" => install_name,
+      "alias_path" => alias_path,
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),
       "source" => source

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -27,11 +27,10 @@ class Tab < OpenStruct
       "time" => Time.now.to_i,
       "source_modified_time" => formula.source_modified_time.to_i,
       "HEAD" => HOMEBREW_REPOSITORY.git_head,
-      "alias_path" => formula.alias_path.to_s,
       "compiler" => compiler,
       "stdlib" => stdlib,
       "source" => {
-        "path" => formula.path.to_s,
+        "path" => formula.specified_path.to_s,
         "tap" => formula.tap ? formula.tap.name : nil,
         "spec" => formula.active_spec_sym.to_s,
         "versions" => {
@@ -55,10 +54,6 @@ class Tab < OpenStruct
     attributes["tabfile"] = path
     attributes["source_modified_time"] ||= 0
     attributes["source"] ||= {}
-
-    if alias_path = attributes["alias_path"]
-      attributes["alias_path"] = Pathname.new(alias_path)
-    end
 
     tapped_from = attributes["tapped_from"]
     unless tapped_from.nil? || tapped_from == "path or URL"
@@ -142,7 +137,7 @@ class Tab < OpenStruct
       tab = empty
       tab.unused_options = f.options.as_flags
       tab.source = {
-        "path" => f.path.to_s,
+        "path" => f.specified_path.to_s,
         "tap" => f.tap ? f.tap.name : f.tap,
         "spec" => f.active_spec_sym.to_s,
         "versions" => {
@@ -166,7 +161,6 @@ class Tab < OpenStruct
       "time" => nil,
       "source_modified_time" => 0,
       "HEAD" => nil,
-      "alias_path" => nil,
       "stdlib" => nil,
       "compiler" => DevelopmentTools.default_compiler,
       "source" => {
@@ -298,7 +292,6 @@ class Tab < OpenStruct
       "time" => time,
       "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,
-      "alias_path" => (alias_path.to_s if alias_path),
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),
       "source" => source

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -56,6 +56,10 @@ class Tab < OpenStruct
     attributes["source_modified_time"] ||= 0
     attributes["source"] ||= {}
 
+    if alias_path = attributes["alias_path"]
+      attributes["alias_path"] = Pathname.new(alias_path)
+    end
+
     tapped_from = attributes["tapped_from"]
     unless tapped_from.nil? || tapped_from == "path or URL"
       attributes["source"]["tap"] = attributes.delete("tapped_from")
@@ -294,7 +298,7 @@ class Tab < OpenStruct
       "time" => time,
       "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,
-      "alias_path" => alias_path,
+      "alias_path" => alias_path && alias_path.to_s,
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),
       "source" => source

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -27,6 +27,7 @@ class Tab < OpenStruct
       "time" => Time.now.to_i,
       "source_modified_time" => formula.source_modified_time.to_i,
       "HEAD" => HOMEBREW_REPOSITORY.git_head,
+      "install_name" => formula.install_name,
       "compiler" => compiler,
       "stdlib" => stdlib,
       "source" => {
@@ -161,6 +162,7 @@ class Tab < OpenStruct
       "time" => nil,
       "source_modified_time" => 0,
       "HEAD" => nil,
+      "install_name" => nil,
       "stdlib" => nil,
       "compiler" => DevelopmentTools.default_compiler,
       "source" => {
@@ -292,6 +294,7 @@ class Tab < OpenStruct
       "time" => time,
       "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,
+      "install_name" => install_name,
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),
       "source" => source

--- a/Library/Homebrew/test/fixtures/receipt.json
+++ b/Library/Homebrew/test/fixtures/receipt.json
@@ -11,7 +11,7 @@
   "poured_from_bottle": true,
   "time": 1403827774,
   "HEAD": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-  "install_name": "test-formula",
+  "alias_path": "test-formula",
   "stdlib": "libcxx",
   "compiler": "clang",
   "source": {

--- a/Library/Homebrew/test/fixtures/receipt.json
+++ b/Library/Homebrew/test/fixtures/receipt.json
@@ -11,6 +11,7 @@
   "poured_from_bottle": true,
   "time": 1403827774,
   "HEAD": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+  "install_name": "test-formula",
   "stdlib": "libcxx",
   "compiler": "clang",
   "source": {

--- a/Library/Homebrew/test/fixtures/receipt.json
+++ b/Library/Homebrew/test/fixtures/receipt.json
@@ -11,7 +11,7 @@
   "poured_from_bottle": true,
   "time": 1403827774,
   "HEAD": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
-  "alias_path": "test-formula",
+  "alias_path": "/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/test-formula",
   "stdlib": "libcxx",
   "compiler": "clang",
   "source": {

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -8,11 +8,28 @@ class FormulaTests < Homebrew::TestCase
     name = "formula_name"
     path = Formulary.core_path(name)
     spec = :stable
+    install_name = "formula_alias"
 
-    f = klass.new(name, path, spec)
+    f = klass.new(name, path, spec, install_name: install_name)
     assert_equal name, f.name
     assert_equal path, f.path
+    assert_equal install_name, f.install_name
     assert_raises(ArgumentError) { klass.new }
+  end
+
+  def test_install_ref_with_alias
+    name = "formula_name"
+    path = Formulary.core_path(name)
+    spec = :stable
+    install_name = "formula_alias"
+
+    f = Testball.new(name, path, spec, install_name: install_name)
+    assert_equal f.install_name, f.install_ref
+  end
+
+  def test_install_ref_with_non_alias
+    f = Testball.new
+    assert_equal f.path, f.install_ref
   end
 
   def test_prefix

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -8,28 +8,13 @@ class FormulaTests < Homebrew::TestCase
     name = "formula_name"
     path = Formulary.core_path(name)
     spec = :stable
-    install_name = "formula_alias"
+    alias_path = "formula_alias"
 
-    f = klass.new(name, path, spec, :install_name => install_name)
+    f = klass.new(name, path, spec, :alias_path => alias_path)
     assert_equal name, f.name
     assert_equal path, f.path
-    assert_equal install_name, f.install_name
+    assert_equal alias_path, f.alias_path
     assert_raises(ArgumentError) { klass.new }
-  end
-
-  def test_install_ref_with_alias
-    name = "formula_name"
-    path = Formulary.core_path(name)
-    spec = :stable
-    install_name = "formula_alias"
-
-    f = Testball.new(name, path, spec, :install_name => install_name)
-    assert_equal f.install_name, f.install_ref
-  end
-
-  def test_install_ref_with_non_alias
-    f = Testball.new
-    assert_equal f.path, f.install_ref
   end
 
   def test_prefix

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -8,7 +8,7 @@ class FormulaTests < Homebrew::TestCase
     name = "formula_name"
     path = Formulary.core_path(name)
     spec = :stable
-    alias_path = "formula_alias"
+    alias_path = CoreTap.instance.alias_dir/"formula_alias"
 
     f = klass.new(name, path, spec, :alias_path => alias_path)
     assert_equal name, f.name

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -10,7 +10,7 @@ class FormulaTests < Homebrew::TestCase
     spec = :stable
     install_name = "formula_alias"
 
-    f = klass.new(name, path, spec, install_name: install_name)
+    f = klass.new(name, path, spec, :install_name => install_name)
     assert_equal name, f.name
     assert_equal path, f.path
     assert_equal install_name, f.install_name
@@ -23,7 +23,7 @@ class FormulaTests < Homebrew::TestCase
     spec = :stable
     install_name = "formula_alias"
 
-    f = Testball.new(name, path, spec, install_name: install_name)
+    f = Testball.new(name, path, spec, :install_name => install_name)
     assert_equal f.install_name, f.install_ref
   end
 

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -86,7 +86,9 @@ class FormularyFactoryTest < Homebrew::TestCase
     alias_dir = CoreTap.instance.alias_dir
     alias_dir.mkpath
     FileUtils.ln_s @path, alias_dir/"foo"
-    assert_kind_of Formula, Formulary.factory("foo")
+    result = Formulary.factory("foo")
+    assert_kind_of Formula, result
+    assert_equal "foo", result.install_name
   ensure
     alias_dir.rmtree
   end

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -85,10 +85,11 @@ class FormularyFactoryTest < Homebrew::TestCase
   def test_factory_from_alias
     alias_dir = CoreTap.instance.alias_dir
     alias_dir.mkpath
-    FileUtils.ln_s @path, alias_dir/"foo"
+    alias_path = alias_dir/"foo"
+    FileUtils.ln_s @path, alias_path
     result = Formulary.factory("foo")
     assert_kind_of Formula, result
-    assert_equal "foo", result.install_name
+    assert_equal alias_path, result.alias_path
   ensure
     alias_dir.rmtree
   end

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -43,9 +43,9 @@ class TabTests < Homebrew::TestCase
     assert_nil tab.stable_version
     assert_nil tab.devel_version
     assert_nil tab.head_version
-    assert_nil tab.alias_path
     assert_equal DevelopmentTools.default_compiler, tab.cxxstdlib.compiler
     assert_nil tab.cxxstdlib.type
+    assert_nil tab.source["path"]
   end
 
   def test_include?
@@ -100,7 +100,7 @@ class TabTests < Homebrew::TestCase
   def test_from_file
     path = Pathname.new(TEST_DIRECTORY).join("fixtures", "receipt.json")
     tab = Tab.from_file(path)
-    alias_path = Pathname.new("/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/test-formula")
+    source_path = "/usr/local/Library/Taps/hombrew/homebrew-core/Formula/foo.rb"
 
     assert_equal @used.sort, tab.used_options.sort
     assert_equal @unused.sort, tab.unused_options.sort
@@ -118,7 +118,7 @@ class TabTests < Homebrew::TestCase
     assert_equal "2.14", tab.stable_version.to_s
     assert_equal "2.15", tab.devel_version.to_s
     assert_equal "HEAD-0000000", tab.head_version.to_s
-    assert_equal alias_path, tab.alias_path
+    assert_equal source_path, tab.source["path"]
   end
 
   def test_to_json
@@ -136,7 +136,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @tab.stable_version, tab.stable_version
     assert_equal @tab.devel_version, tab.devel_version
     assert_equal @tab.head_version, tab.head_version
-    assert_equal @tab.alias_path, tab.alias_path
+    assert_equal @tab.source["path"], tab.source["path"]
   end
 
   def test_remap_deprecated_options

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -121,6 +121,40 @@ class TabTests < Homebrew::TestCase
     assert_equal source_path, tab.source["path"]
   end
 
+  def test_create
+    f = formula { url "foo-1.0" }
+    compiler = DevelopmentTools.default_compiler
+    stdlib = :libcxx
+    tab = Tab.create(f, compiler, stdlib)
+
+    assert_equal f.path.to_s, tab.source["path"]
+  end
+
+  def test_create_from_alias
+    alias_path = CoreTap.instance.alias_dir/"bar"
+    f = formula(:alias_path => alias_path) { url "foo-1.0" }
+    compiler = DevelopmentTools.default_compiler
+    stdlib = :libcxx
+    tab = Tab.create(f, compiler, stdlib)
+
+    assert_equal f.alias_path.to_s, tab.source["path"]
+  end
+
+  def test_for_formula
+    f = formula { url "foo-1.0" }
+    tab = Tab.for_formula(f)
+
+    assert_equal f.path.to_s, tab.source["path"]
+  end
+
+  def test_for_formula_from_alias
+    alias_path = CoreTap.instance.alias_dir/"bar"
+    f = formula(:alias_path => alias_path) { url "foo-1.0" }
+    tab = Tab.for_formula(f)
+
+    assert_equal alias_path.to_s, tab.source["path"]
+  end
+
   def test_to_json
     tab = Tab.new(Utils::JSON.load(@tab.to_json))
     assert_equal @tab.used_options.sort, tab.used_options.sort

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -100,6 +100,7 @@ class TabTests < Homebrew::TestCase
   def test_from_file
     path = Pathname.new(TEST_DIRECTORY).join("fixtures", "receipt.json")
     tab = Tab.from_file(path)
+    alias_path = Pathname.new("/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/test-formula")
 
     assert_equal @used.sort, tab.used_options.sort
     assert_equal @unused.sort, tab.unused_options.sort
@@ -117,7 +118,7 @@ class TabTests < Homebrew::TestCase
     assert_equal "2.14", tab.stable_version.to_s
     assert_equal "2.15", tab.devel_version.to_s
     assert_equal "HEAD-0000000", tab.head_version.to_s
-    assert_equal "test-formula", tab.alias_path
+    assert_equal alias_path, tab.alias_path
   end
 
   def test_to_json

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -43,6 +43,7 @@ class TabTests < Homebrew::TestCase
     assert_nil tab.stable_version
     assert_nil tab.devel_version
     assert_nil tab.head_version
+    assert_nil tab.install_name
     assert_equal DevelopmentTools.default_compiler, tab.cxxstdlib.compiler
     assert_nil tab.cxxstdlib.type
   end
@@ -116,6 +117,7 @@ class TabTests < Homebrew::TestCase
     assert_equal "2.14", tab.stable_version.to_s
     assert_equal "2.15", tab.devel_version.to_s
     assert_equal "HEAD-0000000", tab.head_version.to_s
+    assert_equal "test-formula", tab.install_name
   end
 
   def test_to_json
@@ -133,6 +135,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @tab.stable_version, tab.stable_version
     assert_equal @tab.devel_version, tab.devel_version
     assert_equal @tab.head_version, tab.head_version
+    assert_equal @tab.install_name, tab.install_name
   end
 
   def test_remap_deprecated_options

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -43,7 +43,7 @@ class TabTests < Homebrew::TestCase
     assert_nil tab.stable_version
     assert_nil tab.devel_version
     assert_nil tab.head_version
-    assert_nil tab.install_name
+    assert_nil tab.alias_path
     assert_equal DevelopmentTools.default_compiler, tab.cxxstdlib.compiler
     assert_nil tab.cxxstdlib.type
   end
@@ -117,7 +117,7 @@ class TabTests < Homebrew::TestCase
     assert_equal "2.14", tab.stable_version.to_s
     assert_equal "2.15", tab.devel_version.to_s
     assert_equal "HEAD-0000000", tab.head_version.to_s
-    assert_equal "test-formula", tab.install_name
+    assert_equal "test-formula", tab.alias_path
   end
 
   def test_to_json
@@ -135,7 +135,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @tab.stable_version, tab.stable_version
     assert_equal @tab.devel_version, tab.devel_version
     assert_equal @tab.head_version, tab.head_version
-    assert_equal @tab.install_name, tab.install_name
+    assert_equal @tab.alias_path, tab.alias_path
   end
 
   def test_remap_deprecated_options

--- a/Library/Homebrew/test/testball.rb
+++ b/Library/Homebrew/test/testball.rb
@@ -1,5 +1,5 @@
 class Testball < Formula
-  def initialize(name = "testball", path = Pathname.new(__FILE__).expand_path, spec = :stable, install_name: name)
+  def initialize(name = "testball", path = Pathname.new(__FILE__).expand_path, spec = :stable, alias_path: nil)
     self.class.instance_eval do
       stable.url "file://#{File.expand_path("..", __FILE__)}/tarballs/testball-0.1.tbz"
       stable.sha256 TESTBALL_SHA256

--- a/Library/Homebrew/test/testball.rb
+++ b/Library/Homebrew/test/testball.rb
@@ -1,5 +1,5 @@
 class Testball < Formula
-  def initialize(name = "testball", path = Pathname.new(__FILE__).expand_path, spec = :stable)
+  def initialize(name = "testball", path = Pathname.new(__FILE__).expand_path, spec = :stable, install_name: name)
     self.class.instance_eval do
       stable.url "file://#{File.expand_path("..", __FILE__)}/tarballs/testball-0.1.tbz"
       stable.sha256 TESTBALL_SHA256

--- a/Library/Homebrew/test/testball_bottle.rb
+++ b/Library/Homebrew/test/testball_bottle.rb
@@ -1,5 +1,5 @@
 class TestballBottle < Formula
-  def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable, install_name: name)
+  def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable, alias_path: nil)
     self.class.instance_eval do
       stable.url "file://#{File.expand_path("..", __FILE__)}/tarballs/testball-0.1.tbz"
       stable.sha256 TESTBALL_SHA256

--- a/Library/Homebrew/test/testball_bottle.rb
+++ b/Library/Homebrew/test/testball_bottle.rb
@@ -1,5 +1,5 @@
 class TestballBottle < Formula
-  def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable)
+  def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable, install_name: name)
     self.class.instance_eval do
       stable.url "file://#{File.expand_path("..", __FILE__)}/tarballs/testball-0.1.tbz"
       stable.sha256 TESTBALL_SHA256

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -72,8 +72,8 @@ module Homebrew
     TEST_SHA1   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
     TEST_SHA256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
 
-    def formula(name = "formula_name", path = Formulary.core_path(name), spec = :stable, &block)
-      @_f = Class.new(Formula, &block).new(name, path, spec)
+    def formula(name = "formula_name", path = Formulary.core_path(name), spec = :stable, alias_path: nil, &block)
+      @_f = Class.new(Formula, &block).new(name, path, spec, :alias_path => alias_path)
     end
 
     def mktmpdir(prefix_suffix = nil, &block)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is part of #567 (but not all of it ⏤ I wanted to PR this bit so that I could get feedback since I haven't worked with this codebase before).

This PR adds an `install_name` key to INSTALL_RECEIPT. Usually this will just be set to the name of the formula, but if it was installed as an alias, the `install_name` will be set to the alias instead.

Implementation-wise, I wasn't sure about how best to set the `install_name` on a `Formula` instance (which seemed like the only appropriate place to store it). I thought the best way would probably be a keyword argument, but it could also be a standard optional argument, or an `attr_accessor`. I'm open to suggestions if there's a better way.