### PR TITLE
audit: enforce https for github.com urls

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1343,6 +1343,7 @@ class ResourceAuditor
            %r{^http://(?:[^/]*\.)?bintray\.com/},
            %r{^http://tools\.ietf\.org/},
            %r{^http://launchpad\.net/},
+           %r{^http://github\.com/},
            %r{^http://bitbucket\.org/},
            %r{^http://anonscm\.debian\.org/},
            %r{^http://cpan\.metacpan\.org/},


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Several GitHub-related URL combinations were enforced for HTTPS, but a plain `http://github.com/` URLs weren't. This PR attempts to fix this.
Ref: https://github.com/Homebrew/homebrew-core/pull/9690