### PR TITLE
bottle: fix old_value/value ordering for --merge.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -383,24 +383,24 @@ module Homebrew
               bottle_block_contents.lines.each do |line|
                 line = line.strip
                 next if line.empty?
-                key, value_original, _, tag = line.split " ", 4
+                key, old_value_original, _, tag = line.split " ", 4
                 valid_key = %w[root_url prefix cellar rebuild sha1 sha256].include? key
                 next unless valid_key
 
-                value = value_original.to_s.delete ":'\""
+                old_value = old_value_original.to_s.delete ":'\""
                 tag = tag.to_s.delete ":"
 
                 if !tag.empty?
                   if !bottle_hash["bottle"]["tags"][tag].to_s.empty?
                     mismatches << "#{key} => #{tag}"
                   else
-                    bottle.send(key, value => tag.to_sym)
+                    bottle.send(key, old_value => tag.to_sym)
                   end
                   next
                 end
 
-                old_value_original = bottle_hash["bottle"][key]
-                old_value = old_value_original.to_s
+                value_original = bottle_hash["bottle"][key]
+                value = value_original.to_s
                 next if key == "cellar" && old_value == "any" && value == "any_skip_relocation"
                 if old_value.empty? || value != old_value
                   old_value = old_value_original.inspect


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Previously this was the wrong way around causing it to not be accepting enough on e.g. a bump from :any to :any_no_relocation.