### PR TITLE
audit: flag use of "fails_with :llvm".

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1000,6 +1000,10 @@ class FormulaAuditor
       problem "Use Language::Node for npm install args"
     end
 
+    if line.include?("fails_with :llvm")
+      problem "'fails_with :llvm' is now a no-op so should be removed"
+    end
+
     return unless @strict
 
     if line =~ /system ((["'])[^"' ]*(?:\s[^"' ]*)+\2)/

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2340,6 +2340,8 @@ class Formula
     #   version '4.8.1'
     # end</pre>
     def fails_with(compiler, &block)
+      # TODO: deprecate this in future.
+      # odeprecated "fails_with :llvm" if compiler == :llvm
       specs.each { |spec| spec.fails_with(compiler, &block) }
     end
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -173,6 +173,8 @@ class SoftwareSpec
   end
 
   def fails_with(compiler, &block)
+    # TODO: deprecate this in future.
+    # odeprecated "fails_with :llvm" if compiler == :llvm
     compiler_failures << CompilerFailure.create(compiler, &block)
   end
 


### PR DESCRIPTION
Also, add TODOs for deprecating this properly at a later point.