### PR TITLE
keg_relocate: fix for multiline /usr/bin/file output

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -72,7 +72,7 @@ class Keg
     # file with that fix is only available in macOS Sierra.
     # http://bugs.gw.com/view.php?id=292
     with_custom_locale("C") do
-      files = path.find.reject { |pn|
+      files = Set.new path.find.reject { |pn|
         next true if pn.symlink?
         next true if pn.directory?
         next true if Metafiles::EXTENSIONS.include?(pn.extname)
@@ -82,11 +82,14 @@ class Keg
         end
         false
       }
-      output, _status = Open3.capture2("/usr/bin/xargs -0 /usr/bin/file --no-dereference --brief",
-                                       stdin_data: files.join("\0"))
-      output.each_line.with_index do |line, i|
-        next unless line.include?("text")
-        text_files << files[i]
+      output, _status = Open3.capture2("/usr/bin/xargs -0 /usr/bin/file --no-dereference --print0",
+                                       stdin_data: files.to_a.join("\0"))
+      output.each_line do |line|
+        path, info = line.split("\0")
+        next unless info.to_s.include?("text")
+        path = Pathname.new(path)
+        next unless files.include?(path)
+        text_files << path
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Sometimes, `/usr/bin/file` spits out multiple lines for a single file for some reason. Fix the optimization from #1258, #1267, and #1269 to handle this case.