### PR TITLE
readall: do not require itself.

### DIFF
--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -1,7 +1,6 @@
 require "formula"
 require "tap"
 require "thread"
-require "readall"
 
 module Readall
   class << self


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Make so that `readall.rb` does not require itself.