### PR TITLE
Move superenv? into the ENV namespace.

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -78,7 +78,7 @@ class Build
 
     ENV.activate_extensions!
 
-    if superenv?
+    if ENV.superenv?
       ENV.keg_only_deps = keg_only_deps
       ENV.deps = formula_deps
       ENV.x11 = reqs.any? { |rq| rq.is_a?(X11Requirement) }

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -10,7 +10,7 @@ module Homebrew
 
   def __env
     ENV.activate_extensions!
-    ENV.deps = ARGV.formulae if superenv?
+    ENV.deps = ARGV.formulae if ENV.superenv?
     ENV.setup_build_environment
     ENV.universal_binary if ARGV.build_universal?
 

--- a/Library/Homebrew/cmd/sh.rb
+++ b/Library/Homebrew/cmd/sh.rb
@@ -14,13 +14,13 @@ module Homebrew
   def sh
     ENV.activate_extensions!
 
-    if superenv?
+    if ENV.superenv?
       ENV.set_x11_env_if_installed
       ENV.deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? }
     end
     ENV.setup_build_environment
-    if superenv?
-      # superenv stopped adding brew's bin but generally user's will want it
+    if ENV.superenv?
+      # superenv stopped adding brew's bin but generally users will want it
       ENV["PATH"] = ENV["PATH"].split(File::PATH_SEPARATOR).insert(1, "#{HOMEBREW_PREFIX}/bin").join(File::PATH_SEPARATOR)
     end
     ENV["PS1"] = 'brew \[\033[1;32m\]\w\[\033[0m\]$ '

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -3,11 +3,11 @@ require "extend/ENV/shared"
 require "extend/ENV/std"
 require "extend/ENV/super"
 
-def superenv?
-  ARGV.env != "std" && Superenv.bin
-end
-
 module EnvActivation
+  def superenv?
+    ARGV.env != "std" && Superenv.bin
+  end
+
   def activate_extensions!
     if superenv?
       extend(Superenv)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I'm not sure if exposing `superenv?` outside of the `ENV` namespace was intentional, but moving it into `ENV` makes things slightly clearer. 

cc @sjackman for thoughts/confirmation that this fixes your problem.