### PR TITLE
tap_migrations: support renaming to/from casks.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -186,6 +186,8 @@ class Formulary
           name = new_name
           new_name = @tap.core_tap? ? name : "#{@tap}/#{name}"
         elsif (new_tap_name = @tap.tap_migrations[name])
+          new_tap_user, new_tap_repo, = new_tap_name.split("/")
+          new_tap_name = "#{new_tap_user}/#{new_tap_repo}"
           new_tap = Tap.fetch new_tap_name
           new_tap.install unless new_tap.installed?
           new_tapped_name = "#{new_tap_name}/#{name}"


### PR DESCRIPTION
Allow `tap_migrations` entries to have a `user/repo/formula` or `user/repo/cask` format for migration of formulae to/from casks.