### PR TITLE
caveats: highlight PKG_CONFIG_PATH if exists

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -54,6 +54,11 @@ class Caveats
         EOS
       s << "    LDFLAGS:  -L#{f.opt_lib}\n" if f.lib.directory?
       s << "    CPPFLAGS: -I#{f.opt_include}\n" if f.include.directory?
+
+      if which("pkg-config")
+        s << "    PKG_CONFIG_PATH: #{f.opt_lib}/pkgconfig\n" if (f.lib/"pkgconfig").directory?
+        s << "    PKG_CONFIG_PATH: #{f.opt_share}/pkgconfig\n" if (f.share/"pkgconfig").directory?
+      end
     end
     s << "\n"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We keep getting issues every now & again about people being confused that `keg_only` includes hiding the `pkg-config` files. Perhaps seems reasonable to start pointing out those exist when they do & a hint on how to access them.

This could be complicated a little more by ensuring we only ever print one `PKG_CONFIG_PATH` hint if `pkg-config` files exist in both `lib/pkgconfig` _and_ `share/pkgconfig` but I'm not aware of a situation like that with any existing formula.

Hidden behind a `which` check to avoid redundant messages, although `pkg-config` is an incredibly popular formula. Ran some time tests, no appreciable difference from the status quo.

If accepted:
Closes https://github.com/Homebrew/homebrew-core/issues/4669.