### PR TITLE
Whitelist PHP formulas in shadowed header audit check

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -6,6 +6,8 @@ module FormulaCellarChecks
       formula.name.start_with?(formula_name)
     end
 
+    return if formula.name =~ /^php\d+$/
+
     return if MacOS.version < :mavericks && formula.name.start_with?("postgresql")
     return if MacOS.version < :yosemite  && formula.name.start_with?("memcached")
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----
Instead of having to renaming the include directory in the PHP releases it was suggested by @MikeMcQuaid  that we whitelist the php formulas in https://github.com/Homebrew/homebrew-php/pull/3893