### PR TITLE
Don't warn about unused `brew install` arguments.

### DIFF
--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -103,12 +103,18 @@ class BuildOptions
 
   # @private
   def invalid_options
-    @args - @options
+    @args - @options - BuildOptions.formula_install_options
   end
 
   # @private
   def invalid_option_names
     invalid_options.map(&:flag).sort
+  end
+
+  def self.formula_install_options
+    @formula_install_options ||= ARGV.formula_install_option_names.map do |option_name|
+      Option.new option_name[2..-1]
+    end
   end
 
   private

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -1,4 +1,29 @@
 module HomebrewArgvExtension
+  def formula_install_option_names
+    %w[
+      --debug
+      --env=
+      --ignore-dependencies
+      --cc=
+      --build-from-source
+      --devel
+      --HEAD
+      --keep-tmp
+      --interactive
+      --git
+      --sandbox
+      --no-sandbox
+      --build-bottle
+      --force-bottle
+      --verbose
+      -i
+      -v
+      -d
+      -g
+      -s
+    ].freeze
+  end
+
   def named
     @named ||= self - options_only
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a step closer to better argument handling but for now just fixes the issue in #1217 where it starts complaining about options like `--build-from-source` being used.

CC @MatzFan due to #1217 and @bfontaine as you've been thinking about argument handling.