### PR TITLE
hbc/locations: arg is file only if absolute or .rb file

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/locations.rb
+++ b/Library/Homebrew/cask/lib/hbc/locations.rb
@@ -133,9 +133,8 @@ module Hbc
       def path(query)
         query_path = Pathname.new(query)
 
-        if query_path.exist? || query_path.absolute?
-          return query_path
-        end
+        return query_path if query_path.absolute?
+        return query_path if query_path.exist? && query_path.extname == ".rb"
 
         query_without_extension = query.sub(%r{\.rb$}i, "")
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Handle the case when an argument passed to `brew cask` is both the name
of a Cask and a non-Cask file in the current working directory.

Fixes https://github.com/caskroom/homebrew-cask/issues/25611.

@Homebrew/cask 