### PR TITLE
formula, ARGV: don't output duplicate formulae.

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -44,7 +44,7 @@ module HomebrewArgvExtension
       else
         Formulary.find_with_priority(name, spec)
       end
-    end
+    end.uniq(&:name)
   end
 
   def resolved_formulae
@@ -79,7 +79,7 @@ module HomebrewArgvExtension
       f.follow_installed_alias = false
 
       f
-    end
+    end.uniq(&:name)
   end
 
   def casks

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1406,7 +1406,7 @@ class Formula
         Formulary.from_rack(rack)
       rescue FormulaUnavailableError, TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
       end
-    end.compact
+    end.compact.uniq(&:name)
   end
 
   def self.installed_with_alias_path(alias_path)


### PR DESCRIPTION
If you specify a formula more than once or it exists in the Cellar with an alias name and the main name (e.g. `qt` and `qt5`) you can see the same formula showing up more than once.
Instead, resolve these output lists of formulae such that they are unique based on their `name`. This doesn't use `full_name` as it's `name` that's use for the `Cellar`.

CC @RandomDSdevel 

Fixes https://github.com/Homebrew/homebrew-core/issues/8342