### PR TITLE
Make scons use stdenv only if immediate build dep

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -562,7 +562,7 @@ class FormulaInstaller
 
     if ARGV.env
       args << "--env=#{ARGV.env}"
-    elsif formula.env.std? || formula.recursive_dependencies.any? { |d| d.name == "scons" }
+    elsif formula.env.std? || formula.deps.select(&:build?).any? { |d| d.name == "scons" }
       args << "--env=std"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

formula_installer will use stdenv if scons is anywhere in the formula's
recursive dependency list:

    https://github.com/Homebrew/legacy-homebrew/issues/40401#issuecomment-110066355

Having scons as a dependency should only require stdenv if it is an
immediate build dependency, as otherwise scons shouldn't be invoked.

-----

This should address [#47260 from legacy-homebrew](https://github.com/Homebrew/legacy-homebrew/issues/47260), with more info in [#40401](https://github.com/Homebrew/legacy-homebrew/issues/40401).

This doesn't seem to break things horribly at first glance. `gringo`, which uses `scons` for its build, builds without a hitch, and it seems the `--env=std` flag is being properly passed in that case. Building LLVM with its OCaml bindings appears to be correctly missing the `--env=std` flag.