### PR TITLE
install tap cmd completions

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -77,6 +77,7 @@ module Homebrew
     lib/ruby/site_ruby/[12].*
     lib/ruby/vendor_ruby/[12].*
     manpages/brew.1
+    manpages/brew-cask.1
     share/pypy/*
     share/pypy3/*
     share/info/dir

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -38,7 +38,7 @@ module Homebrew
 
   def tap
     if ARGV.include? "--repair"
-      Tap.each(&:link_manpages)
+      Tap.each(&:link_completions_and_manpages)
     elsif ARGV.include? "--list-official"
       require "official_taps"
       puts OFFICIAL_TAPS.map { |t| "homebrew/#{t}" }

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -104,8 +104,8 @@ module Homebrew
       puts if ARGV.include?("--preinstall")
     end
 
-    link_completions_and_docs
-    Tap.each(&:link_manpages)
+    link_completions_manpages_and_docs
+    Tap.each(&:link_completions_and_manpages)
 
     Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
 
@@ -281,7 +281,7 @@ module Homebrew
       EOS
     end
 
-    link_completions_and_docs(new_homebrew_repository)
+    link_completions_manpages_and_docs(new_homebrew_repository)
 
     ohai "Migrated HOMEBREW_REPOSITORY to #{new_homebrew_repository}!"
     puts <<-EOS.undent
@@ -302,16 +302,11 @@ module Homebrew
     $stderr.puts e.backtrace
   end
 
-  def link_completions_and_docs(repository = HOMEBREW_REPOSITORY)
+  def link_completions_manpages_and_docs(repository = HOMEBREW_REPOSITORY)
     command = "brew update"
-    link_src_dst_dirs(repository/"completions/bash",
-                      HOMEBREW_PREFIX/"etc/bash_completion.d", command)
-    link_src_dst_dirs(repository/"docs",
-                      HOMEBREW_PREFIX/"share/doc/homebrew", command, link_dir: true)
-    link_src_dst_dirs(repository/"completions/zsh",
-                      HOMEBREW_PREFIX/"share/zsh/site-functions", command)
-    link_src_dst_dirs(repository/"manpages",
-                      HOMEBREW_PREFIX/"share/man/man1", command)
+    Utils::Link.link_completions(repository, command)
+    Utils::Link.link_manpages(repository, command)
+    Utils::Link.link_docs(repository, command)
   rescue => e
     ofail <<-EOS.undent
       Failed to link all completions, docs and manpages:

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -236,7 +236,7 @@ class Tap
       raise
     end
 
-    link_manpages
+    link_completions_and_manpages
 
     formula_count = formula_files.size
     puts "Tapped #{formula_count} formula#{plural(formula_count, "e")} (#{path.abv})" unless quiet
@@ -254,8 +254,10 @@ class Tap
     EOS
   end
 
-  def link_manpages
-    link_path_manpages(path, "brew tap --repair")
+  def link_completions_and_manpages
+    command = "brew tap --repair"
+    Utils::Link.link_manpages(path, command)
+    Utils::Link.link_completions(path, command)
   end
 
   # uninstall this {Tap}.
@@ -267,21 +269,12 @@ class Tap
     unpin if pinned?
     formula_count = formula_files.size
     Descriptions.uncache_formulae(formula_names)
-    unlink_manpages
+    Utils::Link.unlink_manpages(path)
+    Utils::Link.unlink_completions(path)
     path.rmtree
     path.parent.rmdir_if_possible
     puts "Untapped #{formula_count} formula#{plural(formula_count, "e")}"
     clear_cache
-  end
-
-  def unlink_manpages
-    return unless (path/"man").exist?
-    (path/"man").find do |src|
-      next if src.directory?
-      dst = HOMEBREW_PREFIX/"share"/src.relative_path_from(path)
-      dst.delete if dst.symlink? && src == dst.resolved_path
-      dst.parent.rmdir_if_possible
-    end
   end
 
   # True if the {#remote} of {Tap} is customized.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -9,6 +9,7 @@ require "utils/git"
 require "utils/github"
 require "utils/hash"
 require "utils/inreplace"
+require "utils/link"
 require "utils/popen"
 require "utils/tty"
 require "time"
@@ -479,38 +480,6 @@ def truncate_text_to_approximate_size(s, max_bytes, options = {})
   out.encode!("UTF-16", invalid: :replace)
   out.encode!("UTF-8")
   out
-end
-
-def link_src_dst_dirs(src_dir, dst_dir, command, link_dir: false)
-  return unless src_dir.exist?
-  conflicts = []
-  src_paths = link_dir ? [src_dir] : src_dir.find
-  src_paths.each do |src|
-    next if src.directory? && !link_dir
-    dst = dst_dir/src.relative_path_from(src_dir)
-    if dst.symlink?
-      next if src == dst.resolved_path
-      dst.unlink
-    end
-    if dst.exist?
-      conflicts << dst
-      next
-    end
-    dst_dir.parent.mkpath
-    dst.make_relative_symlink(src)
-  end
-
-  return if conflicts.empty?
-  onoe <<-EOS.undent
-    Could not link:
-    #{conflicts.join("\n")}
-
-    Please delete these paths and run `#{command}`.
-  EOS
-end
-
-def link_path_manpages(path, command)
-  link_src_dst_dirs(path/"man", HOMEBREW_PREFIX/"share/man", command)
 end
 
 def migrate_legacy_keg_symlinks_if_necessary

--- a/Library/Homebrew/utils/link.rb
+++ b/Library/Homebrew/utils/link.rb
@@ -1,0 +1,70 @@
+module Utils
+  module Link
+    module_function
+
+    def link_src_dst_dirs(src_dir, dst_dir, command, link_dir: false)
+      return unless src_dir.exist?
+      conflicts = []
+      src_paths = link_dir ? [src_dir] : src_dir.find
+      src_paths.each do |src|
+        next if src.directory? && !link_dir
+        dst = dst_dir/src.relative_path_from(src_dir)
+        if dst.symlink?
+          next if src == dst.resolved_path
+          dst.unlink
+        end
+        if dst.exist?
+          conflicts << dst
+          next
+        end
+        dst_dir.parent.mkpath
+        dst.make_relative_symlink(src)
+      end
+
+      return if conflicts.empty?
+      onoe <<-EOS.undent
+        Could not link:
+        #{conflicts.join("\n")}
+
+        Please delete these paths and run `#{command}`.
+      EOS
+    end
+    private_class_method :link_src_dst_dirs
+
+    def unlink_src_dst_dirs(src_dir, dst_dir, unlink_dir: false)
+      return unless src_dir.exist?
+      src_paths = unlink_dir ? [src_dir] : src_dir.find
+      src_paths.each do |src|
+        next if src.directory? && !unlink_dir
+        dst = dst_dir/src.relative_path_from(src_dir)
+        dst.delete if dst.symlink? && src == dst.resolved_path
+        dst.parent.rmdir_if_possible
+      end
+    end
+    private_class_method :unlink_src_dst_dirs
+
+    def link_manpages(path, command)
+      link_src_dst_dirs(path/"manpages", HOMEBREW_PREFIX/"share/man/man1", command)
+    end
+
+    def unlink_manpages(path)
+      unlink_src_dst_dirs(path/"manpages", HOMEBREW_PREFIX/"share/man/man1")
+    end
+
+    def link_completions(path, command)
+      link_src_dst_dirs(path/"completions/bash", HOMEBREW_PREFIX/"etc/bash_completion.d", command)
+      link_src_dst_dirs(path/"completions/zsh", HOMEBREW_PREFIX/"share/zsh/site-functions", command)
+      link_src_dst_dirs(path/"completions/fish", HOMEBREW_PREFIX/"share/fish/vendor_completions.d", command)
+    end
+
+    def unlink_completions(path)
+      unlink_src_dst_dirs(path/"completions/bash", HOMEBREW_PREFIX/"etc/bash_completion.d")
+      unlink_src_dst_dirs(path/"completions/zsh", HOMEBREW_PREFIX/"share/zsh/site-functions")
+      unlink_src_dst_dirs(path/"completions/fish", HOMEBREW_PREFIX/"share/fish/vendor_completions.d")
+    end
+
+    def link_docs(path, command)
+      link_src_dst_dirs(path/"docs", HOMEBREW_PREFIX/"share/doc/homebrew", command, link_dir: true)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Taps can include completion scripts for external commands under
completions/bash, completions/fish, or completions/zsh. brew tap
will automatically install these into the correct directories during
install.

See Homebrew/homebrew-services#73 for a concrete need for completions in a repo.

This PR follows on from https://github.com/Homebrew/brew/pull/1195 but github didn't pick up the extra commits automatically as part of the previous PR (possibly because of my local rebase to pickup changes made later).
