### PR TITLE
audit: deprecate env :std/:userpaths for strict.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1048,6 +1048,8 @@ class FormulaAuditor
 
     return unless @strict
 
+    problem "`#{$1}` in formulae is deprecated" if line =~ /(env :(std|userpaths))/
+
     if line =~ /system ((["'])[^"' ]*(?:\s[^"' ]*)+\2)/
       bad_system = $1
       unless %w[| < > & ; *].any? { |c| bad_system.include? c }


### PR DESCRIPTION
This should apply only for new formulae but we should start gradually phasing it out for older ones too.