### PR TITLE
test: most formulae have tests now

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -1,5 +1,5 @@
 #:  * `test` [`--devel`|`--HEAD`] [`--debug`] [`--keep-tmp`] <formula>:
-#:    A few formulae provide a test method. `brew test` <formula> runs this
+#:    Most formulae provide a test method. `brew test` <formula> runs this
 #:    test method. There is no standard output or return code, but it should
 #:    generally indicate to the user if something is wrong with the installed
 #:    formula.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This might sound like splitting hairs, but we are at 79% test availability for the Core tap now.

```python
% ag "test do" | wc -l
2877
% len($(echo *).split(" "))
3604
% 2877 / 3604
0.7982796892341842
```

I therefore think it's more appropriate to say "most" formulae have a test than just "a few". Besides, this might encourage writing tests for the remaining ones that lack them, which is all-in-all a net positive.