### PR TITLE
gcc_version_formula: Use gcc@4.x rather than gcc4x

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -269,7 +269,7 @@ module SharedEnvExtension
   # @private
   def gcc_version_formula(name)
     version = name[GNU_GCC_REGEXP, 1]
-    gcc_version_name = "gcc#{version.delete(".")}"
+    gcc_version_name = "gcc@#{version}"
 
     gcc = Formulary.factory("gcc")
     if gcc.version_suffix == version
@@ -286,7 +286,6 @@ module SharedEnvExtension
     rescue FormulaUnavailableError => e
       raise <<-EOS.undent
       Homebrew GCC requested, but formula #{e.name} not found!
-      You may need to: brew tap homebrew/versions
       EOS
     end
 


### PR DESCRIPTION
This PR modifies the compiler selection logic to use `Homebrew/core/gcc@4.x` rather than `Homebrew/versions/gcc4x`.

I haven't yet had a chance to test this PR. I wanted to first get feedback that this approach is correct.