### PR TITLE
formula_versions: fix erroneous :stable in version_attributes_map

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -77,7 +77,7 @@ class FormulaVersions
           end
           next unless f.devel
           map[:devel] ||= {}
-          map[:stable][f.devel.version] ||= []
+          map[:devel][f.devel.version] ||= []
           map[:devel][f.devel.version] << f.send(attribute)
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

remove erroneous :stable in version_attributes_map introduced by last commit

@MikeMcQuaid I am believe this is an error, with it potentially contributing to the error in https://github.com/Homebrew/homebrew-core/pull/6898 where bumping the devel version resulted in:
`* stable version should not decrease`. 

The `:stable` may have been intentional, if so feel free to just close this. 

`dbus` and `formula_versions` do currently really seem to be at odds...