### PR TITLE
rubocop: trailing comma in multiline method calls

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -168,6 +168,8 @@ Style/TernaryParentheses:
 # makes diffs nicer
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
 
 Style/VariableNumber:
   Enabled: false

--- a/Library/Homebrew/cask/spec/cask/accessibility_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/accessibility_spec.rb
@@ -19,7 +19,7 @@ describe "Accessibility Access" do
       expect(fake_system_command).to receive(:run!).with(
         "/usr/bin/touch",
         args: [Hbc.pre_mavericks_accessibility_dotfile],
-        sudo: true
+        sudo: true,
       )
 
       shutup do
@@ -41,7 +41,7 @@ describe "Accessibility Access" do
       expect(fake_system_command).to receive(:run!).with(
         "/usr/bin/sqlite3",
         args: [Hbc.tcc_db, "INSERT OR REPLACE INTO access VALUES('kTCCServiceAccessibility','com.example.BasicCask',0,1,1,NULL);"],
-        sudo: true
+        sudo: true,
       )
 
       shutup do
@@ -53,7 +53,7 @@ describe "Accessibility Access" do
       expect(fake_system_command).to receive(:run!).with(
         "/usr/bin/sqlite3",
         args: [Hbc.tcc_db, "DELETE FROM access WHERE client='com.example.BasicCask';"],
-        sudo: true
+        sudo: true,
       )
 
       shutup do

--- a/Library/Homebrew/cask/spec/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/artifact/pkg_spec.rb
@@ -18,7 +18,7 @@ describe Hbc::Artifact::Pkg do
         "/usr/sbin/installer",
         args: ["-pkg", cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/"],
         sudo: true,
-        print_stdout: true
+        print_stdout: true,
       )
 
       shutup do
@@ -60,7 +60,7 @@ describe Hbc::Artifact::Pkg do
         "/usr/sbin/installer",
         args: ["-pkg", cask.staged_path.join("MyFancyPkg", "Fancy.pkg"), "-target", "/", "-applyChoiceChangesXML", cask.staged_path.join("/tmp/choices.xml")],
         sudo: true,
-        print_stdout: true
+        print_stdout: true,
       )
 
       shutup do

--- a/Library/Homebrew/cask/spec/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/artifact/uninstall_spec.rb
@@ -44,12 +44,12 @@ describe Hbc::Artifact::Uninstall do
         it "can uninstall" do
           Hbc::FakeSystemCommand.stubs_command(
             launchctl_list_cmd,
-            service_info
+            service_info,
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             sudo(launchctl_list_cmd),
-            unknown_response
+            unknown_response,
           )
 
           Hbc::FakeSystemCommand.expects_command(launchctl_remove_cmd)
@@ -62,12 +62,12 @@ describe Hbc::Artifact::Uninstall do
         it "can uninstall" do
           Hbc::FakeSystemCommand.stubs_command(
             launchctl_list_cmd,
-            unknown_response
+            unknown_response,
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             sudo(launchctl_list_cmd),
-            service_info
+            service_info,
           )
 
           Hbc::FakeSystemCommand.expects_command(sudo(launchctl_remove_cmd))
@@ -125,7 +125,7 @@ describe Hbc::Artifact::Uninstall do
       it "can uninstall" do
         Hbc::FakeSystemCommand.stubs_command(
           %w[/usr/sbin/pkgutil --pkgs=my.fancy.package.*],
-          "#{main_pkg_id}\n#{agent_pkg_id}"
+          "#{main_pkg_id}\n#{agent_pkg_id}",
         )
 
         [
@@ -134,28 +134,28 @@ describe Hbc::Artifact::Uninstall do
         ].each do |pkg_id, pkg_files, pkg_dirs|
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --only-files --files #{pkg_id}],
-            pkg_files.join("\n")
+            pkg_files.join("\n"),
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --only-dirs --files #{pkg_id}],
-            pkg_dirs.join("\n")
+            pkg_dirs.join("\n"),
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --files #{pkg_id}],
-            (pkg_files + pkg_dirs).join("\n")
+            (pkg_files + pkg_dirs).join("\n"),
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --pkg-info-plist #{pkg_id}],
-            pkg_info_plist
+            pkg_info_plist,
           )
 
           Hbc::FakeSystemCommand.expects_command(sudo(%W[/usr/sbin/pkgutil --forget #{pkg_id}]))
 
           Hbc::FakeSystemCommand.expects_command(
-            sudo(%w[/bin/rm -f --] + pkg_files.map { |path| Pathname("/tmp/#{path}") })
+            sudo(%w[/bin/rm -f --] + pkg_files.map { |path| Pathname("/tmp/#{path}") }),
           )
         end
 
@@ -173,7 +173,7 @@ describe Hbc::Artifact::Uninstall do
         )
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(%W[/sbin/kextunload -b #{kext_id}])
+          sudo(%W[/sbin/kextunload -b #{kext_id}]),
         )
 
         Hbc::FakeSystemCommand.expects_command(
@@ -181,7 +181,7 @@ describe Hbc::Artifact::Uninstall do
         )
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(["/bin/rm", "-rf", "/Library/Extensions/FancyPackage.kext"])
+          sudo(["/bin/rm", "-rf", "/Library/Extensions/FancyPackage.kext"]),
         )
 
         subject
@@ -201,7 +201,7 @@ describe Hbc::Artifact::Uninstall do
         )
 
         Hbc::FakeSystemCommand.stubs_command(
-          %w[/bin/launchctl list]
+          %w[/bin/launchctl list],
         )
 
         subject
@@ -234,7 +234,7 @@ describe Hbc::Artifact::Uninstall do
         Hbc::FakeSystemCommand.expects_command(
           sudo(%w[/bin/rm -rf --],
                Pathname.new("/permissible/absolute/path"),
-               Pathname.new("~/permissible/path/with/tilde").expand_path)
+               Pathname.new("~/permissible/path/with/tilde").expand_path),
         )
 
         subject
@@ -248,7 +248,7 @@ describe Hbc::Artifact::Uninstall do
         Hbc::FakeSystemCommand.expects_command(
           sudo(%w[/bin/rm -rf --],
                Pathname.new("/permissible/absolute/path"),
-               Pathname.new("~/permissible/path/with/tilde").expand_path)
+               Pathname.new("~/permissible/path/with/tilde").expand_path),
         )
 
         subject
@@ -261,11 +261,11 @@ describe Hbc::Artifact::Uninstall do
 
       it "can uninstall" do
         Hbc::FakeSystemCommand.expects_command(
-          sudo(%w[/bin/rm -f --], dir_pathname.join(".DS_Store"))
+          sudo(%w[/bin/rm -f --], dir_pathname.join(".DS_Store")),
         )
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(%w[/bin/rmdir --], dir_pathname)
+          sudo(%w[/bin/rmdir --], dir_pathname),
         )
 
         subject
@@ -280,7 +280,7 @@ describe Hbc::Artifact::Uninstall do
         Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please")
+          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please"),
         )
 
         subject
@@ -295,7 +295,7 @@ describe Hbc::Artifact::Uninstall do
         Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please")
+          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please"),
         )
 
         subject
@@ -308,7 +308,7 @@ describe Hbc::Artifact::Uninstall do
       it "can uninstall" do
         Hbc::FakeSystemCommand.expects_command(
           ["/usr/bin/osascript", "-e", 'tell application "System Events" to delete every login ' \
-                                       'item whose name is "Fancy"']
+                                       'item whose name is "Fancy"'],
         )
 
         subject

--- a/Library/Homebrew/cask/spec/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/artifact/zap_spec.rb
@@ -45,12 +45,12 @@ describe Hbc::Artifact::Zap do
         it "can zap" do
           Hbc::FakeSystemCommand.stubs_command(
             launchctl_list_cmd,
-            service_info
+            service_info,
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             sudo(launchctl_list_cmd),
-            unknown_response
+            unknown_response,
           )
 
           Hbc::FakeSystemCommand.expects_command(launchctl_remove_cmd)
@@ -63,12 +63,12 @@ describe Hbc::Artifact::Zap do
         it "can zap" do
           Hbc::FakeSystemCommand.stubs_command(
             launchctl_list_cmd,
-            unknown_response
+            unknown_response,
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             sudo(launchctl_list_cmd),
-            service_info
+            service_info,
           )
 
           Hbc::FakeSystemCommand.expects_command(sudo(launchctl_remove_cmd))
@@ -126,7 +126,7 @@ describe Hbc::Artifact::Zap do
       it "can zap" do
         Hbc::FakeSystemCommand.stubs_command(
           %w[/usr/sbin/pkgutil --pkgs=my.fancy.package.*],
-          "#{main_pkg_id}\n#{agent_pkg_id}"
+          "#{main_pkg_id}\n#{agent_pkg_id}",
         )
 
         [
@@ -135,28 +135,28 @@ describe Hbc::Artifact::Zap do
         ].each do |pkg_id, pkg_files, pkg_dirs|
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --only-files --files #{pkg_id}],
-            pkg_files.join("\n")
+            pkg_files.join("\n"),
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --only-dirs --files #{pkg_id}],
-            pkg_dirs.join("\n")
+            pkg_dirs.join("\n"),
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --files #{pkg_id}],
-            (pkg_files + pkg_dirs).join("\n")
+            (pkg_files + pkg_dirs).join("\n"),
           )
 
           Hbc::FakeSystemCommand.stubs_command(
             %W[/usr/sbin/pkgutil --pkg-info-plist #{pkg_id}],
-            pkg_info_plist
+            pkg_info_plist,
           )
 
           Hbc::FakeSystemCommand.expects_command(sudo(%W[/usr/sbin/pkgutil --forget #{pkg_id}]))
 
           Hbc::FakeSystemCommand.expects_command(
-            sudo(%w[/bin/rm -f --] + pkg_files.map { |path| Pathname("/tmp/#{path}") })
+            sudo(%w[/bin/rm -f --] + pkg_files.map { |path| Pathname("/tmp/#{path}") }),
           )
         end
 
@@ -174,7 +174,7 @@ describe Hbc::Artifact::Zap do
         )
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(%W[/sbin/kextunload -b #{kext_id}])
+          sudo(%W[/sbin/kextunload -b #{kext_id}]),
         )
 
         Hbc::FakeSystemCommand.expects_command(
@@ -182,7 +182,7 @@ describe Hbc::Artifact::Zap do
         )
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(["/bin/rm", "-rf", "/Library/Extensions/FancyPackage.kext"])
+          sudo(["/bin/rm", "-rf", "/Library/Extensions/FancyPackage.kext"]),
         )
 
         subject
@@ -202,7 +202,7 @@ describe Hbc::Artifact::Zap do
         )
 
         Hbc::FakeSystemCommand.stubs_command(
-          %w[/bin/launchctl list]
+          %w[/bin/launchctl list],
         )
 
         subject
@@ -235,7 +235,7 @@ describe Hbc::Artifact::Zap do
         Hbc::FakeSystemCommand.expects_command(
           sudo(%w[/bin/rm -rf --],
                Pathname.new("/permissible/absolute/path"),
-               Pathname.new("~/permissible/path/with/tilde").expand_path)
+               Pathname.new("~/permissible/path/with/tilde").expand_path),
         )
 
         subject
@@ -249,7 +249,7 @@ describe Hbc::Artifact::Zap do
         Hbc::FakeSystemCommand.expects_command(
           sudo(%w[/bin/rm -rf --],
                Pathname.new("/permissible/absolute/path"),
-               Pathname.new("~/permissible/path/with/tilde").expand_path)
+               Pathname.new("~/permissible/path/with/tilde").expand_path),
         )
 
         subject
@@ -262,11 +262,11 @@ describe Hbc::Artifact::Zap do
 
       it "can zap" do
         Hbc::FakeSystemCommand.expects_command(
-          sudo(%w[/bin/rm -f --], dir_pathname.join(".DS_Store"))
+          sudo(%w[/bin/rm -f --], dir_pathname.join(".DS_Store")),
         )
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(%w[/bin/rmdir --], dir_pathname)
+          sudo(%w[/bin/rmdir --], dir_pathname),
         )
 
         subject
@@ -281,7 +281,7 @@ describe Hbc::Artifact::Zap do
         Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please")
+          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please"),
         )
 
         subject
@@ -296,7 +296,7 @@ describe Hbc::Artifact::Zap do
         Hbc::FakeSystemCommand.expects_command(%w[/bin/chmod -- +x] + [script_pathname])
 
         Hbc::FakeSystemCommand.expects_command(
-          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please")
+          sudo(cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"), "--please"),
         )
 
         subject
@@ -309,7 +309,7 @@ describe Hbc::Artifact::Zap do
       it "can zap" do
         Hbc::FakeSystemCommand.expects_command(
           ["/usr/bin/osascript", "-e", 'tell application "System Events" to delete every login ' \
-                                       'item whose name is "Fancy"']
+                                       'item whose name is "Fancy"'],
         )
 
         subject

--- a/Library/Homebrew/cask/spec/cask/container/dmg_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/container/dmg_spec.rb
@@ -8,7 +8,7 @@ describe Hbc::Container::Dmg do
       dmg = Hbc::Container::Dmg.new(
         transmission,
         Pathname(transmission.url.path),
-        Hbc::SystemCommand
+        Hbc::SystemCommand,
       )
 
       begin

--- a/Library/Homebrew/cask/spec/cask/download_strategy_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/download_strategy_spec.rb
@@ -176,7 +176,7 @@ describe "download strategies" do
 
       expect(downloader).to have_received(:fetch_repo).with(
         downloader.cached_location,
-        cask.url.to_s
+        cask.url.to_s,
       )
     end
 
@@ -196,7 +196,7 @@ describe "download strategies" do
                          "config:miscellany:use-commit-times=yes",
                          cask.url.to_s,
                          downloader.cached_location,
-                       ])
+                       ]),
       )
     end
 
@@ -226,7 +226,7 @@ describe "download strategies" do
                            "--non-interactive",
                            cask.url.to_s,
                            downloader.cached_location,
-                         ])
+                         ]),
         )
       end
     end
@@ -257,7 +257,7 @@ describe "download strategies" do
                            downloader.cached_location,
                            "-r",
                            "10",
-                         ])
+                         ]),
         )
       end
     end
@@ -283,7 +283,7 @@ describe "download strategies" do
                          downloader.tarball_path,
                          "--",
                          ".",
-                       ])
+                       ]),
       )
     end
   end

--- a/Library/Homebrew/cask/spec/cask/macos_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/macos_spec.rb
@@ -1,67 +1,67 @@
 describe MacOS do
   it "says '/' is undeletable" do
     expect(MacOS).to be_undeletable(
-      "/"
+      "/",
     )
     expect(MacOS).to be_undeletable(
-      "/."
+      "/.",
     )
     expect(MacOS).to be_undeletable(
-      "/usr/local/Library/Taps/../../../.."
+      "/usr/local/Library/Taps/../../../..",
     )
   end
 
   it "says '/Applications' is undeletable" do
     expect(MacOS).to be_undeletable(
-      "/Applications"
+      "/Applications",
     )
     expect(MacOS).to be_undeletable(
-      "/Applications/"
+      "/Applications/",
     )
     expect(MacOS).to be_undeletable(
-      "/Applications/."
+      "/Applications/.",
     )
     expect(MacOS).to be_undeletable(
-      "/Applications/Mail.app/.."
+      "/Applications/Mail.app/..",
     )
   end
 
   it "says the home directory is undeletable" do
     expect(MacOS).to be_undeletable(
-      Dir.home
+      Dir.home,
     )
     expect(MacOS).to be_undeletable(
-      "#{Dir.home}/"
+      "#{Dir.home}/",
     )
     expect(MacOS).to be_undeletable(
-      "#{Dir.home}/Documents/.."
+      "#{Dir.home}/Documents/..",
     )
   end
 
   it "says the user library directory is undeletable" do
     expect(MacOS).to be_undeletable(
-      "#{Dir.home}/Library"
+      "#{Dir.home}/Library",
     )
     expect(MacOS).to be_undeletable(
-      "#{Dir.home}/Library/"
+      "#{Dir.home}/Library/",
     )
     expect(MacOS).to be_undeletable(
-      "#{Dir.home}/Library/."
+      "#{Dir.home}/Library/.",
     )
     expect(MacOS).to be_undeletable(
-      "#{Dir.home}/Library/Preferences/.."
+      "#{Dir.home}/Library/Preferences/..",
     )
   end
 
   it "says '/Applications/.app' is deletable" do
     expect(MacOS).not_to be_undeletable(
-      "/Applications/.app"
+      "/Applications/.app",
     )
   end
 
   it "says '/Applications/SnakeOil Professional.app' is deletable" do
     expect(MacOS).not_to be_undeletable(
-      "/Applications/SnakeOil Professional.app"
+      "/Applications/SnakeOil Professional.app",
     )
   end
 end

--- a/Library/Homebrew/cask/spec/cask/pkg_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/pkg_spec.rb
@@ -35,23 +35,23 @@ describe Hbc::Pkg do
       it "forgets the pkg" do
         allow(fake_system_command).to receive(:run!).with(
           "/usr/sbin/pkgutil",
-          args: ["--only-files", "--files", "my.fake.pkg"]
+          args: ["--only-files", "--files", "my.fake.pkg"],
         ).and_return(empty_response)
 
         allow(fake_system_command).to receive(:run!).with(
           "/usr/sbin/pkgutil",
-          args: ["--only-dirs", "--files", "my.fake.pkg"]
+          args: ["--only-dirs", "--files", "my.fake.pkg"],
         ).and_return(empty_response)
 
         allow(fake_system_command).to receive(:run!).with(
           "/usr/sbin/pkgutil",
-          args: ["--files", "my.fake.pkg"]
+          args: ["--files", "my.fake.pkg"],
         ).and_return(empty_response)
 
         expect(fake_system_command).to receive(:run!).with(
           "/usr/sbin/pkgutil",
           args: ["--forget", "my.fake.pkg"],
-          sudo: true
+          sudo: true,
         )
 
         pkg.uninstall

--- a/Library/Homebrew/cask/spec/cask/scopes_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/scopes_spec.rb
@@ -14,7 +14,7 @@ describe Hbc::Scopes do
         %w[
           loaded-cask-bar
           loaded-cask-foo
-        ]
+        ],
       )
     end
 

--- a/Library/Homebrew/cask/spec/cask/url_checker_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/url_checker_spec.rb
@@ -36,7 +36,7 @@ describe Hbc::UrlChecker do
           "Content-Type"   => "application/x-apple-diskimage",
           "ETag"           => '"b4208f3e84967be4b078ecaa03fba941"',
           "Content-Length" => "23726161",
-          "Last-Modified"  => "Sun, 12 Aug 2012 21:17:21 GMT"
+          "Last-Modified"  => "Sun, 12 Aug 2012 21:17:21 GMT",
         )
       end
     end

--- a/Library/Homebrew/cask/spec/formatter_spec.rb
+++ b/Library/Homebrew/cask/spec/formatter_spec.rb
@@ -21,7 +21,7 @@ describe Formatter do
         "aa\n" \
         "bbb\n" \
         "ccc\n" \
-        "dd\n"
+        "dd\n",
       )
     end
 
@@ -32,7 +32,7 @@ describe Formatter do
 
         expect(subject).to eq(
           "aa    ccc\n" \
-          "bbb   dd\n"
+          "bbb   dd\n",
         )
       end
 
@@ -41,7 +41,7 @@ describe Formatter do
         allow(Tty).to receive(:width).and_return(20)
 
         expect(subject).to eq(
-          "aa   bbb  ccc  dd\n"
+          "aa   bbb  ccc  dd\n",
         )
       end
     end

--- a/Library/Homebrew/cask/spec/plist/parser_spec.rb
+++ b/Library/Homebrew/cask/spec/plist/parser_spec.rb
@@ -61,7 +61,7 @@ describe Plist do
             /dev/disk3s1
             /dev/disk3
             /dev/disk3s2
-          ]
+          ],
         )
       end
     end

--- a/Library/Homebrew/cask/spec/support/shared_examples/staged.rb
+++ b/Library/Homebrew/cask/spec/support/shared_examples/staged.rb
@@ -19,7 +19,7 @@ shared_examples Hbc::Staged do
 
   it "can run system commands with list-form arguments" do
     Hbc::FakeSystemCommand.expects_command(
-      ["echo", "homebrew-cask", "rocks!"]
+      ["echo", "homebrew-cask", "rocks!"],
     )
 
     shutup do
@@ -35,7 +35,7 @@ shared_examples Hbc::Staged do
     allow(staged).to receive(:bundle_identifier).and_return("com.example.BasicCask")
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/usr/libexec/PlistBuddy", "-c", "Print CFBundleIdentifier", staged.info_plist_file]
+      ["/usr/libexec/PlistBuddy", "-c", "Print CFBundleIdentifier", staged.info_plist_file],
     )
 
     shutup do
@@ -47,7 +47,7 @@ shared_examples Hbc::Staged do
     allow(staged).to receive(:bundle_identifier).and_return("com.example.BasicCask")
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", staged.info_plist_file]
+      ["/usr/libexec/PlistBuddy", "-c", "Set :JVMOptions:JVMVersion 1.6+", staged.info_plist_file],
     )
 
     shutup do
@@ -60,7 +60,7 @@ shared_examples Hbc::Staged do
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/bin/chmod", "-R", "--", "777", fake_pathname]
+      ["/bin/chmod", "-R", "--", "777", fake_pathname],
     )
 
     shutup do
@@ -73,7 +73,7 @@ shared_examples Hbc::Staged do
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/bin/chmod", "-R", "--", "777", fake_pathname, fake_pathname]
+      ["/bin/chmod", "-R", "--", "777", fake_pathname, fake_pathname],
     )
 
     shutup do
@@ -94,7 +94,7 @@ shared_examples Hbc::Staged do
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/usr/bin/sudo", "-E", "--", "/usr/sbin/chown", "-R", "--", "fake_user:staff", fake_pathname]
+      ["/usr/bin/sudo", "-E", "--", "/usr/sbin/chown", "-R", "--", "fake_user:staff", fake_pathname],
     )
 
     shutup do
@@ -109,7 +109,7 @@ shared_examples Hbc::Staged do
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/usr/bin/sudo", "-E", "--", "/usr/sbin/chown", "-R", "--", "fake_user:staff", fake_pathname, fake_pathname]
+      ["/usr/bin/sudo", "-E", "--", "/usr/sbin/chown", "-R", "--", "fake_user:staff", fake_pathname, fake_pathname],
     )
 
     shutup do
@@ -123,7 +123,7 @@ shared_examples Hbc::Staged do
     allow(staged).to receive(:Pathname).and_return(fake_pathname)
 
     Hbc::FakeSystemCommand.expects_command(
-      ["/usr/bin/sudo", "-E", "--", "/usr/sbin/chown", "-R", "--", "other_user:other_group", fake_pathname]
+      ["/usr/bin/sudo", "-E", "--", "/usr/sbin/chown", "-R", "--", "other_user:other_group", fake_pathname],
     )
 
     shutup do

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -50,7 +50,7 @@ module Homebrew
       tree?: ARGV.include?("--tree"),
       all?: ARGV.include?("--all"),
       topo_order?: ARGV.include?("-n"),
-      union?: ARGV.include?("--union")
+      union?: ARGV.include?("--union"),
     )
 
     if mode.installed? && mode.tree?

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -191,7 +191,7 @@ class FormulaAuditor
       args = curl_args(
         extra_args: extra_args,
         show_output: true,
-        user_agent: user_agent
+        user_agent: user_agent,
       )
       status_code = Open3.popen3(*args) { |_, stdout, _, _| stdout.read }
       break if status_code.start_with? "20"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -277,7 +277,7 @@ module Superenv
     return unless Hardware::CPU.is_32_bit?
     self["HOMEBREW_OPTFLAGS"] = self["HOMEBREW_OPTFLAGS"].sub(
       /-march=\S*/,
-      "-Xarch_#{Hardware::CPU.arch_32_bit} \\0"
+      "-Xarch_#{Hardware::CPU.arch_32_bit} \\0",
     )
   end
 

--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -111,7 +111,7 @@ module Hardware
         @features ||= sysctl_n(
           "machdep.cpu.features",
           "machdep.cpu.extfeatures",
-          "machdep.cpu.leaf7_features"
+          "machdep.cpu.leaf7_features",
         ).split(" ").map { |s| s.downcase.to_sym }
       end
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -431,7 +431,7 @@ class FormulaInstaller
       inherited_options[dep.name] |= inherited_options_for(dep)
       build = effective_build_options_for(
         dependent,
-        inherited_options.fetch(dependent.name, [])
+        inherited_options.fetch(dependent.name, []),
       )
 
       if (dep.optional? || dep.recommended?) && build.without?(dep)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -34,7 +34,7 @@ class Keg
       old_repository: HOMEBREW_REPOSITORY.to_s,
       new_prefix: PREFIX_PLACEHOLDER,
       new_cellar: CELLAR_PLACEHOLDER,
-      new_repository: REPOSITORY_PLACEHOLDER
+      new_repository: REPOSITORY_PLACEHOLDER,
     )
     relocate_dynamic_linkage(relocation)
     replace_text_in_files(relocation)
@@ -47,7 +47,7 @@ class Keg
       old_repository: REPOSITORY_PLACEHOLDER,
       new_prefix: HOMEBREW_PREFIX.to_s,
       new_cellar: HOMEBREW_CELLAR.to_s,
-      new_repository: HOMEBREW_REPOSITORY.to_s
+      new_repository: HOMEBREW_REPOSITORY.to_s,
     )
     relocate_dynamic_linkage(relocation) unless skip_linkage
     replace_text_in_files(relocation, files: files)
@@ -71,7 +71,7 @@ class Keg
       regexp = Regexp.union(
         relocation.old_cellar,
         relocation.old_repository,
-        relocation.old_prefix
+        relocation.old_prefix,
       )
 
       changed = s.gsub!(regexp, replacements)

--- a/Library/Homebrew/test/dependency_expansion_test.rb
+++ b/Library/Homebrew/test/dependency_expansion_test.rb
@@ -93,7 +93,7 @@ class DependencyExpansionTests < Homebrew::TestCase
       deps: [
         build_dep(:foo, [], [@bar, @baz]),
         build_dep(:foo, [], [@baz]),
-      ]
+      ],
     )
 
     deps = Dependency.expand(f) do |_dependent, dep|

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -209,12 +209,12 @@ class FormulaTests < Homebrew::TestCase
     refute_predicate f, :installed?
 
     f.stubs(:installed_prefix).returns(
-      stub(directory?: true, children: [])
+      stub(directory?: true, children: []),
     )
     refute_predicate f, :installed?
 
     f.stubs(:installed_prefix).returns(
-      stub(directory?: true, children: [stub])
+      stub(directory?: true, children: [stub]),
     )
     assert_predicate f, :installed?
   end

--- a/Library/Homebrew/test/language_python_test.rb
+++ b/Library/Homebrew/test/language_python_test.rb
@@ -17,7 +17,7 @@ class LanguagePythonTests < Homebrew::TestCase
 
   def test_virtualenv_creation
     @formula.expects(:resource).with("homebrew-virtualenv").returns(
-      mock("resource", stage: true)
+      mock("resource", stage: true),
     )
     @venv.create
   end
@@ -25,7 +25,7 @@ class LanguagePythonTests < Homebrew::TestCase
   # or at least doesn't crash the second time
   def test_virtualenv_creation_is_idempotent
     @formula.expects(:resource).with("homebrew-virtualenv").returns(
-      mock("resource", stage: true)
+      mock("resource", stage: true),
     )
     @venv.create
     FileUtils.mkdir_p @dir/"bin"

--- a/Library/Homebrew/test/patch_test.rb
+++ b/Library/Homebrew/test/patch_test.rb
@@ -48,7 +48,7 @@ class LegacyPatchTests < Homebrew::TestCase
 
   def test_patch_array
     patches = Patch.normalize_legacy_patches(
-      %w[http://example.com/patch1.diff http://example.com/patch2.diff]
+      %w[http://example.com/patch1.diff http://example.com/patch2.diff],
     )
 
     assert_equal 2, patches.length
@@ -58,7 +58,7 @@ class LegacyPatchTests < Homebrew::TestCase
 
   def test_p0_hash_to_string
     patches = Patch.normalize_legacy_patches(
-      p0: "http://example.com/patch.diff"
+      p0: "http://example.com/patch.diff",
     )
 
     assert_equal 1, patches.length
@@ -67,7 +67,7 @@ class LegacyPatchTests < Homebrew::TestCase
 
   def test_p1_hash_to_string
     patches = Patch.normalize_legacy_patches(
-      p1: "http://example.com/patch.diff"
+      p1: "http://example.com/patch.diff",
     )
 
     assert_equal 1, patches.length
@@ -77,7 +77,7 @@ class LegacyPatchTests < Homebrew::TestCase
   def test_mixed_hash_to_strings
     patches = Patch.normalize_legacy_patches(
       p1: "http://example.com/patch1.diff",
-      p0: "http://example.com/patch0.diff"
+      p0: "http://example.com/patch0.diff",
     )
     assert_equal 2, patches.length
     assert_equal 1, patches.count { |p| p.strip == :p0 }
@@ -89,7 +89,7 @@ class LegacyPatchTests < Homebrew::TestCase
       p1: ["http://example.com/patch10.diff",
            "http://example.com/patch11.diff"],
       p0: ["http://example.com/patch00.diff",
-           "http://example.com/patch01.diff"]
+           "http://example.com/patch01.diff"],
     )
 
     assert_equal 4, patches.length

--- a/Library/Homebrew/test/shell_test.rb
+++ b/Library/Homebrew/test/shell_test.rb
@@ -42,7 +42,7 @@ class ShellSmokeTest < Homebrew::TestCase
     prepend_message = Utils::Shell.prepend_path_in_shell_profile(path)
     assert(
       prepend_message.start_with?(fragment),
-      "#{shell}: expected #{prepend_message} to match #{fragment}"
+      "#{shell}: expected #{prepend_message} to match #{fragment}",
     )
   end
 

--- a/Library/Homebrew/test/support/helper/integration_command_test_case.rb
+++ b/Library/Homebrew/test/support/helper/integration_command_test_case.rb
@@ -35,7 +35,7 @@ class IntegrationCommandTestCase < Homebrew::TestCase
       "HOMEBREW_BREW_FILE" => HOMEBREW_PREFIX/"bin/brew",
       "HOMEBREW_INTEGRATION_TEST" => cmd_id_from_args(args),
       "HOMEBREW_TEST_TMPDIR" => TEST_TMPDIR,
-      "HOMEBREW_DEVELOPER" => ENV["HOMEBREW_DEVELOPER"]
+      "HOMEBREW_DEVELOPER" => ENV["HOMEBREW_DEVELOPER"],
     )
 
     ruby_args = [

--- a/Library/Homebrew/test/tab_test.rb
+++ b/Library/Homebrew/test/tab_test.rb
@@ -32,7 +32,7 @@ class TabTests < Homebrew::TestCase
           "devel" => "0.14",
           "head" => "HEAD-1111111",
         },
-      }
+      },
     )
   end
 

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -164,7 +164,7 @@ class Version
     RCToken::PATTERN,
     PatchToken::PATTERN,
     NumericToken::PATTERN,
-    StringToken::PATTERN
+    StringToken::PATTERN,
   )
 
   class FromURL < Version


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

***

Discussed [here](https://github.com/Homebrew/brew/pull/1987/files#r100693581).

This was [originally](https://github.com/Homebrew/legacy-homebrew/pull/48144#r49928971) ommitted because it wasn't compatible with Ruby 1.8.