### PR TITLE
Implement mechanism to suppress unsupported macOS warnings

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -59,6 +59,8 @@ then
   odie "Cowardly refusing to continue at this prefix: $HOMEBREW_PREFIX"
 fi
 
+HOMEBREW_GIT_CONFIG_FILE="$HOMEBREW_REPOSITORY/.git/config"
+
 # Save value to use for installing gems
 export GEM_OLD_HOME="$GEM_HOME"
 export GEM_OLD_PATH="$GEM_PATH"
@@ -120,6 +122,7 @@ export HOMEBREW_LIBRARY
 export HOMEBREW_VERSION
 export HOMEBREW_CACHE
 export HOMEBREW_CELLAR
+export HOMEBREW_GIT_CONFIG_FILE
 export HOMEBREW_SYSTEM
 export HOMEBREW_CURL
 export HOMEBREW_PROCESSOR
@@ -197,7 +200,6 @@ esac
 
 if [[ -z "$HOMEBREW_DEVELOPER" ]]
 then
-  export HOMEBREW_GIT_CONFIG_FILE="$HOMEBREW_REPOSITORY/.git/config"
   HOMEBREW_GIT_CONFIG_DEVELOPERMODE="$(git config --file="$HOMEBREW_GIT_CONFIG_FILE" --get homebrew.devcmdrun)"
   if [[ "$HOMEBREW_GIT_CONFIG_DEVELOPERMODE" = "true" ]]
   then

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -159,6 +159,10 @@ module HomebrewArgvExtension
     !ENV["HOMEBREW_DEVELOPER"].nil?
   end
 
+  def suppress_unsupported_macos_warnings?
+    !ENV["HOMEBREW_NO_WARN_UNSUPPORTED_MACOS"].nil?
+  end
+
   def sandbox?
     include?("--sandbox") || !ENV["HOMEBREW_SANDBOX"].nil?
   end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -26,7 +26,8 @@ module Homebrew
       end
 
       def check_for_unsupported_macos
-        return if ARGV.homebrew_developer?
+        return if ARGV.homebrew_developer? ||
+                  ARGV.suppress_unsupported_macos_warnings?
 
         who = "We"
         if OS::Mac.prerelease?

--- a/Library/Homebrew/utils/analytics.sh
+++ b/Library/Homebrew/utils/analytics.sh
@@ -14,8 +14,6 @@ migrate-legacy-uuid-file() {
 }
 
 setup-analytics() {
-  local git_config_file="$HOMEBREW_REPOSITORY/.git/config"
-
   migrate-legacy-uuid-file
 
   if [[ -n "$HOMEBREW_NO_ANALYTICS" ]]
@@ -23,8 +21,8 @@ setup-analytics() {
     return
   fi
 
-  local message_seen="$(git config --file="$git_config_file" --get homebrew.analyticsmessage)"
-  local analytics_disabled="$(git config --file="$git_config_file" --get homebrew.analyticsdisabled)"
+  local message_seen="$(git config --file="$HOMEBREW_GIT_CONFIG_FILE" --get homebrew.analyticsmessage)"
+  local analytics_disabled="$(git config --file="$HOMEBREW_GIT_CONFIG_FILE" --get homebrew.analyticsdisabled)"
   if [[ "$message_seen" != "true" || "$analytics_disabled" = "true" ]]
   then
     # Internal variable for brew's use, to differentiate from user-supplied setting
@@ -32,7 +30,7 @@ setup-analytics() {
     return
   fi
 
-  HOMEBREW_ANALYTICS_USER_UUID="$(git config --file="$git_config_file" --get homebrew.analyticsuuid)"
+  HOMEBREW_ANALYTICS_USER_UUID="$(git config --file="$HOMEBREW_GIT_CONFIG_FILE" --get homebrew.analyticsuuid)"
   if [[ -z "$HOMEBREW_ANALYTICS_USER_UUID" ]]
   then
     if [[ -n "$HOMEBREW_LINUX" ]]
@@ -51,7 +49,7 @@ setup-analytics() {
       export HOMEBREW_NO_ANALYTICS_THIS_RUN="1"
       return
     fi
-    git config --file="$git_config_file" --replace-all homebrew.analyticsuuid "$HOMEBREW_ANALYTICS_USER_UUID"
+    git config --file="$HOMEBREW_GIT_CONFIG_FILE" --replace-all homebrew.analyticsuuid "$HOMEBREW_ANALYTICS_USER_UUID"
   fi
 
   if [[ -n "$HOMEBREW_LINUX" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

An idea to entertain, because getting a warning on each brew invocation is genuinely annoying (but that's kind of the point). Fixes #1056.

Design (to quote comments in `brew.sh`):

> Handle suppression of unsupported macOS (prerelease or outdated release)
warnings. Remember the `HOMEBREW_NO_WARN_UNSUPPORTED_MACOS` environment
variable through recording the target macOS major version (e.g. 10.9) as
`homebrew.nowarnmacos` and the "warning epoch" as `homebrew.nowarnmacosepoch`
in the Homebrew repository's git config.

> "Warning epoch" is a positive integer that should be bumped every time we
add basic support for a new prerelease version of macOS or deprecate an old
version. This ensures that a user who has suppressed warnings previously
will start getting warnings again (if applicable) and will have to review
their decision when one of the above happens.

Basically, if you run brew with the `HOMEBREW_NO_WARN_UNSUPPORTED_MACOS` env var once,  your warnings on this particular major macOS version and this particular brew installation will be suppressed until we adjust the criterion.

I'm not sure where we should put this in our docs yet (need to look at the docs) and whether we should document it in the man page — this should be something that is only revealed if you really look for it. I won't work on the docs until the team think this is worth inclusion.