### PR TITLE
keg: make guile's site-dir persistent

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -326,6 +326,7 @@ class Keg
       when /^fish/ then :mkpath
       # Lua, Lua51, Lua53 all need the same handling.
       when /^lua\// then :mkpath
+      when %r{^guile/} then :mkpath
       else :link
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Things that install Guile scheme objects should be doing so in `HOMEBREW_PREFIX/share/guile/site`, which should be persistent rather than a symlink to any formula's Cellar, not even `guile`'s necessarily as Homebrew/homebrew-core@f061d86 managed to expose.

I believe `guile` isn't actually configured correctly to expect this directory, but since absolutely nobody has complained to date as far as I can find & `gnutls` seems to be the only formula using it this way the temptation is to leave it misconfigured & use this directory for site schemes.

I don't really know the deeper issues around messing with `guile`'s configuration so going for a minimal fix seems the safest option.