### PR TITLE
PerlRequirement: Perl version string may lack parentheses

### DIFF
--- a/Library/Homebrew/requirements/perl_requirement.rb
+++ b/Library/Homebrew/requirements/perl_requirement.rb
@@ -10,7 +10,7 @@ class PerlRequirement < Requirement
 
   satisfy(build_env: false) do
     which_all("perl").detect do |perl|
-      perl_version = Utils.popen_read(perl, "--version")[/\(v(\d+\.\d+)(?:\.\d+)?\)/, 1]
+      perl_version = Utils.popen_read(perl, "--version")[/v(\d+\.\d+)(?:\.\d+)?/, 1]
       next unless perl_version
       Version.create(perl_version.to_s) >= Version.create(@version)
     end


### PR DESCRIPTION
There may be no parentheses around the version number. For example:
This is perl, v5.10.1 (*) built for x86_64-linux-thread-multi

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Note that this is a straight cherry-pick from Linuxbrew (excluding a slightly modified commit message), but might affect macOS too in certain situations (eg. using Perl 5.10.1 from perl-build).