### PR TITLE
Refactor `brew cask style` not to require `.rubocop.yml`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/style.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/style.rb
@@ -54,15 +54,15 @@ module Hbc
       end
 
       def default_args
-        ["--format", "simple", "--force-exclusion", "--config", rubocop_config]
+        [
+          "--require", "rubocop-cask",
+          "--format", "simple",
+          "--force-exclusion"
+        ]
       end
 
       def autocorrect_args
         default_args + ["--auto-correct"]
-      end
-
-      def rubocop_config
-        Hbc.default_tap.cask_dir.join(".rubocop.yml")
       end
 
       def fix?

--- a/Library/Homebrew/cask/lib/hbc/cli/style.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/style.rb
@@ -56,6 +56,7 @@ module Hbc
       def default_args
         [
           "--require", "rubocop-cask",
+          "--config", "/dev/null", # always use `rubocop-cask` default config
           "--format", "simple",
           "--force-exclusion"
         ]

--- a/Library/Homebrew/cask/spec/cask/cli/style_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/cli/style_spec.rb
@@ -175,12 +175,8 @@ describe Hbc::CLI::Style do
 
   describe "#default_args" do
     subject { cli.default_args }
-    let(:rubocop_config) { ".rubocop.yml" }
-    before do
-      allow(cli).to receive(:rubocop_config).and_return(rubocop_config)
-    end
 
-    it { is_expected.to include("--format", "simple", "--force-exclusion", "--config", rubocop_config) }
+    it { is_expected.to include("--require", "rubocop-cask", "--format", "simple", "--force-exclusion") }
   end
 
   describe "#autocorrect_args" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since `rubocop-cask` already includes a `default.yml`, we don't need to have a separate YAML file inside `caskroom/cask`. This also fixes the rare case that `brew cask style` fails when `caskroom/cask` is untapped, this is useful so we can have tests for `brew cask style` without having `caskroom/cask` tapped.

--

@Homebrew/cask 