### PR TITLE
weak imports: skip CLT check if Xcode is installed

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/shared.rb
@@ -2,14 +2,14 @@ module SharedEnvExtension
   def no_weak_imports_support?
     return false unless compiler == :clang
 
-    if MacOS::Xcode.version && MacOS::Xcode.version < "8.0"
-      return false
+    if MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      return true
     end
 
-    if MacOS::CLT.version && MacOS::CLT.version < "8.0"
-      return false
+    if MacOS::CLT.version && MacOS::CLT.version >= "8.0"
+      return true
     end
 
-    true
+    false
   end
 end


### PR DESCRIPTION
Xcode 8 plus CLT 7 should return true for weak imports support.

Thanks to @JCount for spotting this bug.