### PR TITLE
test-bot: put exception, retry on missing formula.

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -247,11 +247,13 @@ module Homebrew
 
     def safe_formula_canonical_name(formula_name)
       Formulary.factory(formula_name).full_name
-    rescue TapFormulaUnavailableError => e
+    rescue TapFormulaUnavailableError, FormulaUnavailableError => e
       raise if e.tap.installed?
       test "brew", "tap", e.tap.name
       retry unless steps.last.failed?
-    rescue FormulaUnavailableError, TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError => e
+      onoe e
+      puts e.backtrace
+    rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError => e
       onoe e
       puts e.backtrace
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This will be useful in debugging (and recovering from) the situation where sometimes formulae can't be found when specifying multiple on the command-line.