### PR TITLE
audit: check virtualenv and setuptools resource.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -819,6 +819,11 @@ class FormulaAuditor
       problem "Formulae should not depend on both OpenSSL and LibreSSL (even optionally)."
     end
 
+    if text =~ /virtualenv_(create|install_with_resources)/ &&
+       text =~ /resource\s+['"]setuptools['"]\s+do/
+      problem "Formulae using virtualenvs do not need a `setuptools` resource."
+    end
+
     return unless text.include?('require "language/go"') && !text.include?("go_resource")
     problem "require \"language/go\" is unnecessary unless using `go_resource`s"
   end


### PR DESCRIPTION
`virtualenv_install_with_resources` will automatically define and install a `setuptools` resource so this is unnecessary.

References https://github.com/Homebrew/homebrew-core/pull/8570

CC @ilovezfs @tdsmith.