### PR TITLE
xcode: 8.0 is no longer prerelease

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -28,8 +28,8 @@ module OS
       end
 
       def prerelease?
-        # TODO: bump to version >= "8.1" after Xcode 8.0 is stable.
-        version > "7.3.1"
+        # TODO: bump to version >= "8.2" after Xcode 8.1 is stable.
+        version >= "8.1"
       end
 
       def outdated?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Split out from https://github.com/Homebrew/brew/pull/956 since apparently we're going to have to wait for the 8.x CLT, despite Xcode 8 being released into the wild ~6 hours ago.