### PR TITLE
no_weak_imports: always check for support

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -1,5 +1,5 @@
 module SharedEnvExtension
-  def no_weak_import_support?
+  def no_weak_imports_support?
     return false unless compiler == :clang
 
     if MacOS::Xcode.version && MacOS::Xcode.version < "8.0"

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -143,6 +143,6 @@ module Stdenv
   end
 
   def no_weak_imports
-    append "LDFLAGS", "-Wl,-no_weak_imports"
+    append "LDFLAGS", "-Wl,-no_weak_imports" if no_weak_imports_support?
   end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -113,7 +113,7 @@ module Superenv
   end
 
   def no_weak_imports
-    append "HOMEBREW_CCCFG", "w"
+    append "HOMEBREW_CCCFG", "w" if no_weak_imports_support?
   end
 
   # These methods are no longer necessary under superenv, but are needed to


### PR DESCRIPTION
ENV.no_weak_imports should be a no-op when Xcode doesn't support the
feature to avoid breaking builds with <= Xcode 7.