### PR TITLE
Add requirements class for gfortran

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -127,6 +127,7 @@ class DependencyCollector
     when :tuntap     then TuntapRequirement.new(tags)
     when :ant        then ant_dep(tags)
     when :emacs      then EmacsRequirement.new(tags)
+    when :gfortran   then GfortranRequirement.new(tags)
     # Tiger's ld is too old to properly link some software
     when :ld64       then LD64Dependency.new if MacOS.version < :leopard
     # Tiger doesn't ship expat in /usr/lib

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -14,6 +14,7 @@ require "requirements/tuntap_requirement"
 require "requirements/unsigned_kext_requirement"
 require "requirements/x11_requirement"
 require "requirements/emacs_requirement"
+require "requirements/gfortran_requirement"
 
 class XcodeRequirement < Requirement
   fatal true

--- a/Library/Homebrew/requirements/gfortran_requirement.rb
+++ b/Library/Homebrew/requirements/gfortran_requirement.rb
@@ -1,0 +1,33 @@
+class GfortranRequirement < Requirement
+  fatal true
+  default_formula "gcc"
+
+  satisfy build_env: false do
+    next false unless which "gfortran"
+    next true unless @version
+    gfortran_version = Utils.popen_read("gfortran", "--version").split("\n").first.split(" ").last.chomp
+    Version.create(gfortran_version) >= Version.create(@version)
+  end
+
+  env do
+    ENV.prepend_path "PATH", which("gfortran").dirname
+    ENV["FC"] = "gfortran"
+  end
+
+  def initialize(tags)
+    @version = tags.shift if /(\d\.)+\d/ =~ tags.first
+    super
+  end
+
+  def message
+    version_string = " #{@version}" if @version
+
+    s = "GFortran #{version_string} or later is required to install this formula."
+    s += super
+    s
+  end
+
+  def inspect
+    "#<#{self.class.name}: #{name.inspect} #{tags.inspect} version=#{@version.inspect}>"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

[OpenCoarrays](https://github.com/Homebrew/homebrew-core/pull/8790) provides an implementation of Coarray Fortran compatible with GFortran. It is the official multi-image implementation, and as such has a somewhat tight coupling with GFortran through it's internal API/ABI. This is an attempt at providing formulae with a means of verifying that the fortran compiler is GFortran and that it's version matches or exceeds that required by the formula. However I am a complete blundering fool in Ruby, and therefore I may not have implemented this correctly (testing would suggest this to be the case). I am merely hoping that some kind soul, homebrew maintainer or contributor or otherwise, will take a look at what I have so far and point me in the right direction. The goal is to be able to specify `depends_on :gfortran => "5.4+"` in a formula...

- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

Nope, and I have no idea how to write an effective test for these changes!

- [x] Have you successfully run `brew tests` with your changes locally?

Yes and it's still running... it seems to take quite a while.

-----