### PR TITLE
[Advice needed] search: show checkmark next to installed casks

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -10,6 +10,7 @@ raise "Homebrew must be run under Ruby 2!" unless RUBY_TWO
 
 require "pathname"
 HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
+$:.unshift(HOMEBREW_LIBRARY_PATH.join("cask", "lib").to_s)
 $:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -1,3 +1,4 @@
+$:.unshift File.expand_path("../../cask/lib", __FILE__)
 $:.unshift File.expand_path("../..", __FILE__)
 $:.unshift File.expand_path("../support/lib", __FILE__)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I'm trying to implement #1764.

To do that, I've changed <kbd>brew search</kbd> to search local casks as well as formulae. However, for this to work I needed to use some cask code, which wasn't possible.

@MikeMcQuaid suggested I refactor whatever Cask I needed into Homebrew, but I'm not sure how to do that. Really what I need is something like `Hbc.all_tokens`, but there's no sensible place to put it. One option would be to add a `Cask` class to Homebrew that had some very basic metadata like `name` and `tap`, but that seems like repeating ourselves when the code's already there in Cask.

So, I'm looking for advice on how to refactor the Cask functionality I need to use here into Homebrew. 