### PR TITLE
Fix documentation for --caskroom default

### DIFF
--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -138,7 +138,7 @@ in a future version.
     Abort Cask installation if the Cask does not have a checksum defined.
 
   * `--caskroom=<path>`:
-    Location of the Caskroom, where all binaries are stored. The default value is: `$(brew --repository)/Caskroom`.
+    Location of the Caskroom, where all binaries are stored. The default value is: `$(brew --prefix)/Caskroom`.
 
   * `--verbose`:
     Give additional feedback during installation.

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -139,7 +139,7 @@ Abort Cask installation if the Cask does not have a checksum defined\.
 .
 .TP
 \fB\-\-caskroom=<path>\fR
-Location of the Caskroom, where all binaries are stored\. The default value is: \fB$(brew \-\-repository)/Caskroom\fR\.
+Location of the Caskroom, where all binaries are stored\. The default value is: \fB$(brew \-\-prefix)/Caskroom\fR\.
 .
 .TP
 \fB\-\-verbose\fR


### PR DESCRIPTION
As explained in https://github.com/caskroom/homebrew-cask/issues/24888, the documentation for the default value of `--caskroom` is incorrect.  I don't know if the pull request submitted at https://github.com/caskroom/homebrew-cask/pull/24891 is sufficient or if the changes in this pull request also need to be made.