### PR TITLE
cask: staged: no sudo in set_permissions

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/staged.rb
+++ b/Library/Homebrew/cask/lib/hbc/staged.rb
@@ -27,7 +27,7 @@ module Hbc
       full_paths = remove_nonexistent(paths)
       return if full_paths.empty?
       @command.run!("/bin/chmod", args: ["-R", "--", permissions_str] + full_paths,
-                                  sudo: true)
+                                  sudo: false)
     end
 
     def set_ownership(paths, user: current_user, group: "staff")

--- a/Library/Homebrew/cask/test/support/shared_examples/staged.rb
+++ b/Library/Homebrew/cask/test/support/shared_examples/staged.rb
@@ -47,7 +47,7 @@ shared_examples_for Hbc::Staged do
     staged.stubs(Pathname: fake_pathname)
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/usr/bin/sudo", "-E", "--", "/bin/chmod", "-R", "--", "777", fake_pathname]
+      ["/bin/chmod", "-R", "--", "777", fake_pathname]
     )
     staged.set_permissions(fake_pathname.to_s, "777")
   end
@@ -57,7 +57,7 @@ shared_examples_for Hbc::Staged do
     staged.stubs(:Pathname).returns(fake_pathname)
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/usr/bin/sudo", "-E", "--", "/bin/chmod", "-R", "--", "777", fake_pathname, fake_pathname]
+      ["/bin/chmod", "-R", "--", "777", fake_pathname, fake_pathname]
     )
     staged.set_permissions([fake_pathname.to_s, fake_pathname.to_s], "777")
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Refs https://github.com/caskroom/homebrew-cask/pull/29227#issuecomment-275849981. @jawshooah is there any reason `set_permissions` would require `sudo` by default?