### PR TITLE
formula_installer: add env to allow unlinked deps.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -171,12 +171,14 @@ class FormulaInstaller
       end
     end
 
-    unlinked_deps = recursive_formulae.select do |dep|
-      dep.installed? && !dep.keg_only? && !dep.linked_keg.directory?
-    end
+    unless ENV["HOMEBREW_NO_CHECK_UNLINKED_DEPENDENCIES"]
+      unlinked_deps = recursive_formulae.select do |dep|
+        dep.installed? && !dep.keg_only? && !dep.linked_keg.directory?
+      end
 
-    unless unlinked_deps.empty?
-      raise CannotInstallFormulaError, "You must `brew link #{unlinked_deps*" "}` before #{formula.full_name} can be installed"
+      unless unlinked_deps.empty?
+        raise CannotInstallFormulaError, "You must `brew link #{unlinked_deps*" "}` before #{formula.full_name} can be installed"
+      end
     end
 
     pinned_unsatisfied_deps = recursive_deps.select do |dep|


### PR DESCRIPTION
We can enable this locally and/or in `brew test-bot` to see if this code is needed any more. If we can remove it we can start doing much more interesting things with linking keg-only, versioned formulae and system dupe formulae.

CC @ilovezfs for thoughts as we talked about this.