### PR TITLE
java_requirement: Make macOS overrides extend Requirement

### DIFF
--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -1,4 +1,4 @@
-class JavaRequirement
+class JavaRequirement < Requirement
   cask "java"
 
   env do


### PR DESCRIPTION
This doesn't actually seem to make that much difference,
but it is at least consistent with the main class body and with
the Linux overrides.

Follows up on https://github.com/Homebrew/brew/pull/1632/files#r102066205

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----