### PR TITLE
bottles: --force-bottle feigns or_later.

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -18,8 +18,9 @@
 #:    If `--build-from-source` is passed, download the source rather than a
 #:    bottle.
 #:
-#:    If `--force-bottle` is passed, download a bottle if it exists for the current
-#:    version of macOS, even if it would not be used during installation.
+#:    If `--force-bottle` is passed, download a bottle if it exists for the
+#:    current or newest version of macOS, even if it would not be used during
+#:    installation.
 
 require "formula"
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -32,10 +32,10 @@
 #:    passed, then both <formula> and the dependencies installed as part of this process
 #:    are built from source even if bottles are available.
 #:
-#     Hidden developer option:
-#     If `--force-bottle` is passed, install from a bottle if it exists
-#    for the current version of macOS, even if custom options are given.
-#
+#:    If `--force-bottle` is passed, install from a bottle if it exists for the
+#:    current or newest version of macOS, even if it would not normally be used
+#:    for installation.
+#:
 #:    If `--devel` is passed, and <formula> defines it, install the development version.
 #:
 #:    If `--HEAD` is passed, and <formula> defines it, install the HEAD version,

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -49,6 +49,8 @@ module Utils
           if key.to_s.end_with?("_or_later")
             later_tag = key.to_s[/(\w+)_or_later$/, 1].to_sym
             MacOS::Version.from_symbol(later_tag) <= tag_version
+          elsif ARGV.force_bottle?
+            true
           end
         end
       end

--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -127,8 +127,9 @@ checksum of a previously cached version no longer matches.</p>
 <p>If <code>--build-from-source</code> is passed, download the source rather than a
 bottle.</p>
 
-<p>If <code>--force-bottle</code> is passed, download a bottle if it exists for the current
-version of macOS, even if it would not be used during installation.</p></dd>
+<p>If <code>--force-bottle</code> is passed, download a bottle if it exists for the
+current or newest version of macOS, even if it would not be used during
+installation.</p></dd>
 <dt><code>gist-logs</code> [<code>--new-issue</code>|<code>-n</code>] <var>formula</var></dt><dd><p>Upload logs for a failed build of <var>formula</var> to a new Gist.</p>
 
 <p><var>formula</var> is usually the name of the formula to install, but it can be specified
@@ -184,6 +185,10 @@ from bottles if they are available.</p>
 <p>If <code>HOMEBREW_BUILD_FROM_SOURCE</code> is set, regardless of whether <code>--build-from-source</code> was
 passed, then both <var>formula</var> and the dependencies installed as part of this process
 are built from source even if bottles are available.</p>
+
+<p>If <code>--force-bottle</code> is passed, install from a bottle if it exists for the
+current or newest version of macOS, even if it would not normally be used
+for installation.</p>
 
 <p>If <code>--devel</code> is passed, and <var>formula</var> defines it, install the development version.</p>
 

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "December 2016" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "January 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "December 2016" "Homebrew" "brew"
+.TH "BREW" "1" "January 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -171,7 +171,7 @@ If \fB\-\-deps\fR is passed, also download dependencies for any listed \fIformul
 If \fB\-\-build\-from\-source\fR is passed, download the source rather than a bottle\.
 .
 .IP
-If \fB\-\-force\-bottle\fR is passed, download a bottle if it exists for the current version of macOS, even if it would not be used during installation\.
+If \fB\-\-force\-bottle\fR is passed, download a bottle if it exists for the current or newest version of macOS, even if it would not be used during installation\.
 .
 .TP
 \fBgist\-logs\fR [\fB\-\-new\-issue\fR|\fB\-n\fR] \fIformula\fR
@@ -245,6 +245,9 @@ If \fB\-\-build\-from\-source\fR or \fB\-s\fR is passed, compile the specified \
 .
 .IP
 If \fBHOMEBREW_BUILD_FROM_SOURCE\fR is set, regardless of whether \fB\-\-build\-from\-source\fR was passed, then both \fIformula\fR and the dependencies installed as part of this process are built from source even if bottles are available\.
+.
+.IP
+If \fB\-\-force\-bottle\fR is passed, install from a bottle if it exists for the current or newest version of macOS, even if it would not normally be used for installation\.
 .
 .IP
 If \fB\-\-devel\fR is passed, and \fIformula\fR defines it, install the development version\.


### PR DESCRIPTION
When reproducing issues with software that hasn’t been bottled yet on your version of macOS it can sometimes be helpful to use `or_later` bottle functionality i.e. just use the bottle for the latest version of macOS available. This maps well to the existing `--force-bottle` argument so it will now act as if the latest bottle has a `or_later` ending.