### PR TITLE
Fix dependency option handling.

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -43,8 +43,12 @@ class Dependency
   end
 
   def missing_options(inherited_options)
-    required = options | inherited_options
-    required - Tab.for_formula(to_formula).used_options
+    formula = to_formula
+    required = options
+    required |= inherited_options
+    required &= formula.options.to_a
+    required -= Tab.for_formula(formula).used_options
+    required
   end
 
   def modify_build_environment

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -236,8 +236,7 @@ class FormulaInstaller
 
     @@attempted << formula
 
-    pour_bottle = pour_bottle?(warn: true)
-    if pour_bottle
+    if pour_bottle?(warn: true)
       begin
         pour
       rescue Exception => e
@@ -251,18 +250,17 @@ class FormulaInstaller
         onoe e.message
         opoo "Bottle installation failed: building from source."
         raise BuildToolsError, [formula] unless DevelopmentTools.installed?
+        compute_and_install_dependencies unless skip_deps_check?
       else
-        puts_requirement_messages
         @poured_bottle = true
       end
     end
 
+    puts_requirement_messages
+
     build_bottle_preinstall if build_bottle?
 
     unless @poured_bottle
-      not_pouring = !pour_bottle || @pour_failed
-      compute_and_install_dependencies if not_pouring && !ignore_deps?
-      puts_requirement_messages
       build
       clean
 
@@ -467,6 +465,7 @@ class FormulaInstaller
 
     fi = DependencyInstaller.new(df)
     fi.options           |= tab.used_options
+    fi.options           |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
     fi.options           |= inherited_options
     fi.options           &= df.options
     fi.build_from_source  = ARGV.build_formula_from_source?(df)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- formula_installer: only recompute dependencies when necessary i.e.
when a bottle pour fails.
- formula_installer: re-add accidentally remove dependency options
- dependency: missing options are only those that actually exist on a
formula

Partial revert of #1641.
Fixes #1399.
Fixes https://github.com/Homebrew/homebrew-core/issues/7753.