### PR TITLE
Allow overrides of GIT_* environment variables while updating brew.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -393,8 +393,15 @@ EOS
       odie "Git must be installed and in your PATH!"
     fi
   fi
-  export GIT_TERMINAL_PROMPT="0"
-  export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
+
+  if [[ -z "$GIT_TERMINAL_PROMPT" ]]
+  then
+    export GIT_TERMINAL_PROMPT="0"
+  fi
+  if [[ -z "$GIT_SSH_COMMAND" ]]
+  then
+    export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
+  fi
 
   if [[ -z "$HOMEBREW_VERBOSE" ]]
   then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -394,14 +394,8 @@ EOS
     fi
   fi
 
-  if [[ -z "$GIT_TERMINAL_PROMPT" ]]
-  then
-    export GIT_TERMINAL_PROMPT="0"
-  fi
-  if [[ -z "$GIT_SSH_COMMAND" ]]
-  then
-    export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
-  fi
+  export GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-"0"}
+  export GIT_SSH_COMMAND=${GIT_SSH_COMMAND:-"ssh -oBatchMode=yes"}
 
   if [[ -z "$HOMEBREW_VERBOSE" ]]
   then


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This allows people who need/want to type in passwords while updating brew to do so. In particular, on Sierra even when you don't need to type in a password, batch mode still breaks fetching from certain types of repositories/taps.

 Tested by applying the patch locally, running `GIT_SSH_COMMAND="ssh" brew update`, and seeing that I could now fetch from my private tap. Also ran the plain `brew update` and saw that I couldn't pull from my private tap (the old behavior, as expected). Not sure if I should add unit tests for this change, but I'd be happy to if it'd be helpful!