### PR TITLE
build: copy formula file to logs

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -132,6 +132,9 @@ class Build
       else
         formula.prefix.mkpath
 
+        formula.logs.mkpath
+        FileUtils.cp formula.path, formula.logs/"00.#{formula.name}.rb"
+
         formula.install
 
         stdlibs = detect_stdlibs(ENV.compiler)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

It's useful to include the exact formula file at the time of build in `gist-logs`:

- Users could be building an outdated version of the formula, which we can't tell from gist-logs (`00.config.out` includes the latest core commit, sure, but (1) it's takes effort to pull up the formula at that commit; (2) it's easily masked by a `brew update` post build);

- Occasionally users make modifications to formulae they're building, see https://github.com/Homebrew/homebrew-core/issues/6232 for instance.