### PR TITLE
formula_installer: set specified_path on pour.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -808,6 +808,7 @@ class FormulaInstaller
     tab.poured_from_bottle = true
     tab.time = Time.now.to_i
     tab.head = HOMEBREW_REPOSITORY.git_head
+    tab.source["path"] = formula.specified_path.to_s
     tab.write
   end
 


### PR DESCRIPTION
This means that a `brew install $ALIAS` records the path accordingly so e.g. `Formula#full_installed_specified_name` returns the correct path.

CC @alyssais for thoughts.