### PR TITLE
bump-formula-pr: improve duplicate detection

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -80,7 +80,8 @@ module Homebrew
 
   def fetch_pull_requests(formula)
     GitHub.issues_for_formula(formula.name, tap: formula.tap).select do |pr|
-      pr["html_url"].include?("/pull/")
+      pr["html_url"].include?("/pull/") &&
+        /(^|\s)#{Regexp.quote(formula.name)}(:|\s|$)/i =~ pr["title"]
     end
   rescue GitHub::RateLimitExceededError => e
     opoo e.message


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Reduce the chance of false flagging by making sure that the existing pr surfaced by `GitHub.issues_for_formula` actually contains the exact formula name in its title.

This for instance solves a problem I encountered just now where a pr for `imagemagick` blocks a new one for `imagemagick@6` (<s>unfortunately not the other way round</s>).