### PR TITLE
Use user GEM_HOME for installing gems

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -59,6 +59,10 @@ then
   odie "Cowardly refusing to continue at this prefix: $HOMEBREW_PREFIX"
 fi
 
+# Save value to use for installing gems
+export GEM_OLD_HOME="$GEM_HOME"
+export GEM_OLD_PATH="$GEM_PATH"
+
 # Users may have these set, pointing the system Ruby
 # at non-system gem paths
 unset GEM_HOME


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Save the value of GEM_HOME before unsetting it, and re-set it when a gem needs to be installed (or a previously-installed gem needs to be used). Fixes #944.

Here's what I've been using to test:

```sh
mkdir ~/Desktop/gem_home

GEM_HOME="$HOME/Desktop/gem_home" GEM_PATH="$HOME/Desktop/gem_home" brew tests
# Make sure gems are installed correctly to ~/Desktop/gem_home

GEM_HOME="$HOME/Desktop/gem_home" GEM_PATH="$HOME/Desktop/gem_home" brew tests
# Make sure gems aren't installed again

# Make sure ~/.gem hasn't changed

unset GEM_HOME
unset GEM_PATH

brew tests
# Make sure gems are installed to ~/.gem

brew tests
# Make sure gems aren't installed again
```

I'm also checking all these commands (all the <ins>other</ins> ones that use `Homebrew.install_gem_setup_path!`) with custom GEM_HOMEs and GEM_PATHs set to verify they still work and don't leak into ~/.gem:

- [x] `brew cask-tests`
- [x] `brew cask style`
- [x] `brew style`
- [x] `brew man`