### PR TITLE
update.sh: tweak tag handling.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -218,6 +218,8 @@ merge_or_rebase() {
   if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -z "$HOMEBREW_NO_UPDATE_CLEANUP" ]]
   then
     UPSTREAM_TAG="$(git tag --list --sort=-version:refname | head -n1)"
+  else
+    UPSTREAM_TAG=""
   fi
 
   if [ -n "$UPSTREAM_TAG" ]
@@ -253,7 +255,8 @@ EOS
   fi
 
   INITIAL_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null)"
-  if [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" ]]
+  if [[ -n "$UPSTREAM_TAG" ]] ||
+     [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" ]]
   then
 
     if [[ -z "$HOMEBREW_NO_UPDATE_CLEANUP" ]]
@@ -265,7 +268,8 @@ EOS
 
     # Recreate and check out `#{upstream_branch}` if unable to fast-forward
     # it to `origin/#{@upstream_branch}`. Otherwise, just check it out.
-    if git merge-base --is-ancestor "$UPSTREAM_BRANCH" "$REMOTE_REF" &>/dev/null
+    if [[ -z "$UPSTREAM_TAG" ]] &&
+       git merge-base --is-ancestor "$UPSTREAM_BRANCH" "$REMOTE_REF" &>/dev/null
     then
       git checkout --force "$UPSTREAM_BRANCH" "${QUIET_ARGS[@]}"
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Don't let the `UPSTREAM_TAG` variable bleed into future repository checks.
- Even if the tag branch is an ancestor of the tag ensure that it's forced back to the tag anyway.

This will go into 1.0.1 but I'll hold off for a bit until we get any user reports (should only affect Homebrew developers and even then it's kinda tricky to reproduce).

Fixes #1062.