### PR TITLE
Add --with-custom-python option to virtualenv formulæ

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -102,6 +102,10 @@ module Language
     module Virtualenv
       def self.included(base)
         base.class_eval do
+          # This is a no-op option intended to force a source build in a way
+          # that `brew upgrade` will memorize.
+          option "with-custom-python", "Use the python in PATH instead of Homebrew's python distribution"
+
           resource "homebrew-virtualenv" do
             url PYTHON_VIRTUALENV_URL
             sha256 PYTHON_VIRTUALENV_SHA256


### PR DESCRIPTION
Installing with `-s` in order that `:python` dependencies do not install
Homebrew's python has some poor ergonomics: it's not discoverable and it
doesn't persist with `brew upgrade`. This adds an option to every
virtualenv-based formula with a discoverable name that has no effect
except to force a source build and which will be memorized for upgrades.