### PR TITLE
audit: improve homepage audit reliability.

### DIFF
--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -26,7 +26,7 @@ RUBY_BIN = RUBY_PATH.dirname
 
 HOMEBREW_USER_AGENT_CURL = ENV["HOMEBREW_USER_AGENT_CURL"]
 HOMEBREW_USER_AGENT_RUBY = "#{ENV["HOMEBREW_USER_AGENT"]} ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}".freeze
-HOMEBREW_USER_AGENT_FAKE_SAFARI = "Mozilla/5.0 (#{ENV["HOMEBREW_SYSTEM"]}; #{ENV["HOMEBREW_PROCESSOR"]} #{ENV["HOMEBREW_OS_VERSION"]}) AppleWebKit/602.3.12 (KHTML, like Gecko) Version/10.0.2 Safari/602.3.12".freeze
+HOMEBREW_USER_AGENT_FAKE_SAFARI = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8".freeze
 
 require "tap_constants"
 


### PR DESCRIPTION
Try first with an (exact, actual) browser user agent from Safari and then try again with the default Homebrew `curl` user agent.

Tested with `ansible` and `dbxml` and fixes both cases.

CC @ilovezfs and @woodruffw as you talked about this.
CC @broder as this change may affect your other PRs.

For https://github.com/Homebrew/homebrew-core/issues/8847