### PR TITLE
brew doctor: warn about SSL_CERT_FILE (#1284)

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -617,6 +617,18 @@ module Homebrew
         message
       end
 
+      def check_ssl_cert_file
+        return unless ENV.key?("SSL_CERT_FILE")
+        <<-EOS.undent
+          Setting SSL_CERT_FILE can break downloading files; if that happens
+          you should unset it before running Homebrew.
+
+          Homebrew uses the system curl which uses system certificates by
+          default. Setting SSL_CERT_FILE makes it use an outdated OpenSSL, which
+          does not support modern OpenSSL certificate stores.
+        EOS
+      end
+
       def check_for_symlinked_cellar
         return unless HOMEBREW_CELLAR.exist?
         return unless HOMEBREW_CELLAR.symlink?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally? (Got some warnings about skipped tests).

-----

Multiple issues have been filed about this environment variable, hence
give a warning. #932 might make this unnecessary when merged, but
hopefully this warning can be merged quickly.

Warnings:
- I'm no expert rubyist so the code might be more convoluted than needed (do I really need to assign to `message` before returning it, can't I just return `<<-EOS.undent...` somehow?)
- my local testing is `SSL_CERT_FILE=a brew doctor` and `brew doctor` (with `SSL_CERT_FILE` unset). If you want a unit test for that I'm happy to.
- My explanation on system curl's behavior might be too much, I'm happy to drop it. It's based on the comment in https://github.com/NixOS/nix/issues/921#issuecomment-241675652 and on the pointed to blog post (https://docwhat.org/el-capitan-and-the-evils-of-openssl/).