### PR TITLE
cask depends_on arch: remove everything but 64-bit intel

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/depends_on.rb
@@ -13,30 +13,18 @@ module Hbc
       ].freeze
 
       VALID_ARCHES = {
-        intel:    { type: :intel, bits: [32, 64] },
-        ppc:      { type: :ppc,   bits: [32, 64] },
+        intel:    { type: :intel, bits: 64 },
         # specific
-        i386:     { type: :intel, bits: 32 },
         x86_64:   { type: :intel, bits: 64 },
-        ppc_7400: { type: :ppc,   bits: 32 },
-        ppc_64:   { type: :ppc,   bits: 64 },
       }.freeze
 
       # Intentionally undocumented: catch variant spellings.
       ARCH_SYNONYMS = {
-        x86_32:   :i386,
-        x8632:    :i386,
         x8664:    :x86_64,
-        intel_32: :i386,
-        intel32:  :i386,
         intel_64: :x86_64,
         intel64:  :x86_64,
         amd_64:   :x86_64,
         amd64:    :x86_64,
-        ppc7400:  :ppc_7400,
-        ppc_32:   :ppc_7400,
-        ppc32:    :ppc_7400,
-        ppc64:    :ppc_64,
       }.freeze
 
       attr_accessor :java


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

[`depends_on arch:`](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/depends_on.md#depends_on-arch) is, quite simply, useless as of now. Homebrew-cask itself will likely only run on 64-bit intel, and anything else is too old to care for and support, anyway.

Already made [a PR to remove all of these from casks](https://github.com/caskroom/homebrew-cask/pull/28099) and [from the documentation](https://github.com/caskroom/homebrew-cask/pull/28102).

I’d be wary of removing `depends_on arch:` as a whole, though, lest ARM Macs become a reality.

Ping @Homebrew/cask.