### PR TITLE
uninstall: don't need kegs to exist for --force.

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -21,6 +21,7 @@ module Homebrew
     kegs_by_rack = if ARGV.force?
       Hash[ARGV.named.map do |name|
         rack = Formulary.to_rack(name)
+        next unless rack.directory?
         [rack, rack.subdirs.map { |d| Keg.new(d) }]
       end]
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

Otherwise there's an error which is a regression on previous functionality. This mirrors `rm -f` which doesn't fail if a file doesn't exist.

CC @alyssais to check this isn't a stupid approach and @ilovezfs who mentioned this.