### PR TITLE
os/mac: Remove mention of Mavericks bottles

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,8 +96,7 @@ will use a bottled version of $FORMULA, but
 `brew install $FORMULA --enable-bar` will trigger a source build.
 * The `--build-from-source` option is invoked.
 * The environment variable `HOMEBREW_BUILD_FROM_SOURCE` is set.
-* The machine is not running OS X 10.10+ as all bottled builds are
-generated on Yosemite or later.
+* The machine is not running a supported version of macOS as all bottled builds are generated only for supported macOS versions.
 * Homebrew is installed to a prefix other than the standard
 `/usr/local` (although some bottles support this)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,8 +96,8 @@ will use a bottled version of $FORMULA, but
 `brew install $FORMULA --enable-bar` will trigger a source build.
 * The `--build-from-source` option is invoked.
 * The environment variable `HOMEBREW_BUILD_FROM_SOURCE` is set.
-* The machine is not running OS X 10.9+ as all bottled builds are
-generated on Mavericks or later.
+* The machine is not running OS X 10.10+ as all bottled builds are
+generated on Yosemite or later.
 * Homebrew is installed to a prefix other than the standard
 `/usr/local` (although some bottles support this)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,7 +96,8 @@ will use a bottled version of $FORMULA, but
 `brew install $FORMULA --enable-bar` will trigger a source build.
 * The `--build-from-source` option is invoked.
 * The environment variable `HOMEBREW_BUILD_FROM_SOURCE` is set.
-* The machine is not running a supported version of macOS as all bottled builds are generated only for supported macOS versions.
+* The machine is not running a supported version of macOS as all
+bottled builds are generated only for supported macOS versions.
 * Homebrew is installed to a prefix other than the standard
 `/usr/local` (although some bottles support this)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

After Issue #985 was merged, bottles for Mavericks are no longer
being built, meaning installations on 10.9 are triggering builds.

This PR updates the FAQ to show that builds will most likely now be
triggered on Mavericks since their bottles are not being generated
and hosted on bintray.