### PR TITLE
bump-formula-pr: add --message option

### DIFF
--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -469,8 +469,8 @@ for instance, for implementing pre-commit hooks.</p></dd>
 
 <p>Generate a bottle (binary package) from a formula installed with
 <code>--build-bottle</code>.</p></dd>
-<dt><code>bump-formula-pr</code> [<code>--devel</code>] [<code>--dry-run</code>] [<code>--audit</code>|<code>--strict</code>] <code>--url=</code><var>url</var> <code>--sha256=</code><var>sha-256</var> <var>formula</var>:</dt><dd><p></p></dd>
-<dt><code>bump-formula-pr</code> [<code>--devel</code>] [<code>--dry-run</code>] [<code>--audit</code>|<code>--strict</code>] <code>--tag=</code><var>tag</var> <code>--revision=</code><var>revision</var> <var>formula</var></dt><dd><p>Creates a pull request to update the formula with a new url or a new tag.</p>
+<dt><code>bump-formula-pr</code> [<code>--devel</code>] [<code>--dry-run</code>] [<code>--audit</code>|<code>--strict</code>] [<code>--message=</code><var>message</var>] <code>--url=</code><var>url</var> <code>--sha256=</code><var>sha-256</var> <var>formula</var>:</dt><dd><p></p></dd>
+<dt><code>bump-formula-pr</code> [<code>--devel</code>] [<code>--dry-run</code>] [<code>--audit</code>|<code>--strict</code>] [<code>--message=</code><var>message</var>] <code>--tag=</code><var>tag</var> <code>--revision=</code><var>revision</var> <var>formula</var></dt><dd><p>Creates a pull request to update the formula with a new url or a new tag.</p>
 
 <p>If a <var>url</var> is specified, the <var>sha-256</var> checksum of the new download must
 also be specified. A best effort to determine the <var>sha-256</var> and <var>formula</var>
@@ -496,6 +496,9 @@ making the expected file modifications but not taking any git actions.</p>
 <p>If <code>--version=</code><var>version</var> is passed, use the value to override the value
 parsed from the url or tag. Note that <code>--version=0</code> can be used to delete
 an existing <code>version</code> override from a formula if it has become redundant.</p>
+
+<p>If <code>--message=</code><var>message</var> is passed, append <var>message</var> to the default PR
+message.</p>
 
 <p>Note that this command cannot be used to transition a formula from a
 url-and-sha256 style specification into a tag-and-revision style

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -654,11 +654,11 @@ If \fB\-\-display\-filename\fR is passed, every line of output is prefixed with 
 Generate a bottle (binary package) from a formula installed with \fB\-\-build\-bottle\fR\.
 .
 .TP
-\fBbump\-formula\-pr\fR [\fB\-\-devel\fR] [\fB\-\-dry\-run\fR] [\fB\-\-audit\fR|\fB\-\-strict\fR] \fB\-\-url=\fR\fIurl\fR \fB\-\-sha256=\fR\fIsha\-256\fR \fIformula\fR:
+\fBbump\-formula\-pr\fR [\fB\-\-devel\fR] [\fB\-\-dry\-run\fR] [\fB\-\-audit\fR|\fB\-\-strict\fR] [\fB\-\-message=\fR\fImessage\fR] \fB\-\-url=\fR\fIurl\fR \fB\-\-sha256=\fR\fIsha\-256\fR \fIformula\fR:
 
 .
 .TP
-\fBbump\-formula\-pr\fR [\fB\-\-devel\fR] [\fB\-\-dry\-run\fR] [\fB\-\-audit\fR|\fB\-\-strict\fR] \fB\-\-tag=\fR\fItag\fR \fB\-\-revision=\fR\fIrevision\fR \fIformula\fR
+\fBbump\-formula\-pr\fR [\fB\-\-devel\fR] [\fB\-\-dry\-run\fR] [\fB\-\-audit\fR|\fB\-\-strict\fR] [\fB\-\-message=\fR\fImessage\fR] \fB\-\-tag=\fR\fItag\fR \fB\-\-revision=\fR\fIrevision\fR \fIformula\fR
 Creates a pull request to update the formula with a new url or a new tag\.
 .
 .IP
@@ -687,6 +687,9 @@ If \fB\-\-mirror=\fR\fIurl\fR is passed, use the value as a mirror url\.
 .
 .IP
 If \fB\-\-version=\fR\fIversion\fR is passed, use the value to override the value parsed from the url or tag\. Note that \fB\-\-version=0\fR can be used to delete an existing \fBversion\fR override from a formula if it has become redundant\.
+.
+.IP
+If \fB\-\-message=\fR\fImessage\fR is passed, append \fImessage\fR to the default PR message\.
 .
 .IP
 Note that this command cannot be used to transition a formula from a url\-and\-sha256 style specification into a tag\-and\-revision style specification, nor vice versa\. It must use whichever style specification the preexisting formula already uses\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Add a `--message=<message>` option to `bump-formula-pr` so that user can supply a piece of message to be included in the PR message.

The motivation comes from automatically bumping `imagemagick`. I have a script to do it, but I want to include a reminder to maintainers:

> Please remember to
> ```
> brew mirror imagemagick
> ```
> when merging.

Since `brew-bump-formula-pr` doesn't allow custom PR message, I have to copy the message to clipboard at the end of the script, and remember to paste that into a comment when the PR has been created. I'd like to be able to do

```
brew bump-formula-pr --url=https://dl.bintray.com/homebrew/mirror/imagemagick-6.0.0-0.tar.xz --mirror=https://www.imagemagick.org/download/ImageMagick-6.0.0-0.tar.xz --sha256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 --message=$'Please remember to\n```\nbrew mirror imagemagick\n```\nwhen merging.' imagemagick
```

and forget about it.

I understand that this is a niche feature, but `bump-formula-pr` is a very niche dev cmd to begin with, so I figured it doesn't hurt to suggest this.