### PR TITLE
audit: enforce https for *.sourceforge.io urls

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -585,7 +585,7 @@ class FormulaAuditor
     # exemptions as they are discovered. Treat mixed content on homepages as a bug.
     # Justify each exemptions with a code comment so we can keep track here.
     case homepage
-    when %r{^http://[^/]*github\.io/},
+    when %r{^http://[^/]*\.github\.io/},
          %r{^http://[^/]*\.sourceforge\.io/}
       problem "Please use https:// for #{homepage}"
     end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -584,7 +584,9 @@ class FormulaAuditor
     # People will run into mixed content sometimes, but we should enforce and then add
     # exemptions as they are discovered. Treat mixed content on homepages as a bug.
     # Justify each exemptions with a code comment so we can keep track here.
-    if homepage =~ %r{^http://[^/]*github\.io/}
+    case homepage
+    when %r{^http://[^/]*github\.io/},
+         %r{^http://[^/]*\.sourceforge\.io/}
       problem "Please use https:// for #{homepage}"
     end
 

--- a/Library/Homebrew/test/audit_test.rb
+++ b/Library/Homebrew/test/audit_test.rb
@@ -434,6 +434,7 @@ class FormulaAuditorTests < Homebrew::TestCase
       "sf1" => "http://foo.sourceforge.net/",
       "sf2" => "http://foo.sourceforge.net",
       "sf3" => "http://foo.sf.net/",
+      "sf4" => "http://foo.sourceforge.io/",
       "waldo" => "http://www.gnu.org/waldo",
     }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This update helps avoiding the mistake of forgetting to upgrade protocol to HTTPS from HTTP, when changing `http://*.sourceforge.net/` to `https://*.sourceforge.io/`, as requested by an existing audit rule.