### PR TITLE
FIX: cask changes /usr/local ownership recursively

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/caskroom.rb
+++ b/Library/Homebrew/cask/lib/hbc/caskroom.rb
@@ -13,7 +13,7 @@ module Hbc
         FileUtils.mv repo_caskroom, Hbc.caskroom
       else
         opoo "#{Hbc.caskroom.parent} is not writable, sudo is needed to move the Caskroom."
-        sudo "/bin/mv", repo_caskroom.to_s, Hbc.caskroom.parent.to_s
+        command "/bin/mv", repo_caskroom, Hbc.caskroom.parent, :use_sudo => true
       end
     end
 
@@ -22,16 +22,23 @@ module Hbc
 
       ohai "Creating Caskroom at #{Hbc.caskroom}"
       ohai "We'll set permissions properly so we won't need sudo in the future"
+      use_sudo = !Hbc.caskroom.parent.writable?
 
-      sudo "/bin/mkdir", "-p", Hbc.caskroom
-      sudo "/bin/chmod", "g+rwx", Hbc.caskroom
-      sudo "/usr/sbin/chown", Utils.current_user, Hbc.caskroom
-      sudo "/usr/bin/chgrp", "admin", Hbc.caskroom
+      command "/bin/mkdir", "-p", Hbc.caskroom, :use_sudo => use_sudo
+      command "/bin/chmod", "g+rwx", Hbc.caskroom, :use_sudo => use_sudo
+      command "/usr/sbin/chown", Utils.current_user, Hbc.caskroom, :use_sudo => use_sudo
+      command "/usr/bin/chgrp", "admin", Hbc.caskroom, :use_sudo => use_sudo
     end
 
-    def sudo(*args)
-      ohai "/usr/bin/sudo #{args.join(" ")}"
-      system "/usr/bin/sudo", *args
+    def command(*args)
+      options = args.last.is_a?(Hash) ? args.pop : {}
+
+      if options[:use_sudo]
+        args.unshift "/usr/bin/sudo"
+      end
+
+      ohai args.join(" ")
+      system *args
     end
   end
 end

--- a/Library/Homebrew/cask/lib/hbc/caskroom.rb
+++ b/Library/Homebrew/cask/lib/hbc/caskroom.rb
@@ -13,7 +13,7 @@ module Hbc
         FileUtils.mv repo_caskroom, Hbc.caskroom
       else
         opoo "#{Hbc.caskroom.parent} is not writable, sudo is needed to move the Caskroom."
-        SystemCommand.run("/bin/mv", :args => [repo_caskroom, Hbc.caskroom.parent], :sudo => true)
+        SystemCommand.run("/bin/mv", args: [repo_caskroom, Hbc.caskroom.parent], sudo: true)
       end
     end
 
@@ -24,10 +24,10 @@ module Hbc
       ohai "We'll set permissions properly so we won't need sudo in the future"
       sudo = !Hbc.caskroom.parent.writable?
 
-      SystemCommand.run("/bin/mkdir", :args => ["-p", Hbc.caskroom], :sudo => sudo)
-      SystemCommand.run("/bin/chmod", :args => ["g+rwx", Hbc.caskroom], :sudo => sudo)
-      SystemCommand.run("/usr/sbin/chown", :args => [Utils.current_user, Hbc.caskroom], :sudo => sudo)
-      SystemCommand.run("/usr/bin/chgrp", :args => ["admin", Hbc.caskroom], :sudo => sudo)
+      SystemCommand.run("/bin/mkdir", args: ["-p", Hbc.caskroom], sudo: sudo)
+      SystemCommand.run("/bin/chmod", args: ["g+rwx", Hbc.caskroom], sudo: sudo)
+      SystemCommand.run("/usr/sbin/chown", args: [Utils.current_user, Hbc.caskroom], sudo: sudo)
+      SystemCommand.run("/usr/bin/chgrp", args: ["admin", Hbc.caskroom], sudo: sudo)
     end
   end
 end

--- a/Library/Homebrew/cask/lib/hbc/caskroom.rb
+++ b/Library/Homebrew/cask/lib/hbc/caskroom.rb
@@ -13,7 +13,7 @@ module Hbc
         FileUtils.mv repo_caskroom, Hbc.caskroom
       else
         opoo "#{Hbc.caskroom.parent} is not writable, sudo is needed to move the Caskroom."
-        command "/bin/mv", repo_caskroom, Hbc.caskroom.parent, :use_sudo => true
+        SystemCommand.run("/bin/mv", :args => [repo_caskroom, Hbc.caskroom.parent], :sudo => true)
       end
     end
 
@@ -22,23 +22,12 @@ module Hbc
 
       ohai "Creating Caskroom at #{Hbc.caskroom}"
       ohai "We'll set permissions properly so we won't need sudo in the future"
-      use_sudo = !Hbc.caskroom.parent.writable?
+      sudo = !Hbc.caskroom.parent.writable?
 
-      command "/bin/mkdir", "-p", Hbc.caskroom, :use_sudo => use_sudo
-      command "/bin/chmod", "g+rwx", Hbc.caskroom, :use_sudo => use_sudo
-      command "/usr/sbin/chown", Utils.current_user, Hbc.caskroom, :use_sudo => use_sudo
-      command "/usr/bin/chgrp", "admin", Hbc.caskroom, :use_sudo => use_sudo
-    end
-
-    def command(*args)
-      options = args.last.is_a?(Hash) ? args.pop : {}
-
-      if options[:use_sudo]
-        args.unshift "/usr/bin/sudo"
-      end
-
-      ohai args.join(" ")
-      system *args
+      SystemCommand.run("/bin/mkdir", :args => ["-p", Hbc.caskroom], :sudo => sudo)
+      SystemCommand.run("/bin/chmod", :args => ["g+rwx", Hbc.caskroom], :sudo => sudo)
+      SystemCommand.run("/usr/sbin/chown", :args => [Utils.current_user, Hbc.caskroom], :sudo => sudo)
+      SystemCommand.run("/usr/bin/chgrp", :args => ["admin", Hbc.caskroom], :sudo => sudo)
     end
   end
 end

--- a/Library/Homebrew/cask/lib/hbc/caskroom.rb
+++ b/Library/Homebrew/cask/lib/hbc/caskroom.rb
@@ -13,7 +13,7 @@ module Hbc
         FileUtils.mv repo_caskroom, Hbc.caskroom
       else
         opoo "#{Hbc.caskroom.parent} is not writable, sudo is needed to move the Caskroom."
-        system "/usr/bin/sudo", "--", "/bin/mv", "--", repo_caskroom.to_s, Hbc.caskroom.parent.to_s
+        sudo "/bin/mv", repo_caskroom.to_s, Hbc.caskroom.parent.to_s
       end
     end
 
@@ -21,24 +21,17 @@ module Hbc
       return if Hbc.caskroom.exist?
 
       ohai "Creating Caskroom at #{Hbc.caskroom}"
-      if Hbc.caskroom.parent.writable?
-        Hbc.caskroom.mkpath
-      else
-        ohai "We'll set permissions properly so we won't need sudo in the future"
-        toplevel_dir = Hbc.caskroom
-        toplevel_dir = toplevel_dir.parent until toplevel_dir.parent.root?
-        unless toplevel_dir.directory?
-          # If a toplevel dir such as '/opt' must be created, enforce standard permissions.
-          # sudo in system is rude.
-          system "/usr/bin/sudo", "--", "/bin/mkdir", "--",         toplevel_dir
-          system "/usr/bin/sudo", "--", "/bin/chmod", "--", "0775", toplevel_dir
-        end
-        # sudo in system is rude.
-        system "/usr/bin/sudo", "--", "/bin/mkdir", "-p", "--", Hbc.caskroom
-        unless Hbc.caskroom.parent == toplevel_dir
-          system "/usr/bin/sudo", "--", "/usr/sbin/chown", "-R", "--", "#{Utils.current_user}:staff", Hbc.caskroom.parent.to_s
-        end
-      end
+      ohai "We'll set permissions properly so we won't need sudo in the future"
+
+      sudo "/bin/mkdir", "-p", Hbc.caskroom
+      sudo "/bin/chmod", "g+rwx", Hbc.caskroom
+      sudo "/usr/sbin/chown", Utils.current_user, Hbc.caskroom
+      sudo "/usr/bin/chgrp", "admin", Hbc.caskroom
+    end
+
+    def sudo(*args)
+      ohai "/usr/bin/sudo #{args.join(" ")}"
+      system "/usr/bin/sudo", *args
     end
   end
 end


### PR DESCRIPTION
**Problems**

Relatively old code in `Hbc::Caskroom` recursively changes the ownership
of the directory where the `Caskroom` directory exists, that changes
entire files in `/usr/local` to `user:staff` if Homebrew setup with default
configuration.

This is really dangerous because it's easy to trigger (just simply type
`brew cask something` by following some installation documentation.)

**Solution**

This patch removes entire `chown` with `-R` option and make the logic
simply creating `Caskroom` directory with default Homebrew directories
ownership and permission.