### PR TITLE
caveats: Differentiate zsh completion files and function files

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -19,6 +19,7 @@ class Caveats
     caveats << bash_completion_caveats
     caveats << zsh_completion_caveats
     caveats << fish_completion_caveats
+    caveats << zsh_function_caveats
     caveats << fish_function_caveats
     caveats << plist_caveats
     caveats << python_caveats
@@ -97,6 +98,16 @@ class Caveats
     <<-EOS.undent
       fish completion has been installed to:
         #{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
+    EOS
+  end
+
+  def zsh_function_caveats
+    return unless keg
+    return unless keg.zsh_functions_installed?
+
+    <<-EOS.undent
+      zsh functions have been installed to:
+        #{HOMEBREW_PREFIX}/share/zsh/site-functions
     EOS
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -778,6 +778,14 @@ class Formula
     HOMEBREW_PREFIX+"var"
   end
 
+  # The directory where the formula's ZSH function files should be
+  # installed.
+  # This is symlinked into `HOMEBREW_PREFIX` after installation or with
+  # `brew link` for formulae that are not keg-only.
+  def zsh_function
+    share+"zsh/site-functions"
+  end
+
   # The directory where the formula's fish function files should be
   # installed.
   # This is symlinked into `HOMEBREW_PREFIX` after installation or with

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -297,10 +297,19 @@ class Keg
   def completion_installed?(shell)
     dir = case shell
     when :bash then path.join("etc", "bash_completion.d")
-    when :zsh  then path.join("share", "zsh", "site-functions")
+    when :zsh
+      dir = path.join("share", "zsh", "site-functions")
+      dir if dir && dir.directory? && dir.children.any? { |f| f.basename.to_s.start_with?("_") }
     when :fish then path.join("share", "fish", "vendor_completions.d")
     end
     dir && dir.directory? && !dir.children.empty?
+  end
+
+  def zsh_functions_installed?
+    # Check for non completion functions (i.e. files not started with an underscore),
+    # since those can be checked separately
+    dir = path.join("share", "zsh", "site-functions")
+    dir && dir.directory? && dir.children.any? { |f| !f.basename.to_s.start_with?("_") }
   end
 
   def fish_functions_installed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When installing a file to zsh/site-functions directory, it is assumed this is a zsh completion file,
and the zsh completion caveat is printed after installation.

But not all files in the zsh/site-functions directory are completion files.
Some are files for functions that can be loaded on demand with zsh's autoload command.

- Edit Keg.completion_installed to search specifically for files in the zsh/site-functions
  directory starting with an underscore only (By convention, zsh completion files start with an underscore)
- Add Keg.zsh_functions_installed to search for non-completion files in the zsh/site-functions
- Add Caveats.zsh_functions_caveats to print a caveat if non-completion files have been installed
  to zsh/site-functions