### PR TITLE
audit: fix revision should be removed.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -816,10 +816,12 @@ class FormulaAuditor
 
     return if formula.revision.zero?
     if formula.stable
-      revision_map = attributes_map[:revision][:stable]
-      stable_revisions = revision_map[formula.stable.version] if revision_map
-      if !stable_revisions || stable_revisions.empty?
-        problem "'revision #{formula.revision}' should be removed"
+      if revision_map = attributes_map[:revision][:stable]
+        stable_revisions = revision_map[formula.stable.version]
+        stable_revisions -= [formula.revision]
+        if stable_revisions.empty?
+          problem "'revision #{formula.revision}' should be removed"
+        end
       end
     else # head/devel-only formula
       problem "'revision #{formula.revision}' should be removed"


### PR DESCRIPTION
Regression introduced in #1754 which meant that (due to storing the current formula revision in `attributes_map`) `stable_revisions.empty?` would never be `true`.