### PR TITLE
Cask: Add the choices option to pkg stanza

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/artifact/pkg.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/pkg.rb
@@ -55,19 +55,16 @@ module Hbc
         args << "-verboseR" if Hbc.verbose
         args << "-allowUntrusted" if pkg_install_opts :allow_untrusted
         if pkg_install_opts :choices
-          args << "-applyChoiceChangesXML"
-          args << choices_xml
+          choices_file = choices_xml
+          args << "-applyChoiceChangesXML" << choices_file.path
         end
         @command.run!("/usr/sbin/installer", sudo: true, args: args, print_stdout: true)
       end
 
       def choices_xml
-        path = @cask.staged_path.join("Choices.xml")
-        unless File.exist? path
-          choices = pkg_install_opts :choices
-          IO.write path, Plist::Emit.dump(choices)
-        end
-        path
+        file = Tempfile.open(["", ".xml"])
+        file.write Plist::Emit.dump(pkg_install_opts(:choices))
+        file
       end
     end
   end

--- a/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
+++ b/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
@@ -60,8 +60,9 @@ describe Hbc::Artifact::Pkg do
         </plist>
       EOS
       file.stubs path: Pathname.new("/tmp/choices.xml")
-      file.expects(:close).with true
-      Tempfile.expects(:new).returns file
+      file.expects(:close)
+      file.expects(:unlink)
+      Tempfile.expects(:open).yields file
 
       Hbc::FakeSystemCommand.expects_command(["/usr/bin/sudo", "-E", "--", "/usr/sbin/installer", "-pkg", @cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/", "-applyChoiceChangesXML", @cask.staged_path.join("/tmp/choices.xml")])
 

--- a/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
+++ b/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
@@ -40,31 +40,32 @@ describe Hbc::Artifact::Pkg do
     end
 
     it "passes the choice changes xml to the system installer" do
-      pkg = Hbc::Artifact::Pkg.new(@cask,
-                                   command: Hbc::FakeSystemCommand)
+      pkg = Hbc::Artifact::Pkg.new(@cask, command: Hbc::FakeSystemCommand)
 
-      Hbc::FakeSystemCommand.expects_command(["/usr/bin/sudo", "-E", "--", "/usr/sbin/installer", "-pkg", @cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/", "-applyChoiceChangesXML", @cask.staged_path.join("Choices.xml")])
-
-      shutup do
-        pkg.install_phase
-      end
-
-      IO.read(@cask.staged_path.join("Choices.xml")).must_equal <<-EOS.undent
+      file = mock
+      file.expects(:write).with <<-EOS.undent
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
         <plist version="1.0">
         <array>
-        	<dict>
-        		<key>attributeSetting</key>
-        		<integer>1</integer>
-        		<key>choiceAttribute</key>
-        		<string>selected</string>
-        		<key>choiceIdentifier</key>
-        		<string>choice1</string>
-        	</dict>
+        \t<dict>
+        \t\t<key>attributeSetting</key>
+        \t\t<integer>1</integer>
+        \t\t<key>choiceAttribute</key>
+        \t\t<string>selected</string>
+        \t\t<key>choiceIdentifier</key>
+        \t\t<string>choice1</string>
+        \t</dict>
         </array>
         </plist>
       EOS
+      file.stubs path: Pathname.new("/tmp/choices.xml")
+      Tempfile.expects(:open).returns(file)
+      Hbc::FakeSystemCommand.expects_command(["/usr/bin/sudo", "-E", "--", "/usr/sbin/installer", "-pkg", @cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/", "-applyChoiceChangesXML", @cask.staged_path.join("/tmp/choices.xml")])
+
+      shutup do
+        pkg.install_phase
+      end
     end
   end
 end

--- a/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
+++ b/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
@@ -60,7 +60,9 @@ describe Hbc::Artifact::Pkg do
         </plist>
       EOS
       file.stubs path: Pathname.new("/tmp/choices.xml")
-      Tempfile.expects(:open).returns(file)
+      file.expects(:close).with true
+      Tempfile.expects(:new).returns file
+
       Hbc::FakeSystemCommand.expects_command(["/usr/bin/sudo", "-E", "--", "/usr/sbin/installer", "-pkg", @cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/", "-applyChoiceChangesXML", @cask.staged_path.join("/tmp/choices.xml")])
 
       shutup do

--- a/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
+++ b/Library/Homebrew/cask/test/cask/artifact/pkg_test.rb
@@ -30,4 +30,41 @@ describe Hbc::Artifact::Pkg do
       end
     end
   end
+
+  describe "choices" do
+    before do
+      @cask = Hbc.load("with-choices")
+      shutup do
+        TestHelper.install_without_artifacts(@cask)
+      end
+    end
+
+    it "passes the choice changes xml to the system installer" do
+      pkg = Hbc::Artifact::Pkg.new(@cask,
+                                   command: Hbc::FakeSystemCommand)
+
+      Hbc::FakeSystemCommand.expects_command(["/usr/bin/sudo", "-E", "--", "/usr/sbin/installer", "-pkg", @cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/", "-applyChoiceChangesXML", @cask.staged_path.join("Choices.xml")])
+
+      shutup do
+        pkg.install_phase
+      end
+
+      IO.read(@cask.staged_path.join("Choices.xml")).must_equal <<-EOS.undent
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <array>
+        	<dict>
+        		<key>attributeSetting</key>
+        		<integer>1</integer>
+        		<key>choiceAttribute</key>
+        		<string>selected</string>
+        		<key>choiceIdentifier</key>
+        		<string>choice1</string>
+        	</dict>
+        </array>
+        </plist>
+      EOS
+    end
+  end
 end

--- a/Library/Homebrew/cask/test/support/Casks/with-choices.rb
+++ b/Library/Homebrew/cask/test/support/Casks/with-choices.rb
@@ -1,0 +1,16 @@
+test_cask 'with-choices' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg',
+      choices: [
+                 {
+                   'choiceIdentifier' => 'choice1',
+                   'choiceAttribute'  => 'selected',
+                   'attributeSetting' => 1,
+                 },
+               ]
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

installer command accepts -applyChoiceChangesXML option to change customize options on the GUI installer from the commandline.
(`man installer` for more detailed information)

Some `.pkg` packages need to be supplied this choice changes XML.
Currently that is achieved by some tricks including writing a XML on preflight and execute `installer` command via the arbitrary command execution (`installer` stanza).
This is confusing because these Casks cannot use the standard `pkg` stanza for `.pkg` packages.

The introduced option `choice` enables the choice changes to be supplied
via pkg stanza without tricks in preflight code.

## Example

```
pkg 'MyFancyPkg/Fancy.pkg',
    choices: [
      {
        'choiceIdentifier' => 'choice1',
        'choiceAttribute'  => 'selected',
        'attributeSetting' => 1,
      },
    ]
```

`-applyChoiceChangesXML` option is used in [osxfuse Cask], for example.
This Cask can be written in [a more concise way] with choice option.

[osxfuse Cask]: https://github.com/caskroom/homebrew-cask/blob/master/Casks/osxfuse.rb
[a more concise way]: https://gist.github.com/umireon/ecb8908f8b2514abba907a5ca5c5e233/revisions#diff-15bc398082ca9019e0041ddbadc37bdf

## Related issues
caskroom/homebrew-cask#9578 (closed for lack of interest)
caskroom/homebrew-cask#10137 (stalled?)
caskroom/homebrew-cask#15431 (request for this feature)

Note that I don't mean adding the `--with-xxx` feature mentioned in caskroom/homebrew-cask#10137.