### PR TITLE
Revert "Use `Open3` for integration tests instead of manually forking."

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -217,10 +217,6 @@ class Keg
     true
   end
 
-  def require_relocation?
-    false
-  end
-
   def linked?
     linked_keg_record.symlink? &&
       linked_keg_record.directory? &&

--- a/Library/Homebrew/test/bottle_test.rb
+++ b/Library/Homebrew/test/bottle_test.rb
@@ -14,7 +14,7 @@ class IntegrationCommandTestBottle < IntegrationCommandTestCase
       FileUtils.ln_s "not-exist", "symlink"
     end
     assert_match(/testball-0\.1.*\.bottle\.tar\.gz/,
-                  cmd("bottle", "--no-rebuild", "testball"))
+                  cmd_output("bottle", "--no-rebuild", "testball"))
   ensure
     FileUtils.rm_f Dir["testball-0.1*.bottle.tar.gz"]
   end

--- a/Library/Homebrew/test/options_test.rb
+++ b/Library/Homebrew/test/options_test.rb
@@ -9,7 +9,7 @@ class IntegrationCommandTestOptions < IntegrationCommandTestCase
     EOS
 
     assert_equal "--with-foo\n\tBuild with foo\n--without-bar\n\tBuild without bar support",
-      cmd("options", "testball").chomp
+      cmd_output("options", "testball").chomp
   end
 end
 


### PR DESCRIPTION
Reverts Homebrew/brew#1967