### PR TITLE
Remove Xcode prerelease warnings.

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -4,7 +4,6 @@ module Homebrew
       def development_tools_checks
         %w[
           check_for_unsupported_macos
-          check_for_prerelease_xcode
           check_for_bad_install_name_tool
           check_for_installed_developer_tools
           check_xcode_license_approved
@@ -45,21 +44,6 @@ module Homebrew
         <<-EOS.undent
           You are using macOS #{MacOS.version}.
           #{who} do not provide support for this #{what}.
-          You may encounter build failures or other breakages.
-          Please create pull-requests instead of filing issues.
-        EOS
-      end
-
-      def check_for_prerelease_xcode
-        return if ARGV.homebrew_developer?
-        # Running a pre-release Xcode on a pre-release OS is expected
-        # and likely to cause less problems than a stable Xcode will.
-        return if OS::Mac.prerelease?
-        return unless MacOS::Xcode.installed?
-        return unless MacOS::Xcode.prerelease?
-
-        <<-EOS.undent
-          You are using a pre-release version of Xcode.
           You may encounter build failures or other breakages.
           Please create pull-requests instead of filing issues.
         EOS

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -36,11 +36,6 @@ module OS
         version < minimum_version
       end
 
-      def prerelease?
-        # TODO: bump to version >= "8.4" after Xcode 8.3 is stable.
-        Version.new(version) >= "8.3"
-      end
-
       def outdated?
         Version.new(version) < latest_version
       end


### PR DESCRIPTION
At this point we probably do want to know about issues that crop up in betas so we can fix them before the new version of Xcode is released. Additionally, this doesn't really work well any more with our new
tag-based workflow as it means we need to cut a new tag immediately after a new Xcode is released.

CC @ilovezfs for thoughts.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
