### PR TITLE
Simplify Keg class

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -174,6 +174,12 @@ class Keg
   attr_reader :path, :name, :linked_keg_record, :opt_record
   protected :path
 
+  extend Forwardable
+
+  def_delegators :path,
+    :to_s, :hash, :abv, :disk_usage, :file_count, :directory?, :exist?, :/,
+    :join, :rename, :find
+
   def initialize(path)
     path = path.resolved_path if path.to_s.start_with?("#{HOMEBREW_PREFIX}/opt/")
     raise "#{path} is not a valid keg" unless path.parent.parent.realpath == HOMEBREW_CELLAR.realpath
@@ -182,10 +188,6 @@ class Keg
     @name = path.parent.basename.to_s
     @linked_keg_record = HOMEBREW_LINKED_KEGS/name
     @opt_record = HOMEBREW_PREFIX/"opt/#{name}"
-  end
-
-  def to_s
-    path.to_s
   end
 
   def rack
@@ -203,30 +205,6 @@ class Keg
   end
   alias eql? ==
 
-  def hash
-    path.hash
-  end
-
-  def abv
-    path.abv
-  end
-
-  def disk_usage
-    path.disk_usage
-  end
-
-  def file_count
-    path.file_count
-  end
-
-  def directory?
-    path.directory?
-  end
-
-  def exist?
-    path.exist?
-  end
-
   def empty_installation?
     Pathname.glob("#{path}/**/*") do |file|
       next if file.directory?
@@ -237,18 +215,6 @@ class Keg
     end
 
     true
-  end
-
-  def /(other)
-    path / other
-  end
-
-  def join(*args)
-    path.join(*args)
-  end
-
-  def rename(*args)
-    path.rename(*args)
   end
 
   def linked?
@@ -394,10 +360,6 @@ class Keg
         end
       end
     end
-  end
-
-  def find(*args, &block)
-    path.find(*args, &block)
   end
 
   def oldname_opt_record

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -192,11 +192,7 @@ class Keg
     path.parent
   end
 
-  if Pathname.method_defined?(:to_path)
-    alias to_path to_s
-  else
-    alias to_str to_s
-  end
+  alias to_path to_s
 
   def inspect
     "#<#{self.class.name}:#{path}>"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `Keg` class is pretty complex. It's scattered with repetitive method definitions that just forward to `path`. These are a couple of straightforward changes to make it a bit less difficult to navigate and, well… long.

As far as I can tell, the conditional aliasing of `to_path` is a remnant of Ruby 1.8.

I had a one-off test failure [here](https://github.com/Homebrew/brew/blob/f0249643d47f1dee4a0d08c440eb3afd6da3558a/Library/Homebrew/test/formula_installer_test.rb#L23) as part of [this test](https://github.com/Homebrew/brew/blob/f0249643d47f1dee4a0d08c440eb3afd6da3558a/Library/Homebrew/test/formula_installer_test.rb#L82), but it seems unlikely to be related and I haven't been able to reproduce since…