### PR TITLE
software_spec: no `_or_later` in bottle filenames.

### DIFF
--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -38,7 +38,6 @@ module Utils
 
       # Allows a bottle tag to specify a specific OS or later,
       # so the same bottle can target multiple OSs.
-      # Not used in core, used in taps.
       def find_or_later_tag(tag)
         begin
           tag_version = MacOS::Version.from_symbol(tag)

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -221,7 +221,7 @@ class Bottle
     def initialize(name, version, tag, rebuild)
       @name = name
       @version = version
-      @tag = tag
+      @tag = tag.to_s.gsub(/_or_later$/, "")
       @rebuild = rebuild
     end
 


### PR DESCRIPTION
It's more useful to be able to "bless" an existing bottle to be used on later OSs (e.g. where it cannot yet be built) than it is to have to create a new, identical bottle just to have a different filename.

This will be used to be able to add bottles that can be used on Sierra (after testing) to formulae
that cannot build there yet.