### PR TITLE
Remove `TestCask` class.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cask_loader.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask_loader.rb
@@ -32,17 +32,12 @@ module Hbc
     end
 
     def cask(header_token, &block)
-      @klass = Cask
-      build_cask(header_token, &block)
-    end
-
-    def build_cask(header_token, &block)
       raise CaskTokenDoesNotMatchError.new(@token, header_token) unless @token == header_token
 
       if @path.nil?
-        @klass.new(@token, &block)
+        Cask.new(@token, &block)
       else
-        @klass.new(@token, sourcefile_path: @path, &block)
+        Cask.new(@token, sourcefile_path: @path, &block)
       end
     end
   end

--- a/Library/Homebrew/cask/lib/hbc/cask_loader.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask_loader.rb
@@ -36,11 +36,6 @@ module Hbc
       build_cask(header_token, &block)
     end
 
-    def test_cask(header_token, &block)
-      @klass = TestCask
-      build_cask(header_token, &block)
-    end
-
     def build_cask(header_token, &block)
       raise CaskTokenDoesNotMatchError.new(@token, header_token) unless @token == header_token
 

--- a/Library/Homebrew/cask/spec/spec_helper.rb
+++ b/Library/Homebrew/cask/spec/spec_helper.rb
@@ -21,10 +21,6 @@ Pathname.glob(HOMEBREW_LIBRARY_PATH.join("cask", "spec", "support", "*.rb")).eac
 
 require "hbc"
 
-module Hbc
-  class TestCask < Cask; end
-end
-
 # create and override default directories
 Hbc.appdir = Pathname.new(TEST_TMPDIR).join("Applications").tap(&:mkpath)
 Hbc.cache.mkpath

--- a/Library/Homebrew/cask/test/cask/cli/cat_test.rb
+++ b/Library/Homebrew/cask/test/cask/cli/cat_test.rb
@@ -4,7 +4,7 @@ describe Hbc::CLI::Cat do
   describe "given a basic Cask" do
     before do
       @expected_output = <<-EOS.undent
-        test_cask 'basic-cask' do
+        cask 'basic-cask' do
           version '1.2.3'
           sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/cask/test/test_helper.rb
+++ b/Library/Homebrew/cask/test/test_helper.rb
@@ -35,10 +35,6 @@ Mocha::Integration::MiniTest.activate
 # our baby
 require "hbc"
 
-module Hbc
-  class TestCask < Cask; end
-end
-
 # create and override default directories
 Hbc.appdir = Pathname.new(TEST_TMPDIR).join("Applications").tap(&:mkpath)
 Hbc.cache.mkpath

--- a/Library/Homebrew/compat/hbc/cask_loader.rb
+++ b/Library/Homebrew/compat/hbc/cask_loader.rb
@@ -1,7 +1,7 @@
 module CaskLoaderCompatibilityLayer
   private
 
-  def build_cask(header_token, &block)
+  def cask(header_token, &block)
     if header_token.is_a?(Hash) && header_token.key?(:v1)
       odeprecated %q("cask :v1 => 'token'"), %q("cask 'token'")
       header_token = header_token[:v1]

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-checkpoint-sha256-for-empty-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-checkpoint-sha256-for-empty-string.rb
@@ -1,4 +1,4 @@
-test_cask 'appcast-checkpoint-sha256-for-empty-string' do
+cask 'appcast-checkpoint-sha256-for-empty-string' do
   appcast 'http://localhost/appcast.xml',
           checkpoint: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-invalid-checkpoint.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-invalid-checkpoint.rb
@@ -1,4 +1,4 @@
-test_cask 'appcast-invalid-checkpoint' do
+cask 'appcast-invalid-checkpoint' do
   appcast 'http://localhost/appcast.xml',
           checkpoint: 'not a valid shasum'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-missing-checkpoint.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-missing-checkpoint.rb
@@ -1,3 +1,3 @@
-test_cask 'appcast-missing-checkpoint' do
+cask 'appcast-missing-checkpoint' do
   appcast 'http://localhost/appcast.xml'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-valid-checkpoint.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/appcast-valid-checkpoint.rb
@@ -1,4 +1,4 @@
-test_cask 'appcast-valid-checkpoint' do
+cask 'appcast-valid-checkpoint' do
   appcast 'http://localhost/appcast.xml',
           checkpoint: 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/appdir-interpolation.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/appdir-interpolation.rb
@@ -1,4 +1,4 @@
-test_cask 'appdir-interpolation' do
+cask 'appdir-interpolation' do
   version '2.61'
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
@@ -1,4 +1,4 @@
-test_cask 'auto-updates' do
+cask 'auto-updates' do
   version '2.61'
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
@@ -1,4 +1,4 @@
-test_cask 'bad-checksum' do
+cask 'bad-checksum' do
   version '1.2.3'
   sha256 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
@@ -1,4 +1,4 @@
-test_cask 'basic-cask' do
+cask 'basic-cask' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-7z.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-7z.rb
@@ -1,4 +1,4 @@
-test_cask 'container-7z' do
+cask 'container-7z' do
   version '1.2.3'
   sha256 '3f9542ace85ed5f88549e2d0ea82210f8ddc87e0defbb78469d3aed719b3c964'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-air.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-air.rb
@@ -1,4 +1,4 @@
-test_cask 'container-air' do
+cask 'container-air' do
   version '0.1'
   sha256 '554472e163f8a028629b12b468e29acda9f16b223dff74fcd218bba73cc2365a'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-bzip2.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-bzip2.rb
@@ -1,4 +1,4 @@
-test_cask 'container-bzip2' do
+cask 'container-bzip2' do
   version '1.2.3'
   sha256 'eaf67b3a62cb9275f96e45d05c70b94bef9ef1dae344083e93eda6b0b388a61c'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-cab.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-cab.rb
@@ -1,4 +1,4 @@
-test_cask 'container-cab' do
+cask 'container-cab' do
   version '1.2.3'
   sha256 'c267f5cebb14814c8e612a8b7d2bda02aec913f869509b6f1d3883427c0f552b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-dmg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-dmg.rb
@@ -1,4 +1,4 @@
-test_cask 'container-dmg' do
+cask 'container-dmg' do
   version '1.2.3'
   sha256 '74d89d4fa5cef175cf43666ce11fefa3741aa1522114042ac75e656be37141a1'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-gzip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-gzip.rb
@@ -1,4 +1,4 @@
-test_cask 'container-gzip' do
+cask 'container-gzip' do
   version '1.2.3'
   sha256 'fa4ebb5246583c4b6e62e1df4e3b71b4e38a1d7d91c025665827195d36214b20'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-lzma.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-lzma.rb
@@ -1,4 +1,4 @@
-test_cask 'container-lzma' do
+cask 'container-lzma' do
   version '1.2.3'
   sha256 '9d7edb32d02ab9bd9749a5bde8756595ea4cfcb1da02ca11c30fb591d4c1ed85'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-pkg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-pkg.rb
@@ -1,4 +1,4 @@
-test_cask 'container-pkg' do
+cask 'container-pkg' do
   version '1.2.3'
   sha256 '611c50c8a2a2098951d2cd0fd54787ed81b92cd97b4b08bd7cba17f1e1d8e40b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-rar.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-rar.rb
@@ -1,4 +1,4 @@
-test_cask 'container-rar' do
+cask 'container-rar' do
   version '1.2.3'
   sha256 '419af7864c0e1f125515c49b08bd22e0f7de39f5285897c440fe03c714871763'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-sit.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-sit.rb
@@ -1,4 +1,4 @@
-test_cask 'container-sit' do
+cask 'container-sit' do
   version '1.2.3'
   sha256 '0d21a64dce625044345c8ecca888e5439feaf254dac7f884917028a744f93cf3'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-tar-gz.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-tar-gz.rb
@@ -1,4 +1,4 @@
-test_cask 'container-tar-gz' do
+cask 'container-tar-gz' do
   version '1.2.3'
   sha256 'fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-xar.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-xar.rb
@@ -1,4 +1,4 @@
-test_cask 'container-xar' do
+cask 'container-xar' do
   version '1.2.3'
   sha256 '5bb8e09a6fc630ebeaf266b1fd2d15e2ae7d32d7e4da6668a8093426fa1ba509'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-xz.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-xz.rb
@@ -1,4 +1,4 @@
-test_cask 'container-xz' do
+cask 'container-xz' do
   version '1.2.3'
   sha256 '839263f474edde1d54a9101606e6f0dc9d963acc93f6dcc5af8d10ebc3187c02'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-absolute-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-absolute-target.rb
@@ -1,3 +1,3 @@
-test_cask 'generic-artifact-absolute-target' do
+cask 'generic-artifact-absolute-target' do
   artifact 'Caffeine.app', target: "#{Hbc.appdir}/Caffeine.app"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-no-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-no-target.rb
@@ -1,3 +1,3 @@
-test_cask 'generic-artifact-no-target' do
+cask 'generic-artifact-no-target' do
   artifact 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-relative-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/generic-artifact-relative-target.rb
@@ -1,3 +1,3 @@
-test_cask 'generic-artifact-relative-target' do
+cask 'generic-artifact-relative-target' do
   artifact 'Caffeine.app', target: 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid-sha256.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-sha256' do
+cask 'invalid-sha256' do
   version '1.2.3'
   sha256 'not a valid shasum'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-multiple.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-appcast-multiple' do
+cask 'invalid-appcast-multiple' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-url.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-appcast-url' do
+cask 'invalid-appcast-url' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-conflicts-with-key.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-conflicts-with-key.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-conflicts-with-key' do
+cask 'invalid-conflicts-with-key' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-arch-value.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-arch-value.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-depends-on-arch-value' do
+cask 'invalid-depends-on-arch-value' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-key.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-key.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-depends-on-key' do
+cask 'invalid-depends-on-key' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bad-release.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bad-release.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-depends-on-macos-bad-release' do
+cask 'invalid-depends-on-macos-bad-release' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-conflicting-forms.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-conflicting-forms.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-depends-on-macos-conflicting-forms' do
+cask 'invalid-depends-on-macos-conflicting-forms' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-x11-value.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-x11-value.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-depends-on-x11-value' do
+cask 'invalid-depends-on-x11-value' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-conflicting-keys.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-conflicting-keys.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-conflicting-keys' do
+cask 'invalid-gpg-conflicting-keys' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-key-id.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-key-id.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-key-id' do
+cask 'invalid-gpg-key-id' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-key-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-key-url.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-key-url' do
+cask 'invalid-gpg-key-url' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-missing-key.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-missing-key.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-missing-key' do
+cask 'invalid-gpg-missing-key' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-multiple-stanzas.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-multiple-stanzas.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-multiple-stanzas' do
+cask 'invalid-gpg-multiple-stanzas' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-parameter.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-parameter.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-parameter' do
+cask 'invalid-gpg-parameter' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-signature-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-signature-url.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-signature-url' do
+cask 'invalid-gpg-signature-url' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-type.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-gpg-type.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-gpg-type' do
+cask 'invalid-gpg-type' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
@@ -1,4 +1,4 @@
-test_cask => 'invalid-header-format' do
+cask => 'invalid-header-format' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-header-token-mismatch-this-text-does-not-belong' do
+cask 'invalid-header-token-mismatch-this-text-does-not-belong' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-header-version' do
+cask 'invalid-header-version' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-stage-only-conflict.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-stage-only-conflict.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-stage-only-conflict' do
+cask 'invalid-stage-only-conflict' do
   version '2.61'
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-two-homepage' do
+cask 'invalid-two-homepage' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-two-url' do
+cask 'invalid-two-url' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
@@ -1,4 +1,4 @@
-test_cask 'invalid-two-version' do
+cask 'invalid-two-version' do
   version '1.2.3'
   version '2.0'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
@@ -1,4 +1,4 @@
-test_cask 'local-caffeine' do
+cask 'local-caffeine' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
@@ -1,4 +1,4 @@
-test_cask 'local-transmission' do
+cask 'local-transmission' do
   version '2.61'
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
@@ -1,4 +1,4 @@
-test_cask 'missing-checksum' do
+cask 'missing-checksum' do
   version '1.2.3'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-homepage.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-homepage.rb
@@ -1,4 +1,4 @@
-test_cask 'missing-homepage' do
+cask 'missing-homepage' do
   version '1.2.3'
 
   url 'http://localhost/something.dmg'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-name.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-name.rb
@@ -1,4 +1,4 @@
-test_cask 'missing-name' do
+cask 'missing-name' do
   version '1.2.3'
 
   url 'http://localhost/something.dmg'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-sha256.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-sha256.rb
@@ -1,4 +1,4 @@
-test_cask 'missing-sha256' do
+cask 'missing-sha256' do
   version '1.2.3'
 
   url 'http://localhost/something.dmg'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
@@ -1,4 +1,4 @@
-test_cask 'missing-url' do
+cask 'missing-url' do
   version '1.2.3'
 
   homepage 'http://example.com'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
@@ -1,4 +1,4 @@
-test_cask 'missing-version' do
+cask 'missing-version' do
   url 'http://localhost/something.dmg'
   homepage 'http://example.com'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/naked-executable.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/naked-executable.rb
@@ -1,4 +1,4 @@
-test_cask 'naked-executable' do
+cask 'naked-executable' do
   version '1.2.3'
   sha256 '306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/nested-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/nested-app.rb
@@ -1,4 +1,4 @@
-test_cask 'nested-app' do
+cask 'nested-app' do
   version '1.2.3'
   sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
@@ -1,4 +1,4 @@
-test_cask 'no-checksum' do
+cask 'no-checksum' do
   version '1.2.3'
   sha256 :no_check
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/no-dsl-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/no-dsl-version.rb
@@ -1,4 +1,4 @@
-test_cask 'no-dsl-version' do
+cask 'no-dsl-version' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-correct-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-correct-url-format.rb
@@ -1,4 +1,4 @@
-test_cask 'osdn-correct-url-format' do
+cask 'osdn-correct-url-format' do
   version '1.2.3'
 
   url 'http://user.dl.osdn.jp/something/id/Something-1.2.3.dmg'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-incorrect-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-incorrect-url-format.rb
@@ -1,4 +1,4 @@
-test_cask 'osdn-incorrect-url-format' do
+cask 'osdn-incorrect-url-format' do
   version '1.2.3'
 
   url 'http://osdn.jp/projects/something/files/Something-1.2.3.dmg/download'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-for-empty-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sha256-for-empty-string.rb
@@ -1,4 +1,4 @@
-test_cask 'sha256-for-empty-string' do
+cask 'sha256-for-empty-string' do
   version '1.2.3'
   sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-correct-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-correct-url-format.rb
@@ -1,4 +1,4 @@
-test_cask 'sourceforge-correct-url-format' do
+cask 'sourceforge-correct-url-format' do
   version '1.2.3'
 
   url 'https://downloads.sourceforge.net/something/Something-1.2.3.dmg'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-incorrect-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-incorrect-url-format.rb
@@ -1,4 +1,4 @@
-test_cask 'sourceforge-incorrect-url-format' do
+cask 'sourceforge-incorrect-url-format' do
   version '1.2.3'
 
   url 'http://sourceforge.net/projects/something/files/Something-1.2.3.dmg/download'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-version-latest-correct-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/sourceforge-version-latest-correct-url-format.rb
@@ -1,4 +1,4 @@
-test_cask 'sourceforge-version-latest-correct-url-format' do
+cask 'sourceforge-version-latest-correct-url-format' do
   version :latest
 
   url 'https://sourceforge.net/projects/something/files/latest/download'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/stage-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/stage-only.rb
@@ -1,4 +1,4 @@
-test_cask 'stage-only' do
+cask 'stage-only' do
   version '2.61'
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera-mail.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera-mail.rb
@@ -1,4 +1,4 @@
-test_cask 'test-opera-mail' do
+cask 'test-opera-mail' do
   version '1.0'
   sha256 'afd192e308f8ea8ddb3d426fd6663d97078570417ee78b8e1fa15f515ae3d677'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/test-opera.rb
@@ -1,4 +1,4 @@
-test_cask 'test-opera' do
+cask 'test-opera' do
   version '19.0.1326.47'
   sha256 '7b91f20ab754f7b3fef8dc346e0393917e11676b74c8f577408841619f76040a'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-string.rb
@@ -1,4 +1,4 @@
-test_cask 'version-latest-string' do
+cask 'version-latest-string' do
   version 'latest'
   sha256 :no_check
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-with-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest-with-checksum.rb
@@ -1,4 +1,4 @@
-test_cask 'version-latest-with-checksum' do
+cask 'version-latest-with-checksum' do
   version :latest
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-accessibility-access.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-accessibility-access.rb
@@ -1,4 +1,4 @@
-test_cask 'with-accessibility-access' do
+cask 'with-accessibility-access' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
@@ -1,4 +1,4 @@
-test_cask 'with-alt-target' do
+cask 'with-alt-target' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-appcast.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-appcast.rb
@@ -1,4 +1,4 @@
-test_cask 'with-appcast' do
+cask 'with-appcast' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
@@ -1,4 +1,4 @@
-test_cask 'with-binary' do
+cask 'with-binary' do
   version '1.2.3'
   sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
@@ -1,4 +1,4 @@
-test_cask 'with-caveats' do
+cask 'with-caveats' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-choices.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-choices.rb
@@ -1,4 +1,4 @@
-test_cask 'with-choices' do
+cask 'with-choices' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
@@ -1,4 +1,4 @@
-test_cask 'with-conditional-caveats' do
+cask 'with-conditional-caveats' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with.rb
@@ -1,4 +1,4 @@
-test_cask 'with-conflicts-with' do
+cask 'with-conflicts-with' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-arch' do
+cask 'with-depends-on-arch' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic-helper.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic-helper.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-cask-cyclic-helper' do
+cask 'with-depends-on-cask-cyclic-helper' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-cask-cyclic' do
+cask 'with-depends-on-cask-cyclic' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-multiple.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-cask-multiple' do
+cask 'with-depends-on-cask-multiple' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-cask' do
+cask 'with-depends-on-cask' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-formula-multiple' do
+cask 'with-depends-on-formula-multiple' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-formula' do
+cask 'with-depends-on-formula' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-array.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-array.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-macos-array' do
+cask 'with-depends-on-macos-array' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-comparison.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-comparison.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-macos-comparison' do
+cask 'with-depends-on-macos-comparison' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-macos-failure' do
+cask 'with-depends-on-macos-failure' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-string.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-macos-string' do
+cask 'with-depends-on-macos-string' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-symbol.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-symbol.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-macos-symbol' do
+cask 'with-depends-on-macos-symbol' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11-false.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11-false.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-x11-false' do
+cask 'with-depends-on-x11-false' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11.rb
@@ -1,4 +1,4 @@
-test_cask 'with-depends-on-x11' do
+cask 'with-depends-on-x11' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-dsl-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-dsl-version.rb
@@ -1,4 +1,4 @@
-test_cask :v1 => 'with-dsl-version' do
+cask :v1 => 'with-dsl-version' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-embedded-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-embedded-binary.rb
@@ -1,4 +1,4 @@
-test_cask 'with-embedded-binary' do
+cask 'with-embedded-binary' do
   version '1.2.3'
   sha256 'fe052d3e77d92676775fd916ddb8942e72a565b844ea7f6d055474c99bb4e47b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact-no-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact-no-target.rb
@@ -1,4 +1,4 @@
-test_cask 'with-generic-artifact-no-target' do
+cask 'with-generic-artifact-no-target' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact.rb
@@ -1,4 +1,4 @@
-test_cask 'with-generic-artifact' do
+cask 'with-generic-artifact' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-gpg-key-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-gpg-key-url.rb
@@ -1,4 +1,4 @@
-test_cask 'with-gpg-key-url' do
+cask 'with-gpg-key-url' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-gpg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-gpg.rb
@@ -1,4 +1,4 @@
-test_cask 'with-gpg' do
+cask 'with-gpg' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
@@ -1,4 +1,4 @@
-test_cask 'with-installable' do
+cask 'with-installable' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
@@ -1,4 +1,4 @@
-test_cask 'with-installer-manual' do
+cask 'with-installer-manual' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-script.rb
@@ -1,4 +1,4 @@
-test_cask 'with-installer-script' do
+cask 'with-installer-script' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-macosx-dir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-macosx-dir.rb
@@ -1,4 +1,4 @@
-test_cask 'with-macosx-dir' do
+cask 'with-macosx-dir' do
   version '1.2.3'
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkgutil-zap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkgutil-zap.rb
@@ -1,4 +1,4 @@
-test_cask 'with-pkgutil-zap' do
+cask 'with-pkgutil-zap' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-suite.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-suite.rb
@@ -1,4 +1,4 @@
-test_cask 'with-suite' do
+cask 'with-suite' do
   version '1.2.3'
   sha256 'd95dcc12d4e5be0bc3cb9793c4b7e7f69a25f0b3c7418494b0c883957e6eeae4'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
@@ -1,4 +1,4 @@
-test_cask 'with-two-apps-correct' do
+cask 'with-two-apps-correct' do
   version '1.2.3'
   sha256 '3178fbfd1ea5d87a2a0662a4eb599ebc9a03888e73f37538d9f3f6ee69d2368e'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-incorrect.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-incorrect.rb
@@ -1,4 +1,4 @@
-test_cask 'with-two-apps-incorrect' do
+cask 'with-two-apps-incorrect' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
@@ -1,4 +1,4 @@
-test_cask 'with-two-apps-subdir' do
+cask 'with-two-apps-subdir' do
   version '1.2.3'
   sha256 'd687c22a21c02bd8f07da9302c8292b93a04df9a929e3f04d09aea6c76f75c65'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-delete.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-delete.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-delete' do
+cask 'with-uninstall-delete' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-early-script' do
+cask 'with-uninstall-early-script' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-kext.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-kext.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-kext' do
+cask 'with-uninstall-kext' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-launchctl' do
+cask 'with-uninstall-launchctl' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-login-item.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-login-item.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-login-item' do
+cask 'with-uninstall-login-item' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-pkgutil.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-pkgutil.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-pkgutil' do
+cask 'with-uninstall-pkgutil' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-quit' do
+cask 'with-uninstall-quit' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-rmdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-rmdir.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-rmdir' do
+cask 'with-uninstall-rmdir' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-script' do
+cask 'with-uninstall-script' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-signal' do
+cask 'with-uninstall-signal' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-trash.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-trash.rb
@@ -1,4 +1,4 @@
-test_cask 'with-uninstall-trash' do
+cask 'with-uninstall-trash' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-delete.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-delete.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-delete' do
+cask 'with-zap-delete' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-early-script' do
+cask 'with-zap-early-script' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-kext.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-kext.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-kext' do
+cask 'with-zap-kext' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-launchctl' do
+cask 'with-zap-launchctl' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-login-item.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-login-item.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-login-item' do
+cask 'with-zap-login-item' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-pkgutil.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-pkgutil.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-pkgutil' do
+cask 'with-zap-pkgutil' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-quit.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-quit.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-quit' do
+cask 'with-zap-quit' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-rmdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-rmdir.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-rmdir' do
+cask 'with-zap-rmdir' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-script' do
+cask 'with-zap-script' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-signal.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-signal.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-signal' do
+cask 'with-zap-signal' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-trash.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-trash.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap-trash' do
+cask 'with-zap-trash' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
@@ -1,4 +1,4 @@
-test_cask 'with-zap' do
+cask 'with-zap' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The separation between `Cask` and `TestCask` is not needed anymore because test Casks are not stored in `caskroom/cask´ anymore.