### PR TITLE
dependency: avoid expanding same dep twice

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -78,6 +78,8 @@ class Dependency
       # Keep track dependencies to avoid infinite cyclic dependency recursion.
       @expand_stack ||= []
       @expand_stack.push dependent.name
+      # Keep track of already expanded dependencies.
+      @ready ||= []
 
       expanded_deps = []
 
@@ -88,14 +90,15 @@ class Dependency
         when :prune
           next
         when :skip
-          next if @expand_stack.include? dep.name
+          next if @expand_stack.include?(dep.name) || @ready.include?(dep.name)
           expanded_deps.concat(expand(dep.to_formula, &block))
         when :keep_but_prune_recursive_deps
           expanded_deps << dep
         else
-          next if @expand_stack.include? dep.name
+          next if @expand_stack.include?(dep.name) || @ready.include?(dep.name)
           expanded_deps.concat(expand(dep.to_formula, &block))
           expanded_deps << dep
+          @ready << dep
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

## description

Consider the case when with these formulae:
`a`, `b`, `c`, `d`, `e`.

* `a` dependencies: `b`
* `b` dependencies: `c, e`
* `c` dependencies: `d`
* `e` dependencies: `c`

If we're expanding dependencies using post-order traversal

* expand left subtree
* expand right subtree
* display current node

we're doing some unnecessary computations for `c` and `d` which are
displayed in the parantheses:

```
         a
        /
       b
      / \
     c   e
    /     \
   d      (c)
          /
        (d)
```

Let's expand a's dependencies:

1. `a`, call recursively for `b`
2. `b`, call recursively for `c`
3. `c`, call recursively for `d`
4. `d`, push `d` to dependencies list, which now gets `[d]`, go up to
`c`
5. `c`, push `c` to dependencies list, which now gets `[d, c]`, go up to `b`
6. `b`, call recursively for `e`
7. _`e`, call recursively for `c` <-- unnecessary call_
8. _`c`, call recursively for `d` <-- unnecessary call_
9. `d`, dependencies list already has `[d, c]`, go up to `c`
10. `c`, go up to `e`, push `e` to dependencies list, which now gets `[d, c,
e]`, go up to `b`
11. `b`, push `b` to dependencies list, which now gets `[d, c, e, b]`, go up
to a
12. `a`, push `a` to dependencies list, which now gets `[d, c, e, b, a]`

## tl;dr

Let's skip expanding subtrees of dependencies we have already expanded
once, since they are the same as we have already expanded once.


