### PR TITLE
cleanup: remove GLIDE_HOME cache directories

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -50,7 +50,7 @@ module Homebrew
           cleanup_path(path) { path.unlink }
           next
         end
-        if %w[java_cache npm_cache].include?(path.basename.to_s) && path.directory?
+        if %w[glide_home java_cache npm_cache].include?(path.basename.to_s) && path.directory?
           cleanup_path(path) { FileUtils.rm_rf path }
           next
         end


### PR DESCRIPTION
This is needed since some formulae now set

  ENV["GLIDE_HOME"] = HOMEBREW_CACHE/"glide_home/#{name}"

CC @DomT4