### PR TITLE
log: follow renames.

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -26,7 +26,7 @@ module Homebrew
       EOS
     end
     args = ARGV.options_only
-    args += ["--", path] unless path.nil?
+    args += ["--follow", "--", path] unless path.nil?
     exec "git", "log", *args
   end
 end


### PR DESCRIPTION
Now that we can rename formulae this makes this command more useful for viewing longer histories.