### PR TITLE
Install brew-cask zsh completions by default

### DIFF
--- a/share/zsh/site-functions/_brew_cask
+++ b/share/zsh/site-functions/_brew_cask
@@ -1,0 +1,83 @@
+#compdef brew-cask
+#autoload
+
+# Autocompletion for homebrew-cask (https://github.com/caskroom/homebrew-cask/).
+#
+# Originally sourced from the oh-my-zsh
+# https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/brew-cask/brew-cask.plugin.zsh
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2009-2016 Robby Russell and contributors
+# See the full list at https://github.com/robbyrussell/oh-my-zsh/contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+__brew_all_casks() {
+  brew cask search
+}
+
+__brew_installed_casks() {
+  brew cask list|sed 's/(!)//'
+}
+
+_brew_cask()
+{
+  local curcontext="$curcontext" state state_descr line
+  typeset -A opt_args
+
+  _arguments -C \
+    ':subcmd:->subcmd' \
+    '*::options:->options'
+
+  case $state in
+  (subcmd)
+    local -a subcommands
+    subcommands=(
+      'audit:verifies installability of Casks'
+      'cat:dump raw source of the given Cask to the standard output'
+      'cleanup:cleans up cached downloads and tracker symlinks'
+      'create:creates the given Cask and opens it in an editor'
+      'doctor:checks for configuration issues'
+      'edit:edits the given Cask'
+      'fetch:downloads remote application files to local cache'
+      'home:opens the homepage of the given Cask'
+      'info:displays information about the given Cask'
+      'install:installs the given Cask'
+      'list:with no args, lists installed Casks; given installed Casks, lists staged files'
+      'search:searches all known Casks'
+      'style:checks Cask style using RuboCop'
+      'uninstall:uninstalls the given Cask'
+      "update:a synonym for 'brew update'"
+      'zap:zaps all files associated with the given Cask'
+    )
+    _describe -t commands "brew cask subcommand" subcommands ;;
+  (options)
+    local -a casks installed_casks
+    local expl
+    case "$line[1]" in
+      list|uninstall)
+        installed_casks=($(__brew_installed_casks))
+        _wanted installed_casks expl 'installed casks' compadd -a installed_casks ;;
+      audit|cat|edit|fetch|home|info|install|zap)
+        casks=($(__brew_all_casks))
+        _wanted casks expl 'all casks' compadd -a casks ;;
+    esac ;;
+  esac
+}

--- a/share/zsh/site-functions/_brew_cask
+++ b/share/zsh/site-functions/_brew_cask
@@ -2,31 +2,11 @@
 #autoload
 
 # Zsh Autocompletion script for Homebrew Cask
-# https://github.com/homebrew/brew
+#   https://github.com/homebrew/brew
 
-# The MIT License (MIT)
-#
-# Copyright (c) 2009-2016 Robby Russell and contributors
-# See the full list at https://github.com/robbyrussell/oh-my-zsh/contributors
-# Copyright (c) 2016 Joshua McKinney
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Authors:
+#   Patrick Stadler (https://github.com/pstadler)
+#   Josh McKinney (https://github.com/joshka)
 
 # only display the main commands (but enable completing aliases like 'ls')
 zstyle -T ':completion:*:*:*:brew-cask:*' tag-order && \

--- a/share/zsh/site-functions/_brew_cask
+++ b/share/zsh/site-functions/_brew_cask
@@ -10,6 +10,7 @@
 #
 # Copyright (c) 2009-2016 Robby Russell and contributors
 # See the full list at https://github.com/robbyrussell/oh-my-zsh/contributors
+# Copyright (c) 2016 Joshua McKinney
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +30,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+# only display the main commands (but enable completing aliases like 'ls')
+zstyle -T ':completion:*:*:*:brew-cask:*' tag-order && \
+	zstyle ':completion:*:*:*:brew-cask:*' tag-order 'commands'
+
 __brew_all_casks() {
   local -a list
   local expl
@@ -43,43 +48,168 @@ __brew_installed_casks() {
   _wanted list expl 'installed casks' compadd -a list
 }
 
+__brew_cask_commands() {
+  local -a commands
+  commands=(
+    'audit:verifies installability of Casks'
+    'cat:dump raw source of the given Cask to the standard output'
+    'cleanup:cleans up cached downloads and tracker symlinks'
+    'create:creates the given Cask and opens it in an editor'
+    'doctor:checks for configuration issues'
+    'edit:edits the given Cask'
+    'fetch:downloads remote application files to local cache'
+    'home:opens the homepage of the given Cask'
+    'info:displays information about the given Cask'
+    'install:installs the given Cask'
+    'list:with no args, lists installed Casks; given installed Casks, lists staged files'
+    'search:searches all known Casks'
+    'style:checks Cask style using RuboCop'
+    'uninstall:uninstalls the given Cask'
+    "update:a synonym for 'brew update'"
+    'zap:zaps all files associated with the given Cask'
+  )
+  _describe -t commands "brew cask command" commands
+}
+
+__brew_cask_aliases() {
+  local -a aliases
+  aliases=(
+    'dr'
+    'homepage'
+    'abv'
+    'ls'
+    '-S'
+    'rm'
+    'remove'
+  )
+  _describe -t commands "brew cask command aliases" aliases
+}
+
+__brew_cask_command() {
+  local command="$1"
+  local completion_func="_brew_cask_${command//-/_}"
+  declare -f "$completion_func" >/dev/null && "$completion_func" && return
+}
+
+_brew_cask_abv() {
+  _brew_cask_info
+}
+
+_brew_cask_audit() {
+  __brew_all_casks
+}
+
+_brew_cask_cat() {
+  __brew_all_casks
+}
+
+_brew_cask_cat() {
+  __brew_all_casks
+}
+
+_brew_cask_cleanup() {
+  _arguments '--outdated'
+}
+
+_brew_cask_create() {
+  _arguments '*::token:'
+}
+
+_brew_cask_edit() {
+  __brew_all_casks
+}
+
+_brew_cask_fetch() {
+  _arguments : \
+    '--force' \
+    '*::token:__brew_all_casks'
+}
+
+_brew_cask_home() {
+  __brew_all_casks
+}
+
+_brew_cask_homepage() {
+  __brew_cask_home
+}
+
+_brew_cask_info() {
+  __brew_all_casks
+}
+
+_brew_cask_install() {
+  _arguments : \
+    '--force' \
+    '--skip-cask-deps' \
+    '--require-sha' \
+    '*::token:__brew_all_casks'
+}
+
+_brew_cask_list() {
+  _arguments : \
+    '-1[format output in a single column]' \
+    '-l[format as detailed list]' \
+    '*::token:__brew_installed_casks'
+}
+
+_brew_cask_ls() {
+  _brew_cask_list
+}
+
+_brew_cask_remove() {
+  _brew_cask_uninstall
+}
+
+_brew_cask_rm() {
+  _brew_cask_uninstall
+}
+
+_brew_cask_style() {
+  _arguments : \
+    '--fix' \
+    '*::token:__brew_all_casks'
+}
+
+_brew_cask_uninstall() {
+  _arguments : \
+    '--force' \
+    '*::token:__brew_installed_casks'
+}
+
+_brew_cask_zap() {
+  __brew_all_casks
+}
+
 _brew_cask()
 {
   local curcontext="$curcontext" state state_descr line
   typeset -A opt_args
 
-  _arguments -C \
-    ':subcmd:->subcmd' \
+  _arguments -C : \
+    '--verbose:Give additional feedback during installation.' \
+    '--appdir=-:Target location for Applications. The default value is /Applications:' \
+    '--colorpickerdir=-:Target location for Color Pickers. The default value is ~/Library/ColorPickers.' \
+    '--prefpanedir=-:Target location for Preference Panes. The default value is ~/Library/PreferencePanes.' \
+    '--qlplugindir=-:Target location for QuickLook Plugins. The default value is ~/Library/QuickLook.' \
+    '--fontdir=-:Target location for Fonts. The default value is ~/Library/Fonts.' \
+    '--servicedir=-:Target location for Services. The default value is ~/Library/Services.' \
+    '--input_methoddir=-:Target location for Input Methods. The default value is ~/Library/Input Methods.' \
+    '--internet_plugindir=-:Target location for Internet Plugins. The default value is ~/Library/Internet Plug-Ins.' \
+    '--audio_unit_plugindir=-:Target location for Audio Unit Plugins. The default value is ~/Library/Audio/Plug-Ins/Components.' \
+    '--vst_plugindir=-:Target location for VST Plugins. The default value is ~/Library/Audio/Plug-Ins/VST.' \
+    '--vst3_plugindir=-:Target location for VST3 Plugins. The default value is ~/Library/Audio/Plug-Ins/VST3.' \
+    '--screen_saverdir=-:Target location for Screen Savers. The default value is ~/Library/Screen Savers.' \
+    '--no-binaries:Do not link "helper" executables to /usr/local/bin.' \
+    '--debug:Output debugging information of use to Cask authors and developers.' \
+    ':command:->command' \
     '*::options:->options'
 
-  case $state in
-  (subcmd)
-    local -a subcommands
-    subcommands=(
-      'audit:verifies installability of Casks'
-      'cat:dump raw source of the given Cask to the standard output'
-      'cleanup:cleans up cached downloads and tracker symlinks'
-      'create:creates the given Cask and opens it in an editor'
-      'doctor:checks for configuration issues'
-      'edit:edits the given Cask'
-      'fetch:downloads remote application files to local cache'
-      'home:opens the homepage of the given Cask'
-      'info:displays information about the given Cask'
-      'install:installs the given Cask'
-      'list:with no args, lists installed Casks; given installed Casks, lists staged files'
-      'search:searches all known Casks'
-      'style:checks Cask style using RuboCop'
-      'uninstall:uninstalls the given Cask'
-      "update:a synonym for 'brew update'"
-      'zap:zaps all files associated with the given Cask'
-    )
-    _describe -t commands "brew cask subcommand" subcommands ;;
+  case "$state" in
+  (command)
+    _alternative -C 'brew-cask' \
+      'aliases:alias:__brew_cask_aliases' \
+      'commands:command:__brew_cask_commands' ;;
   (options)
-    case "$line[1]" in
-      list|uninstall)
-        __brew_installed_casks ;;
-      audit|cat|edit|fetch|home|info|install|zap)
-        __brew_all_casks ;;
-    esac ;;
+    __brew_cask_command "$line[1]" ;;
   esac
 }

--- a/share/zsh/site-functions/_brew_cask
+++ b/share/zsh/site-functions/_brew_cask
@@ -1,11 +1,9 @@
 #compdef brew-cask
 #autoload
 
-# Autocompletion for homebrew-cask (https://github.com/caskroom/homebrew-cask/).
-#
-# Originally sourced from the oh-my-zsh
-# https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/brew-cask/brew-cask.plugin.zsh
-#
+# Zsh Autocompletion script for Homebrew Cask
+# https://github.com/homebrew/brew
+
 # The MIT License (MIT)
 #
 # Copyright (c) 2009-2016 Robby Russell and contributors

--- a/share/zsh/site-functions/_brew_cask
+++ b/share/zsh/site-functions/_brew_cask
@@ -108,7 +108,7 @@ _brew_cask_cat() {
 }
 
 _brew_cask_cleanup() {
-  _arguments '--outdated'
+  _arguments '--outdated:only clean up cached downloads older than 10 days old'
 }
 
 _brew_cask_create() {
@@ -121,7 +121,7 @@ _brew_cask_edit() {
 
 _brew_cask_fetch() {
   _arguments : \
-    '--force' \
+    '--force:force re-download even if the files are already cached' \
     '*::token:__brew_all_casks'
 }
 
@@ -139,9 +139,9 @@ _brew_cask_info() {
 
 _brew_cask_install() {
   _arguments : \
-    '--force' \
-    '--skip-cask-deps' \
-    '--require-sha' \
+    '--force:re-install even if the Cask appears to be already present' \
+    '--skip-cask-deps:skip any Cask dependencies' \
+    '--require-sha:abort installation if the Cask does not have a checksum defined' \
     '*::token:__brew_all_casks'
 }
 
@@ -166,13 +166,13 @@ _brew_cask_rm() {
 
 _brew_cask_style() {
   _arguments : \
-    '--fix' \
+    '--fix:auto-correct any style errors if possible' \
     '*::token:__brew_all_casks'
 }
 
 _brew_cask_uninstall() {
   _arguments : \
-    '--force' \
+    '--force:uninstall even if the Cask does not appear to be present' \
     '*::token:__brew_installed_casks'
 }
 

--- a/share/zsh/site-functions/_brew_cask
+++ b/share/zsh/site-functions/_brew_cask
@@ -211,3 +211,5 @@ _brew_cask()
     __brew_cask_command "$line[1]" ;;
   esac
 }
+
+_brew_cask "$@"

--- a/share/zsh/site-functions/_brew_cask
+++ b/share/zsh/site-functions/_brew_cask
@@ -30,11 +30,17 @@
 # SOFTWARE.
 
 __brew_all_casks() {
-  brew cask search
+  local -a list
+  local expl
+  list=( $(brew cask search) )
+  _wanted list expl 'all casks' compadd -a list
 }
 
 __brew_installed_casks() {
-  brew cask list|sed 's/(!)//'
+  local -a list
+  local expl
+  list=( $(brew cask list|sed 's/(!)//') )
+  _wanted list expl 'installed casks' compadd -a list
 }
 
 _brew_cask()
@@ -69,15 +75,11 @@ _brew_cask()
     )
     _describe -t commands "brew cask subcommand" subcommands ;;
   (options)
-    local -a casks installed_casks
-    local expl
     case "$line[1]" in
       list|uninstall)
-        installed_casks=($(__brew_installed_casks))
-        _wanted installed_casks expl 'installed casks' compadd -a installed_casks ;;
+        __brew_installed_casks ;;
       audit|cat|edit|fetch|home|info|install|zap)
-        casks=($(__brew_all_casks))
-        _wanted casks expl 'all casks' compadd -a casks ;;
+        __brew_all_casks ;;
     esac ;;
   esac
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
  - not required
- [x] Have you successfully run `brew tests` with your changes locally?
  - not required

-----

Given that `brew-cask` is now part of Homebrew core, it might be nice to have the zsh completion just work out of the box per discussions on https://github.com/Homebrew/brew/pull/407. Similarly, the same could be said about the bash completions.

These commits mirror those in https://github.com/joshka/brew-cask-zsh-completions with modifications to the commit messages to align better with being part of homebrew.

@MikeMcQuaid