### PR TITLE
Accept "Formulae" as directory of Formula files

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -296,7 +296,11 @@ class Tap
   end
 
   def potential_formula_dirs
-    @potential_formula_dirs ||= [path/"Formula", path/"HomebrewFormula", path].freeze
+    @potential_formula_dirs ||= [path/"Formula",
+                                 path/"Formulae",
+                                 path/"HomebrewFormula",
+                                 path/"HomebrewFormulae",
+                                 path].freeze
   end
 
   # path to the directory of all {Cask} files for this {Tap}.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The plural "formulae" is used frequently throughout the Brew commands and documentation.
Given that, it struck me as odd that the plural form was *not* accepted as the name for the directory of formulae, particularly given you'd generally only want the directory if it were to contain multiple formulae!

This updates it to accept `Formula`, `Formulae`, `HomebrewFormula` and `HomebrewFormulae`.