### PR TITLE
update.sh: only update to semver tags.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -217,7 +217,7 @@ merge_or_rebase() {
 
   if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -z "$HOMEBREW_NO_UPDATE_CLEANUP" ]]
   then
-    UPSTREAM_TAG="$(git tag --list --sort=-version:refname | head -n1)"
+    UPSTREAM_TAG="$(git tag --list --sort=-version:refname | grep '^[0-9]*\.[0-9]*\.[0-9]*$' | head -n1)"
   else
     UPSTREAM_TAG=""
   fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise random e.g. `pr-123` tags may cause `brew update` to update to the wrong version.

Fixes #1071.