### PR TITLE
audit: do not warn about reachability of `brew mirror`ed URL

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1566,6 +1566,9 @@ class ResourceAuditor
 
       strategy = DownloadStrategyDetector.detect(url, using)
       if strategy <= CurlDownloadStrategy && !url.start_with?("file")
+        # A `brew mirror`'ed URL is usually not yet reachable at the time of
+        # pull request.
+        next if url =~ %r{^https://dl.bintray.com/homebrew/mirror/}
         if http_content_problem = FormulaAuditor.check_http_content(url)
           problem http_content_problem
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A `brew mirror`ed URL is usually not yet reachable at the time of pull request.

Example of a false positive fixed by this PR: https://github.com/Homebrew/homebrew-core/pull/10587.

---

**Update.** `dev-cmd/pull.rb` has been updated to warn about unreachable Bintray mirror URLs, and prompt maintainers to run `brew mirror` in that case.