### PR TITLE
Don't choke on invalid UTF-8 in `file` output

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -84,9 +84,12 @@ class Keg
       }
       output, _status = Open3.capture2("/usr/bin/xargs -0 /usr/bin/file --no-dereference --print0",
                                        stdin_data: files.to_a.join("\0"))
+      # `file` output sometimes contains data from the file, which may include
+      # invalid UTF-8 entities, so tell Ruby this is just a bytestring
+      output.force_encoding(Encoding::ASCII_8BIT)
       output.each_line do |line|
-        path, info = line.split("\0")
-        next unless info.to_s.include?("text")
+        path, info = line.split("\0", 2)
+        next unless info.include?("text")
         path = Pathname.new(path)
         next unless files.include?(path)
         text_files << path

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -89,6 +89,10 @@ class Keg
       output.force_encoding(Encoding::ASCII_8BIT)
       output.each_line do |line|
         path, info = line.split("\0", 2)
+        # `file` sometimes prints more than one line of output per file;
+        # subsequent lines do not contain a null-byte separator, so `info`
+        # will be `nil` for those lines
+        next unless info
         next unless info.include?("text")
         path = Pathname.new(path)
         next unless files.include?(path)


### PR DESCRIPTION
Sometimes `file` output contains data from the file under examination,
which may include binary data that does not represent valid UTF-8
codepoints. String#split dies if it doesn't understand the encoding, so
tell Ruby to treat `file` output as a bytestring.