### PR TITLE
formulary: don't warn on old formula name from keg/rack.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -158,8 +158,9 @@ class Formulary
   class TapLoader < FormulaLoader
     attr_reader :tap
 
-    def initialize(tapped_name)
-      name, path = formula_name_path(tapped_name)
+    def initialize(tapped_name, from: nil)
+      warn = ![:keg, :rack].include?(from)
+      name, path = formula_name_path(tapped_name, warn: warn)
       super name, path
     end
 
@@ -236,8 +237,8 @@ class Formulary
   # * a formula pathname
   # * a formula URL
   # * a local bottle reference
-  def self.factory(ref, spec = :stable, alias_path: nil)
-    loader_for(ref).get_formula(spec, alias_path: alias_path)
+  def self.factory(ref, spec = :stable, alias_path: nil, from: nil)
+    loader_for(ref, from: from).get_formula(spec, alias_path: alias_path)
   end
 
   # Return a Formula instance for the given rack.
@@ -253,7 +254,7 @@ class Formulary
     if keg
       from_keg(keg, spec, alias_path: alias_path)
     else
-      factory(rack.basename.to_s, spec || :stable, alias_path: alias_path)
+      factory(rack.basename.to_s, spec || :stable, alias_path: alias_path, from: :rack)
     end
   end
 
@@ -265,13 +266,13 @@ class Formulary
     spec ||= tab.spec
 
     f = if tap.nil?
-      factory(keg.rack.basename.to_s, spec, alias_path: alias_path)
+      factory(keg.rack.basename.to_s, spec, alias_path: alias_path, from: :keg)
     else
       begin
-        factory("#{tap}/#{keg.rack.basename}", spec, alias_path: alias_path)
+        factory("#{tap}/#{keg.rack.basename}", spec, alias_path: alias_path, from: :keg)
       rescue FormulaUnavailableError
         # formula may be migrated to different tap. Try to search in core and all taps.
-        factory(keg.rack.basename.to_s, spec, alias_path: alias_path)
+        factory(keg.rack.basename.to_s, spec, alias_path: alias_path, from: :keg)
       end
     end
     f.build = tab
@@ -309,14 +310,14 @@ class Formulary
     loader_for(ref).path
   end
 
-  def self.loader_for(ref)
+  def self.loader_for(ref, from: nil)
     case ref
     when %r{(https?|ftp|file)://}
       return FromUrlLoader.new(ref)
     when Pathname::BOTTLE_EXTNAME_RX
       return BottleLoader.new(ref)
     when HOMEBREW_TAP_FORMULA_REGEX
-      return TapLoader.new(ref)
+      return TapLoader.new(ref, from: from)
     end
 
     return FromPathLoader.new(ref) if File.extname(ref) == ".rb"
@@ -359,7 +360,7 @@ class Formulary
     end
 
     unless possible_tap_newname_formulae.empty?
-      return TapLoader.new(possible_tap_newname_formulae.first)
+      return TapLoader.new(possible_tap_newname_formulae.first, from: from)
     end
 
     possible_cached_formula = Pathname.new("#{HOMEBREW_CACHE_FORMULA}/#{ref}.rb")

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -119,7 +119,8 @@ module Homebrew
     def stub_formula_loader(formula, ref = formula.full_name)
       loader = mock
       loader.stubs(:get_formula).returns(formula)
-      Formulary.stubs(:loader_for).with(ref).returns(loader)
+      Formulary.stubs(:loader_for).with(ref, from: :keg).returns(loader)
+      Formulary.stubs(:loader_for).with(ref, from: nil).returns(loader)
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If there’s an old installation of e.g. `apple-gcc42` from when it was part of `homebrew/core` then the tab will say it was from the `homebrew/core` tap and then we’ll complain at the user (see #1459 for
an example). Instead, we only want to complain when the user actually types in `homebrew/core/apple-gcc42` into a `brew` command.

CC @DabeDotCom @satorg

Closes #1459.