### PR TITLE
postinstall: allow write access to cellars in repository.

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -35,10 +35,10 @@ module Homebrew
         sandbox.record_log(formula.logs/"postinstall.sandbox.log")
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
-        sandbox.allow_write_cellar(formula)
         sandbox.allow_write_xcode
-        sandbox.allow_write_path HOMEBREW_PREFIX
         sandbox.deny_write_homebrew_repository
+        sandbox.allow_write_path HOMEBREW_PREFIX
+        sandbox.allow_write_cellar(formula)
         sandbox.exec(*args)
       else
         exec(*args)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If HOMEBREW_CELLAR (or HOMEBREW_PREFIX) are children of HOMEBREW_REPOSITORY it’s important to deny write to the repository and enable write to the Cellar/prefix afterwards CC @tdsmith 