### PR TITLE
brew info: include options to dependencies in display

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -165,9 +165,13 @@ module Homebrew
 
   def decorate_dependencies(dependencies)
     deps_status = dependencies.collect do |dep|
-      dep.installed? ? pretty_installed(dep) : pretty_uninstalled(dep)
+      if dep.satisfied?([])
+        pretty_installed(dep_display_s(dep))
+      else
+        pretty_uninstalled(dep_display_s(dep))
+      end
     end
-    deps_status * ", "
+    deps_status.join(", ")
   end
 
   def decorate_requirements(requirements)
@@ -176,5 +180,10 @@ module Homebrew
       req.satisfied? ? pretty_installed(req_s) : pretty_uninstalled(req_s)
     end
     req_status.join(", ")
+  end
+
+  def dep_display_s(dep)
+    return dep.name if dep.option_tags.empty?
+    "#{dep.name} #{dep.option_tags.map { |o| "--#{o}" }.join(" ")}"
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Currently, `brew info` does not take the options of dependencies in to account when displaying them.

For example, `libgroove` depends on `ffmpeg --with-libvorbis`, not plain `ffmpeg`. But the `brew info` output looks like it needs plain `ffmpeg`.

Before:

<img width="585" alt="before" src="https://cloud.githubusercontent.com/assets/2618447/19430231/7a4be53e-9421-11e6-8a9f-6e4b6af6ca86.png">

This PR changes `brew info` to list the options for dependencies which have them, and to take those options in to account when determining whether the dependency is satisfied.

After:

<img width="585" alt="after" src="https://cloud.githubusercontent.com/assets/2618447/19430265/9692d87e-9421-11e6-802b-76d2db7a3032.png">

Note that not only does it add `--with-libvorbis` to the display, but it's now a red X, which I think is correct here, because this is run on a system with the default `ffmpeg` formula installed, and `--with-libvorbis` was not included in the build options. Now the display correctly reflects a formula which will need to be (re-)installed during the `brew install libgroove` process.

Other formulae you can test this on:

anjuta.rb:  depends_on "libxml2" => "with-python"
cmu-sphinxbase.rb:  depends_on "libsamplerate" => "with-libsndfile"
freeling.rb:  depends_on "boost" => "with-icu4c"
git-ftp.rb:  depends_on "curl" => "with-libssh2"
libgroove.rb:  depends_on "ffmpeg" => "with-libvorbis"

If people are in favor of this change, similar options display could be added to `brew deps`.