### PR TITLE
audit: restore check that was lost in #927

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -415,6 +415,12 @@ class FormulaAuditor
             EOS
         when *BUILD_TIME_DEPS
           next if dep.build? || dep.run?
+          problem <<-EOS.undent
+            #{dep} dependency should be
+              depends_on "#{dep}" => :build
+            Or if it is indeed a runtime dependency
+              depends_on "#{dep}" => :run
+          EOS
         end
       end
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This audit check ensures that certain build dependencies
are explicitly marked either as `:build` or `:run`.
It seems to have been lost in #927.
It was also adjusted in #1290.

I tried adding a test in https://github.com/scpeters/brew/commit/fd6e1896efcc5b6f4e3582f93719e7d10751515f, but it doesn't work because the test fixture can't load the `cmake` formula:

~~~
  1) Failure:
FormulaAuditorTests#test_audit_build_time_deps [/usr/local/Homebrew/Library/Homebrew/test/test_audit.rb:484]:
--- expected
+++ actual
@@ -1 +1 @@
-["cmake dependency should be"]
+["Can't find dependency \"cmake\"."]

~~~
