### PR TITLE
Revert "formula: runtime deps of build deps aren't runtime"

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1505,7 +1505,7 @@ class Formula
   # Returns a list of Dependency objects that are required at runtime.
   # @private
   def runtime_dependencies
-    recursive_dependencies { |_, dep| Dependency.prune if dep.build? }
+    recursive_dependencies.reject(&:build?)
   end
 
   # Returns a list of formulae depended on by this formula that aren't

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -651,19 +651,12 @@ class FormulaTests < Homebrew::TestCase
 
     f4 = formula("f4") do
       url "f4-1.0"
-      depends_on "f1"
-    end
-    stub_formula_loader f4
-
-    f5 = formula("f5") do
-      url "f5-1.0"
-      depends_on "f3" => :build
-      depends_on "f4"
+      depends_on "f3"
     end
 
-    assert_equal %w[f3 f4], f5.deps.map(&:name)
-    assert_equal %w[f1 f2 f3 f4], f5.recursive_dependencies.map(&:name)
-    assert_equal %w[f1 f4], f5.runtime_dependencies.map(&:name)
+    assert_equal %w[f3], f4.deps.map(&:name)
+    assert_equal %w[f1 f2 f3], f4.recursive_dependencies.map(&:name)
+    assert_equal %w[f2 f3], f4.runtime_dependencies.map(&:name)
   end
 
   def test_to_hash


### PR DESCRIPTION
Reverts Homebrew/brew#1592

There's a bug where it attempts to resolve optional dependencies (even when the option is not in use for the current build) from other taps that aren't tapped, and so the install goes :boom:

See https://github.com/Homebrew/homebrew-core/issues/7826.