### PR TITLE
java_requirement: don't consider macOS Java stub

### DIFF
--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -12,9 +12,10 @@ class JavaRequirement < Requirement
     javas = []
     javas << Pathname.new(ENV["JAVA_HOME"])/"bin/java" if ENV["JAVA_HOME"]
     javas << java_home_cmd
-    javas << which("java")
-    javas.delete(Pathname.new("/usr/bin/java")) # /usr/bin/java is a stub on macOS
-    javas.compact
+    which_java = which("java")
+    # /usr/bin/java is a stub on macOS
+    javas << which_java if which_java.to_s != "/usr/bin/java"
+    javas
   end
 
   def java_home_cmd

--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -14,7 +14,7 @@ class JavaRequirement < Requirement
     javas << java_home_cmd
     javas << which("java")
     javas.delete(Pathname.new("/usr/bin/java")) # /usr/bin/java is a stub on macOS
-    javas
+    javas.compact
   end
 
   def java_home_cmd

--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -13,6 +13,7 @@ class JavaRequirement < Requirement
     javas << Pathname.new(ENV["JAVA_HOME"])/"bin/java" if ENV["JAVA_HOME"]
     javas << java_home_cmd
     javas << which("java")
+    javas.delete(Pathname.new("/usr/bin/java")) # /usr/bin/java is a stub on macOS
     javas
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes #2231. I don't know what tests to write for this, but I blew away my Java installs with `sudo rm -rf /Library/Java/JavaVirtualMachines/*` (extremely satisfying) and then ran:

```
 $ brew info plantuml
plantuml: stable 8057
Draw UML diagrams
https://plantuml.sourceforge.io/
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/plantuml.rb
==> Dependencies
Required: graphviz (uninstalled)
==> Requirements
Required: java (uninstalled)
```

Switching back to the `master` branch the same command instead says `java (installed)`.

Alternatively, we could just not include the line that says `which("java")`. CC @rwhogg 