### PR TITLE
brew.sh: disable running Homebrew as root.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -239,41 +239,21 @@ fi
 
 check-run-command-as-root() {
   [[ "$(id -u)" = 0 ]] || return
-  export HOMEBREW_NO_SANDBOX="1"
 
+  # Homebrew Cask may need `sudo` for system-wide installation.
   [[ "$HOMEBREW_COMMAND" = "cask" ]] && return
+
+  # Homebrew Services may need `sudo` for system-wide daemons.
   [[ "$HOMEBREW_COMMAND" = "services" ]] && return
+
+  # It's fine to run this as root as it's not changing anything.
   [[ "$HOMEBREW_COMMAND" = "--prefix" ]] && return
 
-  onoe <<EOS
-Running Homebrew as root is extremely dangerous. As Homebrew does not
-drop privileges on installation you are giving all build scripts full access
-to your system. As a result of the macOS sandbox not handling the root user
-correctly HOMEBREW_NO_SANDBOX has been set so the sandbox will not be used. If
-we have not merged a pull request to add privilege dropping by November 1st
-2016 running Homebrew as root will be disabled. No Homebrew maintainers plan
-to work on this functionality.
+  odie <<EOS
+Running Homebrew as root is extremely dangerous and no longer supported.
+As Homebrew does not drop privileges on installation you would be giving all
+build scripts full access to your system.
 EOS
-
-  case "$HOMEBREW_COMMAND" in
-    analytics|create|install|link|migrate|pin|postinstall|reinstall|switch|tap|\
-    tap-pin|update|upgrade|vendor-install)
-      ;;
-    *)
-      return
-      ;;
-  esac
-
-  local brew_file_ls_info=($(ls -nd "$HOMEBREW_BREW_FILE"))
-  if [[ "${brew_file_ls_info[2]}" != 0 ]]
-  then
-    odie <<EOS
-Cowardly refusing to 'sudo brew $HOMEBREW_COMMAND'
-You can use brew with sudo, but only if the brew executable is owned by root.
-However, this is both not recommended and completely unsupported so do so at
-your own risk.
-EOS
-  fi
 }
 check-run-command-as-root
 


### PR DESCRIPTION
November 1st 2016 has come and gone so it's time to disable this.

Also, add comments explaining why the things that have been whitelisted have been (to avoid more being added without good justification).