### PR TITLE
ARGV: add missing "--force" arg to formula_install_option_names

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -16,11 +16,13 @@ module HomebrewArgvExtension
       --build-bottle
       --force-bottle
       --verbose
+      --force
       -i
       -v
       -d
       -g
       -s
+      -f
     ].freeze
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This fixes an erroneous warning when running `brew install --force foo`. This would currently trigger a warning about the foo formula not having a `--force` option.
e.x. `Warning: foo: this formula has no --force option so it will be ignored!`

This fixes #2053