### PR TITLE
Fix failing test caused by `repo_info`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/info.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/info.rb
@@ -20,7 +20,7 @@ module Hbc
         puts "#{cask.token}: #{cask.version}"
         puts Formatter.url(cask.homepage) if cask.homepage
         installation_info(cask)
-        puts "From: #{Formatter.url(repo_info(cask))}" if repo_info(cask)
+        puts "From: #{Formatter.url(repo_info(cask))}"
         name_info(cask)
         artifact_info(cask)
         Installer.print_caveats(cask)
@@ -53,7 +53,11 @@ module Hbc
       def self.repo_info(cask)
         user, repo, token = QualifiedToken.parse(Hbc.all_tokens.detect { |t| t.split("/").last == cask.token })
         remote_tap = Tap.fetch(user, repo)
-        return remote_tap.remote.to_s if remote_tap.custom_remote?
+
+        if remote_tap.custom_remote? && !remote_tap.remote.nil?
+          return remote_tap.remote.to_s
+        end
+
         "#{remote_tap.default_remote}/blob/master/Casks/#{token}.rb"
       end
 

--- a/Library/Homebrew/cask/test/cask/cli/info_test.rb
+++ b/Library/Homebrew/cask/test/cask/cli/info_test.rb
@@ -8,7 +8,7 @@ describe Hbc::CLI::Info do
       local-caffeine: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
+      From: https://github.com/caskroom/homebrew-test/blob/master/Casks/local-caffeine.rb
       ==> Name
       None
       ==> Artifacts
@@ -22,7 +22,7 @@ describe Hbc::CLI::Info do
         local-caffeine: 1.2.3
         http://example.com/local-caffeine
         Not installed
-        From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-caffeine.rb
+        From: https://github.com/caskroom/homebrew-test/blob/master/Casks/local-caffeine.rb
         ==> Name
         None
         ==> Artifacts
@@ -30,7 +30,7 @@ describe Hbc::CLI::Info do
         local-transmission: 2.61
         http://example.com/local-transmission
         Not installed
-        From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/local-transmission.rb
+        From: https://github.com/caskroom/homebrew-test/blob/master/Casks/local-transmission.rb
         ==> Name
         None
         ==> Artifacts
@@ -58,7 +58,7 @@ describe Hbc::CLI::Info do
       with-caveats: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-caveats.rb
+      From: https://github.com/caskroom/homebrew-test/blob/master/Casks/with-caveats.rb
       ==> Name
       None
       ==> Artifacts
@@ -84,7 +84,7 @@ describe Hbc::CLI::Info do
       with-conditional-caveats: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      From: https://github.com/caskroom/homebrew-testcasks/blob/master/Casks/with-conditional-caveats.rb
+      From: https://github.com/caskroom/homebrew-test/blob/master/Casks/with-conditional-caveats.rb
       ==> Name
       None
       ==> Artifacts


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Tests were failing locally because `""` was returned instead of the default remote when the standard remote was `nil`.