### PR TITLE
update-report: migrate on newer auto-update.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -267,6 +267,9 @@ update-preinstall() {
   [[ -z "$HOMEBREW_NO_AUTO_UPDATE" ]] || return
   [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]] || return
 
+  # Allow auto-update migration now we have a fix in place (below in this function).
+  export HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION="1"
+
   if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" || "$HOMEBREW_COMMAND" = "tap" ]]
   then
     brew update --preinstall

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -100,7 +100,8 @@ module Homebrew
     Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
 
     # This should always be the last thing to run (but skip on auto-update).
-    unless ARGV.include?("--preinstall")
+    if !ARGV.include?("--preinstall") ||
+       ENV["HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION"]
       migrate_legacy_repository_if_necessary
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If we have a `brew.sh` which has set `HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION` then let's allow an auto-update migration. That's because it contains the fix below it _before_ the update happened which means the auto-update won't fail in the same way as if updating from an old version.

CC @viktorbenei again just FYI.