### PR TITLE
keg_relocate: run /usr/bin/file in batches

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -72,13 +72,14 @@ class Keg
     # file with that fix is only available in macOS Sierra.
     # http://bugs.gw.com/view.php?id=292
     with_custom_locale("C") do
-      path.find do |pn|
-        next if pn.symlink? || pn.directory?
-        next if Metafiles::EXTENSIONS.include? pn.extname
-        if Utils.popen_read("/usr/bin/file", "--brief", pn).include?("text") ||
-           pn.text_executable?
-          text_files << pn
-        end
+      files = path.find.reject { |pn|
+        pn.symlink? || pn.directory? || Metafiles::EXTENSIONS.include?(pn.extname)
+      }
+      output, _status = Open3.capture2("/usr/bin/xargs -0 /usr/bin/file --no-dereference --brief",
+                                       stdin_data: files.join("\0"))
+      output.each_line.with_index do |line, i|
+        next unless line.include?("text")
+        text_files << files[i]
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Rather than running `/usr/bin/file` on each individual file to determine its type, split all files into batches as large as possible and run `/usr/bin/file` on each batch.

This is an alternative solution to #1250 as suggested by @reitermarkus in https://github.com/Homebrew/brew/pull/1253#discussion_r82602685, though the two solutions could be combined.