### PR TITLE
tests: enforce `super` in lifecycle hooks

### DIFF
--- a/Library/Homebrew/test/ARGV_test.rb
+++ b/Library/Homebrew/test/ARGV_test.rb
@@ -3,6 +3,7 @@ require "extend/ARGV"
 
 class ArgvExtensionTests < Homebrew::TestCase
   def setup
+    super
     @argv = [].extend(HomebrewArgvExtension)
   end
 

--- a/Library/Homebrew/test/ENV_test.rb
+++ b/Library/Homebrew/test/ENV_test.rb
@@ -31,6 +31,7 @@ end
 
 module SharedEnvTests
   def setup
+    super
     @env = {}.extend(EnvActivation)
   end
 

--- a/Library/Homebrew/test/audit_test.rb
+++ b/Library/Homebrew/test/audit_test.rb
@@ -6,11 +6,13 @@ require "dev-cmd/audit"
 
 class FormulaTextTests < Homebrew::TestCase
   def setup
+    super
     @dir = mktmpdir
   end
 
   def teardown
     FileUtils.rm_rf @dir
+    super
   end
 
   def formula_text(name, body = nil, options = {})
@@ -58,11 +60,13 @@ end
 
 class FormulaAuditorTests < Homebrew::TestCase
   def setup
+    super
     @dir = mktmpdir
   end
 
   def teardown
     FileUtils.rm_rf @dir
+    super
   end
 
   def formula_auditor(name, text, options = {})

--- a/Library/Homebrew/test/bottle_collector_test.rb
+++ b/Library/Homebrew/test/bottle_collector_test.rb
@@ -3,6 +3,7 @@ require "utils/bottles"
 
 class BottleCollectorTests < Homebrew::TestCase
   def setup
+    super
     @collector = Utils::Bottles::Collector.new
   end
 

--- a/Library/Homebrew/test/bottle_hooks_test.rb
+++ b/Library/Homebrew/test/bottle_hooks_test.rb
@@ -17,6 +17,7 @@ class BottleHookTests < Homebrew::TestCase
   end
 
   def setup
+    super
     @fi = FormulaInstaller.new FormulaDouble.new
   end
 
@@ -43,5 +44,6 @@ class BottleHookTests < Homebrew::TestCase
 
   def teardown
     Homebrew::Hooks::Bottles.reset_hooks
+    super
   end
 end

--- a/Library/Homebrew/test/build_environment_test.rb
+++ b/Library/Homebrew/test/build_environment_test.rb
@@ -3,6 +3,7 @@ require "build_environment"
 
 class BuildEnvironmentTests < Homebrew::TestCase
   def setup
+    super
     @env = BuildEnvironment.new
   end
 

--- a/Library/Homebrew/test/build_options_test.rb
+++ b/Library/Homebrew/test/build_options_test.rb
@@ -4,6 +4,7 @@ require "options"
 
 class BuildOptionsTests < Homebrew::TestCase
   def setup
+    super
     args = Options.create(%w[--with-foo --with-bar --without-qux])
     opts = Options.create(%w[--with-foo --with-bar --without-baz --without-qux])
     @build = BuildOptions.new(args, opts)

--- a/Library/Homebrew/test/caveats_test.rb
+++ b/Library/Homebrew/test/caveats_test.rb
@@ -4,6 +4,7 @@ require "caveats"
 
 class CaveatsTests < Homebrew::TestCase
   def setup
+    super
     @f = formula { url "foo-1.0" }
     @c = Caveats.new @f
   end

--- a/Library/Homebrew/test/checksum_verification_test.rb
+++ b/Library/Homebrew/test/checksum_verification_test.rb
@@ -19,6 +19,7 @@ class ChecksumVerificationTests < Homebrew::TestCase
 
   def teardown
     @_f.clear_cache
+    super
   end
 
   def test_good_sha256

--- a/Library/Homebrew/test/cleaner_test.rb
+++ b/Library/Homebrew/test/cleaner_test.rb
@@ -6,12 +6,14 @@ class CleanerTests < Homebrew::TestCase
   include FileUtils
 
   def setup
+    super
     @f = formula("cleaner_test") { url "foo-1.0" }
     @f.prefix.mkpath
   end
 
   def teardown
     @f.rack.rmtree if @f.rack.exist?
+    super
   end
 
   def test_clean_file

--- a/Library/Homebrew/test/cleanup_test.rb
+++ b/Library/Homebrew/test/cleanup_test.rb
@@ -14,6 +14,7 @@ end
 
 class CleanupTests < Homebrew::TestCase
   def setup
+    super
     @ds_store = Pathname.new "#{HOMEBREW_PREFIX}/Library/.DS_Store"
     FileUtils.touch @ds_store
   end
@@ -22,6 +23,7 @@ class CleanupTests < Homebrew::TestCase
     FileUtils.rm_f @ds_store
     ARGV.delete "--dry-run"
     ARGV.delete "--prune=all"
+    super
   end
 
   def test_cleanup

--- a/Library/Homebrew/test/commands_test.rb
+++ b/Library/Homebrew/test/commands_test.rb
@@ -13,6 +13,7 @@ end
 
 class CommandsTests < Homebrew::TestCase
   def setup
+    super
     @cmds = [
       # internal commands
       HOMEBREW_LIBRARY_PATH/"cmd/rbcmd.rb",
@@ -28,6 +29,7 @@ class CommandsTests < Homebrew::TestCase
 
   def teardown
     @cmds.each(&:unlink)
+    super
   end
 
   def test_internal_commands

--- a/Library/Homebrew/test/compiler_selector_test.rb
+++ b/Library/Homebrew/test/compiler_selector_test.rb
@@ -31,6 +31,7 @@ class CompilerSelectorTests < Homebrew::TestCase
   end
 
   def setup
+    super
     @f  = Double.new
     @cc = :clang
     @versions = CompilerVersions.new

--- a/Library/Homebrew/test/dependencies_test.rb
+++ b/Library/Homebrew/test/dependencies_test.rb
@@ -5,6 +5,7 @@ require "requirements"
 
 class DependenciesTests < Homebrew::TestCase
   def setup
+    super
     @deps = Dependencies.new
   end
 
@@ -89,6 +90,7 @@ end
 
 class RequirementsTests < Homebrew::TestCase
   def setup
+    super
     @reqs = Requirements.new
   end
 

--- a/Library/Homebrew/test/dependency_collector_test.rb
+++ b/Library/Homebrew/test/dependency_collector_test.rb
@@ -11,11 +11,13 @@ class DependencyCollectorTests < Homebrew::TestCase
   end
 
   def setup
+    super
     @d = DependencyCollector.new
   end
 
   def teardown
     DependencyCollector.clear_cache
+    super
   end
 
   def test_dependency_creation

--- a/Library/Homebrew/test/dependency_expansion_test.rb
+++ b/Library/Homebrew/test/dependency_expansion_test.rb
@@ -9,6 +9,7 @@ class DependencyExpansionTests < Homebrew::TestCase
   end
 
   def setup
+    super
     @foo = build_dep(:foo)
     @bar = build_dep(:bar)
     @baz = build_dep(:baz)

--- a/Library/Homebrew/test/dependency_test.rb
+++ b/Library/Homebrew/test/dependency_test.rb
@@ -3,6 +3,7 @@ require "dependency"
 
 class DependableTests < Homebrew::TestCase
   def setup
+    super
     @tags = ["foo", "bar", :build]
     @dep = Struct.new(:tags).new(@tags).extend(Dependable)
   end

--- a/Library/Homebrew/test/descriptions_test.rb
+++ b/Library/Homebrew/test/descriptions_test.rb
@@ -3,6 +3,8 @@ require "descriptions"
 
 class DescriptionsTest < Homebrew::TestCase
   def setup
+    super
+
     @descriptions_hash = {}
     @descriptions = Descriptions.new(@descriptions_hash)
 
@@ -12,6 +14,7 @@ class DescriptionsTest < Homebrew::TestCase
 
   def teardown
     $stdout = @old_stdout
+    super
   end
 
   def test_single_core_formula

--- a/Library/Homebrew/test/diagnostic_test.rb
+++ b/Library/Homebrew/test/diagnostic_test.rb
@@ -5,12 +5,14 @@ require "diagnostic"
 
 class DiagnosticChecksTest < Homebrew::TestCase
   def setup
+    super
     @env = ENV.to_hash
     @checks = Homebrew::Diagnostic::Checks.new
   end
 
   def teardown
     ENV.replace(@env)
+    super
   end
 
   def test_inject_file_list

--- a/Library/Homebrew/test/download_strategies_test.rb
+++ b/Library/Homebrew/test/download_strategies_test.rb
@@ -15,6 +15,7 @@ class AbstractDownloadStrategyTests < Homebrew::TestCase
   include FileUtils
 
   def setup
+    super
     @name = "foo"
     @resource = ResourceDouble.new
     @strategy = AbstractDownloadStrategy.new(@name, @resource)
@@ -63,6 +64,7 @@ end
 
 class GitHubPrivateRepositoryDownloadStrategyTests < Homebrew::TestCase
   def setup
+    super
     resource = ResourceDouble.new("https://github.com/owner/repo/archive/1.1.5.tar.gz")
     ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
     GitHub.stubs(:repository).returns {}
@@ -87,6 +89,7 @@ end
 
 class GitHubPrivateRepositoryReleaseDownloadStrategyTests < Homebrew::TestCase
   def setup
+    super
     resource = ResourceDouble.new("https://github.com/owner/repo/releases/download/tag/foo_v0.1.0_darwin_amd64.tar.gz")
     ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
     GitHub.stubs(:repository).returns {}
@@ -138,6 +141,7 @@ class GitDownloadStrategyTests < Homebrew::TestCase
   include FileUtils
 
   def setup
+    super
     resource = ResourceDouble.new("https://github.com/homebrew/foo")
     @commit_id = 1
     @strategy = GitDownloadStrategy.new("baz", resource)
@@ -147,6 +151,7 @@ class GitDownloadStrategyTests < Homebrew::TestCase
 
   def teardown
     rmtree @cached_location
+    super
   end
 
   def git_commit_all
@@ -236,6 +241,7 @@ end
 
 class DownloadStrategyDetectorTests < Homebrew::TestCase
   def setup
+    super
     @d = DownloadStrategyDetector.new
   end
 

--- a/Library/Homebrew/test/formula_lock_test.rb
+++ b/Library/Homebrew/test/formula_lock_test.rb
@@ -3,6 +3,7 @@ require "formula_lock"
 
 class FormulaLockTests < Homebrew::TestCase
   def setup
+    super
     @lock = FormulaLock.new("foo")
     @lock.lock
   end
@@ -10,6 +11,7 @@ class FormulaLockTests < Homebrew::TestCase
   def teardown
     @lock.unlock
     HOMEBREW_LOCK_DIR.children.each(&:unlink)
+    super
   end
 
   def test_locking_file_with_existing_lock_raises_error

--- a/Library/Homebrew/test/formula_pin_test.rb
+++ b/Library/Homebrew/test/formula_pin_test.rb
@@ -21,6 +21,7 @@ class FormulaPinTests < Homebrew::TestCase
   end
 
   def setup
+    super
     @f   = FormulaDouble.new
     @pin = FormulaPin.new(@f)
     @f.rack.mkpath
@@ -50,5 +51,6 @@ class FormulaPinTests < Homebrew::TestCase
 
   def teardown
     @f.rack.rmtree
+    super
   end
 end

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -874,6 +874,8 @@ class AliasChangeTests < Homebrew::TestCase
   end
 
   def setup
+    super
+
     alias_name = "bar"
     @alias_path = "#{CoreTap.instance.alias_dir}/#{alias_name}"
 
@@ -942,6 +944,8 @@ class OutdatedVersionsTests < Homebrew::TestCase
   attr_reader :f, :old_formula, :new_formula
 
   def setup
+    super
+
     @f = formula do
       url "foo"
       version "1.20"
@@ -960,6 +964,7 @@ class OutdatedVersionsTests < Homebrew::TestCase
   def teardown
     formulae = [@f, @old_formula, @new_formula]
     formulae.map(&:rack).select(&:exist?).each(&:rmtree)
+    super
   end
 
   def alias_path

--- a/Library/Homebrew/test/formulary_test.rb
+++ b/Library/Homebrew/test/formulary_test.rb
@@ -16,6 +16,7 @@ end
 
 class FormularyFactoryTest < Homebrew::TestCase
   def setup
+    super
     @name = "testball_bottle"
     @path = CoreTap.new.formula_dir/"#{@name}.rb"
     @bottle_dir = Pathname.new("#{TEST_FIXTURE_DIR}/bottles")
@@ -41,6 +42,7 @@ class FormularyFactoryTest < Homebrew::TestCase
 
   def teardown
     @path.unlink
+    super
   end
 
   def test_factory
@@ -129,6 +131,7 @@ end
 
 class FormularyTapFactoryTest < Homebrew::TestCase
   def setup
+    super
     @name = "foo"
     @tap = Tap.new "homebrew", "foo"
     @path = @tap.path/"#{@name}.rb"
@@ -142,6 +145,7 @@ class FormularyTapFactoryTest < Homebrew::TestCase
 
   def teardown
     @tap.path.rmtree
+    super
   end
 
   def test_factory_tap_formula
@@ -174,6 +178,7 @@ end
 
 class FormularyTapPriorityTest < Homebrew::TestCase
   def setup
+    super
     @name = "foo"
     @core_path = CoreTap.new.formula_dir/"#{@name}.rb"
     @tap = Tap.new "homebrew", "foo"
@@ -190,6 +195,7 @@ class FormularyTapPriorityTest < Homebrew::TestCase
   def teardown
     @core_path.unlink
     @tap.path.rmtree
+    super
   end
 
   def test_find_with_priority_core_formula

--- a/Library/Homebrew/test/gpg2_requirement_test.rb
+++ b/Library/Homebrew/test/gpg2_requirement_test.rb
@@ -4,6 +4,7 @@ require "fileutils"
 
 class GPG2RequirementTests < Homebrew::TestCase
   def setup
+    super
     @dir = Pathname.new(mktmpdir)
     (@dir/"bin/gpg").write <<-EOS.undent
       #!/bin/bash
@@ -14,6 +15,7 @@ class GPG2RequirementTests < Homebrew::TestCase
 
   def teardown
     FileUtils.rm_rf @dir
+    super
   end
 
   def test_satisfied

--- a/Library/Homebrew/test/gpg_test.rb
+++ b/Library/Homebrew/test/gpg_test.rb
@@ -3,6 +3,7 @@ require "gpg"
 
 class GpgTest < Homebrew::TestCase
   def setup
+    super
     skip "GPG Unavailable" unless Gpg.available?
     @dir = Pathname.new(mktmpdir)
   end

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -20,6 +20,8 @@ class LinkTestCase < Homebrew::TestCase
   end
 
   def setup
+    super
+
     @keg = setup_test_keg("foo", "1.0")
     @dst = HOMEBREW_PREFIX.join("bin", "helloworld")
     @nonexistent = Pathname.new("/some/nonexistent/path")
@@ -43,6 +45,8 @@ class LinkTestCase < Homebrew::TestCase
 
     rmtree HOMEBREW_PREFIX/"bin"
     rmtree HOMEBREW_PREFIX/"lib"
+
+    super
   end
 end
 

--- a/Library/Homebrew/test/language_python_test.rb
+++ b/Library/Homebrew/test/language_python_test.rb
@@ -4,6 +4,7 @@ require "resource"
 
 class LanguagePythonTests < Homebrew::TestCase
   def setup
+    super
     @dir = Pathname.new(mktmpdir)
     resource = stub("resource", stage: true)
     formula_bin = @dir/"formula_bin"
@@ -16,6 +17,7 @@ class LanguagePythonTests < Homebrew::TestCase
 
   def teardown
     FileUtils.rm_rf @dir
+    super
   end
 
   def test_virtualenv_creation

--- a/Library/Homebrew/test/migrator_test.rb
+++ b/Library/Homebrew/test/migrator_test.rb
@@ -10,6 +10,7 @@ end
 
 class MigratorErrorsTests < Homebrew::TestCase
   def setup
+    super
     @new_f = Testball.new("newname")
     @new_f.oldname = "oldname"
     @old_f = Testball.new("oldname")
@@ -40,6 +41,8 @@ class MigratorTests < Homebrew::TestCase
   include FileUtils
 
   def setup
+    super
+
     @new_f = Testball.new("newname")
     @new_f.oldname = "oldname"
 
@@ -93,6 +96,8 @@ class MigratorTests < Homebrew::TestCase
     @new_f.unpin
 
     HOMEBREW_LOCK_DIR.children.each(&:unlink)
+
+    super
   end
 
   def test_move_cellar

--- a/Library/Homebrew/test/options_test.rb
+++ b/Library/Homebrew/test/options_test.rb
@@ -15,6 +15,7 @@ end
 
 class OptionTests < Homebrew::TestCase
   def setup
+    super
     @option = Option.new("foo")
   end
 
@@ -43,6 +44,7 @@ end
 
 class DeprecatedOptionTests < Homebrew::TestCase
   def setup
+    super
     @deprecated_option = DeprecatedOption.new("foo", "bar")
   end
 
@@ -68,6 +70,7 @@ end
 
 class OptionsTests < Homebrew::TestCase
   def setup
+    super
     @options = Options.new
   end
 

--- a/Library/Homebrew/test/os/mac/bottle_collector_test.rb
+++ b/Library/Homebrew/test/os/mac/bottle_collector_test.rb
@@ -3,6 +3,7 @@ require "utils/bottles"
 
 class OSMacBottleCollectorTests < Homebrew::TestCase
   def setup
+    super
     @collector = Utils::Bottles::Collector.new
   end
 

--- a/Library/Homebrew/test/os/mac/dependency_collector_test.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_test.rb
@@ -7,11 +7,13 @@ class OSMacDependencyCollectorTests < Homebrew::TestCase
   end
 
   def setup
+    super
     @d = DependencyCollector.new
   end
 
   def teardown
     DependencyCollector.clear_cache
+    super
   end
 
   def test_tar_needs_xz_dependency

--- a/Library/Homebrew/test/os/mac/diagnostic_test.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_test.rb
@@ -5,12 +5,14 @@ require "diagnostic"
 
 class OSMacDiagnosticChecksTest < Homebrew::TestCase
   def setup
+    super
     @env = ENV.to_hash
     @checks = Homebrew::Diagnostic::Checks.new
   end
 
   def teardown
     ENV.replace(@env)
+    super
   end
 
   def test_check_for_other_package_managers

--- a/Library/Homebrew/test/os/mac/keg_test.rb
+++ b/Library/Homebrew/test/os/mac/keg_test.rb
@@ -6,6 +6,8 @@ class OSMacLinkTests < Homebrew::TestCase
   include FileUtils
 
   def setup
+    super
+
     keg = HOMEBREW_CELLAR.join("foo", "1.0")
     keg.join("bin").mkpath
 
@@ -34,6 +36,8 @@ class OSMacLinkTests < Homebrew::TestCase
 
     rmtree HOMEBREW_PREFIX/"bin"
     rmtree HOMEBREW_PREFIX/"lib"
+
+    super
   end
 
   def test_mach_o_files_skips_hardlinks

--- a/Library/Homebrew/test/os/mac/mach_test.rb
+++ b/Library/Homebrew/test/os/mac/mach_test.rb
@@ -109,6 +109,7 @@ end
 
 class ArchitectureListExtensionTests < MachOPathnameTests
   def setup
+    super
     @archs = [:i386, :x86_64, :ppc7400, :ppc64].extend(ArchitectureListExtension)
   end
 
@@ -157,11 +158,13 @@ class TextExecutableTests < Homebrew::TestCase
   attr_reader :pn
 
   def setup
+    super
     @pn = HOMEBREW_PREFIX.join("an_executable")
   end
 
   def teardown
     HOMEBREW_PREFIX.join("an_executable").unlink
+    super
   end
 
   def test_simple_shebang

--- a/Library/Homebrew/test/os/mac/version_test.rb
+++ b/Library/Homebrew/test/os/mac/version_test.rb
@@ -4,6 +4,7 @@ require "os/mac/version"
 
 class OSMacVersionTests < Homebrew::TestCase
   def setup
+    super
     @v = MacOS::Version.new("10.7")
   end
 

--- a/Library/Homebrew/test/patch_test.rb
+++ b/Library/Homebrew/test/patch_test.rb
@@ -111,6 +111,7 @@ end
 
 class ExternalPatchTests < Homebrew::TestCase
   def setup
+    super
     @p = ExternalPatch.new(:p1) { url "file:///my.patch" }
   end
 

--- a/Library/Homebrew/test/patching_test.rb
+++ b/Library/Homebrew/test/patching_test.rb
@@ -23,6 +23,7 @@ class PatchingTests < Homebrew::TestCase
   def teardown
     @_f.clear_cache
     @_f.patchlist.each { |p| p.clear_cache if p.external? }
+    super
   end
 
   def assert_patched(formula)

--- a/Library/Homebrew/test/pathname_test.rb
+++ b/Library/Homebrew/test/pathname_test.rb
@@ -7,6 +7,7 @@ module PathnameTestExtension
   include FileUtils
 
   def setup
+    super
     @src  = Pathname.new(mktmpdir)
     @dst  = Pathname.new(mktmpdir)
     @file = @src/"foo"
@@ -16,6 +17,7 @@ module PathnameTestExtension
   def teardown
     rmtree(@src)
     rmtree(@dst)
+    super
   end
 end
 

--- a/Library/Homebrew/test/resource_test.rb
+++ b/Library/Homebrew/test/resource_test.rb
@@ -3,6 +3,7 @@ require "resource"
 
 class ResourceTests < Homebrew::TestCase
   def setup
+    super
     @resource = Resource.new("test")
   end
 

--- a/Library/Homebrew/test/sandbox_test.rb
+++ b/Library/Homebrew/test/sandbox_test.rb
@@ -3,6 +3,7 @@ require "sandbox"
 
 class SandboxTest < Homebrew::TestCase
   def setup
+    super
     skip "sandbox not implemented" unless Sandbox.available?
     @sandbox = Sandbox.new
     @dir = Pathname.new(mktmpdir)
@@ -11,6 +12,7 @@ class SandboxTest < Homebrew::TestCase
 
   def teardown
     @dir.rmtree
+    super
   end
 
   def test_formula?

--- a/Library/Homebrew/test/software_spec_test.rb
+++ b/Library/Homebrew/test/software_spec_test.rb
@@ -3,6 +3,7 @@ require "software_spec"
 
 class SoftwareSpecTests < Homebrew::TestCase
   def setup
+    super
     @spec = SoftwareSpec.new
   end
 
@@ -136,6 +137,7 @@ end
 
 class HeadSoftwareSpecTests < Homebrew::TestCase
   def setup
+    super
     @spec = HeadSoftwareSpec.new
   end
 
@@ -150,6 +152,7 @@ end
 
 class BottleSpecificationTests < Homebrew::TestCase
   def setup
+    super
     @spec = BottleSpecification.new
   end
 

--- a/Library/Homebrew/test/stdlib_test.rb
+++ b/Library/Homebrew/test/stdlib_test.rb
@@ -4,6 +4,7 @@ require "cxxstdlib"
 
 class CxxStdlibTests < Homebrew::TestCase
   def setup
+    super
     @clang = CxxStdlib.create(:libstdcxx, :clang)
     @gcc   = CxxStdlib.create(:libstdcxx, :gcc)
     @gcc40 = CxxStdlib.create(:libstdcxx, :gcc_4_0)

--- a/Library/Homebrew/test/support/helper/integration_command_test_case.rb
+++ b/Library/Homebrew/test/support/helper/integration_command_test_case.rb
@@ -6,6 +6,7 @@ require "test/support/helper/test_case"
 
 class IntegrationCommandTestCase < Homebrew::TestCase
   def setup
+    super
     @cmd_id_index = 0 # Assign unique IDs to invocations of `cmd_output`.
     (HOMEBREW_PREFIX/"bin").mkpath
     FileUtils.touch HOMEBREW_PREFIX/"bin/brew"
@@ -38,6 +39,7 @@ class IntegrationCommandTestCase < Homebrew::TestCase
       coretap.path/"formula_renames.json",
     ].flatten
     FileUtils.rm_rf paths_to_delete
+    super
   end
 
   def needs_test_cmd_taps

--- a/Library/Homebrew/test/support/helper/lifecycle_enforcer.rb
+++ b/Library/Homebrew/test/support/helper/lifecycle_enforcer.rb
@@ -1,0 +1,22 @@
+module Test
+  module Helper
+    module LifecycleEnforcer
+      def setup
+        @__setup_called = true
+        super
+      end
+
+      def teardown
+        @__teardown_called = true
+        super
+      end
+
+      def after_teardown
+        assert @__setup_called, "Expected setup to call `super` but didn't"
+        assert @__teardown_called, "Expected teardown to call `super` but didn't"
+
+        super
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -2,10 +2,12 @@ module Homebrew
   class TestCase < ::Minitest::Test
     require "test/support/helper/env"
     require "test/support/helper/fs_leak_logger"
+    require "test/support/helper/lifecycle_enforcer"
     require "test/support/helper/shutup"
     require "test/support/helper/version_assertions"
     include Test::Helper::Env
     include Test::Helper::FSLeakLogger
+    include Test::Helper::LifecycleEnforcer
     include Test::Helper::Shutup
     include Test::Helper::VersionAssertions
 

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -4,6 +4,8 @@ require "formula"
 
 class TabTests < Homebrew::TestCase
   def setup
+    super
+
     @used = Options.create(%w[--with-foo --without-bar])
     @unused = Options.create(%w[--with-baz --without-qux])
 
@@ -260,6 +262,7 @@ end
 
 class TabLoadingTests < Homebrew::TestCase
   def setup
+    super
     @f = formula { url "foo-1.0" }
     @f.prefix.mkpath
     @path = @f.prefix.join(Tab::FILENAME)
@@ -268,6 +271,7 @@ class TabLoadingTests < Homebrew::TestCase
 
   def teardown
     @f.rack.rmtree
+    super
   end
 
   def test_for_keg

--- a/Library/Homebrew/test/tap_test.rb
+++ b/Library/Homebrew/test/tap_test.rb
@@ -34,6 +34,7 @@ class TapTest < Homebrew::TestCase
   include FileUtils
 
   def setup
+    super
     @path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
     @path.mkpath
     @tap = Tap.new("Homebrew", "foo")
@@ -86,6 +87,7 @@ class TapTest < Homebrew::TestCase
 
   def teardown
     @path.rmtree
+    super
   end
 
   def test_fetch
@@ -285,6 +287,7 @@ class CoreTapTest < Homebrew::TestCase
   include FileUtils
 
   def setup
+    super
     @repo = CoreTap.new
   end
 

--- a/Library/Homebrew/test/uninstall_test.rb
+++ b/Library/Homebrew/test/uninstall_test.rb
@@ -3,6 +3,8 @@ require "cmd/uninstall"
 
 class UninstallTests < Homebrew::TestCase
   def setup
+    super
+
     @dependency = formula("dependency") { url "f-1" }
     @dependent = formula("dependent") do
       url "f-1"
@@ -32,6 +34,7 @@ class UninstallTests < Homebrew::TestCase
       f.installed_kegs.each(&:remove_opt_record)
       f.rack.rmtree
     end
+    super
   end
 
   def handle_unsatisfied_dependents

--- a/Library/Homebrew/test/update_report_test.rb
+++ b/Library/Homebrew/test/update_report_test.rb
@@ -24,6 +24,7 @@ class ReportTests < Homebrew::TestCase
   end
 
   def setup
+    super
     @tap = CoreTap.new
     @reporter = ReporterMock.new(@tap)
     @hub = ReporterHub.new

--- a/Library/Homebrew/test/utils_test.rb
+++ b/Library/Homebrew/test/utils_test.rb
@@ -5,6 +5,7 @@ require "utils/shell"
 
 class UtilTests < Homebrew::TestCase
   def setup
+    super
     @dir = Pathname.new(mktmpdir)
     @env = ENV.to_hash
   end
@@ -12,6 +13,7 @@ class UtilTests < Homebrew::TestCase
   def teardown
     @dir.rmtree
     ENV.replace @env
+    super
   end
 
   def test_ofail


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Made all existing `setup` and `teardown` methods call `super`, and added a `LifecycleEnforcer` test plugin that will enforce this for new tests.

This will allow us to have global setup and teardown for tests.

For example, we can automatically clear caches after each test, to avoid annoying intermittent failures like #1879 and #1886.