### PR TITLE
superenv: help Autotools with 10.12 SDK on 10.11

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -94,6 +94,15 @@ module Superenv
       self["SDKROOT"] = MacOS.sdk_path
     end
 
+    # Filter out symbols known not to be defined on 10.11 since GNU Autotools
+    # can't reliably figure this out with Xcode 8 on its own yet.
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      %w[basename_r clock_getres clock_gettime clock_settime dirname_r
+         getentropy mkostemp mkostemps].each do |s|
+        ENV["ac_cv_func_#{s}"] = "no"
+      end
+    end
+
     # On 10.9, the tools in /usr/bin proxy to the active developer directory.
     # This means we can use them for any combination of CLT and Xcode.
     self["HOMEBREW_PREFER_CLT_PROXIES"] = "1" if MacOS.version >= "10.9"


### PR DESCRIPTION
The GNU Autotools tests for whether a given symbol is defined are
reliably coming to incorrect conclusions on 10.11 with the 10.12 SDK
in Xcode 8. This overrides its decisions by forcing the right answer
in superenv using ac_cv_func_* environment variables and setting them to
"no" on 10.11. The list of problematic symbols is from

  grep 'weak$os10.11' MacOSX.sdk/usr/lib/system/libsystem_c.tbd