### PR TITLE
Compare names not formulae

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1167,7 +1167,7 @@ class Formula
   # Returns false if the formula wasn't installed with an alias.
   def installed_alias_target_changed?
     target = current_installed_alias_target
-    target && target != self
+    target && target.name != name
   end
 
   # Is this formula the target of an alias used to install an old formula?
@@ -1192,7 +1192,7 @@ class Formula
     # it doesn't make sense to say that other formulae are older versions of it
     # because we don't know which came first.
     return [] if alias_path.nil? || installed_alias_target_changed?
-    self.class.installed_with_alias_path(alias_path) - [self]
+    self.class.installed_with_alias_path(alias_path).reject { |f| f.name == name }
   end
 
   # @private

--- a/Library/Homebrew/test/test_formula.rb
+++ b/Library/Homebrew/test/test_formula.rb
@@ -799,8 +799,8 @@ end
 class AliasChangeTests < Homebrew::TestCase
   attr_reader :f, :new_formula, :tab, :alias_path
 
-  def make_formula(version)
-    f = formula(alias_path: alias_path) { url "foo-#{version}" }
+  def make_formula(name, version)
+    f = formula(name, alias_path: alias_path) { url "foo-#{version}" }
     f.build = tab
     f
   end
@@ -811,8 +811,8 @@ class AliasChangeTests < Homebrew::TestCase
 
     @tab = Tab.empty
 
-    @f = make_formula("1.0")
-    @new_formula = make_formula("1.1")
+    @f = make_formula("formula_name", "1.0")
+    @new_formula = make_formula("new_formula_name", "1.1")
 
     Formula.stubs(:installed).returns([f])
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

* Causes a bug in Formula#installed_alias_target_changed? when
  `Formula#superseds_an_installed_formula?` returns true because
  `Formula#old_installed_formulae` includes f for some Formula f.

* Causes a bug when foo@2.4 with alias foo has HEAD or devel version and
  we try to `brew upgrade foo --devel|--HEAD` from stable. The upgrade fails
  while since we installing formula to the same prefix it's alredy installed.
  The reason for that is that we use
  `formula_to_install = outdated.map(&:latest_formula)` in cmd/upgrade
  before calling `upgrade_formula` on foo.

  ```ruby
  def latest_formula
    installed_alias_target_changed? ? current_installed_alias_target : self
  end
  ```

  `Formula#installed_alias_target_changed?` compares formulae using
  `Formula#==`, which is wrong for this case, thus `Formula#latest_formula` doesn't
  return self and returns `Formula#current_installed_alias_target` with spec
  foo was initially installed instead of devel or HEAD, causing the error.

### Reproduce

1. Make `foo@2.4` with stable and devel specs.
2. Make an alias `foo` to `foo@2.4`
3.  `brew install foo`
4.  `brew upgrade foo --devel`

Output looks like this
```bash
➜ vlad:Aliases$ brew upgrade mack --HEAD                                     master ✗
==> Upgrading 1 outdated package, with result:
mack 2.4
==> Upgrading mack
==> Using the sandbox
==> Downloading http://beyondgrep.com/ack-2.14-single-file
Already downloaded: /Users/vlad/Library/Caches/Homebrew/mack@2.4-2.4.14-single-file
==> pod2man /usr/local/Cellar/mack@2.4/2.4/bin/ack ack.1
Error: File exists - /usr/local/Cellar/mack@2.4/2.4/.brew
```