### PR TITLE
os/mac: Replace python linkage check with linkage cleaning.

### DIFF
--- a/Library/Homebrew/extend/os/mac/cleaner.rb
+++ b/Library/Homebrew/extend/os/mac/cleaner.rb
@@ -1,4 +1,44 @@
+require "vendor/macho/macho"
+
 class Cleaner
+  # Remove explicit linkages to
+  def unlink_python_frameworks
+    python_modules = Pathname.glob @f.lib/"python*/site-packages/**/*.so"
+
+    python_modules.each do |obj|
+      # skip modules that are symlinked in, as these usually embed a python
+      # interpreter and as such require explicit linkage.
+      # https://github.com/Homebrew/homebrew-core/pull/7599#issuecomment-270014332
+      next if File.symlink?(obj)
+
+      file = MachO.open(obj.to_s)
+
+      if file.is_a?(MachO::MachOFile)
+        machos = [file]
+      else
+        machos = file.machos
+      end
+
+      machos.each do |macho|
+        macho.dylib_load_commands.each do |dylib|
+          next unless /Python\.framework/ =~ dylib.name.to_s
+
+          opoo <<-EOS.undent
+            Found explicit Python framework linkage in a python module:
+              #{obj}
+            Homebrew will fix these, but upstreams should make an
+            effort to correct their build systems by replacing
+            -lpython and/or -framework Python with -undefined dynamic_lookup.
+          EOS
+
+          macho.delete_command(dylib)
+        end
+      end
+
+      file.write!
+    end
+  end
+
   private
 
   def executable_path?(path)

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -42,23 +42,6 @@ module FormulaCellarChecks
     EOS
   end
 
-  def check_python_framework_links(lib)
-    python_modules = Pathname.glob lib/"python*/site-packages/**/*.so"
-    framework_links = python_modules.select do |obj|
-      dlls = obj.dynamically_linked_libraries
-      dlls.any? { |dll| /Python\.framework/.match dll }
-    end
-    return if framework_links.empty?
-
-    <<-EOS.undent
-      python modules have explicit framework links
-      These python extension modules were linked directly to a Python
-      framework binary. They should be linked with -undefined dynamic_lookup
-      instead of -lpython or -framework Python.
-        #{framework_links * "\n        "}
-    EOS
-  end
-
   def check_linkage
     return unless formula.prefix.directory?
     keg = Keg.new(formula.prefix)
@@ -76,7 +59,6 @@ module FormulaCellarChecks
     generic_audit_installed
     audit_check_output(check_shadowed_headers)
     audit_check_output(check_openssl_links)
-    audit_check_output(check_python_framework_links(formula.lib))
     check_linkage
   end
 end


### PR DESCRIPTION
This allows Homebrew to delete Python framework linkages that would
otherwise cause bottling or relocation failures.

Even though Homebrew fixes these, we still print a nag to
get upstreams to fix these linkages in their build scripts.

I'm not familiar with the `Cleaner` class, but I think that the OS-specific mixin is currently
dead code (since `Cleaner#clean` doesn't make any attempts to run OS-specific cleaning routines). Any thoughts on how to fix this?

cc @tdsmith @nijikon @dunn 

ref Homebrew/homebrew-core#7599

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
