### PR TITLE
emoji tests: make sure to unset install badge env vars

### DIFF
--- a/Library/Homebrew/test/emoji_spec.rb
+++ b/Library/Homebrew/test/emoji_spec.rb
@@ -4,6 +4,11 @@ describe Emoji do
   describe "#install_badge" do
     subject { described_class.install_badge }
 
+    before(:each) do
+      ENV.delete("HOMEBREW_NO_EMOJI")
+      ENV.delete("HOMEBREW_INSTALL_BADGE")
+    end
+
     it "returns 🍺 by default" do
       expect(subject).to eq "🍺"
     end

--- a/Library/Homebrew/test/emoji_spec.rb
+++ b/Library/Homebrew/test/emoji_spec.rb
@@ -9,7 +9,7 @@ describe Emoji do
       ENV.delete("HOMEBREW_INSTALL_BADGE")
     end
 
-    it "returns 🍺 by default" do
+    it "returns 🍺  by default" do
       expect(subject).to eq "🍺"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise the user's specified emoji will be used and the test will fail. For example:

```
Randomized with seed 13929
.F

Failures:

  1) Emoji#install_badge returns 🍺 by default
     Failure/Error: expect(subject).to eq "🍺"

       expected: "🍺"
            got: "🎑"

       (compared using ==)
     # ./test/emoji_spec.rb:8:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:61:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```