### PR TITLE
Remove legacy cask cache instead of migrating.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc.rb
+++ b/Library/Homebrew/cask/lib/hbc.rb
@@ -46,7 +46,7 @@ module Hbc
 
   def self.init
     Cache.ensure_cache_exists
-    Cache.migrate_legacy_cache
+    Cache.delete_legacy_cache
 
     Caskroom.migrate_caskroom_from_repo_to_prefix
     Caskroom.ensure_caskroom_exists

--- a/Library/Homebrew/cask/lib/hbc/cache.rb
+++ b/Library/Homebrew/cask/lib/hbc/cache.rb
@@ -9,27 +9,10 @@ module Hbc
       Hbc.cache.mkpath
     end
 
-    def migrate_legacy_cache
+    def delete_legacy_cache
       return unless Hbc.legacy_cache.exist?
 
-      ohai "Migrating cached files to #{Hbc.cache}..."
-      Hbc.legacy_cache.children.select(&:symlink?).each do |symlink|
-        file = symlink.readlink
-
-        new_name = file.basename
-                       .sub(/\-((?:(\d|#{DSL::Version::DIVIDER_REGEX})*\-\2*)*[^\-]+)$/x,
-                            '--\1')
-
-        renamed_file = Hbc.cache.join(new_name)
-
-        if file.exist?
-          puts "#{file} -> #{renamed_file}"
-          FileUtils.mv(file, renamed_file)
-        end
-
-        FileUtils.rm(symlink)
-      end
-
+      ohai "Deleting legacy cache at #{Hbc.legacy_cache}..."
       FileUtils.remove_entry_secure(Hbc.legacy_cache)
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Cache files stored inside the legacy cache directory are all likely outdated by now, so it makes sense to remove them instead of migrating.