### PR TITLE
pull: fix false positives for nonstandard bump subjects when untapped

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -376,7 +376,7 @@ module Homebrew
           subject_strs << "remove stable"
           formula_name_str += ":" # just for cosmetics
         else
-          subject_strs << formula.version.to_s
+          subject_strs << new[:stable]
         end
       end
       if old[:devel] != new[:devel]
@@ -387,7 +387,7 @@ module Homebrew
             formula_name_str += ":" # just for cosmetics
           end
         else
-          subject_strs << "#{formula.devel.version} (devel)"
+          subject_strs << "#{new[:devel]} (devel)"
         end
       end
       subject = subject_strs.empty? ? nil : "#{formula_name_str} #{subject_strs.join(", ")}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Example:
```
iMac-TMP:dev-cmd joe$ brew pull https://github.com/Homebrew/homebrew-fuse/pull/84
==> Tapping homebrew/fuse
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-fuse'...
remote: Counting objects: 34, done.
remote: Compressing objects: 100% (34/34), done.
remote: Total 34 (delta 0), reused 15 (delta 0), pack-reused 0
Unpacking objects: 100% (34/34), done.
Tapped 28 formulae (87 files, 74K)
==> Fetching patch 
Patch: https://github.com/Homebrew/homebrew-fuse/pull/84.patch
==> Applying patch
Applying: btfs 2.13
==> Patch closes issue #84
Warning: Nonstandard bump subject: btfs 2.13
Warning: Subject should be: btfs 2.12
==> Patch changed:
 Formula/btfs.rb | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

If the formula's tap isn't tapped yet when running `brew pull`, a false
positive occurs for the nonstandard bump subject check, and a bogus
warning is printed, which claims the bump subject should refer to the
old version not the new version.