### PR TITLE
cask: remove newlines when auditing appcast checkpoint

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/audit.rb
+++ b/Library/Homebrew/cask/lib/hbc/audit.rb
@@ -135,7 +135,7 @@ module Hbc
       odebug "Verifying appcast checkpoint is accurate"
       result = @command.run("/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", URL::FAKE_USER_AGENT, cask.appcast], print_stderr: false)
       if result.success?
-        processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}, "")
+        processed_appcast_text = result.stdout.gsub("\n", "").gsub(%r{<pubDate>[^<]*</pubDate>}, "")
         # This step is necessary to replicate running `sed` from the command line
         processed_appcast_text << "\n" unless processed_appcast_text.end_with?("\n")
         expected = cask.appcast.checkpoint


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Companion to caskroom/homebrew-cask#28966.

If we do it with `gsub("\n", "")` (this PR), we get a style error but every other test passes. If we do it with `delete("\n")`, the style test passes but [others do not](https://travis-ci.org/Homebrew/brew/jobs/192445191), and I need help fixing those. Unsure what to do.