### PR TITLE
download_strategy: never verbosely untar

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -231,8 +231,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     when :bzip2_only
       with_system_path { buffered_write("bunzip2") }
     when :gzip, :bzip2, :compress, :tar
-      # Assume these are also tarred
-      tar_flags = ARGV.verbose? && ENV["TRAVIS"].nil? ? "xv" : "x"
+      tar_flags = "x"
       # Older versions of tar require an explicit format flag
       if cached_location.compression_type == :gzip
         tar_flags << "z"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I was responsible for adding the `v` flag to `tar` in d7b6230, and I have to admit, I regretted the decision pretty soon. The verbose mode of `tar` is just too pointlessly verbose. Today I'm finally fed up after having to scroll through [this](https://bot.brew.sh/job/Homebrew%20Core%20Pull%20Requests/8211/version=el_capitan/testReport/junit/brew-test-bot/el_capitan/install_v8/). Let's get rid of it.