### PR TITLE
brew tests: filter out vendor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@
 !/CONTRIBUTING.md
 !/LICENSE.txt
 !/README.md
+
+# Unignore tests' bundle config
+!/Library/Homebrew/test/.bundle

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -57,6 +57,7 @@ module Homebrew
       ENV["SEED"] = ARGV.next if ARGV.include? "--seed"
 
       files = Dir.glob("test/**/*_{spec,test}.rb")
+                 .reject { |p| p =~ %r{^test/vendor/bundle} }
                  .reject { |p| !OS.mac? && p =~ %r{^test/(os/mac|cask)(/.*|_(test|spec)\.rb)$} }
 
       test_args = []

--- a/Library/Homebrew/test/.bundle/config
+++ b/Library/Homebrew/test/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "../vendor/bundle"
+BUNDLE_DISABLE_SHARED_GEMS: '1'


### PR DESCRIPTION
- [x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Not sure why this doesn't consistently repro for me, but I noticed that `brew tests` was failing for me because the test glob was picking up test files from the bundled gems installed in `test/vendor/bundle`.