### PR TITLE
cask: Delete package dir if it is symlink on the uninstall

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/pkg.rb
+++ b/Library/Homebrew/cask/lib/hbc/pkg.rb
@@ -72,7 +72,12 @@ module Hbc
     end
 
     def _rmdir(path)
-      @command.run!("/bin/rmdir", args: ["--", path], sudo: true) if path.children.empty?
+      return unless path.children.empty?
+      if path.symlink?
+        @command.run!("/bin/rm", args: ["-f", "--", path], sudo: true)
+      else
+        @command.run!("/bin/rmdir", args: ["--", path], sudo: true)
+      end
     end
 
     def _with_full_permissions(path)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When a Formula is converted into a Cask (e.g. osxfuse),
a symlink remains at the place of package dir.
This change ensure to remove such leftovers.