### PR TITLE
man: remove an unnecessary `else`

### DIFF
--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -23,9 +23,9 @@ module Homebrew
 
     if ARGV.flag? "--link"
       odie "`brew man --link` is now done automatically by `brew update`."
-    else
-      regenerate_man_pages
     end
+
+    regenerate_man_pages
 
     if system "git", "-C", HOMEBREW_REPOSITORY, "diff", "--quiet", "docs/brew.1.html", "manpages"
       puts "No changes to manpage output detected."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`odie` causes the process to exit immediately, so there's no need for the `regenerate_man_pages` call to be conditional.