### PR TITLE
dev-cmd/man: use SOURCE_PATH instead of HOMEBREW_LIBRARY

### DIFF
--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -41,7 +41,7 @@ module Homebrew
     convert_man_page(markup, TARGET_DOC_PATH/"brew.1.html")
     convert_man_page(markup, TARGET_MAN_PATH/"brew.1")
 
-    cask_markup = (HOMEBREW_LIBRARY/"Homebrew/manpages/brew-cask.1.md").read
+    cask_markup = (SOURCE_PATH/"brew-cask.1.md").read
     convert_man_page(cask_markup, TARGET_MAN_PATH/"brew-cask.1")
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Just some cleanup. `SOURCE_PATH` is set to `HOMEBREW_LIBRARY_PATH/"manpages"`, which is the same as `HOMEBREW_LIBRARY/"Homebrew/manpages"`.