### PR TITLE
tests: ignore test files in test/vendor/bundle

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -46,6 +46,7 @@ module Homebrew
 
       files = Dir.glob("test/**/*_test.rb")
                  .reject { |p| !OS.mac? && p.start_with?("test/os/mac/") }
+                 .reject { |p| p.start_with?("test/vendor/bundle/") }
 
       opts = []
       opts << "--serialize-stdout" if ENV["CI"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Ensure that files matching `test/vendor/bundle/**/*_test.rb` are not picked up when running `brew tests`.