### PR TITLE
development_tools: don't create Versions from `nil`

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -43,8 +43,9 @@ class DevelopmentTools
 
     def gcc_40_build_version
       @gcc_40_build_version ||=
-        if (path = locate("gcc-4.0"))
-          Version.new `#{path} --version 2>/dev/null`[/build (\d{4,})/, 1].to_i
+        if (path = locate("gcc-4.0")) &&
+           build_version = `#{path} --version 2>/dev/null`[/build (\d{4,})/, 1]
+          Version.new build_version
         else
           Version::NULL
         end
@@ -55,8 +56,9 @@ class DevelopmentTools
       @gcc_42_build_version ||=
         begin
           gcc = locate("gcc-4.2") || HOMEBREW_PREFIX.join("opt/apple-gcc42/bin/gcc-4.2")
-          if gcc.exist? && !gcc.realpath.basename.to_s.start_with?("llvm")
-            Version.new `#{gcc} --version 2>/dev/null`[/build (\d{4,})/, 1]
+          if gcc.exist? && !gcc.realpath.basename.to_s.start_with?("llvm")&&
+             build_version = `#{gcc} --version 2>/dev/null`[/build (\d{4,})/, 1]
+            Version.new build_version
           else
             Version::NULL
           end
@@ -66,8 +68,9 @@ class DevelopmentTools
 
     def clang_version
       @clang_version ||=
-        if (path = locate("clang"))
-          Version.new `#{path} --version`[/(?:clang|LLVM) version (\d\.\d)/, 1]
+        if (path = locate("clang")) &&
+           build_version = `#{path} --version`[/(?:clang|LLVM) version (\d\.\d)/, 1]
+          Version.new build_version
         else
           Version::NULL
         end
@@ -75,8 +78,9 @@ class DevelopmentTools
 
     def clang_build_version
       @clang_build_version ||=
-        if (path = locate("clang"))
-          Version.new `#{path} --version`[/clang-(\d{2,})/, 1]
+        if (path = locate("clang")) &&
+           build_version = `#{path} --version`[/clang-(\d{2,})/, 1]
+          Version.new build_version
         else
           Version::NULL
         end
@@ -86,8 +90,9 @@ class DevelopmentTools
       (@non_apple_gcc_version ||= {}).fetch(cc) do
         path = HOMEBREW_PREFIX.join("opt", "gcc", "bin", cc)
         path = locate(cc) unless path.exist?
-        version = if path
-          Version.new(`#{path} --version`[/gcc(?:-\d(?:\.\d)? \(.+\))? (\d\.\d\.\d)/, 1])
+        version = if path &&
+                     build_version = `#{path} --version`[/gcc(?:-\d(?:\.\d)? \(.+\))? (\d\.\d\.\d)/, 1]
+          Version.new build_version
         else
           Version::NULL
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This cause issues when e.g. using `debrew.rb` on a failing `system` command in a formula.

CC @ilovezfs who hit this

CC @mistydemeo For what it's worth I think the better solution would be to make `Version.new nil` create a `Version::NULL`. Somewhat relatedly I think it may make sense to declare Version::NULL inside `version.rb` as it's a constant inside Version rather than a new class. I also wonder if it's worth using e.g. https://ruby-doc.org/stdlib-2.0.0/libdoc/singleton/rdoc/Singleton.html and/or following the pattern `CoreTap` uses (hopefully making them both consistent whichever approach is taken).
