### PR TITLE
Remove `:bsexec` parameter from `SystemCommand`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/artifact/base.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/base.rb
@@ -46,7 +46,7 @@ module Hbc
         arguments = { executable: arguments } if arguments.is_a?(String)
 
         # key sanity
-        permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :bsexec, :print_stdout, :print_stderr]
+        permitted_keys = [:args, :input, :executable, :must_succeed, :sudo, :print_stdout, :print_stderr]
         unknown_keys = arguments.keys - permitted_keys
         unless unknown_keys.empty?
           opoo %Q{Unknown arguments to #{description} -- #{unknown_keys.inspect} (ignored). Running "brew update; brew cleanup; brew cask cleanup" will likely fix it.}

--- a/Library/Homebrew/cask/lib/hbc/system_command.rb
+++ b/Library/Homebrew/cask/lib/hbc/system_command.rb
@@ -48,13 +48,11 @@ module Hbc
 
     def process_options!
       options.extend(HashValidator)
-             .assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo, :bsexec
+             .assert_valid_keys :input, :print_stdout, :print_stderr, :args, :must_succeed, :sudo
       sudo_prefix = %w[/usr/bin/sudo -E --]
       sudo_prefix = sudo_prefix.insert(1, "-A") unless ENV["SUDO_ASKPASS"].nil?
-      bsexec_prefix = ["/bin/launchctl", "bsexec", options[:bsexec] == :startup ? "/" : options[:bsexec]]
       @command = [executable]
       options[:print_stderr] = true    unless options.key?(:print_stderr)
-      @command.unshift(*bsexec_prefix) if  options[:bsexec]
       @command.unshift(*sudo_prefix)   if  options[:sudo]
       @command.concat(options[:args])  if  options.key?(:args) && !options[:args].empty?
       @command[0] = Shellwords.shellescape(@command[0]) if @command.size == 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Closes https://github.com/caskroom/homebrew-cask/issues/8067.