### PR TITLE
audit: don't allow openssl & libressl dependency.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -788,6 +788,10 @@ class FormulaAuditor
       problem "Please set plist_options when using a formula-defined plist."
     end
 
+    if text =~ /depends_on\s+['"]openssl['"]/ && text =~ /depends_on\s+['"]libressl['"]/
+      problem "Formulae should not depend on both OpenSSL and LibreSSL (even optionally)."
+    end
+
     return unless text.include?('require "language/go"') && !text.include?("go_resource")
     problem "require \"language/go\" is unnecessary unless using `go_resource`s"
   end


### PR DESCRIPTION
Formulae should not depend on both OpenSSL and LibreSSL (even
optionally). This is to avoid descending into madness where every
formulae that could use LibreSSL has to have option and switching logic.

Homebrew has standardised on OpenSSL and will do so everywhere that
LibreSSL is not a hard requirement.

CC @ilovezfs for thoughts.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
