### PR TITLE
Point to GitHub Releases in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+See Homebrew's [releases on GitHub](https://github.com/Homebrew/brew/releases) for the changelog.


### PR DESCRIPTION
A lot of people will check here and not find anything (see e.g. #1633). We should point them to the right place.