### PR TITLE
Allow to install any spec

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -832,7 +832,12 @@ class GitHubGitDownloadStrategy < GitDownloadStrategy
     else
       return true unless commit
       return true unless @last_commit.start_with?(commit)
-      multiple_short_commits_exist?(commit)
+      if multiple_short_commits_exist?(commit)
+        true
+      else
+        version.update_commit(commit)
+        false
+      end
     end
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -553,6 +553,28 @@ class Formula
     Pathname.new("#{HOMEBREW_CELLAR}/#{name}/#{v}")
   end
 
+  # Is the formula linked?
+  def linked?
+    linked_keg.symlink?
+  end
+
+  # Is the formula linked to opt?
+  def optlinked?
+    opt_prefix.symlink?
+  end
+
+  # Is formula's linked keg points to the prefix.
+  def prefix_linked?(v = pkg_version)
+    return false unless linked?
+    linked_keg.resolved_path == prefix(v)
+  end
+
+  # {PkgVersion} of the linked keg for the formula.
+  def linked_version
+    return unless linked?
+    Keg.for(linked_keg).version
+  end
+
   # The parent of the prefix; the named directory in the cellar containing all
   # installed versions of this software
   # @private

--- a/Library/Homebrew/test/install_test.rb
+++ b/Library/Homebrew/test/install_test.rb
@@ -22,6 +22,56 @@ class IntegrationCommandTestInstall < IntegrationCommandTestCase
       cmd("install", "testball2")
   end
 
+  def test_install_failures
+    path = setup_test_formula "testball1", "version \"1.0\""
+    devel_content = <<-EOS.undent
+      version "3.0"
+      devel do
+        url "#{Formulary.factory("testball1").stable.url}"
+        sha256 "#{TESTBALL_SHA256}"
+        version "2.0"
+      end
+    EOS
+
+    assert_match "#{HOMEBREW_CELLAR}/testball1/1.0", cmd("install", "testball1")
+
+    FileUtils.rm path
+    setup_test_formula "testball1", devel_content
+
+    assert_match "first `brew unlink testball1`", cmd_fail("install", "testball1")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/1.0", cmd("unlink", "testball1")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/2.0", cmd("install", "testball1", "--devel")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/2.0", cmd("unlink", "testball1")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/3.0", cmd("install", "testball1")
+
+    cmd("switch", "testball1", "2.0")
+    assert_match "already installed, however linked version is",
+      cmd("install", "testball1")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/2.0", cmd("unlink", "testball1")
+    assert_match "just not linked", cmd("install", "testball1")
+  end
+
+  def test_install_keg_only_outdated
+    path_keg_only = setup_test_formula "testball1", <<-EOS.undent
+    version "1.0"
+    keg_only "test reason"
+    EOS
+
+    assert_match "#{HOMEBREW_CELLAR}/testball1/1.0", cmd("install", "testball1")
+
+    FileUtils.rm path_keg_only
+    setup_test_formula "testball1", <<-EOS.undent
+      version "2.0"
+      keg_only "test reason"
+    EOS
+
+    assert_match "keg-only and another version is linked to opt",
+      cmd("install", "testball1")
+
+    assert_match "#{HOMEBREW_CELLAR}/testball1/2.0",
+      cmd("install", "testball1", "--force")
+  end
+
   def test_install_with_invalid_option
     setup_test_formula "testball1"
     assert_match "testball1: this formula has no --with-fo option so it will be ignored!",

--- a/Library/Homebrew/test/install_test.rb
+++ b/Library/Homebrew/test/install_test.rb
@@ -72,6 +72,50 @@ class IntegrationCommandTestInstall < IntegrationCommandTestCase
       cmd("install", "testball1", "--force")
   end
 
+  def test_install_head_installed
+    initial_env = ENV.to_hash
+    %w[AUTHOR COMMITTER].each do |role|
+      ENV["GIT_#{role}_NAME"] = "brew tests"
+      ENV["GIT_#{role}_EMAIL"] = "brew-tests@localhost"
+      ENV["GIT_#{role}_DATE"] = "Thu May 21 00:04:11 2009 +0100"
+    end
+
+    repo_path = HOMEBREW_CACHE.join("repo")
+    repo_path.join("bin").mkpath
+
+    repo_path.cd do
+      shutup do
+        system "git", "init"
+        system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
+        FileUtils.touch "bin/something.bin"
+        FileUtils.touch "README"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "Initial repo commit"
+      end
+    end
+
+    setup_test_formula "testball1", <<-EOS.undent
+      version "1.0"
+      head "file://#{repo_path}", :using => :git
+      def install
+        prefix.install Dir["*"]
+      end
+    EOS
+
+    # Ignore dependencies, because we'll try to resolve requirements in build.rb
+    # and there will be the git requirement, but we cannot instantiate git
+    # formula since we only have testball1 formula.
+    assert_match "#{HOMEBREW_CELLAR}/testball1/HEAD-2ccdf4f", cmd("install", "testball1", "--HEAD", "--ignore-dependencies")
+    assert_match "testball1-HEAD-2ccdf4f already installed",
+      cmd("install", "testball1", "--HEAD", "--ignore-dependencies")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/HEAD-2ccdf4f", cmd("unlink", "testball1")
+    assert_match "#{HOMEBREW_CELLAR}/testball1/1.0", cmd("install", "testball1")
+
+  ensure
+    ENV.replace(initial_env)
+    repo_path.rmtree
+  end
+
   def test_install_with_invalid_option
     setup_test_formula "testball1"
     assert_match "testball1: this formula has no --with-fo option so it will be ignored!",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

This is a possible fix for `install` part of #1162 and possible replacement for #1296.
For now it has some complicated if statements that should probably be replaced and some feedback on how it can be achieved is appreciated.

The behaviour for `install` should be the following:
- **_installing HEAD keg_only should be possible only if:_**
  - Old version installed differs from new one and optlinked
  - `--force` flag is passed
  - HEAD is seriously outdated or outdated with `--fetch-HEAD`
  
  OR
  - Old version installed differs from new one and not optlinked
  
  OR
  - This formula is not installed
- **_installing keg_only should be possible only if:_**
  - Old version installed differs from new one and optlinked
  - `--force` flag is passed
  
  **OR**
  - Old version installed differs from new one and not optlinked
  
  **OR**
  - This formula is not installed
- **_installing HEAD should be possible only if:_**
  - Old HEAD is seriously outdated or outdated with `--fetch-HEAD`
  
  **OR**
  - HEAD is not installed
- **_installing stable or devel should be possible only if:_**
  - Old version installed differs from new one
# 

Here is an example of how it looks like:

```
➜ vlad:Homebrew$ brew info smpeg2                                   explicit-specs ✗
smpeg2: stable 2.0.0 (bottled), HEAD
SDL MPEG Player Library
https://icculus.org/smpeg/
/usr/local/Cellar/smpeg2/2.0.0 (23 files, 613.9K)
  Poured from bottle on 2016-10-22 at 01:45:27
/usr/local/Cellar/smpeg2/HEAD-411 (23 files, 596.4K) *
  Built from source on 2016-07-27 at 18:48:29
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/smpeg2.rb
==> Dependencies
Build: autoconf ✔, automake ✔, libtool ✔, pkg-config ✔
Required: sdl2 ✔
➜ vlad:Homebrew$ brew install smpeg2 --HEAD                         explicit-specs ✗
Warning: smpeg2-HEAD-411 already installed
➜ vlad:Homebrew$ brew install smpeg2                                explicit-specs ✗
Warning: smpeg2-2.0.0 already installed, however linked version is HEAD-411.
You can use `brew switch smpeg2 2.0.0` to link this version.
➜ vlad:Homebrew$ brew install smpeg2 --HEAD --fetch-HEAD            explicit-specs ✗
Error: smpeg2-HEAD-411 already installed
To install this version, first `brew unlink smpeg2`
➜ vlad:Homebrew$ brew unlink smpeg2                                 explicit-specs ✗
Unlinking /usr/local/Cellar/smpeg2/HEAD-411... 8 symlinks removed
➜ vlad:Homebrew$ brew install smpeg2 --HEAD --fetch-HEAD            explicit-specs ✗
==> Using the sandbox
==> Cloning svn://svn.icculus.org/smpeg/trunk
Updating /Users/vlad/Library/Caches/Homebrew/smpeg2--svn-HEAD
==> ./autogen.sh
==> ./configure --prefix=/usr/local/Cellar/smpeg2/HEAD-412 --with-sdl-prefix=/usr/loc
==> make
==> make install
🍺  /usr/local/Cellar/smpeg2/HEAD-412: 24 files, 613.7K, built in 27 seconds
```

CC @MikeMcQuaid @ilovezfs
