### PR TITLE
travis.yml: enable macOS builds again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,23 @@
 language: ruby
-rvm: 2.0.0
-os: linux
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.0
+      rvm: system
+    - os: linux
+      rvm: 2.0.0
 
 before_install:
   - export HOMEBREW_DEVELOPER=1
-  - export PATH="bin:$PATH"
-  - umask 022
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      HOMEBREW_REPOSITORY="$(brew --repo)";
+      sudo rm -rf "$HOMEBREW_REPOSITORY";
+      ln -s "$PWD" "$HOMEBREW_REPOSITORY";
+    else
+      export PATH="$PWD/bin:$PATH";
+      umask 022;
+    fi
 
 script:
   - brew test-bot


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Now that we've got parallel tests going and thing working a bit faster in general let's see if macOS on Travis CI could work for us for this repository again. If so, it can be used to take a bit more load off our Jenkins workers.
