### PR TITLE
formula: unset XDG env vars during test

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1558,6 +1558,9 @@ class Formula
     old_temp = ENV["TEMP"]
     old_tmp = ENV["TMP"]
     old_term = ENV["TERM"]
+    old_xdg_config_home = ENV.delete("XDG_CONFIG_HOME")
+    old_xdg_data_home = ENV.delete("XDG_DATA_HOME")
+    old_xdg_cache_home = ENV.delete("XDG_CACHE_HOME")
     ENV["CURL_HOME"] = old_curl_home || old_home
     ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
     ENV["TERM"] = "dumb"
@@ -1583,6 +1586,9 @@ class Formula
     ENV["TEMP"] = old_temp
     ENV["TMP"] = old_tmp
     ENV["TERM"] = old_term
+    ENV["XDG_CONFIG_HOME"] = old_xdg_config_home
+    ENV["XDG_DATA_HOME"] = old_xdg_data_home
+    ENV["XDG_CACHE_HOME"] = old_xdg_cache_home
   end
 
   # @private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Having XDG environment variables set during test means the possibility of sandbox violation (software writing to `XDG_DATA_HOME` or `XDG_CACHE_HOME` outside the temporary `HOME`, see e.g. `buku`) or undesired configuration pick-up (see e.g. `git-test` and in fact any git-related
tests) when testing XDG Basedir Spec compliant software.