### PR TITLE
uses: properly handle untapped formulae in recursive dependency expansion

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -175,7 +175,7 @@ class TapDependency < Dependency
   attr_reader :tap
 
   def initialize(name, tags = [], env_proc = DEFAULT_ENV_PROC, option_names = [name.split("/").last])
-    @tap = name.rpartition("/").first
+    @tap = Tap.fetch(name.rpartition("/").first)
     super(name, tags, env_proc, option_names)
   end
 

--- a/Library/Homebrew/test/dependency_test.rb
+++ b/Library/Homebrew/test/dependency_test.rb
@@ -118,6 +118,11 @@ class DependencyTests < Homebrew::TestCase
 end
 
 class TapDependencyTests < Homebrew::TestCase
+  def test_tap
+    dep = TapDependency.new("foo/bar/dog")
+    assert_equal Tap.new("foo", "bar"), dep.tap
+  end
+
   def test_option_names
     dep = TapDependency.new("foo/bar/dog")
     assert_equal %w[dog], dep.option_names


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #1776.

If any known formula had a dependency on an untapped tap, `Formula#recursive_dependencies` would throw an exception, which would be caught by the outer exception handler, causing the rest of the dependencies for that formula to be skipped and incomplete output to be generated.

To fix this, I added a check to avoid analysing the dependencies of formulae from uninstalled taps.

Additionally, I removed the aforementioned outer exception handler added in 5fdb89a, because the only other place that should be capable of throwing such an exception is the
statement that was surrounded by another wider exception handler in Homebrew/legacy-homebrew#40682. I verified that the example failures in https://github.com/Homebrew/legacy-homebrew/issues/40636 have still not returned even with this change.

Also, `TapDependency#tap` previously returned a `String`, but a `Tap` instance seemed more sensible and useful, so I changed it. I couldn't find anywhere this method was actually used, so the change
shouldn't break anything.