### PR TITLE
cmd/list: follow aliases

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -107,7 +107,7 @@ module Homebrew
     names = if ARGV.named.empty?
       Formula.racks
     else
-      racks = ARGV.named.map { |n| HOMEBREW_CELLAR+n }
+      racks = ARGV.named.map { |n| Formulary.to_rack(n) }
       racks.select do |rack|
         Homebrew.failed = true unless rack.exist?
         rack.exist?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
From #1514:

* `brew list --versions` behaves exactly as before, and lists all installed formulae by their "true" names.
* `brew list --versions $formula` will "follow" aliases and perform the list operations on the "true" formula. Thus, `brew list --versions mosh` and `brew list --versions mobile-shell` will return the exact same output.

Closes #1514