### PR TITLE
keg: handle dependencies of moved/renamed formulae

### DIFF
--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -377,6 +377,11 @@ class InstalledDependantsTests < LinkTestCase
     dependencies [{ "full_name" => "some/tap/foo", "version" => "1.0" }]
     assert_equal [@dependent], @keg.installed_dependents
     assert_equal [[@keg], ["bar 1.0"]], Keg.find_some_installed_dependents([@keg])
+
+    dependencies nil
+    # It doesn't make sense for a keg with no formula to have any dependents,
+    # so that can't really be tested.
+    assert_nil Keg.find_some_installed_dependents([@keg])
   end
 
   def test_a_dependency_with_no_tap_in_tab


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In #1497 I switched from `Keg#to_formula` for comparing kegs to formulae to comparing the name and tap in the keg's tab to the name and tap of the formula.

However, this fails to match if the name and tap of the formula have changed since the keg was installed, so it's clearly better to use `Keg#to_formula` where possible, and fall back to the information in the tab when `#to_formula` can't be used.