### PR TITLE
Cask: add dictionary artifact

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/artifact.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact.rb
@@ -2,6 +2,7 @@ require "hbc/artifact/app"
 require "hbc/artifact/artifact" # generic 'artifact' stanza
 require "hbc/artifact/binary"
 require "hbc/artifact/colorpicker"
+require "hbc/artifact/dictionary"
 require "hbc/artifact/font"
 require "hbc/artifact/input_method"
 require "hbc/artifact/installer"
@@ -38,6 +39,7 @@ module Hbc
         Pkg,
         Prefpane,
         Qlplugin,
+        Dictionary,
         Font,
         Service,
         StageOnly,

--- a/Library/Homebrew/cask/lib/hbc/artifact/dictionary.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/dictionary.rb
@@ -1,0 +1,8 @@
+require "hbc/artifact/moved"
+
+module Hbc
+  module Artifact
+    class Dictionary < Moved
+    end
+  end
+end

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -54,6 +54,7 @@ module Hbc
       "--colorpickerdir="       => :colorpickerdir=,
       "--prefpanedir="          => :prefpanedir=,
       "--qlplugindir="          => :qlplugindir=,
+      "--dictionarydir="        => :dictionarydir=,
       "--fontdir="              => :fontdir=,
       "--servicedir="           => :servicedir=,
       "--input_methoddir="      => :input_methoddir=,

--- a/Library/Homebrew/cask/lib/hbc/cli/internal_stanza.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/internal_stanza.rb
@@ -28,6 +28,7 @@ module Hbc
         :artifact,
         :prefpane,
         :qlplugin,
+        :dictionary,
         :font,
         :service,
         :colorpicker,

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -24,6 +24,7 @@ module Hbc
       :audio_unit_plugin,
       :binary,
       :colorpicker,
+      :dictionary,
       :font,
       :input_method,
       :internet_plugin,

--- a/Library/Homebrew/cask/lib/hbc/locations.rb
+++ b/Library/Homebrew/cask/lib/hbc/locations.rb
@@ -64,6 +64,12 @@ module Hbc
         @qlplugindir ||= Pathname.new("~/Library/QuickLook").expand_path
       end
 
+      attr_writer :dictionarydir
+
+      def dictionarydir
+        @dictionarydir ||= Pathname.new("~/Library/Dictionaries").expand_path
+      end
+
       attr_writer :fontdir
 
       def fontdir

--- a/Library/Homebrew/cask/test/cask/cli/options_test.rb
+++ b/Library/Homebrew/cask/test/cask/cli/options_test.rb
@@ -57,6 +57,20 @@ describe Hbc::CLI do
     Hbc.colorpickerdir.must_equal Pathname("/some/path/bar")
   end
 
+  it "supports setting the dictionarydir" do
+    Hbc::CLI.process_options %w[help --dictionarydir=/some/path/foo]
+
+    Hbc.dictionarydir.must_equal Pathname("/some/path/foo")
+  end
+
+  it "supports setting the dictionarydir from ENV" do
+    ENV["HOMEBREW_CASK_OPTS"] = "--dictionarydir=/some/path/bar"
+
+    Hbc::CLI.process_options %w[help]
+
+    Hbc.dictionarydir.must_equal Pathname("/some/path/bar")
+  end
+
   it "supports setting the fontdir" do
     Hbc::CLI.process_options %w[help --fontdir=/some/path/foo]
 

--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -155,6 +155,9 @@ in a future version.
   * `--qlplugindir=<path>`:
     Target location for QuickLook Plugins. The default value is `~/Library/QuickLook`.
 
+  * `--dictionarydir=<path>`:
+    Target location for Dictionaries. The default value is `~/Library/Dictionaries`.
+
   * `--fontdir=<path>`:
     Target location for Fonts. The default value is `~/Library/Fonts`.
 

--- a/completions/zsh/_brew_cask
+++ b/completions/zsh/_brew_cask
@@ -169,6 +169,7 @@ _brew_cask()
     '--colorpickerdir=-:Target location for Color Pickers. The default value is ~/Library/ColorPickers.' \
     '--prefpanedir=-:Target location for Preference Panes. The default value is ~/Library/PreferencePanes.' \
     '--qlplugindir=-:Target location for QuickLook Plugins. The default value is ~/Library/QuickLook.' \
+    '--dictionarydir=-:Target location for Dictionaries. The default value is ~/Library/Dictionaries.' \
     '--fontdir=-:Target location for Fonts. The default value is ~/Library/Fonts.' \
     '--servicedir=-:Target location for Services. The default value is ~/Library/Services.' \
     '--input_methoddir=-:Target location for Input Methods. The default value is ~/Library/Input Methods.' \

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -162,6 +162,10 @@ Target location for Preference Panes\. The default value is \fB~/Library/Prefere
 Target location for QuickLook Plugins\. The default value is \fB~/Library/QuickLook\fR\.
 .
 .TP
+\fB\-\-dictionarydir=<path>\fR
+Target location for Dictionaries\. The default value is \fB~/Library/Dictionaries\fR\.
+.
+.TP
 \fB\-\-fontdir=<path>\fR
 Target location for Fonts\. The default value is \fB~/Library/Fonts\fR\.
 .


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren’t other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you’d like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This adds a new artifact type for dictionaries. Presently there are only two dictionaries at Caskroom that would use this, thus this PR is mostly for sake of completion and consistency. That said, the “service” and “input_method” artifacts are used only a couple of times as well.