### PR TITLE
Do not remove unknown bottle tags

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -336,20 +336,19 @@ class BottleSpecification
   end
 
   def checksums
-    checksums = {}
-    os_versions = collector.keys
-    os_versions.map! do |macos|
+    tags = collector.keys.sort_by do |tag|
+      # Sort non-MacOS tags below MacOS tags.
       begin
-        MacOS::Version.from_symbol macos
+        MacOS::Version.from_symbol tag
       rescue
-        nil
+        "0.#{tag}"
       end
-    end.compact!
-    os_versions.sort.reverse_each do |os_version|
-      macos = os_version.to_sym
-      checksum = collector[macos]
+    end
+    checksums = {}
+    tags.reverse_each do |tag|
+      checksum = collector[tag]
       checksums[checksum.hash_type] ||= []
-      checksums[checksum.hash_type] << { checksum => macos }
+      checksums[checksum.hash_type] << { checksum => tag }
     end
     checksums
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

---

Building bottles for Sierra in Homebrew-Science is removing the `:x86_64_linux` bottles for Linuxbrew. See for example https://github.com/Homebrew/homebrew-science/commit/db6b3ed8b40b39c4dc423f6422150b402d81d917

``` diff
--- a/a5.rb
+++ b/a5.rb
@@ -14,10 +14,10 @@ class A5 < Formula

   bottle do
     cellar :any_skip_relocation
+    sha256 "5694a2ae1e9cf95c9c4fdcc2dcb23069c89fc305a05e18f4c3f759caa56c2124" => :sierra
     sha256 "712a52ae946e36d3410f6ea98425605aceffebaa738a397e6721100de6474e12" => :el_capitan
     sha256 "589bb490b43853bd8bbb0817018141efd3e65794844fbcfaf950d6ea55d4d7bb" => :yosemite
     sha256 "c6ae86aad65c91dbcf2b647acdbd25ac5672f8c04f34e7aa9fb991992d9e8fbd" => :mavericks
-    sha256 "174ba48713d53b612375e2ac4b850455625a276a9078edb53f9e02882b11bfc4" => :x86_64_linux
   end

   def install
```
