### PR TITLE
Don't drop .rb suffix for formula names

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -333,7 +333,9 @@ class Formulary
       return TapLoader.new(ref, from: from)
     end
 
-    return FromPathLoader.new(ref) if File.extname(ref) == ".rb"
+    if File.extname(ref) == ".rb" && Pathname.new(ref).expand_path.exist?
+      return FromPathLoader.new(ref)
+    end
 
     formula_with_that_name = core_path(ref)
     if formula_with_that_name.file?


### PR DESCRIPTION
Fixes #1718

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
