### PR TITLE
update.sh: do not restore stable (tag) branch

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -297,7 +297,8 @@ EOS
 
   if [[ -n "$HOMEBREW_NO_UPDATE_CLEANUP" ]]
   then
-    if [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" ]]
+    if [[ "$INITIAL_BRANCH" != "$UPSTREAM_BRANCH" && -n "$INITIAL_BRANCH" &&
+          ! "$INITIAL_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]$ ]]
     then
       git checkout "$INITIAL_BRANCH" "${QUIET_ARGS[@]}"
     fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Restoring stable branch post-update could lead to unsuspecting users
with homebrew.devcmdrun being stuck forever on an old tag.

Fixes #1111. (A much more detailed description of the problem can be found there.)

I'm worried about the damage that's already done. There should be users that are already stuck, and since we no longer update to master, we can't modify their update logic.