### PR TITLE
cmd/install: improve logic for following aliases

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -136,7 +136,12 @@ module Homebrew
         end
 
         current = f if f.installed?
-        current ||= f.old_installed_formulae.first
+        if current.nil? && f.installed_prefixes.empty?
+          old_formula_with_current_alias = f.old_installed_formulae.first
+          if old_formula_with_current_alias && old_formula_with_current_alias.installed?
+            current ||= old_formula_with_current_alias
+          end
+        end
 
         if current
           msg = "#{current.full_name}-#{current.installed_version} already installed"
@@ -148,7 +153,7 @@ module Homebrew
           # Check if the formula we try to install is the same as installed
           # but not migrated one. If --force passed then install anyway.
           opoo "#{f.oldname} already installed, it's just not migrated"
-          puts "You can migrate formula with `brew migrate #{f}`"
+          puts "You should migrate formula with `brew migrate #{f}`"
           puts "Or you can force install it with `brew install #{f} --force`"
         else
           formulae << f

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1188,10 +1188,11 @@ class Formula
   end
 
   def old_installed_formulae
+    return [] if alias_path.nil?
     # If this formula isn't the current target of the alias,
     # it doesn't make sense to say that other formulae are older versions of it
     # because we don't know which came first.
-    return [] if alias_path.nil? || installed_alias_target_changed?
+    return [] if installed_alias_target_changed?
     self.class.installed_with_alias_path(alias_path) - [self]
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

Changes for `cmd/install`:
https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/install.rb#L138-L139
`f.installed?` means that last prefix is installed for formula spec. However it seems to me that here it's treated as a check for any version being installed.

Before the change `f.installed?` did everything properly, it just refused to install formula if its latest prefix was installed. Not sure it was right to do so, but if `f.installed?` check had failed and formula still had been installed then `formula_installer` would have handled this.
Here is the diff with that change:
https://github.com/Homebrew/brew/pull/971/files#diff-b82c90101b7f1236459d3ba357ccc6e0

Also, 
`current ||= f.old_installed_formulae.first` doesn't always mean that `f.old_installed_formulae.first.installed?` is true.

These lines confuse me a little. As for now we can have formula installed and its revision changed, which means that `f.installed?` is false and let's suppose `f.old_installed_formulae.first` is not `nil`. 

The fix is to check if `f.installed?` is true or old formulae installed
with `f`'s current alias is `installed?` which implies that its latest prefix
is installed.

Maybe this is not the best fix for the issue, but I think we'll figure out what is best and then I'll update the PR.

CC @MikeMcQuaid @alyssais 
