### PR TITLE
formula_installer: prevent version mismatched deps

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -146,7 +146,23 @@ class FormulaInstaller
     return if ignore_deps?
 
     recursive_deps = formula.recursive_dependencies
-    unlinked_deps = recursive_deps.map(&:to_formula).select do |dep|
+    recursive_formulae = recursive_deps.map(&:to_formula)
+
+    version_hash = {}
+    version_conflicts = Set.new
+    recursive_formulae.each do |f|
+      name = f.name
+      unversioned_name, = name.split("@")
+      version_hash[unversioned_name] ||= Set.new
+      version_hash[unversioned_name] << name
+      next if version_hash[unversioned_name].length < 2
+      version_conflicts += version_hash[unversioned_name]
+    end
+    unless version_conflicts.empty?
+      raise CannotInstallFormulaError, "#{formula.full_name} contains conflicting version dependencies (#{version_conflicts.to_a.join " "}) so cannot be installed"
+    end
+
+    unlinked_deps = recursive_formulae.select do |dep|
       dep.installed? && !dep.keg_only? && !dep.linked_keg.directory?
     end
 


### PR DESCRIPTION
Don't allow e.g. the use of `openssl` and `openssl@1.1` in the same dependency tree to avoid runtime failures and general weirdness.