### PR TITLE
utils: convert formula name from pathname to string

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -627,7 +627,7 @@ def migrate_legacy_keg_symlinks_if_necessary
 
   HOMEBREW_LINKED_KEGS.mkpath unless legacy_linked_kegs.children.empty?
   legacy_linked_kegs.children.each do |link|
-    name = link.basename
+    name = link.basename.to_s
     src = begin
       link.realpath
     rescue Errno::ENOENT
@@ -648,7 +648,7 @@ def migrate_legacy_keg_symlinks_if_necessary
 
   HOMEBREW_PINNED_KEGS.mkpath unless legacy_pinned_kegs.children.empty?
   legacy_pinned_kegs.children.each do |link|
-    name = link.basename
+    name = link.basename.to_s
     src = link.realpath
     dst = HOMEBREW_PINNED_KEGS/name
     FileUtils.ln_sf(src.relative_path_from(dst.parent), dst)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`name` is passed as argument to `Formulary.factory` which could later be downcased at `formulary.rb:349`, but `Pathname` doesn't have a `downcase` method. Converting `name` to `String` as it should be fixes the problem.

Fixes #1000.