### PR TITLE
docs: fix titles on docs.brew.sh

### DIFF
--- a/docs/Acceptable-Formulae.md
+++ b/docs/Acceptable-Formulae.md
@@ -1,4 +1,5 @@
 # Acceptable Formulae
+
 Some formulae should not go in
 [homebrew/core](https://github.com/Homebrew/homebrew-core). But there are
 additional [Interesting Taps & Forks](Interesting-Taps-&-Forks.md) and anyone can start their

--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -1,4 +1,5 @@
 # Anonymous Aggregate User Behaviour Analytics
+
 Homebrew has begun gathering anonymous aggregate user behaviour analytics and reporting these to Google Analytics. You will be notified the first time you run `brew update` or install Homebrew.
 
 ## Why?

--- a/docs/Bottles.md
+++ b/docs/Bottles.md
@@ -1,4 +1,5 @@
 # Bottles (binary packages)
+
 Bottles are produced by installing a formula with `brew install --build-bottle $FORMULA` and then bottling it with `brew bottle $FORMULA`. This outputs the bottle DSL which should be inserted into the formula file.
 
 ## Usage

--- a/docs/Brew-Test-Bot-For-Core-Contributors.md
+++ b/docs/Brew-Test-Bot-For-Core-Contributors.md
@@ -1,4 +1,5 @@
 # Brew Test Bot For Core Contributors
+
 If a build has run and passed on `brew test-bot` then it can be used to quickly bottle formulae.
 
 There are two types of Jenkins jobs you will interact with:

--- a/docs/Brew-Test-Bot.md
+++ b/docs/Brew-Test-Bot.md
@@ -1,4 +1,5 @@
 # Brew Test Bot
+
 `brew test-bot` is the name for the automated review and testing system funded
 by [our Kickstarter in 2013](https://www.kickstarter.com/projects/homebrew/brew-test-bot).
 

--- a/docs/C++-Standard-Libraries.md
+++ b/docs/C++-Standard-Libraries.md
@@ -1,4 +1,5 @@
 # C++ Standard Libraries
+
 There are two C++ standard libraries supported by Apple compilers.
 
 The default for 10.8 and earlier is **libstdc++**, supported by Apple GCC

--- a/docs/Checksum_Deprecation.md
+++ b/docs/Checksum_Deprecation.md
@@ -1,4 +1,5 @@
 # MD5 and SHA-1 Deprecation
+
 During early 2015 Homebrew started the process of deprecating _SHA1_ for package
 integrity verification. Since then every formulae under the Homebrew organisation
 has been moved onto _SHA256_ verification; this includes both source packages

--- a/docs/Common-Issues.md
+++ b/docs/Common-Issues.md
@@ -1,4 +1,5 @@
 # Common Issues
+
 This is a list of commonly encountered problems, known issues, and their solutions.
 
 ### `brew` complains about absence of "Command Line Tools"

--- a/docs/Custom-GCC-and-cross-compilers.md
+++ b/docs/Custom-GCC-and-cross-compilers.md
@@ -1,4 +1,5 @@
 # Custom GCC and Cross Compilers
+
 Homebrew depends on having an up-to-date version of Xcode because it comes with
 specific versions of build tools e.g. `clang`.
 

--- a/docs/External-Commands.md
+++ b/docs/External-Commands.md
@@ -1,4 +1,5 @@
 # External Commands
+
 Homebrew, like Git, supports *external commands*. This lets you create new commands that can be run like:
 
 ```shell

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -1,4 +1,5 @@
 # Formula Cookbook
+
 A formula is a package definition written in Ruby. It can be created with `brew create $URL`, installed with `brew install $FORMULA`, and debugged with `brew install --debug --verbose $FORMULA`. Formulae use the [Formula API](http://www.rubydoc.info/github/Homebrew/brew/master/Formula) which provides various Homebrew-specific helpers.
 
 ## Homebrew Terminology

--- a/docs/Gems,-Eggs-and-Perl-Modules.md
+++ b/docs/Gems,-Eggs-and-Perl-Modules.md
@@ -1,4 +1,5 @@
 # Gems, Eggs and Perl Modules
+
 On a fresh macOS installation there are three empty directories for
 add-ons available to all users:
 

--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -1,4 +1,5 @@
 # Python
+
 This page describes how Python is handled in Homebrew for users. See [Python for Formula Authors](Python-for-Formula-Authors.md) for advice on writing formulae to install packages written in Python.
 
 Homebrew should work with any [CPython](https://stackoverflow.com/questions/2324208/is-there-any-difference-between-cpython-and-python) and defaults to the macOS system Python.

--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -1,4 +1,5 @@
 # How to Create and Maintain a Tap
+
 Taps are external sources of Homebrew formulae and/or external commands. They
 can be created by anyone to provide their own formulae and/or external commands
 to any Homebrew user.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,4 +1,5 @@
 # Installation
+
 The suggested and easiest way to install Homebrew is on the
 [homepage](http://brew.sh).
 

--- a/docs/Interesting-Taps-&-Forks.md
+++ b/docs/Interesting-Taps-&-Forks.md
@@ -1,4 +1,5 @@
 # Interesting Taps & Forks
+
 A Tap is homebrew-speak for a git repository containing extra formulae.
 Homebrew has the capability to add (and remove) multiple taps to your local installation with the `brew tap` and `brew untap` command. Type `man brew` in your Terminal. The main repository https://github.com/Homebrew/homebrew-core, often called `homebrew/core`, is always built-in.
 

--- a/docs/Kickstarter-Supporters.md
+++ b/docs/Kickstarter-Supporters.md
@@ -1,4 +1,5 @@
 # Kickstarter Supporters
+
 This file contains a list of the awesome people who gave £5 or more to
 [our Kickstarter](https://www.kickstarter.com/projects/homebrew/brew-test-bot).
 

--- a/docs/Maintainer-Guidelines.md
+++ b/docs/Maintainer-Guidelines.md
@@ -1,4 +1,5 @@
 # Maintainer Guidelines
+
 **This guide is for maintainers.** These special people have **write
 access** to Homebrew’s repository and help merge the contributions of
 others. You may find what is written here interesting, but it’s

--- a/docs/Maintainers-Avoiding-Burnout.md
+++ b/docs/Maintainers-Avoiding-Burnout.md
@@ -1,4 +1,5 @@
 # Maintainers: Avoiding Burnout
+
 **This guide is for maintainers.** These special people have **write
 access** to Homebrew’s repository and help merge the contributions of
 others. You may find what is written here interesting, but it’s

--- a/docs/Migrating-A-Formula-To-A-Tap.md
+++ b/docs/Migrating-A-Formula-To-A-Tap.md
@@ -1,4 +1,5 @@
 # Migrating A Formula To A Tap
+
 There are times when we may wish to migrate a formula from one tap into another tap. To do this:
 
 1. Create a pull request to the new tap adding the formula file as-is from the original tap. Fix any test failures that may occur due to the stricter requirements for new formulae than existing formula (e.g. `brew audit --strict` must pass for that formula).

--- a/docs/New-Maintainer-Checklist.md
+++ b/docs/New-Maintainer-Checklist.md
@@ -1,4 +1,5 @@
 # New Maintainer Checklist
+
 **This is a guide used by existing maintainers to invite new maintainers. You might find it interesting but there's nothing here users should have to know.**
 
 So, there's someone who has been making consistently high-quality contributions to Homebrew for a long time and shown themselves able to make slightly more advanced contributions than just e.g. formula updates? Let's invite them to be a maintainer!

--- a/docs/Querying-Brew.md
+++ b/docs/Querying-Brew.md
@@ -1,4 +1,5 @@
 # Querying `brew`
+
 _In this document we will be using [jq](https://stedolan.github.io/jq/) to parse JSON, available from Homebrew using `brew install jq`._
 
 ## Overview

--- a/docs/Versions.md
+++ b/docs/Versions.md
@@ -1,4 +1,5 @@
 # Versions
+
 Now that [Homebrew/versions](https://github.com/homebrew/homebrew-versions) has been deprecated [Homebrew/core](https://github.com/homebrew/homebrew-core) supports multiple versions of formulae with a new naming format.
 
 In [Homebrew/versions](https://github.com/homebrew/homebrew-versions) the formula for GCC 6 was named `gcc6.rb` and began `class Gcc6 < Formula`. In [Homebrew/core](https://github.com/homebrew/homebrew-core) this same formula is named `gcc@6.rb` and begins `class GccAT6 < Formula`.

--- a/docs/brew-tap.md
+++ b/docs/brew-tap.md
@@ -1,4 +1,5 @@
 # Taps (third-party repositories)
+
 `brew tap` adds more repos to the list of formulae that `brew` tracks, updates,
 and installs from. By default, `tap` assumes that the repos come from GitHub,
 but the command isn't limited to any one location.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

The new docs website is awesome but some of the titles are broken ([wrong title](http://docs.brew.sh/Installation.html); [right title](http://docs.brew.sh/Xcode.html)). It looks like Github Pages requires a newline after the title to properly pick detect the title.  
