### PR TITLE
apr_requirement: use Homebrew's Apr for Sierra

### DIFF
--- a/Library/Homebrew/requirements/apr_requirement.rb
+++ b/Library/Homebrew/requirements/apr_requirement.rb
@@ -4,16 +4,17 @@ class AprRequirement < Requirement
   fatal true
   default_formula "apr-util"
 
-  # APR shipped in Tiger is too old, but Leopard+ is usable
-  satisfy(build_env: false) { MacOS.version > :leopard && MacOS::CLT.installed? }
+  # APR shipped in Tiger is too old, but Leopard+ is usable.
+  # The *-config scripts were removed in Sierra, which is widely breaking.
+  satisfy(build_env: false) do
+    MacOS.version > :leopard && MacOS.version < :sierra && MacOS::CLT.installed?
+  end
 
   env do
-    unless MacOS::CLT.installed?
-      ENV.prepend_path "PATH", Formula["apr-util"].opt_bin
-      ENV.prepend_path "PATH", Formula["apr"].opt_bin
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_libexec}/lib/pkgconfig"
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_libexec}/lib/pkgconfig"
-    end
+    ENV.prepend_path "PATH", Formula["apr-util"].opt_bin
+    ENV.prepend_path "PATH", Formula["apr"].opt_bin
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_libexec}/lib/pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_libexec}/lib/pkgconfig"
   end
 
   def to_dependency

--- a/Library/Homebrew/requirements/apr_requirement.rb
+++ b/Library/Homebrew/requirements/apr_requirement.rb
@@ -7,7 +7,8 @@ class AprRequirement < Requirement
   # APR shipped in Tiger is too old, but Leopard+ is usable.
   # The *-config scripts were removed in Sierra, which is widely breaking.
   satisfy(build_env: false) do
-    MacOS.version > :leopard && MacOS.version < :sierra && MacOS::CLT.installed?
+    MacOS.version > :leopard && MacOS.version < :sierra &&
+      MacOS::CLT.installed? || Formula["apr-util"].installed?
   end
 
   env do

--- a/Library/Homebrew/requirements/apr_requirement.rb
+++ b/Library/Homebrew/requirements/apr_requirement.rb
@@ -7,18 +7,19 @@ class AprRequirement < Requirement
   # APR shipped in Tiger is too old, but Leopard+ is usable.
   # The *-config scripts were removed in Sierra, which is widely breaking.
   satisfy(build_env: false) do
-    MacOS.version > :leopard && MacOS.version < :sierra &&
-      MacOS::CLT.installed? || Formula["apr-util"].installed?
+    next false if MacOS.version <= :leopard
+    next false if MacOS.version >= :sierra
+    MacOS::CLT.installed? || Formula["apr-util"].installed?
   end
 
   env do
-    # Prefer system Apr as much as possible, even if our's is installed.
-    unless MacOS.version > :leopard && MacOS.version < :sierra && MacOS::CLT.installed?
-      ENV.prepend_path "PATH", Formula["apr-util"].opt_bin
-      ENV.prepend_path "PATH", Formula["apr"].opt_bin
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_libexec}/lib/pkgconfig"
-      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_libexec}/lib/pkgconfig"
-    end
+    next if MacOS.version <= :leopard
+    next if MacOS.version >= :sierra
+    next if MacOS::CLT.installed?
+    ENV.prepend_path "PATH", Formula["apr-util"].opt_bin
+    ENV.prepend_path "PATH", Formula["apr"].opt_bin
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_libexec}/lib/pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_libexec}/lib/pkgconfig"
   end
 
   def to_dependency

--- a/Library/Homebrew/requirements/apr_requirement.rb
+++ b/Library/Homebrew/requirements/apr_requirement.rb
@@ -12,10 +12,13 @@ class AprRequirement < Requirement
   end
 
   env do
-    ENV.prepend_path "PATH", Formula["apr-util"].opt_bin
-    ENV.prepend_path "PATH", Formula["apr"].opt_bin
-    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_libexec}/lib/pkgconfig"
-    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_libexec}/lib/pkgconfig"
+    # Prefer system Apr as much as possible, even if our's is installed.
+    unless MacOS.version > :leopard && MacOS.version < :sierra && MacOS::CLT.installed?
+      ENV.prepend_path "PATH", Formula["apr-util"].opt_bin
+      ENV.prepend_path "PATH", Formula["apr"].opt_bin
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr"].opt_libexec}/lib/pkgconfig"
+      ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["apr-util"].opt_libexec}/lib/pkgconfig"
+    end
   end
 
   def to_dependency


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Sierra ships the headers/libraries still but for some reason decided to bin the config scripts, which whilst seemingly not an issue for `mesos` or `ganglia` it has broken `subversion`, `log4cxx`, `ctail`, `shibboleth` and `passenger` that we know of so far. Let's assume more often than not things are going to break without those config scripts around.