### PR TITLE
formula: don't expand unused optional dependencies

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1505,7 +1505,12 @@ class Formula
   # Returns a list of Dependency objects that are required at runtime.
   # @private
   def runtime_dependencies
-    recursive_dependencies { |_, dep| Dependency.prune if dep.build? }
+    recursive_dependencies do |_dependent, dependency|
+      Dependency.prune if dependency.build?
+      if dependency.optional? || dependency.recommended?
+        Dependency.prune unless build.with?(dependency)
+      end
+    end
   end
 
   # Returns a list of formulae depended on by this formula that aren't

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1505,7 +1505,7 @@ class Formula
   # Returns a list of Dependency objects that are required at runtime.
   # @private
   def runtime_dependencies
-    recursive_dependencies.reject(&:build?)
+    recursive_dependencies { |_, dep| Dependency.prune if dep.build? }
   end
 
   # Returns a list of formulae depended on by this formula that aren't

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1507,9 +1507,7 @@ class Formula
   def runtime_dependencies
     recursive_dependencies do |_dependent, dependency|
       Dependency.prune if dependency.build?
-      if dependency.optional? || dependency.recommended?
-        Dependency.prune unless build.with?(dependency)
-      end
+      Dependency.prune if !dependency.required? && build.without?(dependency)
     end
   end
 

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -651,12 +651,19 @@ class FormulaTests < Homebrew::TestCase
 
     f4 = formula("f4") do
       url "f4-1.0"
-      depends_on "f3"
+      depends_on "f1"
+    end
+    stub_formula_loader f4
+
+    f5 = formula("f5") do
+      url "f5-1.0"
+      depends_on "f3" => :build
+      depends_on "f4"
     end
 
-    assert_equal %w[f3], f4.deps.map(&:name)
-    assert_equal %w[f1 f2 f3], f4.recursive_dependencies.map(&:name)
-    assert_equal %w[f2 f3], f4.runtime_dependencies.map(&:name)
+    assert_equal %w[f3 f4], f5.deps.map(&:name)
+    assert_equal %w[f1 f2 f3 f4], f5.recursive_dependencies.map(&:name)
+    assert_equal %w[f1 f4], f5.runtime_dependencies.map(&:name)
   end
 
   def test_to_hash


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

—--

This properly addresses the issue reported in Homebrew/homebrew-core#7826, so `Formula#runtime_dependencies` no longer attempts to expand optional dependencies that aren't being used in the current build.

As such, it reverts #1665, and so unreverts #1592.