### PR TITLE
formula: set TERM to dumb during test

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1434,8 +1434,10 @@ class Formula
     old_tmpdir = ENV["TMPDIR"]
     old_temp = ENV["TEMP"]
     old_tmp = ENV["TMP"]
+    old_term = ENV["TERM"]
     ENV["CURL_HOME"] = old_curl_home || old_home
     ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
+    ENV["TERM"] = "dumb"
     mktemp("#{name}-test") do |staging|
       staging.retain! if ARGV.keep_tmp?
       @testpath = staging.tmpdir
@@ -1457,6 +1459,7 @@ class Formula
     ENV["TMPDIR"] = old_tmpdir
     ENV["TEMP"] = old_temp
     ENV["TMP"] = old_tmp
+    ENV["TERM"] = old_term
   end
 
   # @private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Software that tries to print different things (e.g. ANSI color) based on different termcaps often relies on the `TERM` environment variable, and could fail without it. This results in confusing test issues where certain tests can be successfully run by users testing locally with `TERM`
set, but choke up on our CI.

Always setting TERM to dumb leads to better consistency between local tests and CI tests, and saves much probing in certain cases.

---

Some examples:

- `aalib`: Existing test [fails on the CI](https://bot.brew.sh/job/Homebrew%20Testing/1084/version=el_capitan/testReport/junit/brew-test-bot/el_capitan/test_aalib/) without TERM — I was investigating the failure just now;

- `hopenpgp-tools`: [I was confused by this just a short while ago](https://github.com/Homebrew/homebrew-core/pull/3997#issuecomment-240604992);

- In core:

    ```
$ grep -rI 'ENV\["TERM"\]'
Formula/asciiquarium.rb:    ENV["TERM"] = "xterm"
Formula/browser.rb:    ENV["TERM"] = "xterm"
Formula/bvi.rb:    ENV["TERM"] = "xterm"
Formula/clipsafe.rb:    ENV["TERM"] = "dumb"
Formula/diff-so-fancy.rb:    ENV["TERM"] = "xterm"
Formula/dshb.rb:    ENV["TERM"] = "xterm"
Formula/ee.rb:    ENV["TERM"] = "xterm"
Formula/eg.rb:    ENV["TERM"] = "xterm"
Formula/git-test.rb:    ENV["TERM"] = "xterm"
Formula/hopenpgp-tools.rb:    ENV["TERM"] = "dumb"
Formula/htop-osx.rb:    ENV["TERM"] = "xterm"
Formula/htop.rb:    ENV["TERM"] = "xterm"
Formula/jp2a.rb:    ENV["TERM"] = "xterm-256color"
Formula/le.rb:    ENV["TERM"] = "xterm"
Formula/mobile-shell.rb:    ENV["TERM"] = "xterm"
Formula/multitail.rb:    ENV["TERM"] = "xterm"
Formula/ne.rb:    ENV["TERM"] = "xterm"
Formula/newt.rb:    ENV["TERM"] = "xterm"
Formula/pwntools.rb:    ENV["TERM"] = "xterm"
Formula/slrn.rb:    ENV["TERM"] = "xterm"
Formula/sngrep.rb:    ENV["TERM"] = "xterm"
Formula/tnote.rb:    ENV["TERM"] = "xterm"
Formula/watch.rb:    ENV["TERM"] = "xterm"
Formula/weechat.rb:    ENV["TERM"] = "xterm"
```

    So many formulae require a workaround that could be easily resolved in general. Setting `TERM` to `xterm` is also "wrong" because on the CI the logging facilities definitely don't have xterm capabilities. If a formula specifically requires xterm in order to work, it can still be overridden in the test block as before.