### PR TITLE
Don't list duplicate dylibs for universal

### DIFF
--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -54,7 +54,7 @@ module MachOShim
   def dynamically_linked_libraries(except: :none)
     lcs = macho.dylib_load_commands.reject { |lc| lc.type == except }
 
-    lcs.map(&:name).map(&:to_s)
+    lcs.map(&:name).map(&:to_s).uniq
   end
 
   def dylib_id


### PR DESCRIPTION
Issue reported there: https://github.com/Homebrew/brew/pull/1469#pullrequestreview-25123081

Apply `uniq` to the result of `lcs.map(&:name).map(&:to_s)` otherwise universal libraries show up twice. This then triggers a failure to bottle universal binaries & libraries, like my wine PR (https://github.com/Homebrew/homebrew-core/pull/10532 ; test results: https://bot.brew.sh/job/Homebrew%20Core/17442/version=sierra/testReport/junit/brew-test-bot/sierra/bottle_wine/)

Before the commit linked above, this code relied on `macho.linked_dylibs`, which does apply `uniq`:

```
    def linked_dylibs
      # Individual architectures in a fat binary can link to different subsets
      # of libraries, but at this point we want to have the full picture, i.e.
      # the union of all libraries used by all architectures.
      machos.map(&:linked_dylibs).flatten.uniq
    end
```