### PR TITLE
audit: forbid `deprecated_option` in new formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -448,6 +448,11 @@ class FormulaAuditor
         problem "Use '--with#{$1}-test' instead of '--#{o.name}'. Migrate '--#{o.name}' with `deprecated_option`."
       end
     end
+
+    return unless @new_formula
+    unless formula.deprecated_options.empty?
+      problem "New formulae should not use `deprecated_option`."
+    end
   end
 
   def audit_desc


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It doesn't make sense to include `deprecated_options` in a new formula. This PR adds an check on `brew audit --new formula` to restrict this. I didn't add a test because it seems like there weren't any tests for options; let me know if there's a place that the test belongs. 