### PR TITLE
keg_relocate: Check HOMEBREW_TEMP's realpath when excluding name changes

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -6,7 +6,9 @@ class Keg
 
         each_install_name_for(file) do |bad_name|
           # Don't fix absolute paths unless they are rooted in the build directory
-          next if bad_name.start_with?("/") && !bad_name.start_with?(HOMEBREW_TEMP.to_s)
+          next if bad_name.start_with?("/") &&
+                  !bad_name.start_with?(HOMEBREW_TEMP.to_s) &&
+                  !bad_name.start_with?(HOMEBREW_TEMP.realpath.to_s)
 
           new_name = fixed_name(file, bad_name)
           change_install_name(bad_name, new_name, file) unless new_name == bad_name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since `/tmp` (the default `HOMEBREW_TEMP`) is a symlink to `/private/tmp`,
some build systems (like Parrot's) will attempt to use the realpath
instead of the literal `/tmp` we supply it with. This breaks the relocation
code, which only tested the literal `HOMEBREW_TEMP` and not its realpath.

Fixes parrot bottling in Homebrew/homebrew-core#6408.

Ping @ilovezfs 