### PR TITLE
tab: don't interpret unknown deps as no deps

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -60,7 +60,6 @@ class Tab < OpenStruct
   def self.from_file_content(content, path)
     attributes = Utils::JSON.load(content)
     attributes["tabfile"] = path
-    attributes["runtime_dependencies"] ||= []
     attributes["source_modified_time"] ||= 0
     attributes["source"] ||= {}
 

--- a/Library/Homebrew/test/test_tab.rb
+++ b/Library/Homebrew/test/test_tab.rb
@@ -97,7 +97,7 @@ class TabTests < Homebrew::TestCase
     assert_equal TEST_SHA1, tab.HEAD
     assert_equal :clang, tab.cxxstdlib.compiler
     assert_equal :libcxx, tab.cxxstdlib.type
-    assert_empty tab.runtime_dependencies
+    assert_nil tab.runtime_dependencies
   end
 
   def test_from_file


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change? <ins>See below.</ins>
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I extracted this change from #1082 in the hope it can be merged as soon as possible, because without this change incorrect data could be being recorded in install receipts.

When I made `runtime_dependencies` default to `[]`, it didn't occur to me that tabs could be modified outside of the context of a new installation. However, I've just noticed that `brew bottle` does this. So, if there was a keg installed before #1032 was merged, and it was later bottled, I think the install receipt in the bottle would incorrectly record that there were no runtime dependencies, rather than correctly leaving them unspecified.