### PR TITLE
brew info --json=[v1|pretty|lines]

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -7,8 +7,8 @@
 #:    To view formula history locally: `brew log -p <formula>`.
 #:
 #:  * `info` `--json=`<version> (`--all`|`--installed`|<formulae>):
-#:    Print a JSON representation of <formulae>. Currently the only accepted value
-#:    for <version> is `v1`.
+#:    Print a JSON representation of <formulae>.
+#:    Current options for <version>: `v1|pretty|lines`.
 #:
 #:    Pass `--all` to get information on all formulae, or `--installed` to get
 #:    information on all installed formulae.
@@ -28,10 +28,8 @@ module Homebrew
   module_function
 
   def info
-    # eventually we'll solidify an API, but we'll keep old versions
-    # awhile around for compatibility
-    if ARGV.json == "v1"
-      print_json
+    if ARGV.json
+      print_json ARGV.json
     elsif ARGV.flag? "--github"
       exec_browser(*ARGV.formulae.map { |f| github_info(f) })
     else
@@ -63,7 +61,7 @@ module Homebrew
     end
   end
 
-  def print_json
+  def print_json(mode)
     ff = if ARGV.include? "--all"
       Formula
     elsif ARGV.include? "--installed"
@@ -72,7 +70,20 @@ module Homebrew
       ARGV.formulae
     end
     json = ff.map(&:to_hash)
-    puts JSON.generate(json)
+    # eventually we'll solidify an API, but we'll keep old versions
+    # awhile around for compatibility
+    if mode=="v1"
+      puts JSON.generate(json)
+    elsif mode=="pretty"
+      puts JSON.pretty_generate(json)
+    elsif mode=="lines"
+      json.each do |child|
+        puts JSON.generate(child)
+      end
+    else
+      puts "valid modes:[v1|pretty|lines], passed '#{mode}'"
+      raise
+    end
   end
 
   def github_remote_path(remote, path)


### PR DESCRIPTION
@MikeMcQuaid @ilovezfs

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?
-----
- [ ] follow steps in https://github.com/Homebrew/brew/pull/1973/files (Update CONTRIBUTING.md)

* Rationale: given in https://github.com/Homebrew/brew/issues/2172 (closed it even though current functionality was lacking: --json=v1 only dumps in a single line, which doesn't play well with common line oriented tools eg grep etc; and is slower (not line oriented...)

```
#show all installed_on_request formulas:
$ brew info --json=lines --installed|grep '"installed_on_request":true'

#show caveats:
$ brew info --json=lines --installed | grep -v '"caveats":null'

# show non-relocatable formulas:
brew info --json=lines --all | grep -v '"cellar":":any"' | rdmd --loop='line.parseJSON["name"].str.writeln'

# more readable output:
$ brew info --json=pretty dmd
[
  {
    "name": "dmd",
    "full_name": "dmd",
    "desc": "D programming language compiler for macOS",
    "homepage": "https://dlang.org/",
    "oldname": null,
    "aliases": [

    ],
    "versions": {
      "stable": "2.073.1",
      "bottle": false,
      "devel": null,
      "head": "HEAD"

```
etc.

This simple change gives quite powerful possibilities


* it also fixes a bug where `--json=whatever` will silently call print_info instead of saying you passed a wrong arg to json

* if this will be accepted, i can try to finish the TODO's
