### PR TITLE
keg: fall back for dependencies of buggy tabs

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -104,8 +104,10 @@ class Keg
     # so need them to be calculated now.
     #
     # This happens after the initial dependency check because it's sloooow.
-    remaining_formulae = Formula.installed.select do |f|
-      f.installed_kegs.any? { |k| Tab.for_keg(k).runtime_dependencies.nil? }
+    remaining_formulae = Formula.installed.reject do |f|
+      f.installed_kegs.all? do |k|
+        Tab.for_keg(k).reliable_runtime_dependencies?
+      end
     end
 
     keg_names = kegs.map(&:name)
@@ -360,7 +362,7 @@ class Keg
     tap = Tab.for_keg(self).source["tap"]
     Keg.all.select do |keg|
       tab = Tab.for_keg(keg)
-      next if tab.runtime_dependencies.nil? # no dependency information saved.
+      next unless tab.reliable_runtime_dependencies?
       tab.runtime_dependencies.any? do |dep|
         # Resolve formula rather than directly comparing names
         # in case of conflicts between formulae from different taps.

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -104,10 +104,8 @@ class Keg
     # so need them to be calculated now.
     #
     # This happens after the initial dependency check because it's sloooow.
-    remaining_formulae = Formula.installed.reject do |f|
-      f.installed_kegs.all? do |k|
-        Tab.for_keg(k).reliable_runtime_dependencies?
-      end
+    remaining_formulae = Formula.installed.select do |f|
+      f.installed_kegs.any? { |k| Tab.for_keg(k).runtime_dependencies.nil? }
     end
 
     keg_names = kegs.map(&:name)
@@ -362,7 +360,7 @@ class Keg
     tap = Tab.for_keg(self).source["tap"]
     Keg.all.select do |keg|
       tab = Tab.for_keg(keg)
-      next unless tab.reliable_runtime_dependencies?
+      next if tab.runtime_dependencies.nil?
       tab.runtime_dependencies.any? do |dep|
         # Resolve formula rather than directly comparing names
         # in case of conflicts between formulae from different taps.

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -248,7 +248,7 @@ class Tab < OpenStruct
 
   def parsed_homebrew_version
     return Version::NULL if homebrew_version.nil?
-    Version.new(homebrew_tag)
+    Version.new(homebrew_version)
   end
 
   # Whether there is reliable runtime dependency information in the receipt.

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -242,6 +242,26 @@ class Tab < OpenStruct
     super || DevelopmentTools.default_compiler
   end
 
+  def homebrew_tag
+    homebrew_version.sub(/\-\d+\-g([a-f0-9]+)(?:\-dirty)?\Z/, "")
+  end
+
+  def parsed_homebrew_version
+    return Version::NULL if homebrew_version.nil?
+    Version.new(homebrew_tag)
+  end
+
+  # Whether there is reliable runtime dependency information in the receipt.
+  def reliable_runtime_dependencies?
+    return false if runtime_dependencies.nil?
+
+    # Homebrew versions prior to 1.1.6 generated incorrect runtime dependency
+    # lists.
+    return false if parsed_homebrew_version < "1.1.6"
+
+    true
+  end
+
   def cxxstdlib
     # Older tabs won't have these values, so provide sensible defaults
     lib = stdlib.to_sym if stdlib

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -247,15 +247,10 @@ class Tab < OpenStruct
     Version.new(homebrew_version)
   end
 
-  # Whether there is reliable runtime dependency information in the receipt.
-  def reliable_runtime_dependencies?
-    return false if runtime_dependencies.nil?
-
+  def runtime_dependencies
     # Homebrew versions prior to 1.1.6 generated incorrect runtime dependency
     # lists.
-    return false if parsed_homebrew_version < "1.1.6"
-
-    true
+    super unless parsed_homebrew_version < "1.1.6"
   end
 
   def cxxstdlib

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -242,10 +242,6 @@ class Tab < OpenStruct
     super || DevelopmentTools.default_compiler
   end
 
-  def homebrew_tag
-    homebrew_version.sub(/\-\d+\-g([a-f0-9]+)(?:\-dirty)?\Z/, "")
-  end
-
   def parsed_homebrew_version
     return Version::NULL if homebrew_version.nil?
     Version.new(homebrew_version)

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -348,6 +348,8 @@ class InstalledDependantsTests < LinkTestCase
     tab.write
   end
 
+  # 1.1.6 is the earliest version of Homebrew that generates correct runtime
+  # dependency lists in tabs.
   def dependencies(deps, homebrew_version: "1.1.6")
     alter_tab do |tab|
       tab.homebrew_version = homebrew_version
@@ -357,6 +359,8 @@ class InstalledDependantsTests < LinkTestCase
   end
 
   def unreliable_dependencies(deps)
+    # 1.1.5 is (hopefully!) the last version of Homebrew that generates
+    # incorrect runtime dependency lists in tabs.
     dependencies(deps, homebrew_version: "1.1.5")
   end
 

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -348,11 +348,16 @@ class InstalledDependantsTests < LinkTestCase
     tab.write
   end
 
-  def dependencies(deps)
+  def dependencies(deps, homebrew_version: "1.1.6")
     alter_tab do |tab|
+      tab.homebrew_version = homebrew_version
       tab.tabfile = @dependent.join("INSTALL_RECEIPT.json")
       tab.runtime_dependencies = deps
     end
+  end
+
+  def unreliable_dependencies(deps)
+    dependencies(deps, homebrew_version: "1.1.5")
   end
 
   # Test with a keg whose formula isn't known.
@@ -405,5 +410,12 @@ class InstalledDependantsTests < LinkTestCase
     dependencies [{ "full_name" => "foo", "version" => "1.0" }]
     assert_equal [@dependent], @keg.installed_dependents
     assert_equal [[@keg], ["bar 1.0"]], Keg.find_some_installed_dependents([@keg])
+  end
+
+  def test_fallback_for_old_versions
+    unreliable_dependencies [{ "full_name" => "baz", "version" => "1.0" }]
+    Formula["bar"].class.depends_on "foo"
+    assert_empty @keg.installed_dependents
+    assert_equal [[@keg], ["bar"]], Keg.find_some_installed_dependents([@keg])
   end
 end

--- a/Library/Homebrew/test/support/fixtures/receipt.json
+++ b/Library/Homebrew/test/support/fixtures/receipt.json
@@ -1,4 +1,5 @@
 {
+  "homebrew_version": "1.1.6",
   "used_options": [
     "--with-foo",
     "--without-bar"

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -69,6 +69,53 @@ class TabTests < Homebrew::TestCase
     assert_predicate tab, :universal?
   end
 
+  def test_homebrew_tag
+    tab = Tab.new(homebrew_version: "1.2.3")
+    assert_equal "1.2.3", tab.homebrew_tag
+
+    tab.homebrew_version = "1.2.4-567-g12789abdf"
+    assert_equal "1.2.4", tab.homebrew_tag
+
+    tab.homebrew_version = "2.0.0-134-gabcdefabc-dirty"
+    assert_equal "2.0.0", tab.homebrew_tag
+  end
+
+  def test_parsed_homebrew_version
+    tab = Tab.new
+    assert_same Version::NULL, tab.parsed_homebrew_version
+
+    tab = Tab.new(homebrew_version: "1.2.3")
+    assert_equal "1.2.3", tab.parsed_homebrew_version
+    assert_kind_of Version, tab.parsed_homebrew_version
+
+    tab = Tab.new(homebrew_version: "2.0.0-134-gabcdefabc-dirty")
+    assert_equal "2.0.0", tab.parsed_homebrew_version
+    assert_kind_of Version, tab.parsed_homebrew_version
+  end
+
+  def test_reliable_runtime_dependencies?
+    tab = Tab.new
+    refute_predicate tab, :reliable_runtime_dependencies?
+
+    tab.homebrew_version = "1.1.6"
+    refute_predicate tab, :reliable_runtime_dependencies?
+
+    tab.runtime_dependencies = []
+    assert_predicate tab, :reliable_runtime_dependencies?
+
+    tab.homebrew_version = "1.1.5"
+    refute_predicate tab, :reliable_runtime_dependencies?
+
+    tab.homebrew_version = "1.1.7"
+    assert_predicate tab, :reliable_runtime_dependencies?
+
+    tab.homebrew_version = "1.1.10"
+    assert_predicate tab, :reliable_runtime_dependencies?
+
+    tab.runtime_dependencies = [{ "full_name" => "foo", "version" => "1.0" }]
+    assert_predicate tab, :reliable_runtime_dependencies?
+  end
+
   def test_cxxstdlib
     assert_equal :clang, @tab.cxxstdlib.compiler
     assert_equal :libcxx, @tab.cxxstdlib.type

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -69,17 +69,6 @@ class TabTests < Homebrew::TestCase
     assert_predicate tab, :universal?
   end
 
-  def test_homebrew_tag
-    tab = Tab.new(homebrew_version: "1.2.3")
-    assert_equal "1.2.3", tab.homebrew_tag
-
-    tab.homebrew_version = "1.2.4-567-g12789abdf"
-    assert_equal "1.2.4", tab.homebrew_tag
-
-    tab.homebrew_version = "2.0.0-134-gabcdefabc-dirty"
-    assert_equal "2.0.0", tab.homebrew_tag
-  end
-
   def test_parsed_homebrew_version
     tab = Tab.new
     assert_same Version::NULL, tab.parsed_homebrew_version

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -86,11 +86,18 @@ class TabTests < Homebrew::TestCase
 
     tab = Tab.new(homebrew_version: "1.2.3")
     assert_equal "1.2.3", tab.parsed_homebrew_version
+    assert tab.parsed_homebrew_version < "1.2.3-1-g12789abdf"
     assert_kind_of Version, tab.parsed_homebrew_version
 
+    tab.homebrew_version = "1.2.4-567-g12789abdf"
+    assert tab.parsed_homebrew_version > "1.2.4"
+    assert tab.parsed_homebrew_version > "1.2.4-566-g21789abdf"
+    assert tab.parsed_homebrew_version < "1.2.4-568-g01789abdf"
+
     tab = Tab.new(homebrew_version: "2.0.0-134-gabcdefabc-dirty")
-    assert_equal "2.0.0", tab.parsed_homebrew_version
-    assert_kind_of Version, tab.parsed_homebrew_version
+    assert tab.parsed_homebrew_version > "2.0.0"
+    assert tab.parsed_homebrew_version > "2.0.0-133-g21789abdf"
+    assert tab.parsed_homebrew_version < "2.0.0-135-g01789abdf"
   end
 
   def test_reliable_runtime_dependencies?

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -32,6 +32,11 @@ class TabTests < Homebrew::TestCase
 
   def test_defaults
     tab = Tab.empty
+
+    # FIXME: remove this line after Homebrew 1.1.6 is released.
+    # See https://github.com/Homebrew/brew/pull/1750#discussion_r94254622
+    tab.homebrew_version = "1.1.6"
+
     assert_empty tab.unused_options
     assert_empty tab.used_options
     assert_nil tab.changed_files
@@ -89,27 +94,27 @@ class TabTests < Homebrew::TestCase
     assert tab.parsed_homebrew_version < "2.0.0-135-g01789abdf"
   end
 
-  def test_reliable_runtime_dependencies?
+  def test_runtime_dependencies
     tab = Tab.new
-    refute_predicate tab, :reliable_runtime_dependencies?
+    assert_nil tab.runtime_dependencies
 
     tab.homebrew_version = "1.1.6"
-    refute_predicate tab, :reliable_runtime_dependencies?
+    assert_nil tab.runtime_dependencies
 
     tab.runtime_dependencies = []
-    assert_predicate tab, :reliable_runtime_dependencies?
+    refute_nil tab.runtime_dependencies
 
     tab.homebrew_version = "1.1.5"
-    refute_predicate tab, :reliable_runtime_dependencies?
+    assert_nil tab.runtime_dependencies
 
     tab.homebrew_version = "1.1.7"
-    assert_predicate tab, :reliable_runtime_dependencies?
+    refute_nil tab.runtime_dependencies
 
     tab.homebrew_version = "1.1.10"
-    assert_predicate tab, :reliable_runtime_dependencies?
+    refute_nil tab.runtime_dependencies
 
     tab.runtime_dependencies = [{ "full_name" => "foo", "version" => "1.0" }]
-    assert_predicate tab, :reliable_runtime_dependencies?
+    refute_nil tab.runtime_dependencies
   end
 
   def test_cxxstdlib
@@ -193,6 +198,10 @@ class TabTests < Homebrew::TestCase
     compiler = DevelopmentTools.default_compiler
     stdlib = :libcxx
     tab = Tab.create(f, compiler, stdlib)
+
+    # FIXME: remove this line after Homebrew 1.1.6 is released.
+    # See https://github.com/Homebrew/brew/pull/1750#discussion_r94254622
+    tab.homebrew_version = "1.1.6"
 
     runtime_dependencies = [
       { "full_name" => "bar", "version" => "2.0" },

--- a/Library/Homebrew/test/uninstall_test.rb
+++ b/Library/Homebrew/test/uninstall_test.rb
@@ -12,6 +12,7 @@ class UninstallTests < Homebrew::TestCase
     [@dependency, @dependent].each { |f| f.installed_prefix.mkpath }
 
     tab = Tab.empty
+    tab.homebrew_version = "1.1.6"
     tab.tabfile = @dependent.installed_prefix/Tab::FILENAME
     tab.runtime_dependencies = [
       { "full_name" => "dependency", "version" => "1" },


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #1554.

If a keg was installed with Homebrew < 1.1.6 (which had bugs when populating the `runtime_dependencies` field in the install receipt), just treat it as if `runtime_dependencies` wasn't present in the tab and use the formula-based fallback.

To test:

1. `brew install hello`
2. Modify `hello`'s install receipt to add another installed formula as a dependency, e.g. `{ "full_name": "autoconf", "version": "2.14" }`.
3. Attempt to uninstall that formula e.g. `brew uninstall autoconf`. Verify that no warning or error is produced (because the information in the receipt isn't trusted).
4. Reinstall it: `brew install autoconf`
5. Modify `hello`'s install receipt to set `homebrew_version` to `1.1.6` or greater. You might want to try with different variations of `git describe --tags --dirty`, e.g. `1.1.6-1-gabcd12345` or `1.1.6-2-54321fedbca-dirty`.
6. Attempt to uninstall the dependency again e.g. `brew uninstall autoconf`. Verify that there is now a warning (or error if you're not a `HOMEBREW_DEVELOPER`).
