### PR TITLE
Tap tests: sort tap names for comparison

### DIFF
--- a/Library/Homebrew/test/test_tap.rb
+++ b/Library/Homebrew/test/test_tap.rb
@@ -105,7 +105,7 @@ class TapTest < Homebrew::TestCase
   end
 
   def test_names
-    assert_equal ["homebrew/core", "homebrew/foo"], Tap.names
+    assert_equal ["homebrew/core", "homebrew/foo"], Tap.names.sort
   end
 
   def test_attributes


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since the directories returned by filesystem operations aren't necessarily in alphabetical order, this could fail in really pedantic ways:

```
 10) Failure:
TapTest#test_names [/home/vagrant/.linuxbrew/Library/Homebrew/test/test_tap.rb:108]:
--- expected
+++ actual
@@ -1 +1 @@
-["homebrew/core", "homebrew/foo"]
+["homebrew/foo", "homebrew/core"]
```