### PR TITLE
bottle: improve relocatability check

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -251,6 +251,8 @@ module Homebrew
           relocatable = false if keg_contain?(cellar, keg, ignores)
           if prefix != prefix_check
             relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg)
+            relocatable = false if keg_contain?("#{prefix}/etc", keg, ignores)
+            relocatable = false if keg_contain?("#{prefix}/var", keg, ignores)
           end
           skip_relocation = relocatable && !keg.require_relocation?
         end


### PR DESCRIPTION
Given how common it is for formulae to hard-code `etc` and `var`, check
for those paths (`/usr/local/etc` and `/usr/local/var`) when determing
relocatability.

Fixes https://github.com/Homebrew/homebrew-core/issues/6454.