### PR TITLE
Fix `search_tap` regex/string matching.

### DIFF
--- a/Library/Homebrew/test/test_search_remote_tap.rb
+++ b/Library/Homebrew/test/test_search_remote_tap.rb
@@ -1,0 +1,19 @@
+require "testing_env"
+require "cmd/search"
+
+class SearchRemoteTapTests < Homebrew::TestCase
+  def test_search_remote_tap
+    json_response = {
+      "tree" => [
+        {
+          "path" => "Formula/not-a-formula.rb",
+          "type" => "blob",
+        },
+      ],
+    }
+
+    GitHub.stubs(:open).yields(json_response)
+
+    assert_equal ["homebrew/not-a-tap/not-a-formula"], Homebrew.search_tap("homebrew", "not-a-tap", "not-a-formula")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes the error introduced in https://github.com/Homebrew/brew/commit/52ff98853068c03b3bfa777932da1da69e35e583#diff-791b01b40fb03181802be9c2315258b2R153.

Not sure if the test I have added is the best way to go, but I didn't find another command which even get's to this stage in `search_tap`. Couldn't even get it to work locally yet as I am getting a GitHub API error, despite having set `HOMEBREW_GITHUB_API_TOKEN`.