### PR TITLE
formulary: handle ScriptError in formula

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -131,6 +131,19 @@ class FormulaClassUnavailableError < FormulaUnavailableError
   end
 end
 
+class FormulaUnreadableError < FormulaUnavailableError
+  attr_reader :formula_error
+
+  def initialize(name, error)
+    super(name)
+    @formula_error = error
+  end
+
+  def to_s
+    "#{name}: " + formula_error.to_s
+  end
+end
+
 class TapFormulaAmbiguityError < RuntimeError
   attr_reader :name, :paths, :formulae
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -22,7 +22,11 @@ class Formulary
 
     mod = Module.new
     const_set(namespace, mod)
-    mod.module_eval(contents, path)
+    begin
+      mod.module_eval(contents, path)
+    rescue ScriptError => e
+      raise FormulaUnreadableError.new(name, e)
+    end
     class_name = class_s(name)
 
     begin

--- a/Library/Homebrew/test/exceptions_test.rb
+++ b/Library/Homebrew/test/exceptions_test.rb
@@ -56,6 +56,11 @@ class ExceptionsTest < Homebrew::TestCase
       FormulaClassUnavailableError.new("foo", "foo.rb", "Foo", list).to_s
   end
 
+  def test_formula_unreadable_error
+    formula_error = LoadError.new("bar")
+    assert_equal "foo: bar", FormulaUnreadableError.new("foo", formula_error).to_s
+  end
+
   def test_tap_unavailable_error
     assert_equal "No available tap foo.\n", TapUnavailableError.new("foo").to_s
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I added a new `FormulaUnreadableError` subclass of `FormulaUnavailableError` so existing `rescue`s of `FormulaUnavailableError` handle this as well.

The new subclass will output the name of the formula with the error (because this isn't always obvious from the original exception message) followed by the original error message.

Fixes #1927.
