### PR TITLE
Use git describe to get the HOMEBREW_VERSION.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -14,7 +14,7 @@ $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 
 if ARGV == %w[--version] || ARGV == %w[-v]
-  puts "Homebrew #{Homebrew.homebrew_version_string}"
+  puts "Homebrew #{HOMEBREW_VERSION}"
   puts "Homebrew/homebrew-core #{Homebrew.core_tap_version_string}"
   exit 0
 end

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -1,4 +1,8 @@
-HOMEBREW_VERSION="1.0.0"
+HOMEBREW_VERSION="$(git describe --tags --dirty 2>/dev/null)"
+if [[ -z "$HOMEBREW_VERSION" ]]
+then
+  HOMEBREW_VERSION=">1.0.0 (no git repository)"
+fi
 
 onoe() {
   if [[ -t 2 ]] # check whether stderr is a tty.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -248,15 +248,6 @@ module Homebrew
     _system(cmd, *args)
   end
 
-  def self.homebrew_version_string
-    if pretty_revision = HOMEBREW_REPOSITORY.git_short_head
-      last_commit = HOMEBREW_REPOSITORY.git_last_commit_date
-      "#{HOMEBREW_VERSION} (git revision #{pretty_revision}; last commit #{last_commit})"
-    else
-      "#{HOMEBREW_VERSION} (no git repository)"
-    end
-  end
-
   def self.core_tap_version_string
     require "tap"
     tap = CoreTap.instance


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

For tagged commits produces the output:
- `1.0.1`

For untagged commits with a dirty tree produces the output:
- `1.0.1-19-g23efbc5-dirty`

Performance:
```
git describe --tags --dirty 2> /dev/null
0.07s user 0.01s system 96% cpu 0.086 total
```

This means we can tag any commit without needing to manually remember
to bump the revision every time.