### PR TITLE
Improve debugging information based on failures

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -223,25 +223,12 @@ module Homebrew
 
   def check_development_tools
     checks = Diagnostic::Checks.new
-    all_development_tools_checks = checks.development_tools_checks +
-                                   checks.fatal_development_tools_checks
-    all_development_tools_checks.each do |check|
+    checks.fatal_development_tools_checks.each do |check|
       out = checks.send(check)
       next if out.nil?
-      if checks.fatal_development_tools_checks.include?(check)
-        odie out
-      else
-        opoo out
-      end
+      ofail out
     end
-  end
-
-  def check_macports
-    return if MacOS.macports_or_fink.empty?
-
-    opoo "It appears you have MacPorts or Fink installed."
-    puts "Software installed with other package managers causes known problems for"
-    puts "Homebrew. If a formula fails to build, uninstall MacPorts/Fink and try again."
+    exit 1 if Homebrew.failed?
   end
 
   def check_cellar
@@ -283,8 +270,5 @@ module Homebrew
     # another formula. In that case, don't generate an error, just move on.
   rescue CannotInstallFormulaError => e
     ofail e.message
-  rescue BuildError
-    check_macports
-    raise
   end
 end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -86,12 +86,13 @@ module Homebrew
       def development_tools_checks
         %w[
           check_for_installed_developer_tools
-        ]
+        ].freeze
       end
 
       def fatal_development_tools_checks
         %w[
-        ]
+        ].freeze
+      end
       end
 
       def check_for_installed_developer_tools

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -93,6 +93,10 @@ module Homebrew
         %w[
         ].freeze
       end
+
+      def build_error_checks
+        (development_tools_checks + %w[
+        ]).freeze
       end
 
       def check_for_installed_developer_tools

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -327,22 +327,9 @@ class BuildError < RuntimeError
   end
 
   def dump
-    if !ARGV.verbose?
-      puts
-      puts Formatter.error(Formatter.url(OS::ISSUES_URL), label: "READ THIS")
-      if formula.tap
-        case formula.tap.name
-        when "homebrew/boneyard"
-          puts "#{formula} was moved to homebrew-boneyard because it has unfixable issues."
-          puts "Please do not file any issues about this. Sorry!"
-        else
-          if issues_url = formula.tap.issues_url
-            puts "If reporting this issue please do so at (not Homebrew/brew):"
-            puts "  #{Formatter.url(issues_url)}"
-          end
-        end
-      end
-    else
+    puts
+
+    if ARGV.verbose?
       require "system_config"
       require "build_environment"
 
@@ -360,7 +347,37 @@ class BuildError < RuntimeError
         puts logs.map { |fn| "     #{fn}" }.join("\n")
       end
     end
+
+    if formula.tap && formula.tap.name == "homebrew/boneyard"
+      onoe <<-EOS.undent
+        #{formula} was moved to homebrew-boneyard because it has unfixable issues.
+        Please do not file any issues about this. Sorry!
+      EOS
+      return
+    end
+
+    if formula.tap
+      if formula.tap.official?
+        puts Formatter.error(Formatter.url(OS::ISSUES_URL), label: "READ THIS")
+      elsif issues_url = formula.tap.issues_url
+        puts <<-EOS.undent
+          If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
+          #{Formatter.url(issues_url)}
+        EOS
+      else
+        puts <<-EOS.undent
+          If reporting this issue please do so to (not Homebrew/brew or Homebrew/core):
+          #{formula.tap}
+        EOS
+      end
+    else
+      puts <<-EOS.undent
+        Do not report this issue to Homebrew/brew or Homebrew/core!
+      EOS
+    end
+
     puts
+
     if issues && !issues.empty?
       puts "These open issues may also help:"
       puts issues.map { |i| "#{i["title"]} #{i["html_url"]}" }.join("\n")
@@ -369,7 +386,9 @@ class BuildError < RuntimeError
     require "diagnostic"
     checks = Homebrew::Diagnostic::Checks.new
     checks.build_error_checks.each do |check|
+      out = checks.send(check)
       next if out.nil?
+      puts
       ofail out
     end
   end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -367,8 +367,11 @@ class BuildError < RuntimeError
     end
 
     require "diagnostic"
-    unsupported_macos = Homebrew::Diagnostic::Checks.new.check_for_unsupported_macos
-    opoo unsupported_macos if unsupported_macos
+    checks = Homebrew::Diagnostic::Checks.new
+    checks.build_error_checks.each do |check|
+      next if out.nil?
+      ofail out
+    end
   end
 end
 

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -104,6 +104,27 @@ module Homebrew
         EOS
       end
 
+      def check_xcode_minimum_version
+        return unless MacOS::Xcode.installed?
+        return unless MacOS::Xcode.minimum_version?
+
+        <<-EOS.undent
+          Your Xcode (#{MacOS::Xcode.version}) is too outdated.
+          Please update to Xcode #{MacOS::Xcode.latest_version} (or delete it).
+          #{MacOS::Xcode.update_instructions}
+        EOS
+      end
+
+      def check_clt_minimum_version
+        return unless MacOS::CLT.installed?
+        return unless MacOS::CLT.minimum_version?
+
+        <<-EOS.undent
+          Your Command Line Tools are too outdated.
+          #{MacOS::CLT.update_instructions}
+        EOS
+      end
+
       def check_for_osx_gcc_installer
         return unless MacOS.version < "10.7" || ((MacOS::Xcode.version || "0") > "4.1")
         return unless DevelopmentTools.clang_version == "2.1"

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -62,7 +62,8 @@ module Homebrew
       end
 
       def check_xcode_up_to_date
-        return unless MacOS::Xcode.installed? && MacOS::Xcode.outdated?
+        return unless MacOS::Xcode.installed?
+        return unless MacOS::Xcode.outdated?
 
         message = <<-EOS.undent
           Your Xcode (#{MacOS::Xcode.version}) is outdated.
@@ -83,7 +84,8 @@ module Homebrew
       end
 
       def check_clt_up_to_date
-        return unless MacOS::CLT.installed? && MacOS::CLT.outdated?
+        return unless MacOS::CLT.installed?
+        return unless MacOS::CLT.outdated?
 
         <<-EOS.undent
           A newer Command Line Tools release is available.
@@ -94,7 +96,8 @@ module Homebrew
       def check_xcode_8_without_clt_on_el_capitan
         return unless MacOS::Xcode.without_clt?
         # Scope this to Xcode 8 on El Cap for now
-        return unless MacOS.version == :el_capitan && MacOS::Xcode.version >= "8"
+        return unless MacOS.version == :el_capitan
+        return unless MacOS::Xcode.version >= "8"
 
         <<-EOS.undent
           You have Xcode 8 installed without the CLT;

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -22,6 +22,11 @@ module Homebrew
           check_clt_minimum_version
         ].freeze
       end
+
+      def build_error_checks
+        (development_tools_checks + %w[
+          check_for_unsupported_macos
+        ]).freeze
       end
 
       def check_for_unsupported_macos

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -10,19 +10,18 @@ module Homebrew
           check_xcode_license_approved
           check_for_osx_gcc_installer
           check_xcode_8_without_clt_on_el_capitan
-        ]
+          check_xcode_up_to_date
+          check_clt_up_to_date
+          check_for_other_package_managers
+        ].freeze
       end
 
       def fatal_development_tools_checks
-        if MacOS.version >= :sierra && ENV["CI"].nil?
-          %w[
-            check_xcode_up_to_date
-            check_clt_up_to_date
-          ]
-        else
-          %w[
-          ]
-        end
+        %w[
+          check_xcode_minimum_version
+          check_clt_minimum_version
+        ].freeze
+      end
       end
 
       def check_for_unsupported_macos

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -13,7 +13,10 @@ module OS
 
   if OS.mac?
     require "os/mac"
-    ISSUES_URL = "https://git.io/brew-troubleshooting".freeze
+    # Don't tell people to report issues on unsupported versions of macOS.
+    if !OS::Mac.prerelease? && !OS::Mac.outdated_release?
+      ISSUES_URL = "https://git.io/brew-troubleshooting".freeze
+    end
     PATH_OPEN = "/usr/bin/open".freeze
     # compatibility
     ::MACOS_FULL_VERSION = OS::Mac.full_version.to_s.freeze

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -25,6 +25,17 @@ module OS
         end
       end
 
+      def minimum_version
+        case MacOS.version
+        when "10.12" then "8.0"
+        else "2.0"
+        end
+      end
+
+      def minimum_version?
+        version < minimum_version
+      end
+
       def prerelease?
         # TODO: bump to version >= "8.3" after Xcode 8.2 is stable.
         version >= "8.2"
@@ -203,6 +214,17 @@ module OS
         else
           "425.0.28"
         end
+      end
+
+      def minimum_version
+        case MacOS.version
+        when "10.12" then "8.0.0"
+        else "4.0.0"
+        end
+      end
+
+      def minimum_version?
+        version < minimum_version
       end
 
       def outdated?


### PR DESCRIPTION
Rather than front-loading a bunch of warnings (some of which are fatal) about e.g. development tools not being installed in anticipation of causing a build failure let's instead print them out if a build actually fails. Similarly, rather than making people on Sierra have an always up-to-date Xcode let's enforce what we actually care about: a minimum
Xcode version on Sierra (that you shouldn't be able to get out of just by setting an environment variable). This will be useful to make similar enforcements for newer versions (and, if we choose to, for older versions too).

This will also stop complaining on unsupported versions of macOS but just warn those people on failures and not tell them to report issues (similarly with the boneyard).

CC @ilovezfs who will likely be interested.