### PR TITLE
test-bot: use UPSTREAM_BOTTLE_KEEP_OLD.

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -857,7 +857,11 @@ module Homebrew
       safe_system "brew", "pull", "--clean", pull_pr
     end
 
-    system "brew", "bottle", "--merge", "--write", *json_files
+    if ENV["UPSTREAM_BOTTLE_KEEP_OLD"]
+      system "brew", "bottle", "--merge", "--write", "--keep-old", *json_files
+    else
+      system "brew", "bottle", "--merge", "--write", *json_files
+    end
 
     remote = "git@github.com:BrewTestBot/homebrew-#{tap.repo}.git"
     git_tag = pr ? "pr-#{pr}" : "testing-#{number}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is set by Jenkins to indicate a downstream bottle upload job needs to use `brew bottle --keep-old`.