### PR TITLE
superenv: treat timingsafe_bcmp as weak on 10.11

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -98,7 +98,7 @@ module Superenv
     # can't reliably figure this out with Xcode 8 on its own yet.
     if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
       %w[basename_r clock_getres clock_gettime clock_settime dirname_r
-         getentropy mkostemp mkostemps].each do |s|
+         getentropy mkostemp mkostemps timingsafe_bcmp].each do |s|
         ENV["ac_cv_func_#{s}"] = "no"
       end
 


### PR DESCRIPTION
Xcode 8.1 added timingsafe_bcmp to string.h and libsystem_c.tbd,
and 10.12.1 added it to libsystem_c.dylib, but it is not present in
libsystem_c.dylib on 10.11.6 (15G1108).

It may appear in libsystem_c.dylib in a later 10.11 release or it may
be marked weak on 10.11 in a later Xcode release.

Fixes Homebrew/homebrew-core#6344.

CC @achivetta