### PR TITLE
Add needs :cxx14

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -75,6 +75,17 @@ class CompilerFailure
       create(gcc: "4.5"),
       create(gcc: "4.6"),
     ],
+    cxx14: [
+      create(:clang) { build 600 },
+      create(:gcc_4_0),
+      create(:gcc_4_2),
+      create(gcc: "4.3"),
+      create(gcc: "4.4"),
+      create(gcc: "4.5"),
+      create(gcc: "4.6"),
+      create(gcc: "4.7"),
+      create(gcc: "4.8"),
+    ],
     openmp: [
       create(:clang),
     ],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Homebrew/science/kmc 3 needs C++14 to build.
See https://github.com/Homebrew/homebrew-science/pull/4954

`brew tests` currently fails for me on `master`. Not sure what's up there.
`Library/Homebrew/test/vendor/bundle/ruby/2.0.0/gems/json-2.0.3/tests/json_ext_parser_test.rb:2:in 'require': cannot load such file -- test_helper (LoadError)`