### PR TITLE
Update the CaskAlreadyInstalledError with new reinstall command

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/exceptions.rb
+++ b/Library/Homebrew/cask/lib/hbc/exceptions.rb
@@ -41,7 +41,7 @@ module Hbc
     def reinstall_message
       <<-EOS.undent
         To re-install #{token}, run:
-          brew cask uninstall --force #{token} && brew cask install #{token}
+          brew cask reinstall #{token}
       EOS
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). (should I really?)
- [x] Have you successfully run `brew tests` with your changes locally? (should I really?)

-----

e.g. this changes:

```
To re-install google-chrome, run:
  brew cask uninstall --force google-chrome && brew cask install google-chrome
```

To:

```
To re-install google-chrome, run:
  brew cask reinstall google-chrome
```