### PR TITLE
install: suppress redundunt warnings with `depends_on` requirement

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -251,6 +251,7 @@ class FormulaInstaller
         opoo "Bottle installation failed: building from source."
         raise BuildToolsError, [formula] unless DevelopmentTools.installed?
       else
+        puts @requirement_messages
         @poured_bottle = true
       end
     end
@@ -260,6 +261,7 @@ class FormulaInstaller
     unless @poured_bottle
       not_pouring = !pour_bottle || @pour_failed
       compute_and_install_dependencies if not_pouring && !ignore_deps?
+      puts @requirement_messages
       build
       clean
 
@@ -334,17 +336,21 @@ class FormulaInstaller
   end
 
   def check_requirements(req_map)
+    @requirement_messages = []
     fatals = []
 
     req_map.each_pair do |dependent, reqs|
       next if dependent.installed?
       reqs.each do |req|
-        puts "#{dependent}: #{req.message}"
+        @requirement_messages << "#{dependent}: #{req.message}"
         fatals << req if req.fatal?
       end
     end
 
-    raise UnsatisfiedRequirements, fatals unless fatals.empty?
+    return if fatals.empty?
+
+    puts @requirement_messages
+    raise UnsatisfiedRequirements, fatals
   end
 
   def install_requirement_default_formula?(req, dependent, build)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -52,6 +52,7 @@ class FormulaInstaller
     @debug = false
     @options = Options.new
     @invalid_option_names = []
+    @requirement_messages = []
 
     @@attempted ||= Set.new
 
@@ -251,7 +252,7 @@ class FormulaInstaller
         opoo "Bottle installation failed: building from source."
         raise BuildToolsError, [formula] unless DevelopmentTools.installed?
       else
-        puts @requirement_messages
+        puts_requirement_messages
         @poured_bottle = true
       end
     end
@@ -261,7 +262,7 @@ class FormulaInstaller
     unless @poured_bottle
       not_pouring = !pour_bottle || @pour_failed
       compute_and_install_dependencies if not_pouring && !ignore_deps?
-      puts @requirement_messages
+      puts_requirement_messages
       build
       clean
 
@@ -349,7 +350,7 @@ class FormulaInstaller
 
     return if fatals.empty?
 
-    puts @requirement_messages
+    puts_requirement_messages
     raise UnsatisfiedRequirements, fatals
   end
 
@@ -836,5 +837,11 @@ class FormulaInstaller
     @@locked.each(&:unlock)
     @@locked.clear
     @hold_locks = false
+  end
+
+  def puts_requirement_messages
+    return unless @requirement_messages
+    return if @requirement_messages.empty?
+    puts @requirement_messages
   end
 end

--- a/Library/Homebrew/test/install_test.rb
+++ b/Library/Homebrew/test/install_test.rb
@@ -27,4 +27,27 @@ class IntegrationCommandTestInstall < IntegrationCommandTestCase
     assert_match "testball1: this formula has no --with-fo option so it will be ignored!",
       cmd("install", "testball1", "--with-fo")
   end
+
+  def test_install_with_nonfatal_requirement
+    setup_test_formula "testball1", <<-EOS.undent
+      class NonFatalRequirement < Requirement
+        satisfy { false }
+      end
+      depends_on NonFatalRequirement
+    EOS
+    message = "NonFatalRequirement unsatisfied!"
+    assert_equal 1, cmd("install", "testball1").scan(message).size
+  end
+
+  def test_install_with_fatal_requirement
+    setup_test_formula "testball1", <<-EOS.undent
+      class FatalRequirement < Requirement
+        fatal true
+        satisfy { false }
+      end
+      depends_on FatalRequirement
+    EOS
+    message = "FatalRequirement unsatisfied!"
+    assert_equal 1, cmd_fail("install", "testball1").scan(message).size
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When a formula depends on any [requirements], they evaluated at most three times.

- Before locking: [verify_deps_exist in FormulaInstaller#prelude]
- Before installing: [compute_dependencies in FormulaInstaller#install]
- Before building formula: [compute_and_install_dependencies in FormulaInstaller#install]

These methods call [FormulaInstaller#check_requirements], which `puts` the warning messages generated by the specified requirement class.

The problem is when a non-fatal requirement is specified and thus evaluated three times,
mostly the same warning message is also emitted three times.

[requirements]: https://github.com/Homebrew/brew/blob/59e2d6772158d8df0735708ae78ddec6ccc68026/Library/Homebrew/requirement.rb
[verify_deps_exist in FormulaInstaller#prelude]: https://github.com/Homebrew/brew/blob/59e2d6772158d8df0735708ae78ddec6ccc68026/Library/Homebrew/formula_installer.rb#L127
[compute_dependencies in FormulaInstaller#install]: https://github.com/Homebrew/brew/blob/59e2d6772158d8df0735708ae78ddec6ccc68026/Library/Homebrew/formula_installer.rb#L200
[compute_and_install_dependencies in FormulaInstaller#install]: https://github.com/Homebrew/brew/blob/59e2d6772158d8df0735708ae78ddec6ccc68026/Library/Homebrew/formula_installer.rb#L262
[FormulaInstaller#check_requirements]: https://github.com/Homebrew/brew/blob/59e2d6772158d8df0735708ae78ddec6ccc68026/Library/Homebrew/formula_installer.rb#L336-L348

## Example
```
$ brew install python
$ brew install gdb --with-python
Updating Homebrew...
gdb: A build of GDB using a brewed Python was requested, but Python is not
a universal build.

GDB requires Python to be built as a universal binary or it will fail
if attempting to debug a 32-bit binary on a 64-bit host.
gdb: A build of GDB using a brewed Python was requested, but Python is not
a universal build.

GDB requires Python to be built as a universal binary or it will fail
if attempting to debug a 32-bit binary on a 64-bit host.
gdb: A build of GDB using a brewed Python was requested, but Python is not
a universal build.

GDB requires Python to be built as a universal binary or it will fail
if attempting to debug a 32-bit binary on a 64-bit host.
==> Using the sandbox
==> Downloading https://ftpmirror.gnu.org/gdb/gdb-7.12.tar.xz

```


This change restricts printing the warning messages only when a bottle is
successfully installed or before building.
Since this timing is after the final dependency computation for each cases,
the warnings will be most useful to check what is not yet satisfied.