### PR TITLE
integration_command_test_case: improve fail output

### DIFF
--- a/Library/Homebrew/test/support/helper/integration_command_test_case.rb
+++ b/Library/Homebrew/test/support/helper/integration_command_test_case.rb
@@ -106,16 +106,20 @@ class IntegrationCommandTestCase < Homebrew::TestCase
   def cmd(*args)
     output = cmd_output(*args)
     status = $?.exitstatus
-    puts "\n'brew #{args.join " "}' output: #{output}" if status.nonzero?
-    assert_equal 0, status
+    assert_equal 0, status, <<-EOS.undent
+      `brew #{args.join " "}` exited with non-zero status!
+      #{output}
+    EOS
     output
   end
 
   def cmd_fail(*args)
     output = cmd_output(*args)
     status = $?.exitstatus
-    $stderr.puts "\n'brew #{args.join " "}'" if status.zero?
-    refute_equal 0, status
+    refute_equal 0, status, <<-EOS.undent
+      `brew #{args.join " "}` exited with zero status!
+      #{output}
+    EOS
     output
   end
 


### PR DESCRIPTION
Instead of `puts`ing when the failure occurs save it until the error message and print a prose description of what the failure was and the output from the command.
This makes the output from failing tests significantly easier to read.

Another thing I'd like to investigate but currently causes a bunch of failures is using `--debug` by default for all the integration test commands so they include a backtrace for exceptions.