### PR TITLE
Get file extension with `curl`’s `filename_effective`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/container/criteria.rb
+++ b/Library/Homebrew/cask/lib/hbc/container/criteria.rb
@@ -9,6 +9,14 @@ module Hbc
       end
 
       def extension(regex)
+        effective_filename = @command.run!("/usr/bin/xattr", args: ["-p", "curl.filename_effective", @path]).stdout.chomp
+
+        path = if effective_filename.empty?
+          @path
+        else
+          Pathname.new(effective_filename)
+        end
+
         path.extname.sub(/^\./, "") =~ Regexp.new(regex.source, regex.options | Regexp::IGNORECASE)
       end
 

--- a/Library/Homebrew/cask/lib/hbc/container/naked.rb
+++ b/Library/Homebrew/cask/lib/hbc/container/naked.rb
@@ -16,7 +16,14 @@ module Hbc
 
       def target_file
         return @path.basename if @nested
-        URI.decode(File.basename(@cask.url.path))
+
+        effective_filename = @command.run!("/usr/bin/xattr", args: ["-p", "curl.filename_effective", @path]).stdout.chomp
+
+        if effective_filename.empty?
+          URI.decode(File.basename(@cask.url.path))
+        else
+          effective_filename
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes https://github.com/caskroom/homebrew-cask/issues/28348 in that the “real“ filename is stored as an extended attribute on the cached file named `token--version.ext`. Otherwise a `.pkg` may not be detectable without the right extension.

There is a bit of a problem here though, which could break some casks.

Let's take https://github.com/caskroom/homebrew-cask/issues/28348 as an example. If we fix it now, we would have to rename the `pkg` stanza to `airvpn--#{version}.pkg`, some casks are already using this naming, which will break, because with this PR they will now have the “real“ filename, i. e `airvpn_osx_x64_installer.pkg`.