### PR TITLE
xcode: reduce minimum CLT version.

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -226,7 +226,7 @@ module OS
       def minimum_version
         case MacOS.version
         when "10.12" then "8.0.0"
-        else "4.0.0"
+        else "1.0.0"
         end
       end
 


### PR DESCRIPTION
This should be 1.0.0 to be nicer to 10.7 users.

Fixes #1893.