### PR TITLE
xcodebuild audit: match xcodebuild with no args

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -924,7 +924,7 @@ class FormulaAuditor
       end
     end
 
-    if text =~ /xcodebuild[ (]["'*]/ && !text.include?("SYMROOT=")
+    if text =~ /xcodebuild[ (]*["'*]*/ && !text.include?("SYMROOT=")
       problem 'xcodebuild should be passed an explicit "SYMROOT"'
     end
 

--- a/Library/Homebrew/test/audit_test.rb
+++ b/Library/Homebrew/test/audit_test.rb
@@ -465,4 +465,38 @@ class FormulaAuditorTests < Homebrew::TestCase
       end
     end
   end
+
+  def test_audit_xcodebuild_suggests_symroot
+    fa = formula_auditor "foo", <<-EOS.undent
+      class Foo < Formula
+        url "http://example.com/foo-1.0.tgz"
+        homepage "http://example.com"
+
+        def install
+          xcodebuild "-project", "meow.xcodeproject"
+        end
+      end
+    EOS
+
+    fa.audit_text
+
+    assert_match 'xcodebuild should be passed an explicit "SYMROOT"', fa.problems.first
+  end
+
+  def test_audit_bare_xcodebuild_suggests_symroot_also
+    fa = formula_auditor "foo", <<-EOS.undent
+      class Foo < Formula
+        url "http://example.com/foo-1.0.tgz"
+        homepage "http://example.com"
+
+        def install
+          xcodebuild
+        end
+      end
+    EOS
+
+    fa.audit_text
+
+    assert_match 'xcodebuild should be passed an explicit "SYMROOT"', fa.problems.first
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The old regex only matched `xcodebuild` if passed arguments, but we want to pass `SYMROOT` in all circumstances. For example, without this patch, `brew audit eject` returns no problems, but with this patch it reports `* xcodebuild should be passed an explicit "SYMROOT"`.