### PR TITLE
Fix cask installation from untapped Tap not working.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/source/tapped_qualified.rb
+++ b/Library/Homebrew/cask/lib/hbc/source/tapped_qualified.rb
@@ -2,11 +2,21 @@ require "hbc/source/tapped"
 
 class Hbc::Source::TappedQualified < Hbc::Source::Tapped
   def self.me?(query)
-    !Hbc::QualifiedToken.parse(query).nil? && path_for_query(query).exist?
+    return if (tap = tap_for_query(query)).nil?
+
+    tap.installed? && path_for_query(query).exist?
+  end
+
+  def self.tap_for_query(query)
+    qualified_token = Hbc::QualifiedToken.parse(query)
+    return if qualified_token.nil?
+
+    user, repo, token = qualified_token
+    Tap.fetch(user, repo)
   end
 
   def self.path_for_query(query)
     user, repo, token = Hbc::QualifiedToken.parse(query)
-    Tap.new(user, repo).cask_dir.join(token.sub(%r{(\.rb)?$}i, ".rb"))
+    Tap.fetch(user, repo).cask_dir.join(token.sub(%r{(\.rb)?$}i, ".rb"))
   end
 end

--- a/Library/Homebrew/cask/lib/hbc/source/untapped_qualified.rb
+++ b/Library/Homebrew/cask/lib/hbc/source/untapped_qualified.rb
@@ -1,11 +1,10 @@
 require "hbc/source/tapped_qualified"
 
 class Hbc::Source::UntappedQualified < Hbc::Source::TappedQualified
-  def self.path_for_query(query)
-    user, repo, token = Hbc::QualifiedToken.parse(query)
+  def self.me?(query)
+    return if (tap = tap_for_query(query)).nil?
 
-    tap = Tap.fetch(user, repo)
-    tap.install unless tap.installed?
-    tap.cask_dir.join(token.sub(%r{(\.rb)?$}i, ".rb"))
+    tap.install
+    tap.installed? && path_for_query(query).exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the recognition of `UntappedQualified` cask sources as calling `cask_dir` on an untapped Tap returns `nil`.

--

cc @Homebrew/cask 

--
Fixes https://github.com/caskroom/homebrew-cask/issues/24394.