### PR TITLE
disable oputput of brew tap at initialize

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -213,6 +213,7 @@ case "$HOMEBREW_COMMAND" in
   environment) HOMEBREW_COMMAND="--env" ;;
   --config)    HOMEBREW_COMMAND="config" ;;
 esac
+HOMEBREW_COMMAND_ARGS=("$@")
 
 if [[ -z "$HOMEBREW_DEVELOPER" ]]
 then
@@ -304,7 +305,7 @@ update-preinstall() {
   # Allow auto-update migration now we have a fix in place (below in this function).
   export HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION="1"
 
-  if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" || "$HOMEBREW_COMMAND" = "tap" ]]
+  if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" || ( "$HOMEBREW_COMMAND" = "tap" && $HOMEBREW_ARG_COUNT -gt 1 && ! "${HOMEBREW_COMMAND_ARGS[0]}" =~ ^--list ) ]]
   then
     brew update --preinstall
   fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently "Auto Update" is launched at commands of install, upgrade and tap.

Sometime I want to obtain a list of taps, and use brew tap command.
But if Auto Update is launched, there are additional lines about Auto Update.

Any installation is done at brew tap only when a repository is given,
and Auto Update is necessary only for such a case.

Therefore, this update disables Auto Update if no additional arguments are given to brew tap or listing options of --list* are given.

(this is renewed PR of #1436 w/o debug output.)