### PR TITLE
uninstall: refuse when dependents still installed

### DIFF
--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -18,8 +18,13 @@ module Homebrew
       ARGV.resolved_formulae
     end
 
-    Diagnostic.missing_deps(ff, ARGV.value("hide")) do |name, missing|
-      print "#{name}: " if ff.size > 1
+    hide = (ARGV.value("hide") || "").split(",")
+
+    ff.each do |f|
+      missing = f.missing_dependencies(hide: hide)
+      next if missing.empty?
+
+      print "#{f}: " if ff.size > 1
       puts missing.join(" ")
     end
   end

--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -3,7 +3,7 @@
 #:    given, check all installed brews.
 #:
 #:    If `--hide=`<hidden> is passed, act as if none of <hidden> are installed.
-#:    <hidden> should be a comma-seperated list of formulae.
+#:    <hidden> should be a comma-separated list of formulae.
 
 require "formula"
 require "tab"

--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -18,7 +18,7 @@ module Homebrew
       ARGV.resolved_formulae
     end
 
-    Diagnostic.missing_deps(ff) do |name, missing|
+    Diagnostic.missing_deps(ff, ARGV.value("hide")) do |name, missing|
       print "#{name}: " if ff.size > 1
       puts missing.join(" ")
     end

--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -1,6 +1,9 @@
-#:  * `missing` [<formulae>]:
+#:  * `missing` [`--hide=`<hidden>] [<formulae>]:
 #:    Check the given <formulae> for missing dependencies. If no <formulae> are
 #:    given, check all installed brews.
+#:
+#:    If `--hide=`<hidden> is passed, act as if none of <hidden> are installed.
+#:    <hidden> should be a comma-seperated list of formulae.
 
 require "formula"
 require "tab"

--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -18,10 +18,8 @@ module Homebrew
       ARGV.resolved_formulae
     end
 
-    hide = (ARGV.value("hide") || "").split(",")
-
     ff.each do |f|
-      missing = f.missing_dependencies(hide: hide)
+      missing = f.missing_dependencies(hide: ARGV.values("hide"))
       next if missing.empty?
 
       print "#{f}: " if ff.size > 1

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -15,18 +15,18 @@ module Homebrew
     raise KegUnspecifiedError if ARGV.named.empty?
 
     kegs_by_rack = if ARGV.force?
-      Hash[ARGV.named.map do |name|
+      Hash[ARGV.named.map { |name|
         rack = Formulary.to_rack(name)
         [rack, rack.subdirs.map { |d| Keg.new(d) }]
-      end]
+      }]
     else
       ARGV.kegs.group_by(&:rack)
     end
 
     # --ignore-dependencies, to be consistent with install
     unless ARGV.include?("--ignore-dependencies") || ARGV.homebrew_developer?
-      kegs = kegs_by_rack.values.flatten(1)
-      return if check_for_dependents kegs
+      all_kegs = kegs_by_rack.values.flatten(1)
+      return if check_for_dependents all_kegs
     end
 
     kegs_by_rack.each do |rack, kegs|
@@ -77,13 +77,13 @@ module Homebrew
   def check_for_dependents(kegs)
     kegs.each do |keg|
       dependents = keg.installed_dependents - kegs
-      if dependents.any?
-        dependents_output = dependents.map { |k| "#{k.name} #{k.version}" }.join(", ")
-        conjugation = dependents.count == 1 ? "is" : "are"
-        ofail "Refusing to uninstall #{keg} because it is required by #{dependents_output}, which #{conjugation} currently installed."
-        puts "You can override this and force removal with `brew uninstall --ignore-dependencies #{keg.name}`."
-        return true
-      end
+      next if dependents.empty?
+
+      dependents_output = dependents.map { |k| "#{k.name} #{k.version}" }.join(", ")
+      conjugation = dependents.count == 1 ? "is" : "are"
+      ofail "Refusing to uninstall #{keg} because it is required by #{dependents_output}, which #{conjugation} currently installed."
+      puts "You can override this and force removal with `brew uninstall --ignore-dependencies #{keg.name}`."
+      return true
     end
     false
   end

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -25,7 +25,7 @@ module Homebrew
     end
 
     # --ignore-dependencies, to be consistent with install
-    unless ARGV.include?("--ignore-dependencies") || ARGV.homebrew_developer?
+    if !ARGV.include?("--ignore-dependencies") && !ARGV.homebrew_developer?
       all_kegs = kegs_by_rack.values.flatten(1)
       return if check_for_dependents all_kegs
     end

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -16,7 +16,7 @@ module Homebrew
 
     if !ARGV.force?
       ARGV.kegs.each do |keg|
-        dependents = keg.installed_dependents
+        dependents = keg.installed_dependents - ARGV.kegs
         if dependents.any?
           dependents_output = dependents.map { |k| "#{k.name} #{k.version}" }.join(", ")
           conjugation = dependents.count == 1 ? "is" : "are"

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -21,7 +21,7 @@ module Homebrew
           dependants_output = dependants.map { |k| "#{k.name} #{k.version}" }.join(", ")
           conjugation = dependants.count == 1 ? "is" : "are"
           ofail "Refusing to uninstall #{keg} because it is required by #{dependants_output}, which #{conjugation} currently installed."
-          puts "Remove it anyway with `brew uninstall --force #{keg.name}`."
+          puts "You can override this and force removal with `brew uninstall --force #{keg.name}`."
           next
         end
 

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -16,6 +16,15 @@ module Homebrew
 
     if !ARGV.force?
       ARGV.kegs.each do |keg|
+        dependants = keg.installed_dependants
+        if dependants.any?
+          dependants_output = dependants.map { |k| "#{k.name} #{k.version}" }.join(", ")
+          conjugation = dependants.count == 1 ? "is" : "are"
+          ofail "Refusing to uninstall #{keg} because it is required by #{dependants_output}, which #{conjugation} currently installed."
+          puts "Remove it anyway with `brew uninstall --force #{keg.name}`."
+          next
+        end
+
         keg.lock do
           puts "Uninstalling #{keg}... (#{keg.abv})"
           keg.unlink

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -92,39 +92,6 @@ module Homebrew
     true
   end
 
-  # Will return some kegs, and some dependencies, if they're present.
-  # For efficiency, we don't bother trying to get complete data.
-  def find_some_installed_dependents(kegs)
-    kegs.each do |keg|
-      dependents = keg.installed_dependents - kegs
-      dependents.map! { |d| "#{d.name} #{d.version}" }
-      return [keg], dependents if dependents.any?
-    end
-
-    # Find formulae that didn't have dependencies saved in all of their kegs,
-    # so need them to be calculated now.
-    #
-    # This happens after the initial dependency check because it's sloooow.
-    remaining_formulae = Formula.installed.select { |f|
-      f.installed_kegs.any? { |k| Tab.for_keg(k).runtime_dependencies.nil? }
-    }
-
-    keg_names = kegs.map(&:name)
-    kegs_by_name = kegs.group_by(&:to_formula)
-    remaining_formulae.each do |dependent|
-      required = dependent.missing_dependencies(hide: keg_names)
-      required.select! do |f|
-        kegs_by_name.key?(f)
-      end
-      next unless required.any?
-
-      required_kegs = required.map { |f| kegs_by_name[f].sort_by(&:version).last }
-      return required_kegs, [dependent]
-    end
-
-    nil
-  end
-
   def rm_pin(rack)
     Formulary.from_rack(rack).unpin
   rescue

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -16,11 +16,11 @@ module Homebrew
 
     if !ARGV.force?
       ARGV.kegs.each do |keg|
-        dependants = keg.installed_dependants
-        if dependants.any?
-          dependants_output = dependants.map { |k| "#{k.name} #{k.version}" }.join(", ")
-          conjugation = dependants.count == 1 ? "is" : "are"
-          ofail "Refusing to uninstall #{keg} because it is required by #{dependants_output}, which #{conjugation} currently installed."
+        dependents = keg.installed_dependents
+        if dependents.any?
+          dependents_output = dependents.map { |k| "#{k.name} #{k.version}" }.join(", ")
+          conjugation = dependents.count == 1 ? "is" : "are"
+          ofail "Refusing to uninstall #{keg} because it is required by #{dependents_output}, which #{conjugation} currently installed."
           puts "You can override this and force removal with `brew uninstall --force #{keg.name}`."
           next
         end

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -16,10 +16,10 @@ module Homebrew
     raise KegUnspecifiedError if ARGV.named.empty?
 
     kegs_by_rack = if ARGV.force?
-      Hash[ARGV.named.map { |name|
+      Hash[ARGV.named.map do |name|
         rack = Formulary.to_rack(name)
         [rack, rack.subdirs.map { |d| Keg.new(d) }]
-      }]
+      end]
     else
       ARGV.kegs.group_by(&:rack)
     end

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -24,8 +24,7 @@ module Homebrew
       ARGV.kegs.group_by(&:rack)
     end
 
-    # --ignore-dependencies, to be consistent with install
-    if !ARGV.include?("--ignore-dependencies") && !ARGV.homebrew_developer?
+    if should_check_for_dependents?
       all_kegs = kegs_by_rack.values.flatten(1)
       return if check_for_dependents all_kegs
     end
@@ -73,6 +72,13 @@ module Homebrew
         rack.unlink if rack.symlink? && !rack.resolved_path_exists?
       end
     end
+  end
+
+  def should_check_for_dependents?
+    # --ignore-dependencies, to be consistent with install
+    return false if ARGV.include?("--ignore-dependencies")
+    return false if ARGV.homebrew_developer?
+    true
   end
 
   def check_for_dependents(kegs)

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -1,8 +1,11 @@
-#:  * `uninstall`, `rm`, `remove` [`--force`] <formula>:
+#:  * `uninstall`, `rm`, `remove` [`--force`] [`--ignore-dependencies`] <formula>:
 #:    Uninstall <formula>.
 #:
 #:    If `--force` is passed, and there are multiple versions of <formula>
 #:    installed, delete all installed versions.
+#:
+#:    If `--ignore-dependencies` is passed, uninstalling won't fail, even if
+#:    formulae depending on <formula> would still be installed.
 
 require "keg"
 require "formula"

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -8,6 +8,8 @@ require "utils/shell"
 module Homebrew
   module Diagnostic
     def self.missing_deps(ff, hide = nil)
+      hide ||= []
+
       missing = {}
       ff.each do |f|
         missing_deps = f.recursive_dependencies do |dependent, dep|
@@ -20,12 +22,8 @@ module Homebrew
         end
 
         missing_deps.map!(&:to_formula)
-        if hide
-          missing_deps.reject! do |d|
-            !hide.include?(d.name) && d.installed_prefixes.any?
-          end
-        else
-          missing_deps.reject! { |d| d.installed_prefixes.any? }
+        missing_deps.reject! do |d|
+          !hide.include?(d.name) && d.installed_prefixes.any?
         end
 
         unless missing_deps.empty?

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -8,27 +8,13 @@ require "utils/shell"
 module Homebrew
   module Diagnostic
     def self.missing_deps(ff, hide = nil)
-      hide ||= []
-
       missing = {}
       ff.each do |f|
-        missing_deps = f.recursive_dependencies do |dependent, dep|
-          if dep.optional? || dep.recommended?
-            tab = Tab.for_formula(dependent)
-            Dependency.prune unless tab.with?(dep)
-          elsif dep.build?
-            Dependency.prune
-          end
-        end
+        missing_dependencies = f.missing_dependencies(hide: hide)
 
-        missing_deps.map!(&:to_formula)
-        missing_deps.reject! do |d|
-          !hide.include?(d.name) && d.installed_prefixes.any?
-        end
-
-        unless missing_deps.empty?
-          yield f.full_name, missing_deps if block_given?
-          missing[f.full_name] = missing_deps
+        unless missing_dependencies.empty?
+          yield f.full_name, missing_dependencies if block_given?
+          missing[f.full_name] = missing_dependencies
         end
       end
       missing

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -7,7 +7,7 @@ require "utils/shell"
 
 module Homebrew
   module Diagnostic
-    def self.missing_deps(ff)
+    def self.missing_deps(ff, hide = nil)
       missing = {}
       ff.each do |f|
         missing_deps = f.recursive_dependencies do |dependent, dep|
@@ -20,7 +20,13 @@ module Homebrew
         end
 
         missing_deps.map!(&:to_formula)
-        missing_deps.reject! { |d| d.installed_prefixes.any? }
+        if hide
+          missing_deps.reject! do |d|
+            !hide.include?(d.name) && d.installed_prefixes.any?
+          end
+        else
+          missing_deps.reject! { |d| d.installed_prefixes.any? }
+        end
 
         unless missing_deps.empty?
           yield f.full_name, missing_deps if block_given?

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -121,6 +121,13 @@ module HomebrewArgvExtension
     flag_with_value.strip_prefix(arg_prefix) if flag_with_value
   end
 
+  # Returns an array of values that were given as a comma-seperated list.
+  # @see value
+  def values(name)
+    return unless val = value(name)
+    val.split(",")
+  end
+
   def force?
     flag? "--force"
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1337,6 +1337,13 @@ class Formula
     end
   end
 
+  # Clear caches of .racks and .installed.
+  # @private
+  def self.clear_cache
+    @racks = nil
+    @installed = nil
+  end
+
   # An array of all racks currently installed.
   # @private
   def self.racks

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -116,7 +116,7 @@ class Keg
       next unless required.any?
 
       required_kegs = required.map { |f| kegs_by_name[f].sort_by(&:version).last }
-      return required_kegs, [dependent]
+      return required_kegs, [dependent.to_s]
     end
 
     nil

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -292,6 +292,21 @@ class Keg
     PkgVersion.parse(path.basename.to_s)
   end
 
+  def formula
+    Formulary.from_keg(self)
+  end
+
+  def installed_dependants
+    Formula.installed.flat_map(&:installed_kegs).select do |keg|
+      Tab.for_keg(keg).runtime_dependencies.any? do |dep|
+        # Resolve formula rather than directly comparing names
+        # in case of conflicts between formulae from different taps.
+        dep_formula = Formulary.factory(dep["full_name"])
+        dep_formula == formula && dep["version"] == version.to_s
+      end
+    end
+  end
+
   def find(*args, &block)
     path.find(*args, &block)
   end

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -292,7 +292,7 @@ class Keg
     PkgVersion.parse(path.basename.to_s)
   end
 
-  def formula
+  def to_formula
     Formulary.from_keg(self)
   end
 
@@ -302,7 +302,7 @@ class Keg
         # Resolve formula rather than directly comparing names
         # in case of conflicts between formulae from different taps.
         dep_formula = Formulary.factory(dep["full_name"])
-        dep_formula == formula && dep["version"] == version.to_s
+        dep_formula == to_formula && dep["version"] == version.to_s
       end
     end
   end

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -87,6 +87,41 @@ class Keg
     mime-info pixmaps sounds postgresql
   ].freeze
 
+  # Will return some kegs, and some dependencies, if they're present.
+  # For efficiency, we don't bother trying to get complete data.
+  def self.find_some_installed_dependents(kegs)
+    # First, check in the tabs of installed Formulae.
+    kegs.each do |keg|
+      dependents = keg.installed_dependents - kegs
+      dependents.map! { |d| "#{d.name} #{d.version}" }
+      return [keg], dependents if dependents.any?
+    end
+
+    # Some kegs won't have modern Tabs with the dependencies listed.
+    # In this case, fall back to Formula#missing_dependencies.
+
+    # Find formulae that didn't have dependencies saved in all of their kegs,
+    # so need them to be calculated now.
+    #
+    # This happens after the initial dependency check because it's sloooow.
+    remaining_formulae = Formula.installed.select { |f|
+      f.installed_kegs.any? { |k| Tab.for_keg(k).runtime_dependencies.nil? }
+    }
+
+    keg_names = kegs.map(&:name)
+    kegs_by_name = kegs.group_by(&:to_formula)
+    remaining_formulae.each do |dependent|
+      required = dependent.missing_dependencies(hide: keg_names)
+      required.select! { |f| kegs_by_name.key?(f) }
+      next unless required.any?
+
+      required_kegs = required.map { |f| kegs_by_name[f].sort_by(&:version).last }
+      return required_kegs, [dependent]
+    end
+
+    nil
+  end
+
   # if path is a file in a keg then this will return the containing Keg object
   def self.for(path)
     path = path.realpath

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -104,9 +104,9 @@ class Keg
     # so need them to be calculated now.
     #
     # This happens after the initial dependency check because it's sloooow.
-    remaining_formulae = Formula.installed.select { |f|
+    remaining_formulae = Formula.installed.select do |f|
       f.installed_kegs.any? { |k| Tab.for_keg(k).runtime_dependencies.nil? }
-    }
+    end
 
     keg_names = kegs.map(&:name)
     kegs_by_name = kegs.group_by(&:to_formula)

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -298,7 +298,9 @@ class Keg
 
   def installed_dependents
     Formula.installed.flat_map(&:installed_kegs).select do |keg|
-      Tab.for_keg(keg).runtime_dependencies.any? do |dep|
+      tab = Tab.for_keg(keg)
+      next if tab.runtime_dependencies.nil? # no dependency information saved.
+      tab.runtime_dependencies.any? do |dep|
         # Resolve formula rather than directly comparing names
         # in case of conflicts between formulae from different taps.
         dep_formula = Formulary.factory(dep["full_name"])

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -296,7 +296,7 @@ class Keg
     Formulary.from_keg(self)
   end
 
-  def installed_dependants
+  def installed_dependents
     Formula.installed.flat_map(&:installed_kegs).select do |keg|
       Tab.for_keg(keg).runtime_dependencies.any? do |dep|
         # Resolve formula rather than directly comparing names

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -1,6 +1,7 @@
 require "extend/pathname"
 require "keg_relocate"
 require "formula_lock"
+require "diagnostic"
 require "ostruct"
 
 class Keg
@@ -297,14 +298,33 @@ class Keg
   end
 
   def installed_dependents
-    Formula.installed.flat_map(&:installed_kegs).select do |keg|
-      Tab.for_keg(keg).runtime_dependencies.any? do |dep|
+    installed_kegs = Formula.installed.flat_map(&:installed_kegs)
+    installed_kegs_and_tabs = installed_kegs.map { |k| [k, Tab.for_keg(k)] }
+    kegs_by_tab_deps_presence = installed_kegs_and_tabs.group_by do |_, tab|
+      !tab.runtime_dependencies.nil?
+    end
+    [true, false].each { |v| kegs_by_tab_deps_presence[v] ||= [] }
+
+    kegs_by_tab_deps_presence[true].select! do |_, tab|
+      tab.runtime_dependencies.any? do |dep|
         # Resolve formula rather than directly comparing names
         # in case of conflicts between formulae from different taps.
         dep_formula = Formulary.factory(dep["full_name"])
         dep_formula == to_formula && dep["version"] == version.to_s
       end
     end
+
+    remaining_kegs_and_tabs = kegs_by_tab_deps_presence[false]
+    remaining_formulae = remaining_kegs_and_tabs.map { |k, _| k.to_formula }
+
+    # Expensive if installed_dependents of multiple kegs are being checked
+    deps = Homebrew::Diagnostic.missing_deps(remaining_formulae, [name])
+    remaining_kegs_and_tabs.select! do |keg, _|
+      keg_deps = deps[keg.to_formula.full_name]
+      keg_deps && keg_deps.any?
+    end
+
+    kegs_by_tab_deps_presence.values.flatten(1).map { |k, _| k }
   end
 
   def find(*args, &block)

--- a/Library/Homebrew/test/helper/integration_command_test_case.rb
+++ b/Library/Homebrew/test/helper/integration_command_test_case.rb
@@ -127,7 +127,6 @@ class IntegrationCommandTestCase < Homebrew::TestCase
         sha256 "#{TESTBALL_SHA256}"
 
         option "with-foo", "Build with foo"
-        #{content}
 
         def install
           (prefix/"foo"/"test").write("test") if build.with? "foo"
@@ -137,6 +136,8 @@ class IntegrationCommandTestCase < Homebrew::TestCase
           bin.mkpath
           system ENV.cc, "test.c", "-o", bin/"test"
         end
+
+        #{content}
 
         # something here
       EOS

--- a/Library/Homebrew/test/helper/integration_command_test_case.rb
+++ b/Library/Homebrew/test/helper/integration_command_test_case.rb
@@ -73,10 +73,12 @@ class IntegrationCommandTestCase < Homebrew::TestCase
     cmd_args << "-rintegration_mocks"
     cmd_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
     cmd_args += args
+    developer = ENV["HOMEBREW_DEVELOPER"]
     Bundler.with_original_env do
       ENV["HOMEBREW_BREW_FILE"] = HOMEBREW_PREFIX/"bin/brew"
       ENV["HOMEBREW_INTEGRATION_TEST"] = cmd_id_from_args(args)
       ENV["HOMEBREW_TEST_TMPDIR"] = TEST_TMPDIR
+      ENV["HOMEBREW_DEVELOPER"] = developer
       env.each_pair do |k, v|
         ENV[k] = v
       end

--- a/Library/Homebrew/test/test_ARGV.rb
+++ b/Library/Homebrew/test/test_ARGV.rb
@@ -62,4 +62,19 @@ class ArgvExtensionTests < Homebrew::TestCase
     assert !@argv.flag?("--frotz")
     assert !@argv.flag?("--debug")
   end
+
+  def test_value
+    @argv << "--foo=" << "--bar=ab"
+    assert_equal "", @argv.value("foo")
+    assert_equal "ab", @argv.value("bar")
+    assert_nil @argv.value("baz")
+  end
+
+  def test_values
+    @argv << "--foo=" << "--bar=a" << "--baz=b,c"
+    assert_equal [], @argv.values("foo")
+    assert_equal ["a"], @argv.values("bar")
+    assert_equal ["b", "c"], @argv.values("baz")
+    assert_nil @argv.values("qux")
+  end
 end

--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -339,8 +339,29 @@ class InstalledDependantsTests < LinkTests
     tab.write
   end
 
+  def test_unknown_dependencies
+    dependencies nil
+
+    bar = formula "bar" do
+      url "bar-1.0"
+      depends_on "foo"
+    end
+    stub_formula_loader bar
+
+    assert_equal [@dependent], @keg.installed_dependents
+  end
+
   def test_no_dependencies
     dependencies []
+
+    # Make sure formula dependencies aren't checked when dependencies are
+    # recorded in the tab.
+    bar = formula "bar" do
+      url "bar-1.0"
+      depends_on "foo"
+    end
+    stub_formula_loader bar
+
     assert_empty @keg.installed_dependents
   end
 

--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -339,29 +339,8 @@ class InstalledDependantsTests < LinkTests
     tab.write
   end
 
-  def test_unknown_dependencies
-    dependencies nil
-
-    bar = formula "bar" do
-      url "bar-1.0"
-      depends_on "foo"
-    end
-    stub_formula_loader bar
-
-    assert_equal [@dependent], @keg.installed_dependents
-  end
-
   def test_no_dependencies
     dependencies []
-
-    # Make sure formula dependencies aren't checked when dependencies are
-    # recorded in the tab.
-    bar = formula "bar" do
-      url "bar-1.0"
-      depends_on "foo"
-    end
-    stub_formula_loader bar
-
     assert_empty @keg.installed_dependents
   end
 

--- a/Library/Homebrew/test/test_keg.rb
+++ b/Library/Homebrew/test/test_keg.rb
@@ -329,34 +329,34 @@ class InstalledDependantsTests < LinkTests
 
   def setup
     super
-    @dependant = setup_test_keg("bar", "1.0")
+    @dependent = setup_test_keg("bar", "1.0")
   end
 
   def dependencies(deps)
-    tab = Tab.for_keg(@dependant)
-    tab.tabfile = @dependant.join("INSTALL_RECEIPT.json")
+    tab = Tab.for_keg(@dependent)
+    tab.tabfile = @dependent.join("INSTALL_RECEIPT.json")
     tab.runtime_dependencies = deps
     tab.write
   end
 
   def test_no_dependencies
     dependencies []
-    assert_empty @keg.installed_dependants
+    assert_empty @keg.installed_dependents
   end
 
   def test_same_name_different_version
     dependencies [{ "full_name" => "foo", "version" => "1.1" }]
-    assert_empty @keg.installed_dependants
+    assert_empty @keg.installed_dependents
   end
 
   def test_different_name_same_version
     stub_formula_name("baz")
     dependencies [{ "full_name" => "baz", "version" => @keg.version.to_s }]
-    assert_empty @keg.installed_dependants
+    assert_empty @keg.installed_dependents
   end
 
   def test_same_name_and_version
     dependencies [{ "full_name" => "foo", "version" => "1.0" }]
-    assert_equal [@dependant], @keg.installed_dependants
+    assert_equal [@dependent], @keg.installed_dependents
   end
 end

--- a/Library/Homebrew/test/test_missing.rb
+++ b/Library/Homebrew/test/test_missing.rb
@@ -1,11 +1,34 @@
 require "helper/integration_command_test_case"
 
 class IntegrationCommandTestMissing < IntegrationCommandTestCase
-  def test_missing
+  def setup
+    super
+
     setup_test_formula "foo"
     setup_test_formula "bar"
+  end
 
-    (HOMEBREW_CELLAR/"bar/1.0").mkpath
+  def make_prefix(name)
+    (HOMEBREW_CELLAR/name/"1.0").mkpath
+  end
+
+  def test_missing_missing
+    make_prefix "bar"
+
     assert_match "foo", cmd("missing")
+  end
+
+  def test_missing_not_missing
+    make_prefix "foo"
+    make_prefix "bar"
+
+    assert_empty cmd("missing")
+  end
+
+  def test_missing_hide
+    make_prefix "foo"
+    make_prefix "bar"
+
+    assert_match "foo", cmd("missing", "--hide=foo")
   end
 end

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -31,6 +31,32 @@ class IntegrationCommandTestUninstall < IntegrationCommandTestCase
     assert_empty Formulary.factory(testball).installed_kegs
   end
 
+  def test_uninstall_with_unrelated_missing_deps_in_tab
+    setup_test_formula "testball"
+    run_as_not_developer do
+      cmd("install", testball)
+      cmd("install", "testball_f2")
+      cmd("uninstall", "--ignore-dependencies", "testball_f1")
+      cmd("uninstall", testball)
+    end
+  end
+
+  def test_uninstall_with_unrelated_missing_deps_not_in_tab
+    setup_test_formula "testball"
+    run_as_not_developer do
+      cmd("install", testball)
+      cmd("install", "testball_f2")
+
+      f2_keg = f2.installed_kegs.first
+      f2_tab = Tab.for_keg(f2_keg)
+      f2_tab.runtime_dependencies = nil
+      f2_tab.write
+
+      cmd("uninstall", "--ignore-dependencies", "testball_f1")
+      cmd("uninstall", testball)
+    end
+  end
+
   def test_uninstall_leaving_dependents
     cmd("install", "testball_f2")
     run_as_not_developer do

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -17,35 +17,75 @@ class IntegrationCommandTestUninstall < IntegrationCommandTestCase
     CONTENT
   end
 
+  def f1
+    Formulary.factory(@f1_path)
+  end
+
+  def f2
+    Formulary.factory(@f2_path)
+  end
+
   def test_uninstall
     cmd("install", testball)
     assert_match "Uninstalling testball", cmd("uninstall", "--force", testball)
+    assert_empty Formulary.factory(testball).installed_kegs
   end
 
   def test_uninstall_leaving_dependents
     cmd("install", "testball_f2")
-    assert_match "Refusing to uninstall", cmd_fail("uninstall", "testball_f1")
-    assert_match "Uninstalling #{Formulary.factory(@f2_path).rack}",
-      cmd("uninstall", "testball_f2")
+    run_as_not_developer do
+      assert_match "Refusing to uninstall",
+        cmd_fail("uninstall", "testball_f1")
+      refute_empty f1.installed_kegs
+      assert_match "Uninstalling #{f2.rack}",
+        cmd("uninstall", "testball_f2")
+      assert_empty f2.installed_kegs
+    end
   end
 
   def test_uninstall_force_leaving_dependents
     cmd("install", "testball_f2")
-    assert_match "Refusing to uninstall",
-      cmd_fail("uninstall", "testball_f1", "--force")
-    assert_match "Uninstalling testball_f2",
-      cmd("uninstall", "testball_f2", "--force")
+    run_as_not_developer do
+      assert_match "Refusing to uninstall",
+        cmd_fail("uninstall", "testball_f1", "--force")
+      refute_empty f1.installed_kegs
+      assert_match "Uninstalling testball_f2",
+        cmd("uninstall", "testball_f2", "--force")
+      assert_empty f2.installed_kegs
+    end
+  end
+
+  def test_uninstall_ignore_dependencies_leaving_dependents
+    cmd("install", "testball_f2")
+    run_as_not_developer do
+      assert_match "Uninstalling #{f1.rack}",
+        cmd("uninstall", "testball_f1", "--ignore-dependencies")
+      assert_empty f1.installed_kegs
+    end
+  end
+
+  def test_uninstall_leaving_dependents_developer
+    cmd("install", "testball_f2")
+    assert_match "Uninstalling #{f1.rack}",
+      cmd("uninstall", "testball_f1")
+    assert_empty f1.installed_kegs
   end
 
   def test_uninstall_dependent_first
     cmd("install", "testball_f2")
-    assert_match "Uninstalling #{Formulary.factory(@f1_path).rack}",
-      cmd("uninstall", "testball_f2", "testball_f1")
+    run_as_not_developer do
+      assert_match "Uninstalling #{f1.rack}",
+        cmd("uninstall", "testball_f2", "testball_f1")
+      assert_empty f1.installed_kegs
+    end
   end
 
   def test_uninstall_dependent_last
     cmd("install", "testball_f2")
-    assert_match "Uninstalling #{Formulary.factory(@f2_path).rack}",
-      cmd("uninstall", "testball_f1", "testball_f2")
+    run_as_not_developer do
+      assert_match "Uninstalling #{f2.rack}",
+        cmd("uninstall", "testball_f1", "testball_f2")
+      assert_empty f2.installed_kegs
+    end
   end
 end

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -1,8 +1,43 @@
 require "helper/integration_command_test_case"
 
 class IntegrationCommandTestUninstall < IntegrationCommandTestCase
+  def setup
+    super
+    @f1_path = setup_test_formula "testball_f1", <<-CONTENT
+      def install
+        FileUtils.touch prefix/touch("hello")
+      end
+    CONTENT
+    @f2_path = setup_test_formula "testball_f2", <<-CONTENT
+      depends_on "testball_f1"
+
+      def install
+        FileUtils.touch prefix/touch("hello")
+      end
+    CONTENT
+  end
+
   def test_uninstall
     cmd("install", testball)
     assert_match "Uninstalling testball", cmd("uninstall", "--force", testball)
+  end
+
+  def test_uninstall_leaving_dependents
+    cmd("install", "testball_f2")
+    assert_match "Refusing to uninstall", cmd_fail("uninstall", "testball_f1")
+    assert_match "Uninstalling #{Formulary.factory(@f2_path).rack}",
+      cmd("uninstall", "testball_f2")
+  end
+
+  def test_uninstall_dependent_first
+    cmd("install", "testball_f2")
+    assert_match "Uninstalling #{Formulary.factory(@f1_path).rack}",
+      cmd("uninstall", "testball_f2", "testball_f1")
+  end
+
+  def test_uninstall_dependent_last
+    cmd("install", "testball_f2")
+    assert_match "Uninstalling #{Formulary.factory(@f2_path).rack}",
+      cmd("uninstall", "testball_f1", "testball_f2")
   end
 end

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -1,4 +1,26 @@
 require "helper/integration_command_test_case"
+require "cmd/uninstall"
+
+class UninstallTests < Homebrew::TestCase
+  def test_check_for_testball_f2s_when_developer
+    refute_predicate Homebrew, :should_check_for_dependents?
+  end
+
+  def test_check_for_dependents_when_not_developer
+    run_as_not_developer do
+      assert_predicate Homebrew, :should_check_for_dependents?
+    end
+  end
+
+  def test_check_for_dependents_when_ignore_dependencies
+    ARGV << "--ignore-dependencies"
+    run_as_not_developer do
+      refute_predicate Homebrew, :should_check_for_dependents?
+    end
+  ensure
+    ARGV.delete("--ignore-dependencies")
+  end
+end
 
 class IntegrationCommandTestUninstall < IntegrationCommandTestCase
   def setup

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -48,110 +48,21 @@ class IntegrationCommandTestUninstall < IntegrationCommandTestCase
   end
 
   def test_uninstall
-    cmd("install", testball)
-    assert_match "Uninstalling testball", cmd("uninstall", "--force", testball)
-    assert_empty Formulary.factory(testball).installed_kegs
-  end
-
-  def test_uninstall_with_unrelated_missing_deps_in_tab
-    setup_test_formula "testball"
-    run_as_not_developer do
-      cmd("install", testball)
-      cmd("install", "testball_f2")
-      cmd("uninstall", "--ignore-dependencies", "testball_f1")
-      cmd("uninstall", testball)
-    end
-  end
-
-  def test_uninstall_with_unrelated_missing_deps_not_in_tab
-    setup_test_formula "testball"
-    run_as_not_developer do
-      cmd("install", testball)
-      cmd("install", "testball_f2")
-
-      f2_keg = f2.installed_kegs.first
-      f2_tab = Tab.for_keg(f2_keg)
-      f2_tab.runtime_dependencies = nil
-      f2_tab.write
-
-      cmd("uninstall", "--ignore-dependencies", "testball_f1")
-      cmd("uninstall", testball)
-    end
-  end
-
-  def test_uninstall_leaving_dependents
     cmd("install", "testball_f2")
     run_as_not_developer do
+
       assert_match "Refusing to uninstall",
         cmd_fail("uninstall", "testball_f1")
       refute_empty f1.installed_kegs
+
       assert_match "Uninstalling #{f2.rack}",
         cmd("uninstall", "testball_f2")
       assert_empty f2.installed_kegs
-    end
-  end
 
-  def test_uninstall_leaving_dependents_no_runtime_dependencies_in_tab
-    cmd("install", "testball_f2")
-
-    f2_keg = f2.installed_kegs.first
-    f2_tab = Tab.for_keg(f2_keg)
-    f2_tab.runtime_dependencies = nil
-    f2_tab.write
-
-    run_as_not_developer do
-      assert_match "Refusing to uninstall",
-        cmd_fail("uninstall", "testball_f1")
-      refute_empty f1.installed_kegs
-      assert_match "Uninstalling #{f2.rack}",
-        cmd("uninstall", "testball_f2")
-      assert_empty f2.installed_kegs
-    end
-  end
-
-  def test_uninstall_force_leaving_dependents
-    cmd("install", "testball_f2")
-    run_as_not_developer do
-      assert_match "Refusing to uninstall",
-        cmd_fail("uninstall", "testball_f1", "--force")
-      refute_empty f1.installed_kegs
-      assert_match "Uninstalling testball_f2",
-        cmd("uninstall", "testball_f2", "--force")
-      assert_empty f2.installed_kegs
-    end
-  end
-
-  def test_uninstall_ignore_dependencies_leaving_dependents
-    cmd("install", "testball_f2")
-    run_as_not_developer do
       assert_match "Uninstalling #{f1.rack}",
-        cmd("uninstall", "testball_f1", "--ignore-dependencies")
+        cmd("uninstall", "testball_f1")
       assert_empty f1.installed_kegs
-    end
-  end
 
-  def test_uninstall_leaving_dependents_developer
-    cmd("install", "testball_f2")
-    assert_match "Uninstalling #{f1.rack}",
-      cmd("uninstall", "testball_f1")
-    assert_empty f1.installed_kegs
-  end
-
-  def test_uninstall_dependent_first
-    cmd("install", "testball_f2")
-    run_as_not_developer do
-      assert_match "Uninstalling #{f1.rack}",
-        cmd("uninstall", "testball_f2", "testball_f1")
-      assert_empty f1.installed_kegs
-    end
-  end
-
-  def test_uninstall_dependent_last
-    cmd("install", "testball_f2")
-    run_as_not_developer do
-      assert_match "Uninstalling #{f2.rack}",
-        cmd("uninstall", "testball_f1", "testball_f2")
-      assert_empty f2.installed_kegs
     end
   end
 end

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -23,44 +23,8 @@ class UninstallTests < Homebrew::TestCase
 end
 
 class IntegrationCommandTestUninstall < IntegrationCommandTestCase
-  def setup
-    super
-    @f1_path = setup_test_formula "testball_f1", <<-CONTENT
-      def install
-        FileUtils.touch prefix/touch("hello")
-      end
-    CONTENT
-    @f2_path = setup_test_formula "testball_f2", <<-CONTENT
-      depends_on "testball_f1"
-
-      def install
-        FileUtils.touch prefix/touch("hello")
-      end
-    CONTENT
-  end
-
-  def f1
-    Formulary.factory(@f1_path)
-  end
-
-  def f2
-    Formulary.factory(@f2_path)
-  end
-
   def test_uninstall
-    cmd("install", "testball_f2")
-    run_as_not_developer do
-      assert_match "Refusing to uninstall",
-        cmd_fail("uninstall", "testball_f1")
-      refute_empty f1.installed_kegs
-
-      assert_match "Uninstalling #{f2.rack}",
-        cmd("uninstall", "testball_f2")
-      assert_empty f2.installed_kegs
-
-      assert_match "Uninstalling #{f1.rack}",
-        cmd("uninstall", "testball_f1")
-      assert_empty f1.installed_kegs
-    end
+    cmd("install", testball)
+    assert_match "Uninstalling testball", cmd("uninstall", "--force", testball)
   end
 end

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -50,7 +50,6 @@ class IntegrationCommandTestUninstall < IntegrationCommandTestCase
   def test_uninstall
     cmd("install", "testball_f2")
     run_as_not_developer do
-
       assert_match "Refusing to uninstall",
         cmd_fail("uninstall", "testball_f1")
       refute_empty f1.installed_kegs
@@ -62,7 +61,6 @@ class IntegrationCommandTestUninstall < IntegrationCommandTestCase
       assert_match "Uninstalling #{f1.rack}",
         cmd("uninstall", "testball_f1")
       assert_empty f1.installed_kegs
-
     end
   end
 end

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -43,6 +43,24 @@ class IntegrationCommandTestUninstall < IntegrationCommandTestCase
     end
   end
 
+  def test_uninstall_leaving_dependents_no_runtime_dependencies_in_tab
+    cmd("install", "testball_f2")
+
+    f2_keg = f2.installed_kegs.first
+    f2_tab = Tab.for_keg(f2_keg)
+    f2_tab.runtime_dependencies = nil
+    f2_tab.write
+
+    run_as_not_developer do
+      assert_match "Refusing to uninstall",
+        cmd_fail("uninstall", "testball_f1")
+      refute_empty f1.installed_kegs
+      assert_match "Uninstalling #{f2.rack}",
+        cmd("uninstall", "testball_f2")
+      assert_empty f2.installed_kegs
+    end
+  end
+
   def test_uninstall_force_leaving_dependents
     cmd("install", "testball_f2")
     run_as_not_developer do

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -29,6 +29,14 @@ class IntegrationCommandTestUninstall < IntegrationCommandTestCase
       cmd("uninstall", "testball_f2")
   end
 
+  def test_uninstall_force_leaving_dependents
+    cmd("install", "testball_f2")
+    assert_match "Refusing to uninstall",
+      cmd_fail("uninstall", "testball_f1", "--force")
+    assert_match "Uninstalling testball_f2",
+      cmd("uninstall", "testball_f2", "--force")
+  end
+
   def test_uninstall_dependent_first
     cmd("install", "testball_f2")
     assert_match "Uninstalling #{Formulary.factory(@f1_path).rack}",

--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -245,8 +245,11 @@ packages.</p>
 
 <p>If <code>--force</code> is passed, then treat installed <var>formulae</var> and passed <var>formulae</var>
 like if they are from same taps and migrate them anyway.</p></dd>
-<dt><code>missing</code> [<var>formulae</var>]</dt><dd><p>Check the given <var>formulae</var> for missing dependencies. If no <var>formulae</var> are
-given, check all installed brews.</p></dd>
+<dt><code>missing</code> [<code>--hide=</code><var>hidden</var>] [<var>formulae</var>]</dt><dd><p>Check the given <var>formulae</var> for missing dependencies. If no <var>formulae</var> are
+given, check all installed brews.</p>
+
+<p>If <code>--hide=</code><var>hidden</var> is passed, act as if none of <var>hidden</var> are installed.
+<var>hidden</var> should be a comma-seperated list of formulae.</p></dd>
 <dt><code>options</code> [<code>--compact</code>] (<code>--all</code>|<code>--installed</code>|<var>formulae</var>)</dt><dd><p>Display install options specific to <var>formulae</var>.</p>
 
 <p>If <code>--compact</code> is passed, show all options on a single line separated by
@@ -348,10 +351,13 @@ for <var>version</var> is <code>v1</code>.</p>
 <dt><code>tap-pin</code> <var>tap</var></dt><dd><p>Pin <var>tap</var>, prioritizing its formulae over core when formula names are supplied
 by the user. See also <code>tap-unpin</code>.</p></dd>
 <dt><code>tap-unpin</code> <var>tap</var></dt><dd><p>Unpin <var>tap</var> so its formulae are no longer prioritized. See also <code>tap-pin</code>.</p></dd>
-<dt><code>uninstall</code>, <code>rm</code>, <code>remove</code> [<code>--force</code>] <var>formula</var></dt><dd><p>Uninstall <var>formula</var>.</p>
+<dt><code>uninstall</code>, <code>rm</code>, <code>remove</code> [<code>--force</code>] [<code>--ignore-dependencies</code>] <var>formula</var></dt><dd><p>Uninstall <var>formula</var>.</p>
 
 <p>If <code>--force</code> is passed, and there are multiple versions of <var>formula</var>
-installed, delete all installed versions.</p></dd>
+installed, delete all installed versions.</p>
+
+<p>If <code>--ignore-dependencies</code> is passed, uninstalling won't fail, even if
+formulae depending on <var>formula</var> would still be installed.</p></dd>
 <dt><code>unlink</code> [<code>--dry-run</code>] <var>formula</var></dt><dd><p>Remove symlinks for <var>formula</var> from the Homebrew prefix. This can be useful
 for temporarily disabling a formula:
 <code>brew unlink foo &amp;&amp; commands &amp;&amp; brew link foo</code>.</p>

--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -249,7 +249,7 @@ like if they are from same taps and migrate them anyway.</p></dd>
 given, check all installed brews.</p>
 
 <p>If <code>--hide=</code><var>hidden</var> is passed, act as if none of <var>hidden</var> are installed.
-<var>hidden</var> should be a comma-seperated list of formulae.</p></dd>
+<var>hidden</var> should be a comma-separated list of formulae.</p></dd>
 <dt><code>options</code> [<code>--compact</code>] (<code>--all</code>|<code>--installed</code>|<var>formulae</var>)</dt><dd><p>Display install options specific to <var>formulae</var>.</p>
 
 <p>If <code>--compact</code> is passed, show all options on a single line separated by

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -329,8 +329,11 @@ Migrate renamed packages to new name, where \fIformulae\fR are old names of pack
 If \fB\-\-force\fR is passed, then treat installed \fIformulae\fR and passed \fIformulae\fR like if they are from same taps and migrate them anyway\.
 .
 .TP
-\fBmissing\fR [\fIformulae\fR]
+\fBmissing\fR [\fB\-\-hide=\fR\fIhidden\fR] [\fIformulae\fR]
 Check the given \fIformulae\fR for missing dependencies\. If no \fIformulae\fR are given, check all installed brews\.
+.
+.IP
+If \fB\-\-hide=\fR\fIhidden\fR is passed, act as if none of \fIhidden\fR are installed\. \fIhidden\fR should be a comma\-seperated list of formulae\.
 .
 .TP
 \fBoptions\fR [\fB\-\-compact\fR] (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR)
@@ -484,11 +487,14 @@ Pin \fItap\fR, prioritizing its formulae over core when formula names are suppli
 Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
 .
 .TP
-\fBuninstall\fR, \fBrm\fR, \fBremove\fR [\fB\-\-force\fR] \fIformula\fR
+\fBuninstall\fR, \fBrm\fR, \fBremove\fR [\fB\-\-force\fR] [\fB\-\-ignore\-dependencies\fR] \fIformula\fR
 Uninstall \fIformula\fR\.
 .
 .IP
 If \fB\-\-force\fR is passed, and there are multiple versions of \fIformula\fR installed, delete all installed versions\.
+.
+.IP
+If \fB\-\-ignore\-dependencies\fR is passed, uninstalling won\'t fail, even if formulae depending on \fIformula\fR would still be installed\.
 .
 .TP
 \fBunlink\fR [\fB\-\-dry\-run\fR] \fIformula\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -333,7 +333,7 @@ If \fB\-\-force\fR is passed, then treat installed \fIformulae\fR and passed \fI
 Check the given \fIformulae\fR for missing dependencies\. If no \fIformulae\fR are given, check all installed brews\.
 .
 .IP
-If \fB\-\-hide=\fR\fIhidden\fR is passed, act as if none of \fIhidden\fR are installed\. \fIhidden\fR should be a comma\-seperated list of formulae\.
+If \fB\-\-hide=\fR\fIhidden\fR is passed, act as if none of \fIhidden\fR are installed\. \fIhidden\fR should be a comma\-separated list of formulae\.
 .
 .TP
 \fBoptions\fR [\fB\-\-compact\fR] (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

Makes `brew uninstall foo` (but not `brew uninstall --force foo`) refuse to uninstall `foo` if kegs that depend on it are still installed.

Closes #934.
