### PR TITLE
Check the specs of dependencies if they're installed but not satisfied

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -437,6 +437,7 @@ class FormulaInstaller
         elsif req.build? && install_bottle_for_dependent
           Requirement.prune
         elsif install_requirement_formula?(req_dependency, req, install_bottle_for_dependent)
+          req_dependency.use_closest_for_dependency_upgrade_spec!
           deps.unshift(req_dependency)
           formulae.unshift(req_dependency.to_formula)
           Requirement.prune

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -111,11 +111,15 @@ class FormulaInstaller
       return false
     end
 
+    stable_deps_needed = formula.deps.reject do |dep|
+      dep.closest_spec_for_dependency_upgrade_sym == :stable
+    end.map(&:name)
+
     if formula.deps.any? { |dep| dep.closest_spec_for_dependency_upgrade_sym != :stable }
       if install_bottle_options[:warn]
         opoo <<-EOS.undent
           Building #{formula.full_name} from source:
-            The bottle needs stable dependencies which are not installed.
+            The bottle needs stable dependencies which are not installed (#{stable_deps_needed.join(", ")}).
         EOS
       end
       return false

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -111,6 +111,16 @@ class FormulaInstaller
       return false
     end
 
+    if formula.deps.any? { |dep| dep.closest_spec_for_dependency_upgrade_sym != :stable }
+      if install_bottle_options[:warn]
+        opoo <<-EOS.undent
+          Building #{formula.full_name} from source:
+            The bottle needs stable dependencies which are not installed.
+        EOS
+      end
+      return false
+    end
+
     true
   end
 

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -118,6 +118,15 @@ describe Dependency do
     expect(described_class.expand(formula, [bar, baz])).to eq([bar, baz])
   end
 
+  it "resolves returns devel dep if closest spec is devel" do
+    foo = build_dep(:foo, [:build])
+    allow(foo).to receive(:closest_spec_for_dependency_upgrade_sym).and_return(:devel)
+
+    f = double(name: "f", deps: [foo])
+    expect(described_class.expand(f)).to eq([foo])
+    expect(foo.spec).to eq(:devel)
+  end
+
   it "doesn't raise an error when a dependency is cyclic" do
     foo = build_dep(:foo)
     bar = build_dep(:bar, [], [foo])

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -107,6 +107,22 @@ describe Formula do
     end
   end
 
+  describe "#determine_active_spec" do
+    let(:f) do
+      formula do
+        url "foo-1.0"
+      end
+    end
+
+    it "returns stable if no head defined" do
+      expect(f.send(:determine_active_spec, :devel)).to eq(f.stable)
+    end
+
+    it "returns stable if no head defined" do
+      expect(f.send(:determine_active_spec, :head)).to eq(f.stable)
+    end
+  end
+
   example "installed alias with core" do
     f = formula do
       url "foo-1.0"

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -10,9 +10,35 @@ module Test
       # Use a stubbed {Formulary::FormulaLoader} to make a given formula be found
       # when loading from {Formulary} with `ref`.
       def stub_formula_loader(formula, ref = formula.full_name)
-        loader = double(get_formula: formula)
+        loader = double
+        allow(loader).to receive(:get_formula).and_return(formula)
+
+        allow(loader).to receive(:get_formula).with(:stable, alias_path: anything) do
+          begin
+            formula.active_spec = :stable
+          rescue FormulaSpecificationError
+            nil
+          end
+        end.and_return(formula)
+
+        allow(loader).to receive(:get_formula).with(:devel, alias_path: anything) do
+          begin
+            formula.active_spec = :devel
+          rescue FormulaSpecificationError
+            nil
+          end
+        end.and_return(formula)
+
+        allow(loader).to receive(:get_formula).with(:head, alias_path: anything) do
+          begin
+            formula.active_spec = :head
+          rescue FormulaSpecificationError
+            nil
+          end
+        end.and_return(formula)
         allow(Formulary).to receive(:loader_for).with(ref, from: :keg).and_return(loader)
         allow(Formulary).to receive(:loader_for).with(ref, from: nil).and_return(loader)
+        allow(Formulary).to receive(:loader_for).with(ref, from: :rack).and_return(loader)
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

# Description

Fixes https://github.com/Homebrew/brew/issues/668

About 18 tests fail now and 15 of them fail due to `FormulaUnavailableError`since `Dependency#use_best_spec!` uses `Formulary.factory` and tests don't expect that. Let's just skip it for now both with implementing new tests, since it's the approach which is important at this point. This PR is a possible solution of https://github.com/Homebrew/brew/issues/668. Can be pretty raw though.

Basically the idea is to mind specs of installed formulae for dependencies and requirements unless the `--ignore-installed-specs` flag is passed. The logic to determine the spec to use for dependency is implemented in `Formula#best_upgrade_spec_sym`.

Any feedback is apprecieated.

CC @ilovezfs @MikeMcQuaid 