### PR TITLE
keg_relocate: cache files rewritten during brew bottle

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -187,12 +187,13 @@ module Homebrew
 
     keg.lock do
       original_tab = nil
+      changed_files = nil
 
       begin
         unless ARGV.include? "--skip-relocation"
           keg.relocate_dynamic_linkage prefix, Keg::PREFIX_PLACEHOLDER,
             cellar, Keg::CELLAR_PLACEHOLDER
-          keg.relocate_text_files prefix, Keg::PREFIX_PLACEHOLDER,
+          changed_files = keg.relocate_text_files prefix, Keg::PREFIX_PLACEHOLDER,
             cellar, Keg::CELLAR_PLACEHOLDER,
             repository, Keg::REPOSITORY_PLACEHOLDER
         end
@@ -205,6 +206,7 @@ module Homebrew
         tab.poured_from_bottle = false
         tab.HEAD = nil
         tab.time = nil
+        tab.changed_files = changed_files
         tab.write
 
         keg.find do |file|
@@ -268,7 +270,7 @@ module Homebrew
               Keg::CELLAR_PLACEHOLDER, cellar
             keg.relocate_text_files Keg::PREFIX_PLACEHOLDER, prefix,
               Keg::CELLAR_PLACEHOLDER, cellar,
-              Keg::REPOSITORY_PLACEHOLDER, repository
+              Keg::REPOSITORY_PLACEHOLDER, repository, changed_files
           end
         end
       end

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -191,11 +191,7 @@ module Homebrew
 
       begin
         unless ARGV.include? "--skip-relocation"
-          keg.relocate_dynamic_linkage prefix, Keg::PREFIX_PLACEHOLDER,
-            cellar, Keg::CELLAR_PLACEHOLDER
-          changed_files = keg.relocate_text_files prefix, Keg::PREFIX_PLACEHOLDER,
-            cellar, Keg::CELLAR_PLACEHOLDER,
-            repository, Keg::REPOSITORY_PLACEHOLDER
+          changed_files = keg.replace_locations_with_placeholders
         end
 
         keg.delete_pyc_files!
@@ -266,11 +262,7 @@ module Homebrew
         ignore_interrupts do
           original_tab.write if original_tab
           unless ARGV.include? "--skip-relocation"
-            keg.relocate_dynamic_linkage Keg::PREFIX_PLACEHOLDER, prefix,
-              Keg::CELLAR_PLACEHOLDER, cellar
-            keg.relocate_text_files Keg::PREFIX_PLACEHOLDER, prefix,
-              Keg::CELLAR_PLACEHOLDER, cellar,
-              Keg::REPOSITORY_PLACEHOLDER, repository, changed_files
+            keg.replace_placeholders_with_locations changed_files
           end
         end
       end

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -17,19 +17,19 @@ class Keg
     generic_fix_dynamic_linkage
   end
 
-  def relocate_dynamic_linkage(old_prefix, new_prefix, old_cellar, new_cellar)
+  def relocate_dynamic_linkage(relocation)
     mach_o_files.each do |file|
       file.ensure_writable do
         if file.dylib?
-          id = dylib_id_for(file).sub(old_prefix, new_prefix)
+          id = dylib_id_for(file).sub(relocation.old_prefix, relocation.new_prefix)
           change_dylib_id(id, file)
         end
 
         each_install_name_for(file) do |old_name|
-          if old_name.start_with? old_cellar
-            new_name = old_name.sub(old_cellar, new_cellar)
-          elsif old_name.start_with? old_prefix
-            new_name = old_name.sub(old_prefix, new_prefix)
+          if old_name.start_with? relocation.old_cellar
+            new_name = old_name.sub(relocation.old_cellar, relocation.new_cellar)
+          elsif old_name.start_with? relocation.old_prefix
+            new_name = old_name.sub(relocation.old_prefix, relocation.new_prefix)
           end
 
           change_install_name(old_name, new_name, file) if new_name

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -762,18 +762,12 @@ class FormulaInstaller
     end
 
     keg = Keg.new(formula.prefix)
-    tab_file = formula.prefix.join(Tab::FILENAME)
-    # Skip the cache since the receipt will be rewritten
-    orig_tab = Tab.from_file_content(tab_file.read, tab_file)
-    changed_files = orig_tab.changed_files.map { |f| formula.prefix.join(f) }
 
     unless formula.bottle_specification.skip_relocation?
-      keg.relocate_dynamic_linkage Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s,
-        Keg::CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s
+      tab = Tab.for_keg(keg)
+      Tab.clear_cache
+      keg.replace_placeholders_with_locations tab.changed_files
     end
-    keg.relocate_text_files Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s,
-      Keg::CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s,
-      Keg::REPOSITORY_PLACEHOLDER, HOMEBREW_REPOSITORY.to_s, changed_files
 
     Pathname.glob("#{formula.bottle_prefix}/{etc,var}/**/*") do |path|
       path.extend(InstallRenamed)
@@ -781,7 +775,7 @@ class FormulaInstaller
     end
     FileUtils.rm_rf formula.bottle_prefix
 
-    tab = Tab.for_keg(formula.prefix)
+    tab = Tab.for_keg(keg)
 
     CxxStdlib.check_compatibility(
       formula, formula.recursive_dependencies,

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -762,13 +762,18 @@ class FormulaInstaller
     end
 
     keg = Keg.new(formula.prefix)
+    tab_file = formula.prefix.join(Tab::FILENAME)
+    # Skip the cache since the receipt will be rewritten
+    orig_tab = Tab.from_file_content(tab_file.read, tab_file)
+    changed_files = orig_tab.changed_files.map { |f| formula.prefix.join(f) }
+
     unless formula.bottle_specification.skip_relocation?
       keg.relocate_dynamic_linkage Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s,
         Keg::CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s
     end
     keg.relocate_text_files Keg::PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s,
       Keg::CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s,
-      Keg::REPOSITORY_PLACEHOLDER, HOMEBREW_REPOSITORY.to_s
+      Keg::REPOSITORY_PLACEHOLDER, HOMEBREW_REPOSITORY.to_s, changed_files
 
     Pathname.glob("#{formula.bottle_prefix}/{etc,var}/**/*") do |path|
       path.extend(InstallRenamed)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -3,6 +3,14 @@ class Keg
   CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@".freeze
   REPOSITORY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@".freeze
 
+  Relocation = Struct.new(:old_prefix, :old_cellar, :old_repository,
+                          :new_prefix, :new_cellar, :new_repository) do
+    # Use keyword args instead of positional args for initialization
+    def initialize(**kwargs)
+      super(*members.map { |k| kwargs[k] })
+    end
+  end
+
   def fix_dynamic_linkage
     symlink_files.each do |file|
       link = file.readlink
@@ -15,38 +23,49 @@ class Keg
   end
   alias generic_fix_dynamic_linkage fix_dynamic_linkage
 
-  def relocate_dynamic_linkage(_old_prefix, _new_prefix, _old_cellar, _new_cellar)
+  def relocate_dynamic_linkage(_relocation)
     []
   end
 
   def replace_locations_with_placeholders
-    relocate_dynamic_linkage(HOMEBREW_PREFIX.to_s, PREFIX_PLACEHOLDER,
-      HOMEBREW_CELLAR.to_s, CELLAR_PLACEHOLDER)
-    replacements = {
-      HOMEBREW_PREFIX.to_s => PREFIX_PLACEHOLDER,
-      HOMEBREW_CELLAR.to_s => CELLAR_PLACEHOLDER,
-      HOMEBREW_REPOSITORY.to_s => REPOSITORY_PLACEHOLDER,
-    }
-    replace_text_in_files(replacements)
+    relocation = Relocation.new(
+      old_prefix: HOMEBREW_PREFIX.to_s,
+      old_cellar: HOMEBREW_CELLAR.to_s,
+      old_repository: HOMEBREW_REPOSITORY.to_s,
+      new_prefix: PREFIX_PLACEHOLDER,
+      new_cellar: CELLAR_PLACEHOLDER,
+      new_repository: REPOSITORY_PLACEHOLDER
+    )
+    relocate_dynamic_linkage(relocation)
+    replace_text_in_files(relocation)
   end
 
   def replace_placeholders_with_locations(files)
-    relocate_dynamic_linkage(PREFIX_PLACEHOLDER, HOMEBREW_PREFIX.to_s,
-      CELLAR_PLACEHOLDER, HOMEBREW_CELLAR.to_s)
-    replacements = {
-      PREFIX_PLACEHOLDER => HOMEBREW_PREFIX.to_s,
-      CELLAR_PLACEHOLDER => HOMEBREW_CELLAR.to_s,
-      REPOSITORY_PLACEHOLDER => HOMEBREW_REPOSITORY.to_s,
-    }
-    replace_text_in_files(replacements, files)
+    relocation = Relocation.new(
+      old_prefix: PREFIX_PLACEHOLDER,
+      old_cellar: CELLAR_PLACEHOLDER,
+      old_repository: REPOSITORY_PLACEHOLDER,
+      new_prefix: HOMEBREW_PREFIX.to_s,
+      new_cellar: HOMEBREW_CELLAR.to_s,
+      new_repository: HOMEBREW_REPOSITORY.to_s
+    )
+    relocate_dynamic_linkage(relocation)
+    replace_text_in_files(relocation, files: files)
   end
 
-  def replace_text_in_files(replacements, files = nil)
+  def replace_text_in_files(relocation, files: nil)
     files ||= text_files | libtool_files
 
     changed_files = []
     files.map(&path.method(:join)).group_by { |f| f.stat.ino }.each_value do |first, *rest|
       s = first.open("rb", &:read)
+
+      replacements = {
+        relocation.old_prefix => relocation.new_prefix,
+        relocation.old_cellar => relocation.new_cellar,
+        relocation.old_repository => relocation.new_repository,
+      }
+
       regexp = Regexp.union(replacements.keys)
       changed = s.gsub!(regexp, replacements)
 

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -25,7 +25,7 @@ class Keg
     replacements = {
       HOMEBREW_PREFIX.to_s => PREFIX_PLACEHOLDER,
       HOMEBREW_CELLAR.to_s => CELLAR_PLACEHOLDER,
-      HOMEBREW_REPOSITORY.to_s => REPOSITORY_PLACEHOLDER
+      HOMEBREW_REPOSITORY.to_s => REPOSITORY_PLACEHOLDER,
     }
     replace_text_in_files(replacements)
   end
@@ -36,7 +36,7 @@ class Keg
     replacements = {
       PREFIX_PLACEHOLDER => HOMEBREW_PREFIX.to_s,
       CELLAR_PLACEHOLDER => HOMEBREW_CELLAR.to_s,
-      REPOSITORY_PLACEHOLDER => HOMEBREW_REPOSITORY.to_s
+      REPOSITORY_PLACEHOLDER => HOMEBREW_REPOSITORY.to_s,
     }
     replace_text_in_files(replacements, files)
   end

--- a/Library/Homebrew/metafiles.rb
+++ b/Library/Homebrew/metafiles.rb
@@ -1,13 +1,15 @@
+require "set"
+
 class Metafiles
   # https://github.com/github/markup#markups
   EXTENSIONS = %w[
     .adoc .asc .asciidoc .creole .html .markdown .md .mdown .mediawiki .mkdn
     .org .pod .rdoc .rst .rtf .textile .txt .wiki
-  ].freeze
+  ].to_set.freeze
   BASENAMES = %w[
     about authors changelog changes copying copyright history license licence
     news notes notice readme todo
-  ].freeze
+  ].to_set.freeze
 
   def self.list?(file)
     return false if %w[.DS_Store INSTALL_RECEIPT.json].include?(file)

--- a/Library/Homebrew/metafiles.rb
+++ b/Library/Homebrew/metafiles.rb
@@ -2,14 +2,14 @@ require "set"
 
 class Metafiles
   # https://github.com/github/markup#markups
-  EXTENSIONS = %w[
+  EXTENSIONS = Set.new %w[
     .adoc .asc .asciidoc .creole .html .markdown .md .mdown .mediawiki .mkdn
     .org .pod .rdoc .rst .rtf .textile .txt .wiki
-  ].to_set.freeze
-  BASENAMES = %w[
+  ].freeze
+  BASENAMES = Set.new %w[
     about authors changelog changes copying copyright history license licence
     news notes notice readme todo
-  ].to_set.freeze
+  ].freeze
 
   def self.list?(file)
     return false if %w[.DS_Store INSTALL_RECEIPT.json].include?(file)

--- a/Library/Homebrew/metafiles.rb
+++ b/Library/Homebrew/metafiles.rb
@@ -1,6 +1,6 @@
 require "set"
 
-class Metafiles
+module Metafiles
   # https://github.com/github/markup#markups
   EXTENSIONS = Set.new %w[
     .adoc .asc .asciidoc .creole .html .markdown .md .mdown .mediawiki .mkdn
@@ -11,12 +11,14 @@ class Metafiles
     news notes notice readme todo
   ].freeze
 
-  def self.list?(file)
+  module_function
+
+  def list?(file)
     return false if %w[.DS_Store INSTALL_RECEIPT.json].include?(file)
     !copy?(file)
   end
 
-  def self.copy?(file)
+  def copy?(file)
     file = file.downcase
     ext  = File.extname(file)
     file = File.basename(file, ext) if EXTENSIONS.include?(ext)

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -25,7 +25,6 @@ class Tab < OpenStruct
       "tabfile" => formula.prefix.join(FILENAME),
       "built_as_bottle" => build.bottle?,
       "poured_from_bottle" => false,
-      "changed_files" => [],
       "time" => Time.now.to_i,
       "source_modified_time" => formula.source_modified_time.to_i,
       "HEAD" => HOMEBREW_REPOSITORY.git_head,
@@ -62,7 +61,6 @@ class Tab < OpenStruct
     attributes = Utils::JSON.load(content)
     attributes["tabfile"] = path
     attributes["source_modified_time"] ||= 0
-    attributes["changed_files"] ||= []
     attributes["source"] ||= {}
 
     tapped_from = attributes["tapped_from"]
@@ -173,7 +171,6 @@ class Tab < OpenStruct
       "unused_options" => [],
       "built_as_bottle" => false,
       "poured_from_bottle" => false,
-      "changed_files" => [],
       "time" => nil,
       "source_modified_time" => 0,
       "HEAD" => nil,
@@ -306,7 +303,7 @@ class Tab < OpenStruct
       "unused_options" => unused_options.as_flags,
       "built_as_bottle" => built_as_bottle,
       "poured_from_bottle" => poured_from_bottle,
-      "changed_files" => changed_files.map(&:to_s),
+      "changed_files" => changed_files && changed_files.map(&:to_s),
       "time" => time,
       "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -25,6 +25,7 @@ class Tab < OpenStruct
       "tabfile" => formula.prefix.join(FILENAME),
       "built_as_bottle" => build.bottle?,
       "poured_from_bottle" => false,
+      "changed_files" => [],
       "time" => Time.now.to_i,
       "source_modified_time" => formula.source_modified_time.to_i,
       "HEAD" => HOMEBREW_REPOSITORY.git_head,
@@ -61,6 +62,7 @@ class Tab < OpenStruct
     attributes = Utils::JSON.load(content)
     attributes["tabfile"] = path
     attributes["source_modified_time"] ||= 0
+    attributes["changed_files"] ||= []
     attributes["source"] ||= {}
 
     tapped_from = attributes["tapped_from"]
@@ -171,6 +173,7 @@ class Tab < OpenStruct
       "unused_options" => [],
       "built_as_bottle" => false,
       "poured_from_bottle" => false,
+      "changed_files" => [],
       "time" => nil,
       "source_modified_time" => 0,
       "HEAD" => nil,
@@ -303,6 +306,7 @@ class Tab < OpenStruct
       "unused_options" => unused_options.as_flags,
       "built_as_bottle" => built_as_bottle,
       "poured_from_bottle" => poured_from_bottle,
+      "changed_files" => changed_files.map(&:to_s),
       "time" => time,
       "source_modified_time" => source_modified_time.to_i,
       "HEAD" => self.HEAD,

--- a/Library/Homebrew/test/fixtures/receipt.json
+++ b/Library/Homebrew/test/fixtures/receipt.json
@@ -9,6 +9,10 @@
   ],
   "built_as_bottle": false,
   "poured_from_bottle": true,
+  "changed_files": [
+    "INSTALL_RECEIPT.json",
+    "bin/foo"
+  ],
   "time": 1403827774,
   "HEAD": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
   "alias_path": "/usr/local/Library/Taps/homebrew/homebrew-core/Aliases/test-formula",

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -34,7 +34,7 @@ class TabTests < Homebrew::TestCase
     tab = Tab.empty
     assert_empty tab.unused_options
     assert_empty tab.used_options
-    assert_empty tab.changed_files
+    assert_nil tab.changed_files
     refute_predicate tab, :built_as_bottle
     refute_predicate tab, :poured_from_bottle
     assert_predicate tab, :stable?

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -11,6 +11,7 @@ class TabTests < Homebrew::TestCase
                    "unused_options"       => @unused.as_flags,
                    "built_as_bottle"      => false,
                    "poured_from_bottle"   => true,
+                   "changed_files"        => [],
                    "time"                 => nil,
                    "source_modified_time" => 0,
                    "HEAD"                 => TEST_SHA1,
@@ -33,6 +34,7 @@ class TabTests < Homebrew::TestCase
     tab = Tab.empty
     assert_empty tab.unused_options
     assert_empty tab.used_options
+    assert_empty tab.changed_files
     refute_predicate tab, :built_as_bottle
     refute_predicate tab, :poured_from_bottle
     assert_predicate tab, :stable?
@@ -105,9 +107,11 @@ class TabTests < Homebrew::TestCase
     tab = Tab.from_file(path)
     source_path = "/usr/local/Library/Taps/hombrew/homebrew-core/Formula/foo.rb"
     runtime_dependencies = [{ "full_name" => "foo", "version" => "1.0" }]
+    changed_files = %w[INSTALL_RECEIPT.json bin/foo]
 
     assert_equal @used.sort, tab.used_options.sort
     assert_equal @unused.sort, tab.unused_options.sort
+    assert_equal changed_files, tab.changed_files
     refute_predicate tab, :built_as_bottle
     assert_predicate tab, :poured_from_bottle
     assert_predicate tab, :stable?
@@ -187,6 +191,7 @@ class TabTests < Homebrew::TestCase
     assert_equal @tab.unused_options.sort, tab.unused_options.sort
     assert_equal @tab.built_as_bottle, tab.built_as_bottle
     assert_equal @tab.poured_from_bottle, tab.poured_from_bottle
+    assert_equal @tab.changed_files, tab.changed_files
     assert_equal @tab.tap, tab.tap
     assert_equal @tab.spec, tab.spec
     assert_equal @tab.time, tab.time


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew bottle` replaces instances of the Homebrew prefix, cellar, and repository with placeholders in all text files. Cache these files in INSTALL_RECEIPT.json so that we don't have to check every single text file for placeholders on install.

Also add a couple of other optimizations to speed up building bottles.

Fixes https://github.com/Homebrew/brew/issues/1250.