### PR TITLE
Add a sleep of 10 seconds after displaying the analytics warning

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -30,6 +30,8 @@ module Homebrew
         ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
         puts "Read the analytics documentation (and how to opt-out) here:"
         puts "  https://git.io/brew-analytics"
+        puts "Sleeping for 10 seconds. Press CTRL+C if you'd like to configure analytics"
+        sleep 10
 
         # Consider the message possibly missed if not a TTY.
         if $stdout.tty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This will give people the time to digest the message and act upon it, which should reduce some friction around how analytics works.

I've noticed that a lot of people complain that the warning is "buried" in update output - especially those that tend not to upgrade often - so placing the sleep here seems pretty reasonable to me.