### PR TITLE
formula: help CMake with 10.12 SDK on 10.11

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1266,7 +1266,7 @@ class Formula
   # Note: there isn't a std_autotools variant because autotools is a lot
   # less consistent and the standard parameters are more memorable.
   def std_cmake_args
-    %W[
+    args = %W[
       -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG
       -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG
       -DCMAKE_INSTALL_PREFIX=#{prefix}
@@ -1275,6 +1275,14 @@ class Formula
       -DCMAKE_VERBOSE_MAKEFILE=ON
       -Wno-dev
     ]
+
+    # Avoid false positives for clock_gettime support on 10.11.
+    # CMake cache entries for other weak symbols may be added here as needed.
+    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+      args << "-DHAVE_CLOCK_GETTIME:INTERNAL=0"
+    end
+
+    args
   end
 
   # an array of all core {Formula} names


### PR DESCRIPTION
This adds a CMake cache entry to std_cmake_args specifying that the
function clock_gettime is not available on 10.11 in order to avoid
runtime errors such as

  dyld: lazy symbol binding failed: Symbol not found: _clock_gettime

when the build system is confused by Xcode 8's weak symbols.

Other weak symbols on 10.11, which may merit the same treatment in the
future, can be found with

  grep 'weak$os10.11' MacOSX.sdk/usr/lib/system/libsystem_c.tbd