### PR TITLE
keg: handle missing alias opt link on uninstall.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -239,7 +239,10 @@ class Keg
 
   def remove_opt_record
     opt_record.unlink
-    aliases.each { |a| (opt_record.parent/a).unlink }
+    aliases.each do |a|
+      next if !opt_record.symlink? && !opt_record.exist?
+      (opt_record.parent/a).delete
+    end
     opt_record.parent.rmdir_if_possible
   end
 


### PR DESCRIPTION
Fixes an issue introduced in #1192 where there would be a failure if the alias link didn't exist on removal (which would be the case for anything with an alias installed before #1192 was merged).