### PR TITLE
audit: Don't check new formulae for version decreases

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -653,6 +653,7 @@ class FormulaAuditor
   def audit_revision_and_version_scheme
     return unless formula.tap # skip formula not from core or any taps
     return unless formula.tap.git? # git log is required
+    return if @new_formula
 
     fv = FormulaVersions.new(formula, max_depth: 10)
     no_decrease_attributes = [:revision, :version_scheme]
@@ -668,7 +669,7 @@ class FormulaAuditor
     end
 
     versions = attributes_map[:version].keys
-    if formula.version < versions.max
+    if !versions.empty? && formula.version < versions.max
       problem "version should not decrease"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Right now `brew audit` fails on new formulae because they don’t have previous version. We don’t have to do these checks on new formulae anyway, hence this `return if @new_formula`.
However this doesn’t fix the bug because it stills fail if `brew audit` is run on a new formula without the `--new-formula` flag. We have to check if `versions` has at least one element before looking for its max value.

[Current error](https://bot.brew.sh/job/Homebrew%20Core/10380/version=yosemite/testReport/junit/brew-test-bot/yosemite/audit_osmfilter___new_formula/):
```
Error: comparison of Version::FromURL with nil failed
Please report this bug:
  https://git.io/brew-troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:671:in `<'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:671:in `audit_revision_and_version_scheme'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1030:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:72:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:68:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:68:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```

See also https://github.com/Homebrew/brew/pull/1366#issuecomment-257132396

cc @MikeMcQuaid 