### PR TITLE
shims/scm/git: fix on old OS X versions.

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -111,7 +111,15 @@ then
   #   /usr/bin/<tool> will be a popup stub under such configuration.
   # xcrun hangs if xcode-select is set to "/"
   xcode_path="$(/usr/bin/xcode-select -print-path 2>/dev/null)"
-  [[ -n "$xcode_path" ]] || popup_stub=1
+  if [[ -z "$xcode_path" ]]
+  then
+    macos_version="$(/usr/bin/sw_vers -productVersion)"
+    printf -v macos_version_numeric "%02d%02d%02d" ${macos_version//./ }
+    if [[ "$macos_version_numeric" -ge "100900" ]]
+    then
+      unset popup_stub=1
+    fi
+  fi
   if [[ -z "$popup_stub" && "$xcode_path" != "/" ]]
   then
     path="$(/usr/bin/xcrun -find "$SCM_FILE" 2>/dev/null)"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

On older versions of OS X (i.e. pre-Mavericks) `xcode-select` is not required to be set when using the CLT. Fix this behaviour so `brew update` doesn't tell everyone on that configuration to `brew install git`.