### PR TITLE
tests: clean up file system for all tests

### DIFF
--- a/Library/Homebrew/test/ARGV_test.rb
+++ b/Library/Homebrew/test/ARGV_test.rb
@@ -22,8 +22,6 @@ class ArgvExtensionTests < Homebrew::TestCase
     keg.mkpath
     @argv << "mxcl"
     assert_equal 1, @argv.kegs.length
-  ensure
-    keg.parent.rmtree
   end
 
   def test_argv_named

--- a/Library/Homebrew/test/audit_test.rb
+++ b/Library/Homebrew/test/audit_test.rb
@@ -10,11 +10,6 @@ class FormulaTextTests < Homebrew::TestCase
     @dir = mktmpdir
   end
 
-  def teardown
-    FileUtils.rm_rf @dir
-    super
-  end
-
   def formula_text(name, body = nil, options = {})
     path = Pathname.new "#{@dir}/#{name}.rb"
     path.open("w") do |f|
@@ -62,11 +57,6 @@ class FormulaAuditorTests < Homebrew::TestCase
   def setup
     super
     @dir = mktmpdir
-  end
-
-  def teardown
-    FileUtils.rm_rf @dir
-    super
   end
 
   def formula_auditor(name, text, options = {})

--- a/Library/Homebrew/test/checksum_verification_test.rb
+++ b/Library/Homebrew/test/checksum_verification_test.rb
@@ -17,11 +17,6 @@ class ChecksumVerificationTests < Homebrew::TestCase
     end
   end
 
-  def teardown
-    @_f.clear_cache
-    super
-  end
-
   def test_good_sha256
     formula do
       sha256 TESTBALL_SHA256

--- a/Library/Homebrew/test/cleaner_test.rb
+++ b/Library/Homebrew/test/cleaner_test.rb
@@ -11,11 +11,6 @@ class CleanerTests < Homebrew::TestCase
     @f.prefix.mkpath
   end
 
-  def teardown
-    @f.rack.rmtree if @f.rack.exist?
-    super
-  end
-
   def test_clean_file
     @f.bin.mkpath
     @f.lib.mkpath

--- a/Library/Homebrew/test/cleanup_test.rb
+++ b/Library/Homebrew/test/cleanup_test.rb
@@ -55,9 +55,6 @@ class CleanupTests < Homebrew::TestCase
     refute_predicate f1, :installed?
     refute_predicate f2, :installed?
     assert_predicate f3, :installed?
-  ensure
-    [f1, f2, f3].each(&:clear_cache)
-    f3.rack.rmtree
   end
 
   def test_cleanup_logs

--- a/Library/Homebrew/test/diagnostic_test.rb
+++ b/Library/Homebrew/test/diagnostic_test.rb
@@ -105,8 +105,6 @@ class DiagnosticChecksTest < Homebrew::TestCase
 
     assert_match "/usr/bin occurs before #{HOMEBREW_PREFIX}/bin",
       @checks.check_user_path_1
-  ensure
-    bin.rmtree
   end
 
   def test_check_user_path_bin

--- a/Library/Homebrew/test/download_strategies_test.rb
+++ b/Library/Homebrew/test/download_strategies_test.rb
@@ -149,11 +149,6 @@ class GitDownloadStrategyTests < Homebrew::TestCase
     mkpath @cached_location
   end
 
-  def teardown
-    rmtree @cached_location
-    super
-  end
-
   def git_commit_all
     shutup do
       system "git", "add", "--all"

--- a/Library/Homebrew/test/formula_installer_test.rb
+++ b/Library/Homebrew/test/formula_installer_test.rb
@@ -125,11 +125,7 @@ class FormulaInstallerTests < Homebrew::TestCase
     fi = FormulaInstaller.new(dependent)
     assert_raises(CannotInstallFormulaError) { fi.check_install_sanity }
   ensure
-    dependency.unpin
     dependency_keg.unlink
-    dependency_keg.uninstall
-    dependency.clear_cache
-    dep_path.unlink
     Formulary::FORMULAE.delete(dep_path)
   end
 end

--- a/Library/Homebrew/test/formula_lock_test.rb
+++ b/Library/Homebrew/test/formula_lock_test.rb
@@ -10,7 +10,6 @@ class FormulaLockTests < Homebrew::TestCase
 
   def teardown
     @lock.unlock
-    HOMEBREW_LOCK_DIR.children.each(&:unlink)
     super
   end
 

--- a/Library/Homebrew/test/formula_pin_test.rb
+++ b/Library/Homebrew/test/formula_pin_test.rb
@@ -48,9 +48,4 @@ class FormulaPinTests < Homebrew::TestCase
     refute_predicate @pin, :pinned?
     refute_predicate HOMEBREW_PINNED_KEGS, :directory?
   end
-
-  def teardown
-    @f.rack.rmtree
-    super
-  end
 end

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -961,12 +961,6 @@ class OutdatedVersionsTests < Homebrew::TestCase
     @old_alias_target_prefix = HOMEBREW_CELLAR/"#{old_formula.name}/1.0"
   end
 
-  def teardown
-    formulae = [@f, @old_formula, @new_formula]
-    formulae.map(&:rack).select(&:exist?).each(&:rmtree)
-    super
-  end
-
   def alias_path
     "#{@f.tap.alias_dir}/bar"
   end

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -176,8 +176,6 @@ class FormulaTests < Homebrew::TestCase
     prefix.mkpath
     FileUtils.touch prefix+Tab::FILENAME
     assert_predicate f, :any_version_installed?
-  ensure
-    f.rack.rmtree
   end
 
   def test_migration_needed
@@ -203,9 +201,6 @@ class FormulaTests < Homebrew::TestCase
     newname_prefix.mkpath
 
     refute_predicate f, :migration_needed?
-  ensure
-    oldname_prefix.parent.rmtree
-    newname_prefix.parent.rmtree
   end
 
   def test_installed?
@@ -240,8 +235,6 @@ class FormulaTests < Homebrew::TestCase
     prefix = HOMEBREW_CELLAR+f.name+f.head.version
     prefix.mkpath
     assert_equal prefix, f.installed_prefix
-  ensure
-    f.rack.rmtree
   end
 
   def test_installed_prefix_devel_installed
@@ -255,8 +248,6 @@ class FormulaTests < Homebrew::TestCase
     prefix = HOMEBREW_CELLAR+f.name+f.devel.version
     prefix.mkpath
     assert_equal prefix, f.installed_prefix
-  ensure
-    f.rack.rmtree
   end
 
   def test_installed_prefix_stable_installed
@@ -270,8 +261,6 @@ class FormulaTests < Homebrew::TestCase
     prefix = HOMEBREW_CELLAR+f.name+f.version
     prefix.mkpath
     assert_equal prefix, f.installed_prefix
-  ensure
-    f.rack.rmtree
   end
 
   def test_installed_prefix_outdated_stable_head_installed
@@ -289,8 +278,6 @@ class FormulaTests < Homebrew::TestCase
     tab.write
 
     assert_equal HOMEBREW_CELLAR/"#{f.name}/#{f.version}", f.installed_prefix
-  ensure
-    f.rack.rmtree
   end
 
   def test_installed_prefix_outdated_devel_head_installed
@@ -311,8 +298,6 @@ class FormulaTests < Homebrew::TestCase
     tab.write
 
     assert_equal HOMEBREW_CELLAR/"#{f.name}/#{f.version}", f.installed_prefix
-  ensure
-    f.rack.rmtree
   end
 
   def test_installed_prefix_head
@@ -358,8 +343,6 @@ class FormulaTests < Homebrew::TestCase
 
     prefix = HOMEBREW_CELLAR/"#{f.name}/HEAD-222222_2"
     assert_equal prefix, f.latest_head_prefix
-  ensure
-    f.rack.rmtree
   end
 
   def test_equality
@@ -571,7 +554,6 @@ class FormulaTests < Homebrew::TestCase
     assert_equal Version.create("HEAD-5658946"), f.head.version
   ensure
     ENV.replace(initial_env)
-    cached_location.rmtree
   end
 
   def test_legacy_options
@@ -771,9 +753,6 @@ class FormulaTests < Homebrew::TestCase
 
     assert_equal f3.installed_kegs.sort_by(&:version)[0..1],
                  f3.eligible_kegs_for_cleanup.sort_by(&:version)
-  ensure
-    [f1, f2, f3].each(&:clear_cache)
-    f3.rack.rmtree
   end
 
   def test_eligible_kegs_for_cleanup_keg_pinned
@@ -795,10 +774,6 @@ class FormulaTests < Homebrew::TestCase
     assert_predicate f3, :installed?
 
     assert_equal [Keg.new(f2.prefix)], shutup { f3.eligible_kegs_for_cleanup }
-  ensure
-    f1.unpin
-    [f1, f2, f3].each(&:clear_cache)
-    f3.rack.rmtree
   end
 
   def test_eligible_kegs_for_cleanup_head_installed
@@ -821,8 +796,6 @@ class FormulaTests < Homebrew::TestCase
 
     eligible_kegs = f.installed_kegs - [Keg.new(f.prefix("HEAD-111111_1"))]
     assert_equal eligible_kegs, f.eligible_kegs_for_cleanup
-  ensure
-    f.rack.rmtree
   end
 
   def test_pour_bottle
@@ -1173,11 +1146,6 @@ class OutdatedVersionsTests < Homebrew::TestCase
   ensure
     ENV.replace(initial_env)
     testball_repo.rmtree if testball_repo.exist?
-    outdated_stable_prefix.rmtree if outdated_stable_prefix.exist?
-    head_prefix_b.rmtree if head_prefix.exist?
-    head_prefix_c.rmtree if head_prefix_c.exist?
-    FileUtils.rm_rf HOMEBREW_CACHE/"testball--git"
-    FileUtils.rm_rf HOMEBREW_CELLAR/"testball"
   end
 
   def test_outdated_kegs_version_scheme_changed
@@ -1191,8 +1159,6 @@ class OutdatedVersionsTests < Homebrew::TestCase
     setup_tab_for_prefix(prefix, versions: { "stable" => "0.1" })
 
     refute_predicate f.outdated_kegs, :empty?
-  ensure
-    prefix.rmtree
   end
 
   def test_outdated_kegs_mixed_version_schemes
@@ -1220,8 +1186,6 @@ class OutdatedVersionsTests < Homebrew::TestCase
     prefix_d = HOMEBREW_CELLAR.join("testball/20141011")
     setup_tab_for_prefix(prefix_d, versions: { "stable" => "20141009", "version_scheme" => 3 })
     assert_predicate f.outdated_kegs, :empty?
-  ensure
-    f.rack.rmtree
   end
 
   def test_outdated_kegs_head_with_version_scheme
@@ -1241,7 +1205,5 @@ class OutdatedVersionsTests < Homebrew::TestCase
 
     setup_tab_for_prefix(head_prefix, versions: { "stable" => "1.0", "version_scheme" => 2 })
     assert_predicate f.outdated_kegs, :empty?
-  ensure
-    head_prefix.rmtree
   end
 end

--- a/Library/Homebrew/test/formulary_test.rb
+++ b/Library/Homebrew/test/formulary_test.rb
@@ -40,11 +40,6 @@ class FormularyFactoryTest < Homebrew::TestCase
     EOS
   end
 
-  def teardown
-    @path.unlink
-    super
-  end
-
   def test_factory
     assert_kind_of Formula, Formulary.factory(@name)
   end
@@ -142,11 +137,6 @@ class FormularyTapFactoryTest < Homebrew::TestCase
     @path.write @code
   end
 
-  def teardown
-    @tap.path.rmtree
-    super
-  end
-
   def test_factory_tap_formula
     assert_kind_of Formula, Formulary.factory(@name)
   end
@@ -189,12 +179,6 @@ class FormularyTapPriorityTest < Homebrew::TestCase
     EOS
     @core_path.write code
     @tap_path.write code
-  end
-
-  def teardown
-    @core_path.unlink
-    @tap.path.rmtree
-    super
   end
 
   def test_find_with_priority_core_formula

--- a/Library/Homebrew/test/formulary_test.rb
+++ b/Library/Homebrew/test/formulary_test.rb
@@ -58,8 +58,6 @@ class FormularyFactoryTest < Homebrew::TestCase
     path.write "class Wrong#{Formulary.class_s(name)} < Formula\nend\n"
 
     assert_raises(FormulaClassUnavailableError) { Formulary.factory(name) }
-  ensure
-    path.unlink
   end
 
   def test_factory_from_path
@@ -87,8 +85,6 @@ class FormularyFactoryTest < Homebrew::TestCase
     result = Formulary.factory("foo")
     assert_kind_of Formula, result
     assert_equal alias_path.to_s, result.alias_path
-  ensure
-    alias_dir.rmtree
   end
 
   def test_factory_from_rack_and_from_keg
@@ -104,9 +100,6 @@ class FormularyFactoryTest < Homebrew::TestCase
     assert_kind_of Tab, f.build
   ensure
     keg.unlink
-    keg.uninstall
-    formula.clear_cache
-    formula.bottle.clear_cache
   end
 
   def test_load_from_contents
@@ -118,8 +111,6 @@ class FormularyFactoryTest < Homebrew::TestCase
     (HOMEBREW_CELLAR/@name).mkpath
     assert_equal HOMEBREW_CELLAR/@name, Formulary.to_rack(@name)
     assert_raises(TapFormulaUnavailableError) { Formulary.to_rack("a/b/#{@name}") }
-  ensure
-    FileUtils.rm_rf HOMEBREW_CELLAR/@name
   end
 end
 

--- a/Library/Homebrew/test/gpg_test.rb
+++ b/Library/Homebrew/test/gpg_test.rb
@@ -15,7 +15,5 @@ class GpgTest < Homebrew::TestCase
         assert_predicate @dir/".gnupg/secring.gpg", :exist?
       end
     end
-  ensure
-    @dir.rmtree
   end
 end

--- a/Library/Homebrew/test/install_test.rb
+++ b/Library/Homebrew/test/install_test.rb
@@ -113,7 +113,6 @@ class IntegrationCommandTestInstall < IntegrationCommandTestCase
 
   ensure
     ENV.replace(initial_env)
-    repo_path.rmtree
   end
 
   def test_install_with_invalid_option

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -298,8 +298,6 @@ class LinkTests < LinkTestCase
     assert_equal 2, lib.children.length
   ensure
     a.unlink
-    a.uninstall
-    b.uninstall
   end
 
   def test_removes_broken_symlinks_that_conflict_with_directories
@@ -315,7 +313,6 @@ class LinkTests < LinkTestCase
     keg.link
   ensure
     keg.unlink
-    keg.uninstall
   end
 end
 
@@ -427,9 +424,6 @@ class InstalledDependantsTests < LinkTestCase
 
     result = Keg.find_some_installed_dependents([renamed_keg])
     assert_equal [[renamed_keg], ["bar"]], result
-  ensure
-    # Move it back to where it was so it'll be cleaned up.
-    (HOMEBREW_CELLAR/"foo-old").rename(HOMEBREW_CELLAR/"foo")
   end
 
   def test_empty_dependencies_in_tab

--- a/Library/Homebrew/test/keg_test.rb
+++ b/Library/Homebrew/test/keg_test.rb
@@ -36,16 +36,9 @@ class LinkTestCase < Homebrew::TestCase
   end
 
   def teardown
-    @kegs.each do |keg|
-      keg.unlink
-      keg.uninstall
-    end
-
+    @kegs.each(&:unlink)
     $stdout = @old_stdout
-
-    rmtree HOMEBREW_PREFIX/"bin"
     rmtree HOMEBREW_PREFIX/"lib"
-
     super
   end
 end

--- a/Library/Homebrew/test/language_python_test.rb
+++ b/Library/Homebrew/test/language_python_test.rb
@@ -15,11 +15,6 @@ class LanguagePythonTests < Homebrew::TestCase
     @venv = Language::Python::Virtualenv::Virtualenv.new(@formula, @dir, "python")
   end
 
-  def teardown
-    FileUtils.rm_rf @dir
-    super
-  end
-
   def test_virtualenv_creation
     @formula.expects(:resource).with("homebrew-virtualenv").returns(
       mock("resource", stage: true)

--- a/Library/Homebrew/test/migrator_test.rb
+++ b/Library/Homebrew/test/migrator_test.rb
@@ -32,8 +32,6 @@ class MigratorErrorsTests < Homebrew::TestCase
     tab.source["tap"] = "homebrew/core"
     tab.write
     assert_raises(Migrator::MigratorDifferentTapsError) { Migrator.new(@new_f) }
-  ensure
-    keg.parent.rmtree
   end
 end
 

--- a/Library/Homebrew/test/migrator_test.rb
+++ b/Library/Homebrew/test/migrator_test.rb
@@ -72,30 +72,14 @@ class MigratorTests < Homebrew::TestCase
   end
 
   def teardown
-    @old_pin.unlink if @old_pin.symlink?
-
-    if @old_keg_record.parent.symlink?
-      @old_keg_record.parent.unlink
-    elsif @old_keg_record.directory?
+    if !@old_keg_record.parent.symlink? && @old_keg_record.directory?
       @keg.unlink
-      @keg.uninstall
     end
 
     if @new_keg_record.directory?
       new_keg = Keg.new(@new_keg_record)
       new_keg.unlink
-      new_keg.uninstall
     end
-
-    @old_keg_record.parent.rmtree if @old_keg_record.parent.directory?
-    @new_keg_record.parent.rmtree if @new_keg_record.parent.directory?
-
-    rmtree HOMEBREW_PREFIX/"bin"
-    rmtree HOMEBREW_PREFIX/"opt" if (HOMEBREW_PREFIX/"opt").directory?
-    # What to do with pin?
-    @new_f.unpin
-
-    HOMEBREW_LOCK_DIR.children.each(&:unlink)
 
     super
   end

--- a/Library/Homebrew/test/os/mac/keg_test.rb
+++ b/Library/Homebrew/test/os/mac/keg_test.rb
@@ -30,11 +30,9 @@ class OSMacLinkTests < Homebrew::TestCase
 
   def teardown
     @keg.unlink
-    @keg.uninstall
 
     $stdout = @old_stdout
 
-    rmtree HOMEBREW_PREFIX/"bin"
     rmtree HOMEBREW_PREFIX/"lib"
 
     super

--- a/Library/Homebrew/test/os/mac/keg_test.rb
+++ b/Library/Homebrew/test/os/mac/keg_test.rb
@@ -50,7 +50,6 @@ class OSMacLinkTests < Homebrew::TestCase
     assert_equal 1, keg.mach_o_files.size
   ensure
     keg.unlink
-    keg.uninstall
   end
 
   def test_mach_o_files_isnt_confused_by_symlinks
@@ -66,6 +65,5 @@ class OSMacLinkTests < Homebrew::TestCase
     assert_equal 1, keg.mach_o_files.size
   ensure
     keg.unlink
-    keg.uninstall
   end
 end

--- a/Library/Homebrew/test/patching_test.rb
+++ b/Library/Homebrew/test/patching_test.rb
@@ -20,12 +20,6 @@ class PatchingTests < Homebrew::TestCase
     end
   end
 
-  def teardown
-    @_f.clear_cache
-    @_f.patchlist.each { |p| p.clear_cache if p.external? }
-    super
-  end
-
   def assert_patched(formula)
     shutup do
       formula.brew do

--- a/Library/Homebrew/test/pathname_test.rb
+++ b/Library/Homebrew/test/pathname_test.rb
@@ -13,12 +13,6 @@ module PathnameTestExtension
     @file = @src/"foo"
     @dir  = @src/"bar"
   end
-
-  def teardown
-    rmtree(@src)
-    rmtree(@dst)
-    super
-  end
 end
 
 class PathnameTests < Homebrew::TestCase

--- a/Library/Homebrew/test/sandbox_test.rb
+++ b/Library/Homebrew/test/sandbox_test.rb
@@ -10,11 +10,6 @@ class SandboxTest < Homebrew::TestCase
     @file = @dir/"foo"
   end
 
-  def teardown
-    @dir.rmtree
-    super
-  end
-
   def test_formula?
     f = formula { url "foo-1.0" }
     f2 = formula { url "bar-1.0" }

--- a/Library/Homebrew/test/support/helper/integration_command_test_case.rb
+++ b/Library/Homebrew/test/support/helper/integration_command_test_case.rb
@@ -12,36 +12,6 @@ class IntegrationCommandTestCase < Homebrew::TestCase
     FileUtils.touch HOMEBREW_PREFIX/"bin/brew"
   end
 
-  def teardown
-    coretap = CoreTap.new
-    paths_to_delete = [
-      HOMEBREW_LINKED_KEGS,
-      HOMEBREW_PINNED_KEGS,
-      HOMEBREW_CELLAR.children,
-      HOMEBREW_CACHE.children,
-      HOMEBREW_LOCK_DIR.children,
-      HOMEBREW_LOGS.children,
-      HOMEBREW_TEMP.children,
-      HOMEBREW_PREFIX/".git",
-      HOMEBREW_PREFIX/"bin",
-      HOMEBREW_PREFIX/"share",
-      HOMEBREW_PREFIX/"opt",
-      HOMEBREW_PREFIX/"Caskroom",
-      HOMEBREW_LIBRARY/"Taps/caskroom",
-      HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-bundle",
-      HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo",
-      HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-services",
-      HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-shallow",
-      HOMEBREW_REPOSITORY/".git",
-      coretap.path/".git",
-      coretap.alias_dir,
-      coretap.formula_dir.children,
-      coretap.path/"formula_renames.json",
-    ].flatten
-    FileUtils.rm_rf paths_to_delete
-    super
-  end
-
   def needs_test_cmd_taps
     return if ENV["HOMEBREW_TEST_OFFICIAL_CMD_TAPS"]
     skip "HOMEBREW_TEST_OFFICIAL_CMD_TAPS is not set"

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -20,8 +20,37 @@ module Homebrew
     end
 
     def teardown
-      Tab.clear_cache
       ARGV.replace(@__argv)
+
+      Tab.clear_cache
+
+      coretap = CoreTap.new
+      paths_to_delete = [
+        HOMEBREW_LINKED_KEGS,
+        HOMEBREW_PINNED_KEGS,
+        HOMEBREW_CELLAR.children,
+        HOMEBREW_CACHE.children,
+        HOMEBREW_LOCK_DIR.children,
+        HOMEBREW_LOGS.children,
+        HOMEBREW_TEMP.children,
+        HOMEBREW_PREFIX/".git",
+        HOMEBREW_PREFIX/"bin",
+        HOMEBREW_PREFIX/"share",
+        HOMEBREW_PREFIX/"opt",
+        HOMEBREW_PREFIX/"Caskroom",
+        HOMEBREW_LIBRARY/"Taps/caskroom",
+        HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-bundle",
+        HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo",
+        HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-services",
+        HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-shallow",
+        HOMEBREW_REPOSITORY/".git",
+        coretap.path/".git",
+        coretap.alias_dir,
+        coretap.formula_dir.children,
+        coretap.path/"formula_renames.json",
+      ].flatten
+      FileUtils.rm_rf paths_to_delete
+
       super
     end
 

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -269,11 +269,6 @@ class TabLoadingTests < Homebrew::TestCase
     @path.write TEST_FIXTURE_DIR.join("receipt.json").read
   end
 
-  def teardown
-    @f.rack.rmtree
-    super
-  end
-
   def test_for_keg
     tab = Tab.for_keg(@f.prefix)
     assert_equal @path, tab.tabfile

--- a/Library/Homebrew/test/tap_test.rb
+++ b/Library/Homebrew/test/tap_test.rb
@@ -168,8 +168,6 @@ class TapTest < Homebrew::TestCase
       end
     end
     refute_predicate services_tap, :private?
-  ensure
-    services_tap.path.rmtree if services_tap
   end
 
   def test_remote_not_git_repo
@@ -253,8 +251,6 @@ class TapTest < Homebrew::TestCase
     refute_predicate tap, :installed?
     refute_predicate HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1", :exist?
     refute_predicate HOMEBREW_PREFIX/"share/man/man1", :exist?
-  ensure
-    (HOMEBREW_PREFIX/"share").rmtree if (HOMEBREW_PREFIX/"share").exist?
   end
 
   def test_pin_and_unpin
@@ -320,8 +316,5 @@ class CoreTapTest < Homebrew::TestCase
     assert_equal ["bar"], @repo.aliases
     assert_equal @repo.alias_table, "bar" => "foo"
     assert_equal @repo.alias_reverse_table, "foo" => ["bar"]
-  ensure
-    @formula_file.unlink
-    @repo.alias_dir.rmtree
   end
 end

--- a/Library/Homebrew/test/tap_test.rb
+++ b/Library/Homebrew/test/tap_test.rb
@@ -85,11 +85,6 @@ class TapTest < Homebrew::TestCase
     ENV.replace(env)
   end
 
-  def teardown
-    @path.rmtree
-    super
-  end
-
   def test_fetch
     assert_kind_of CoreTap, Tap.fetch("Homebrew", "homebrew")
     tap = Tap.fetch("Homebrew", "foo")

--- a/Library/Homebrew/test/uninstall_test.rb
+++ b/Library/Homebrew/test/uninstall_test.rb
@@ -30,10 +30,6 @@ class UninstallTests < Homebrew::TestCase
 
   def teardown
     Homebrew.failed = false
-    [@dependency, @dependent].each do |f|
-      f.installed_kegs.each(&:remove_opt_record)
-      f.rack.rmtree
-    end
     super
   end
 

--- a/Library/Homebrew/test/utils_test.rb
+++ b/Library/Homebrew/test/utils_test.rb
@@ -11,7 +11,6 @@ class UtilTests < Homebrew::TestCase
   end
 
   def teardown
-    @dir.rmtree
     ENV.replace @env
     super
   end

--- a/Library/Homebrew/test/versions_test.rb
+++ b/Library/Homebrew/test/versions_test.rb
@@ -185,8 +185,6 @@ class VersionParsingTests < Homebrew::TestCase
     d = HOMEBREW_CELLAR/"foo-0.1.9"
     d.mkpath
     assert_equal version("0.1.9"), d.version
-  ensure
-    d.unlink
   end
 
   def test_no_version


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

(No longer just integration tests.)

This was a big change, and I wanted to avoid removing any `ensure`/`teardown` code that would later end up needing to be added back in, so it's likely there'll be a few lines I could have removed but missed.

Similarly, I'm sure there are more directories that could be purged in teardown safely, but I decided to do an 80/20 and just copy the list from the integration tests for now.