### PR TITLE
Add compatibility for `MacOS.release`.

### DIFF
--- a/Library/Homebrew/compat/macos.rb
+++ b/Library/Homebrew/compat/macos.rb
@@ -136,6 +136,11 @@ module OS
         odeprecated "MacOS.has_apple_developer_tools?", "DevelopmentTools.installed?"
         DevelopmentTools.installed?
       end
+
+      def release
+        odeprecated "MacOS.release", "MacOS.version"
+        version
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This was removed during the merge. All Casks were migrated, but those that were installed before or those in custom taps are still using `MacOS.release`.

--

@Homebrew/cask 