### PR TITLE
Add /usr/libexec/cups to the list of system dirs

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/macos.rb
+++ b/Library/Homebrew/cask/lib/hbc/macos.rb
@@ -181,6 +181,7 @@ module OS
       "/usr/include",
       "/usr/lib",
       "/usr/libexec",
+      "/usr/libexec/cups",
       "/usr/local",
       "/usr/local/Cellar",
       "/usr/local/Frameworks",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?
-----
Currently some `uninstall pkgutil:` casks ([example](https://github.com/caskroom/homebrew-drivers/issues/8)) fail on uninstall when trying to `chmod 777 /usr/libexec/cups` since this directory has `sunlnk` flag set. This PR adds it to the list of system directories to prevent uninstaller from trying to change the permissions or remove it.