### PR TITLE
Revert "Fix early exit condition for check_for_member_of_admin_group"

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1071,7 +1071,7 @@ module Homebrew
 
       def check_for_member_of_admin_group
         groups = Utils.popen_read("groups").split
-        return if groups.include?("admin")
+        return unless groups.include?("admin")
 
         <<-EOS.undent
           You are not a member of the "admin" group, which will cause

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1069,19 +1069,6 @@ module Homebrew
         message
       end
 
-      def check_for_member_of_admin_group
-        groups = Utils.popen_read("groups").split
-        return unless groups.include?("admin")
-
-        <<-EOS.undent
-          You are not a member of the "admin" group, which will cause
-          commands like `brew linkapps` to fail.
-
-          To fix this, you can run:
-            `sudo dseditgroup -o edit -a $(whoami) -t user admin`
-        EOS
-      end
-
       def all
         methods.map(&:to_s).grep(/^check_/)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Reverts #1567 and #1562 because we intentionally don't run as an admin user in CI which makes CI go 💥. Relatedly, see https://github.com/Homebrew/homebrew-test-bot/pull/26 where I want to ensure we start always running `brew doctor` here to catch it in future.

As for the check itself @woodruffw, I think the better fix for now is to fix any permission issues in `brew linkapps` and print the warning there if you can't write to `/Applications` (although that command itself will be deprecated soon for a multitude of reasons so feel free to punt on it). My bad on merging this.