### PR TITLE
bump-formula-pr: fix removal of old mirrors

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -156,7 +156,9 @@ module Homebrew
       replacement_pairs << [/^  revision \d+\n(\n(  head "))?/m, "\\2"]
     end
 
-    replacement_pairs << [/(^  mirror .*\n)?/, ""] if requested_spec == :stable
+    replacement_pairs += formula_spec.mirrors.map do |mirror|
+      [/ +mirror \"#{mirror}\"\n/m, ""]
+    end
 
     replacement_pairs += if new_url_hash
       [


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Previously, old mirrors are only removed if the requested spec is stable, and if the mirror lines only have two leading spaces. This leads to stale mirror line(s) when the formula has a stable block like

```rb
  stable do
    url "http://example.com/v1.0.tar.gz"
    mirror "http://example.net/v1.0.tar.gz"
  end
```

where the mirror line is lead by four spaces.

In this commit, we discard the `/(^ mirror .*\n)?/` pattern, and instead create a pattern with the exact url and flexible leading spaces for each mirror of the requested spec.

---

Test case (on homebrew/core 718bd8444838b27318cf74fadcac97ac99e1224e):

<details>
<summary>Before (wrong):</summary>

```diff
$ brew bump-formula-pr --dry-run --write --url=https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz --mirror=https://www.zsh.org/pub/zsh-5.3.1.tar.gz zsh && git -C "$(brew --repo homebrew/core)" --no-pager diff && git -C "$(brew --repo homebrew/core)" checkout Formula/zsh.rb
==> Downloading https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz
Already downloaded: /Users/zmwang/Library/Caches/Homebrew/zsh-5.3.1.tar.gz
==> brew update
==> replace /(^  mirror .*\n)?/ with ""
==> replace "https://www.zsh.org/pub/zsh-5.3.tar.gz" with "https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz"
==> replace "1da273fa96041b395ee9f628d14f2aff08f9a62e98423a990218e2ea037b9a6d" with "3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e"
==> replace /^( +)(url \"https:\/\/downloads.sourceforge.net\/project\/zsh\/zsh\/5.3.1\/zsh-5.3.1.tar.gz\"\n)/m with "\\1\\2\\1mirror \"https://www.zsh.org/pub/zsh-5.3.1.tar.gz\"\n"
==> git checkout --no-track -b zsh-5.3.1 origin/master
==> git commit --no-edit --verbose --message='zsh 5.3.1' -- /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/zsh.rb
==> hub fork --no-remote
==> hub fork
==> hub fork (to read $HUB_REMOTE)
==> git push --set-upstream $HUB_REMOTE zsh-5.3.1:zsh-5.3.1
==> hub pull-request --browse -m 'zsh 5.3.1'
==> git checkout -
diff --git a/Formula/zsh.rb b/Formula/zsh.rb
index 2b09982644..1cbba41682 100644
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -3,9 +3,10 @@ class Zsh < Formula
   homepage "https://www.zsh.org/"

   stable do
-    url "https://www.zsh.org/pub/zsh-5.3.tar.gz"
+    url "https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz"
+    mirror "https://www.zsh.org/pub/zsh-5.3.1.tar.gz"
     mirror "https://downloads.sourceforge.net/project/zsh/zsh/5.3/zsh-5.3.tar.gz"
-    sha256 "1da273fa96041b395ee9f628d14f2aff08f9a62e98423a990218e2ea037b9a6d"
+    sha256 "3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e"

     # We cannot build HTML doc on HEAD, because yodl which is required for
     # building zsh.texi is not available.
```
</details>

<details>
<summary>After (correct):</summary>

```diff
$ brew bump-formula-pr --dry-run --write --url=https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz --mirror=https://www.zsh.org/pub/zsh-5.3.1.tar.gz zsh && git -C "$(brew --repo homebrew/core)" --no-pager diff && git -C "$(brew --repo homebrew/core)" checkout Formula/zsh.rb
==> Downloading https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz
Already downloaded: /Users/zmwang/Library/Caches/Homebrew/zsh-5.3.1.tar.gz
==> brew update
==> replace / +mirror \"https:\/\/downloads.sourceforge.net\/project\/zsh\/zsh\/5.3\/zsh-5.3.tar.gz\"\n/m with ""
==> replace "https://www.zsh.org/pub/zsh-5.3.tar.gz" with "https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz"
==> replace "1da273fa96041b395ee9f628d14f2aff08f9a62e98423a990218e2ea037b9a6d" with "3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e"
==> replace /^( +)(url \"https:\/\/downloads.sourceforge.net\/project\/zsh\/zsh\/5.3.1\/zsh-5.3.1.tar.gz\"\n)/m with "\\1\\2\\1mirror \"https://www.zsh.org/pub/zsh-5.3.1.tar.gz\"\n"
==> git checkout --no-track -b zsh-5.3.1 origin/master
==> git commit --no-edit --verbose --message='zsh 5.3.1' -- /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/zsh.rb
==> hub fork --no-remote
==> hub fork
==> hub fork (to read $HUB_REMOTE)
==> git push --set-upstream $HUB_REMOTE zsh-5.3.1:zsh-5.3.1
==> hub pull-request --browse -m 'zsh 5.3.1'
==> git checkout -
diff --git a/Formula/zsh.rb b/Formula/zsh.rb
index 2b09982644..f6f2fcd48c 100644
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -3,9 +3,9 @@ class Zsh < Formula
   homepage "https://www.zsh.org/"

   stable do
-    url "https://www.zsh.org/pub/zsh-5.3.tar.gz"
-    mirror "https://downloads.sourceforge.net/project/zsh/zsh/5.3/zsh-5.3.tar.gz"
-    sha256 "1da273fa96041b395ee9f628d14f2aff08f9a62e98423a990218e2ea037b9a6d"
+    url "https://downloads.sourceforge.net/project/zsh/zsh/5.3.1/zsh-5.3.1.tar.gz"
+    mirror "https://www.zsh.org/pub/zsh-5.3.1.tar.gz"
+    sha256 "3d94a590ff3c562ecf387da78ac356d6bea79b050a9ef81e3ecb9f8ee513040e"

     # We cannot build HTML doc on HEAD, because yodl which is required for
     # building zsh.texi is not available.
```
</details>

---

There might be other problems with devel mirror handling, but I didn't bother to look at the code carefully.