### PR TITLE
osxfuse_requirement: add library and include paths

### DIFF
--- a/Library/Homebrew/requirements/osxfuse_requirement.rb
+++ b/Library/Homebrew/requirements/osxfuse_requirement.rb
@@ -14,6 +14,11 @@ class OsxfuseRequirement < Requirement
 
   env do
     ENV.append_path "PKG_CONFIG_PATH", HOMEBREW_LIBRARY/"Homebrew/os/mac/pkgconfig/fuse"
+
+    unless HOMEBREW_PREFIX.to_s == "/usr/local"
+      ENV.append_path "HOMEBREW_LIBRARY_PATHS", "/usr/local/lib"
+      ENV.append_path "HOMEBREW_INCLUDE_PATHS", "/usr/local/include/osxfuse"
+    end
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In the installation whose prefix is other than /usr/local,
osxfuse library and include path must explicitly be specified during build.
Although brew's pkg-config is configured to prepend appropriates paths,
the prepended paths (/usr/local) supercede the original HOMEBREW_PREFIX.
This behavior will cause the linker to select libraries outside brew's tree.

By adding /usr/local to HOMEBREW_LIBRARY_PATHS, superenv ensures that appears
only after the HOMEBREW_PREFIX, and thus fixes this problem.

HOMEBREW_INCLUDE_PATHS is also configured like keg-only Formulae.

## Example ([homebrew/fuse/s3fs](https://github.com/Homebrew/homebrew-fuse/blob/master/Formula/s3fs.rb))
I have an installation at /usr/local, and I have another installation at /Users/umireon/homebrew.
I installed s3fs in both environment, and then I got:

```
$ otool -L /Users/umireon/homebrew/Cellar/s3fs/1.80/bin/s3fs
/Users/umireon/homebrew/Cellar/s3fs/1.80/bin/s3fs:
	/usr/local/lib/libosxfuse.2.dylib (compatibility version 12.0.0, current version 12.7.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 8.0.0)
	/usr/lib/libxml2.2.dylib (compatibility version 10.0.0, current version 10.9.0)
	/Users/umireon/homebrew/opt/gnutls/lib/libgnutls.30.dylib (compatibility version 37.0.0, current version 37.8.0)
	/usr/local/opt/libgcrypt/lib/libgcrypt.20.dylib (compatibility version 22.0.0, current version 22.3.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```

It reveals libgcrypt outside of the tree (the first installation's one) is linked.

The relevant log of superenv cc:
```
clang++ called with: -g -O2 -Wall -D_FILE_OFFSET_BITS=64 -o s3fs s3fs.o curl.o cache.o string_util.o s3fs_util.o fdcache.o common_auth.o addhead.o gnutls_auth.o -L/Users/umireon/homebrew/Cellar/gnutls/3.4.16/lib -L/usr/local/lib -losxfuse -lcurl -lxml2 -lgnutls -lgnutls -lgcrypt
superenv removed:  -g -O2 -Wall
superenv added:    -pipe -w -Os -march=native -isystem/Users/umireon/homebrew/include -isystem/usr/include/libxml2 -isystem/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -L/Users/umireon/homebrew/lib -L/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries -Wl,-headerpad_max_install_names
superenv executed: clang++ -pipe -w -Os -march=native -D_FILE_OFFSET_BITS=64 -o s3fs s3fs.o curl.o cache.o string_util.o s3fs_util.o fdcache.o common_auth.o addhead.o gnutls_auth.o -L/Users/umireon/homebrew/Cellar/gnutls/3.4.16/lib -L/usr/local/lib -losxfuse -lcurl -lxml2 -lgnutls -lgnutls -lgcrypt -isystem/Users/umireon/homebrew/include -isystem/usr/include/libxml2 -isystem/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers -L/Users/umireon/homebrew/lib -L/System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries -Wl,-headerpad_max_install_names
```

This links the produces object files with osxfuse and gcrypt at the same time.
`-L/usr/local/lib` appears before `-L/Users/umireon/homebrew/lib`.