### PR TITLE
Make `core_tap_version_string` reusable.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -14,8 +14,9 @@ $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 
 if ARGV == %w[--version] || ARGV == %w[-v]
+  require "tap"
   puts "Homebrew #{HOMEBREW_VERSION}"
-  puts "Homebrew/homebrew-core #{Homebrew.core_tap_version_string}"
+  puts "Homebrew/homebrew-core #{CoreTap.instance.version_string}"
   exit 0
 end
 

--- a/Library/Homebrew/cask/lib/hbc/version.rb
+++ b/Library/Homebrew/cask/lib/hbc/version.rb
@@ -1,13 +1,10 @@
-HBC_VERSION = "0.60.0".freeze
-
 module Hbc
   def self.full_version
     @full_version ||= begin
-      revision, commit = Dir.chdir(Hbc.default_tap.path) do
-        [`git rev-parse --short=4 --verify -q HEAD 2>/dev/null`.chomp,
-         `git show -s --format="%cr" HEAD 2>/dev/null`.chomp]
-      end
-      "#{HBC_VERSION} (git revision #{revision}; last commit #{commit})"
+      <<-EOS.undent
+        Homebrew-Cask #{HOMEBREW_VERSION}
+        caskroom/homebrew-cask #{Hbc.default_tap.version_string}
+      EOS
     end
   end
 end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -138,6 +138,13 @@ class Tap
     name
   end
 
+  def version_string
+    return "N/A" unless installed?
+    pretty_revision = git_short_head
+    return "(no git repository)" unless pretty_revision
+    "(git revision #{pretty_revision}; last commit #{git_last_commit_date})"
+  end
+
   # True if this {Tap} is an official Homebrew tap.
   def official?
     user == "Homebrew"
@@ -525,7 +532,7 @@ class CoreTap < Tap
   end
 
   def self.instance
-    @instance ||= CoreTap.new
+    @instance ||= new
   end
 
   def self.ensure_installed!(options = {})

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -173,18 +173,6 @@ module Homebrew
     _system(cmd, *args)
   end
 
-  def core_tap_version_string
-    require "tap"
-    tap = CoreTap.instance
-    return "N/A" unless tap.installed?
-    if pretty_revision = tap.git_short_head
-      last_commit = tap.git_last_commit_date
-      "(git revision #{pretty_revision}; last commit #{last_commit})"
-    else
-      "(no git repository)"
-    end
-  end
-
   def install_gem_setup_path!(name, version = nil, executable = name)
     # Respect user's preferences for where gems should be installed.
     ENV["GEM_HOME"] = ENV["GEM_OLD_HOME"].to_s


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew --version` and `brew cask --version` both use the same format to output the tap version, so it makes sense to have a common method for that in the `Tap` class.

@Homebrew/cask, also updated `HBC_VERSION` to `0.60.1`, since that is the actual latest tag, but that also doesn't make sense anymore, so we should probably just use `HOMEBREW_VERSION` instead.