### PR TITLE
formula: make prefix usually return opt_prefix.

### DIFF
--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -11,7 +11,7 @@ module Homebrew
     if ARGV.named.empty?
       puts HOMEBREW_PREFIX
     else
-      puts ARGV.resolved_formulae.map { |f| f.opt_prefix.exist? ? f.opt_prefix : f.installed_prefix }
+      puts ARGV.resolved_formulae.map(&:installed_prefix)
     end
   end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -546,7 +546,7 @@ class FormulaInstaller
   def summary
     s = ""
     s << "#{Emoji.install_badge}  " if Emoji.enabled?
-    s << "#{formula.prefix}: #{formula.prefix.abv}"
+    s << "#{formula.prefix.resolved_path}: #{formula.prefix.abv}"
     s << ", built in #{pretty_duration build_time}" if build_time
     s
   end

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -147,6 +147,7 @@ class Keg
   protected :path
 
   def initialize(path)
+    path = path.resolved_path if path.to_s.start_with?("#{HOMEBREW_PREFIX}/opt/")
     raise "#{path} is not a valid keg" unless path.parent.parent.realpath == HOMEBREW_CELLAR.realpath
     raise "#{path} is not a directory" unless path.directory?
     @path = path


### PR DESCRIPTION
This avoids the need to use `opt_prefix` etc. everywhere and generally means we don't what is an implementation detail (i.e. the full Cellar path) to applications that have a habit of hard-coding it.