### PR TITLE
do not show curl progress bar in TTYs < 80 chars wide

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -8,10 +8,9 @@ def curl_args(extra_args = [])
 
   flags = HOMEBREW_CURL_ARGS
   flags -= ["--progress-bar"] if ARGV.verbose?
-
   args = [curl.to_s] + flags + extra_args
   args << "--verbose" if ENV["HOMEBREW_CURL_VERBOSE"]
-  args << "--silent" if !$stdout.tty? || ENV["TRAVIS"]
+  args << "--silent" if !$stdout.tty? || ENV["TRAVIS"] || Tty.width < 80
   args
 end
 


### PR DESCRIPTION
Fixes #981

It looks like `curl` outputs a progress bar at a fixed 80 column width. This means that if you run `brew` with a `fetch` or other `curl`-using action in a terminal less than 80 columns wide, the progress bar gets copied to multiple lines, messing up the output.

This PR disables `curl` progress output when it's run in a terminal narrower than 80 columns.

Before:

<img width="550" alt="screen shot 2016-09-17 at 11 19 40 pm" src="https://cloud.githubusercontent.com/assets/2618447/18612808/60fc0f24-7d32-11e6-87e2-afec68ac9744.png">

After:

<img width="536" alt="screen shot 2016-09-17 at 11 57 23 pm" src="https://cloud.githubusercontent.com/assets/2618447/18612811/7ce976cc-7d32-11e6-8033-5be4069faced.png">
