### PR TITLE
list: fix exit code for --verbose and --pinned

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -106,7 +106,11 @@ module Homebrew
     names = if ARGV.named.empty?
       Formula.racks
     else
-      ARGV.named.map { |n| HOMEBREW_CELLAR+n }.select(&:exist?)
+      racks = ARGV.named.map { |n| HOMEBREW_CELLAR+n }
+      racks.select do |rack|
+        Homebrew.failed = true unless rack.exist?
+        rack.exist?
+      end
     end
     if ARGV.include? "--pinned"
       pinned_versions = {}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew list --verbose <formulae>` lists only those kegs that
are installed and exits with 0 if all <formulae> installed.
If one or more formulae from <formulae> are not installed, the
command lists installed versions and exits with 1.

`brew list --pinned formula` exits with 1 if formula is not pinned.

Fixes #1172