### PR TITLE
Make `brew upgrade` and `brew outdated` follow alias changes

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -133,9 +133,14 @@ module Homebrew
           raise "No devel block is defined for #{f.full_name}"
         end
 
-        if f.installed?
-          msg = "#{f.full_name}-#{f.installed_version} already installed"
-          msg << ", it's just not linked" unless f.linked_keg.symlink? || f.keg_only?
+        current = f if f.installed?
+        current ||= f.old_installed_formulae.first
+
+        if current
+          msg = "#{current.full_name}-#{current.installed_version} already installed"
+          unless current.linked_keg.symlink? || current.keg_only?
+            msg << ", it's just not linked"
+          end
           opoo msg
         elsif f.migration_needed? && !ARGV.force?
           # Check if the formula we try to install is the same as installed

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -59,8 +59,8 @@ module Homebrew
           group_by { |keg| Formulary.from_keg(keg) }.
           sort_by { |formula, kegs| formula.full_name }.
           map do |formula, kegs|
-            "#{formula.full_name} (#{kegs.map(&:version) * ", "})"
-          end * ", "
+            "#{formula.full_name} (#{kegs.map(&:version).join(", ")})"
+          end.join(", ")
 
         puts "#{outdated_versions} < #{current_version}"
       else

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -56,9 +56,11 @@ module Homebrew
         end
 
         outdated_versions = outdated_kegs.
-          group_by(&:name).
-          sort_by(&:first).
-          map { |name, kegs| "#{name} (#{kegs.map(&:version) * ", "})" } * ", "
+          group_by { |keg| Formulary.from_keg(keg) }.
+          sort_by { |formula, kegs| formula.full_name }.
+          map do |formula, kegs|
+            "#{formula.full_name} (#{kegs.map(&:version) * ", "})"
+          end * ", "
 
         puts "#{outdated_versions} < #{current_version}"
       else

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -43,15 +43,26 @@ module Homebrew
 
     outdated_formulae.each do |f|
       if verbose
-        outdated_versions = f.outdated_versions(fetch_head: fetch_head)
-        current_version = if f.head? && outdated_versions.any? { |v| v.to_s == f.pkg_version.to_s }
+        outdated_kegs = f.outdated_kegs(fetch_head: fetch_head)
+
+        current_version = if f.alias_changed?
+          latest = f.latest_formula
+          "#{latest.name} (#{latest.pkg_version})"
+        elsif f.head? && outdated_kegs.any? { |k| k.version.to_s == f.pkg_version.to_s }
+          # There is a newer HEAD but the version number has not changed.
           "latest HEAD"
         else
           f.pkg_version.to_s
         end
-        puts "#{f.full_name} (#{outdated_versions.join(", ")}) < #{current_version}"
+
+        outdated_versions = outdated_kegs.
+          group_by(&:name).
+          sort_by(&:first).
+          map { |name, kegs| "#{name} (#{kegs.map(&:version) * ", "})" } * ", "
+
+        puts "#{outdated_versions} < #{current_version}"
       else
-        puts f.full_name
+        puts f.full_installed_specified_name
       end
     end
   end
@@ -62,7 +73,7 @@ module Homebrew
     outdated_formulae = formulae.select { |f| f.outdated?(fetch_head: fetch_head) }
 
     outdated = outdated_formulae.each do |f|
-      outdated_versions = f.outdated_versions(fetch_head: fetch_head)
+      outdated_versions = f.outdated_kegs(fetch_head: fetch_head).map(&:version)
       current_version = if f.head? && outdated_versions.any? { |v| v.to_s == f.pkg_version.to_s }
         "HEAD"
       else

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -37,10 +37,10 @@ module Homebrew
       (ARGV.resolved_formulae - outdated).each do |f|
         versions = f.installed_kegs.map(&:version)
         if versions.empty?
-          onoe "#{f.full_name} not installed"
+          onoe "#{f.full_specified_name} not installed"
         else
           version = versions.max
-          onoe "#{f.full_name} #{version} already installed"
+          onoe "#{f.full_specified_name} #{version} already installed"
         end
       end
       exit 1 if outdated.empty?
@@ -51,19 +51,21 @@ module Homebrew
       outdated -= pinned
     end
 
-    if outdated.empty?
+    formulae_to_install = outdated.map(&:latest_formula)
+
+    if formulae_to_install.empty?
       oh1 "No packages to upgrade"
     else
-      oh1 "Upgrading #{outdated.length} outdated package#{plural(outdated.length)}, with result:"
-      puts outdated.map { |f| "#{f.full_name} #{f.pkg_version}" } * ", "
+      oh1 "Upgrading #{formulae_to_install.length} outdated package#{plural(formulae_to_install.length)}, with result:"
+      puts formulae_to_install.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 
     unless upgrade_pinned? || pinned.empty?
       oh1 "Not upgrading #{pinned.length} pinned package#{plural(pinned.length)}:"
-      puts pinned.map { |f| "#{f.full_name} #{f.pkg_version}" } * ", "
+      puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 
-    outdated.each do |f|
+    formulae_to_install.each do |f|
       upgrade_formula(f)
       next unless ARGV.include?("--cleanup")
       next unless f.installed?
@@ -76,7 +78,11 @@ module Homebrew
   end
 
   def upgrade_formula(f)
-    outdated_keg = Keg.new(f.linked_keg.resolved_path) if f.linked_keg.directory?
+    formulae_maybe_with_kegs = [f] + f.old_installed_formulae
+    outdated_kegs = formulae_maybe_with_kegs.
+      map(&:linked_keg).
+      select(&:directory?).
+      map { |k| Keg.new(k.resolved_path) }
 
     fi = FormulaInstaller.new(f)
     fi.options             = f.build.used_options
@@ -87,12 +93,12 @@ module Homebrew
     fi.debug               = ARGV.debug?
     fi.prelude
 
-    oh1 "Upgrading #{f.full_name}"
+    oh1 "Upgrading #{f.full_specified_name}"
 
     # first we unlink the currently active keg for this formula otherwise it is
     # possible for the existing build to interfere with the build we are about to
     # do! Seriously, it happens!
-    outdated_keg.unlink if outdated_keg
+    outdated_kegs.each(&:unlink)
 
     fi.install
     fi.finish
@@ -117,7 +123,7 @@ module Homebrew
   ensure
     # restore previous installation state if build failed
     begin
-      outdated_keg.link if outdated_keg && !f.installed?
+      outdated_kegs.each(&:link) if !f.installed?
     rescue
       nil
     end

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -37,11 +37,23 @@ module HomebrewArgvExtension
             f.version.update_commit(k.version.version.commit) if k.version.head?
           end
         end
-        f
       else
         rack = Formulary.to_rack(name)
-        Formulary.from_rack(rack, spec(nil))
+        alias_path = Formulary.factory(name).alias_path
+        f = Formulary.from_rack(rack, spec(nil), alias_path: alias_path)
       end
+
+      # If this formula was installed with an alias that has since changed,
+      # then it was specified explicitly in ARGV. (Using the alias would
+      # instead have found the new formula.)
+      #
+      # Because of this, the user is referring to this specific formula,
+      # not any formula targetted by the same alias, so in this context
+      # the formula shouldn't be considered outdated if the alias used to
+      # install it has changed.
+      f.follow_installed_alias = false
+
+      f
     end
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -60,7 +60,7 @@ class Formula
   # e.g. `this-formula`
   attr_reader :name
 
-  # The name specified when installing this {Formula}.
+  # The name that was used to identify this {Formula}.
   # Could be the name of the {Formula}, or an alias.
   # e.g. `another-name-for-this-formula`
   attr_reader :alias_path
@@ -228,7 +228,15 @@ class Formula
 
   public
 
-  # The path that was specified to find/install this formula.
+  # The alias path that was used to install this formula, if present.
+  # Can differ from alias_path, which is the alias used to find the formula,
+  # and is specified to this instance.
+  def installed_alias_path
+    path = build.source["path"] if build.is_a?(Tab)
+    path if path =~ %r{#{HOMEBREW_TAP_DIR_REGEX}/Aliases}
+  end
+
+  # The path that was specified to find this formula.
   def specified_path
     alias_path || path
   end
@@ -503,13 +511,13 @@ class Formula
     prefix.parent
   end
 
-  # All of current installed prefix directories.
+  # All currently installed prefix directories.
   # @private
   def installed_prefixes
     rack.directory? ? rack.subdirs : []
   end
 
-  # All of current installed kegs.
+  # All currently installed kegs.
   # @private
   def installed_kegs
     installed_prefixes.map { |dir| Keg.new(dir) }

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1139,7 +1139,9 @@ class Formula
       tab = Tab.for_keg(keg)
       next if version_scheme > tab.version_scheme
       next if version_scheme == tab.version_scheme && pkg_version > version
-      next if follow_installed_alias? && installed_alias_target_changed?
+
+      # don't consider this keg current if there's a newer formula available
+      next if follow_installed_alias? && new_formula_available?
 
       return [] # this keg is the current version of the formula, so it's not outdated
     end
@@ -1155,6 +1157,10 @@ class Formula
     else
       all_kegs.sort_by(&:version)
     end
+  end
+
+  def new_formula_available?
+    installed_alias_target_changed? && !latest_formula.installed?
   end
 
   def current_installed_alias_target

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1164,7 +1164,8 @@ class Formula
   # Has the target of the alias used to install this formula changed?
   # Returns false if the formula wasn't installed with an alias.
   def installed_alias_target_changed?
-    ![self, nil].include?(current_installed_alias_target)
+    target = current_installed_alias_target
+    target && target != self
   end
 
   # Is this formula the target of an alias used to install an old formula?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1186,7 +1186,11 @@ class Formula
   end
 
   def old_installed_formulae
-    alias_path ? self.class.installed_with_alias_path(alias_path) : []
+    # If this formula isn't the current target of the alias,
+    # it doesn't make sense to say that other formulae are older versions of it
+    # because we don't know which came first.
+    return [] if alias_path.nil? || installed_alias_target_changed?
+    self.class.installed_with_alias_path(alias_path) - [self]
   end
 
   # @private

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -77,8 +77,11 @@ class Formulary
     end
 
     # Gets the formula instance.
-    def get_formula(spec)
-      klass.new(name, path, spec, alias_path: alias_path)
+    #
+    # `alias_path` can be overridden here in case an alias was used to refer to
+    # a formula that was loaded in another way.
+    def get_formula(spec, alias_path: nil)
+      klass.new(name, path, spec, alias_path: alias_path || self.alias_path)
     end
 
     def klass
@@ -103,7 +106,7 @@ class Formulary
       super name, Formulary.path(full_name)
     end
 
-    def get_formula(spec)
+    def get_formula(spec, alias_path: nil)
       formula = super
       formula.local_bottle_path = @bottle_filename
       formula_version = formula.pkg_version
@@ -120,7 +123,7 @@ class Formulary
       path = alias_path.resolved_path
       name = path.basename(".rb").to_s
       super name, path
-      @alias_path = alias_path
+      @alias_path = alias_path.to_s
     end
   end
 
@@ -175,7 +178,7 @@ class Formulary
       super name, path
     end
 
-    def get_formula(spec)
+    def get_formula(spec, alias_path: nil)
       super
     rescue FormulaUnavailableError => e
       raise TapFormulaUnavailableError.new(tap, name), "", e.backtrace
@@ -187,7 +190,7 @@ class Formulary
       super name, Formulary.core_path(name)
     end
 
-    def get_formula(_spec)
+    def get_formula(_spec, alias_path: nil)
       raise FormulaUnavailableError, name
     end
   end
@@ -215,38 +218,42 @@ class Formulary
   # * a formula pathname
   # * a formula URL
   # * a local bottle reference
-  def self.factory(ref, spec = :stable)
-    loader_for(ref).get_formula(spec)
+  def self.factory(ref, spec = :stable, alias_path: nil)
+    loader_for(ref).get_formula(spec, alias_path: alias_path)
   end
 
   # Return a Formula instance for the given rack.
   # It will auto resolve formula's spec when requested spec is nil
-  def self.from_rack(rack, spec = nil)
+  #
+  # The :alias_path option will be used if the formula is found not to be
+  # installed, and discarded if it is installed because the alias_path used
+  # to install the formula will be set instead.
+  def self.from_rack(rack, spec = nil, alias_path: nil)
     kegs = rack.directory? ? rack.subdirs.map { |d| Keg.new(d) } : []
     keg = kegs.detect(&:linked?) || kegs.detect(&:optlinked?) || kegs.max_by(&:version)
 
     if keg
-      from_keg(keg, spec)
+      from_keg(keg, spec, :alias_path => alias_path)
     else
-      factory(rack.basename.to_s, spec || :stable)
+      factory(rack.basename.to_s, spec || :stable, :alias_path => alias_path)
     end
   end
 
   # Return a Formula instance for the given keg.
   # It will auto resolve formula's spec when requested spec is nil
-  def self.from_keg(keg, spec = nil)
+  def self.from_keg(keg, spec = nil, alias_path: nil)
     tab = Tab.for_keg(keg)
     tap = tab.tap
     spec ||= tab.spec
 
     f = if tap.nil?
-      factory(keg.rack.basename.to_s, spec)
+      factory(keg.rack.basename.to_s, spec, :alias_path => alias_path)
     else
       begin
-        factory("#{tap}/#{keg.rack.basename}", spec)
+        factory("#{tap}/#{keg.rack.basename}", spec, :alias_path => alias_path)
       rescue FormulaUnavailableError
         # formula may be migrated to different tap. Try to search in core and all taps.
-        factory(keg.rack.basename.to_s, spec)
+        factory(keg.rack.basename.to_s, spec, :alias_path => alias_path)
       end
     end
     f.build = tab
@@ -346,7 +353,7 @@ class Formulary
   end
 
   def self.core_path(name)
-    CoreTap.instance.formula_dir/"#{name.downcase}.rb"
+    CoreTap.instance.formula_dir/"#{name.to_s.downcase}.rb"
   end
 
   def self.tap_paths(name, taps = Dir["#{HOMEBREW_LIBRARY}/Taps/*/*/"])

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -126,7 +126,6 @@ class FormulaTests < Homebrew::TestCase
   def test_installed_alias_with_tap
     tap = Tap.new("user", "repo")
     name = "foo"
-    full_name = "#{tap.user}/#{tap.repo}/#{name}"
     path = "#{tap.path}/Formula/#{name}.rb"
     f = formula(name, path) { url "foo-1.0" }
 

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -637,42 +637,42 @@ class OutdatedVersionsTests < Homebrew::TestCase
     tab
   end
 
-  def reset_outdated_versions
-    f.instance_variable_set(:@outdated_versions, nil)
+  def reset_outdated_kegs
+    f.instance_variable_set(:@outdated_kegs, nil)
   end
 
   def test_greater_different_tap_installed
     setup_tab_for_prefix(greater_prefix, tap: "user/repo")
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   end
 
   def test_greater_same_tap_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(greater_prefix, tap: "homebrew/core")
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   end
 
   def test_outdated_different_tap_installed
     setup_tab_for_prefix(outdated_prefix, tap: "user/repo")
-    refute_predicate f.outdated_versions, :empty?
+    refute_predicate f.outdated_kegs, :empty?
   end
 
   def test_outdated_same_tap_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(outdated_prefix, tap: "homebrew/core")
-    refute_predicate f.outdated_versions, :empty?
+    refute_predicate f.outdated_kegs, :empty?
   end
 
   def test_same_head_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(head_prefix, tap: "homebrew/core")
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   end
 
   def test_different_head_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(head_prefix, tap: "user/repo")
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   end
 
   def test_mixed_taps_greater_version_installed
@@ -680,12 +680,12 @@ class OutdatedVersionsTests < Homebrew::TestCase
     setup_tab_for_prefix(outdated_prefix, tap: "homebrew/core")
     setup_tab_for_prefix(greater_prefix, tap: "user/repo")
 
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
 
     setup_tab_for_prefix(greater_prefix, tap: "homebrew/core")
-    reset_outdated_versions
+    reset_outdated_kegs
 
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   end
 
   def test_mixed_taps_outdated_version_installed
@@ -695,38 +695,38 @@ class OutdatedVersionsTests < Homebrew::TestCase
 
     setup_tab_for_prefix(outdated_prefix)
     setup_tab_for_prefix(extra_outdated_prefix, tap: "homebrew/core")
-    reset_outdated_versions
+    reset_outdated_kegs
 
-    refute_predicate f.outdated_versions, :empty?
+    refute_predicate f.outdated_kegs, :empty?
 
     setup_tab_for_prefix(outdated_prefix, tap: "user/repo")
-    reset_outdated_versions
+    reset_outdated_kegs
 
-    refute_predicate f.outdated_versions, :empty?
+    refute_predicate f.outdated_kegs, :empty?
   end
 
   def test_same_version_tap_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(same_prefix, tap: "homebrew/core")
 
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
 
     setup_tab_for_prefix(same_prefix, tap: "user/repo")
-    reset_outdated_versions
+    reset_outdated_kegs
 
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   end
 
   def test_outdated_installed_head_less_than_stable
     tab = setup_tab_for_prefix(head_prefix, versions: { "stable" => "1.0" })
-    refute_predicate f.outdated_versions, :empty?
+    refute_predicate f.outdated_kegs, :empty?
 
     # Tab.for_keg(head_prefix) will be fetched from CACHE but we write it anyway
     tab.source["versions"] = { "stable" => f.version.to_s }
     tab.write
-    reset_outdated_versions
+    reset_outdated_kegs
 
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   end
 
   def test_outdated_fetch_head
@@ -764,20 +764,20 @@ class OutdatedVersionsTests < Homebrew::TestCase
       end
     end
 
-    refute_predicate f.outdated_versions(fetch_head: true), :empty?
+    refute_predicate f.outdated_kegs(fetch_head: true), :empty?
 
     tab_a.source["versions"] = { "stable" => f.version.to_s }
     tab_a.write
-    reset_outdated_versions
-    refute_predicate f.outdated_versions(fetch_head: true), :empty?
+    reset_outdated_kegs
+    refute_predicate f.outdated_kegs(fetch_head: true), :empty?
 
     head_prefix_a.rmtree
-    reset_outdated_versions
-    refute_predicate f.outdated_versions(fetch_head: true), :empty?
+    reset_outdated_kegs
+    refute_predicate f.outdated_kegs(fetch_head: true), :empty?
 
     setup_tab_for_prefix(head_prefix_c, source_modified_time: 1)
-    reset_outdated_versions
-    assert_predicate f.outdated_versions(fetch_head: true), :empty?
+    reset_outdated_kegs
+    assert_predicate f.outdated_kegs(fetch_head: true), :empty?
   ensure
     ENV.replace(initial_env)
     testball_repo.rmtree if testball_repo.exist?
@@ -788,7 +788,7 @@ class OutdatedVersionsTests < Homebrew::TestCase
     FileUtils.rm_rf HOMEBREW_CELLAR/"testball"
   end
 
-  def test_outdated_versions_version_scheme_changed
+  def test_outdated_kegs_version_scheme_changed
     @f = formula("testball") do
       url "foo"
       version "20141010"
@@ -798,12 +798,12 @@ class OutdatedVersionsTests < Homebrew::TestCase
     prefix = HOMEBREW_CELLAR.join("testball/0.1")
     setup_tab_for_prefix(prefix, versions: { "stable" => "0.1" })
 
-    refute_predicate f.outdated_versions, :empty?
+    refute_predicate f.outdated_kegs, :empty?
   ensure
     prefix.rmtree
   end
 
-  def test_outdated_versions_mixed_version_schemes
+  def test_outdated_kegs_mixed_version_schemes
     @f = formula("testball") do
       url "foo"
       version "20141010"
@@ -816,23 +816,23 @@ class OutdatedVersionsTests < Homebrew::TestCase
     prefix_b = HOMEBREW_CELLAR.join("testball/2.14")
     setup_tab_for_prefix(prefix_b, versions: { "stable" => "2.14", "version_scheme" => 2 })
 
-    refute_predicate f.outdated_versions, :empty?
-    reset_outdated_versions
+    refute_predicate f.outdated_kegs, :empty?
+    reset_outdated_kegs
 
     prefix_c = HOMEBREW_CELLAR.join("testball/20141009")
     setup_tab_for_prefix(prefix_c, versions: { "stable" => "20141009", "version_scheme" => 3 })
 
-    refute_predicate f.outdated_versions, :empty?
-    reset_outdated_versions
+    refute_predicate f.outdated_kegs, :empty?
+    reset_outdated_kegs
 
     prefix_d = HOMEBREW_CELLAR.join("testball/20141011")
     setup_tab_for_prefix(prefix_d, versions: { "stable" => "20141009", "version_scheme" => 3 })
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   ensure
     f.rack.rmtree
   end
 
-  def test_outdated_versions_head_with_version_scheme
+  def test_outdated_kegs_head_with_version_scheme
     @f = formula("testball") do
       url "foo"
       version "1.0"
@@ -842,13 +842,13 @@ class OutdatedVersionsTests < Homebrew::TestCase
     head_prefix = HOMEBREW_CELLAR.join("testball/HEAD")
 
     setup_tab_for_prefix(head_prefix, versions: { "stable" => "1.0", "version_scheme" => 1 })
-    refute_predicate f.outdated_versions, :empty?
+    refute_predicate f.outdated_kegs, :empty?
 
-    reset_outdated_versions
+    reset_outdated_kegs
     head_prefix.rmtree
 
     setup_tab_for_prefix(head_prefix, versions: { "stable" => "1.0", "version_scheme" => 2 })
-    assert_predicate f.outdated_versions, :empty?
+    assert_predicate f.outdated_kegs, :empty?
   ensure
     head_prefix.rmtree
   end

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -663,19 +663,19 @@ class OutdatedVersionsTests < Homebrew::TestCase
     refute_predicate f.outdated_kegs, :empty?
   end
 
-  def test_same_head_installed
+  def test_outdated_same_head_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(head_prefix, tap: "homebrew/core")
     assert_predicate f.outdated_kegs, :empty?
   end
 
-  def test_different_head_installed
+  def test_outdated_different_head_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(head_prefix, tap: "user/repo")
     assert_predicate f.outdated_kegs, :empty?
   end
 
-  def test_mixed_taps_greater_version_installed
+  def test_outdated_mixed_taps_greater_version_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(outdated_prefix, tap: "homebrew/core")
     setup_tab_for_prefix(greater_prefix, tap: "user/repo")
@@ -688,7 +688,7 @@ class OutdatedVersionsTests < Homebrew::TestCase
     assert_predicate f.outdated_kegs, :empty?
   end
 
-  def test_mixed_taps_outdated_version_installed
+  def test_outdated_mixed_taps_outdated_version_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
 
     extra_outdated_prefix = HOMEBREW_CELLAR/"#{f.name}/1.0"
@@ -705,7 +705,7 @@ class OutdatedVersionsTests < Homebrew::TestCase
     refute_predicate f.outdated_kegs, :empty?
   end
 
-  def test_same_version_tap_installed
+  def test_outdated_same_version_tap_installed
     f.instance_variable_set(:@tap, CoreTap.instance)
     setup_tab_for_prefix(same_prefix, tap: "homebrew/core")
 

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -248,6 +248,32 @@ class FormulaTests < Homebrew::TestCase
     assert_nil Testball.new <=> Object.new
   end
 
+  def test_alias_paths_with_build_options
+    alias_path = CoreTap.instance.alias_dir/"another_name"
+    f = formula(:alias_path => alias_path) { url "foo-1.0" }
+    f.build = BuildOptions.new({}, {})
+    assert_equal alias_path, f.alias_path
+    assert_nil f.installed_alias_path
+  end
+
+  def test_alias_paths_with_tab_with_non_alias_source_path
+    alias_path = CoreTap.instance.alias_dir/"another_name"
+    source_path = CoreTap.instance.formula_dir/"another_other_name"
+    f = formula(:alias_path => alias_path) { url "foo-1.0" }
+    f.build = Tab.new(:source => { "path" => source_path.to_s })
+    assert_equal alias_path, f.alias_path
+    assert_nil f.installed_alias_path
+  end
+
+  def test_alias_paths_with_tab_with_alias_source_path
+    alias_path = CoreTap.instance.alias_dir/"another_name"
+    source_path = CoreTap.instance.alias_dir/"another_other_name"
+    f = formula(:alias_path => alias_path) { url "foo-1.0" }
+    f.build = Tab.new(:source => { "path" => source_path.to_s })
+    assert_equal alias_path, f.alias_path
+    assert_equal source_path.to_s, f.installed_alias_path
+  end
+
   def test_formula_spec_integration
     f = formula do
       homepage "http://example.com"

--- a/Library/Homebrew/test/test_formulary.rb
+++ b/Library/Homebrew/test/test_formulary.rb
@@ -89,7 +89,7 @@ class FormularyFactoryTest < Homebrew::TestCase
     FileUtils.ln_s @path, alias_path
     result = Formulary.factory("foo")
     assert_kind_of Formula, result
-    assert_equal alias_path, result.alias_path
+    assert_equal alias_path.to_s, result.alias_path
   ensure
     alias_dir.rmtree
   end

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -121,5 +121,13 @@ module Homebrew
         ENV.replace old
       end
     end
+
+    # Use a stubbed {Formulary::FormulaLoader} to make a given formula be found
+    # when loading from {Formulary} with `ref`.
+    def stub_formula_loader(formula, ref = formula.name)
+      loader = mock
+      loader.stubs(:get_formula).returns(formula)
+      Formulary.stubs(:loader_for).with(ref).returns(loader)
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

  <del>I've written <em>a few</em> tests, but plan on writing more.</del> <ins>Done!</ins>
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This pull request makes `brew outdated` and `brew update` follow alias changes, as described in #567.