### PR TITLE
Fix `Hbc::Locations` in tests.

### DIFF
--- a/Library/Homebrew/cask/Rakefile
+++ b/Library/Homebrew/cask/Rakefile
@@ -1,8 +1,7 @@
 require "rake/testtask"
 require "rspec/core/rake_task"
 
-homebrew_repo = `brew --repository`.chomp
-$LOAD_PATH.unshift(File.expand_path("#{homebrew_repo}/Library/Homebrew"))
+$LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_REPOSITORY"]}/Library/Homebrew"))
 $LOAD_PATH.unshift(File.expand_path("../lib", __FILE__))
 
 namespace :test do

--- a/Library/Homebrew/cask/lib/hbc/caskroom.rb
+++ b/Library/Homebrew/cask/lib/hbc/caskroom.rb
@@ -3,7 +3,7 @@ module Hbc
     module_function
 
     def migrate_caskroom_from_repo_to_prefix
-      repo_caskroom = Hbc.homebrew_repository.join("Caskroom")
+      repo_caskroom = HOMEBREW_REPOSITORY.join("Caskroom")
       return if Hbc.caskroom.exist?
       return unless repo_caskroom.directory?
 

--- a/Library/Homebrew/cask/lib/hbc/cli/doctor.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/doctor.rb
@@ -8,9 +8,9 @@ module Hbc
         ohai "Ruby Path:", render_with_none_as_error(RbConfig.ruby)
         # TODO: consider removing most Homebrew constants from doctor output
         ohai "Homebrew Version:", render_with_none_as_error(homebrew_version)
-        ohai "Homebrew Executable Path:", render_with_none_as_error(Hbc.homebrew_executable)
+        ohai "Homebrew Executable Path:", render_with_none_as_error(HOMEBREW_BREW_FILE)
         ohai "Homebrew Cellar Path:", render_with_none_as_error(homebrew_cellar)
-        ohai "Homebrew Repository Path:", render_with_none_as_error(homebrew_repository)
+        ohai "Homebrew Repository Path:", render_with_none_as_error(HOMEBREW_REPOSITORY)
         ohai "Homebrew Origin:", render_with_none_as_error(homebrew_origin)
         ohai "Homebrew-Cask Version:", render_with_none_as_error(Hbc.full_version)
         ohai "Homebrew-Cask Install Location:", render_install_location
@@ -48,7 +48,7 @@ module Hbc
       def self.homebrew_origin
         homebrew_origin = notfound_string
         begin
-          Dir.chdir(homebrew_repository) do
+          Dir.chdir(HOMEBREW_REPOSITORY) do
             homebrew_origin = SystemCommand.run("/usr/bin/git",
                                                      args:         %w[config --get remote.origin.url],
                                                      print_stderr: false).stdout.strip
@@ -64,10 +64,6 @@ module Hbc
         homebrew_origin
       end
 
-      def self.homebrew_repository
-        homebrew_constants("repository")
-      end
-
       def self.homebrew_cellar
         homebrew_constants("cellar")
       end
@@ -77,9 +73,7 @@ module Hbc
       end
 
       def self.homebrew_taps
-        @homebrew_taps ||= if homebrew_repository.respond_to?(:join)
-          homebrew_repository.join("Library", "Taps")
-        end
+        Tap::TAP_DIRECTORY
       end
 
       def self.homebrew_constants(name)
@@ -87,7 +81,7 @@ module Hbc
         return @homebrew_constants[name] if @homebrew_constants.key?(name)
         @homebrew_constants[name] = notfound_string
         begin
-          @homebrew_constants[name] = SystemCommand.run!(Hbc.homebrew_executable,
+          @homebrew_constants[name] = SystemCommand.run!(HOMEBREW_BREW_FILE,
                                                          args:         ["--#{name}"],
                                                          print_stderr: false)
                                                    .stdout

--- a/Library/Homebrew/cask/lib/hbc/cli/update.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/update.rb
@@ -2,8 +2,8 @@ module Hbc
   class CLI
     class Update < Base
       def self.run(*_ignored)
-        result = SystemCommand.run(Hbc.homebrew_executable,
-                                   args: %w[update])
+        result = SystemCommand.run(HOMEBREW_BREW_FILE,
+                                   args: ["update"])
         # TODO: separating stderr/stdout is undesirable here.
         #       Hbc::SystemCommand should have an option for plain
         #       unbuffered output.

--- a/Library/Homebrew/cask/lib/hbc/dsl/caveats.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/caveats.rb
@@ -31,7 +31,7 @@ module Hbc
 
       def files_in_usr_local
         localpath = "/usr/local"
-        return unless Hbc.homebrew_prefix.to_s.downcase.start_with?(localpath)
+        return unless HOMEBREW_PREFIX.to_s.downcase.start_with?(localpath)
         puts <<-EOS.undent
           Cask #{@cask} installs files under "#{localpath}". The presence of such
           files can cause warnings when running "brew doctor", which is considered

--- a/Library/Homebrew/cask/lib/hbc/installer.rb
+++ b/Library/Homebrew/cask/lib/hbc/installer.rb
@@ -188,13 +188,13 @@ module Hbc
       ohai "Installing Formula dependencies from Homebrew"
       @cask.depends_on.formula.each do |dep_name|
         print "#{dep_name} ... "
-        installed = @command.run(Hbc.homebrew_executable,
+        installed = @command.run(HOMEBREW_BREW_FILE,
                                  args:         ["list", "--versions", dep_name],
                                  print_stderr: false).stdout.include?(dep_name)
         if installed
           puts "already installed"
         else
-          @command.run!(Hbc.homebrew_executable,
+          @command.run!(HOMEBREW_BREW_FILE,
                         args: ["install", dep_name])
           puts "done"
         end

--- a/Library/Homebrew/cask/lib/hbc/locations.rb
+++ b/Library/Homebrew/cask/lib/hbc/locations.rb
@@ -10,7 +10,7 @@ module Hbc
       end
 
       def default_caskroom
-        @default_caskroom ||= homebrew_prefix.join("Caskroom")
+        @default_caskroom ||= HOMEBREW_PREFIX.join("Caskroom")
       end
 
       def caskroom
@@ -39,11 +39,11 @@ module Hbc
       end
 
       def legacy_cache
-        @legacy_cache ||= homebrew_cache.join("Casks")
+        @legacy_cache ||= HOMEBREW_CACHE.join("Casks")
       end
 
       def cache
-        @cache ||= homebrew_cache.join("Cask")
+        @cache ||= HOMEBREW_CACHE.join("Cask")
       end
 
       attr_writer :appdir
@@ -91,7 +91,7 @@ module Hbc
       attr_writer :binarydir
 
       def binarydir
-        @binarydir ||= homebrew_prefix.join("bin")
+        @binarydir ||= HOMEBREW_PREFIX.join("bin")
       end
 
       attr_writer :input_methoddir
@@ -178,36 +178,6 @@ module Hbc
 
       def x11_libpng
         @x11_libpng ||= [Pathname.new("/opt/X11/lib/libpng.dylib"), Pathname.new("/usr/X11/lib/libpng.dylib")]
-      end
-
-      def homebrew_cache
-        @homebrew_cache ||= HOMEBREW_CACHE
-      end
-
-      def homebrew_cache=(path)
-        @homebrew_cache = path ? Pathname.new(path) : path
-      end
-
-      def homebrew_executable
-        @homebrew_executable ||= HOMEBREW_BREW_FILE
-      end
-
-      def homebrew_prefix
-        # where Homebrew links
-        @homebrew_prefix ||= HOMEBREW_PREFIX
-      end
-
-      def homebrew_prefix=(path)
-        @homebrew_prefix = path ? Pathname.new(path) : path
-      end
-
-      def homebrew_repository
-        # where Homebrew's .git dir is found
-        @homebrew_repository ||= HOMEBREW_REPOSITORY
-      end
-
-      def homebrew_repository=(path)
-        @homebrew_repository = path ? Pathname.new(path) : path
       end
     end
   end

--- a/Library/Homebrew/cask/spec/spec_helper.rb
+++ b/Library/Homebrew/cask/spec/spec_helper.rb
@@ -29,7 +29,7 @@ end
 # create and override default directories
 Hbc.appdir = Pathname.new(TEST_TMPDIR).join("Applications").tap(&:mkpath)
 Hbc.cache.mkpath
-Hbc.caskroom.mkpath
+Hbc.caskroom = Hbc.default_caskroom.tap(&:mkpath)
 Hbc.default_tap = Tap.fetch("caskroom", "spec").tap do |tap|
   # link test casks
   FileUtils.mkdir_p tap.path.dirname

--- a/Library/Homebrew/cask/test/support/fake_dirs.rb
+++ b/Library/Homebrew/cask/test/support/fake_dirs.rb
@@ -8,7 +8,7 @@ module FakeDirHooks
     @canned_dirs = {}
 
     DIRS.each do |dir_name|
-      dir = Hbc.homebrew_prefix.join("#{dir_name}-#{Time.now.to_i}-#{rand(1024)}")
+      dir = HOMEBREW_PREFIX.join("#{dir_name}-#{Time.now.to_i}-#{rand(1024)}")
       dir.mkpath
       Hbc.send("#{dir_name}=", dir)
       @canned_dirs[:dir_name] = dir

--- a/Library/Homebrew/cask/test/test_helper.rb
+++ b/Library/Homebrew/cask/test/test_helper.rb
@@ -41,8 +41,10 @@ module Hbc
   class TestCask < Cask; end
 end
 
+# create and override default directories
+Hbc.appdir = Pathname.new(TEST_TMPDIR).join("Applications").tap(&:mkpath)
 Hbc.cache.mkpath
-Hbc.caskroom.mkpath
+Hbc.caskroom = Hbc.default_caskroom.tap(&:mkpath)
 Hbc.default_tap = Tap.fetch("caskroom", "test").tap do |tap|
   # link test casks
   FileUtils.mkdir_p tap.path.dirname


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This should fix the 100+ errors caused by unintentional usage of `Hbc.legacy_caskroom` during tests as can be seen in https://github.com/Homebrew/brew/pull/1473.

---

@Homebrew/cask 