### PR TITLE
keg: don't return nil dependencies

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -102,8 +102,8 @@ module Homebrew
     attr_reader :reqs, :deps
 
     def initialize(requireds, dependents)
-      @reqs = requireds.compact
-      @deps = dependents.compact
+      @reqs = requireds
+      @deps = dependents
     end
 
     protected

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -119,7 +119,7 @@ class Keg
         next unless f_kegs
 
         f_kegs.sort_by(&:version).last
-      end
+      end.compact
 
       next unless required_kegs.any?
 

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -369,6 +369,19 @@ class InstalledDependantsTests < LinkTestCase
     assert_equal [[@keg], ["bar 1.0"]], Keg.find_some_installed_dependents([@keg])
   end
 
+  def test_a_dependency_with_no_tap_in_tab
+    @tap_dep = setup_test_keg("baz", "1.0")
+
+    alter_tab(@keg) { |t| t.source["tap"] = nil }
+
+    dependencies nil
+    Formula["bar"].class.depends_on "foo"
+    Formula["bar"].class.depends_on "baz"
+
+    result = Keg.find_some_installed_dependents([@keg, @tap_dep])
+    assert_equal [[@tap_dep], ["bar"]], result
+  end
+
   def test_no_dependencies_anywhere
     dependencies nil
     assert_empty @keg.installed_dependents


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a more correct solution to [this problem](https://github.com/Homebrew/homebrew-core/issues/3958#issuecomment-260632390) than @MikeMcQuaid's quick fix in #1510.

The problem arises when trying to uninstall at least two dependencies of the same keg (which must have `null` `runtime_dependencies` in its install receipt), when the name and tap information in some (but not all) of the install receipts of those dependencies do not match the current name and tap in the corresponding formulae (e.g. if the formula was renamed or moved, or it was installed from a file or URL). What an edge case!

Since #1751, it'll no longer produce a `NoMethodError`, but it will still produce a slightly broken error message without either fix (#1510 or this one). Note the floating comma:

<pre><samp>
Warning: , /Users/alyssa/code/brew/Cellar/readline/7.0.1 are required by clisp, which is currently installed.
You can silence this warning with:
  brew uninstall --ignore-dependencies libsigsegv readline
</samp></pre>

This PR fixes the problem by removing the `nil` values as soon as they occur. (Not doing this before was an oversight on my part — it was always the intended behaviour.)

To test:

1. Install a keg with a null tap in its install receipt: <kbd>brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/master/Formula/libsigsegv.rb</kbd>
2. Install a keg that depends on that keg and another (normal) one: <kbd>brew install clisp</kbd>
3. Edit `clisp`'s install receipt to set the `runtime_dependencies` to `null`.
4. Check if there are empty items in the list in the warning/error message generated by <kbd>brew uninstall libsigsegv readline</kbd>. (There shouldn't be.)