### PR TITLE
Add brew LLVM libOMP/omp.h to header/lib search path

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -164,7 +164,11 @@ module Superenv
   end
 
   def determine_include_paths
-    keg_only_deps.map { |d| d.opt_include.to_s }.to_path_s
+    paths = keg_only_deps.map { |d| d.opt_include.to_s }
+    if compiler == :llvm_clang && Formula["llvm"].installed?
+      paths << "#{Formula["llvm"].opt_lib}/libomp"
+    end
+    paths.to_path_s
   end
 
   def homebrew_extra_library_paths
@@ -174,6 +178,9 @@ module Superenv
   def determine_library_paths
     paths = keg_only_deps.map { |d| d.opt_lib.to_s }
     paths << "#{HOMEBREW_PREFIX}/lib"
+    if compiler == :llvm_clang && Formula["llvm"].installed?
+      paths << "#{Formula["llvm"].opt_lib}/libomp"
+    end
     paths += homebrew_extra_library_paths
     paths.to_path_s
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Finally a "fix" for the issue @ilovezfs found in #1130. At least as far as I could test, this works, but I wouldn't call it clean enough to merge. Sorry for the delay, for what it's worth.

I can't seem to run `brew tests`, either; tests fail with LoadErrors or NameErrors. I'll be looking into that in the meantime...