### PR TITLE
brew.sh: allow --prefix to be run as root without warning

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -243,6 +243,7 @@ check-run-command-as-root() {
 
   [[ "$HOMEBREW_COMMAND" = "cask" ]] && return
   [[ "$HOMEBREW_COMMAND" = "services" ]] && return
+  [[ "$HOMEBREW_COMMAND" = "--prefix" ]] && return
 
   onoe <<EOS
 Running Homebrew as root is extremely dangerous. As Homebrew does not


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In the files `.bashrc` or `.zshrc` the command `brew --prefix xyz` is often used to set the correct `$PATH` for executables. For example: `export PATH="$(brew --prefix php70)/bin:$PATH"`

When the `*rc` files are executed as `root` (e.g. via `sudo -s`) then `--prefix` should be considered a legitimate use of the `brew` command while under uid `0`.

Old behavior:
```
$ brew --prefix gcc
Error: Running Homebrew as root is extremely dangerous. As Homebrew does not
drop privileges on installation you are giving all build scripts full access
to your system. As a result of the macOS sandbox not handling the root user
correctly HOMEBREW_NO_SANDBOX has been set so the sandbox will not be used. If
we have not merged a pull request to add privilege dropping by November 1st
2016 running Homebrew as root will be disabled. No Homebrew maintainers plan
to work on this functionality.
/usr/local/Cellar/gcc/6.2.0
$ brew --prefix gcc 2>/dev/null
/usr/local/Cellar/gcc/6.2.0
```

New behavior:
```
$ brew --prefix gcc
/usr/local/Cellar/gcc/6.2.0
```