### PR TITLE
bump-formula-pr: use correct version in download path when --version is specified

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -134,6 +134,7 @@ module Homebrew
       rsrc = Resource.new { @url = rsrc_url }
       rsrc.download_strategy = CurlDownloadStrategy
       rsrc.owner = Resource.new(formula.name)
+      rsrc.version = forced_version if forced_version
       rsrc_path = rsrc.fetch
       if Utils.popen_read("/usr/bin/tar", "-tf", rsrc_path) =~ %r{/.*\.}
         new_hash = rsrc_path.sha256


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When a `--version` is specified, use this specified version in the name of the downloaded file rather than the default that is parsed from the URL.

For instance,

```sh
brew bump-formula-pr --devel \
  --url=http://www.zsh.org/pub/development/zsh-5.2-test-2.tar.gz \
  --version=5.2-test-2 zsh
```

should download to `$HOMEBREW_CACHE/zsh-5.2-test-2.tar.gz` (correct behavior after this commit) rather than `$HOMEBREW_CACHE/zsh-2.tar.gz` (wrong behavior before this commit).