### PR TITLE
audit: whitelist node@* to use conflicts_with

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -519,14 +519,6 @@ class FormulaAuditor
   end
 
   def audit_conflicts
-    if formula.conflicts.any? && formula.versioned_formula?
-      problem <<-EOS
-        Versioned formulae should not use `conflicts_with`.
-        Use `keg_only :versioned_formula` instead.
-      EOS
-      return
-    end
-
     formula.conflicts.each do |c|
       begin
         Formulary.factory(c.name)
@@ -539,6 +531,13 @@ class FormulaAuditor
         problem "Ambiguous conflicting formula #{c.name.inspect}."
       end
     end
+
+    return unless formula.conflicts.any? && formula.versioned_formula?
+    return if formula.name.start_with? "node@"
+    problem <<-EOS
+      Versioned formulae should not use `conflicts_with`.
+      Use `keg_only :versioned_formula` instead.
+    EOS
   end
 
   def audit_options


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Add exceptions for node@* versioned formulae to use conflicts_with instead of keg_only :versioned_formula since they, and the main node formula, all currently overwrite npm during postinstall.