### PR TITLE
Add 'B' for bytes to cleanup command output

### DIFF
--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -30,13 +30,13 @@ describe Pathname do
     describe "#abv" do
       context "when called on a directory" do
         it "returns a string with the file count and disk usage" do
-          expect(dir.abv).to eq("3 files, 1M")
+          expect(dir.abv).to eq("3 files, 1MB")
         end
       end
 
       context "when called on a file" do
         it "returns the disk usage" do
-          expect((dir/"a-file").abv).to eq("1M")
+          expect((dir/"a-file").abv).to eq("1MB")
         end
       end
     end

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -232,10 +232,10 @@ describe "globally-scoped helper methods" do
   specify "#disk_usage_readable" do
     expect(disk_usage_readable(1)).to eq("1B")
     expect(disk_usage_readable(1000)).to eq("1000B")
-    expect(disk_usage_readable(1024)).to eq("1K")
-    expect(disk_usage_readable(1025)).to eq("1K")
-    expect(disk_usage_readable(4_404_020)).to eq("4.2M")
-    expect(disk_usage_readable(4_509_715_660)).to eq("4.2G")
+    expect(disk_usage_readable(1024)).to eq("1KB")
+    expect(disk_usage_readable(1025)).to eq("1KB")
+    expect(disk_usage_readable(4_404_020)).to eq("4.2MB")
+    expect(disk_usage_readable(4_509_715_660)).to eq("4.2GB")
   end
 
   describe "#number_readable" do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -422,13 +422,13 @@ end
 def disk_usage_readable(size_in_bytes)
   if size_in_bytes >= 1_073_741_824
     size = size_in_bytes.to_f / 1_073_741_824
-    unit = "G"
+    unit = "GB"
   elsif size_in_bytes >= 1_048_576
     size = size_in_bytes.to_f / 1_048_576
-    unit = "M"
+    unit = "MB"
   elsif size_in_bytes >= 1_024
     size = size_in_bytes.to_f / 1_024
-    unit = "K"
+    unit = "KB"
   else
     size = size_in_bytes
     unit = "B"


### PR DESCRIPTION
When `brew cleanup` is run it prints out a message like the following:

> This operation has freed approximately 222M of disk space.

The '222M' refers to megabytes but the normal acronym for megabytes would be
'MB'. The 'B' is also missing from kilobytes and gigabytes in the output, so
that's what this commit adds.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
