### PR TITLE
system_config: check if devtools installed

### DIFF
--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -7,19 +7,35 @@ require "development_tools"
 class SystemConfig
   class << self
     def gcc_4_2
-      @gcc_4_2 ||= DevelopmentTools.gcc_4_2_build_version if DevelopmentTools.installed?
+      @gcc_4_2 ||= if DevelopmentTools.installed?
+        DevelopmentTools.gcc_4_2_build_version
+      else
+        Version::NULL
+      end
     end
 
     def gcc_4_0
-      @gcc_4_0 ||= DevelopmentTools.gcc_4_0_build_version if DevelopmentTools.installed?
+      @gcc_4_0 ||= if DevelopmentTools.installed?
+        DevelopmentTools.gcc_4_0_build_version
+      else
+        Version::NULL
+      end
     end
 
     def clang
-      @clang ||= DevelopmentTools.clang_version if DevelopmentTools.installed?
+      @clang ||= if DevelopmentTools.installed?
+        DevelopmentTools.clang_version
+      else
+        Version::NULL
+      end
     end
 
     def clang_build
-      @clang_build ||= DevelopmentTools.clang_build_version if DevelopmentTools.installed?
+      @clang_build ||= if DevelopmentTools.installed?
+        DevelopmentTools.clang_build_version
+      else
+        Version::NULL
+      end
     end
 
     def head


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #2192

### Steps to reproduce:

Go to `extend/os/mac/development_tools.rb` and patch `DevelopmentTools.installed?` like this:

```ruby
 21     def installed?
 22       false
 23     end
```

Then try `brew config`
