### PR TITLE
Skip Xcode outdated check on CircleCI

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -53,8 +53,8 @@ module Homebrew
         return unless MacOS::Xcode.installed?
         return unless MacOS::Xcode.outdated?
 
-        # Travis CI images are going to end up outdated so don't complain.
-        return if ENV["TRAVIS"]
+        # CI images are going to end up outdated so don't complain.
+        return if ENV["TRAVIS"] || ENV["CIRCLECI"]
 
         message = <<-EOS.undent
           Your Xcode (#{MacOS::Xcode.version}) is outdated.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Hey folks,
Currently, the Xcode version check is skipped when the `TRAVIS` env var is set, but the same problems exist for other CI environments too (including CircleCI).

Many of these services, including Travis, set the `CI` environment variable. This PR changes that check to use this env var instead, to not break CI environments.

When the feature was first introduced, it was changed to CI and Sierra only (https://github.com/Homebrew/brew/commit/12aad5c65fee39c5f044e39ca1efcbed58aebd39#diff-04e700045721a197c725bc15b7f2a173), but seems to have changed back since then.

Thanks!