### PR TITLE
Remove some remnants of Ruby 1.8.7 support

### DIFF
--- a/Library/Homebrew/emoji.rb
+++ b/Library/Homebrew/emoji.rb
@@ -1,17 +1,7 @@
 module Emoji
   class << self
-    def tick
-      # necessary for 1.8.7 unicode handling since many installs are on 1.8.7
-      @tick ||= ["2714".hex].pack("U*")
-    end
-
-    def cross
-      # necessary for 1.8.7 unicode handling since many installs are on 1.8.7
-      @cross ||= ["2718".hex].pack("U*")
-    end
-
     def install_badge
-      ENV["HOMEBREW_INSTALL_BADGE"] || "\xf0\x9f\x8d\xba"
+      ENV["HOMEBREW_INSTALL_BADGE"] || "🍺"
     end
 
     def enabled?

--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -3,7 +3,7 @@ require "tmpdir"
 require "etc"
 
 # Homebrew extends Ruby's `FileUtils` to make our code more readable.
-# @see http://ruby-doc.org/stdlib-1.8.7/libdoc/fileutils/rdoc/FileUtils.html Ruby's FileUtils API
+# @see http://ruby-doc.org/stdlib-2.0.0/libdoc/fileutils/rdoc/FileUtils.html Ruby's FileUtils API
 module FileUtils
   # Create a temporary directory then yield. When the block returns,
   # recursively delete the temporary directory. Passing opts[:retain]

--- a/Library/Homebrew/test/emoji_test.rb
+++ b/Library/Homebrew/test/emoji_test.rb
@@ -1,0 +1,11 @@
+require "testing_env"
+require "emoji"
+
+class EmojiTest < Homebrew::TestCase
+  def test_install_badge
+    assert_equal "🍺", Emoji.install_badge
+
+    ENV["HOMEBREW_INSTALL_BADGE"] = "foo"
+    assert_equal "foo", Emoji.install_badge
+  end
+end

--- a/Library/Homebrew/test/utils_test.rb
+++ b/Library/Homebrew/test/utils_test.rb
@@ -9,13 +9,9 @@ class UtilTests < Homebrew::TestCase
     @dir = Pathname.new(mktmpdir)
   end
 
-  # Helper for matching escape sequences.
-  def e(code)
+  def esc(code)
     /(\e\[\d+m)*\e\[#{code}m/
   end
-
-  # Helper for matching that style is reset at the end of a string.
-  Z = /(\e\[\d+m)*\e\[0m\Z/
 
   def test_ofail
     shutup { ofail "foo" }
@@ -32,10 +28,12 @@ class UtilTests < Homebrew::TestCase
   def test_pretty_installed
     $stdout.stubs(:tty?).returns true
     ENV.delete("HOMEBREW_NO_EMOJI")
-    assert_match(/\A#{e 1}foo #{e 32}✔#{Z}/, pretty_installed("foo"))
+    tty_with_emoji_output = /\A#{esc 1}foo #{esc 32}✔#{esc 0}\Z/
+    assert_match tty_with_emoji_output, pretty_installed("foo")
 
     ENV["HOMEBREW_NO_EMOJI"] = "1"
-    assert_match(/\A#{e 1}foo \(installed\)#{Z}/, pretty_installed("foo"))
+    tty_no_emoji_output = /\A#{esc 1}foo \(installed\)#{esc 0}\Z/
+    assert_match tty_no_emoji_output, pretty_installed("foo")
 
     $stdout.stubs(:tty?).returns false
     assert_equal "foo", pretty_installed("foo")
@@ -44,10 +42,12 @@ class UtilTests < Homebrew::TestCase
   def test_pretty_uninstalled
     $stdout.stubs(:tty?).returns true
     ENV.delete("HOMEBREW_NO_EMOJI")
-    assert_match(/\A#{e 1}foo #{e 31}✘#{Z}/, pretty_uninstalled("foo"))
+    tty_with_emoji_output = /\A#{esc 1}foo #{esc 31}✘#{esc 0}\Z/
+    assert_match tty_with_emoji_output, pretty_uninstalled("foo")
 
     ENV["HOMEBREW_NO_EMOJI"] = "1"
-    assert_match(/\A#{e 1}foo \(uninstalled\)#{Z}/, pretty_uninstalled("foo"))
+    tty_no_emoji_output = /\A#{esc 1}foo \(uninstalled\)#{esc 0}\Z/
+    assert_match tty_no_emoji_output, pretty_uninstalled("foo")
 
     $stdout.stubs(:tty?).returns false
     assert_equal "foo", pretty_uninstalled("foo")

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -106,7 +106,7 @@ def pretty_installed(f)
   if !$stdout.tty?
     f.to_s
   elsif Emoji.enabled?
-    "#{Tty.bold}#{f} #{Formatter.success(Emoji.tick)}#{Tty.reset}"
+    "#{Tty.bold}#{f} #{Formatter.success("✔")}#{Tty.reset}"
   else
     Formatter.success("#{Tty.bold}#{f} (installed)#{Tty.reset}")
   end
@@ -116,7 +116,7 @@ def pretty_uninstalled(f)
   if !$stdout.tty?
     f.to_s
   elsif Emoji.enabled?
-    "#{Tty.bold}#{f} #{Formatter.error(Emoji.cross)}#{Tty.reset}"
+    "#{Tty.bold}#{f} #{Formatter.error("✘")}#{Tty.reset}"
   else
     Formatter.error("#{Tty.bold}#{f} (uninstalled)#{Tty.reset}")
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since the emoji hack is no longer required, and `Emoji.tick` and `.cross` are only called in one place, I just inlined them so there weren't methods on `Emoji` that just return a one-character `String`.