### PR TITLE
Fix macOS version comparison

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -256,7 +256,7 @@ module OS
         return MacOS::Xcode.version if MacOS::Xcode.installed? && Xcode::Version.new(MacOS::Xcode.version) < "3.0"
 
         [MAVERICKS_PKG_ID, MAVERICKS_NEW_PKG_ID, STANDALONE_PKG_ID, FROM_XCODE_PKG_ID].find do |id|
-          if Xcode::Version.new(MacOS.version) >= :mavericks.to_s
+          if MacOS.version >= :mavericks
             next unless File.exist?("#{MAVERICKS_PKG_PATH}/usr/bin/clang")
           end
           version = MacOS.pkgutil_info(id)[/version: (.+)$/, 1]


### PR DESCRIPTION
Comparing against the `:mavericks` symbol fails on Mac OS X 10.7 Lion. The block is nexted and the `pkgutil` check is never reached.