### PR TITLE
Deprecate brew (un)linkapps.

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -23,7 +23,6 @@ class Caveats
     caveats << fish_function_caveats
     caveats << plist_caveats
     caveats << python_caveats
-    caveats << app_caveats
     caveats << elisp_caveats
     caveats.compact.join("\n")
   end
@@ -167,16 +166,6 @@ class Caveats
       s += instructions
     end
     s
-  end
-
-  def app_caveats
-    return unless keg
-    return unless keg.app_installed?
-
-    <<-EOS.undent
-      .app bundles were installed.
-      Run `brew linkapps #{keg.name}` to symlink these to /Applications.
-    EOS
   end
 
   def elisp_caveats

--- a/Library/Homebrew/cmd/linkapps.rb
+++ b/Library/Homebrew/cmd/linkapps.rb
@@ -1,6 +1,11 @@
 #:  * `linkapps` [`--local`] [<formulae>]:
 #:    Find installed formulae that provide `.app`-style macOS apps and symlink them
-#:    into `/Applications`, allowing for easier access.
+#:    into `/Applications`, allowing for easier access (deprecated).
+#:
+#:    Unfortunately `brew linkapps` cannot behave nicely with e.g. Spotlight using
+#:    either aliases or symlinks and Homebrew formulae do not build "proper" `.app`
+#:    bundles that can be relocated. Instead, please consider using `brew cask` and
+#:    migrate formulae using `.app`s to casks.
 #:
 #:    If no <formulae> are provided, all of them will have their apps symlinked.
 #:
@@ -14,6 +19,15 @@ module Homebrew
   module_function
 
   def linkapps
+    opoo <<-EOS.undent
+      `brew linkapps` has been deprecated and will eventually be removed!
+
+      Unfortunately `brew linkapps` cannot behave nicely with e.g. Spotlight using
+      either aliases or symlinks and Homebrew formulae do not build "proper" `.app`
+      bundles that can be relocated. Instead, please consider using `brew cask` and
+      migrate formulae using `.app`s to casks.
+    EOS
+
     target_dir = linkapps_target(local: ARGV.include?("--local"))
 
     unless target_dir.directory?

--- a/Library/Homebrew/cmd/unlinkapps.rb
+++ b/Library/Homebrew/cmd/unlinkapps.rb
@@ -1,5 +1,10 @@
 #:  * `unlinkapps` [`--local`] [`--dry-run`] [<formulae>]:
-#:    Remove symlinks created by `brew linkapps` from `/Applications`.
+#:    Remove symlinks created by `brew linkapps` from `/Applications` (deprecated).
+#:
+#:    Unfortunately `brew linkapps` cannot behave nicely with e.g. Spotlight using
+#:    either aliases or symlinks and Homebrew formulae do not build "proper" `.app`
+#:    bundles that can be relocated. Instead, please consider using `brew cask` and
+#:    migrate formulae using `.app`s to casks.
 #:
 #:    If no <formulae> are provided, all linked apps will be removed.
 #:
@@ -15,6 +20,12 @@ module Homebrew
   module_function
 
   def unlinkapps
+    opoo <<-EOS.undent
+      `brew unlinkapps` has been deprecated and will eventually be removed!
+
+      Unfortunately `brew linkapps` cannot behave nicely with e.g. Spotlight using either aliases or symlinks and Homebrew formulae do not build "proper" `.app` bundles that can be relocated. Instead, please consider using `brew cask` and migrate formulae using `.app`s to casks.
+    EOS
+
     target_dir = linkapps_target(local: ARGV.include?("--local"))
 
     unlinkapps_from_dir(target_dir, dry_run: ARGV.dry_run?)

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -367,10 +367,6 @@ class Keg
     Pathname.glob("#{app_prefix}/{,libexec/}*.app")
   end
 
-  def app_installed?
-    !apps.empty?
-  end
-
   def elisp_installed?
     return false unless (path/"share/emacs/site-lisp"/name).exist?
     (path/"share/emacs/site-lisp"/name).children.any? { |f| %w[.el .elc].include? f.extname }

--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -223,7 +223,12 @@ actually link or delete any files.</p>
 
 <p>If <code>--force</code> is passed, Homebrew will allow keg-only formulae to be linked.</p></dd>
 <dt><code>linkapps</code> [<code>--local</code>] [<var>formulae</var>]</dt><dd><p>Find installed formulae that provide <code>.app</code>-style macOS apps and symlink them
-into <code>/Applications</code>, allowing for easier access.</p>
+into <code>/Applications</code>, allowing for easier access (deprecated).</p>
+
+<p>Unfortunately <code>brew linkapps</code> cannot behave nicely with e.g. Spotlight using
+either aliases or symlinks and Homebrew formulae do not build "proper" <code>.app</code>
+bundles that can be relocated. Instead, please consider using <code>brew cask</code> and
+migrate formulae using <code>.app</code>s to casks.</p>
 
 <p>If no <var>formulae</var> are provided, all of them will have their apps symlinked.</p>
 
@@ -369,7 +374,12 @@ for temporarily disabling a formula:
 
 <p>If <code>--dry-run</code> or <code>-n</code> is passed, Homebrew will list all files which would
 be unlinked, but will not actually unlink or delete any files.</p></dd>
-<dt><code>unlinkapps</code> [<code>--local</code>] [<code>--dry-run</code>] [<var>formulae</var>]</dt><dd><p>Remove symlinks created by <code>brew linkapps</code> from <code>/Applications</code>.</p>
+<dt><code>unlinkapps</code> [<code>--local</code>] [<code>--dry-run</code>] [<var>formulae</var>]</dt><dd><p>Remove symlinks created by <code>brew linkapps</code> from <code>/Applications</code> (deprecated).</p>
+
+<p>Unfortunately <code>brew linkapps</code> cannot behave nicely with e.g. Spotlight using
+either aliases or symlinks and Homebrew formulae do not build "proper" <code>.app</code>
+bundles that can be relocated. Instead, please consider using <code>brew cask</code> and
+migrate formulae using <code>.app</code>s to casks.</p>
 
 <p>If no <var>formulae</var> are provided, all linked apps will be removed.</p>
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -294,7 +294,10 @@ If \fB\-\-force\fR is passed, Homebrew will allow keg\-only formulae to be linke
 .
 .TP
 \fBlinkapps\fR [\fB\-\-local\fR] [\fIformulae\fR]
-Find installed formulae that provide \fB\.app\fR\-style macOS apps and symlink them into \fB/Applications\fR, allowing for easier access\.
+Find installed formulae that provide \fB\.app\fR\-style macOS apps and symlink them into \fB/Applications\fR, allowing for easier access (deprecated)\.
+.
+.IP
+Unfortunately \fBbrew linkapps\fR cannot behave nicely with e\.g\. Spotlight using either aliases or symlinks and Homebrew formulae do not build "proper" \fB\.app\fR bundles that can be relocated\. Instead, please consider using \fBbrew cask\fR and migrate formulae using \fB\.app\fRs to casks\.
 .
 .IP
 If no \fIformulae\fR are provided, all of them will have their apps symlinked\.
@@ -508,7 +511,10 @@ If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which
 .
 .TP
 \fBunlinkapps\fR [\fB\-\-local\fR] [\fB\-\-dry\-run\fR] [\fIformulae\fR]
-Remove symlinks created by \fBbrew linkapps\fR from \fB/Applications\fR\.
+Remove symlinks created by \fBbrew linkapps\fR from \fB/Applications\fR (deprecated)\.
+.
+.IP
+Unfortunately \fBbrew linkapps\fR cannot behave nicely with e\.g\. Spotlight using either aliases or symlinks and Homebrew formulae do not build "proper" \fB\.app\fR bundles that can be relocated\. Instead, please consider using \fBbrew cask\fR and migrate formulae using \fB\.app\fRs to casks\.
 .
 .IP
 If no \fIformulae\fR are provided, all linked apps will be removed\.


### PR DESCRIPTION
Unfortunately `brew linkapps` cannot behave nicely with e.g. Spotlight using either aliases or symlinks and Homebrew formulae do not build "proper" `.app` bundles that can be relocated. Instead, please consider using `brew cask` and migrate formulae using `.app`s to casks.

CC @ilovezfs as we've talked about this before.