### PR TITLE
Formatter: identifier: only reset color, not full styling

### DIFF
--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -12,7 +12,7 @@ module Formatter
   end
 
   def identifier(string)
-    "#{Tty.green}#{string}#{Tty.reset}"
+    "#{Tty.green}#{string}#{Tty.default}"
   end
 
   def success(string, label: nil)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

`Formatter.identifier` does a full `reset` to undo the green it applies. This also clobbers any bold/underline/italic or other styling, which could be a problem if it is called inside a span of text which has other styling on it.

You can see this when doing a `brew install` which has multiple dependencies. The `oh1` line should be all bold. But only the first dependency is bold; after that the line gets reset to normal text.

<img width="725" alt="before" src="https://cloud.githubusercontent.com/assets/2618447/19425668/727c2a6c-9403-11e6-986d-d525d53d1943.png">

This PR changes `Formatter.identifier` to reset only the color of the text. It's not a perfect restoration of state, but it's better than doing a full clobber.

After:
<img width="830" alt="after" src="https://cloud.githubusercontent.com/assets/2618447/19425677/99cd65a4-9403-11e6-839b-0d6bbeae9612.png">

Note that now, all the dependencies are listed in bold.