### PR TITLE
tests: clear tab cache in global teardown

### DIFF
--- a/Library/Homebrew/test/formulary_test.rb
+++ b/Library/Homebrew/test/formulary_test.rb
@@ -112,7 +112,6 @@ class FormularyFactoryTest < Homebrew::TestCase
     keg.uninstall
     formula.clear_cache
     formula.bottle.clear_cache
-    Tab.clear_cache
   end
 
   def test_load_from_contents

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -14,6 +14,11 @@ module Homebrew
     TEST_SHA1   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
     TEST_SHA256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
 
+    def teardown
+      Tab.clear_cache
+      super
+    end
+
     def formula(name = "formula_name", path = Formulary.core_path(name), spec = :stable, alias_path: nil, &block)
       @_f = Class.new(Formula, &block).new(name, path, spec, alias_path: alias_path)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I'm planning on adding more to this global `teardown`, but I decided to just do this to start with so we could address the current CI failures ASAP (and see if anything breaks).