### PR TITLE
Split two headers so that both render

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -359,6 +359,7 @@ Now, please [open a pull request](http://docs.brew.sh/How-To-Open-a-Homebrew-Pul
 *   Keep merge commits out of the pull request
 
 # Convenience Tools
+
 ## Messaging
 
 Three commands are provided for displaying informational messages to the user:


### PR DESCRIPTION
The "Messaging" heading was failing to be rendered due to a missing newline between it and "Convenience Tools". While this works on Github, it appears that it doesn't online: http://docs.brew.sh/Formula-Cookbook.html#convenience-tools

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [N/A] Have you successfully run `brew tests` with your changes locally?

-----