### PR TITLE
Tests: prevent `git commit` from GPG signing

### DIFF
--- a/Library/Homebrew/test/cmd/bundle_spec.rb
+++ b/Library/Homebrew/test/cmd/bundle_spec.rb
@@ -6,7 +6,7 @@ describe "brew bundle", :integration_test, :needs_test_cmd_taps do
       HOMEBREW_REPOSITORY.cd do
         shutup do
           system "git", "init"
-          system "git", "commit", "--allow-empty", "-m", "This is a test commit"
+          system "git", "commit", "--no-gpg-sign", "--allow-empty", "-m", "This is a test commit"
         end
       end
 

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -162,7 +162,7 @@ describe "brew install", :integration_test do
         FileUtils.touch "bin/something.bin"
         FileUtils.touch "README"
         system "git", "add", "--all"
-        system "git", "commit", "-m", "Initial repo commit"
+        system "git", "commit", "--no-gpg-sign", "-m", "Initial repo commit"
       end
     end
 

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -3,7 +3,7 @@ describe "brew log", :integration_test do
     HOMEBREW_REPOSITORY.cd do
       shutup do
         system "git", "init"
-        system "git", "commit", "--allow-empty", "-m", "This is a test commit"
+        system "git", "commit", "--no-gpg-sign", "--allow-empty", "-m", "This is a test commit"
       end
     end
 
@@ -21,7 +21,7 @@ describe "brew log", :integration_test do
       shutup do
         system "git", "init"
         system "git", "add", "--all"
-        system "git", "commit", "-m", "This is a test commit for Testball"
+        system "git", "commit", "--no-gpg-sign", "-m", "This is a test commit for Testball"
       end
     end
 

--- a/Library/Homebrew/test/dev-cmd/tap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap_spec.rb
@@ -8,7 +8,7 @@ describe "brew tap", :integration_test do
         system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
         FileUtils.touch "readme"
         system "git", "add", "--all"
-        system "git", "commit", "-m", "init"
+        system "git", "commit", "--no-gpg-sign", "-m", "init"
       end
     end
 

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -149,7 +149,7 @@ describe GitDownloadStrategy do
   def git_commit_all
     shutup do
       system "git", "add", "--all"
-      system "git", "commit", "-m", "commit number #{@commit_id}"
+      system "git", "commit", "--no-gpg-sign", "-m", "commit number #{@commit_id}"
       @commit_id += 1
     end
   end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -575,7 +575,7 @@ describe Formula do
       shutup do
         system("git", "init")
         system("git", "add", "--all")
-        system("git", "commit", "-m", "Initial commit")
+        system("git", "commit", "--no-gpg-sign", "-m", "Initial commit")
       end
     end
 
@@ -1197,7 +1197,7 @@ describe Formula do
             shutup do
               system("git", "init")
               system("git", "add", "--all")
-              system("git", "commit", "-m", "Initial commit")
+              system("git", "commit", "--no-gpg-sign", "-m", "Initial commit")
             end
           end
 

--- a/Library/Homebrew/test/support/helper/integration_command_test_case.rb
+++ b/Library/Homebrew/test/support/helper/integration_command_test_case.rb
@@ -130,7 +130,7 @@ class IntegrationCommandTestCase < Homebrew::TestCase
       shutup do
         system "git", "init"
         system "git", "add", "--all"
-        system "git", "commit", "-m",
+        system "git", "commit", "--no-gpg-sign", "-m",
           "#{old_name.capitalize} has not yet been renamed"
       end
     end
@@ -143,7 +143,7 @@ class IntegrationCommandTestCase < Homebrew::TestCase
     core_tap.path.cd do
       shutup do
         system "git", "add", "--all"
-        system "git", "commit", "-m",
+        system "git", "commit", "--no-gpg-sign", "-m",
           "#{old_name.capitalize} has been renamed to #{new_name.capitalize}"
       end
     end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -151,7 +151,7 @@ RSpec.shared_context "integration test" do
       CoreTap.instance.path.cd do |tap_path|
         system "git", "init"
         system "git", "add", "--all"
-        system "git", "commit", "-m",
+        system "git", "commit", "--no-gpg-sign", "-m",
           "#{old_name.capitalize} has not yet been renamed"
 
         brew "install", old_name
@@ -160,7 +160,7 @@ RSpec.shared_context "integration test" do
         (tap_path/"formula_renames.json").write JSON.generate(old_name => new_name)
 
         system "git", "add", "--all"
-        system "git", "commit", "-m",
+        system "git", "commit", "--no-gpg-sign", "-m",
           "#{old_name.capitalize} has been renamed to #{new_name.capitalize}"
       end
     end

--- a/Library/Homebrew/test/tap_test.rb
+++ b/Library/Homebrew/test/tap_test.rb
@@ -41,7 +41,7 @@ class TapTest < Homebrew::TestCase
         system "git", "init"
         system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-foo"
         system "git", "add", "--all"
-        system "git", "commit", "-m", "init"
+        system "git", "commit", "--no-gpg-sign", "-m", "init"
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If the user has GPG signing on by default, git will try to get the user to type their passphrase when signing commits on every test that runs `git commit`. That obviously sucks and it prevents the tests from passing.