### PR TITLE
Print warning when reinstalling with invalid options

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -25,19 +25,21 @@ module Homebrew
       backup keg
     end
 
-    options = BuildOptions.new(Options.create(ARGV.flags_only), f.options).used_options
+    build_options = BuildOptions.new(Options.create(ARGV.flags_only), f.options)
+    options = build_options.used_options
     options |= f.build.used_options
     options &= f.options
 
     fi = FormulaInstaller.new(f)
-    fi.options             = options
-    fi.build_bottle        = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
-    fi.build_from_source   = ARGV.build_from_source? || ARGV.build_all_from_source?
-    fi.force_bottle        = ARGV.force_bottle?
-    fi.interactive         = ARGV.interactive?
-    fi.git                 = ARGV.git?
-    fi.verbose             = ARGV.verbose?
-    fi.debug               = ARGV.debug?
+    fi.options              = options
+    fi.invalid_option_names = build_options.invalid_option_names
+    fi.build_bottle         = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
+    fi.build_from_source    = ARGV.build_from_source? || ARGV.build_all_from_source?
+    fi.force_bottle         = ARGV.force_bottle?
+    fi.interactive          = ARGV.interactive?
+    fi.git                  = ARGV.git?
+    fi.verbose              = ARGV.verbose?
+    fi.debug                = ARGV.debug?
     fi.prelude
 
     oh1 "Reinstalling #{f.full_name} #{options.to_a.join " "}"

--- a/Library/Homebrew/test/reinstall_test.rb
+++ b/Library/Homebrew/test/reinstall_test.rb
@@ -12,4 +12,13 @@ class IntegrationCommandTestReinstall < IntegrationCommandTestCase
       cmd("reinstall", "testball")
     assert foo_dir.exist?
   end
+
+  def test_reinstall_with_invalid_option
+    setup_test_formula "testball"
+
+    cmd("install", "testball", "--with-foo")
+
+    assert_match "testball: this formula has no --with-fo option so it will be ignored!",
+      cmd("reinstall", "testball", "--with-fo")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR eliminates a small inconsistency between `brew install` and `brew reinstall`. While the former does output a warning for inexistent options, the latter does not. This was reported in https://github.com/Homebrew/brew/issues/1944.

#### Before

```
$ brew reinstall wget --with-foo
==> Reinstalling wget
```

#### After

```
$ brew reinstall wget --with-foo
==> Reinstalling wget
Warning: wget: this formula has no --with-foo option so it will be ignored!
```

-----

/fixes https://github.com/Homebrew/brew/issues/1944 💚
/cc @timotheecour since you reported this 📄 
/cc @MikeMcQuaid because I met you recently 😉
