### PR TITLE
Remove kernel extensions specified in `uninstall :kext`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/artifact/uninstall_base.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/uninstall_base.rb
@@ -187,6 +187,10 @@ module Hbc
             @command.run!("/sbin/kextunload", args: ["-b", kext], sudo: true)
             sleep 1
           end
+          @command.run!("/usr/sbin/kextfind", args: ["-b", kext], sudo: true).stdout.chomp.lines.each do |kext_path|
+            ohai "Removing kernel extension #{kext_path}"
+            @command.run!("/bin/rm", args: ["-rf", kext_path], sudo: true)
+          end
         end
       end
 

--- a/Library/Homebrew/cask/test/cask/artifact/uninstall_test.rb
+++ b/Library/Homebrew/cask/test/cask/artifact/uninstall_test.rb
@@ -192,6 +192,14 @@ describe Hbc::Artifact::Uninstall do
           sudo(%W[/sbin/kextunload -b #{kext_id}])
         )
 
+        Hbc::FakeSystemCommand.expects_command(
+          sudo(%W[/usr/sbin/kextfind -b #{kext_id}]), "/Library/Extensions/FancyPackage.kext\n"
+        )
+
+        Hbc::FakeSystemCommand.expects_command(
+          sudo(["/bin/rm", "-rf", "/Library/Extensions/FancyPackage.kext"])
+        )
+
         subject
       end
     end

--- a/Library/Homebrew/cask/test/cask/artifact/zap_test.rb
+++ b/Library/Homebrew/cask/test/cask/artifact/zap_test.rb
@@ -193,6 +193,14 @@ describe Hbc::Artifact::Zap do
           sudo(%W[/sbin/kextunload -b #{kext_id}])
         )
 
+        Hbc::FakeSystemCommand.expects_command(
+          sudo(%W[/usr/sbin/kextfind -b #{kext_id}]), "/Library/Extensions/FancyPackage.kext\n"
+        )
+
+        Hbc::FakeSystemCommand.expects_command(
+          sudo(["/bin/rm", "-rf", "/Library/Extensions/FancyPackage.kext"])
+        )
+
         subject
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Before, `.kext`s would be left in e. g. `/Library/Extension` on `uninstall` instead of being removed.

---

@Homebrew/cask 