### PR TITLE
Custom Cops for `brew audit`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -6,10 +6,9 @@ AllCops:
     - '**/Casks/**/*'
     - '**/vendor/**/*'
 
-require:
-  - ./Homebrew/rubocops/bottle_block_cop.rb
+require: ./Homebrew/rubocops.rb
 
-CustomCops/CorrectBottleBlock:
+Homebrew/CorrectBottleBlock:
   Enabled: true
 
 Metrics/AbcSize:
@@ -47,7 +46,7 @@ Lint/AssignmentInCondition:
   Enabled: false
 
 Lint/EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false
@@ -69,7 +68,7 @@ Style/BlockDelimiters:
   EnforcedStyle: line_count_based
 
 Style/CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -6,6 +6,12 @@ AllCops:
     - '**/Casks/**/*'
     - '**/vendor/**/*'
 
+require:
+  - ./Homebrew/rubocops/bottle_block_cop.rb
+
+CustomCops/CorrectBottleBlock:
+  Enabled: true
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1,11 +1,14 @@
-#:  * `audit` [`--strict`] [`--online`] [`--new-formula`] [`--display-cop-names`] [`--display-filename`] [<formulae>]:
+#:  * `audit` [`--strict`] [`--fix`] [`--online`] [`--new-formula`] [`--display-cop-names`] [`--display-filename`] [<formulae>]:
 #:    Check <formulae> for Homebrew coding style violations. This should be
 #:    run before submitting a new formula.
 #:
 #:    If no <formulae> are provided, all of them are checked.
 #:
 #:    If `--strict` is passed, additional checks are run, including RuboCop
-#:    style checks.
+#:    style checks and custom cop checks.
+#:
+#:    If `--fix` is passed, style violations and custom cop violations will be
+#:    automatically fixed using RuboCop's `--auto-correct` feature.
 #:
 #:    If `--online` is passed, additional slower checks that require a network
 #:    connection are run.
@@ -62,8 +65,9 @@ module Homebrew
     end
 
     if strict
+      options = { fix: ARGV.flag?("--fix"), realpath: true }
       # Check style in a single batch run up front for performance
-      style_results = check_style_json(files, realpath: true)
+      style_results = check_style_json(files, options)
     end
 
     ff.each do |f|

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -5,9 +5,9 @@
 #:    If no <formulae> are provided, all of them are checked.
 #:
 #:    If `--strict` is passed, additional checks are run, including RuboCop
-#:    style checks and custom cop checks.
+#:    style checks.
 #:
-#:    If `--fix` is passed, style violations and custom cop violations will be
+#:    If `--fix` is passed, style violations will be
 #:    automatically fixed using RuboCop's `--auto-correct` feature.
 #:
 #:    If `--online` is passed, additional slower checks that require a network

--- a/Library/Homebrew/rubocops.rb
+++ b/Library/Homebrew/rubocops.rb
@@ -1,0 +1,1 @@
+require_relative "./rubocops/bottle_block_cop"

--- a/Library/Homebrew/rubocops/bottle_block_cop.rb
+++ b/Library/Homebrew/rubocops/bottle_block_cop.rb
@@ -1,0 +1,54 @@
+module RuboCop
+  module Cop
+   module CustomCops 
+      class CorrectBottleBlock < Cop
+        MSG = 'Use rebuild instead of revision in bottle block'.freeze
+
+        def on_block(node)
+          return if block_length(node).zero?
+          method, _args, _body = *node
+
+          keyword, method_name = *method
+
+          if method_name.equal?(:bottle) and has_revision?(_body)
+            add_offense(node, :expression)
+          end
+        end
+
+        private
+
+        def autocorrect(node)
+          ->(corrector) do
+            # Check for revision
+            method, _args, _body = *node
+            if has_revision?(_body)
+              replace_revision(corrector, node)
+            end
+          end
+        end
+
+        def has_revision?(body)
+          body.children.each do |method_call_node|
+            _receiver, _method_name, *args = *method_call_node
+            if _method_name == :revision
+              return true
+            end
+          end
+          false
+        end
+
+        def replace_revision(corrector, node)
+          new_source = String.new
+          node.source.each_line do |line|
+            if line =~ /\A\s*revision/
+              line = line.sub('revision','rebuild')
+            end
+            new_source << line
+          end
+          corrector.insert_before(node.source_range, new_source)
+          corrector.remove(node.source_range)
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/rubocops/bottle_block_cop.rb
+++ b/Library/Homebrew/rubocops/bottle_block_cop.rb
@@ -1,6 +1,6 @@
 module RuboCop
   module Cop
-    module CustomCops
+    module Homebrew
       class CorrectBottleBlock < Cop
         MSG = "Use rebuild instead of revision in bottle block".freeze
 

--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -453,13 +453,16 @@ the <code>prefix</code> and <code>repository</code> are the same directory.</p><
 <h2 id="DEVELOPER-COMMANDS">DEVELOPER COMMANDS</h2>
 
 <dl>
-<dt><code>audit</code> [<code>--strict</code>] [<code>--online</code>] [<code>--new-formula</code>] [<code>--display-cop-names</code>] [<code>--display-filename</code>] [<var>formulae</var>]</dt><dd><p>Check <var>formulae</var> for Homebrew coding style violations. This should be
+<dt><code>audit</code> [<code>--strict</code>] [<code>--fix</code>] [<code>--online</code>] [<code>--new-formula</code>] [<code>--display-cop-names</code>] [<code>--display-filename</code>] [<var>formulae</var>]</dt><dd><p>Check <var>formulae</var> for Homebrew coding style violations. This should be
 run before submitting a new formula.</p>
 
 <p>If no <var>formulae</var> are provided, all of them are checked.</p>
 
 <p>If <code>--strict</code> is passed, additional checks are run, including RuboCop
 style checks.</p>
+
+<p>If <code>--fix</code> is passed, style violations will be
+automatically fixed using RuboCop's <code>--auto-correct</code> feature.</p>
 
 <p>If <code>--online</code> is passed, additional slower checks that require a network
 connection are run.</p>

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "January 2017" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "February 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "January 2017" "Homebrew" "brew"
+.TH "BREW" "1" "February 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -625,7 +625,7 @@ Print the version number of Homebrew to standard output and exit\.
 .SH "DEVELOPER COMMANDS"
 .
 .TP
-\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-online\fR] [\fB\-\-new\-formula\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-display\-filename\fR] [\fIformulae\fR]
+\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-fix\fR] [\fB\-\-online\fR] [\fB\-\-new\-formula\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-display\-filename\fR] [\fIformulae\fR]
 Check \fIformulae\fR for Homebrew coding style violations\. This should be run before submitting a new formula\.
 .
 .IP
@@ -633,6 +633,9 @@ If no \fIformulae\fR are provided, all of them are checked\.
 .
 .IP
 If \fB\-\-strict\fR is passed, additional checks are run, including RuboCop style checks\.
+.
+.IP
+If \fB\-\-fix\fR is passed, style violations will be automatically fixed using RuboCop\'s \fB\-\-auto\-correct\fR feature\.
 .
 .IP
 If \fB\-\-online\fR is passed, additional slower checks that require a network connection are run\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR implements Custom Cops for a simple rule in `brew audit` command as discussed in #569 

>  `revision` in a `bottle do` block should be renamed to `rebuild` and Rubocop should autocorrect it to `rebuild`

More rules can be added/migrated as cops, and RuboCop can be leveraged to check for style violations instead of regular expressions as being done currently when `brew audit` is ran.

Using `--strict` would check for CustomCop/style violations.
The newly added `--fix` option would automatically correct the source code if any CustomCop/style violations are found.