### PR TITLE
keg_relocate: left out text_executable? check in #1258

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -79,6 +79,7 @@ class Keg
                                        stdin_data: files.join("\0"))
       output.each_line.with_index do |line, i|
         next unless line.include?("text")
+        next unless files[i].text_executable?
         text_files << files[i]
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This `Pathname#text_executable?` check got left out of #1258 by mistake.