### PR TITLE
version: improve alpha and rc detection (elasticsearch)

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -203,6 +203,10 @@ class VersionParsingTests < Homebrew::TestCase
     assert_version_detected "0.7.1", "https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1"
   end
 
+  def test_elasticsearch_alpha_style
+    assert_version_detected "5.0.0-alpha5", "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/5.0.0-alpha5/elasticsearch-5.0.0-alpha5.tar.gz"
+  end
+
   def test_gloox_beta_style
     assert_version_detected "1.0-beta7", "http://camaya.net/download/gloox-1.0-beta7.tar.bz2"
   end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -340,8 +340,8 @@ class Version
     m = /-((?:\d+\.)*\d+(?:[abc]|rc|RC)\d*)$/.match(stem)
     return m.captures.first unless m.nil?
 
-    # e.g. foobar-4.5.0-beta1, or foobar-4.50-beta
-    m = /-((?:\d+\.)*\d+-beta\d*)$/.match(stem)
+    # e.g. foobar-4.5.0-alpha5, foobar-4.5.0-beta1, or foobar-4.50-beta
+    m = /-((?:\d+\.)*\d+-(?:alpha|beta|rc)\d*)$/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. http://ftpmirror.gnu.org/libidn/libidn-1.29-win64.zip


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Previously we were in a weird situation where `elasticsearch 5.0.0-beta1` can be detected but `5.0.0-alpha5` cannot.