### PR TITLE
audit: check for version aliases.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -295,6 +295,27 @@ class FormulaAuditor
 
     problem "File should end with a newline" unless text.trailing_newline?
 
+    versioned_formulae = Dir[formula.path.to_s.gsub(/\.rb$/, "@*.rb")]
+    needs_versioned_alias = !versioned_formulae.empty? &&
+                            formula.tap &&
+                            formula.aliases.grep(/.@\d/).empty?
+    if needs_versioned_alias
+      _, last_alias_version = File.basename(versioned_formulae.sort.reverse.first)
+                                  .gsub(/\.rb$/, "")
+                                  .split("@")
+      major, minor, = formula.version.to_s.split(".")
+      alias_name = if last_alias_version.split(".").length == 1
+        "#{formula.name}@#{major}"
+      else
+        "#{formula.name}@#{major}.#{minor}"
+      end
+      problem <<-EOS.undent
+        Formula has other versions so create an alias:
+          cd #{formula.tap.alias_dir}
+          ln -s #{formula.path.to_s.gsub(formula.tap.path, "..")} #{alias_name}
+      EOS
+    end
+
     return unless @strict
 
     present = audit_components
@@ -410,7 +431,8 @@ class FormulaAuditor
           problem "Dependency '#{dep.name}' was renamed; use new name '#{dep_f.name}'."
         end
 
-        if @@aliases.include?(dep.name)
+        if @@aliases.include?(dep.name) &&
+           (core_formula? || !dep_f.versioned_formula?)
           problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
         end
 

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -24,16 +24,15 @@ module Readall
       !failed
     end
 
-    def valid_aliases?(alias_dirs)
+    def valid_aliases?(alias_dir, formula_dir)
+      return false unless alias_dir.directory?
+
       failed = false
-      alias_dirs.each do |alias_dir|
-        next unless alias_dir.directory?
-        alias_dir.children.each do |f|
-          next unless f.symlink?
-          next if f.file?
-          onoe "Broken alias: #{f}"
-          failed = true
-        end
+      alias_dir.each_child do |f|
+        next unless f.symlink?
+        next if f.file? && !(formula_dir/"#{f.basename}.rb").exist?
+        onoe "Broken alias: #{f}"
+        failed = true
       end
       !failed
     end
@@ -57,7 +56,7 @@ module Readall
     def valid_tap?(tap, options = {})
       failed = false
       if options[:aliases]
-        valid_aliases = valid_aliases?([tap.alias_dir])
+        valid_aliases = valid_aliases?(tap.alias_dir, tap.formula_dir)
         failed = true unless valid_aliases
       end
       valid_formulae = valid_formulae?(tap.formula_files)


### PR DESCRIPTION
Current version aliases should be provided for versioned formulae so people can `brew install foo@1.2` to provide pin-like behaviour.

If agreed, I'll add these for Homebrew/core before this is merged.