### PR TITLE
test-bot: cleanup etc/var after each build.

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -749,7 +749,7 @@ module Homebrew
       end
     end
 
-    def cleanup_git
+    def cleanup_shared
       git "gc", "--auto"
       test "git", "clean", "-ffdx", "--exclude=Library/Taps"
 
@@ -759,8 +759,8 @@ module Homebrew
         safe_system "brew", "untap", tap
       end
 
-      Formula.installed.each do |formula|
-        safe_system "brew", "uninstall", "--force", formula
+      Dir.glob("#{HOMEBREW_PREFIX}/{Cellar,etc,var}/**/*").each do |file|
+        FileUtils.rm_rf file
       end
       safe_system "brew", "prune"
 
@@ -792,7 +792,7 @@ module Homebrew
         git "reset", "--hard", "origin/master"
       end
 
-      cleanup_git
+      cleanup_shared
 
       pr_locks = "#{@repository}/.git/refs/remotes/*/pr/*/*.lock"
       Dir.glob(pr_locks) { |lock| FileUtils.rm_rf lock }
@@ -813,7 +813,7 @@ module Homebrew
         git "stash", "pop"
         test "brew", "cleanup", "--prune=7"
 
-        cleanup_git
+        cleanup_shared
 
         if ARGV.include? "--local"
           FileUtils.rm_rf ENV["HOMEBREW_HOME"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This has been causing issues when bottling files that are installed to these paths due to the diff algorithm we use for figuring out whether files installed into etc/var belong to a given bottle.