### PR TITLE
Update macOS Xcode tool checks do use Version class for comparisons

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -27,15 +27,15 @@ module OS
 
       def prerelease?
         # TODO: bump to version >= "8.3" after Xcode 8.2 is stable.
-        version >= "8.2"
+        Version.create(version) >= Version.create("8.2")
       end
 
       def outdated?
-        version < latest_version
+        Version.create(version) < Version.create(latest_version)
       end
 
       def without_clt?
-        installed? && version >= "4.3" && !MacOS::CLT.installed?
+        installed? && Version.create(version) >= Version.create("4.3") && !MacOS::CLT.installed?
       end
 
       # Returns a Pathname object corresponding to Xcode.app's Developer
@@ -56,7 +56,7 @@ module OS
       end
 
       def toolchain_path
-        Pathname.new("#{prefix}/Toolchains/XcodeDefault.xctoolchain") if installed? && version >= "4.3"
+        Pathname.new("#{prefix}/Toolchains/XcodeDefault.xctoolchain") if installed? && Version.create(version) >= Version.create("4.3")
       end
 
       # Ask Spotlight where Xcode is. If the user didn't install the
@@ -71,7 +71,7 @@ module OS
       end
 
       def update_instructions
-        if MacOS.version >= "10.9" && !OS::Mac.prerelease?
+        if Version.create(MacOS.version) >= Version.create("10.9") && !OS::Mac.prerelease?
           <<-EOS.undent
             Xcode can be updated from the App Store.
           EOS
@@ -145,15 +145,15 @@ module OS
       end
 
       def provides_gcc?
-        installed? && version < "4.3"
+        installed? && Version.create(version) < Version.create("4.3")
       end
 
       def provides_cvs?
-        installed? && version < "5.0"
+        installed? && Version.create(version) < Version.create("5.0")
       end
 
       def default_prefix?
-        if version < "4.3"
+        if Version.create(version) < Version.create("4.3")
           prefix.to_s.start_with? "/Developer"
         else
           prefix.to_s == "/Applications/Xcode.app/Contents/Developer"
@@ -177,7 +177,7 @@ module OS
       end
 
       def update_instructions
-        if MacOS.version >= "10.9"
+        if Version.create(MacOS.version) >= Version.create("10.9")
           <<-EOS.undent
             Update them from Software Update in the App Store.
           EOS
@@ -206,13 +206,13 @@ module OS
       end
 
       def outdated?
-        if MacOS.version >= :mavericks
+        if Version.create(MacOS.version) >= Version.create(:mavericks.to_s)
           version = Utils.popen_read("#{MAVERICKS_PKG_PATH}/usr/bin/clang --version")
         else
           version = Utils.popen_read("/usr/bin/clang --version")
         end
         version = version[/clang-(\d+\.\d+\.\d+(\.\d+)?)/, 1] || "0"
-        version < latest_version
+        Version.create(version) < Version.create(latest_version)
       end
 
       # Version string (a pretty long one) of the CLT package.
@@ -228,7 +228,7 @@ module OS
         return MacOS::Xcode.version if MacOS::Xcode.installed? && MacOS::Xcode.version < "3.0"
 
         [MAVERICKS_PKG_ID, MAVERICKS_NEW_PKG_ID, STANDALONE_PKG_ID, FROM_XCODE_PKG_ID].find do |id|
-          if MacOS.version >= :mavericks
+          if Version.create(MacOS.version) >= Version.create(:mavericks.to_s)
             next unless File.exist?("#{MAVERICKS_PKG_PATH}/usr/bin/clang")
           end
           version = MacOS.pkgutil_info(id)[/version: (.+)$/, 1]

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -195,7 +195,7 @@ module OS
         # on the older supported platform for that Xcode release, i.e there's no
         # CLT package for 10.11 that contains the Clang version from Xcode 8.
         case MacOS.version
-        when "10.12" then "800.0.38"
+        when "10.12" then "800.0.42.1"
         when "10.11" then "703.0.31"
         when "10.10" then "700.1.81"
         when "10.9"  then "600.0.57"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Right now, Library/Homebrew/os/mac/xcode.rb uses string comparisons to determine if the version of a local tool is outdated. This will create false results if the two version strings are of different lengths, ie. "1000" < "800" will return true instead of false. Brew already has a class for proper comparison of semantic version strings and this PR updates xcode.rb to make use of it.

I have not added any tests since that would require somehow mocking the data returned by the system commands that xcode.rb uses to determine the versions of the installed tools, and I don't know how to do that at the moment.