### PR TITLE
Skip upgrade of pinned dependency if it's outdated

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -8,7 +8,13 @@ module Homebrew
   def reinstall
     FormulaInstaller.prevent_build_flags unless DevelopmentTools.installed?
 
-    ARGV.resolved_formulae.each { |f| reinstall_formula(f) }
+    ARGV.resolved_formulae.each do |f|
+      if f.pinned?
+        onoe "#{f.full_name} is pinned. You must unpin it to reinstall."
+        next
+      end
+      reinstall_formula(f)
+    end
   end
 
   def reinstall_formula(f)

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -531,6 +531,18 @@ class IntegrationCommandTests < Homebrew::TestCase
     assert foo_dir.exist?
   end
 
+  def test_reinstall_pinned
+    setup_test_formula "testball"
+
+    HOMEBREW_CELLAR.join("testball/0.1").mkpath
+    HOMEBREW_LIBRARY.join("PinnedKegs").mkpath
+    FileUtils.ln_s HOMEBREW_CELLAR.join("testball/0.1"), HOMEBREW_LIBRARY.join("PinnedKegs/testball")
+
+    assert_match "testball is pinned. You must unpin it to reinstall.", cmd("reinstall", "testball")
+
+    HOMEBREW_LIBRARY.join("PinnedKegs").rmtree
+  end
+
   def test_home
     setup_test_formula "testball"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Description:
====

A fix for #831 was introduced in #846 but the behaviour of install process should have been reconsidered anyway. This PR implements the ideas being discussed in #846.

_Idea:_ Don't upgrade dependency of formula if this dependency is pinned while installing the formula.

```
Let's suppose A depends on B and then do the following:
      * install B with version 0.1.
      * pin B with version 0.1.
      * bump new version of B, e.g. 1.0
      * install A

    B shouldn't get upgraded while we installing A if it's pinned and
    installed with the proper options. This commit implements such
    behaviour.
```

TODO?
======

I'm not sure about two things here:

1. Do I need to add a test for the change. And if we need a test, then where should I put it. Possible variants are `test_integration_cmds`, `test_formula_installer` or `test_dependency`?

2. Do we need to `repin` formula `B` if it's pinned and installation of `A` that depends on `B` requires different options from ones being used in pinned keg of `B`, so we eventually upgrade/reinstall `B`, but don't repin it.

CC @MikeMcQuaid @ilovezfs 