### PR TITLE
Don't require/recommend ownership of /usr/local.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -341,12 +341,13 @@ EOS
   fi
 
   # check permissions
-  if [[ "$HOMEBREW_PREFIX" = "/usr/local" && ! -w /usr/local ]]
+  if [[ -e "$HOMEBREW_CELLAR" && ! -w "$HOMEBREW_CELLAR" ]]
   then
     odie <<EOS
-/usr/local is not writable. You should change the ownership
-and permissions of /usr/local back to your user account:
-  sudo chown -R \$(whoami) /usr/local
+$HOMEBREW_CELLAR is not writable. You should change the
+ownership and permissions of $HOMEBREW_CELLAR back to your
+user account:
+  sudo chown -R \$(whoami) $HOMEBREW_CELLAR
 EOS
   fi
 

--- a/share/doc/homebrew/Troubleshooting.md
+++ b/share/doc/homebrew/Troubleshooting.md
@@ -13,7 +13,7 @@ brew gist-logs <formula>
 * Read through the [Common Issues](Common-Issues.md).
 * If you’re installing something Java-related, maybe you need to install Java (`brew cask install java`)?
 * Check that **Command Line Tools for Xcode (CLT)** and/or **Xcode** are up to date.
-* If things fail with permissions errors, check the permissions in `/usr/local`. If you’re unsure what to do, you can `sudo chown -R $(whoami) /usr/local`.
+* If things fail with permissions errors, check the permissions of `/usr/local`'s subdirectories. If you’re unsure what to do, you can `cd /usr/local && sudo chown -R $(whoami) bin etc include lib sbin share var Frameworks`.
 
 ## Check to see if the issue has been reported
 * Check the [issue tracker](https://github.com/Homebrew/homebrew-core/issues) to see if someone else has already reported the same issue.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Apple reset this on every OS X major (and some minor) updates and it always proves a painful and unnecessary step. Instead just check the directories we actually care about are writable.

This may mean if these directories do not already exist (although they are now created by the installed) that `brew link` will fail and require manual intervention but this seems to be superior for both new and the majority of existing users.