### PR TITLE
brew create: add meson support

### DIFF
--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -504,7 +504,7 @@ message.</p>
 url-and-sha256 style specification into a tag-and-revision style
 specification, nor vice versa. It must use whichever style specification
 the preexisting formula already uses.</p></dd>
-<dt><code>create</code> <var>URL</var> [<code>--autotools</code>|<code>--cmake</code>] [<code>--no-fetch</code>] [<code>--set-name</code> <var>name</var>] [<code>--set-version</code> <var>version</var>] [<code>--tap</code> <var>user</var><code>/</code><var>repo</var>]</dt><dd><p>Generate a formula for the downloadable file at <var>URL</var> and open it in the editor.
+<dt><code>create</code> <var>URL</var> [<code>--autotools</code>|<code>--cmake</code>|<code>--meson</code>] [<code>--no-fetch</code>] [<code>--set-name</code> <var>name</var>] [<code>--set-version</code> <var>version</var>] [<code>--tap</code> <var>user</var><code>/</code><var>repo</var>]</dt><dd><p>Generate a formula for the downloadable file at <var>URL</var> and open it in the editor.
 Homebrew will attempt to automatically derive the formula name
 and version, but if it fails, you'll have to make your own template. The <code>wget</code>
 formula serves as a simple example. For the complete API have a look at</p>
@@ -512,7 +512,8 @@ formula serves as a simple example. For the complete API have a look at</p>
 <p><a href="http://www.rubydoc.info/github/Homebrew/brew/master/Formula" data-bare-link="true">http://www.rubydoc.info/github/Homebrew/brew/master/Formula</a></p>
 
 <p>If <code>--autotools</code> is passed, create a basic template for an Autotools-style build.
-If <code>--cmake</code> is passed, create a basic template for a CMake-style build.</p>
+If <code>--cmake</code> is passed, create a basic template for a CMake-style build.
+If <code>--meson</code> is passed, create a basic template for a Meson-style build.</p>
 
 <p>If <code>--no-fetch</code> is passed, Homebrew will not download <var>URL</var> to the cache and
 will thus not add the SHA256 to the formula for you.</p>

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "November 2016" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "December 2016" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "November 2016" "Homebrew" "brew"
+.TH "BREW" "1" "December 2016" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -695,14 +695,14 @@ If \fB\-\-message=\fR\fImessage\fR is passed, append \fImessage\fR to the defaul
 Note that this command cannot be used to transition a formula from a url\-and\-sha256 style specification into a tag\-and\-revision style specification, nor vice versa\. It must use whichever style specification the preexisting formula already uses\.
 .
 .TP
-\fBcreate\fR \fIURL\fR [\fB\-\-autotools\fR|\fB\-\-cmake\fR] [\fB\-\-no\-fetch\fR] [\fB\-\-set\-name\fR \fIname\fR] [\fB\-\-set\-version\fR \fIversion\fR] [\fB\-\-tap\fR \fIuser\fR\fB/\fR\fIrepo\fR]
+\fBcreate\fR \fIURL\fR [\fB\-\-autotools\fR|\fB\-\-cmake\fR|\fB\-\-meson\fR] [\fB\-\-no\-fetch\fR] [\fB\-\-set\-name\fR \fIname\fR] [\fB\-\-set\-version\fR \fIversion\fR] [\fB\-\-tap\fR \fIuser\fR\fB/\fR\fIrepo\fR]
 Generate a formula for the downloadable file at \fIURL\fR and open it in the editor\. Homebrew will attempt to automatically derive the formula name and version, but if it fails, you\'ll have to make your own template\. The \fBwget\fR formula serves as a simple example\. For the complete API have a look at
 .
 .IP
 \fIhttp://www\.rubydoc\.info/github/Homebrew/brew/master/Formula\fR
 .
 .IP
-If \fB\-\-autotools\fR is passed, create a basic template for an Autotools\-style build\. If \fB\-\-cmake\fR is passed, create a basic template for a CMake\-style build\.
+If \fB\-\-autotools\fR is passed, create a basic template for an Autotools\-style build\. If \fB\-\-cmake\fR is passed, create a basic template for a CMake\-style build\. If \fB\-\-meson\fR is passed, create a basic template for a Meson\-style build\.
 .
 .IP
 If \fB\-\-no\-fetch\fR is passed, Homebrew will not download \fIURL\fR to the cache and will thus not add the SHA256 to the formula for you\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). Not necessary I think
- [x] Have you successfully run `brew tests` with your changes locally?

-----

meson is quickly gaining popularity as build system, in combination with
ninja. Several Gnome projects for example are currently transitioning
from autotools to meson, mostly because it allows for Visual Studio
builds, which is impossible to accomplish with autotools.

In order to facilitate generating meson based Formulas, I added support
for meson to brew-create.