### PR TITLE
rubocop: allow hash rockets in taps.

### DIFF
--- a/Library/.rubocop_rules.yml
+++ b/Library/.rubocop_rules.yml
@@ -1,4 +1,3 @@
-
 # ruby style guide favorite
 Style/StringLiterals:
   EnforcedStyle: double_quotes
@@ -18,6 +17,12 @@ Style/NumericLiteralPrefix:
 # percent-x is allowed for multiline
 Style/CommandLiteral:
   EnforcedStyle: mixed
+
+# depends_on foo: :bar looks rubbish
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  Exclude:
+    - 'Taps/**/*'
 
 # paths abound, easy escape
 Style/RegexpLiteral:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Because `depends_on foo: :bar` looks rubbish.