### PR TITLE
test-bot: handle missing tap in exception.

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -248,8 +248,9 @@ module Homebrew
     def safe_formula_canonical_name(formula_name)
       Formulary.factory(formula_name).full_name
     rescue TapFormulaUnavailableError, FormulaUnavailableError => e
-      raise if e.tap.installed?
-      test "brew", "tap", e.tap.name
+      exception_tap = e.tap || CoreTap.instance
+      raise if exception_tap.installed?
+      test "brew", "tap", exception_tap.name
       retry unless steps.last.failed?
       onoe e
       puts e.backtrace


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Handle the case where a `FormulaUnavailableError` does not contain a tap reference so fall back to `CoreTap` in this case.