### PR TITLE
download_strategy: silence unzip and unrar

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -224,7 +224,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
   def stage
     case cached_location.compression_type
     when :zip
-      with_system_path { quiet_safe_system "unzip", { quiet_flag: "-qq" }, cached_location }
+      with_system_path { quiet_safe_system "unzip", "-qq", cached_location }
       chdir
     when :gzip_only
       with_system_path { buffered_write("gunzip") }
@@ -252,7 +252,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     when :xar
       safe_system "/usr/bin/xar", "-xf", cached_location
     when :rar
-      quiet_safe_system "unrar", "x", { quiet_flag: "-inul" }, cached_location
+      quiet_safe_system "unrar", "x", "-inul", cached_location
     when :p7zip
       safe_system "7zr", "x", cached_location
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We silenced tar in 5e3a26b. It makes sense to make `unzip` and `unrar` output comparably succinct.