### PR TITLE
Allow overriding `MacOS.version`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -142,6 +142,10 @@ module Hbc
     end
 
     def self.process(arguments)
+      unless ENV["MACOS_VERSION"].nil?
+        MacOS.full_version = ENV["MACOS_VERSION"]
+      end
+
       command_string, *rest = *arguments
       rest = process_options(rest)
       command = Hbc.help ? "help" : lookup_command(command_string)

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -27,6 +27,11 @@ module OS
       @full_version ||= Version.new((ENV["HOMEBREW_MACOS_VERSION"] || ENV["HOMEBREW_OSX_VERSION"]).chomp)
     end
 
+    def full_version=(version)
+      @full_version = Version.new(version.chomp)
+      @version = nil
+    end
+
     def prerelease?
       # TODO: bump version when new OS is released
       version >= "10.13"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Bringing back `MACOS_RELEASE` doesn't make sense, since we already deprecated `MacOS.release`. So should we add a new variable `MACOS_VERSION` or only allow overriding `HOMEBREW_MACOS_VERSION`, or both?

---

Fixes https://github.com/caskroom/homebrew-cask/issues/28843.