### PR TITLE
Allow skipping `uninstall script:` when `--force` is passed.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/artifact/uninstall_base.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/uninstall_base.rb
@@ -201,7 +201,15 @@ module Hbc
         ohai "Running uninstall script #{executable}"
         raise CaskInvalidError.new(@cask, "#{stanza} :#{directive_name} without :executable.") if executable.nil?
         executable_path = @cask.staged_path.join(executable)
-        @command.run("/bin/chmod", args: ["--", "+x", executable_path]) if File.exist?(executable_path)
+
+        unless executable_path.exist?
+          message = "uninstall script #{executable} does not exist"
+          raise CaskError, "#{message}." unless force
+          opoo "#{message}, skipping."
+          return
+        end
+
+        @command.run("/bin/chmod", args: ["--", "+x", executable_path])
         @command.run(executable_path, script_arguments)
         sleep 1
       end

--- a/Library/Homebrew/cask/spec/cask/cli/uninstall_spec.rb
+++ b/Library/Homebrew/cask/spec/cask/cli/uninstall_spec.rb
@@ -60,6 +60,34 @@ describe Hbc::CLI::Uninstall do
     expect(Hbc.appdir.join("MyFancyApp.app")).not_to exist
   end
 
+  it "can uninstall Casks when the uninstall script is missing, but only when using `--force`" do
+    cask = Hbc::CaskLoader.load_from_file(TEST_FIXTURE_DIR/"cask/Casks/with-uninstall-script-app.rb")
+
+    shutup do
+      Hbc::Installer.new(cask).install
+    end
+
+    expect(cask).to be_installed
+
+    Hbc.appdir.join("MyFancyApp.app").rmtree
+
+    expect {
+      shutup do
+        Hbc::CLI::Uninstall.run("with-uninstall-script-app")
+      end
+    }.to raise_error(Hbc::CaskError, /does not exist/)
+
+    expect(cask).to be_installed
+
+    expect {
+      shutup do
+        Hbc::CLI::Uninstall.run("with-uninstall-script-app", "--force")
+      end
+    }.not_to raise_error
+
+    expect(cask).not_to be_installed
+  end
+
   describe "when multiple versions of a cask are installed" do
     let(:token) { "versioned-cask" }
     let(:first_installed_version) { "1.2.3" }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Only warn if uninstall script doesn't exist when using `--force`.