### PR TITLE
prune: don't remove top-level directories.

### DIFF
--- a/Library/Homebrew/cmd/prune.rb
+++ b/Library/Homebrew/cmd/prune.rb
@@ -35,7 +35,7 @@ module Homebrew
               path.unlink
             end
           end
-        elsif path.directory?
+        elsif path.directory? && !Keg::PRUNEABLE_DIRECTORIES.include?(path)
           dirs << path
         end
       end


### PR DESCRIPTION
Even if they're empty we want to keep these top-level directories around as the installer has nicely created them with the correct permissions and this avoids potentially having to use `sudo` to recreate them.