### PR TITLE
cask-test: fix reinstall a non installed Cask

### DIFF
--- a/Library/Homebrew/cask/test/cask/cli/reinstall_test.rb
+++ b/Library/Homebrew/cask/test/cask/cli/reinstall_test.rb
@@ -14,9 +14,6 @@ describe Hbc::CLI::Reinstall do
   end
 
   it "allows reinstalling a non installed Cask" do
-    shutup do
-      Hbc::CLI::Uninstall.run("local-transmission")
-    end
     Hbc.load("local-transmission").wont_be :installed?
 
     shutup do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
This is the change for the test itself.
- [x] Have you successfully run `brew cask-tests` with your changes locally?

-----

Trying to uninstall a non installed Cask made this test fail.
This commit remove that and thus this test passes.
Note that every Cask is uninstalled after each test case.