### PR TITLE
keg_relocate: include hard links and fix replacement ordering

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -77,7 +77,7 @@ class Keg
       changed = s.gsub!(regexp, replacements)
 
       next unless changed
-      changed_files << first.relative_path_from(path)
+      changed_files += [first, *rest].map { |file| file.relative_path_from(path) }
 
       begin
         first.atomic_write(s)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -66,7 +66,14 @@ class Keg
         relocation.old_repository => relocation.new_repository,
       }
 
-      regexp = Regexp.union(replacements.keys)
+      # Order matters here since `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are
+      # children of `HOMEBREW_PREFIX` by default.
+      regexp = Regexp.union(
+        relocation.old_cellar,
+        relocation.old_repository,
+        relocation.old_prefix
+      )
+
       changed = s.gsub!(regexp, replacements)
 
       next unless changed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Only one handle for each inode was being added to `changed_files` in `replace_locations_with_placeholders`, which broke things when that handle was overwritten with a new inode in `replace_placeholders_with_locations`.

Replacement ordering wasn't the root issue here, but it easily could have been.

Fixes https://github.com/Homebrew/brew/issues/1417.