### PR TITLE
ARGV: kegs: error on empty arguments

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -65,6 +65,8 @@ module HomebrewArgvExtension
     require "keg"
     require "formula"
     @kegs ||= downcased_unique_named.collect do |name|
+      raise UsageError if name.empty?
+
       rack = Formulary.to_rack(name.downcase)
 
       dirs = rack.directory? ? rack.subdirs : []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When an argument is empty, `Formulary.to_rack(name.downcase)` returns `HOMEBREW_CELLAR`, then the list of kegs `dirs` become the list of racks, which is wrong, and leads to the bewildering behavior in #1138.

We need to error out on an empty argument, but whether `NoSuchKegError` is the most appropriate error here is debatable.

Fixes #1138.

**Update.** Switched to `UsageError`.