### PR TITLE
Fix audit version_scheme and revision checks.

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -7,21 +7,22 @@ class FormulaVersions
     ErrorDuringExecution, LoadError, MethodDeprecatedError
   ].freeze
 
+  MAX_VERSIONS_DEPTH = 2
+
   attr_reader :name, :path, :repository, :entry_name
 
-  def initialize(formula, options = {})
+  def initialize(formula)
     @name = formula.name
     @path = formula.path
     @repository = formula.tap.path
     @entry_name = @path.relative_path_from(repository).to_s
-    @max_depth = options[:max_depth]
+    @current_formula = formula
   end
 
   def rev_list(branch)
     repository.cd do
-      depth = 0
       Utils.popen_read("git", "rev-list", "--abbrev-commit", "--remove-empty", branch, "--", entry_name) do |io|
-        yield io.readline.chomp until io.eof? || (@max_depth && (depth += 1) > @max_depth)
+        yield io.readline.chomp until io.eof?
       end
     end
   end
@@ -49,11 +50,15 @@ class FormulaVersions
 
   def bottle_version_map(branch)
     map = Hash.new { |h, k| h[k] = [] }
+
+    versions_seen = 0
     rev_list(branch) do |rev|
       formula_at_revision(rev) do |f|
         bottle = f.bottle_specification
         map[f.pkg_version] << bottle.rebuild unless bottle.checksums.empty?
+        versions_seen = (map.keys + [f.pkg_version]).uniq.length
       end
+      return map if versions_seen > MAX_VERSIONS_DEPTH
     end
     map
   end
@@ -62,27 +67,35 @@ class FormulaVersions
     attributes_map = {}
     return attributes_map if attributes.empty?
 
-    attributes.each do |attribute|
-      attributes_map[attribute] ||= {}
-    end
-
+    stable_versions_seen = 0
     rev_list(branch) do |rev|
       formula_at_revision(rev) do |f|
         attributes.each do |attribute|
+          attributes_map[attribute] ||= {}
           map = attributes_map[attribute]
-          if f.stable
-            map[:stable] ||= {}
-            map[:stable][f.stable.version] ||= []
-            map[:stable][f.stable.version] << f.send(attribute)
-          end
-          next unless f.devel
-          map[:devel] ||= {}
-          map[:devel][f.devel.version] ||= []
-          map[:devel][f.devel.version] << f.send(attribute)
+          set_attribute_map(map, f, attribute)
+
+          stable_keys_length = (map[:stable].keys + [f.version]).uniq.length
+          stable_versions_seen = [stable_versions_seen, stable_keys_length].max
         end
       end
+      break if stable_versions_seen > MAX_VERSIONS_DEPTH
     end
 
     attributes_map
+  end
+
+  private
+
+  def set_attribute_map(map, f, attribute)
+    if f.stable
+      map[:stable] ||= {}
+      map[:stable][f.stable.version] ||= []
+      map[:stable][f.stable.version] << f.send(attribute)
+    end
+    return unless f.devel
+    map[:devel] ||= {}
+    map[:devel][f.devel.version] ||= []
+    map[:devel][f.devel.version] << f.send(attribute)
   end
 end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -93,6 +93,7 @@ RSpec.configure do |config|
         HOMEBREW_PREFIX/"opt",
         HOMEBREW_PREFIX/"Caskroom",
         HOMEBREW_LIBRARY/"Taps/caskroom",
+        HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-bar",
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-bundle",
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo",
         HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-services",

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -270,4 +270,12 @@ describe "globally-scoped helper methods" do
       }.to raise_error(MethodDeprecatedError, %r{method.*replacement.*homebrew/homebrew-core.*homebrew/core}m)
     end
   end
+
+  describe "#puts_hash" do
+    it "outputs a hash" do
+      expect {
+        puts_hash(a: 1, b: 2, c: [3, { "d"=>4 }])
+      }.to output("a: 1\nb: 2\nc: [3, {\"d\"=>4}]\n").to_stdout
+    end
+  end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -517,3 +517,19 @@ def migrate_legacy_keg_symlinks_if_necessary
   end
   FileUtils.rm_rf legacy_pinned_kegs
 end
+
+def puts_hash(hash, indent: 0)
+  return hash unless hash.is_a? Hash
+  hash.each do |key, value|
+    indent_spaces = " " * (indent * 2)
+    printf "#{indent_spaces}#{key}:"
+    if value.is_a? Hash
+      puts
+      puts_hash(value, indent: indent+1)
+    else
+      puts " #{value}"
+    end
+  end
+  hash
+end
+alias ph puts_hash


### PR DESCRIPTION
Another attempt at fixing `brew audit` issues around detecting `revision` and `version_scheme` changes correctly. First done in #1754 and #2086 (reverted in #2099 and #2100).


Fixes #1731.