### PR TITLE
update-report: further improve analytics messaging

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -25,11 +25,19 @@ module Homebrew
         Utils.popen_read("git", "config", "--local", "--get", "homebrew.analyticsmessage").chuzzle
       analytics_disabled = \
         Utils.popen_read("git", "config", "--local", "--get", "homebrew.analyticsdisabled").chuzzle
-      if analytics_message_displayed != "true" && analytics_disabled != "true" && !ENV["HOMEBREW_NO_ANALYTICS"]
+      if analytics_message_displayed != "true" && analytics_disabled != "true" &&
+         !ENV["HOMEBREW_NO_ANALYTICS"] && !ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"]
         ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
-        ohai "Homebrew has enabled anonymous aggregate user behaviour analytics"
-        puts "Read the analytics documentation (and how to opt-out) here:"
-        puts "  https://git.io/brew-analytics"
+        # Use the shell's audible bell.
+        print "\a"
+
+        # Use an extra newline and bold to avoid this being missed.
+        ohai <<-EOS.undent
+          Homebrew has enabled anonymous aggregate user behaviour analytics
+          Read the analytics documentation (and how to opt-out) here:
+            https://git.io/brew-analytics
+
+        EOS
 
         # Consider the message possibly missed if not a TTY.
         if $stdout.tty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Don't output the analytics message and mark it as read if `HOMEBREW_NO_ANALYTICS_THIS_RUN` is set. This mostly simplifies the installer code where we can display the message ourselves there rather than having `brew update` print it out sometimes and not others (i.e. when there's no system Git installed).
- Use the shell's audible bell to nudge people to actually read this message (and give them less excuse to complain when they don't).
- Add an extra newline and bold all the analytics messaging so it's more visible in the output.