### PR TITLE
Filter formula build options based on those that exist.

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -22,6 +22,7 @@ module Homebrew
   def reinstall_formula(f)
     options = BuildOptions.new(Options.create(ARGV.flags_only), f.options).used_options
     options |= f.build.used_options
+    options &= f.options
 
     notice  = "Reinstalling #{f.full_name}"
     notice += " with #{options * ", "}" unless options.empty?

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -96,6 +96,7 @@ module Homebrew
 
     fi = FormulaInstaller.new(f)
     fi.options             = f.build.used_options
+    fi.options            &= f.options
     fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
     fi.build_from_source   = ARGV.build_from_source? || ARGV.build_all_from_source?
     fi.verbose             = ARGV.verbose?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -457,6 +457,7 @@ class FormulaInstaller
     fi.options           |= tab.used_options
     fi.options           |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
     fi.options           |= inherited_options
+    fi.options           &= df.options
     fi.build_from_source  = ARGV.build_formula_from_source?(df)
     fi.verbose            = verbose? && !quieter?
     fi.debug              = debug?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

If `--with-foo` is provided to a formula through a tab or through another formula depending on it and this option does not exist it should be filtered. If it is not (the prior behaviour) then this can prevent bottles being used unnecessarily.

Fixes #1399.