### PR TITLE
compat/sha1: disable SHA-1 support.

### DIFF
--- a/Library/Homebrew/compat/sha1.rb
+++ b/Library/Homebrew/compat/sha1.rb
@@ -1,36 +1,29 @@
 class Formula
-  def self.sha1(val)
-    odeprecated "Formula.sha1", "Formula.sha256"
-    stable.sha1(val)
+  def self.sha1(_val)
+    odisabled "Formula.sha1", "Formula.sha256"
   end
 end
 
 class SoftwareSpec
-  def sha1(val)
-    odeprecated "SoftwareSpec#sha1", "SoftwareSpec#sha256"
-    @resource.sha1(val)
+  def sha1(_val)
+    odisabled "SoftwareSpec#sha1", "SoftwareSpec#sha256"
   end
 end
 
 class Resource
-  def sha1(val)
-    odeprecated "Resource#sha1", "Resource#sha256"
-    @checksum = Checksum.new(:sha1, val)
+  def sha1(_val)
+    odisabled "Resource#sha1", "Resource#sha256"
   end
 end
 
 class BottleSpecification
-  def sha1(val)
-    odeprecated "BottleSpecification#sha1", "BottleSpecification#sha256"
-    digest, tag = val.shift
-    collector[tag] = Checksum.new(:sha1, digest)
+  def sha1(_val)
+    odisabled "BottleSpecification#sha1", "BottleSpecification#sha256"
   end
 end
 
 class Pathname
   def sha1
-    require "digest/sha1"
-    odeprecated "Pathname#sha1", "Pathname#sha256"
-    incremental_hash(Digest::SHA1)
+    odisabled "Pathname#sha1", "Pathname#sha256"
   end
 end


### PR DESCRIPTION
This has been deprecated for quite a while now so disabling seems reasonable.