### PR TITLE
InreplaceError: fix undefined method crash

### DIFF
--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -1,9 +1,10 @@
 module Utils
   class InreplaceError < RuntimeError
     def initialize(errors)
-      super errors.inject("inreplace failed\n") do |s, (path, errs)|
+      formatted_errors = errors.inject("inreplace failed\n") do |s, (path, errs)|
         s << "#{path}:\n" << errs.map { |e| "  #{e}\n" }.join
       end
+      super formatted_errors
     end
   end
 


### PR DESCRIPTION
When the first parameter to inreplace was an array, and the replacement
failed, InreplaceError would end up crashing with an undefined method
exception because the order of operations resulted in super not being
passed the value of the entire inject block.

Fixes https://github.com/Homebrew/homebrew-core/issues/8754.