### PR TITLE
uninstall_test: require testing_env

### DIFF
--- a/Library/Homebrew/test/uninstall_test.rb
+++ b/Library/Homebrew/test/uninstall_test.rb
@@ -1,3 +1,4 @@
+require "testing_env"
 require "cmd/uninstall"
 
 class UninstallTests < Homebrew::TestCase


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the issue @sjackman reported (#1605). Without requiring `testing_env`, `brew tests --only=uninstall` fails even though the tests themselves pass if you do `brew tests` alone.

Fixes #1605.