### PR TITLE
Use array of constants to set up test directories.

### DIFF
--- a/Library/Homebrew/test/Gemfile
+++ b/Library/Homebrew/test/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "mocha"
 gem "minitest"
+gem "minitest-reporters"
 gem "parallel_tests"
 
 group :coverage do

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ansi (1.5.0)
+    builder (3.2.3)
     codecov (0.1.9)
       json
       simplecov
@@ -9,11 +11,17 @@ GEM
     json (2.0.3)
     metaclass (0.0.4)
     minitest (5.10.1)
+    minitest-reporters (1.1.14)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     mocha (1.2.1)
       metaclass (~> 0.0.1)
     parallel (1.10.0)
     parallel_tests (2.13.0)
       parallel
+    ruby-progressbar (1.8.1)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -27,6 +35,7 @@ PLATFORMS
 DEPENDENCIES
   codecov
   minitest
+  minitest-reporters
   mocha
   parallel_tests
   simplecov

--- a/Library/Homebrew/test/support/helper/fs_leak_logger.rb
+++ b/Library/Homebrew/test/support/helper/fs_leak_logger.rb
@@ -9,13 +9,13 @@ module Test
         klass.make_my_diffs_pretty!
       end
 
-      def before_setup
+      def setup
         @__files_before_test = []
         Find.find(TEST_TMPDIR) { |f| @__files_before_test << f.sub(TEST_TMPDIR, "") }
         super
       end
 
-      def after_teardown
+      def teardown
         super
         files_after_test = []
         Find.find(TEST_TMPDIR) { |f| files_after_test << f.sub(TEST_TMPDIR, "") }

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -12,6 +12,20 @@ module Homebrew
     TEST_SHA1   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
     TEST_SHA256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
 
+    def before_setup
+      [
+        HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-core/Formula",
+        HOMEBREW_CACHE,
+        HOMEBREW_CACHE_FORMULA,
+        HOMEBREW_LOCK_DIR,
+        HOMEBREW_CELLAR,
+        HOMEBREW_LOGS,
+        HOMEBREW_TEMP,
+      ].each(&:mkpath)
+
+      super
+    end
+
     def setup
       super
 
@@ -23,6 +37,10 @@ module Homebrew
       ARGV.replace(@__argv)
       ENV.replace(@__env)
 
+      super
+    end
+
+    def after_teardown
       Tab.clear_cache
 
       coretap = CoreTap.new

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -12,7 +12,7 @@ module Homebrew
     TEST_SHA1   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
     TEST_SHA256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
 
-    def before_setup
+    def setup
       [
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-core/Formula",
         HOMEBREW_CACHE,
@@ -24,10 +24,6 @@ module Homebrew
       ].each(&:mkpath)
 
       super
-    end
-
-    def setup
-      super
 
       @__argv = ARGV.dup
       @__env = ENV.to_hash # dup doesn't work on ENV
@@ -37,10 +33,6 @@ module Homebrew
       ARGV.replace(@__argv)
       ENV.replace(@__env)
 
-      super
-    end
-
-    def after_teardown
       Tab.clear_cache
 
       coretap = CoreTap.new

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -12,16 +12,18 @@ module Homebrew
     TEST_SHA1   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
     TEST_SHA256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
 
+    TEST_DIRECTORIES = [
+      CoreTap.instance.path/"Formula",
+      HOMEBREW_CACHE,
+      HOMEBREW_CACHE_FORMULA,
+      HOMEBREW_CELLAR,
+      HOMEBREW_LOCK_DIR,
+      HOMEBREW_LOGS,
+      HOMEBREW_TEMP,
+    ].freeze
+
     def setup
-      [
-        HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-core/Formula",
-        HOMEBREW_CACHE,
-        HOMEBREW_CACHE_FORMULA,
-        HOMEBREW_LOCK_DIR,
-        HOMEBREW_CELLAR,
-        HOMEBREW_LOGS,
-        HOMEBREW_TEMP,
-      ].each(&:mkpath)
+      TEST_DIRECTORIES.each(&:mkpath)
 
       super
 
@@ -35,15 +37,10 @@ module Homebrew
 
       Tab.clear_cache
 
-      coretap = CoreTap.new
-      paths_to_delete = [
+      FileUtils.rm_rf [
+        TEST_DIRECTORIES.map(&:children),
         HOMEBREW_LINKED_KEGS,
         HOMEBREW_PINNED_KEGS,
-        HOMEBREW_CELLAR.children,
-        HOMEBREW_CACHE.children,
-        HOMEBREW_LOCK_DIR.children,
-        HOMEBREW_LOGS.children,
-        HOMEBREW_TEMP.children,
         HOMEBREW_PREFIX/".git",
         HOMEBREW_PREFIX/"bin",
         HOMEBREW_PREFIX/"share",
@@ -55,12 +52,10 @@ module Homebrew
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-services",
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-shallow",
         HOMEBREW_REPOSITORY/".git",
-        coretap.path/".git",
-        coretap.alias_dir,
-        coretap.formula_dir.children,
-        coretap.path/"formula_renames.json",
-      ].flatten
-      FileUtils.rm_rf paths_to_delete
+        CoreTap.instance.path/".git",
+        CoreTap.instance.alias_dir,
+        CoreTap.instance.path/"formula_renames.json",
+      ]
 
       super
     end

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -1,3 +1,6 @@
+require "formulary"
+require "tap"
+
 module Homebrew
   class TestCase < ::Minitest::Test
     require "test/support/helper/fs_leak_logger"

--- a/Library/Homebrew/test/support/helper/test_case.rb
+++ b/Library/Homebrew/test/support/helper/test_case.rb
@@ -23,6 +23,8 @@ module Homebrew
     ].freeze
 
     def setup
+      # These directories need to be created before
+      # `FSLeakLogger` is called with `super`.
       TEST_DIRECTORIES.each(&:mkpath)
 
       super

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -1,18 +1,18 @@
-$LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"))
-$LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/test/support/lib"))
-
-require "simplecov" if ENV["HOMEBREW_TESTS_COVERAGE"]
-require "global"
-
 begin
   require "minitest/autorun"
   require "minitest/reporters"
   Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
-  require "parallel_tests/test/runtime_logger"
   require "mocha/setup"
+  require "parallel_tests/test/runtime_logger"
+  require "simplecov" if ENV["HOMEBREW_TESTS_COVERAGE"]
 rescue LoadError
-  abort "Run `bundle install` or install the mocha and minitest gems before running the tests"
+  abort "Run `bundle install` before running the tests."
 end
+
+$LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"))
+$LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/test/support/lib"))
+
+require "global"
 
 require "test/support/helper/test_case"
 require "test/support/helper/integration_command_test_case"

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -1,16 +1,14 @@
-$:.unshift File.expand_path("../..", __FILE__)
-$:.unshift File.expand_path("../support/lib", __FILE__)
+$LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew"))
+$LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/test/support/lib"))
 
 require "simplecov" if ENV["HOMEBREW_TESTS_COVERAGE"]
 require "global"
 require "formulary"
 
-# Test environment setup
-(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-core/Formula").mkpath
-%w[cache formula_cache locks cellar logs temp].each { |d| HOMEBREW_PREFIX.parent.join(d).mkpath }
-
 begin
   require "minitest/autorun"
+  require "minitest/reporters"
+  Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
   require "parallel_tests/test/runtime_logger"
   require "mocha/setup"
 rescue LoadError

--- a/Library/Homebrew/test/testing_env.rb
+++ b/Library/Homebrew/test/testing_env.rb
@@ -3,7 +3,6 @@ $LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/test/su
 
 require "simplecov" if ENV["HOMEBREW_TESTS_COVERAGE"]
 require "global"
-require "formulary"
 
 begin
   require "minitest/autorun"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Extracted from https://github.com/Homebrew/brew/pull/1314 for easier review.

Move creation of test directories into `Homebrew::TestCase` and use the existing constants instead of duplicating them with an array of strings.

Also updates `minitest` and adds `minitest-reporters` to assimilate with Cask's `test_helper`.