### PR TITLE
os: update Linux troubleshooting url

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -19,7 +19,7 @@ module OS
     ::MACOS_FULL_VERSION = OS::Mac.full_version.to_s.freeze
     ::MACOS_VERSION = OS::Mac.version.to_s.freeze
   elsif OS.linux?
-    ISSUES_URL = "https://github.com/Homebrew/linuxbrew/wiki/troubleshooting".freeze
+    ISSUES_URL = "https://github.com/Linuxbrew/brew/wiki/troubleshooting".freeze
     PATH_OPEN = "xdg-open".freeze
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

The existing Linux troubleshooting URL has two issues:
* It doesn't reflect Linuxbrew's move to a separate GitHub org
* It redirects to the legacy-linuxbrew (pre-core/brew split) wiki