### PR TITLE
New feature: Allow download from private GitHub repository

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -542,7 +542,7 @@ end
 # works with public one, but in that case simply use CurlDownloadStrategy.
 class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   require "utils/formatter"
-  require 'utils/github'
+  require "utils/github"
 
   def initialize(name, resource)
     super
@@ -551,12 +551,12 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   end
 
   def parse_url_pattern
-    url_pattern = %r|https://github.com/([^/]+)/([^/]+)/(\S+)|
+    url_pattern = %r{https://github.com/([^/]+)/([^/]+)/(\S+)}
     unless @url =~ url_pattern
       raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Repository."
     end
 
-    _, @owner, @repo, @filepath = *(@url.match(url_pattern))
+    _, @owner, @repo, @filepath = *@url.match(url_pattern)
   end
 
   def download_url
@@ -578,18 +578,16 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   end
 
   def validate_github_repository_access!
-    begin
-      # Test access to the repository
-      GitHub.repository(@owner, @repo)
-    rescue GitHub::HTTPNotFoundError
-      # We only handle HTTPNotFoundError here,
-      # becase AuthenticationFailedError is handled within util/github.
-      message = <<-EOS.undent
+    # Test access to the repository
+    GitHub.repository(@owner, @repo)
+  rescue GitHub::HTTPNotFoundError
+    # We only handle HTTPNotFoundError here,
+    # becase AuthenticationFailedError is handled within util/github.
+    message = <<-EOS.undent
         HOMEBREW_GITHUB_API_TOKEN can not access the repository: #{@owner}/#{@repo}
         This token may not have permission to access the repository or the url of formula may be incorrect.
-      EOS
-      raise CurlDownloadStrategyError, message
-    end
+    EOS
+    raise CurlDownloadStrategyError, message
   end
 end
 
@@ -600,12 +598,12 @@ end
 # environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
 class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDownloadStrategy
   def parse_url_pattern
-    url_pattern = %r|https://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)|
+    url_pattern = %r{https://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)}
     unless @url =~ url_pattern
       raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Release."
     end
 
-    _, @owner, @repo, @tag, @filename = *(@url.match(url_pattern))
+    _, @owner, @repo, @tag, @filename = *@url.match(url_pattern)
   end
 
   def download_url
@@ -615,7 +613,7 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
   def _fetch
     # HTTP request header `Accept: application/octet-stream` is required.
     # Without this, the GitHub API will respond with metadata, not binary.
-    curl download_url, "-C", downloaded_size, "-o", temporary_path, "-H", 'Accept: application/octet-stream'
+    curl download_url, "-C", downloaded_size, "-o", temporary_path, "-H", "Accept: application/octet-stream"
   end
 
   private
@@ -626,10 +624,10 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
 
   def resolve_asset_id
     release_metadata = fetch_release_metadata
-    assets = release_metadata["assets"].select{ |a| a["name"] == @filename }
+    assets = release_metadata["assets"].select { |a| a["name"] == @filename }
     raise CurlDownloadStrategyError, "Asset file not found." if assets.empty?
 
-    return assets.first["id"]
+    assets.first["id"]
   end
 
   def fetch_release_metadata

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -541,10 +541,13 @@ end
 # it lets you use a private GttHub repository for internal distribution.  It
 # works with public one, but in that case simply use CurlDownloadStrategy.
 class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
+  require "utils/formatter"
+  require 'utils/github'
+
   def initialize(name, resource)
     super
-    set_github_token
     parse_url_pattern
+    set_github_token
   end
 
   def parse_url_pattern
@@ -571,6 +574,22 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
     unless @github_token
       raise CurlDownloadStrategyError, "Environmental variable HOMEBREW_GITHUB_API_TOKEN is required."
     end
+    validate_github_repository_access!
+  end
+
+  def validate_github_repository_access!
+    begin
+      # Test access to the repository
+      GitHub.repository(@owner, @repo)
+    rescue GitHub::HTTPNotFoundError
+      # We only handle HTTPNotFoundError here,
+      # becase AuthenticationFailedError is handled within util/github.
+      message = <<-EOS.undent
+        HOMEBREW_GITHUB_API_TOKEN can not access the repository: #{@owner}/#{@repo}
+        This token may not have permission to access the repository or the url of formula may be incorrect.
+      EOS
+      raise CurlDownloadStrategyError, message
+    end
   end
 end
 
@@ -580,9 +599,6 @@ end
 # of your formula. This download strategy uses GitHub access tokens (in the
 # environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
 class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDownloadStrategy
-  require "utils/formatter"
-  require 'utils/github'
-
   def parse_url_pattern
     url_pattern = %r|https://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)|
     unless @url =~ url_pattern

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -546,16 +546,10 @@ class GitHubReleaseDownloadStrategy < CurlDownloadStrategy
     super
 
     @github_token = ENV["GITHUB_TOKEN"]
-    unless @github_token
-      puts "Environmental variable GITHUB_TOKEN is required."
-      raise CurlDownloadStrategyError, @url
-    end
+    raise CurlDownloadStrategyError, "Environmental variable GITHUB_TOKEN is required." unless @github_token
 
     url_pattern = %r|https://github.com/(\S+)/(\S+)/releases/download/(\S+)/(\S+)|
-    unless @url =~ url_pattern
-      puts "Invalid url pattern for GitHub Release."
-      raise CurlDownloadStrategyError, @url
-    end
+    raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Release." unless @url =~ url_pattern
 
     _, @owner, @repo, @tag, @filename = *(@url.match(url_pattern))
   end
@@ -580,10 +574,7 @@ class GitHubReleaseDownloadStrategy < CurlDownloadStrategy
   def resolve_asset_id
     release_metadata = fetch_release_metadata
     assets = release_metadata["assets"].select{ |a| a["name"] == @filename }
-    if assets.empty?
-      puts "Asset file not found."
-      raise CurlDownloadStrategyError, @url
-    end
+    raise CurlDownloadStrategyError, "Asset file not found." if assets.empty?
 
     return assets.first["id"]
   end
@@ -597,8 +588,7 @@ class GitHubReleaseDownloadStrategy < CurlDownloadStrategy
       release_response = open(release_url, {:http_basic_authentication => [@github_token]}).read
     rescue OpenURI::HTTPError => e
       if e.message == '404 Not Found'
-        puts "GitHub Release not found."
-        raise CurlDownloadStrategyError, @url
+        raise CurlDownloadStrategyError, "GitHub Release not found."
       else
         raise e
       end

--- a/Library/Homebrew/test/download_strategies_test.rb
+++ b/Library/Homebrew/test/download_strategies_test.rb
@@ -117,7 +117,7 @@ class GitHubPrivateRepositoryReleaseDownloadStrategyTests < Homebrew::TestCase
           "id" => 456,
           "name" => "foo_v0.1.0_darwin_amd64.tar.gz",
         },
-      ]
+      ],
     }
     @strategy.stubs(:fetch_release_metadata).returns(release_metadata)
     assert_equal 456, @strategy.send(:resolve_asset_id)

--- a/Library/Homebrew/test/download_strategies_test.rb
+++ b/Library/Homebrew/test/download_strategies_test.rb
@@ -61,25 +61,47 @@ class VCSDownloadStrategyTests < Homebrew::TestCase
   end
 end
 
-class GitHubReleaseDownloadStrategyTests < Homebrew::TestCase
+class GitHubPrivateRepositoryDownloadStrategyTests < Homebrew::TestCase
+  def setup
+    resource = ResourceDouble.new("https://github.com/owner/repo/archive/1.1.5.tar.gz")
+    ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
+    @strategy = GitHubPrivateRepositoryDownloadStrategy.new("foo", resource)
+  end
+
+  def test_set_github_token
+    assert_equal "token", @strategy.instance_variable_get(:@github_token)
+  end
+
+  def test_parse_url_pattern
+    assert_equal "owner", @strategy.instance_variable_get(:@owner)
+    assert_equal "repo", @strategy.instance_variable_get(:@repo)
+    assert_equal "archive/1.1.5.tar.gz", @strategy.instance_variable_get(:@filepath)
+  end
+
+  def test_download_url
+    expected = "https://token@github.com/owner/repo/archive/1.1.5.tar.gz"
+    assert_equal expected, @strategy.download_url
+  end
+end
+
+class GitHubPrivateRepositoryReleaseDownloadStrategyTests < Homebrew::TestCase
   def setup
     resource = ResourceDouble.new("https://github.com/owner/repo/releases/download/tag/foo_v0.1.0_darwin_amd64.tar.gz")
     ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
-    @strategy = GitHubReleaseDownloadStrategy.new("foo", resource)
+    @strategy = GitHubPrivateRepositoryReleaseDownloadStrategy.new("foo", resource)
   end
 
-  def test_initialize
-    assert_equal "token", @strategy.instance_variable_get(:@github_token)
+  def test_parse_url_pattern
     assert_equal "owner", @strategy.instance_variable_get(:@owner)
     assert_equal "repo", @strategy.instance_variable_get(:@repo)
     assert_equal "tag", @strategy.instance_variable_get(:@tag)
     assert_equal "foo_v0.1.0_darwin_amd64.tar.gz", @strategy.instance_variable_get(:@filename)
   end
 
-  def test_asset_url
+  def test_download_url
     @strategy.stubs(:resolve_asset_id).returns(456)
     expected = "https://token@api.github.com/repos/owner/repo/releases/assets/456"
-    assert_equal expected, @strategy.send(:asset_url)
+    assert_equal expected, @strategy.download_url
   end
 
   def test_resolve_asset_id
@@ -99,9 +121,14 @@ class GitHubReleaseDownloadStrategyTests < Homebrew::TestCase
     assert_equal 456, @strategy.send(:resolve_asset_id)
   end
 
-  def test_release_url
-    expected = "https://api.github.com/repos/owner/repo/releases/tags/tag"
-    assert_equal expected, @strategy.send(:release_url)
+  def test_fetch_release_metadata
+    expected_release_url = "https://api.github.com/repos/owner/repo/releases/tags/tag"
+    github_mock = MiniTest::Mock.new
+    github_mock.expect :call, {}, [expected_release_url]
+    GitHub.stub :open, github_mock do
+      @strategy.send(:fetch_release_metadata)
+    end
+    github_mock.verify
   end
 end
 

--- a/Library/Homebrew/test/download_strategies_test.rb
+++ b/Library/Homebrew/test/download_strategies_test.rb
@@ -64,7 +64,7 @@ end
 class GitHubReleaseDownloadStrategyTests < Homebrew::TestCase
   def setup
     resource = ResourceDouble.new("https://github.com/owner/repo/releases/download/tag/foo_v0.1.0_darwin_amd64.tar.gz")
-    ENV["GITHUB_TOKEN"] = "token"
+    ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
     @strategy = GitHubReleaseDownloadStrategy.new("foo", resource)
   end
 

--- a/Library/Homebrew/test/download_strategies_test.rb
+++ b/Library/Homebrew/test/download_strategies_test.rb
@@ -65,6 +65,7 @@ class GitHubPrivateRepositoryDownloadStrategyTests < Homebrew::TestCase
   def setup
     resource = ResourceDouble.new("https://github.com/owner/repo/archive/1.1.5.tar.gz")
     ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
+    GitHub.stubs(:repository).returns {}
     @strategy = GitHubPrivateRepositoryDownloadStrategy.new("foo", resource)
   end
 
@@ -88,6 +89,7 @@ class GitHubPrivateRepositoryReleaseDownloadStrategyTests < Homebrew::TestCase
   def setup
     resource = ResourceDouble.new("https://github.com/owner/repo/releases/download/tag/foo_v0.1.0_darwin_amd64.tar.gz")
     ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
+    GitHub.stubs(:repository).returns {}
     @strategy = GitHubPrivateRepositoryReleaseDownloadStrategy.new("foo", resource)
   end
 


### PR DESCRIPTION
## Why?
I would like to download the release asset of the private GitHub repository.

I'm using a private brew tap at my company and the prebuild binaries for internal tools are uploaded to the private GitHub Release page.
For such in-house use, S3DownloadStrategy already exists, but most of the source code are managed by GitHub, I think it would be useful to download the binary directly from GitHub.

## What I did
I implemented a new DownloadStrategy to find and download asset using GitHub API.

## How I did it
First, resolve the asset_id associated with the release tag with the following API:
https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name

and then, download the asset with the following API:
https://developer.github.com/v3/repos/releases/#get-a-single-release-asset

## How to verify it
To use it, add `:using => GitHubReleaseDownloadStrategy` to the URL section of your formula.

```rb
require "formula"

class Hoge < Formula
  url "https://github.com/:owner/:repo/releases/download/:tag/hoge_v0.1.0_darwin_amd64.tar.gz", :using => GitHubReleaseDownloadStrategy
  ...

end
```

```bash
$ export HOMEBREW_GITHUB_API_TOKEN=xxxxxx
$ brew install hoge
```

Please review this.

## Check List
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?