### PR TITLE
Make `MacOS.language` less opinionated and add `language` stanza.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/auditor.rb
+++ b/Library/Homebrew/cask/lib/hbc/auditor.rb
@@ -4,10 +4,9 @@ module Hbc
       saved_languages = MacOS.instance_variable_get(:@languages)
 
       if languages_blocks = cask.instance_variable_get(:@dsl).instance_variable_get(:@language_blocks)
-        languages_blocks.keys.map(&:first).each do |language|
-          ohai "Auditing language #{language.to_s}"
-          language = "en-US" if language == :default
-          MacOS.instance_variable_set(:@languages, [language])
+        languages_blocks.keys.each do |languages|
+          ohai "Auditing language: #{languages.map { |lang| "'#{lang}'" }.join(", ")}"
+          MacOS.instance_variable_set(:@languages, languages)
           audit_cask_instance(Hbc.load(cask.sourcefile_path), audit_download, check_token_conflicts)
           CLI::Cleanup.run(cask.token) if audit_download
         end

--- a/Library/Homebrew/cask/lib/hbc/auditor.rb
+++ b/Library/Homebrew/cask/lib/hbc/auditor.rb
@@ -1,6 +1,24 @@
 module Hbc
   class Auditor
     def self.audit(cask, audit_download: false, check_token_conflicts: false)
+      saved_languages = MacOS.instance_variable_get(:@languages)
+
+      if languages_blocks = cask.instance_variable_get(:@dsl).instance_variable_get(:@language_blocks)
+        languages_blocks.keys.map(&:first).each do |language|
+          ohai "Auditing language #{language.to_s}"
+          language = "en-US" if language == :default
+          MacOS.instance_variable_set(:@languages, [language])
+          audit_cask_instance(Hbc.load(cask.sourcefile_path), audit_download, check_token_conflicts)
+          CLI::Cleanup.run(cask.token) if audit_download
+        end
+      else
+        audit_cask_instance(cask, audit_download, check_token_conflicts)
+      end
+    ensure
+      MacOS.instance_variable_set(:@languages, saved_languages)
+    end
+
+    def self.audit_cask_instance(cask, audit_download, check_token_conflicts)
       download = audit_download && Download.new(cask)
       audit = Audit.new(cask, download:              download,
                               check_token_conflicts: check_token_conflicts)

--- a/Library/Homebrew/cask/lib/hbc/cask.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask.rb
@@ -11,7 +11,10 @@ module Hbc
       @token = token
       @sourcefile_path = sourcefile_path
       @dsl = dsl || DSL.new(@token)
-      @dsl.instance_eval(&block) if block_given?
+      if block_given?
+        @dsl.instance_eval(&block)
+        @dsl.language_eval
+      end
     end
 
     DSL::DSL_METHODS.each do |method_name|

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -179,6 +179,10 @@ module Hbc
     def self.parser
       # If you modify these arguments, please update USAGE.md
       @parser ||= OptionParser.new do |opts|
+        opts.on("--language STRING") do
+          # handled in OS::Mac
+        end
+
         OPTIONS.each do |option, method|
           opts.on("#{option}" "PATH", Pathname) do |path|
             Hbc.public_send(method, path)

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -64,6 +64,7 @@ module Hbc
                             :depends_on,
                             :gpg,
                             :homepage,
+                            :language,
                             :license,
                             :name,
                             :sha256,
@@ -96,6 +97,31 @@ module Hbc
     def homepage(homepage = nil)
       assert_only_one_stanza_allowed :homepage, !homepage.nil?
       @homepage ||= homepage
+    end
+
+    def language(*args, &block)
+      @language ||= {}
+
+      if !args.empty? && block_given?
+        args.each do |arg|
+          MacOS.languages.each_with_index do |l, index|
+            string_or_regex = arg == :default ? %r{^en} : arg
+            next unless l.match(string_or_regex)
+            next unless @language[:level].nil? || @language[:level] > index
+            @language = {
+                          block: block,
+                          level: index,
+                        }
+          end
+        end
+
+        if args.include?(:default)
+          # :default has to be the last language block in order to assign return value of the selected `language` block to `@language`
+          @language = @language[:block].call
+        end
+      else
+        @language
+      end
     end
 
     def url(*args, &block)

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -103,8 +103,15 @@ module Hbc
     def language(*args, default: false, &block)
       if !args.empty? && block_given?
         @language_blocks ||= {}
-        @language_blocks.default = block if default
         @language_blocks[args] = block
+
+        return unless default
+
+        unless @language_blocks.default.nil?
+          raise CaskInvalidError.new(token, "Only one default language may be defined")
+        end
+
+        @language_blocks.default = block
       else
         language_eval
         @language

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -103,8 +103,7 @@ module Hbc
       if !args.empty? && block_given?
         args.each do |arg|
           MacOS.languages.each_with_index do |l, index|
-            string_or_regex = arg == :default ? %r{^en} : arg
-            next unless l.match(string_or_regex)
+            next unless arg == :default || l.match(arg)
             next unless @language.nil? || @language[:level].nil? || @language[:level] > index
             @language = {
                           block: block,

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -100,27 +100,28 @@ module Hbc
     end
 
     def language(*args, &block)
-      @language ||= {}
-
       if !args.empty? && block_given?
         args.each do |arg|
           MacOS.languages.each_with_index do |l, index|
             string_or_regex = arg == :default ? %r{^en} : arg
             next unless l.match(string_or_regex)
-            next unless @language[:level].nil? || @language[:level] > index
+            next unless @language.nil? || @language[:level].nil? || @language[:level] > index
             @language = {
                           block: block,
                           level: index,
                         }
           end
         end
-
-        if args.include?(:default)
-          # :default has to be the last language block in order to assign return value of the selected `language` block to `@language`
-          @language = @language[:block].call
-        end
       else
+        language_eval
         @language
+      end
+    end
+
+
+    def language_eval
+      if @language.is_a?(Hash) && @language.key?(:block)
+        @language = @language[:block].call
       end
     end
 

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -114,22 +114,25 @@ module Hbc
         @language_blocks.default = block
       else
         language_eval
-        @language
       end
     end
 
     def language_eval
-      return if instance_variable_defined?(:@language)
+      return @language if instance_variable_defined?(:@language)
 
-      return unless instance_variable_defined?(:@language_blocks)
+      if @language_blocks.nil? || @language_blocks.empty?
+        return @language = nil
+      end
 
-      MacOS.languages.map(&Locale.method(:parse)).any? { |locale|
+      MacOS.languages.map(&Locale.method(:parse)).each do |locale|
         key = @language_blocks.keys.detect { |strings|
           strings.any? { |string| locale.include?(string) }
         }
 
-        return @language = @language_blocks[key].call unless key.nil?
-      }
+        next if key.nil?
+
+        return @language = @language_blocks[key].call
+      end
 
       @language = @language_blocks.default.call
     end

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -122,8 +122,13 @@ module Hbc
             regexes_or_strings = regexes_or_strings - [:default] + [%r{^en}]
           end
 
-          case language
-          when *regexes_or_strings
+          regexes_or_strings.each do |regex_or_string|
+            if regex_or_string.class == language.class
+              next unless regex_or_string == language
+            else
+              next unless regex_or_string =~ language
+            end
+
             @language = block.call
             return
           end

--- a/Library/Homebrew/cask/lib/hbc/dsl/base.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/base.rb
@@ -8,7 +8,7 @@ module Hbc
         @command = command
       end
 
-      def_delegators :@cask, :token, :version, :caskroom_path, :staged_path, :appdir
+      def_delegators :@cask, :token, :version, :caskroom_path, :staged_path, :appdir, :language
 
       def system_command(executable, options = {})
         @command.run!(executable, options)

--- a/Library/Homebrew/cask/spec/locale_spec.rb
+++ b/Library/Homebrew/cask/spec/locale_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+require "locale"
+
+describe Locale do
+  describe "::parse" do
+    it "parses a string in the correct format" do
+      expect(described_class.parse("zh")).to eql(described_class.new("zh", nil, nil))
+      expect(described_class.parse("zh-CN")).to eql(described_class.new("zh", "CN", nil))
+      expect(described_class.parse("zh-Hans")).to eql(described_class.new("zh", nil, "Hans"))
+      expect(described_class.parse("zh-CN-Hans")).to eql(described_class.new("zh", "CN", "Hans"))
+    end
+
+    context "raises a ParserError when given" do
+      it "an empty string" do
+        expect{ described_class.parse("") }.to raise_error(Locale::ParserError)
+      end
+
+      it "a string in a wrong format" do
+        expect { described_class.parse("zh_CN_Hans") }.to raise_error(Locale::ParserError)
+        expect { described_class.parse("zhCNHans") }.to raise_error(Locale::ParserError)
+        expect { described_class.parse("zh-CN_Hans") }.to raise_error(Locale::ParserError)
+        expect { described_class.parse("zhCN") }.to raise_error(Locale::ParserError)
+        expect { described_class.parse("zh_Hans") }.to raise_error(Locale::ParserError)
+      end
+    end
+  end
+
+  describe "::new" do
+    it "raises an ArgumentError when all arguments are nil" do
+      expect { described_class.new(nil, nil, nil) }.to raise_error(ArgumentError)
+    end
+
+    it "raises a ParserError when one of the arguments does not match the locale format" do
+      expect { described_class.new("ZH", nil, nil) }.to raise_error(Locale::ParserError)
+      expect { described_class.new(nil, "cn", nil) }.to raise_error(Locale::ParserError)
+      expect { described_class.new(nil, nil, "hans") }.to raise_error(Locale::ParserError)
+    end
+  end
+
+  subject { described_class.new("zh", "CN", "Hans") }
+
+  describe "#include?" do
+    it { is_expected.to include("zh") }
+    it { is_expected.to include("zh-CN") }
+    it { is_expected.to include("CN") }
+    it { is_expected.to include("CN-Hans") }
+    it { is_expected.to include("Hans") }
+    it { is_expected.to include("zh-CN-Hans") }
+  end
+
+  describe "#eql?" do
+    subject { described_class.new("zh", "CN", "Hans") }
+
+    context "all parts match" do
+      it { is_expected.to eql("zh-CN-Hans") }
+      it { is_expected.to eql(subject) }
+    end
+
+    context "only some parts match" do
+      it { is_expected.to_not eql("zh") }
+      it { is_expected.to_not eql("zh-CN") }
+      it { is_expected.to_not eql("CN") }
+      it { is_expected.to_not eql("CN-Hans") }
+      it { is_expected.to_not eql("Hans") }
+    end
+
+    it "does not raise if 'other' cannot be parsed" do
+      expect { subject.eql?("zh_CN_Hans") }.not_to raise_error
+      expect(subject.eql?("zh_CN_Hans")).to be false
+    end
+  end
+end

--- a/Library/Homebrew/cask/test/cask/dsl_test.rb
+++ b/Library/Homebrew/cask/test/cask/dsl_test.rb
@@ -122,6 +122,39 @@ describe Hbc::DSL do
     end
   end
 
+  describe "language stanza" do
+    after(:each) do
+      ENV["HOMEBREW_LANGUAGES"] = nil
+    end
+
+    it "allows multilingual casks" do
+      cask = lambda {
+        Hbc::Cask.new("cask-with-apps") do
+          language "FIRST_LANGUAGE" do
+            :first
+          end
+
+          language %r{SECOND_LANGUAGE} do
+            :second
+          end
+
+          language :default do
+            :default
+          end
+        end
+      }
+
+      ENV["HOMEBREW_LANGUAGES"] = "FIRST_LANGUAGE"
+      cask.call.language.must_equal :first
+
+      ENV["HOMEBREW_LANGUAGES"] = "SECOND_LANGUAGE"
+      cask.call.language.must_equal :second
+
+      ENV["HOMEBREW_LANGUAGES"] = "THIRD_LANGUAGE"
+      cask.call.language.must_equal :default
+    end
+  end
+
   describe "app stanza" do
     it "allows you to specify app stanzas" do
       cask = Hbc::Cask.new("cask-with-apps") do

--- a/Library/Homebrew/cask/test/cask/dsl_test.rb
+++ b/Library/Homebrew/cask/test/cask/dsl_test.rb
@@ -123,10 +123,6 @@ describe Hbc::DSL do
   end
 
   describe "language stanza" do
-    after(:each) do
-      ENV["HOMEBREW_LANGUAGES"] = nil
-    end
-
     it "allows multilingual casks" do
       cask = lambda {
         Hbc::Cask.new("cask-with-apps") do
@@ -144,13 +140,13 @@ describe Hbc::DSL do
         end
       }
 
-      ENV["HOMEBREW_LANGUAGES"] = "FIRST_LANGUAGE"
+      MacOS.stubs(languages: ["FIRST_LANGUAGE"])
       cask.call.language.must_equal :first
 
-      ENV["HOMEBREW_LANGUAGES"] = "SECOND_LANGUAGE"
+      MacOS.stubs(languages: ["SECOND_LANGUAGE"])
       cask.call.language.must_equal :second
 
-      ENV["HOMEBREW_LANGUAGES"] = "THIRD_LANGUAGE"
+      MacOS.stubs(languages: ["THIRD_LANGUAGE"])
       cask.call.language.must_equal :default
     end
   end

--- a/Library/Homebrew/cask/test/cask/dsl_test.rb
+++ b/Library/Homebrew/cask/test/cask/dsl_test.rb
@@ -148,6 +148,12 @@ describe Hbc::DSL do
 
       MacOS.stubs(languages: ["THIRD_LANGUAGE"])
       cask.call.language.must_equal :default
+
+      MacOS.stubs(languages: ["THIRD_LANGUAGE", "SECOND_LANGUAGE", "FIRST_LANGUAGE"])
+      cask.call.language.must_equal :second
+
+      MacOS.stubs(languages: ["THIRD_LANGUAGE", "FIRST_LANGUAGE", "SECOND_LANGUAGE"])
+      cask.call.language.must_equal :first
     end
   end
 

--- a/Library/Homebrew/cask/test/cask/dsl_test.rb
+++ b/Library/Homebrew/cask/test/cask/dsl_test.rb
@@ -124,36 +124,51 @@ describe Hbc::DSL do
 
   describe "language stanza" do
     it "allows multilingual casks" do
-      cask = lambda {
+      cask = lambda do
         Hbc::Cask.new("cask-with-apps") do
-          language "FIRST_LANGUAGE" do
-            :first
+          language "zh" do
+            sha256 "abc123"
+            "zh-CN"
           end
 
-          language %r{SECOND_LANGUAGE} do
-            :second
+          language "en-US", default: true do
+            sha256 "xyz789"
+            "en-US"
           end
 
-          language :default do
-            :default
-          end
+          url "https://example.org/#{language}.zip"
         end
-      }
+      end
 
-      MacOS.stubs(languages: ["FIRST_LANGUAGE"])
-      cask.call.language.must_equal :first
+      MacOS.stubs(languages: ["zh"])
+      cask.call.language.must_equal "zh-CN"
+      cask.call.sha256.must_equal "abc123"
+      cask.call.url.to_s.must_equal "https://example.org/zh-CN.zip"
 
-      MacOS.stubs(languages: ["SECOND_LANGUAGE"])
-      cask.call.language.must_equal :second
+      MacOS.stubs(languages: ["zh-XX"])
+      cask.call.language.must_equal "zh-CN"
+      cask.call.sha256.must_equal "abc123"
+      cask.call.url.to_s.must_equal "https://example.org/zh-CN.zip"
 
-      MacOS.stubs(languages: ["THIRD_LANGUAGE"])
-      cask.call.language.must_equal :default
+      MacOS.stubs(languages: ["en"])
+      cask.call.language.must_equal "en-US"
+      cask.call.sha256.must_equal "xyz789"
+      cask.call.url.to_s.must_equal "https://example.org/en-US.zip"
 
-      MacOS.stubs(languages: ["THIRD_LANGUAGE", "SECOND_LANGUAGE", "FIRST_LANGUAGE"])
-      cask.call.language.must_equal :second
+      MacOS.stubs(languages: ["xx-XX"])
+      cask.call.language.must_equal "en-US"
+      cask.call.sha256.must_equal "xyz789"
+      cask.call.url.to_s.must_equal "https://example.org/en-US.zip"
 
-      MacOS.stubs(languages: ["THIRD_LANGUAGE", "FIRST_LANGUAGE", "SECOND_LANGUAGE"])
-      cask.call.language.must_equal :first
+      MacOS.stubs(languages: ["xx-XX", "zh", "en"])
+      cask.call.language.must_equal "zh-CN"
+      cask.call.sha256.must_equal "abc123"
+      cask.call.url.to_s.must_equal "https://example.org/zh-CN.zip"
+
+      MacOS.stubs(languages: ["xx-XX", "en-US", "zh"])
+      cask.call.language.must_equal "en-US"
+      cask.call.sha256.must_equal "xyz789"
+      cask.call.url.to_s.must_equal "https://example.org/en-US.zip"
     end
   end
 

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -1,0 +1,68 @@
+class Locale
+  class ParserError < ::RuntimeError
+  end
+
+  LANGUAGE_REGEX = /(?:[a-z]{2})/
+  REGION_REGEX = /(?:[A-Z]{2})/
+  SCRIPT_REGEX = /(?:[A-Z][a-z]{3})/
+
+  LOCALE_REGEX = /^(#{LANGUAGE_REGEX})?(?:(?:^|-)(#{REGION_REGEX}))?(?:(?:^|-)(#{SCRIPT_REGEX}))?$/
+
+  def self.parse(string)
+    language, region, script = string.to_s.scan(LOCALE_REGEX)[0]
+
+    if language.nil? && region.nil? && script.nil?
+      raise ParserError, "'#{string}' cannot be parsed to a #{self.class}"
+    end
+
+    new(language, region, script)
+  end
+
+  attr_reader :language, :region, :script
+
+  def initialize(language, region, script)
+    if language.nil? && region.nil? && script.nil?
+      raise ArgumentError, "#{self.class} cannot be empty"
+    end
+
+    {
+      language: language,
+      region:   region,
+      script:   script,
+    }.each do |key, value|
+      next if value.nil?
+
+      regex = self.class.const_get("#{key.upcase}_REGEX")
+      raise ParserError, "'#{value}' does not match #{regex}" unless value =~ regex
+      instance_variable_set(:"@#{key}", value)
+    end
+
+    self
+  end
+
+  def include?(other)
+    other = self.class.parse(other) unless other.is_a?(self.class)
+
+    [:language, :region, :script].all? { |var|
+      if other.public_send(var).nil?
+        true
+      else
+        public_send(var) == other.public_send(var)
+      end
+    }
+  end
+
+  def eql?(other)
+    other = self.class.parse(other) unless other.is_a?(self.class)
+    [:language, :region, :script].all? { |var|
+      public_send(var) == other.public_send(var)
+    }
+  rescue ParserError
+    false
+  end
+  alias == eql?
+
+  def to_s
+    [@language, @region, @script].compact.join("-")
+  end
+end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -42,11 +42,19 @@ module OS
     end
 
     def languages
-      @languages ||= if ENV["HOMEBREW_LANGUAGES"]
-        ENV["HOMEBREW_LANGUAGES"].split(",")
-      else
-        Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").scan(/[^ \n"(),]+/)
+      return @languages unless @languages.nil?
+
+      @languages = Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").scan(/[^ \n"(),]+/)
+
+      if ENV["HOMEBREW_LANGUAGES"]
+        @languages = ENV["HOMEBREW_LANGUAGES"].split(",") + @languages
       end
+
+      if ARGV.value("language")
+        @languages = ARGV.value("language").split(",") + @languages
+      end
+
+      @languages = @languages.uniq
     end
 
     def language

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -42,7 +42,11 @@ module OS
     end
 
     def languages
-      @languages ||= Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").scan(/[^ \n"(),]+/)
+      if ENV["HOMEBREW_LANGUAGES"]
+        ENV["HOMEBREW_LANGUAGES"].split(",")
+      else
+        @languages ||= Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").scan(/[^ \n"(),]+/)
+      end
     end
 
     def language

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -41,8 +41,12 @@ module OS
       version.to_sym
     end
 
+    def languages
+      @languages ||= Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").scan(/[^ \n"(),]+/)
+    end
+
     def language
-      @language ||= Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").delete(" \n\"()").sub(/,.*/, "")
+      languages.first
     end
 
     def active_developer_dir

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -42,10 +42,10 @@ module OS
     end
 
     def languages
-      if ENV["HOMEBREW_LANGUAGES"]
+      @languages ||= if ENV["HOMEBREW_LANGUAGES"]
         ENV["HOMEBREW_LANGUAGES"].split(",")
       else
-        @languages ||= Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").scan(/[^ \n"(),]+/)
+        Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").scan(/[^ \n"(),]+/)
       end
     end
 

--- a/Library/Homebrew/test/test_os_mac_language.rb
+++ b/Library/Homebrew/test/test_os_mac_language.rb
@@ -2,7 +2,15 @@ require "testing_env"
 require "os/mac"
 
 class OSMacLanguageTests < Homebrew::TestCase
+  LANGUAGE_REGEX = /\A[a-z]{2}(-[A-Z]{2})?(-[A-Z][a-z]{3})?\Z/
+
+  def test_languages_format
+    OS::Mac.languages.each do |language|
+      assert_match LANGUAGE_REGEX, language
+    end
+  end
+
   def test_language_format
-    assert_match(/\A[a-z]{2}(-[A-Z]{2})?\Z/, OS::Mac.language)
+    assert_match LANGUAGE_REGEX, OS::Mac.language
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a `languages` method which returns an array, which in turn is called by `language`.

A second addition is a `language` stanza to the cask DSL, which will hopefully make it easier to create and maintain multilingual casks.