### PR TITLE
Revert "Skip Xcode outdated check on CircleCI"

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -53,8 +53,8 @@ module Homebrew
         return unless MacOS::Xcode.installed?
         return unless MacOS::Xcode.outdated?
 
-        # CI images are going to end up outdated so don't complain.
-        return if ENV["TRAVIS"] || ENV["CIRCLECI"]
+        # Travis CI images are going to end up outdated so don't complain.
+        return if ENV["TRAVIS"]
 
         message = <<-EOS.undent
           Your Xcode (#{MacOS::Xcode.version}) is outdated.

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -54,7 +54,7 @@ module Homebrew
         return unless MacOS::Xcode.outdated?
 
         # Travis CI images are going to end up outdated so don't complain when
-        # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew 
+        # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI provider
         # Homebrew/brew is currently using.
         return if ENV["TRAVIS"]

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -55,7 +55,7 @@ module Homebrew
 
         # Travis CI images are going to end up outdated so don't complain when
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew 
-        # repository. This only needs to support whatever CI provided 
+        # repository. This only needs to support whatever CI provider
         # Homebrew/brew is currently using.
         return if ENV["TRAVIS"]
 

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -53,7 +53,10 @@ module Homebrew
         return unless MacOS::Xcode.installed?
         return unless MacOS::Xcode.outdated?
 
-        # Travis CI images are going to end up outdated so don't complain.
+        # Travis CI images are going to end up outdated so don't complain when
+        # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew 
+        # repository. This only needs to support whatever CI provided 
+        # Homebrew/brew is currently using.
         return if ENV["TRAVIS"]
 
         message = <<-EOS.undent


### PR DESCRIPTION
Reverts Homebrew/brew#1983

CC @alyssais and FYI of @DanToml.

I'm a bit disappointed that CircleCI requested such a quick turnaround on this but didn't provide the specific reproduction steps as requested multiple times.