### PR TITLE
upgrade: unlink kegs of renamed formulae

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -171,6 +171,11 @@ class Keg
     Formula.racks.flat_map(&:subdirs).map { |d| new(d) }
   end
 
+  def self.linked
+    return [] unless HOMEBREW_LINKED_KEGS.directory?
+    HOMEBREW_LINKED_KEGS.subdirs.map(&method(:for))
+  end
+
   attr_reader :path, :name, :linked_keg_record, :opt_record
   protected :path
 

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -52,6 +52,13 @@ class LinkTests < LinkTestCase
     assert_equal [@keg], Keg.all
   end
 
+  def test_linked
+    assert_empty Keg.linked
+
+    @keg.link
+    assert_equal [@keg], Keg.linked
+  end
+
   def test_empty_installation
     %w[.DS_Store INSTALL_RECEIPT.json LICENSE.txt].each do |file|
       touch @keg/file

--- a/Library/Homebrew/test/support/lib/config.rb
+++ b/Library/Homebrew/test/support/lib/config.rb
@@ -8,7 +8,7 @@ require "pathname"
 HOMEBREW_BREW_FILE = Pathname.new(ENV["HOMEBREW_BREW_FILE"])
 
 TEST_TMPDIR = ENV.fetch("HOMEBREW_TEST_TMPDIR") do |k|
-  dir = Dir.mktmpdir("homebrew-tests-", ENV["HOMEBREW_TEMP"] || "/tmp")
+  dir = Dir.mktmpdir("homebrew-tests-", File.realpath(ENV["HOMEBREW_TEMP"] || "/tmp"))
   at_exit { FileUtils.remove_entry(dir) }
   ENV[k] = dir
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a solution to #1770.

Because this change refactors some alias-resolving logic, I re-ran all the test commands I used in #971 to make sure that behaviour was still correct.

This PR changes the way <kbd>brew upgrade</kbd> finds linked kegs to be unlinked. Instead of looking for the linked keg based on the current name of the formula, it loops through all linked kegs to find any that were installed with the formula under any name. For efficiency (to avoid iterating all linked kegs for every formula) the list of linked kegs is generated for all formulae to be uninstalled in the same iteration and stored in an instance variable.

While this fixes the problem in #1770, I can see kegs installed with previous names of formulae causing lots more problems in future, because a lot of the code in `Formula` assumes that kegs can be found on the filesystem based on the current name of the formula. So, I'm wondering if, instead of working around that in this one specific case, it might be worth changing `brew upgrade` to migrate any kegs of renamed formulae?