### PR TITLE
cleanup: consider version_scheme

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1843,7 +1843,16 @@ class Formula
       eligible_kegs = if head? && (head_prefix = latest_head_prefix)
         installed_kegs - [Keg.new(head_prefix)]
       else
-        installed_kegs.select { |k| pkg_version > k.version }
+        installed_kegs.select do |keg|
+          tab = Tab.for_keg(keg)
+          if version_scheme > tab.version_scheme
+            true
+          elsif version_scheme == tab.version_scheme
+            pkg_version > keg.version
+          else
+            false
+          end
+        end
       end
 
       unless eligible_kegs.empty?

--- a/Library/Homebrew/test/cleanup_test.rb
+++ b/Library/Homebrew/test/cleanup_test.rb
@@ -36,25 +36,40 @@ class CleanupTests < Homebrew::TestCase
   end
 
   def test_cleanup_formula
-    f1 = Class.new(Testball) { version "0.1" }.new
-    f2 = Class.new(Testball) { version "0.2" }.new
-    f3 = Class.new(Testball) { version "0.3" }.new
+    f1 = Class.new(Testball) do
+      version "1.0"
+    end.new
+    f2 = Class.new(Testball) do
+      version "0.2"
+      version_scheme 1
+    end.new
+    f3 = Class.new(Testball) do
+      version "0.3"
+      version_scheme 1
+    end.new
+    f4 = Class.new(Testball) do
+      version "0.1"
+      version_scheme 2
+    end.new
 
     shutup do
-      f1.brew { f1.install }
-      f2.brew { f2.install }
-      f3.brew { f3.install }
+      [f1, f2, f3, f4].each do |f|
+        f.brew { f.install }
+        Tab.create(f, DevelopmentTools.default_compiler, :libcxx).write
+      end
     end
 
     assert_predicate f1, :installed?
     assert_predicate f2, :installed?
     assert_predicate f3, :installed?
+    assert_predicate f4, :installed?
 
     shutup { Homebrew::Cleanup.cleanup_formula f3 }
 
     refute_predicate f1, :installed?
     refute_predicate f2, :installed?
     assert_predicate f3, :installed?
+    assert_predicate f4, :installed?
   end
 
   def test_cleanup_logs

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -727,21 +727,35 @@ class FormulaTests < Homebrew::TestCase
   end
 
   def test_eligible_kegs_for_cleanup
-    f1 = Class.new(Testball) { version "0.1" }.new
-    f2 = Class.new(Testball) { version "0.2" }.new
-    f3 = Class.new(Testball) { version "0.3" }.new
+    f1 = Class.new(Testball) do
+      version "1.0"
+    end.new
+    f2 = Class.new(Testball) do
+      version "0.2"
+      version_scheme 1
+    end.new
+    f3 = Class.new(Testball) do
+      version "0.3"
+      version_scheme 1
+    end.new
+    f4 = Class.new(Testball) do
+      version "0.1"
+      version_scheme 2
+    end.new
 
     shutup do
-      f1.brew { f1.install }
-      f2.brew { f2.install }
-      f3.brew { f3.install }
+      [f1, f2, f3, f4].each do |f|
+        f.brew { f.install }
+        Tab.create(f, DevelopmentTools.default_compiler, :libcxx).write
+      end
     end
 
     assert_predicate f1, :installed?
     assert_predicate f2, :installed?
     assert_predicate f3, :installed?
+    assert_predicate f4, :installed?
 
-    assert_equal f3.installed_kegs.sort_by(&:version)[0..1],
+    assert_equal [f2, f1].map { |f| Keg.new(f.prefix) },
                  f3.eligible_kegs_for_cleanup.sort_by(&:version)
   end
 


### PR DESCRIPTION
`brew cleanup` should cleanup formulae which have the older
version scheme.