### PR TITLE
Fix early exit condition for check_for_member_of_admin_group

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1071,7 +1071,7 @@ module Homebrew
 
       def check_for_member_of_admin_group
         groups = Utils.popen_read("groups").split
-        return unless groups.include?("admin")
+        return if groups.include?("admin")
 
         <<-EOS.undent
           You are not a member of the "admin" group, which will cause


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

You don't have to do anything if you're already in the admin group. 