### PR TITLE
cmd/outdated: group specs of same formula

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -58,10 +58,10 @@ module Homebrew
         end
 
         outdated_versions = outdated_kegs
-                            .group_by { |keg| Formulary.from_keg(keg) }
-                            .sort_by { |formula, _kegs| formula.full_name }
-                            .map do |formula, kegs|
-          "#{formula.full_name} (#{kegs.map(&:version).join(", ")})"
+                            .group_by { |keg| Formulary.from_keg(keg).full_name }
+                            .sort_by { |full_name, _kegs| full_name }
+                            .map do |full_name, kegs|
+          "#{full_name} (#{kegs.map(&:version).join(", ")})"
         end.join(", ")
 
         puts "#{outdated_versions} < #{current_version}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Suppose you have devel and stable versions of `foo` installed.
Their versions should be grouped together regardless their specs.

Output before the change:
```bash
$ brew outdated foo
foo (2.4), foo (3.28-01) < 5.1
```

Output after the change:
```bash
$ brew outdated foo
foo (2.4, 3.28-01) < 5.1
```