### PR TITLE
update-reset: add new command.

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -1,0 +1,43 @@
+#: @hide_from_man_page
+#:  * `update-reset`:
+#:    Fetches and resets Homebrew and all tap repositories using `git`(1) to
+#:    their latest `origin/master`.
+
+homebrew-update-reset() {
+  local DIR
+
+  for option in "$@"
+  do
+    case "$option" in
+      -\?|-h|--help|--usage)          brew help update-reset; exit $? ;;
+      --debug)                        HOMEBREW_DEBUG=1 ;;
+      -*)
+        [[ "$option" = *d* ]] && HOMEBREW_DEBUG=1
+        ;;
+      *)
+        odie <<EOS
+This command updates brew itself, and does not take formula names.
+Use 'brew upgrade <formula>'.
+EOS
+        ;;
+    esac
+  done
+
+  if [[ -n "$HOMEBREW_DEBUG" ]]
+  then
+    set -x
+  fi
+
+  for DIR in "$HOMEBREW_REPOSITORY" "$HOMEBREW_LIBRARY"/Taps/*/*
+  do
+    [[ -d "$DIR/.git" ]] || continue
+    cd "$DIR" || continue
+    echo "==> Fetching $DIR..."
+    git fetch --tags --force origin
+    echo
+
+    echo "==> Resetting $DIR..."
+    git checkout -B master origin/master
+    echo
+  done
+}


### PR DESCRIPTION
Add new `brew update-reset` command to provide a helpful troubleshooting fallback to fetch and reset all repositories. This could have lived in
`brew update` but it makes sense to avoid the complexity of sharing logic between these scripts and keeping this one simpler.