### PR TITLE
diagnostic: check for bad tap files.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1075,6 +1075,29 @@ module Homebrew
         message
       end
 
+      def check_for_tap_ruby_files_locations
+        bad_tap_files = {}
+        Tap.each do |tap|
+          unused_formula_dirs = tap.potential_formula_dirs - [tap.formula_dir]
+          unused_formula_dirs.each do |dir|
+            next unless dir.exist?
+            dir.children.each do |path|
+              next unless path.extname == ".rb"
+              bad_tap_files[tap] ||= []
+              bad_tap_files[tap] << path
+            end
+          end
+        end
+        return if bad_tap_files.empty?
+        bad_tap_files.keys.map do |tap|
+          <<-EOS.undent
+            Found Ruby file outside #{tap} tap formula directory
+            (#{tap.formula_dir}):
+              #{bad_tap_files[tap].join("\n  ")}
+          EOS
+        end.join("\n")
+      end
+
       def all
         methods.map(&:to_s).grep(/^check_/)
       end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -292,7 +292,11 @@ class Tap
 
   # path to the directory of all {Formula} files for this {Tap}.
   def formula_dir
-    @formula_dir ||= [path/"Formula", path/"HomebrewFormula", path].detect(&:directory?)
+    @formula_dir ||= potential_formula_dirs.detect(&:directory?)
+  end
+
+  def potential_formula_dirs
+    @potential_formula_dirs ||= [path/"Formula", path/"HomebrewFormula", path].freeze
   end
 
   # path to the directory of all {Cask} files for this {Tap}.


### PR DESCRIPTION
Check for Ruby files in taps that are outside of the detected `Formula` directory for a tap but inside one of the other potential directories.

This usually indicates a formula has been added in the wrong directory in a tap and is used to fail CI in this case.