### PR TITLE
create: remove :x11 dep from new formula template

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -178,7 +178,6 @@ class FormulaCreator
     <% elsif mode.nil? %>
       # depends_on "cmake" => :build
     <% end %>
-      depends_on :x11 # if your formula requires any X11/XQuartz components
 
       def install
         # ENV.deparallelize  # if your formula fails when building in parallel


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

IMO `brew create` mostly caters to core, and :x11 dep isn't something we encourage in core. Here's a list of core formulae with an :x11 dep, along with the commit and date they were introduced:

<details>
<summary>List</summary>

```zsh
$ grep -rl :x11 Formula | while read f; do f=$f:r:t; printf '%s: ' $f; brew log --pretty='format:%h: %ci' $f | tail -1; print; done
at-spi2-core: 7ecda193fa: 2013-02-02 18:47:06 -0600
cairo: b901cd391c: 2010-04-27 09:34:30 -0700
diff-pdf: 36257d1eb7: 2014-05-18 23:23:45 -0500
ghostscript: bf7a82e66d: 2009-09-10 19:23:03 +0100
giflib: 2201bf8b23: 2009-11-08 15:21:14 +0000
giflossy: 9aee557512: 2015-06-18 02:18:15 +0100
gifsicle: e990d03870: 2010-05-01 09:41:07 -0700
gnu-smalltalk: 76de754e70: 2009-09-19 11:35:43 +0200
gnuplot: b1679ccfff: 2009-09-22 19:56:22 +0100
goocanvas: ca086fcfd1: 2013-08-05 21:50:19 -0700
gource: 4c23d4c47f: 2010-05-08 10:46:59 -0700
gpac: 150cac8cb0: 2010-08-12 07:42:04 -0700
graphicsmagick: fa2a4c818c: 2009-11-07 18:22:36 +0000
graphviz: b8f509f85a: 2009-09-29 23:52:17 +0100
gst-plugins-good: 6b7bbf0e4d: 2010-08-14 16:16:31 -0700
harbour: a44a1dc048: 2014-08-16 19:20:20 -0700
imagemagick: 4018e05d35: 2009-06-28 16:56:15 +0100
imlib2: a6eb8c316e: 2010-10-20 21:30:20 -0700
jed: eb204999b2: 2010-07-14 07:20:41 -0700
lesstif: 6ea6ca3a0a: 2010-09-27 09:24:02 -0700
libcaca: a8810fdc99: 2010-04-10 17:40:51 +0200
libspnav: 28f05afd48: 2015-08-14 21:42:00 +0100
links: b562b5e48b: 2009-09-25 00:00:55 -0400
lsh: 59d13f3f23: 2014-11-30 17:04:40 +0000
mal4s: 72e74dfbad: 2014-01-05 14:16:16 +0000
mit-scheme: 3bf0dbb1f6: 2011-04-14 13:58:54 -0700
mjpegtools: a93f067f67: 2011-10-27 17:27:36 -0700
modules: 9c0cc2a53b: 2014-04-17 05:43:09 -0700
mpv: 2d56414704: 2015-12-26 21:47:14 +0000
mtools: ee4c35199d: 2011-12-30 20:20:41 -0600
ngspice: 6de6676db1: 2010-10-31 16:44:12 -0700
ocaml: bf8cc3aa37: 2015-08-14 08:42:07 +0100
ode: cb6a4298ab: 2010-04-23 21:21:38 -0700
pango: 2c3ddb15fe: 2010-02-07 12:18:10 -0800
pike: b0093804dd: 2012-11-11 16:58:22 -0800
plan9port: e343b98e78: 2014-02-02 10:07:29 +0000
plotutils: 568d4adf63: 2010-10-30 18:25:02 -0700
plplot: abbb233139: 2013-01-04 11:43:39 -0800
python: 16727d3937: 2009-07-31 00:28:38 +0100
python3: 77a8b25638: 2010-07-09 20:38:14 -0700
ruby: 4f0d14b994: 2009-09-14 20:33:46 +0100
sdl: 9faf689de1: 2009-08-31 01:46:19 +0100
suil: 7d1206acd9: 2015-12-12 14:04:48 +0100
swftools: 06b5f23927: 2009-11-07 18:22:35 +0000
swi-prolog: 7e8a284932: 2010-01-30 14:18:04 +0100
tesseract: 67fe99f417: 2010-01-30 14:11:29 +0100
vim: 8319b6db13: 2012-10-19 19:07:59 -0700
wine: 6570815c23: 2009-10-04 18:36:44 +0100
wordnet: dd98285287: 2009-10-12 17:26:44 +0100
x11vnc: be23806907: 2013-11-16 11:06:51 -0800
xplanet: 6b9c5fd1b8: 2012-02-20 19:30:18 -0800
zbar: b53133e37a: 2010-06-18 10:49:40 -0700
```
</details><br>

As you can see, not a single :x11 formula was added to core in 2016. Therefore, :x11 no longer deserves a special place in the new formula template.

(Even outside core, I'm not convinced that :x11 is more important than, say, :java.)