### PR TITLE
Add static libs and dylibs commonly put in /usr/local/lib by Symantec…

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -170,6 +170,8 @@ module Homebrew
           "libublio.*.dylib", # NTFS-3G
           "libUFSDNTFS.dylib", # Paragon NTFS
           "libUFSDExtFS.dylib", # Paragon ExtFS
+          "libecomlodr.dylib", # Symantec Endpoint Protection
+          "libsymsea.*.dylib", # Symantec Endpoint Protection
         ]
 
         __check_stray_files "/usr/local/lib", "*.dylib", white_list, <<-EOS.undent
@@ -190,6 +192,13 @@ module Homebrew
           "libntfs-3g.a", # NTFS-3G
           "libntfs.a", # NTFS-3G
           "libublio.a", # NTFS-3G
+          "libappfirewall.a", # Symantec Endpoint Protection
+          "libautoblock.a", # Symantec Endpoint Protection
+          "libautosetup.a", # Symantec Endpoint Protection
+          "libconnectionsclient.a", # Symantec Endpoint Protection
+          "liblocationawareness.a", # Symantec Endpoint Protection
+          "libpersonalfirewall.a", # Symantec Endpoint Protection
+          "libtrustedcomponents.a", # Symantec Endpoint Protection
         ]
 
         __check_stray_files "/usr/local/lib", "*.a", white_list, <<-EOS.undent


### PR DESCRIPTION
...Endpoint Protection to the diagnostics white lists of known libraries

Symantec Endpoint Protection for Mac has an annoying issue where it drops both static and dynamic libraries into /usr/local/lib if System Integrity Protection is enabled.  SEP is common on centrally-managed Macs and these extra libs upset `brew doctor`.  So, add them to the whitelists to be ignored.