### PR TITLE
Add language method to `OS::Mac`.

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -41,6 +41,10 @@ module OS
       version.to_sym
     end
 
+    def language
+      @language ||= Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").delete(" \n\"()").sub(/,.*/, "")
+    end
+
     # Locates a (working) copy of install_name_tool, guaranteed to function
     # whether the user has developer tools installed or not.
     def install_name_tool

--- a/Library/Homebrew/test/test_os_mac_language.rb
+++ b/Library/Homebrew/test/test_os_mac_language.rb
@@ -1,0 +1,8 @@
+require "testing_env"
+require "os/mac"
+
+class OSMacLanguageTests < Homebrew::TestCase
+  def test_language_format
+    assert_match %r{\A[a-z]{2}(-[A-Z]{2})?\Z}, OS::Mac.language
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a `language` method to the `MacOS` module, to be used in casks, such as https://github.com/caskroom/homebrew-cask/pull/24343.

cc @Homebrew/cask 