### PR TITLE
Added a hint how to link a formula that is installed but not linked

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -142,6 +142,7 @@ module Homebrew
           msg = "#{current.full_name}-#{current.installed_version} already installed"
           unless current.linked_keg.symlink? || current.keg_only?
             msg << ", it's just not linked"
+            puts "You can link formula with `brew link #{f}`"
           end
           opoo msg
         elsif f.migration_needed? && !ARGV.force?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Usually when an operation fail, homebrew is helpful to suggest a solution. In the case of installing a formula that was already installed but not linked, this is not currently the case. I suggest adding this minor but helpful message in this case.