### PR TITLE
fix 'cask info' for external repos with numbers

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/info.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/info.rb
@@ -18,7 +18,7 @@ class Hbc::CLI::Info < Hbc::CLI::Base
     puts "#{cask.token}: #{cask.version}"
     puts formatted_url(cask.homepage) if cask.homepage
     installation_info(cask)
-    puts "From: #{formatted_url(github_info(cask))}" if github_info(cask)
+    puts "From: #{formatted_url(repo_info(cask))}" if repo_info(cask)
     name_info(cask)
     artifact_info(cask)
     Hbc::Installer.print_caveats(cask)
@@ -48,9 +48,11 @@ class Hbc::CLI::Info < Hbc::CLI::Base
     puts cask.name.empty? ? "#{Tty.red}None#{Tty.reset}" : cask.name
   end
 
-  def self.github_info(cask)
+  def self.repo_info(cask)
     user, repo, token = Hbc::QualifiedToken.parse(Hbc.all_tokens.detect { |t| t.split("/").last == cask.token })
-    "#{Tap.fetch(user, repo).default_remote}/blob/master/Casks/#{token}.rb"
+    remote = Tap.fetch(user, repo).remote
+    return "#{remote}/blob/master/Casks/#{token}.rb" if remote.include? "github.com"
+    "#{remote}"
   end
 
   def self.artifact_info(cask)

--- a/Library/Homebrew/cask/lib/hbc/qualified_token.rb
+++ b/Library/Homebrew/cask/lib/hbc/qualified_token.rb
@@ -2,7 +2,7 @@ module Hbc::QualifiedToken
   REPO_PREFIX = "homebrew-".freeze
 
   # per https://github.com/Homebrew/homebrew/blob/4c7bc9ec3bca729c898ee347b6135ba692ee0274/Library/Homebrew/cmd/tap.rb#L121
-  USER_REGEX = %r{[a-z_\-]+}
+  USER_REGEX = %r{[a-z0-9_\-]+}
 
   # per https://github.com/Homebrew/homebrew/blob/4c7bc9ec3bca729c898ee347b6135ba692ee0274/Library/Homebrew/cmd/tap.rb#L121
   REPO_REGEX = %r{(?:#{REPO_PREFIX})?\w+}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

No tests, not sure if it was necessary?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

fixes 2 issues: error when username has a number, correct url for repos not on github