### PR TITLE
tests: speed up integration tests coverage

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -20,7 +20,13 @@ SimpleCov.start do
     at_exit do
       exit_code = $!.nil? ? 0 : $!.status
       $stdout.reopen("/dev/null")
-      SimpleCov.result # Just save result, but don't write formatted output.
+
+      # Just save result, but don't write formatted output.
+      coverage_result = Coverage.result
+      SimpleCov.add_not_loaded_files(coverage_result)
+      simplecov_result = SimpleCov::Result.new(coverage_result)
+      SimpleCov::ResultMerger.store_result(simplecov_result)
+
       exit! exit_code
     end
   else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is the speed-up I was referring to in #1041.

Previously, .simplecov called `SimpleCov.result` to store the coverage result, and ignored the return value. `SimpleCov.result`'s return can be slow to calculate, which wastes a lot of time when it's ignored.

This pull request extracts the code needed to store the SimpleCov result from `SimpleCov.result`, and calls it directly, without doing the busywork to compute the return value every time.

In my testing, this more than halves the time taken to run all the integration tests.