### PR TITLE
brew-cask tests never fail on BrewTestBot

### DIFF
--- a/Library/Homebrew/cask/cmd/brew-cask-tests.rb
+++ b/Library/Homebrew/cask/cmd/brew-cask-tests.rb
@@ -26,6 +26,8 @@ repo_root.cd do
 
   ENV["HOMEBREW_TESTS_COVERAGE"] = "1" if ARGV.flag?("--coverage")
 
+  failed = false
+
   if rspec
     run_tests "parallel_rspec", Dir["spec/**/*_spec.rb"], %w[
       --color
@@ -34,15 +36,17 @@ repo_root.cd do
       --format ParallelTests::RSpec::RuntimeLogger
       --out tmp/parallel_runtime_rspec.log
     ]
+    failed ||= !$CHILD_STATUS.success?
   end
 
   if minitest
     run_tests "parallel_test", Dir["test/**/*_test.rb"]
+    failed ||= !$CHILD_STATUS.success?
   end
+
+  Homebrew.failed = failed
 
   if ENV["CODECOV_TOKEN"]
     system "bundle", "exec", "rake", "test:coverage:upload"
   end
-
-  Homebrew.failed = !$CHILD_STATUS.success?
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
This is the change to the test runner itself.
- [x] Have you successfully run `brew tests` with your changes locally?
The current tests for Cask successfully fail due to #1472.

-----

`brew cask-tests` collected the test results in an improper way so that it reports a false success in certain situations.
Specially, the session under BrewTestBot always reports success regardless of the test status.
With this update, the exit code of `brew cask-tests` is 1 when the test fails, and then CI preperly works.