### PR TITLE
.simplecov: require English with capital E

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require "english"
+require "English"
 
 SimpleCov.start do
   coverage_dir File.expand_path("../test/coverage", File.realpath(__FILE__))


### PR DESCRIPTION
On case-sensitive filesystems, require "english" will fail with "cannot load such file -- english"

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?