### PR TITLE
Fix RuboCop for Taps.

### DIFF
--- a/Library/.rubocop_rules.yml
+++ b/Library/.rubocop_rules.yml
@@ -110,13 +110,7 @@ Style/TernaryParentheses:
 
 # dashes in filenames are typical
 Style/FileName:
-  # matches:
-  #   file_name.rb (default)
-  #   file-name.rb, --filename.rb (command names)
-  #   FILENAME.rb (ARGV and ENV)
-  # does not match:
-  #   dashes-and_underscores.rb
-  Regex: !ruby/regexp /^((([\dA-Z]+|[\da-z\+]+)(_([\dA-Z]+|[\da-z\+]+))*|(\-\-)?([\dA-Z]+|[\da-z\+\.]+)([-@]([\dA-Z]+|[\da-z\+\.]+))*))(\.rb)?$/
+  Regex: !ruby/regexp /^[\w\@\-\+\.]+(\.rb)?$/
 
 # no percent word array, being friendly to non-ruby users
 # TODO: enforce when rubocop has fixed this


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Excluded Taps from Lint/UnneededSplatExpansion and Style/NumericPredicate cops and changed the Style/FileName regex.