### PR TITLE
superenv: more 10.11 clock_gettime Autotools fixes

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -101,6 +101,11 @@ module Superenv
          getentropy mkostemp mkostemps].each do |s|
         ENV["ac_cv_func_#{s}"] = "no"
       end
+
+      ENV["ac_cv_search_clock_gettime"] = "no"
+
+      # works around libev.m4 unsetting ac_cv_func_clock_gettime
+      ENV["ac_have_clock_syscall"] = "no"
     end
 
     # On 10.9, the tools in /usr/bin proxy to the active developer directory.


### PR DESCRIPTION
some build systems check ac_cv_search_clock_gettime instead of
ac_cv_func_clock_gettime so the former should also be set to "no"

libev.m4 unsets ac_cv_func_clock_gettime, but if ac_have_clock_syscall
is defined, it will leave ac_cv_func_clock_gettime alone:

  http://cvs.schmorp.de/libev/libev.m4?view=markup#l23