### PR TITLE
Add internal command to calculate appcast checkpoint.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/audit.rb
+++ b/Library/Homebrew/cask/lib/hbc/audit.rb
@@ -133,20 +133,19 @@ module Hbc
 
     def check_appcast_checkpoint_accuracy
       odebug "Verifying appcast checkpoint is accurate"
-      result = @command.run("/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", URL::FAKE_USER_AGENT, cask.appcast], print_stderr: false)
-      if result.success?
-        processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}, "")
-        # This step is necessary to replicate running `sed` from the command line
-        processed_appcast_text << "\n" unless processed_appcast_text.end_with?("\n")
+      result = cask.appcast.calculate_checkpoint
+
+      actual_checkpoint = result[:checkpoint]
+
+      if actual_checkpoint.nil?
+        add_warning "error retrieving appcast: #{result[:command_result].stderr}"
+      else
         expected = cask.appcast.checkpoint
-        actual = Digest::SHA2.hexdigest(processed_appcast_text)
-        add_warning <<-EOS.undent unless expected == actual
+        add_warning <<-EOS.undent unless expected == actual_checkpoint
           appcast checkpoint mismatch
           Expected: #{expected}
-          Actual: #{actual}
+          Actual: #{actual_checkpoint}
         EOS
-      else
-        add_warning "error retrieving appcast: #{result.stderr}"
       end
     end
 

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -23,6 +23,7 @@ require "hbc/cli/zap"
 
 require "hbc/cli/internal_use_base"
 require "hbc/cli/internal_audit_modified_casks"
+require "hbc/cli/internal_appcast_checkpoint"
 require "hbc/cli/internal_checkurl"
 require "hbc/cli/internal_dump"
 require "hbc/cli/internal_help"

--- a/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
@@ -6,7 +6,18 @@ module Hbc
         cask_tokens = cask_tokens_from(args)
         raise CaskUnspecifiedError if cask_tokens.empty?
 
-        appcask_checkpoint(cask_tokens, calculate)
+        if cask_tokens.all? { |t| t =~ %r{^https?://} && t !~ /\.rb$/ }
+          appcask_checkpoint_for_url(cask_tokens)
+        else
+          appcask_checkpoint(cask_tokens, calculate)
+        end
+      end
+
+      def self.appcask_checkpoint_for_url(urls)
+        urls.each do |url|
+          appcast = DSL::Appcast.new(url)
+          puts appcast.calculate_checkpoint[:checkpoint]
+        end
       end
 
       def self.appcask_checkpoint(cask_tokens, calculate)
@@ -39,7 +50,7 @@ module Hbc
       end
 
       def self.help
-        "prints (no flag) or calculates ('--calculate') a given Cask's appcast checkpoint"
+        "prints (no flag) or calculates ('--calculate') a given Cask's (or URL's) appcast checkpoint"
       end
 
       def self.needs_init?

--- a/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
@@ -2,13 +2,14 @@ module Hbc
   class CLI
     class InternalAppcastCheckpoint < InternalUseBase
       def self.run(*args)
+        calculate = args.include? "--calculate"
         cask_tokens = cask_tokens_from(args)
         raise CaskUnspecifiedError if cask_tokens.empty?
 
-        appcask_checkpoint(cask_tokens)
+        appcask_checkpoint(cask_tokens, calculate)
       end
 
-      def self.appcask_checkpoint(cask_tokens)
+      def self.appcask_checkpoint(cask_tokens, calculate)
         count = 0
 
         cask_tokens.each do |cask_token|
@@ -17,9 +18,13 @@ module Hbc
           if cask.appcast.nil?
             opoo "Cask '#{cask}' is missing an `appcast` stanza."
           else
-            result = cask.appcast.calculate_checkpoint
+            if calculate
+              result = cask.appcast.calculate_checkpoint
 
-            checkpoint = result[:checkpoint]
+              checkpoint = result[:checkpoint]
+            else
+              checkpoint = cask.appcast.checkpoint
+            end
 
             if checkpoint.nil?
               onoe "Could not retrieve `appcast` checkpoint for cask '#{cask}': #{result[:command_result].stderr}"
@@ -34,7 +39,7 @@ module Hbc
       end
 
       def self.help
-        "calculates a given Cask's appcast checkpoint"
+        "prints (no flag) or calculates ('--calculate') a given Cask's appcast checkpoint"
       end
 
       def self.needs_init?

--- a/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
@@ -50,7 +50,7 @@ module Hbc
       end
 
       def self.help
-        "prints (no flag) or calculates ('--calculate') a given Cask's (or URL's) appcast checkpoint"
+        "prints or calculates a given Cask's or URL's appcast checkpoint"
       end
 
       def self.needs_init?

--- a/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/internal_appcast_checkpoint.rb
@@ -1,0 +1,45 @@
+module Hbc
+  class CLI
+    class InternalAppcastCheckpoint < InternalUseBase
+      def self.run(*args)
+        cask_tokens = cask_tokens_from(args)
+        raise CaskUnspecifiedError if cask_tokens.empty?
+
+        appcask_checkpoint(cask_tokens)
+      end
+
+      def self.appcask_checkpoint(cask_tokens)
+        count = 0
+
+        cask_tokens.each do |cask_token|
+          cask = Hbc.load(cask_token)
+
+          if cask.appcast.nil?
+            opoo "Cask '#{cask}' is missing an `appcast` stanza."
+          else
+            result = cask.appcast.calculate_checkpoint
+
+            checkpoint = result[:checkpoint]
+
+            if checkpoint.nil?
+              onoe "Could not retrieve `appcast` checkpoint for cask '#{cask}': #{result[:command_result].stderr}"
+            else
+              puts cask_tokens.count > 1 ? "#{checkpoint}  #{cask}": checkpoint
+              count += 1
+            end
+          end
+        end
+
+        count == cask_tokens.count
+      end
+
+      def self.help
+        "calculates a given Cask's appcast checkpoint"
+      end
+
+      def self.needs_init?
+        true
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cask/lib/hbc/dsl/appcast.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/appcast.rb
@@ -1,3 +1,5 @@
+require "hbc/system_command"
+
 module Hbc
   class DSL
     class Appcast
@@ -7,6 +9,24 @@ module Hbc
         @parameters     = parameters
         @uri            = UnderscoreSupportingURI.parse(uri)
         @checkpoint     = @parameters[:checkpoint]
+      end
+
+      def calculate_checkpoint
+        result = SystemCommand.run("/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", URL::FAKE_USER_AGENT, @uri], print_stderr: false)
+
+        checkpoint = if result.success?
+          processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}, "")
+
+          # This step is necessary to replicate running `sed` from the command line
+          processed_appcast_text << "\n" unless processed_appcast_text.end_with?("\n")
+
+          Digest::SHA2.hexdigest(processed_appcast_text)
+        end
+
+        {
+          checkpoint: checkpoint,
+          command_result: result,
+        }
       end
 
       def to_yaml

--- a/Library/Homebrew/cask/lib/hbc/dsl/appcast.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/appcast.rb
@@ -15,11 +15,7 @@ module Hbc
         result = SystemCommand.run("/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", URL::FAKE_USER_AGENT, @uri], print_stderr: false)
 
         checkpoint = if result.success?
-          processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}, "")
-
-          # This step is necessary to replicate running `sed` from the command line
-          processed_appcast_text << "\n" unless processed_appcast_text.end_with?("\n")
-
+          processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}m, "")
           Digest::SHA2.hexdigest(processed_appcast_text)
         end
 

--- a/Library/Homebrew/cask/spec/cask/audit_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/audit_spec.rb
@@ -162,7 +162,7 @@ describe Hbc::Audit do
 
         before do
           allow(audit).to receive(:check_appcast_http_code)
-          allow(fake_system_command).to receive(:run).and_return(fake_curl_result)
+          allow(Hbc::SystemCommand).to receive(:run).and_return(fake_curl_result)
           allow(fake_curl_result).to receive(:success?).and_return(success)
         end
 

--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -120,6 +120,13 @@ names, and other aspects of this manual are still subject to change.
 
     **`zap` may remove files which are shared between applications.**
 
+## INTERNAL COMMANDS
+
+  * `_appcast_checkpoint` [--calculate] [ <token> ... | <URL> ... ]:
+    Given a `token`, returns the current appcast checkpoint, or calculates
+    the appcast checkpoint if the `--calculate` flag is specified.  
+    Given a `URL`, calculates the appcast checkpoint for it.
+
 ## OPTIONS
 
 To make these options persistent, see the ENVIRONMENT section, below.

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -105,6 +105,15 @@ If the Cask definition contains a \fBzap\fR stanza, performs additional \fBzap\f
 .
 .IP "" 0
 .
+.SH "INTERNAL COMMANDS"
+.
+.TP
+\fB_appcast_checkpoint\fR [\-\-calculate] [ \fItoken\fR \.\.\. | \fIURL\fR \.\.\. ]
+Given a \fBtoken\fR, returns the current appcast checkpoint, or calculates the appcast checkpoint if the \fB\-\-calculate\fR flag is specified\.
+.
+.br
+Given a \fBURL\fR, calculates the appcast checkpoint for it\.
+.
 .SH "OPTIONS"
 To make these options persistent, see the ENVIRONMENT section, below\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

@vitorgalvao, I think (*finally*) implementing this is better than adding yet another workaround (`tr "\n"`).

Closes https://github.com/caskroom/homebrew-cask/issues/24811, https://github.com/caskroom/homebrew-cask/pull/28966 and https://github.com/Homebrew/brew/pull/1876.