### PR TITLE
keg: installed dependencies of unknown formulae

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -357,7 +357,7 @@ class Keg
   end
 
   def installed_dependents
-    my_tab = Tab.for_keg(self)
+    tap = Tab.for_keg(self).source["tap"]
     Keg.all.select do |keg|
       tab = Tab.for_keg(keg)
       next if tab.runtime_dependencies.nil? # no dependency information saved.
@@ -368,7 +368,7 @@ class Keg
           dep_formula = Formulary.factory(dep["full_name"])
           next false unless dep_formula == to_formula
         rescue FormulaUnavailableError
-          next false unless my_tab["full_name"] = dep["full_name"]
+          next false unless "#{tap}/#{name}" == dep["full_name"]
         end
 
         dep["version"] == version.to_s

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -2,7 +2,7 @@ require "testing_env"
 require "keg"
 require "stringio"
 
-class LinkTests < Homebrew::TestCase
+class LinkTestCase < Homebrew::TestCase
   include FileUtils
 
   def setup_test_keg(name, version)
@@ -44,7 +44,9 @@ class LinkTests < Homebrew::TestCase
     rmtree HOMEBREW_PREFIX/"bin"
     rmtree HOMEBREW_PREFIX/"lib"
   end
+end
 
+class LinkTests < LinkTestCase
   def test_empty_installation
     %w[.DS_Store INSTALL_RECEIPT.json LICENSE.txt].each do |file|
       touch @keg/file
@@ -315,7 +317,7 @@ class LinkTests < Homebrew::TestCase
   end
 end
 
-class InstalledDependantsTests < LinkTests
+class InstalledDependantsTests < LinkTestCase
   def stub_formula_name(name)
     f = formula(name) { url "foo-1.0" }
     stub_formula_loader f

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -47,6 +47,11 @@ class LinkTestCase < Homebrew::TestCase
 end
 
 class LinkTests < LinkTestCase
+  def test_all
+    Formula.clear_racks_cache
+    assert_equal [@keg], Keg.all
+  end
+
   def test_empty_installation
     %w[.DS_Store INSTALL_RECEIPT.json LICENSE.txt].each do |file|
       touch @keg/file
@@ -355,10 +360,11 @@ class InstalledDependantsTests < LinkTestCase
   # from a file path or URL.
   def test_unknown_formula
     Formulary.unstub(:loader_for)
-    dependencies []
+    alter_tab { |t| t.source["tap"] = "some/tap" }
+    dependencies [{ "full_name" => "some/tap/bar", "version" => "1.0" }]
     alter_tab { |t| t.source["path"] = nil }
-    assert_empty @keg.installed_dependents
-    assert_nil Keg.find_some_installed_dependents([@keg])
+    assert_equal [@dependent], @keg.installed_dependents
+    assert_equal [[@keg], ["bar 1.0"]], Keg.find_some_installed_dependents([@keg])
   end
 
   def test_no_dependencies_anywhere

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -360,9 +360,11 @@ class InstalledDependantsTests < LinkTestCase
   # from a file path or URL.
   def test_unknown_formula
     Formulary.unstub(:loader_for)
-    alter_tab { |t| t.source["tap"] = "some/tap" }
-    dependencies [{ "full_name" => "some/tap/bar", "version" => "1.0" }]
-    alter_tab { |t| t.source["path"] = nil }
+    alter_tab(@keg) do |t|
+      t.source["tap"] = "some/tap"
+      t.source["path"] = nil
+    end
+    dependencies [{ "full_name" => "some/tap/foo", "version" => "1.0" }]
     assert_equal [@dependent], @keg.installed_dependents
     assert_equal [[@keg], ["bar 1.0"]], Keg.find_some_installed_dependents([@keg])
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Previously, trying to resolve the dependencies of a keg would raise an exception if the formulae for any of the dependencies could not be found (e.g. if it had been moved to another tap).

This commit updates the dependency finding logic to catch these exceptions, and fall back to comparing names and taps of formulae, which should give the correct behaviour.

Fixes #1586.