### PR TITLE
Fix detection of self-extracting `.exe` files.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/container/cab.rb
+++ b/Library/Homebrew/cask/lib/hbc/container/cab.rb
@@ -8,7 +8,7 @@ module Hbc
       def self.me?(criteria)
         cabextract = which("cabextract")
 
-        criteria.magic_number(/^MSCF/n) &&
+        criteria.magic_number(/^(MSCF|MZ)/n) &&
           !cabextract.nil? &&
           criteria.command.run(cabextract, args: ["-t", "--", criteria.path.to_s]).stderr.empty?
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Apparently `cabextract` is not dead yet as self-extracting `.exe` files can be extracted with it.

Fixes https://github.com/caskroom/homebrew-fonts/issues/916.