### PR TITLE
diagnostic: skip xcode-select check with no Xcode.

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -233,6 +233,7 @@ module Homebrew
 
       def check_xcode_select_path
         return if MacOS::CLT.installed?
+        return unless MacOS::Xcode.installed?
         return if File.file?("#{MacOS.active_developer_dir}/usr/bin/xcodebuild")
 
         path = MacOS::Xcode.bundle_path


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Skip the `xcode-select` configuration check if there's no CLT or Xcode installed as in that case neither will be used.

Fixes #1055.