### PR TITLE
Remove old cctools references now that only ruby-macho is used.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -255,7 +255,7 @@ module Homebrew
           if prefix != prefix_check
             relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg)
           end
-          skip_relocation = relocatable && !keg.require_install_name_tool?
+          skip_relocation = relocatable && !keg.require_relocation?
         end
         puts if !relocatable && ARGV.verbose?
       rescue Interrupt

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -124,7 +124,7 @@ class Keg
   end
 
   def self.file_linked_libraries(file, string)
-    # Check dynamic library linkage. Importantly, do not run otool on static
+    # Check dynamic library linkage. Importantly, do not perform for static
     # libraries, which will falsely report "linkage" to themselves.
     if file.mach_o_executable? || file.dylib? || file.mach_o_bundle?
       file.dynamically_linked_libraries.select { |lib| lib.include? string }

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -45,26 +45,6 @@ module OS
       @language ||= Utils.popen_read("defaults", "read", ".GlobalPreferences", "AppleLanguages").delete(" \n\"()").sub(/,.*/, "")
     end
 
-    # Locates a (working) copy of install_name_tool, guaranteed to function
-    # whether the user has developer tools installed or not.
-    def install_name_tool
-      if (path = HOMEBREW_PREFIX/"opt/cctools/bin/install_name_tool").executable?
-        path
-      else
-        DevelopmentTools.locate("install_name_tool")
-      end
-    end
-
-    # Locates a (working) copy of otool, guaranteed to function whether the user
-    # has developer tools installed or not.
-    def otool
-      if (path = HOMEBREW_PREFIX/"opt/cctools/bin/otool").executable?
-        path
-      else
-        DevelopmentTools.locate("otool")
-      end
-    end
-
     def active_developer_dir
       @active_developer_dir ||= Utils.popen_read("/usr/bin/xcode-select", "-print-path").strip
     end

--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -1,6 +1,6 @@
 class Keg
   def change_dylib_id(id, file)
-    @require_install_name_tool = true
+    @require_relocation = true
     puts "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}" if ARGV.debug?
     MachO::Tools.change_dylib_id(file, id, strict: false)
   rescue MachO::MachOError
@@ -13,7 +13,7 @@ class Keg
   end
 
   def change_install_name(old, new, file)
-    @require_install_name_tool = true
+    @require_relocation = true
     puts "Changing install name in #{file}\n  from #{old}\n    to #{new}" if ARGV.debug?
     MachO::Tools.change_install_name(file, old, new, strict: false)
   rescue MachO::MachOError
@@ -25,7 +25,7 @@ class Keg
     raise
   end
 
-  def require_install_name_tool?
-    @require_install_name_tool
+  def require_relocation?
+    @require_relocation
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Continuation of #1051. The big changes here are that `Keg#require_install_name_tool?` is now `Keg#require_relocation?` and `OS::Mac.{install_name_tool,otool}` are removed.

Other notes:

We still check for `otool` and `install_name_tool` behavior in *extend/os/mac/diagnostic.rb*, even though both are currently eliminated entirely from the codebase.

Is it worth keeping checks like `check_for_bad_install_name_tool`? A cursory search of the core shows that at least 11 formulae invoke it directly, rather than using our ruby implementation.

cc @UniqMartin, @MikeMcQuaid 