### PR TITLE
which_all: don't assume path is a string.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -300,7 +300,7 @@ def which(cmd, path = ENV["PATH"])
 end
 
 def which_all(cmd, path = ENV["PATH"])
-  path.split(File::PATH_SEPARATOR).map do |p|
+  path.to_s.split(File::PATH_SEPARATOR).map do |p|
     begin
       pcmd = File.expand_path(cmd, p)
     rescue ArgumentError


### PR DESCRIPTION
Fixes #1635.