### PR TITLE
audit: disable version checking for new formulas.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -668,7 +668,7 @@ class FormulaAuditor
     end
 
     versions = attributes_map[:version].keys
-    if formula.version < versions.max
+    if !versions.empty? && formula.version < versions.max
       problem "version should not decrease"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

### Bug reports:

`brew audit --new-formula <formula>` fails with the below output:

```
        ==> Installing or updating 'rubocop' gem
Successfully installed rainbow-2.1.0
Successfully installed ast-2.3.0
Successfully installed parser-2.3.1.4
Successfully installed powerpack-0.1.1
Successfully installed ruby-progressbar-1.8.1
Successfully installed unicode-display_width-1.1.1
Successfully installed rubocop-0.43.0
7 gems installed
Error: comparison of Version::FromURL with nil failed
Please report this bug:
  https://git.io/brew-troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:671:in `<'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:671:in `audit_revision_and_version_scheme'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1030:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:72:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:68:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:68:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'
```
(See https://bot.brew.sh/job/Homebrew%20Core/10363/ and https://bot.brew.sh/job/Homebrew%20Core/10367/)

This seems to be caused by code in 9ab38dd, which ensures that the version for a formula haven't decreased from the previous one. `brew audit` fails for new formulas because no previous version can be obtained. 

### What these changes do
The changes in this PR skips the version checking mentioned above for new formulas.