### PR TITLE
bottle: fix handling of the `keep-old` option

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -160,7 +160,7 @@ module Homebrew
     if ARGV.include?("--no-rebuild") || !f.tap
       rebuild = 0
     elsif ARGV.include? "--keep-old" && !f.bottle_specification.checksums.empty?
-        rebuild = f.bottle_specification.rebuild
+      rebuild = f.bottle_specification.rebuild
     else
       ohai "Determining #{f.full_name} bottle rebuild..."
       versions = FormulaVersions.new(f)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -159,8 +159,8 @@ module Homebrew
 
     if ARGV.include?("--no-rebuild") || !f.tap
       rebuild = 0
-    elsif ARGV.include? "--keep-old"
-      rebuild = f.bottle_specification.rebuild
+    elsif ARGV.include? "--keep-old" && !f.bottle_specification.checksums.empty?
+        rebuild = f.bottle_specification.rebuild
     else
       ohai "Determining #{f.full_name} bottle rebuild..."
       versions = FormulaVersions.new(f)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -159,7 +159,7 @@ module Homebrew
 
     if ARGV.include?("--no-rebuild") || !f.tap
       rebuild = 0
-    elsif ARGV.include? "--keep-old" && !f.bottle_specification.checksums.empty?
+    elsif ARGV.include?("--keep-old") && !f.bottle_specification.checksums.empty?
       rebuild = f.bottle_specification.rebuild
     else
       ohai "Determining #{f.full_name} bottle rebuild..."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
---

Check that the bottle block exists even if `--keep-old` was specified. Currently, rebuild is attempted even if no `bottle` block exists in the formula. This results in a failure (e.g. [here](https://circleci.com/gh/Linuxbrew/homebrew-core/2557)):

```
  bottle do
    sha256 "ef7298980136873930bb837e89d666802be9464a7e4f2dec88e3e46059e77112" => :x86_64_linux
  end
==> brew bottle --merge --write --no-commit ./ladspa-swh-0.4.16.x86_64_linux.bottle.json --keep-old
Error: --keep-old was passed but there was no existing bottle block!
```
