### PR TITLE
Fix flaky tests.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1337,10 +1337,14 @@ class Formula
     end
   end
 
-  # Clear caches of .racks and .installed.
-  # @private
-  def self.clear_cache
+  # Clear cache of .racks
+  def self.clear_racks_cache
     @racks = nil
+  end
+
+  # Clear caches of .racks and .installed.
+  def self.clear_installed_formulae_cache
+    clear_racks_cache
     @installed = nil
   end
 

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -317,6 +317,10 @@ class Tab < OpenStruct
   end
 
   def write
+    # If this is a new installation, the cache of installed formulae
+    # will no longer be valid.
+    Formula.clear_cache unless tabfile.exist?
+
     CACHE[tabfile] = self
     tabfile.atomic_write(to_json)
   end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -319,7 +319,7 @@ class Tab < OpenStruct
   def write
     # If this is a new installation, the cache of installed formulae
     # will no longer be valid.
-    Formula.clear_cache unless tabfile.exist?
+    Formula.clear_installed_formulae_cache unless tabfile.exist?
 
     CACHE[tabfile] = self
     tabfile.atomic_write(to_json)

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -327,7 +327,6 @@ class InstalledDependantsTests < LinkTests
     f = stub_formula_name(name)
     keg = super
     Tab.create(f, DevelopmentTools.default_compiler, :libcxx).write
-    Formula.clear_cache
     keg
   end
 

--- a/Library/Homebrew/test/uninstall_test.rb
+++ b/Library/Homebrew/test/uninstall_test.rb
@@ -34,13 +34,11 @@ class UninstallTests < Homebrew::TestCase
   end
 
   def test_check_for_testball_f2s_when_developer
-    skip "Flaky test"
     assert_match "Warning", handle_unsatisfied_dependents
     refute_predicate Homebrew, :failed?
   end
 
   def test_check_for_dependents_when_not_developer
-    skip "Flaky test"
     run_as_not_developer do
       assert_match "Error", handle_unsatisfied_dependents
       assert_predicate Homebrew, :failed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The issue was that the `Formula.installed` result was getting cached as `[]` by a previous test.

I've made `Tab#write` clear the cache if the tab didn't exist before, which _should_ stop this coming up again, but I wonder if we should clear the cache automatically in the teardown of every test as well, which would _definitely_ stop this coming up again, and shouldn't have too much overhead. <ins>Thoughts?</ins>