### PR TITLE
Warn developers when uninstalling a dependency

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -96,7 +96,7 @@ module Homebrew
   end
 
   class DependentsMessage
-    attr :reqs, :deps
+    attr_reader :reqs, :deps
 
     def initialize(requireds, dependents)
       @reqs = requireds
@@ -105,11 +105,11 @@ module Homebrew
 
     protected
 
-    def is(items)
+    def are(items)
       items.count == 1 ? "is" : "are"
     end
 
-    def it(items)
+    def they(items)
       items.count == 1 ? "it" : "they"
     end
 
@@ -121,15 +121,15 @@ module Homebrew
       "brew uninstall --ignore-dependencies #{list reqs.map(&:name)}"
     end
 
-    def is_required_by_deps
-      "#{is reqs} required by #{list deps}, which #{is deps} currently installed"
+    def are_required_by_deps
+      "#{are reqs} required by #{list deps}, which #{are deps} currently installed"
     end
   end
 
   class DeveloperDependentsMessage < DependentsMessage
     def output
       opoo <<-EOS.undent
-        #{list reqs} #{is_required_by_deps}.
+        #{list reqs} #{are_required_by_deps}.
         You can silence this warning with:
           #{sample_command}
       EOS
@@ -140,7 +140,7 @@ module Homebrew
     def output
       ofail <<-EOS.undent
         Refusing to uninstall #{list reqs}
-        because #{it reqs} #{is_required_by_deps}.
+        because #{they reqs} #{are_required_by_deps}.
         You can override this and force removal with:
           #{sample_command}
       EOS

--- a/Library/Homebrew/test/test_uninstall.rb
+++ b/Library/Homebrew/test/test_uninstall.rb
@@ -2,20 +2,55 @@ require "helper/integration_command_test_case"
 require "cmd/uninstall"
 
 class UninstallTests < Homebrew::TestCase
+  def setup
+    @dependency = formula("dependency") { url "f-1" }
+    @dependent = formula("dependent") do
+      url "f-1"
+      depends_on "dependency"
+    end
+
+    [@dependency, @dependent].each { |f| f.installed_prefix.mkpath }
+
+    tab = Tab.empty
+    tab.tabfile = @dependent.installed_prefix/Tab::FILENAME
+    tab.runtime_dependencies = [
+      { "full_name" => "dependency", "version" => "1" },
+    ]
+    tab.write
+
+    stub_formula_loader @dependency
+    stub_formula_loader @dependent
+  end
+
+  def teardown
+    Homebrew.failed = false
+    [@dependency, @dependent].each { |f| f.rack.rmtree }
+  end
+
+  def handle_unsatisfied_dependents
+    capture_stderr do
+      opts = { @dependency.rack => [Keg.new(@dependency.installed_prefix)] }
+      Homebrew.handle_unsatisfied_dependents(opts)
+    end
+  end
+
   def test_check_for_testball_f2s_when_developer
-    refute_predicate Homebrew, :should_check_for_dependents?
+    assert_match "Warning", handle_unsatisfied_dependents
+    refute_predicate Homebrew, :failed?
   end
 
   def test_check_for_dependents_when_not_developer
     run_as_not_developer do
-      assert_predicate Homebrew, :should_check_for_dependents?
+      assert_match "Error", handle_unsatisfied_dependents
+      assert_predicate Homebrew, :failed?
     end
   end
 
   def test_check_for_dependents_when_ignore_dependencies
     ARGV << "--ignore-dependencies"
     run_as_not_developer do
-      refute_predicate Homebrew, :should_check_for_dependents?
+      assert_empty handle_unsatisfied_dependents
+      refute_predicate Homebrew, :failed?
     end
   ensure
     ARGV.delete("--ignore-dependencies")

--- a/Library/Homebrew/test/test_utils.rb
+++ b/Library/Homebrew/test/test_utils.rb
@@ -174,6 +174,10 @@ class UtilTests < Homebrew::TestCase
     end
   end
 
+  def test_capture_stderr
+    assert_equal "test\n", capture_stderr { $stderr.puts "test" }
+  end
+
   def test_shell_profile
     ENV["SHELL"] = "/bin/sh"
     assert_equal "~/.bash_profile", Utils::Shell.shell_profile

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -377,7 +377,8 @@ ensure
 end
 
 def capture_stderr
-  old, $stderr = $stderr, StringIO.new
+  old = $stderr
+  $stderr = StringIO.new
   yield
   $stderr.string
 ensure

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -376,6 +376,14 @@ ensure
   trap("INT", std_trap)
 end
 
+def capture_stderr
+  old, $stderr = $stderr, StringIO.new
+  yield
+  $stderr.string
+ensure
+  $stderr = old
+end
+
 def nostdout
   if ARGV.verbose?
     yield


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally? <ins>Only with #1497 merged.</ins>

-----

Suggested by @MikeMcQuaid in https://github.com/Homebrew/brew/pull/1082#discussion_r87691728.

Tests will fail as a side effect of #1496. When #1497 is merged, run the CI here again. It should go green and this should then be ready to merge.

I fixed the existing error message for non-developers as part of this too, so that it's output entirely to `stderr`. Previously, the first line was sent to `stderr` and subsequent ones went to `stdout`.