### PR TITLE
completion: Avoid aliases with `command ls`

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -52,7 +52,7 @@ __brew_complete_formulae() {
 
 __brew_complete_installed() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local inst="$(ls "$(brew --cellar)")"
+  local inst="$(command ls "$(brew --cellar)" 2>/dev/null)"
   COMPREPLY=($(compgen -W "$inst" -- "$cur"))
 }
 
@@ -71,7 +71,7 @@ __brew_complete_versions() {
 
 __brew_complete_logs() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local logs="$(ls "${HOMEBREW_LOGS:-~/Library/Logs/Homebrew/}")"
+  local logs="$(command ls "${HOMEBREW_LOGS:-${HOME}/Library/Logs/Homebrew/}" 2>/dev/null)"
   COMPREPLY=($(compgen -W "$logs" -- "$cur"))
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

I haven't written new tests because there aren't really any tests for the bash completion. Additionally, when running `brew tests`, several tests fail with this error:
```
git config --file=/tmp/homebrew-tests-20160909-38939-rk5nwv/prefix/.git/config --replace-all homebrew.devcmdrun true
error: could not lock config file /tmp/homebrew-tests-20160909-38939-rk5nwv/prefix/.git/config: No such file or directory
```
The same tests fail without my changes, though. I'm not sure what that issue is.

-----

If the user has an alias overriding the `ls` command that modifies the output (e.g. `alias ls='ls -F'`), it will cause unexpected characters to appear in completions. Using `command ls` forces the shell to use the command directly, without alias expansion.

This also blackholes the stderr of `ls` in the `__brew_complete_logs` function to avoid printing  errors during completion if the Homebrew logs directory does not exist.