### PR TITLE
Revert "keg_relocate: left out text_executable? check in #1258"

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -79,7 +79,6 @@ class Keg
                                        stdin_data: files.join("\0"))
       output.each_line.with_index do |line, i|
         next unless line.include?("text")
-        next unless files[i].text_executable?
         text_files << files[i]
       end
     end


### PR DESCRIPTION
Reverts Homebrew/brew#1267

@jawshooah This change was incorrect as it's now not including any files that are `text_executable` whereas it should be instead adding them to the list without needing to run `file` on them.