### PR TITLE
formula: return runtime_dependencies in to_hash.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1618,6 +1618,7 @@ class Formula
         "used_options" => tab.used_options.as_flags,
         "built_as_bottle" => tab.built_as_bottle,
         "poured_from_bottle" => tab.poured_from_bottle,
+        "runtime_dependencies" => tab.runtime_dependencies,
       }
     end
 


### PR DESCRIPTION
Which, in turn, provides it for `brew info --json=v1` so other tools such as e.g. `brew bundle` can make use of this information.

CC @alyssais in case you have thoughts.