### PR TITLE
hbc/qualified_token: simplify token parsing

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/qualified_token.rb
+++ b/Library/Homebrew/cask/lib/hbc/qualified_token.rb
@@ -2,10 +2,8 @@ module Hbc
   module QualifiedToken
     def self.parse(arg)
       return nil unless arg.is_a?(String)
-      return nil unless arg.downcase =~ HOMEBREW_TAP_CASK_REGEX
-      # eg caskroom/cask/google-chrome
-      # per https://github.com/Homebrew/brew/blob/master/docs/brew-tap.md
-      user, repo, token = arg.downcase.split("/")
+      return nil unless match = arg.downcase.match(HOMEBREW_TAP_CASK_REGEX)
+      user, repo, token = match.captures
       odebug "[user, repo, token] might be [#{user}, #{repo}, #{token}]"
       [user, repo, token]
     end

--- a/Library/Homebrew/cask/lib/hbc/qualified_token.rb
+++ b/Library/Homebrew/cask/lib/hbc/qualified_token.rb
@@ -1,37 +1,11 @@
 module Hbc
   module QualifiedToken
-    REPO_PREFIX = "homebrew-".freeze
-
-    # per https://github.com/Homebrew/homebrew/blob/4c7bc9ec3bca729c898ee347b6135ba692ee0274/Library/Homebrew/cmd/tap.rb#L121
-    USER_REGEX = /[a-z0-9_\-]+/
-
-    # per https://github.com/Homebrew/homebrew/blob/4c7bc9ec3bca729c898ee347b6135ba692ee0274/Library/Homebrew/cmd/tap.rb#L121
-    REPO_REGEX = /(?:#{REPO_PREFIX})?\w+/
-
-    # per https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#generating-a-token-for-the-cask
-    TOKEN_REGEX = /[a-z0-9\-]+/
-
-    TAP_REGEX = %r{#{USER_REGEX}[/\-]#{REPO_REGEX}}
-
-    QUALIFIED_TOKEN_REGEX = %r{#{TAP_REGEX}/#{TOKEN_REGEX}}
-
     def self.parse(arg)
-      return nil unless arg.is_a?(String) && arg.downcase =~ /^#{QUALIFIED_TOKEN_REGEX}$/
-      path_elements = arg.downcase.split("/")
-      if path_elements.count == 2
-        # eg phinze-cask/google-chrome.
-        # Not certain this form is needed, but it was supported in the past.
-        token = path_elements[1]
-        dash_elements = path_elements[0].split("-")
-        repo = dash_elements.pop
-        dash_elements.pop if dash_elements.count > 1 && dash_elements[-1] + "-" == REPO_PREFIX
-        user = dash_elements.join("-")
-      else
-        # eg caskroom/cask/google-chrome
-        # per https://github.com/Homebrew/brew/blob/master/docs/brew-tap.md
-        user, repo, token = path_elements
-      end
-      repo.sub!(/^#{REPO_PREFIX}/, "")
+      return nil unless arg.is_a?(String)
+      return nil unless arg.downcase =~ HOMEBREW_TAP_CASK_REGEX
+      # eg caskroom/cask/google-chrome
+      # per https://github.com/Homebrew/brew/blob/master/docs/brew-tap.md
+      user, repo, token = arg.downcase.split("/")
       odebug "[user, repo, token] might be [#{user}, #{repo}, #{token}]"
       [user, repo, token]
     end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -76,7 +76,7 @@ module Homebrew
     unless ARGV.force?
       ARGV.named.each do |name|
         next if File.exist?(name)
-        if name !~ HOMEBREW_TAP_FORMULA_REGEX && name !~ HOMEBREW_CASK_TAP_FORMULA_REGEX
+        if name !~ HOMEBREW_TAP_FORMULA_REGEX && name !~ HOMEBREW_CASK_TAP_CASK_REGEX
           next
         end
         tap = Tap.fetch($1, $2)

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -58,7 +58,7 @@ module HomebrewArgvExtension
   end
 
   def casks
-    @casks ||= downcased_unique_named.grep HOMEBREW_CASK_TAP_FORMULA_REGEX
+    @casks ||= downcased_unique_named.grep HOMEBREW_CASK_TAP_CASK_REGEX
   end
 
   def kegs

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -1,5 +1,7 @@
 # match taps' formulae, e.g. someuser/sometap/someformula
 HOMEBREW_TAP_FORMULA_REGEX = %r{^([\w-]+)/([\w-]+)/([\w+-.@]+)$}
+# match taps' casks, e.g. someuser/sometap/somecask
+HOMEBREW_TAP_CASK_REGEX = %r{^([\w-]+)/([\w-]+)/([a-z0-9\-]+)$}
 # match taps' directory paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap
 HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/([\w-]+)/([\w-]+)}
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -7,4 +7,4 @@ HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY.to_s)}/Taps/([\w-]+
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula
 HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
 # match the default and the versions brew-cask tap e.g. Caskroom/cask or Caskroom/versions
-HOMEBREW_CASK_TAP_FORMULA_REGEX = %r{^([Cc]askroom)/(cask|versions)/([\w+-.]+)$}
+HOMEBREW_CASK_TAP_CASK_REGEX = %r{^([Cc]askroom)/(cask|versions)/([\w+-.]+)$}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Reduce unnecessary complexity in `qualified_token.rb`. Add a single constant `HOMEBREW_TAP_CASK_REGEX` to `tap_constants.rb` and stop supporting the old `user-repo/token` syntax, which hasn't been used in years.

@Homebrew/cask