### PR TITLE
diagnostic: add check for missing header file

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -281,6 +281,23 @@ module Homebrew
           We recommend only installing stable releases of XQuartz.
         EOS
       end
+
+      def check_for_sip_deleted_header_file_installed_by_xcode
+        # Starting in El Capitan the upgrade of macOS lead to the deletion of the
+        # /usr/include directory due to SIP.
+        return if MacOS::CLT.installed? && File.file?("/usr/include/zlib.h")
+
+        <<-EOS.undent
+          A header file installed by xcode is missing and can lead to builds failing.
+          Due to SIP (System Integrity Protection) this can occur after a macOS
+          system has been upgraded.
+
+          Please run:
+            xcode-select --install
+
+          to reinstall the header file.
+        EOS
+      end
     end
   end
 end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -281,23 +281,6 @@ module Homebrew
           We recommend only installing stable releases of XQuartz.
         EOS
       end
-
-      def check_for_sip_deleted_header_file_installed_by_xcode
-        # Starting in El Capitan the upgrade of macOS lead to the deletion of the
-        # /usr/include directory due to SIP.
-        return if MacOS::CLT.installed? && File.file?("/usr/include/zlib.h")
-
-        <<-EOS.undent
-          A header file installed by xcode is missing and can lead to builds failing.
-          Due to SIP (System Integrity Protection) this can occur after a macOS
-          system has been upgraded.
-
-          Please run:
-            xcode-select --install
-
-          to reinstall the header file.
-        EOS
-      end
     end
   end
 end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -173,7 +173,14 @@ module OS
       # Returns true even if outdated tools are installed, e.g.
       # tools from Xcode 4.x on 10.9
       def installed?
-        !detect_version.nil?
+        # Starting in El Capitan the upgrade of macOS, ex 10.10->10.11
+        # leads to the deletion of the /usr/include directory due to SIP.
+        # CLT should be considered not installed if a header file is missing.
+        if MacOS.version >= "10.11"
+          !detect_version.nil? && File.file?("/usr/include/zlib.h")
+        else
+          !detect_version.nil?
+        end
       end
 
       def update_instructions


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----
In the PHP tap we see an error with the zlib header missing quite often. This is generally caused by an upgrade of the OS starting in El Capitan where SIP was introduced which seems to delete the /usr/include directory at each operating system upgrade. The PR only checks the zlib.h file since that's the one we've seen problems with but it should be indicative enough to tell if the files are missing or not. I had some problems with the wording due to that but I'm willing to take feedback and make updates =)
