### PR TITLE
uninstall: ignore deprecations when uninstalling.

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -81,6 +81,9 @@ module Homebrew
 
     all_kegs = kegs_by_rack.values.flatten(1)
     check_for_dependents all_kegs
+  rescue MethodDeprecatedError
+    # Silently ignore deprecations when uninstalling.
+    nil
   end
 
   def check_for_dependents(kegs)


### PR DESCRIPTION
Handle `MethodDeprecatedError` because we want people to be able to uninstall regardless of the content of their formula.

Addresses https://github.com/Homebrew/homebrew-core/issues/6999.