### PR TITLE
Fix `uninstall` when some formulae are missing

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -89,12 +89,12 @@ class Dependency
           next
         when :skip
           next if @expand_stack.include? dep.name
-          expanded_deps.concat(expand(dep.to_formula, &block))
+          expanded_deps.concat(expand_dependency(dep, &block))
         when :keep_but_prune_recursive_deps
           expanded_deps << dep
         else
           next if @expand_stack.include? dep.name
-          expanded_deps.concat(expand(dep.to_formula, &block))
+          expanded_deps.concat(expand_dependency(dep, &block))
           expanded_deps << dep
         end
       end
@@ -167,6 +167,16 @@ class Dependency
       else
         [] # Means both build and runtime dependency.
       end
+    end
+
+    def expand_dependency(dependency)
+      formula = begin
+        dependency.to_formula
+      rescue FormulaUnavailableError
+        return []
+      end
+
+      expand(formula)
     end
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1548,7 +1548,13 @@ class Formula
       end
     end
 
-    missing_dependencies.map!(&:to_formula)
+    missing_dependencies.map! do |dependency|
+      begin
+        dependency.to_formula
+      rescue FormulaUnavailableError
+      end
+    end
+    missing_dependencies.compact!
     missing_dependencies.select! do |d|
       hide.include?(d.name) || d.installed_prefixes.empty?
     end

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -670,6 +670,15 @@ class FormulaTests < Homebrew::TestCase
     assert_equal [Dependency.new("f1")], f2.recursive_dependencies
   end
 
+  def test_missing_dependencies_with_missing_formula
+    f2 = formula("f2") do
+      url "f-2"
+      depends_on "f1"
+    end
+
+    assert_empty f2.missing_dependencies
+  end
+
   def test_requirements
     f1 = formula("f1") do
       url "f1-1"

--- a/Library/Homebrew/test/formula_test.rb
+++ b/Library/Homebrew/test/formula_test.rb
@@ -661,6 +661,15 @@ class FormulaTests < Homebrew::TestCase
     assert_equal %w[foo/bar/f1 baz/qux/f2], f3.runtime_dependencies.map(&:name)
   end
 
+  def test_dependencies_with_missing_formula
+    f2 = formula("f2") do
+      url "f-2"
+      depends_on "f1"
+    end
+
+    assert_equal [Dependency.new("f1")], f2.recursive_dependencies
+  end
+
   def test_requirements
     f1 = formula("f1") do
       url "f1-1"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the issue reported in #1928 and #2027 by essentially ignoring formulae that are missing (by e.g. being untapped).

Since there's no way to access that dependency information, saying there aren't any dependencies of that particular package is the best we can do (and is much better than raising an exception, which is the current behaviour).