### PR TITLE
update.sh: update to latest Homebrew/brew tag.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -1,4 +1,4 @@
-HOMEBREW_VERSION="0.9.9"
+HOMEBREW_VERSION="1.0.0"
 
 onoe() {
   if [[ -t 2 ]] # check whether stderr is a tty.

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -348,7 +348,7 @@ EOS
     set -x
   fi
 
-  if [[ -z "$HOMEBREW_UPDATE_CLEANUP" ]]
+  if [[ -z "$HOMEBREW_UPDATE_CLEANUP" && -z "$HOMEBREW_UPDATE_TO_TAG" ]]
   then
     if [[ -n "$HOMEBREW_DEVELOPER" || -n "$HOMEBREW_DEV_CMD_RUN" ]]
     then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -215,7 +215,18 @@ merge_or_rebase() {
 
   trap reset_on_interrupt SIGINT
 
-  REMOTE_REF="origin/$UPSTREAM_BRANCH"
+  if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -z "$HOMEBREW_NO_UPDATE_CLEANUP" ]]
+  then
+    UPSTREAM_TAG="$(git tag --list --sort=-version:refname | head -n1)"
+  fi
+
+  if [ -n "$UPSTREAM_TAG" ]
+  then
+    REMOTE_REF="refs/tags/$UPSTREAM_TAG"
+    UPSTREAM_BRANCH="v$UPSTREAM_TAG"
+  else
+    REMOTE_REF="origin/$UPSTREAM_BRANCH"
+  fi
 
   if [[ -n "$(git status --untracked-files=all --porcelain 2>/dev/null)" ]]
   then


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Rather than following every change on `master` let’s have non-developer users (i.e. those who have never run a `dev-cmd` or set `HOMEBREW_DEVELOPER`) update between tags.

This provides a fairly natural beta (the `master` branch) and stable (the tags) approach without restricting us to any particular way of managing our tags.

Also, ensure we always fetch tags and allow forcing tag update functionality by setting
`HOMEBREW_UPDATE_TO_TAG`.

This shouldn't be merged until after we tag 1.0.0 as 0.9.9 is too old to have users on for now.