### PR TITLE
tests: remove temporary tab homebrew_version override

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -168,6 +168,7 @@ class Tab < OpenStruct
 
   def self.empty
     attributes = {
+      "homebrew_version" => HOMEBREW_VERSION,
       "used_options" => [],
       "unused_options" => [],
       "built_as_bottle" => false,

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -33,6 +33,7 @@ class TabTests < Homebrew::TestCase
   def test_defaults
     tab = Tab.empty
 
+    assert_equal HOMEBREW_VERSION, tab.homebrew_version
     assert_empty tab.unused_options
     assert_empty tab.used_options
     assert_nil tab.changed_files

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -33,10 +33,6 @@ class TabTests < Homebrew::TestCase
   def test_defaults
     tab = Tab.empty
 
-    # FIXME: remove this line after Homebrew 1.1.6 is released.
-    # See https://github.com/Homebrew/brew/pull/1750#discussion_r94254622
-    tab.homebrew_version = "1.1.6"
-
     assert_empty tab.unused_options
     assert_empty tab.used_options
     assert_nil tab.changed_files
@@ -198,10 +194,6 @@ class TabTests < Homebrew::TestCase
     compiler = DevelopmentTools.default_compiler
     stdlib = :libcxx
     tab = Tab.create(f, compiler, stdlib)
-
-    # FIXME: remove this line after Homebrew 1.1.6 is released.
-    # See https://github.com/Homebrew/brew/pull/1750#discussion_r94254622
-    tab.homebrew_version = "1.1.6"
 
     runtime_dependencies = [
       { "full_name" => "bar", "version" => "2.0" },


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

***

This had to be added in #1750 to work around special-casing for tabs generated with Homebrew versions < 1.1.6. Now that 1.1.6 is the current version, we can remove this hack.

I set `homebrew_version` in `Tab.empty` so the [`#runtime_dependencies` override](https://github.com/Homebrew/brew/blob/fc11f633b29e6a2c9c4d49d5fd5452549b328193/Library/Homebrew/tab.rb#L253) isn't triggered (which would force `runtime_dependencies` to default to `nil` – unexpected behaviour that would cause a test to fail).