### PR TITLE
Change `A Cask for #{token} is already installed.` message.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/install.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/install.rb
@@ -27,7 +27,7 @@ module Hbc
           rescue CaskAlreadyInstalledError => e
             opoo e.message
             count += 1
-          rescue CaskAutoUpdatesError => e
+          rescue CaskAlreadyInstalledAutoUpdatesError => e
             opoo e.message
             count += 1
           rescue CaskUnavailableError => e

--- a/Library/Homebrew/cask/lib/hbc/exceptions.rb
+++ b/Library/Homebrew/cask/lib/hbc/exceptions.rb
@@ -65,21 +65,19 @@ module Hbc
     end
 
     def to_s
-      <<-EOS
-  Command failed to execute!
-
-  ==> Failed command:
-  #{@cmd}
-
-  ==> Standard Output of failed command:
-  #{@stdout}
-
-  ==> Standard Error of failed command:
-  #{@stderr}
-
-  ==> Exit status of failed command:
-  #{@status.inspect}
-      EOS
+      s = "Command failed to execute!\n"
+      s.concat("\n")
+      s.concat("==> Failed command:\n")
+      s.concat(@cmd).concat("\n")
+      s.concat("\n")
+      s.concat("==> Standard Output of failed command:\n")
+      s.concat(@stdout).concat("\n")
+      s.concat("\n")
+      s.concat("==> Standard Error of failed command:\n")
+      s.concat(@stderr).concat("\n")
+      s.concat("\n")
+      s.concat("==> Exit status of failed command:\n")
+      s.concat(@status.inspect).concat("\n")
     end
   end
 

--- a/Library/Homebrew/cask/lib/hbc/exceptions.rb
+++ b/Library/Homebrew/cask/lib/hbc/exceptions.rb
@@ -41,7 +41,7 @@ module Hbc
     def reinstall_message
       <<-EOS.undent
         To re-install #{token}, run:
-          brew cask uninstall --force #{token}; brew cask install #{token}
+          brew cask uninstall --force #{token} && brew cask install #{token}
       EOS
     end
   end

--- a/Library/Homebrew/cask/lib/hbc/exceptions.rb
+++ b/Library/Homebrew/cask/lib/hbc/exceptions.rb
@@ -29,13 +29,30 @@ module Hbc
 
   class CaskAlreadyInstalledError < AbstractCaskErrorWithToken
     def to_s
-      %Q{A Cask for #{token} is already installed. Add the "--force" option to force re-install.}
+      s = <<-EOS.undent
+        A Cask for #{token} is already installed.
+      EOS
+
+      s.concat("\n").concat(reinstall_message)
+    end
+
+    private
+
+    def reinstall_message
+      <<-EOS.undent
+        To re-install #{token}, run:
+          brew cask uninstall --force #{token}; brew cask install #{token}
+      EOS
     end
   end
 
-  class CaskAutoUpdatesError < AbstractCaskErrorWithToken
+  class CaskAlreadyInstalledAutoUpdatesError < CaskAlreadyInstalledError
     def to_s
-      %Q{A Cask for #{token} is already installed and using auto-updates. Add the "--force" option to force re-install.}
+      s = <<-EOS.undent
+        A Cask for #{token} is already installed and using auto-updates.
+      EOS
+
+      s.concat("\n").concat(reinstall_message)
     end
   end
 

--- a/Library/Homebrew/cask/lib/hbc/installer.rb
+++ b/Library/Homebrew/cask/lib/hbc/installer.rb
@@ -58,11 +58,10 @@ module Hbc
     def install
       odebug "Hbc::Installer.install"
 
-      if @cask.installed? && @cask.auto_updates && !force
-        raise CaskAutoUpdatesError, @cask
+      if @cask.installed? && !force
+        raise CaskAlreadyInstalledAutoUpdatesError, @cask if @cask.auto_updates
+        raise CaskAlreadyInstalledError, @cask
       end
-
-      raise CaskAlreadyInstalledError, @cask if @cask.installed? && !force
 
       print_caveats
 

--- a/Library/Homebrew/cask/test/cask/cli/install_test.rb
+++ b/Library/Homebrew/cask/test/cask/cli/install_test.rb
@@ -29,7 +29,7 @@ describe Hbc::CLI::Install do
 
     TestHelper.must_output(self, lambda {
       Hbc::CLI::Install.run("local-transmission", "")
-    }, %r{Warning: A Cask for local-transmission is already installed. Add the "--force" option to force re-install.})
+    }, %r{Warning: A Cask for local-transmission is already installed.})
   end
 
   it "allows double install with --force" do

--- a/Library/Homebrew/cask/test/cask/installer_test.rb
+++ b/Library/Homebrew/cask/test/cask/installer_test.rb
@@ -272,7 +272,7 @@ describe Hbc::Installer do
 
       lambda {
         installer.install
-      }.must_raise(Hbc::CaskAutoUpdatesError)
+      }.must_raise(Hbc::CaskAlreadyInstalledAutoUpdatesError)
     end
 
     it "allows already-installed Casks which auto-update to be installed if force is provided" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

----

Changed the message from suggesting `brew cask install --force` to `brew cask uninstall --force`, followed by a normal `brew cask install`.

Also fixed the indentation of `CaskCommandFailedError`.

--

@Homebrew/cask 