### PR TITLE
scm/git: more old OS X versions tweaks.

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -104,6 +104,7 @@ do
     safe_exec "$path" "$@"
   fi
 done
+unset IFS
 
 if executable "/usr/bin/xcode-select"
 then
@@ -113,11 +114,14 @@ then
   xcode_path="$(/usr/bin/xcode-select -print-path 2>/dev/null)"
   if [[ -z "$xcode_path" ]]
   then
-    macos_version="$(/usr/bin/sw_vers -productVersion)"
-    printf -v macos_version_numeric "%02d%02d%02d" ${macos_version//./ }
+    if [[ -z "$HOMEBREW_MACOS_VERSION" ]]
+    then
+      HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
+    fi
+    printf -v macos_version_numeric "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
     if [[ "$macos_version_numeric" -ge "100900" ]]
     then
-      unset popup_stub=1
+      popup_stub=1
     fi
   fi
   if [[ -z "$popup_stub" && "$xcode_path" != "/" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- unset IFS to fix version parsing on older Bashes
- reuse existing HOMEBREW_MACOS_VERSION if it’s available
- set rather than unset popup_stub