### PR TITLE
Warn when using Xcode 8 without CLT on 10.11

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -9,6 +9,7 @@ module Homebrew
           check_for_installed_developer_tools
           check_xcode_license_approved
           check_for_osx_gcc_installer
+          check_xcode_8_without_clt_on_el_capitan
         ]
       end
 
@@ -87,6 +88,19 @@ module Homebrew
         <<-EOS.undent
           A newer Command Line Tools release is available.
           #{MacOS::CLT.update_instructions}
+        EOS
+      end
+
+      def check_xcode_8_without_clt_on_el_capitan
+        return unless MacOS::Xcode.without_clt?
+        # Scope this to Xcode 8 on El Cap for now
+        return unless MacOS.version == :el_capitan && MacOS::Xcode.version >= "8"
+
+        <<-EOS.undent
+          You have Xcode 8 installed without the CLT;
+          this causes certain builds to fail on OS X 10.11.
+          Please install the CLT via:
+            sudo xcode-select --install
         EOS
       end
 

--- a/Library/Homebrew/test/test_os_mac_diagnostic.rb
+++ b/Library/Homebrew/test/test_os_mac_diagnostic.rb
@@ -38,4 +38,12 @@ class OSMacDiagnosticChecksTest < Homebrew::TestCase
     MacOS::XQuartz.stubs(:version).returns("2.7.10_beta2")
     assert_match "The following beta release of XQuartz is installed: 2.7.10_beta2", @checks.check_for_beta_xquartz
   end
+
+  def test_check_xcode_8_without_clt_on_el_capitan
+    MacOS.stubs(:version).returns OS::Mac::Version.new("10.11")
+    MacOS::Xcode.stubs(:installed?).returns true
+    MacOS::Xcode.stubs(:version).returns "8.0"
+    MacOS::Xcode.stubs(:without_clt?).returns true
+    assert_match "You have Xcode 8 installed without the CLT", @checks.check_xcode_8_without_clt_on_el_capitan
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Xcode 8 on 10.11 has more issues than the usual mismatched SDK problems, and we're going to get a decent degree of breakage. I think it's important that `brew doctor` tell people to install the CLT in this case.

It may be worth rethinking whether we want to support the Xcode-only-without-OS-specific-SDK usecase going forward. We've put a good amount of work into supporting Xcode-only over the years, but we're getting increasing amounts of pain for our efforts. I'd be happy to turn this PR into a blanket warn for that usecase, instead of something that only covers Xcode 8 on 10.11.

cc @DomT4 