### PR TITLE
boneyard-formula-pr: respect HOMEBREW_NO_AUTO_UPDATE

### DIFF
--- a/Library/Homebrew/dev-cmd/boneyard-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/boneyard-formula-pr.rb
@@ -30,7 +30,7 @@ module Homebrew
     boneyard_tap = Tap.fetch("homebrew", "boneyard")
     tap_migrations_path = formula.tap.path/"tap_migrations.json"
     if ARGV.dry_run?
-      puts "brew update"
+      puts "brew update" if ENV["HOMEBREW_NO_AUTO_UPDATE"].nil?
       puts "brew tap #{boneyard_tap.name}"
       puts "cd #{formula.tap.path}"
       cd formula.tap.path
@@ -43,7 +43,7 @@ module Homebrew
       puts "Loading tap_migrations.json"
       puts "Adding #{formula.name} to tap_migrations.json"
     else
-      safe_system HOMEBREW_BREW_FILE, "update"
+      safe_system HOMEBREW_BREW_FILE, "update" if ENV["HOMEBREW_NO_AUTO_UPDATE"].nil?
       safe_system HOMEBREW_BREW_FILE, "tap", boneyard_tap.name
       cd formula.tap.path
       cp formula_relpath, boneyard_tap.formula_dir


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Very simple: make `boneyard-formula-pr` respect `HOMEBREW_NO_AUTO_UPDATE`. (People who are at the pay grade of running this command typically should be on top of updates.)

Apparently `bump-formula-pr` should receive the same treatment, but I don't use it, and ILZ will get to it (on an infinite time scale®).