### PR TITLE
test-bot: do not require brew style in core tap

### DIFF
--- a/Library/Homebrew/dev-cmd/test-bot.rb
+++ b/Library/Homebrew/dev-cmd/test-bot.rb
@@ -634,7 +634,6 @@ module Homebrew
           install_passed = steps.last.passed?
         end
       end
-      test "brew", "style", formula_name
       test "brew", "audit", *audit_args
       if install_passed
         if formula.stable? && !ARGV.include?("--fast") && !ARGV.include?("--no-bottle") && !formula.bottle_disabled?
@@ -740,7 +739,6 @@ module Homebrew
           test "brew", "cask-tests", *coverage_args
         end
       elsif @tap
-        test "brew", "style", @tap.name if @tap.name == "homebrew/core"
         test "brew", "readall", "--aliases", @tap.name
       end
     end


### PR DESCRIPTION
The hashrocket changes in particular have siginficantly degraded the
readability, consistency, clarity, and style of formulae, as well as
expanded the opportunities for ambiguity, in exchange for no tangible
benefits to the contributors and maintainers of core.

`brew style` enforcement should be restricted to homebrew/brew alone.