### PR TITLE
warning only functionality

### DIFF
--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -101,6 +101,15 @@ class BuildOptions
     @options - @args
   end
 
+  # @private
+  def invalid_options
+    (@options | @args) - @options
+  end
+
+  def invalid_flag_names
+    invalid_options.map(&:flag).sort
+  end
+
   private
 
   def option_defined?(name)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -272,7 +272,9 @@ module Homebrew
     f.print_tap_action
 
     fi = FormulaInstaller.new(f)
-    fi.options             = f.build.used_options
+    build_options = f.build
+    fi.options             = build_options.used_options
+    fi.invalid_flag_names  = build_options.invalid_flag_names
     fi.ignore_deps         = ARGV.ignore_deps?
     fi.only_deps           = ARGV.only_deps?
     fi.build_bottle        = ARGV.build_bottle?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -30,7 +30,7 @@ class FormulaInstaller
   end
 
   attr_reader :formula
-  attr_accessor :options, :build_bottle
+  attr_accessor :options, :build_bottle, :invalid_flag_names
   mode_attr_accessor :show_summary_heading, :show_header
   mode_attr_accessor :build_from_source, :force_bottle
   mode_attr_accessor :ignore_deps, :only_deps, :interactive, :git
@@ -50,6 +50,7 @@ class FormulaInstaller
     @quieter = false
     @debug = false
     @options = Options.new
+    @invalid_flag_names = []
 
     @@attempted ||= Set.new
 
@@ -210,6 +211,10 @@ class FormulaInstaller
       old_flag = deprecated_option.old_flag
       new_flag = deprecated_option.current_flag
       opoo "#{formula.full_name}: #{old_flag} was deprecated; using #{new_flag} instead!"
+    end
+
+    invalid_flag_names.each do |flag|
+      opoo "#{formula.full_name}: #{flag} is invalid for this formula and will be ignored!"
     end
 
     oh1 "Installing #{Tty.green}#{formula.full_name}#{Tty.reset}" if show_header?

--- a/Library/Homebrew/test/test_build_options.rb
+++ b/Library/Homebrew/test/test_build_options.rb
@@ -7,6 +7,8 @@ class BuildOptionsTests < Homebrew::TestCase
     args = Options.create(%w[--with-foo --with-bar --without-qux])
     opts = Options.create(%w[--with-foo --with-bar --without-baz --without-qux])
     @build = BuildOptions.new(args, opts)
+    bad_args = Options.create(%w[--with-foo --with-bar --without-bas --without-qux --without-abc])
+    @bad_build = BuildOptions.new(bad_args, opts)
   end
 
   def test_include
@@ -30,5 +32,18 @@ class BuildOptionsTests < Homebrew::TestCase
 
   def test_unused_options
     assert_includes @build.unused_options, "--without-baz"
+  end
+
+  def test_invalid_options
+    assert_empty @build.invalid_options
+    assert_includes @bad_build.invalid_options, "--without-bas"
+    assert_includes @bad_build.invalid_options, "--without-abc"
+    refute_includes @bad_build.invalid_options, "--with-foo"
+    refute_includes @bad_build.invalid_options, "--with-baz"
+  end
+
+  def test_invalid_flag_names
+    assert_empty @build.invalid_flag_names
+    assert_equal @bad_build.invalid_flag_names, %w[--without-abc --without-bas]
   end
 end

--- a/Library/Homebrew/test/test_formula_installer.rb
+++ b/Library/Homebrew/test/test_formula_installer.rb
@@ -37,6 +37,8 @@ class InstallTests < Homebrew::TestCase
   end
 
   def test_a_basic_install
+    # fail test if invalid option warnings change to fail, or need user input
+    ARGV << "--with-invalid_flag"
     temporary_install(Testball.new) do |f|
       # Test that things made it into the Keg
       assert_predicate f.prefix+"readme", :exist?

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -304,6 +304,7 @@ class IntegrationCommandTests < Homebrew::TestCase
       cmd("install", "testball2")
 
     setup_test_formula "testball3"
+    cmd("unlink", "testball1") # prevent link failure, as testball1 is built earlier
     assert_match "testball3: --with-fo is invalid for this formula and will be ignored!",
       cmd("install", "testball3", "--with-fo")
   end

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -294,8 +294,6 @@ class IntegrationCommandTests < Homebrew::TestCase
     assert_match "No available formula", cmd_fail("install", "formula")
     assert_match "This similarly named formula was found",
       cmd_fail("install", "testball")
-    assert_match "testball1: --with-fo is invalid for this formula and will be ignored!",
-      cmd("install", "testball1", "--with-fo")
 
     setup_test_formula "testball2"
     assert_match "These similarly named formulae were found",
@@ -304,6 +302,10 @@ class IntegrationCommandTests < Homebrew::TestCase
     install_and_rename_coretap_formula "testball1", "testball2"
     assert_match "testball1 already installed, it's just not migrated",
       cmd("install", "testball2")
+
+    setup_test_formula "testball3"
+    assert_match "testball3: --with-fo is invalid for this formula and will be ignored!",
+      cmd("install", "testball3", "--with-fo")
   end
 
   def test_bottle

--- a/Library/Homebrew/test/test_integration_cmds.rb
+++ b/Library/Homebrew/test/test_integration_cmds.rb
@@ -294,6 +294,8 @@ class IntegrationCommandTests < Homebrew::TestCase
     assert_match "No available formula", cmd_fail("install", "formula")
     assert_match "This similarly named formula was found",
       cmd_fail("install", "testball")
+    assert_match "testball1: --with-fo is invalid for this formula and will be ignored!",
+      cmd("install", "testball1", "--with-fo")
 
     setup_test_formula "testball2"
     assert_match "These similarly named formulae were found",


### PR DESCRIPTION
Re [my proposal](https://github.com/MatzFan/brew-evolution/blob/invalid_install_option_warnings/XXX-invalid-install-option-warnings.md), have implemented simplest case of warnings of any invalid build option args - no user interaction. Be interested in any feedback :)
