### PR TITLE
Add Kaby Lake to Linux hardware list

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -47,6 +47,8 @@ module Hardware
             :haswell
           when 0x3d, 0x47, 0x4f, 0x56
             :broadwell
+          when 0x8e
+            :kabylake
           else
             cpu_family_model
           end

--- a/Library/Homebrew/test/hardware_test.rb
+++ b/Library/Homebrew/test/hardware_test.rb
@@ -8,7 +8,7 @@ class HardwareTests < Homebrew::TestCase
 
   if Hardware::CPU.intel?
     def test_hardware_intel_family
-      families = [:core, :core2, :penryn, :nehalem, :arrandale, :sandybridge, :ivybridge, :haswell, :broadwell, :skylake, :dunno]
+      families = [:core, :core2, :penryn, :nehalem, :arrandale, :sandybridge, :ivybridge, :haswell, :broadwell, :skylake, :kabylake, :dunno]
       assert_includes families, Hardware::CPU.family
     end
   end


### PR DESCRIPTION
Note that no Mac hardware using a Kaby Lake processor has been released
yet, so do not add it to the equivalent list for macOS.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The motivation for this change is that `brew tests --only=hardware` fails on my new laptop.

```
  1) Failure:
HardwareTests#test_hardware_intel_family [/home/linuxbrew/.linuxbrew/Library/Homebrew/test/hardware_test.rb:15]:
Expected [:core,
 :core2,
 :penryn,
 :nehalem,
 :arrandale,
 :sandybridge,
 :ivybridge,
 :haswell,
 :broadwell,
 :skylake,
 :dunno,
 :westmere,
 :merom,
 :dothan,
 :atom,
 :presler,
 :prescott,
 :arm]
 to include "0x68e"
.
```