### PR TITLE
Migrate a Formula to Multiple Versions: add docs.

### DIFF
--- a/docs/Migrate-A-Formula-To-Multiple-Versions.md
+++ b/docs/Migrate-A-Formula-To-Multiple-Versions.md
@@ -21,7 +21,7 @@ In separate pull-requests:
 
 In separate pull-requests:
 
-1. [Migrate the formula](Migrating-A-Formula-To-A-Tap) from Homebrew/homebrew-versions to Homebrew/homebrew-core with the same, old name e.g. `boost160.rb`.
+1. [Migrate the formula](Migrating-A-Formula-To-A-Tap.md) from Homebrew/homebrew-versions to Homebrew/homebrew-core with the same, old name e.g. `boost160.rb`.
 2. [Rename the formula](Rename-A-Formula.md) from e.g. `boost160.rb` to e.g. `boost@1.60.rb`. This should not require any `revision`ing or significant formula modification beyond the formula name.
 3. Tap authors should have their `depends_on "boost160"` updated to `depends_on "boost@1.60"`.
 5. When `boost@1.60` has two major/minor versions newer than it (e.g. `boost@1.62`) then consider removing `boost@1.60.rb` and anything that depends on it.

--- a/docs/Migrate-A-Formula-To-Multiple-Versions.md
+++ b/docs/Migrate-A-Formula-To-Multiple-Versions.md
@@ -1,0 +1,27 @@
+# Migrate a Formula to Multiple Versions
+## Migrating an existing formula to multiple versions
+
+In separate pull-requests:
+
+1. [Rename the formula](Rename-A-Formula.md) from e.g. `boost.rb` to e.g. `boost@1.61.rb` and, in the same pull request, add an alias named `boost`. This should not require any `revision`ing or significant formula modification beyond the formula name.
+2. Add the new version formula e.g. `boost@1.62.rb`
+3. Tap authors should have their `depends_on "boost"` updated to `depends_on "boost@1.61"` or `depends_on "boost@1.62"`.
+4. Modify the `boost` alias to point to `boost@1.62.rb`. Any formulae that need the old version of `boost` should have their `depends_on "boost"` to be updated to `depends_on "boost@1.61"`.
+5. When `boost@1.62` has two major/minor versions newer than it (e.g. `boost@1.64`) then consider removing `boost@1.62.rb` and anything that depends on it.
+
+## Upgrading a multiple version formula
+
+In separate pull-requests:
+
+1. Add the new version formula e.g. `boost@1.63.rb`
+2. Modify the `boost` alias to point to `boost@1.63.rb`. Any formulae that need the old version of `boost` should have their `depends_on "boost"` to be updated to `depends_on "boost@1.62"`.
+3. When `boost@1.63` has two major/minor versions newer than it (e.g. `boost@1.65`) then consider removing `boost@1.63.rb` and anything that depends on it.
+
+## Importing a homebrew/versions formula into homebrew/core
+
+In separate pull-requests:
+
+1. [Migrate the formula](Migrating-A-Formula-To-A-Tap) from Homebrew/homebrew-versions to Homebrew/homebrew-core with the same, old name e.g. `boost160.rb`.
+2. [Rename the formula](Rename-A-Formula.md) from e.g. `boost160.rb` to e.g. `boost@1.60.rb`. This should not require any `revision`ing or significant formula modification beyond the formula name.
+3. Tap authors should have their `depends_on "boost160"` updated to `depends_on "boost@1.60"`.
+5. When `boost@1.60` has two major/minor versions newer than it (e.g. `boost@1.62`) then consider removing `boost@1.60.rb` and anything that depends on it.

--- a/docs/Migrate-A-Formula-To-Multiple-Versions.md
+++ b/docs/Migrate-A-Formula-To-Multiple-Versions.md
@@ -4,24 +4,24 @@
 In separate pull-requests:
 
 1. [Rename the formula](Rename-A-Formula.md) from e.g. `boost.rb` to e.g. `boost@1.61.rb` and, in the same pull request, add an alias named `boost`. This should not require any `revision`ing or significant formula modification beyond the formula name.
-2. Add the new version formula e.g. `boost@1.62.rb`
+2. Add the new `keg_only` version formula e.g. `boost@1.62.rb`
 3. Tap authors should have their `depends_on "boost"` updated to `depends_on "boost@1.61"` or `depends_on "boost@1.62"`.
-4. Modify the `boost` alias to point to `boost@1.62.rb`. Any formulae that need the old version of `boost` should have their `depends_on "boost"` to be updated to `depends_on "boost@1.61"`.
+4. Modify the `boost` alias to point to `boost@1.62.rb`. Any formulae that need the old version of `boost` should have their `depends_on "boost"` to be updated to `depends_on "boost@1.61"`. `boost@1.62.rb` should no longer be `keg_only` and `boost@1.61.rb` should become `keg_only`.
 5. When `boost@1.62` has two major/minor versions newer than it (e.g. `boost@1.64`) then consider removing `boost@1.62.rb` and anything that depends on it.
 
 ## Upgrading a multiple version formula
 
 In separate pull-requests:
 
-1. Add the new version formula e.g. `boost@1.63.rb`
-2. Modify the `boost` alias to point to `boost@1.63.rb`. Any formulae that need the old version of `boost` should have their `depends_on "boost"` to be updated to `depends_on "boost@1.62"`.
+1. Add the new `keg_only` version formula e.g. `boost@1.63.rb`
+2. Modify the `boost` alias to point to `boost@1.63.rb`. Any formulae that need the old version of `boost` should have their `depends_on "boost"` to be updated to `depends_on "boost@1.62"`. `boost@1.63.rb` should no longer be `keg_only` and `boost@1.62.rb` should become `keg_only`.
 3. When `boost@1.63` has two major/minor versions newer than it (e.g. `boost@1.65`) then consider removing `boost@1.63.rb` and anything that depends on it.
 
 ## Importing a homebrew/versions formula into homebrew/core
 
 In separate pull-requests:
 
-1. [Migrate the formula](Migrating-A-Formula-To-A-Tap.md) from Homebrew/homebrew-versions to Homebrew/homebrew-core with the same, old name e.g. `boost160.rb`.
+1. [Migrate the formula](Migrating-A-Formula-To-A-Tap.md) from Homebrew/homebrew-versions to Homebrew/homebrew-core with the same, old name e.g. `boost160.rb` and to be `keg_only`.
 2. [Rename the formula](Rename-A-Formula.md) from e.g. `boost160.rb` to e.g. `boost@1.60.rb`. This should not require any `revision`ing or significant formula modification beyond the formula name.
 3. Tap authors should have their `depends_on "boost160"` updated to `depends_on "boost@1.60"`.
 5. When `boost@1.60` has two major/minor versions newer than it (e.g. `boost@1.62`) then consider removing `boost@1.60.rb` and anything that depends on it.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add a document describing how to migrate a formula to our new multiple versions support, upgrade a multiple version formula and how to import a homebrew/versions formula into homebrew/core.

CC @Homebrew/maintainers @Homebrew/science @Homebrew/php @Homebrew/linux @alyssais  @sjackman to help me think this through. This is the least disruptive way I can see of having us migrate to the path that will avoid taps needing `revision` bumps immediately in future and instead give them time to upgrade to newer versions while in core we can upgrade en-masse when we choose to while still having the new version be immediately available.

Please feel free not to just pick out flaws but to debate the approach and constraints.

Part of https://github.com/Homebrew/brew/issues/620.