### PR TITLE
superenv: prune -Wl,-z,defs when refurbishing

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -169,6 +169,8 @@ class Cmd
     when "-Wno-deprecated-register"
       # older gccs don't support these flags
       args << arg unless tool =~ /^g..-4.[02]/
+    when /^-Wl,-z,defs/
+      # -Wl,-undefined,error is already the default
     when /^-W[alp],/, /^-Wno-/
       args << arg
     when /^-W.*/


### PR DESCRIPTION
`-Wl,-z,defs` should be pruned out entirely since `-z defs` is not
understood by macOS's `ld`, and the analogue `-undefined error` is
already the default.