### PR TITLE
install: prune build-only deps of deps

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -114,7 +114,7 @@ class FormulaInstaller
 
   def install_bottle_for?(dep, build)
     return pour_bottle? if dep == formula
-    return false if build_from_source?
+    return false if ARGV.build_formula_from_source?(dep)
     return false unless dep.bottle && dep.pour_bottle?
     return false unless build.used_options.empty?
     return false unless dep.bottle.compatible_cellar?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This avoids needlessly installing `:build` dependencies of dependencies which are not themselves being built from source.

Fixes #1272. See it for details of the problematic behavior.

Before:

```
$ brew info diff-pdf | grep Build:
Build: pkg-config, automake, autoconf
$ brew info openjpeg | grep Build:
Build: cmake, doxygen
$ brew install -s diff-pdf
==> Installing dependencies for diff-pdf: cmake, doxygen
==> Installing diff-pdf dependency: cmake
```

`cmake` and `doxygen` are `:build` deps of `openjpeg`, which is not being built from source in this scenario, so they shouldn't be picked up.

After:

```
$ brew install -s diff-pdf
==> Using the sandbox
```

(No attempt to install `cmake` or `doxygen`.)