### PR TITLE
version: don't let a/b imply alpha/beta.

### DIFF
--- a/Library/Homebrew/test/test_versions.rb
+++ b/Library/Homebrew/test/test_versions.rb
@@ -63,6 +63,8 @@ class VersionComparisonTests < Homebrew::TestCase
   end
 
   def test_comparing_alpha_versions
+    assert_operator version("1.2.3alpha"), :<, version("1.2.3")
+    assert_operator version("1.2.3"), :<, version("1.2.3a")
     assert_operator version("1.2.3alpha4"), :==, version("1.2.3a4")
     assert_operator version("1.2.3alpha4"), :==, version("1.2.3A4")
     assert_operator version("1.2.3alpha4"), :>, version("1.2.3alpha3")

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -95,7 +95,7 @@ class Version
   end
 
   class AlphaToken < CompositeToken
-    PATTERN = /a(?:lpha)?[0-9]*/i
+    PATTERN = /alpha[0-9]*|a[0-9]+/i
 
     def <=>(other)
       case other
@@ -108,7 +108,7 @@ class Version
   end
 
   class BetaToken < CompositeToken
-    PATTERN = /b(?:eta)?[0-9]*/i
+    PATTERN = /beta[0-9]*|b[0-9]+/i
 
     def <=>(other)
       case other


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is assumption is broken for at least OpenSSL which makes it a bad general rule.

As discussed in #1102.