### PR TITLE
Teach brew to recognize gcc-HEAD as valid compiler

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -1,7 +1,7 @@
 # @private
 module CompilerConstants
-  GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6]
-  GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-6])$/
+  GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7]
+  GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-7])$/
   COMPILER_SYMBOL_MAP = {
     "gcc-4.0"  => :gcc_4_0,
     "gcc-4.2"  => :gcc,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Building gcc with --HEAD results in most of the executables not having a
version suffix, e.g. Building/installing gcc 6 would result in gcc-6,
g++-6, etc. being installed, while building/installing gcc --HEAD would
result in gcc-, g++-, etc. being installed.

The lack of a version suffix prevented brew from recognizing a valid gcc
install, resulting in brew instructing users to install gcc before
building certain formulae even though gcc is installed.

This, coupled with a patch to the gcc formula that makes the string
"HEAD" the version string for --HEAD builds should allow brew to
recognize gcc installs from trunk.