### PR TITLE
pull: warn (not die) on bottle publish failure.

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -746,7 +746,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Additionally, the date used in new manpages will match those in the existing
     manpages (to allow comparison without factoring in the date).
 
-  * `pull` [`--bottle`] [`--bump`] [`--clean`] [`--ignore-whitespace`] [`--resolve`] [`--branch-okay`] [`--no-pbcopy`] [`--no-publish`] <var>patch-source</var> [<var>patch-source</var>]:
+  * `pull` [`--bottle`] [`--bump`] [`--clean`] [`--ignore-whitespace`] [`--resolve`] [`--branch-okay`] [`--no-pbcopy`] [`--no-publish`] [`--warn-on-publish-failure`] <var>patch-source</var> [<var>patch-source</var>]:
+
     Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
     Optionally, installs the formulae changed by the patch.
 
@@ -785,6 +786,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     clipboard.
 
     If `--no-publish` is passed, do not publish bottles to Bintray.
+
+    If `--warn-on-publish-failure` was passed, do not exit if there's a
+    failure publishing bottles on Bintray.
 
   * `release-notes` [`--markdown`] [<var>previous_tag</var>] [<var>end_ref</var>]:
     Output the merged pull requests on Homebrew/brew between two Git refs.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -770,7 +770,9 @@ Generate Homebrew\'s manpages\.
 If \fB\-\-fail\-if\-changed\fR is passed, the command will return a failing status code if changes are detected in the manpage outputs\. This can be used for CI to be notified when the manpages are out of date\. Additionally, the date used in new manpages will match those in the existing manpages (to allow comparison without factoring in the date)\.
 .
 .TP
-\fBpull\fR [\fB\-\-bottle\fR] [\fB\-\-bump\fR] [\fB\-\-clean\fR] [\fB\-\-ignore\-whitespace\fR] [\fB\-\-resolve\fR] [\fB\-\-branch\-okay\fR] [\fB\-\-no\-pbcopy\fR] [\fB\-\-no\-publish\fR] \fIpatch\-source\fR [\fIpatch\-source\fR]
+\fBpull\fR [\fB\-\-bottle\fR] [\fB\-\-bump\fR] [\fB\-\-clean\fR] [\fB\-\-ignore\-whitespace\fR] [\fB\-\-resolve\fR] [\fB\-\-branch\-okay\fR] [\fB\-\-no\-pbcopy\fR] [\fB\-\-no\-publish\fR] [\fB\-\-warn\-on\-publish\-failure\fR] \fIpatch\-source\fR [\fIpatch\-source\fR]:
+.
+.IP
 Gets a patch from a GitHub commit or pull request and applies it to Homebrew\. Optionally, installs the formulae changed by the patch\.
 .
 .IP
@@ -811,6 +813,9 @@ If \fB\-\-no\-pbcopy\fR is passed, do not copy anything to the system clipboard\
 .
 .IP
 If \fB\-\-no\-publish\fR is passed, do not publish bottles to Bintray\.
+.
+.IP
+If \fB\-\-warn\-on\-publish\-failure\fR was passed, do not exit if there\'s a failure publishing bottles on Bintray\.
 .
 .TP
 \fBrelease\-notes\fR [\fB\-\-markdown\fR] [\fIprevious_tag\fR] [\fIend_ref\fR]


### PR DESCRIPTION
This is useful when you're pulling PRs where individual bottles can't be uploaded/built but you still want to pull the PR as a whole anyway.

CC @ilovezfs for thoughts.