### PR TITLE
rubocop: exclude more tap dirs from hash rockets.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -88,7 +88,10 @@ Style/GuardClause:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Exclude:
+    - '**/bin/**/*'
     - '**/cmd/**/*'
+    - '**/lib/**/*'
+    - '**/spec/**/*'
 
 # disabled until it respects line length
 Style/IfUnlessModifier:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is useful for e.g. homebrew/bundle that doesn't live in just `cmd`.