### PR TITLE
bottle: fix nonexistent pyc bug

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -190,11 +190,11 @@ module Homebrew
       changed_files = nil
 
       begin
+        keg.delete_pyc_files!
+
         unless ARGV.include? "--skip-relocation"
           changed_files = keg.replace_locations_with_placeholders
         end
-
-        keg.delete_pyc_files!
 
         Tab.clear_cache
         tab = Tab.for_keg(keg)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We were deleting pyc files *after* replace_locations_with_placeholders and recording changed_files, meaning that some of the recorded files were to be deleted. The correct order is the opposite.

A sample failed session: https://bot.brew.sh/job/Homebrew%20Core/10080/version=el_capitan/testReport/junit/brew-test-bot/el_capitan/bottle_buku/.

P.S. This is a regression in #1253.