### PR TITLE
Catch system libressl in openssl audit as well

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -29,13 +29,14 @@ module FormulaCellarChecks
     keg = Keg.new(formula.prefix)
     system_openssl = keg.mach_o_files.select do |obj|
       dlls = obj.dynamically_linked_libraries
-      dlls.any? { |dll| %r{/usr/lib/lib(crypto|ssl)\..*dylib}.match dll }
+      dlls.any? { |dll| %r{/usr/lib/lib(crypto|ssl|tls)\..*dylib}.match dll }
     end
     return if system_openssl.empty?
 
     <<-EOS.undent
       object files were linked against system openssl
-      These object files were linked against the deprecated system OpenSSL.
+      These object files were linked against the deprecated system OpenSSL or
+      the system's private LibreSSL.
       Adding `depends_on "openssl"` to the formula may help.
         #{system_openssl * "\n        "}
     EOS

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -29,7 +29,7 @@ module FormulaCellarChecks
     keg = Keg.new(formula.prefix)
     system_openssl = keg.mach_o_files.select do |obj|
       dlls = obj.dynamically_linked_libraries
-      dlls.any? { |dll| %r{/usr/lib/lib(crypto|ssl)\.(\d\.)*dylib}.match dll }
+      dlls.any? { |dll| %r{/usr/lib/lib(crypto|ssl)\..*dylib}.match dll }
     end
     return if system_openssl.empty?
 


### PR DESCRIPTION
The regex didn't match libcrypto.35.dylib, and it should have.