### PR TITLE
Revert "formula_installer: set specified_path on pour."

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -808,7 +808,6 @@ class FormulaInstaller
     tab.poured_from_bottle = true
     tab.time = Time.now.to_i
     tab.head = HOMEBREW_REPOSITORY.git_head
-    tab.source["path"] = formula.specified_path.to_s
     tab.write
   end
 


### PR DESCRIPTION
Reverts Homebrew/brew#1847

I'm not sure this was such a good idea. I think we'll want to be able to unalias things in the future but this will have the consequence of making aliases permanent, which doesn't really make sense.