### PR TITLE
Use constants for RuboCop version.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/style.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/style.rb
@@ -23,12 +23,10 @@ module Hbc
         $CHILD_STATUS.success?
       end
 
-      RUBOCOP_CASK_VERSION = "~> 0.10.6".freeze
-
       def install_rubocop
         Utils.capture_stderr do
           begin
-            Homebrew.install_gem_setup_path! "rubocop-cask", RUBOCOP_CASK_VERSION, "rubocop"
+            Homebrew.install_gem_setup_path! "rubocop-cask", HOMEBREW_RUBOCOP_CASK_VERSION, "rubocop"
           rescue SystemExit
             raise CaskError, Tty.strip_ansi($stderr.string).chomp.sub(/\AError: /, "")
           end

--- a/Library/Homebrew/cask/spec/cask/cli/style_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/cli/style_spec.rb
@@ -1,4 +1,6 @@
 require "English"
+require "open3"
+require "rubygems"
 
 describe Hbc::CLI::Style do
   let(:args) { [] }
@@ -75,6 +77,20 @@ describe Hbc::CLI::Style do
 
       it "raises an error" do
         expect { subject }.to raise_error(Hbc::CaskError)
+      end
+    end
+
+    context "version" do
+      it "matches `HOMEBREW_RUBOCOP_VERSION`" do
+        stdout, status = Open3.capture2("gem", "dependency", "rubocop-cask", "--version", HOMEBREW_RUBOCOP_CASK_VERSION, "--pipe", "--remote")
+
+        expect(status).to be_a_success
+
+        requirement = Gem::Requirement.new(stdout.scan(/rubocop --version '(.*)'/).flatten.first)
+        version = Gem::Version.new(HOMEBREW_RUBOCOP_VERSION)
+
+        expect(requirement).not_to be_none
+        expect(requirement).to be_satisfied_by(version)
       end
     end
   end

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -47,7 +47,7 @@ module Homebrew
 
   def check_style_impl(files, output_type, options = {})
     fix = options[:fix]
-    Homebrew.install_gem_setup_path! "rubocop", "0.47.1"
+    Homebrew.install_gem_setup_path! "rubocop", HOMEBREW_RUBOCOP_VERSION
 
     args = %w[
       --force-exclusion

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -48,3 +48,7 @@ end
 
 # Load path used by standalone scripts to access the Homebrew code base
 HOMEBREW_LOAD_PATH = HOMEBREW_LIBRARY_PATH
+
+# RuboCop version used for `brew style` and `brew cask style`
+HOMEBREW_RUBOCOP_VERSION = "0.47.1".freeze
+HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.10.6".freeze # has to be updated when RuboCop version changes

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -2,6 +2,8 @@ unless ENV["HOMEBREW_BREW_FILE"]
   raise "HOMEBREW_BREW_FILE was not exported! Please call bin/brew directly!"
 end
 
+require "constants"
+
 # Path to `bin/brew` main executable in HOMEBREW_PREFIX
 HOMEBREW_BREW_FILE = Pathname.new(ENV["HOMEBREW_BREW_FILE"])
 
@@ -48,7 +50,3 @@ end
 
 # Load path used by standalone scripts to access the Homebrew code base
 HOMEBREW_LOAD_PATH = HOMEBREW_LIBRARY_PATH
-
-# RuboCop version used for `brew style` and `brew cask style`
-HOMEBREW_RUBOCOP_VERSION = "0.47.1".freeze
-HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.10.6".freeze # has to be updated when RuboCop version changes

--- a/Library/Homebrew/constants.rb
+++ b/Library/Homebrew/constants.rb
@@ -1,0 +1,3 @@
+# RuboCop version used for `brew style` and `brew cask style`
+HOMEBREW_RUBOCOP_VERSION = "0.47.1".freeze
+HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.10.6".freeze # has to be updated when RuboCop version changes

--- a/Library/Homebrew/constants.rb
+++ b/Library/Homebrew/constants.rb
@@ -1,3 +1,3 @@
 # RuboCop version used for `brew style` and `brew cask style`
 HOMEBREW_RUBOCOP_VERSION = "0.47.1".freeze
-HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.10.6".freeze # has to be updated when RuboCop version changes
+HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.11.0".freeze # has to be updated when RuboCop version changes

--- a/Library/Homebrew/test/support/lib/config.rb
+++ b/Library/Homebrew/test/support/lib/config.rb
@@ -2,6 +2,8 @@ unless ENV["HOMEBREW_BREW_FILE"]
   raise "HOMEBREW_BREW_FILE was not exported! Please call bin/brew directly!"
 end
 
+require "constants"
+
 require "tmpdir"
 require "pathname"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When updating the RuboCop version, we need to make sure to also update it for `rubocop-cask`, otherwise these will conflict, as is the case at the moment.