### PR TITLE
audit: reject versions starting with HEAD

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -755,6 +755,9 @@ class FormulaAuditor
       if version.to_s !~ /\d/
         problem "#{name}: version (#{version}) is set to a string without a digit"
       end
+      if version.to_s.start_with?("HEAD")
+        problem "#{name}: non-HEAD version name (#{version}) should not begin with HEAD"
+      end
     end
 
     if formula.stable && formula.devel


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Many parts of Homebrew assume that a version string beginning with "HEAD" is, in fact, a head build. A stable version that begins with "HEAD" violates this assumption and causes problems, as it's treated as a head build in some places and as a stable build in others. Fixes #2238