### PR TITLE
Add a method for installing fish function files

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -19,6 +19,7 @@ class Caveats
     caveats << bash_completion_caveats
     caveats << zsh_completion_caveats
     caveats << fish_completion_caveats
+    caveats << fish_function_caveats
     caveats << plist_caveats
     caveats << python_caveats
     caveats << app_caveats
@@ -96,6 +97,17 @@ class Caveats
     <<-EOS.undent
       fish completion has been installed to:
         #{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
+    EOS
+  end
+
+  def fish_function_caveats
+    return unless keg
+    return unless keg.fish_functions_installed?
+    return unless which("fish")
+
+    <<-EOS.undent
+      fish functions have been installed to:
+        #{HOMEBREW_PREFIX}/share/fish/vendor_functions.d
     EOS
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -778,6 +778,14 @@ class Formula
     HOMEBREW_PREFIX+"var"
   end
 
+  # The directory where the formula's fish function files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def fish_function
+    share+"fish/vendor_functions.d"
+  end
+
   # The directory where the formula's Bash completion files should be
   # installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -303,6 +303,11 @@ class Keg
     dir && dir.directory? && !dir.children.empty?
   end
 
+  def fish_functions_installed?
+    dir = path.join("share", "fish", "vendor_functions.d")
+    dir && dir.directory? && !dir.children.empty?
+  end
+
   def plist_installed?
     !Dir["#{path}/*.plist"].empty?
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fish shell allows third-party software vendors to put their own function files in a directory for their software.
For brew installed Fish shell, this is /usr/local/share/fish/vendor_functions.d