### PR TITLE
update-test: fix tag updating, skip core tap.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -113,6 +113,7 @@ module Homebrew
   end
 
   def install_core_tap_if_necessary
+    return if ENV["HOMEBREW_UPDATE_TEST"]
     core_tap = CoreTap.instance
     return if core_tap.installed?
     CoreTap.ensure_installed! quiet: false

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -16,7 +16,14 @@
 
 module Homebrew
   def update_test
-    ENV["HOMEBREW_UPDATE_TO_TAG"] = "1" if ARGV.include?("--to-tag")
+    ENV["HOMEBREW_UPDATE_TEST"] = "1"
+
+    if ARGV.include?("--to-tag")
+      ENV["HOMEBREW_UPDATE_TO_TAG"] = "1"
+      branch = "stable"
+    else
+      branch = "master"
+    end
 
     cd HOMEBREW_REPOSITORY
     start_commit = if commit = ARGV.value("commit")
@@ -57,10 +64,10 @@ module Homebrew
       # run brew update
       oh1 "Running brew update..."
       safe_system "brew", "update", "--verbose"
-      actual_end_commit = Utils.popen_read("git", "rev-parse", "master").chomp
+      actual_end_commit = Utils.popen_read("git", "rev-parse", branch).chomp
       if start_commit != end_commit && start_commit == actual_end_commit
         raise <<-EOS.undent
-          brew update didn't update master!
+          brew update didn't update #{branch}!
           Start commit:        #{start_commit}
           Expected end commit: #{end_commit}
           Actual end commit:   #{actual_end_commit}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix updating the `stable` branch used for tagged updates and ensure that the core tap isn’t retapped (the slowest part by far of this test).

CC @ilovezfs 