### PR TITLE
Delete pkgutil directories that are really files.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/pkg.rb
+++ b/Library/Homebrew/cask/lib/hbc/pkg.rb
@@ -26,6 +26,7 @@ module Hbc
       _deepest_path_first(pkgutil_bom_dirs).each do |dir|
         next unless dir.exist? && !MacOS.undeletable?(dir)
         _with_full_permissions(dir) do
+          _delete_broken_file_dir(dir) && next
           _clean_broken_symlinks(dir)
           _clean_ds_store(dir)
           _rmdir(dir)
@@ -95,6 +96,13 @@ module Hbc
       paths.sort do |path_a, path_b|
         path_b.to_s.split("/").count <=> path_a.to_s.split("/").count
       end
+    end
+
+    # Some pkgs (microsoft office for one) leave files (generally nibs) but
+    # report them as directories.  We remove these as files instead.
+    def _delete_broken_file_dir(path)
+      return unless path.file? && !path.symlink?
+      @command.run!("/bin/rm", args: ["-f", "--", path], sudo: true)
     end
 
     # Some pkgs leave broken symlinks hanging around; we clean them out before

--- a/Library/Homebrew/cask/lib/hbc/pkg.rb
+++ b/Library/Homebrew/cask/lib/hbc/pkg.rb
@@ -98,8 +98,8 @@ module Hbc
       end
     end
 
-    # Some pkgs (microsoft office for one) leave files (generally nibs) but
-    # report them as directories.  We remove these as files instead.
+    # Some pkgs incorrectly report files (generally nibs)
+    # as directories; we remove these as files instead.
     def _delete_broken_file_dir(path)
       return unless path.file? && !path.symlink?
       @command.run!("/bin/rm", args: ["-f", "--", path], sudo: true)

--- a/Library/Homebrew/cask/test/cask/pkg_test.rb
+++ b/Library/Homebrew/cask/test/cask/pkg_test.rb
@@ -68,11 +68,11 @@ describe Hbc::Pkg do
       fake_dir.must_be :exist?
     end
 
-    it "chokes on directories that are really files" do
+    it "cleans files incorrectly reported as directories" do
       pkg = Hbc::Pkg.new("my.fake.pkg", Hbc::NeverSudoSystemCommand)
 
       fake_dir  = Pathname(Dir.mktmpdir)
-      fake_file = fake_dir.join("ima_file").tap { |path| FileUtils.touch(path) }
+      fake_file = fake_dir.join("ima_file_pretending_to_be_a_dir").tap { |path| FileUtils.touch(path) }
 
       pkg.stubs(:pkgutil_bom_specials).returns([])
       pkg.stubs(:pkgutil_bom_files).returns([])

--- a/Library/Homebrew/cask/test/cask/pkg_test.rb
+++ b/Library/Homebrew/cask/test/cask/pkg_test.rb
@@ -5,13 +5,13 @@ describe Hbc::Pkg do
     it "removes files and dirs referenced by the pkg" do
       pkg = Hbc::Pkg.new("my.fake.pkg", Hbc::NeverSudoSystemCommand)
 
-      some_files = Array.new(3) { Pathname(Tempfile.new("testfile").path) }
+      some_files = Array.new(3) { Pathname.new(Tempfile.new("testfile").path) }
       pkg.stubs(:pkgutil_bom_files).returns some_files
 
-      some_specials = Array.new(3) { Pathname(Tempfile.new("testfile").path) }
+      some_specials = Array.new(3) { Pathname.new(Tempfile.new("testfile").path) }
       pkg.stubs(:pkgutil_bom_specials).returns some_specials
 
-      some_dirs = Array.new(3) { Pathname(Dir.mktmpdir) }
+      some_dirs = Array.new(3) { Pathname.new(Dir.mktmpdir) }
       pkg.stubs(:pkgutil_bom_dirs).returns some_dirs
 
       pkg.stubs(:forget)
@@ -50,7 +50,7 @@ describe Hbc::Pkg do
     it "cleans broken symlinks, but leaves AOK symlinks" do
       pkg = Hbc::Pkg.new("my.fake.pkg", Hbc::NeverSudoSystemCommand)
 
-      fake_dir  = Pathname(Dir.mktmpdir)
+      fake_dir  = Pathname.new(Dir.mktmpdir)
       fake_file = fake_dir.join("ima_file").tap { |path| FileUtils.touch(path) }
 
       intact_symlink = fake_dir.join("intact_symlink").tap { |path| path.make_symlink(fake_file) }
@@ -71,7 +71,7 @@ describe Hbc::Pkg do
     it "cleans files incorrectly reported as directories" do
       pkg = Hbc::Pkg.new("my.fake.pkg", Hbc::NeverSudoSystemCommand)
 
-      fake_dir  = Pathname(Dir.mktmpdir)
+      fake_dir  = Pathname.new(Dir.mktmpdir)
       fake_file = fake_dir.join("ima_file_pretending_to_be_a_dir").tap { |path| FileUtils.touch(path) }
 
       pkg.stubs(:pkgutil_bom_specials).returns([])
@@ -88,7 +88,7 @@ describe Hbc::Pkg do
     it "snags permissions on ornery dirs, but returns them afterwords" do
       pkg = Hbc::Pkg.new("my.fake.pkg", Hbc::NeverSudoSystemCommand)
 
-      fake_dir = Pathname(Dir.mktmpdir)
+      fake_dir = Pathname.new(Dir.mktmpdir)
 
       fake_file = fake_dir.join("ima_installed_file").tap { |path| FileUtils.touch(path) }
 

--- a/Library/Homebrew/cask/test/cask/pkg_test.rb
+++ b/Library/Homebrew/cask/test/cask/pkg_test.rb
@@ -68,6 +68,23 @@ describe Hbc::Pkg do
       fake_dir.must_be :exist?
     end
 
+    it "chokes on directories that are really files" do
+      pkg = Hbc::Pkg.new("my.fake.pkg", Hbc::NeverSudoSystemCommand)
+
+      fake_dir  = Pathname(Dir.mktmpdir)
+      fake_file = fake_dir.join("ima_file").tap { |path| FileUtils.touch(path) }
+
+      pkg.stubs(:pkgutil_bom_specials).returns([])
+      pkg.stubs(:pkgutil_bom_files).returns([])
+      pkg.stubs(:pkgutil_bom_dirs).returns([fake_file, fake_dir])
+      pkg.stubs(:forget)
+
+      pkg.uninstall
+
+      fake_file.wont_be :exist?
+      fake_dir.wont_be :exist?
+    end
+
     it "snags permissions on ornery dirs, but returns them afterwords" do
       pkg = Hbc::Pkg.new("my.fake.pkg", Hbc::NeverSudoSystemCommand)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew cask-tests` with your changes locally?

-----

Sometimes, pkgutil will return actual files (usually .nib files) as if they were part of the directory.  Microsoft Office is an example of this: in a recent update the file `/Library/Application Support/Microsoft/MAU2.0/Microsoft AutoUpdate.app/Contents/SharedSupport/Microsoft Error Reporting.app/Contents/Resources/en.lproj/MainWindowAlt.nib` was returning from `/usr/sbin/pkgutil --only-dirs --files com.microsoft.package.component` even though it should have been a file instead of a directory.  This caused the `rmdir` command to fail.

This patch will check if we are trying to delete a “directory” that is really a “file” - and if we are, we just delete the file instead.  This will allow packages that get in this state to be uninstalled cleanly.


--

Fixes https://github.com/caskroom/homebrew-cask/issues/29804.