### PR TITLE
brew deps --tree: fix gap in line between reqs and deps

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -143,15 +143,23 @@ module Homebrew
 
   def recursive_deps_tree(f, prefix)
     reqs = f.requirements.select(&:default_formula?)
+    deps = f.deps.default
     max = reqs.length - 1
     reqs.each_with_index do |req, i|
-      chr = i == max ? "└──" : "├──"
+      chr = if i == max && deps.empty?
+        "└──"
+      else
+        "├──"
+      end
       puts prefix + "#{chr} :#{dep_display_name(req.to_dependency)}"
     end
-    deps = f.deps.default
     max = deps.length - 1
     deps.each_with_index do |dep, i|
-      chr = i == max ? "└──" : "├──"
+      chr = if i == max
+        "└──"
+      else
+        "├──"
+      end
       prefix_ext = i == max ? "    " : "│   "
       puts prefix + "#{chr} #{dep_display_name(dep)}"
       recursive_deps_tree(Formulary.factory(dep.name), prefix + prefix_ext)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Minor cosmetic change. In `brew deps --tree`, if a formula has both Requirements and Dependencies, there's a gap in the line between them. This fixes it to draw the line as continuous.

Example output from `brew deps --tree mbsystem`:

Before:

```
├── gdal
│   ├── :python3
│   ├── :gcc
│   └── :git
│   ├── libpng
│   ├── jpeg
```

(Note the broken line between `:git` and `libpng`.)

After:
```
├── gdal
│   ├── :python3
│   ├── :gcc
│   ├── :git
│   ├── libpng
│   ├── jpeg
```