### PR TITLE
Updated homepage 404 check to use explicit parameters and return the …

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -564,11 +564,10 @@ class FormulaAuditor
     end
 
     return unless @online
-    begin
-      nostdout { curl "--connect-timeout", "15", "-o", "/dev/null", homepage }
-    rescue ErrorDuringExecution
-      problem "The homepage is not reachable (curl exit code #{$?.exitstatus})"
-    end
+    status_code, = curl_output "--connect-timeout", "15", "--output", "/dev/null", "--range", "0-0", \
+                                   "--write-out", "%{http_code}", homepage
+    return if status_code.start_with? "20"
+    problem "The homepage #{homepage} is not reachable (HTTP status code #{status_code})"
   end
 
   def audit_bottle_spec

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -564,8 +564,8 @@ class FormulaAuditor
     end
 
     return unless @online
-    status_code, = curl_output "--connect-timeout", "15", "--output", "/dev/null", "--range", "0-0", \
-                                   "--write-out", "%{http_code}", homepage
+    status_code, = curl_output "--connect-timeout", "15", "--output", "/dev/null", "--range", "0-0",
+                               "--write-out", "%{http_code}", homepage
     return if status_code.start_with? "20"
     problem "The homepage #{homepage} is not reachable (HTTP status code #{status_code})"
   end

--- a/Library/Homebrew/test/audit_test.rb
+++ b/Library/Homebrew/test/audit_test.rb
@@ -429,8 +429,8 @@ class FormulaAuditorTests < Homebrew::TestCase
 
     fa.audit_homepage
     assert_equal ["The homepage should start with http or https " \
-      "(URL is #{fa.formula.homepage}).", "The homepage is not reachable " \
-      "(curl exit code #{$?.exitstatus})"], fa.problems
+      "(URL is #{fa.formula.homepage}).", "The homepage #{fa.formula.homepage} is not reachable " \
+      "(HTTP status code 000)"], fa.problems
 
     formula_homepages = {
       "bar" => "http://www.freedesktop.org/wiki/bar",


### PR DESCRIPTION
…status code

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Updating the `brew audit --online` homepage check to use more explicit parameters and return an HTTP status code as in #1637