### PR TITLE
audit: Escape interpolated string in regexp

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -741,7 +741,7 @@ class FormulaAuditor
     end
     bin_names.each do |name|
       ["system", "shell_output", "pipe_output"].each do |cmd|
-        if text =~ /(def test|test do).*#{cmd}[\(\s]+['"]#{name}[\s'"]/m
+        if text =~ /(def test|test do).*#{cmd}[\(\s]+['"]#{Regexp.escape name}[\s'"]/m
           problem %(fully scope test #{cmd} calls e.g. #{cmd} "\#{bin}/#{name}")
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This avoids issues with names that contain special characters like `[` (Fixes #1431).