### PR TITLE
xcode, xquartz: use default location when possible.

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -3,6 +3,7 @@ module OS
     module Xcode
       module_function
 
+      DEFAULT_BUNDLE_PATH = Pathname.new("/Applications/Xcode.app").freeze
       BUNDLE_ID = "com.apple.dt.Xcode".freeze
       OLD_BUNDLE_ID = "com.apple.Xcode".freeze
 
@@ -67,11 +68,14 @@ module OS
         Pathname.new("#{prefix}/Toolchains/XcodeDefault.xctoolchain")
       end
 
-      # Ask Spotlight where Xcode is. If the user didn't install the
-      # helper tools and installed Xcode in a non-conventional place, this
-      # is our only option. See: https://superuser.com/questions/390757
       def bundle_path
-        MacOS.app_with_bundle_id(V4_BUNDLE_ID, V3_BUNDLE_ID)
+        # Use the default location if it exists.
+        return DEFAULT_BUNDLE_PATH if DEFAULT_BUNDLE_PATH.exist?
+
+        # Ask Spotlight where Xcode is. If the user didn't install the
+        # helper tools and installed Xcode in a non-conventional place, this
+        # is our only option. See: https://superuser.com/questions/390757
+        MacOS.app_with_bundle_id(BUNDLE_ID, OLD_BUNDLE_ID)
       end
 
       def installed?

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -3,8 +3,8 @@ module OS
     module Xcode
       module_function
 
-      V4_BUNDLE_ID = "com.apple.dt.Xcode".freeze
-      V3_BUNDLE_ID = "com.apple.Xcode".freeze
+      BUNDLE_ID = "com.apple.dt.Xcode".freeze
+      OLD_BUNDLE_ID = "com.apple.Xcode".freeze
 
       def latest_version
         case MacOS.version
@@ -51,9 +51,9 @@ module OS
           begin
             dir = MacOS.active_developer_dir
 
-            if dir.empty? || dir == CLT::MAVERICKS_PKG_PATH || !File.directory?(dir)
+            if dir.empty? || dir == CLT::PKG_PATH || !File.directory?(dir)
               path = bundle_path
-              path.join("Contents", "Developer") if path
+              path/"Contents/Developer" if path
             else
               # Use cleanpath to avoid pathological trailing slash
               Pathname.new(dir).cleanpath
@@ -182,7 +182,7 @@ module OS
       FROM_XCODE_PKG_ID = "com.apple.pkg.DeveloperToolsCLI".freeze
       MAVERICKS_PKG_ID = "com.apple.pkg.CLTools_Executables".freeze
       MAVERICKS_NEW_PKG_ID = "com.apple.pkg.CLTools_Base".freeze # obsolete
-      MAVERICKS_PKG_PATH = "/Library/Developer/CommandLineTools".freeze
+      PKG_PATH = "/Library/Developer/CommandLineTools".freeze
 
       # Returns true even if outdated tools are installed, e.g.
       # tools from Xcode 4.x on 10.9
@@ -237,7 +237,7 @@ module OS
         return false if MacOS.version < :lion
 
         if MacOS.version >= :mavericks
-          version = Utils.popen_read("#{MAVERICKS_PKG_PATH}/usr/bin/clang --version")
+          version = Utils.popen_read("#{PKG_PATH}/usr/bin/clang --version")
         else
           version = Utils.popen_read("/usr/bin/clang --version")
         end
@@ -261,7 +261,7 @@ module OS
 
         [MAVERICKS_PKG_ID, MAVERICKS_NEW_PKG_ID, STANDALONE_PKG_ID, FROM_XCODE_PKG_ID].find do |id|
           if MacOS.version >= :mavericks
-            next unless File.exist?("#{MAVERICKS_PKG_PATH}/usr/bin/clang")
+            next unless File.exist?("#{PKG_PATH}/usr/bin/clang")
           end
           version = MacOS.pkgutil_info(id)[/version: (.+)$/, 1]
           return version if version

--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -5,6 +5,8 @@ module OS
     module XQuartz
       module_function
 
+      # TODO: confirm this path when you have internet
+      DEFAULT_BUNDLE_PATH = Pathname.new("Applications/Utilities/XQuartz.app").freeze
       FORGE_BUNDLE_ID = "org.macosforge.xquartz.X11".freeze
       APPLE_BUNDLE_ID = "org.x.X11".freeze
       FORGE_PKG_ID = "org.macosforge.xquartz.pkg".freeze
@@ -56,6 +58,11 @@ module OS
       end
 
       def bundle_path
+        # Use the default location if it exists.
+        return DEFAULT_BUNDLE_PATH if DEFAULT_BUNDLE_PATH.exist?
+
+        # Ask Spotlight where XQuartz is. If the user didn't install XQuartz
+        # in the conventional place, this is our only option.
         MacOS.app_with_bundle_id(FORGE_BUNDLE_ID, APPLE_BUNDLE_ID)
       end
 


### PR DESCRIPTION
Xcode and XQuartz can be installed anywhere but for most people they are in their default locations so just look there before looking at Spotlight which can return weird results on e.g. backup disks.

Fixes #1587.