### PR TITLE
added "CLT" abbreviation after "Command Line Tools" in Installation.md doc

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -11,7 +11,7 @@ it does it too. And you have to confirm everything it will do before it starts.
 ## Requirements
 * An Intel CPU <sup>[1](#1)</sup>
 * OS X 10.10 or higher <sup>[2](#2)</sup>
-* Command Line Tools for Xcode: `xcode-select --install`,
+* Command Line Tools (CLT) for Xcode: `xcode-select --install`,
   https://developer.apple.com/downloads or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
 * A Bourne-compatible shell for installation (e.g. bash or zsh) <sup>[4](#4)</sup>


### PR DESCRIPTION
The [footnote-3](https://github.com/Homebrew/brew/blob/master/docs/Installation.md#3) talks about "CLT" without explicitly specifying what it means. Someone who is new to OSX might not know what "CLT" means. 

With this change I'm proposing, if someone follows the link to footnote-3, the meaning of 'CLT' in footnote would be clear because of explicit mention of "CLT" being an acronym for "Command Line Tools" at the point in doc where footnote is referenced from.