### PR TITLE
Rename FormulaMethodDeprecatedError to  MethodDeprecatedError.

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -56,7 +56,7 @@ end
 
 class FormulaSpecificationError < StandardError; end
 
-class FormulaMethodDeprecatedError < StandardError; end
+class MethodDeprecatedError < StandardError; end
 
 class FormulaUnavailableError < RuntimeError
   attr_reader :name

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -4,7 +4,7 @@ class FormulaVersions
   IGNORED_EXCEPTIONS = [
     ArgumentError, NameError, SyntaxError, TypeError,
     FormulaSpecificationError, FormulaValidationError,
-    ErrorDuringExecution, LoadError, FormulaMethodDeprecatedError
+    ErrorDuringExecution, LoadError, MethodDeprecatedError
   ].freeze
 
   attr_reader :name, :path, :repository, :entry_name

--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -249,7 +249,7 @@ class UtilTests < Homebrew::TestCase
 
   def test_odeprecated
     ARGV.stubs(:homebrew_developer?).returns false
-    e = assert_raises(FormulaMethodDeprecatedError) do
+    e = assert_raises(MethodDeprecatedError) do
       odeprecated("method", "replacement",
         caller: ["#{HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core/"],
         die: true)

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -83,7 +83,7 @@ def odeprecated(method, replacement = nil, options = {})
 
   if ARGV.homebrew_developer? || options[:die] ||
      Homebrew.raise_deprecation_exceptions?
-    raise FormulaMethodDeprecatedError, message
+    raise MethodDeprecatedError, message
   else
     opoo "#{message}\n"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----


Since this exception is not only used for deprecation warnings on formulae, it makes sense to rename it to be more general.
