### PR TITLE
audit: only check previous formula version.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -661,7 +661,7 @@ class FormulaAuditor
     return unless formula.tap.git? # git log is required
     return if @new_formula
 
-    fv = FormulaVersions.new(formula, max_depth: 10)
+    fv = FormulaVersions.new(formula, max_depth: 1)
     attributes = [:revision, :version_scheme]
 
     attributes_map = fv.version_attributes_map(attributes, "origin/master")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For calculating the stable/devel versions this should be sufficient as it's looking at `origin/master` so for a e.g. unmerged pull request this will stop complaining about mistakes outside the pull request itself.

CC @ilovezfs 

This will silence all warnings for historic version mistakes (i.e.
before these audit checks were all enabled) which is normally a bad
thing but as this case would rely on modifying history to complete is a
good one.