### PR TITLE
tests: add a missing Tab cache clear

### DIFF
--- a/Library/Homebrew/test/formula_installer_test.rb
+++ b/Library/Homebrew/test/formula_installer_test.rb
@@ -61,6 +61,8 @@ class InstallTests < Homebrew::TestCase
       assert_equal 3, bin.children.length
       assert_predicate f.prefix/".brew/testball.rb", :readable?
     end
+  ensure
+    ARGV.reject! { |a| a == "--with-invalid_flag" }
   end
 
   def test_bottle_unneeded_formula_install

--- a/Library/Homebrew/test/formulary_test.rb
+++ b/Library/Homebrew/test/formulary_test.rb
@@ -110,6 +110,7 @@ class FormularyFactoryTest < Homebrew::TestCase
     keg.uninstall
     formula.clear_cache
     formula.bottle.clear_cache
+    Tab.clear_cache
   end
 
   def test_load_from_contents


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This was responsible for the sporadic failures I encountered in #1878.

It feels like constant whack-a-mole with these caches causing order-dependent test failures, and it's a hugely complicated process to reproduce, isolate and fix them (this one took me the better part of a day). We should try to implement some means of checking after each test to ensure they're not accidentally leaving behind persistent state.