### PR TITLE
brew.rb: don't exit when failing to set devcmdrun.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -65,8 +65,8 @@ begin
     unless internal_cmd
       internal_cmd = require? HOMEBREW_LIBRARY_PATH.join("dev-cmd", cmd)
       if internal_cmd && !ARGV.homebrew_developer?
-        safe_system "git", "config", "--file=#{HOMEBREW_REPOSITORY}/.git/config",
-                                     "--replace-all", "homebrew.devcmdrun", "true"
+        system "git", "config", "--file=#{HOMEBREW_REPOSITORY}/.git/config",
+                                "--replace-all", "homebrew.devcmdrun", "true"
         ENV["HOMEBREW_DEV_CMD_RUN"] = "1"
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It's not necessary to make this a hard failure so don't (and this makes it more consistent with `brew.sh`).

CC @vszakats 

Fixes #1462.