### PR TITLE
postinstall: don't allow writes to prefix itself.

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -37,8 +37,10 @@ module Homebrew
         sandbox.allow_write_log(formula)
         sandbox.allow_write_xcode
         sandbox.deny_write_homebrew_repository
-        sandbox.allow_write_path HOMEBREW_PREFIX
         sandbox.allow_write_cellar(formula)
+        Keg::TOP_LEVEL_DIRECTORIES.each do |dir|
+          sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
+        end
         sandbox.exec(*args)
       else
         exec(*args)


### PR DESCRIPTION
Only the top-level directories inside it. We don't want formulae writing random junk in e.g. `/usr/local` even in `postinstall`.