### PR TITLE
Tap.formula_files: Sort files to be determinstic

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -303,7 +303,7 @@ class Tap
   # an array of all {Formula} files of this {Tap}.
   def formula_files
     @formula_files ||= if formula_dir
-      formula_dir.children.select(&method(:formula_file?))
+      formula_dir.children.select(&method(:formula_file?)).sort
     else
       []
     end
@@ -312,7 +312,7 @@ class Tap
   # an array of all {Cask} files of this {Tap}.
   def cask_files
     @cask_files ||= if cask_dir
-      cask_dir.children.select(&method(:cask_file?))
+      cask_dir.children.select(&method(:cask_file?)).sort
     else
       []
     end

--- a/Library/Homebrew/test/uses_test.rb
+++ b/Library/Homebrew/test/uses_test.rb
@@ -11,6 +11,6 @@ class IntegrationCommandTestUses < IntegrationCommandTestCase
 
     assert_equal "", cmd("uses", "baz")
     assert_equal "baz", cmd("uses", "bar")
-    assert_match(/(bar\nbaz|baz\nbar)/, cmd("uses", "--recursive", "foo"))
+    assert_match("bar\nbaz", cmd("uses", "--recursive", "foo"))
   end
 end


### PR DESCRIPTION
Pathname.children returns files in an arbitrary order that
depends on the file system, making this function both
non-determinstic and variable depending the configuration of
the host system.