### PR TITLE
diagnostic: make using outdated dev tools fatal

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -14,13 +14,13 @@ module Homebrew
       end
 
       def fatal_development_tools_checks
-        if MacOS.prerelease?
+        if ENV["TRAVIS"] || ARGV.homebrew_developer?
           %w[
-            check_xcode_up_to_date
-            check_clt_up_to_date
           ]
         else
           %w[
+            check_xcode_up_to_date
+            check_clt_up_to_date
           ]
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A smarter form of https://github.com/Homebrew/brew/commit/559cea7fa9d7f9f2557f2523092687dec45c5316. Travis users can't force Travis to update 10.11 to Xcode 8, so this was murdering builds left, right & centre.

Fixes https://github.com/Homebrew/brew/issues/1096 whilst still retaining the point of the original commit. Also offers developers an opt-out so if we need to test something on 10.11 with Xcode 7.x we can, etc.