### PR TITLE
Proposed fix for "Failed to eject" errors with DMGs

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/container/dmg.rb
+++ b/Library/Homebrew/cask/lib/hbc/container/dmg.rb
@@ -43,12 +43,17 @@ module Hbc
           next unless mountpath.exist?
 
           begin
-            tries ||= 2
-            @command.run("/usr/sbin/diskutil",
-                         args:         ["unmount", "force", mountpath],
-                         print_stderr: false)
-
-            raise CaskError, "Failed to unmount #{mountpath}" if mountpath.exist?
+            tries ||= 3
+            if tries > 1
+              @command.run("/usr/sbin/diskutil",
+                           args:         ["eject", mountpath],
+                           print_stderr: false)
+            else
+              @command.run("/usr/sbin/diskutil",
+                           args:         ["unmount", "force", mountpath],
+                           print_stderr: false)
+            end
+            raise CaskError, "Failed to eject #{mountpath}" if mountpath.exist?
           rescue CaskError => e
             raise e if (tries -= 1).zero?
             sleep 1

--- a/Library/Homebrew/cask/lib/hbc/container/dmg.rb
+++ b/Library/Homebrew/cask/lib/hbc/container/dmg.rb
@@ -45,10 +45,10 @@ module Hbc
           begin
             tries ||= 2
             @command.run("/usr/sbin/diskutil",
-                         args:         ["eject", mountpath],
+                         args:         ["unmount", "force", mountpath],
                          print_stderr: false)
 
-            raise CaskError, "Failed to eject #{mountpath}" if mountpath.exist?
+            raise CaskError, "Failed to unmount #{mountpath}" if mountpath.exist?
           rescue CaskError => e
             raise e if (tries -= 1).zero?
             sleep 1


### PR DESCRIPTION
Getting frequent "Failed to eject" errors when DMGs are installing with Homebrew Cask on macOS Sierra 10.12.2. Use "diskutil unmount force" to unmount DMGs instead of "diskutil eject".

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----
