### PR TITLE
formula_cellar_checks: check for prefix/etc.

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -153,6 +153,16 @@ module FormulaCellarChecks
     EOS
   end
 
+  def check_etc
+    bad_etc = (formula.prefix/"etc")
+    return unless bad_etc.directory?
+    <<-EOS.undent
+      #{bad_etc} exists!
+      The contents should instead be installed into:
+      #{formula.etc}
+    EOS
+  end
+
   def audit_installed
     audit_check_output(check_manpages)
     audit_check_output(check_infopages)
@@ -165,6 +175,7 @@ module FormulaCellarChecks
     audit_check_output(check_easy_install_pth(formula.lib))
     audit_check_output(check_elisp_dirname(formula.share, formula.name))
     audit_check_output(check_elisp_root(formula.share, formula.name))
+    audit_check_output(check_etc)
   end
   alias generic_audit_installed audit_installed
 


### PR DESCRIPTION
This directory indicates that configuration files have been installed into the wrong location.

References:
- https://github.com/Homebrew/homebrew-core/issues/8711
- https://github.com/Homebrew/brew/pull/1839
- https://github.com/Homebrew/homebrew-core/pull/8818

CC @justinmayer