### PR TITLE
Disable auto update at tap command for listing.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -88,7 +88,10 @@ Style/GuardClause:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Exclude:
+    - '**/bin/**/*'
     - '**/cmd/**/*'
+    - '**/lib/**/*'
+    - '**/spec/**/*'
 
 # disabled until it respects line length
 Style/IfUnlessModifier:

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -213,6 +213,7 @@ case "$HOMEBREW_COMMAND" in
   environment) HOMEBREW_COMMAND="--env" ;;
   --config)    HOMEBREW_COMMAND="config" ;;
 esac
+HOMEBREW_COMMAND_ARGS=("$@")
 
 if [[ -z "$HOMEBREW_DEVELOPER" ]]
 then
@@ -304,7 +305,7 @@ update-preinstall() {
   # Allow auto-update migration now we have a fix in place (below in this function).
   export HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION="1"
 
-  if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" || "$HOMEBREW_COMMAND" = "tap" ]]
+  if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" || ( "$HOMEBREW_COMMAND" = "tap" && $HOMEBREW_ARG_COUNT -gt 1 && ! "${HOMEBREW_COMMAND_ARGS[0]}" =~ ^--list ) ]]
   then
     brew update --preinstall
   fi

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -132,6 +132,8 @@ class Build
       else
         formula.prefix.mkpath
 
+        (formula.logs/"00.options.out").write \
+          "#{formula.full_name} #{formula.build.used_options.sort.join(" ")}".strip
         formula.install
 
         stdlibs = detect_stdlibs(ENV.compiler)

--- a/Library/Homebrew/cask/lib/hbc/utils.rb
+++ b/Library/Homebrew/cask/lib/hbc/utils.rb
@@ -117,7 +117,7 @@ module Hbc
 
     def self.error_message_with_suggestions
       <<-EOS.undent
-        Follow the instuctions here:
+        Follow the instructions here:
           #{Formatter.url(PREBUG_URL)}
 
         If this doesn’t fix the problem, please report this bug:

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -47,13 +47,16 @@ module Homebrew
 
     if ARGV.include?("--new-issue") || ARGV.switch?("n")
       if GitHub.api_credentials_type == :none
-        puts "You can create a personal access token: https://github.com/settings/tokens"
-        puts "and then set HOMEBREW_GITHUB_API_TOKEN as authentication method."
-        puts
+        puts <<-EOS.undent
+          You can create a new personal access token:
+           #{GitHub::ALL_SCOPES_URL}
+          and then set the new HOMEBREW_GITHUB_API_TOKEN as the authentication method.
+
+        EOS
         login!
       end
 
-      url = new_issue(f.tap, "#{f.name} failed to build on #{MacOS.full_version}", url)
+      url = create_issue(f.tap, "#{f.name} failed to build on #{MacOS.full_version}", url)
     end
 
     puts url if url
@@ -103,13 +106,17 @@ module Homebrew
   end
 
   def create_gist(files, description)
+    url = "https://api.github.com/gists"
     data = { "public" => true, "files" => files, "description" => description }
-    GitHub.open("https://api.github.com/gists", data)["html_url"]
+    scopes = GitHub::CREATE_GIST_SCOPES
+    GitHub.open(url, data: data, scopes: scopes)["html_url"]
   end
 
-  def new_issue(repo, title, body)
+  def create_issue(repo, title, body)
+    url = "https://api.github.com/repos/#{repo}/issues"
     data = { "title" => title, "body" => body }
-    GitHub.open("https://api.github.com/repos/#{repo}/issues", data)["html_url"]
+    scopes = GitHub::CREATE_ISSUE_SCOPES
+    GitHub.open(url, data: data, scopes: scopes)["html_url"]
   end
 
   def gist_logs

--- a/Library/Homebrew/cmd/unpack.rb
+++ b/Library/Homebrew/cmd/unpack.rb
@@ -6,7 +6,7 @@
 #:    If `--patch` is passed, patches for <formulae> will be applied to the
 #:    unpacked source.
 #:
-#:    If `--git` is passed, a Git repository will be initalized in the unpacked
+#:    If `--git` is passed, a Git repository will be initialized in the unpacked
 #:    source. This is useful for creating patches for the software.
 
 require "stringio"

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -11,7 +11,7 @@
 #:    connection are run.
 #:
 #:    If `--new-formula` is passed, various additional checks are run that check
-#:    if a new formula is eligable for Homebrew. This should be used when creating
+#:    if a new formula is eligible for Homebrew. This should be used when creating
 #:    new formulae and implies `--strict` and `--online`.
 #:
 #:    If `--display-cop-names` is passed, the RuboCop cop name for each violation

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -415,6 +415,12 @@ class FormulaAuditor
             EOS
         when *BUILD_TIME_DEPS
           next if dep.build? || dep.run?
+          problem <<-EOS.undent
+            #{dep} dependency should be
+              depends_on "#{dep}" => :build
+            Or if it is indeed a runtime dependency
+              depends_on "#{dep}" => :run
+          EOS
         end
       end
     end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -741,7 +741,7 @@ class FormulaAuditor
     end
     bin_names.each do |name|
       ["system", "shell_output", "pipe_output"].each do |cmd|
-        if text =~ /(def test|test do).*#{cmd}[\(\s]+['"]#{name}[\s'"]/m
+        if text =~ /(def test|test do).*#{cmd}[\(\s]+['"]#{Regexp.escape name}[\s'"]/m
           problem %(fully scope test #{cmd} calls e.g. #{cmd} "\#{bin}/#{name}")
         end
       end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -741,7 +741,7 @@ class FormulaAuditor
     end
     bin_names.each do |name|
       ["system", "shell_output", "pipe_output"].each do |cmd|
-        if text =~ /(def test|test do).*#{cmd}[\(\s]+['"]#{name}/m
+        if text =~ /(def test|test do).*#{cmd}[\(\s]+['"]#{name}[\s'"]/m
           problem %(fully scope test #{cmd} calls e.g. #{cmd} "\#{bin}/#{name}")
         end
       end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -740,8 +740,10 @@ class FormulaAuditor
       bin_names += dir.children.map(&:basename).map(&:to_s)
     end
     bin_names.each do |name|
-      if text =~ /test do.*system\s+['"]#{name}/m
-        problem %(fully scope test system calls e.g. system "\#{bin}/#{name}")
+      ["system", "shell_output", "pipe_output"].each do |cmd|
+        if text =~ /(def test|test do).*#{cmd}[\(\s]+['"]#{name}/m
+          problem %(fully scope test #{cmd} calls e.g. #{cmd} "\#{bin}/#{name}")
+        end
       end
     end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -20,7 +20,7 @@ class AbstractDownloadStrategy
   def fetch
   end
 
-  # Supress output
+  # Suppress output
   def shutup!
     @shutup = true
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1599,7 +1599,7 @@ class Formula
     HOMEBREW_LIBRARY_PATH.join("test", "fixtures", file)
   end
 
-  # This method is overriden in {Formula} subclasses to provide the installation instructions.
+  # This method is overridden in {Formula} subclasses to provide the installation instructions.
   # The sources (from {.url}) are downloaded, hash-checked and
   # Homebrew changes into a temporary directory where the
   # archive was unpacked or repository cloned.

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -165,7 +165,7 @@ class Migrator
     rescue Interrupt
       ignore_interrupts { backup_oldname }
     rescue Exception => e
-      onoe "Error occured while migrating."
+      onoe "Error occurred while migrating."
       puts e
       puts e.backtrace if ARGV.debug?
       puts "Backuping..."
@@ -293,7 +293,7 @@ class Migrator
     end
   end
 
-  # Backup everything if errors occured while migrating.
+  # Backup everything if errors occurred while migrating.
   def backup_oldname
     unlink_oldname_opt
     unlink_oldname_cellar

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -6,6 +6,11 @@ module GitHub
 
   ISSUES_URI = URI.parse("https://api.github.com/search/issues")
 
+  CREATE_GIST_SCOPES = ["gist"].freeze
+  CREATE_ISSUE_SCOPES = ["public_repo"].freeze
+  ALL_SCOPES = (CREATE_GIST_SCOPES + CREATE_ISSUE_SCOPES).freeze
+  ALL_SCOPES_URL = Formatter.url("https://github.com/settings/tokens/new?scopes=#{ALL_SCOPES.join(",")}&description=Homebrew").freeze
+
   Error = Class.new(RuntimeError)
   HTTPNotFoundError = Class.new(Error)
 
@@ -14,7 +19,7 @@ module GitHub
       super <<-EOS.undent
         GitHub API Error: #{error}
         Try again in #{pretty_ratelimit_reset(reset)}, or create a personal access token:
-          #{Formatter.url("https://github.com/settings/tokens/new?scopes=&description=Homebrew")}
+          #{ALL_SCOPES_URL}
         and then set the token as: export HOMEBREW_GITHUB_API_TOKEN="your_new_token"
       EOS
     end
@@ -38,7 +43,7 @@ module GitHub
           Clear them with:
             printf "protocol=https\\nhost=github.com\\n" | git credential-osxkeychain erase
           Or create a personal access token:
-            #{Formatter.url("https://github.com/settings/tokens/new?scopes=&description=Homebrew")}
+            #{ALL_SCOPES_URL}
           and then set the token as: export HOMEBREW_GITHUB_API_TOKEN="your_new_token"
         EOS
       end
@@ -92,28 +97,32 @@ module GitHub
     end
   end
 
-  def api_credentials_error_message(response_headers)
+  def api_credentials_error_message(response_headers, needed_scopes)
     return if response_headers.empty?
 
     @api_credentials_error_message_printed ||= begin
       unauthorized = (response_headers["http/1.1"] == "401 Unauthorized")
       scopes = response_headers["x-accepted-oauth-scopes"].to_s.split(", ")
+      needed_human_scopes = needed_scopes.join(", ")
+      needed_human_scopes = "none" if needed_human_scopes.empty?
       if !unauthorized && scopes.empty?
-        credentials_scopes = response_headers["x-oauth-scopes"].to_s.split(", ")
+        credentials_scopes = response_headers["x-oauth-scopes"]
 
         case GitHub.api_credentials_type
         when :keychain
           onoe <<-EOS.undent
             Your macOS keychain GitHub credentials do not have sufficient scope!
+            Scopes they need: #{needed_human_scopes}
             Scopes they have: #{credentials_scopes}
-            Create a personal access token: #{Formatter.url("https://github.com/settings/tokens")}
+            Create a personal access token: #{ALL_SCOPES_URL}
             and then set HOMEBREW_GITHUB_API_TOKEN as the authentication method instead.
           EOS
         when :environment
           onoe <<-EOS.undent
             Your HOMEBREW_GITHUB_API_TOKEN does not have sufficient scope!
+            Scopes they need: #{needed_human_scopes}
             Scopes it has: #{credentials_scopes}
-            Create a new personal access token: #{Formatter.url("https://github.com/settings/tokens")}
+            Create a new personal access token: #{ALL_SCOPES_URL}
             and then set the new HOMEBREW_GITHUB_API_TOKEN as the authentication method instead.
           EOS
         end
@@ -122,7 +131,7 @@ module GitHub
     end
   end
 
-  def open(url, data = nil)
+  def open(url, data: nil, scopes: [].freeze)
     # This is a no-op if the user is opting out of using the GitHub API.
     return if ENV["HOMEBREW_NO_GITHUB_API"]
 
@@ -172,7 +181,7 @@ module GitHub
 
     begin
       if !http_code.start_with?("2") && !status.success?
-        raise_api_error(output, errors, http_code, headers)
+        raise_api_error(output, errors, http_code, headers, scopes)
       end
       json = Utils::JSON.load output
       if block_given?
@@ -185,7 +194,7 @@ module GitHub
     end
   end
 
-  def raise_api_error(output, errors, http_code, headers)
+  def raise_api_error(output, errors, http_code, headers, scopes)
     meta = {}
     headers.lines.each do |l|
       key, _, value = l.delete(":").partition(" ")
@@ -200,7 +209,7 @@ module GitHub
       raise RateLimitExceededError.new(reset, error)
     end
 
-    GitHub.api_credentials_error_message(meta)
+    GitHub.api_credentials_error_message(meta, scopes)
 
     case http_code
     when "401", "403"

--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -374,7 +374,7 @@ be created in the directory named by <code>&lt;path></code> instead.</p>
 <p>If <code>--patch</code> is passed, patches for <var>formulae</var> will be applied to the
 unpacked source.</p>
 
-<p>If <code>--git</code> is passed, a Git repository will be initalized in the unpacked
+<p>If <code>--git</code> is passed, a Git repository will be initialized in the unpacked
 source. This is useful for creating patches for the software.</p></dd>
 <dt><code>unpin</code> <var>formulae</var></dt><dd><p>Unpin <var>formulae</var>, allowing them to be upgraded by <code>brew upgrade</code>. See also
 <code>pin</code>.</p></dd>
@@ -447,7 +447,7 @@ style checks.</p>
 connection are run.</p>
 
 <p>If <code>--new-formula</code> is passed, various additional checks are run that check
-if a new formula is eligable for Homebrew. This should be used when creating
+if a new formula is eligible for Homebrew. This should be used when creating
 new formulae and implies <code>--strict</code> and <code>--online</code>.</p>
 
 <p>If <code>--display-cop-names</code> is passed, the RuboCop cop name for each violation

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "October 2016" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "November 2016" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "October 2016" "Homebrew" "brew"
+.TH "BREW" "1" "November 2016" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -518,7 +518,7 @@ Unpack the source files for \fIformulae\fR into subdirectories of the current wo
 If \fB\-\-patch\fR is passed, patches for \fIformulae\fR will be applied to the unpacked source\.
 .
 .IP
-If \fB\-\-git\fR is passed, a Git repository will be initalized in the unpacked source\. This is useful for creating patches for the software\.
+If \fB\-\-git\fR is passed, a Git repository will be initialized in the unpacked source\. This is useful for creating patches for the software\.
 .
 .TP
 \fBunpin\fR \fIformulae\fR
@@ -626,7 +626,7 @@ If \fB\-\-strict\fR is passed, additional checks are run, including RuboCop styl
 If \fB\-\-online\fR is passed, additional slower checks that require a network connection are run\.
 .
 .IP
-If \fB\-\-new\-formula\fR is passed, various additional checks are run that check if a new formula is eligable for Homebrew\. This should be used when creating new formulae and implies \fB\-\-strict\fR and \fB\-\-online\fR\.
+If \fB\-\-new\-formula\fR is passed, various additional checks are run that check if a new formula is eligible for Homebrew\. This should be used when creating new formulae and implies \fB\-\-strict\fR and \fB\-\-online\fR\.
 .
 .IP
 If \fB\-\-display\-cop\-names\fR is passed, the RuboCop cop name for each violation is included in the output\.


### PR DESCRIPTION
- [x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently "Auto Update" is launched at commands of `install`, `upgrade` and `tap`.

Sometime I want to obtain a list of taps, and use `brew tap` command.
But if Auto Update is launched, there are additional lines about Auto Update.

Any installation is done at `brew tap` only when a repository is given,
and Auto Update is necessary only for such a case.

Therefore, this update disables Auto Update  if no additional arguments are given to `brew tap` or listing options of `--list*` are given.