### PR TITLE
brew boneyard: show contents of deleted formula.

### DIFF
--- a/Library/Homebrew/cmd/boneyard.rb
+++ b/Library/Homebrew/cmd/boneyard.rb
@@ -1,0 +1,29 @@
+#:  * `boneyard` [<git-log-options>] <formula> ...:
+#:    Show the last contents for a deleted formula.
+
+require "formula"
+
+module Homebrew
+  module_function
+
+  def boneyard
+    raise FormulaUnspecifiedError if ARGV.named.empty?
+    name = ARGV.named.first
+    path = Formulary.path name
+    cd path.dirname # supports taps
+
+    if File.exist? "#{`git rev-parse --show-toplevel`.chomp}/.git/shallow"
+      opoo <<-EOS.undent
+        The git repository is a shallow clone therefore the output may be incomplete.
+        Use `git fetch --unshallow` to get the full repository.
+      EOS
+    end
+
+    log_cmd = "git log --name-only --max-count=1 --format=format:%H -- #{path}"
+    revision, path = Utils.popen_read(log_cmd).lines.map(&:chomp)
+    if revision.to_s.empty? || path.to_s.empty?
+      raise FormulaUnavailableError, name
+    end
+    exec "git", "show", "#{revision}^:#{path}"
+  end
+end

--- a/Library/Homebrew/test/boneyard_test.rb
+++ b/Library/Homebrew/test/boneyard_test.rb
@@ -1,0 +1,20 @@
+require "testing_env"
+
+class IntegrationCommandTestBoneyard < IntegrationCommandTestCase
+  def test_boneyard
+    setup_test_formula "testball"
+    setup_test_formula "testball2"
+
+    CoreTap.instance.path.cd do
+      shutup do
+        system "git", "init"
+        system "git", "add", "--all"
+        system "git", "commit", "-m", "add testballs"
+        system "git", "rm", "Formula/testball2.rb"
+        system "git", "commit", "-m", "remove testball2"
+      end
+    end
+
+    assert_match "class Testball2", cmd("boneyard", "testball2")
+  end
+end

--- a/docs/brew.1.html
+++ b/docs/brew.1.html
@@ -39,6 +39,7 @@ If no search term is given, all locally available formulae are listed.</p></dd>
 Read more at <a href="http://docs.brew.sh/Analytics.html" data-bare-link="true">http://docs.brew.sh/Analytics.html</a>.</p></dd>
 <dt><code>analytics</code> (<code>on</code>|<code>off</code>)</dt><dd><p>Turn on/off Homebrew's analytics.</p></dd>
 <dt><code>analytics</code> <code>regenerate-uuid</code></dt><dd><p>Regenerate UUID used in Homebrew's analytics.</p></dd>
+<dt><code>boneyard</code> [<var>git-log-options</var>] <var>formula</var> ...</dt><dd><p>Show the last contents for a deleted formula.</p></dd>
 <dt><code>cat</code> <var>formula</var></dt><dd><p>Display the source to <var>formula</var>.</p></dd>
 <dt><code>cleanup</code> [<code>--prune=</code><var>days</var>] [<code>--dry-run</code>] [<code>-s</code>] [<var>formulae</var>]</dt><dd><p>For all installed or specific formulae, remove any older versions from the
 cellar. In addition, old downloads from the Homebrew download-cache are deleted.</p>

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -56,6 +56,10 @@ Turn on/off Homebrew\'s analytics\.
 Regenerate UUID used in Homebrew\'s analytics\.
 .
 .TP
+\fBboneyard\fR [\fIgit\-log\-options\fR] \fIformula\fR \.\.\.
+Show the last contents for a deleted formula\.
+.
+.TP
 \fBcat\fR \fIformula\fR
 Display the source to \fIformula\fR\.
 .


### PR DESCRIPTION
This command will help us be able to remove the homebrew/boneyard tap by making it easier for people to resurrect deleted formulae into their own taps.