### PR TITLE
download_strategy: broaden https svn support/usage

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -640,6 +640,14 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
   def initialize(name, resource)
     super
     @url = @url.sub("svn+http://", "")
+
+    # System SVN tends to barf on https, but brewed SVN should consistently
+    # work due to being linked to brewed OpenSSL & generated PEM, so we can
+    # provide automatic upgrades to https where possible.
+    if !ENV["HOMEBREW_SVN"].nil? || which("svn").to_s.include?(HOMEBREW_PREFIX) &&
+                                    @url =~ /svn\.code\.sf\.net/
+      @url = @url.sub(%r{^(http://|svn://)}, "https://")
+    end
   end
 
   def fetch


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? _Don't see much worthwhile to do on this, since CI will only have the system SVN installed._
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Homebrew, for a hilarious amount of years, has gone back and forth on which protocol to use for the Sourceforge SVN checkouts. This is complicated by the system SVN, out-of-the-box, being garbage at handling secure connections, ending up more often than not in situations like this:
```
~> brew fetch gpsim -v --HEAD
==> Cloning https://svn.code.sf.net/p/gpsim/code/trunk
...
Error validating server certificate for 'https://svn.code.sf.net:443':
 - The certificate is not issued by a trusted authority. Use the
   fingerprint to validate the certificate manually!
Certificate information:
 - Hostname: *.code.sf.net
 - Valid: from Apr  6 00:00:00 2016 GMT until Jun  5 23:59:59 2017 GMT
 - Issuer: GeoTrust SSL CA - G3, GeoTrust Inc., US
 - Fingerprint: 9C:63:DE:5C:24:C4:86:ED:D2:53:26:E1:26:6B:52:0D:DD:B0:95:A3
(R)eject, accept (t)emporarily or accept (p)ermanently?
```
This happens a fair bit with SVN `HEAD` urls in core for example because those aren't being CI checked and flagged as problematic. Not such an issue because really, the number of users ever using HEAD is limited.

However, there is very infrequently if ever a problem with HTTPS SVN checkouts using Homebrew's SVN, or even a custom SVN linked to a newish OpenSSL with an up-to-date knowledge of the most common CA root certs. Using/abusing this knowledge, we can silently rewrite insecure URLs to use HTTPS when someone has Homebrew's own SVN installed/has specified using an alternative SVN with the `HOMEBREW_SVN` env variable.

My personal temptation given Homebrew is slowly abandoning the system tools as time goes on is just to abandon the system SVN, but I don't hold hope of nudging that through remaining maintainers so this seems a reasonable alternative which remaining maintainers might not actually completely dislike.

This can likely be expanded to other URLs but Sourceforge is the most common use case and is used for some actual stable/devel URLs rather than just HEAD and consequently has more user exposure and more user exposure to plaintext connections.

Realistically, until Homebrew reaches a point where it moves away from the system SVN, which may very well be never, this is a problem that cannot be accurately audited, but can be caught like this and "fixed".

Tested with Homebrew's vanilla SVN installed against variety of stable/head formulae:
```
==> Cloning https://svn.code.sf.net/p/netpbm/code/advanced
==> Checking out 2825
==> Cloning https://svn.code.sf.net/p/astyle/code/trunk/AStyle
==> Cloning https://svn.code.sf.net/p/ctags/code/trunk
==> Cloning https://svn.code.sf.net/p/dasm-dillon/code/trunk
==> Cloning https://svn.code.sf.net/p/gpsim/code/trunk
==> Cloning https://svn.code.sf.net/p/syntaxhighlight/code/highlight/
==> Cloning https://svn.code.sf.net/p/netpbm/code/trunk
==> Cloning https://svn.code.sf.net/p/quex/code/trunk
```

And without:
```
==> Cloning http://svn.code.sf.net/p/netpbm/code/advanced
==> Checking out 2825
==> Cloning svn://svn.code.sf.net/p/astyle/code/trunk/AStyle
==> Cloning http://svn.code.sf.net/p/ctags/code/trunk
==> Cloning svn://svn.code.sf.net/p/dasm-dillon/code/trunk
==> Cloning svn://svn.code.sf.net/p/gpsim/code/trunk
==> Cloning svn://svn.code.sf.net/p/syntaxhighlight/code/highlight/
==> Cloning http://svn.code.sf.net/p/netpbm/code/trunk
==> Cloning http://svn.code.sf.net/p/quex/code/trunk
```