### PR TITLE
Complain about HEP 6 violations.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -49,7 +49,6 @@ module Homebrew
     strict = new_formula || ARGV.include?("--strict")
     online = new_formula || ARGV.include?("--online")
 
-    ENV["HOMEBREW_USER_PATH"] = ENV["PATH"]
     ENV.activate_extensions!
     ENV.setup_build_environment
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -49,6 +49,7 @@ module Homebrew
     strict = new_formula || ARGV.include?("--strict")
     online = new_formula || ARGV.include?("--online")
 
+    ENV["HOMEBREW_USER_PATH"] = ENV["PATH"]
     ENV.activate_extensions!
     ENV.setup_build_environment
 

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -74,8 +74,9 @@ module FormulaCellarChecks
   def check_python_shebangs
     return unless formula.bin.directory?
     return if formula_requires_python?(formula) && default_python_is_system_python?
+    shibboleth = "#!/usr/bin/python"
     system_python_shebangs = formula.bin.children.select do |bin|
-      (bin.open { |f| f.read(32) }).start_with?("#!/usr/bin/python")
+      (bin.open { |f| f.read(shibboleth.length) }) == shibboleth
     end
     return if system_python_shebangs.empty?
 

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -133,6 +133,6 @@ module FormulaCellarChecks
   end
 
   def formula_requires_python?(formula)
-    formula.requirements.any { |r| r.name == "python" }
+    formula.requirements.any? { |r| r.name == "python" }
   end
 end

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -117,7 +117,7 @@ module FormulaCellarChecks
     begin
       # Run `python` in the user's environment to get the real answer because
       # the python we find in the user's PATH might be a pyenv shim
-      ENV["PATH"] = ENV["HOMEBREW_USER_PATH"]
+      ENV["PATH"] = ORIGINAL_PATHS.join(File::PATH_SEPARATOR)
       which_python = which("python")
       python_exec, = Open3.capture2(which_python, "-c", "import sys; print(sys.executable)")
       python_exec = Pathname.new(python_exec.strip).realpath

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -60,7 +60,7 @@ module FormulaCellarChecks
   end
 
   def check_python_virtualenv
-    return if default_python_is_system_python?
+    return if formula_requires_python?(formula) && default_python_is_system_python?
     framework = formula.libexec/".Python"
     return unless framework.symlink?
     return unless framework.realpath.to_s.start_with?("/System")
@@ -73,7 +73,7 @@ module FormulaCellarChecks
 
   def check_python_shebangs
     return unless formula.bin.directory?
-    return if default_python_is_system_python?
+    return if formula_requires_python?(formula) && default_python_is_system_python?
     system_python_shebangs = formula.bin.children.select do |bin|
       (bin.open { |f| f.read(32) }).start_with?("#!/usr/bin/python")
     end
@@ -129,5 +129,9 @@ module FormulaCellarChecks
 
     return nil unless python_exec.exist?
     python_exec.to_s.start_with?("/usr/bin/python")
+  end
+
+  def formula_requires_python?(formula)
+    formula.requirements.any { |r| r.name == "python" }
   end
 end

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -118,7 +118,7 @@ module FormulaCellarChecks
       # the python we find in the user's PATH might be a pyenv shim
       ENV["PATH"] = ENV["HOMEBREW_USER_PATH"]
       which_python = which("python")
-      python_exec, _ = Open3.capture2(which_python, "-c", "import sys; print(sys.executable)")
+      python_exec, = Open3.capture2(which_python, "-c", "import sys; print(sys.executable)")
       python_exec = Pathname.new(python_exec.strip).realpath
     rescue => e
       opoo "Inconsistent Python environment: #{e}"
@@ -128,6 +128,6 @@ module FormulaCellarChecks
     end
 
     return nil unless python_exec.exist?
-    return python_exec.to_s.start_with?("/usr/bin/python")
+    python_exec.to_s.start_with?("/usr/bin/python")
   end
 end


### PR DESCRIPTION
The shebang check may be too stringent; these may be small scripts that
don't touch the network and installing Python for them could be
overkill. Or maybe not!
