### PR TITLE
Don't check Subversion HTTPS pre-Sierra.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -680,8 +680,6 @@ class FormulaAuditor
 
     return unless @online
 
-    # The system Curl is too old and unreliable with HTTPS homepages on
-    # Yosemite and below.
     return unless DevelopmentTools.curl_handles_most_https_homepages?
     if http_content_problem = FormulaAuditor.check_http_content(homepage,
                                              user_agents: [:browser, :default])
@@ -1571,6 +1569,7 @@ class ResourceAuditor
           problem "The URL #{url} is not a valid git URL"
         end
       elsif strategy <= SubversionDownloadStrategy
+        next unless DevelopmentTools.subversion_handles_most_https_certificates?
         unless Utils.svn_remote_exists url
           problem "The URL #{url} is not a valid svn URL"
         end

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -117,6 +117,10 @@ class DevelopmentTools
     def curl_handles_most_https_homepages?
       true
     end
+
+    def subversion_handles_most_https_certificates?
+      true
+    end
   end
 end
 

--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -78,8 +78,15 @@ class DevelopmentTools
     end
 
     def curl_handles_most_https_homepages?
-      # The system Curl is too old for some modern HTTPS homepages on Yosemite.
+      # The system Curl is too old for some modern HTTPS homepages on
+      # older macOS versions.
       MacOS.version >= :el_capitan
+    end
+
+    def subversion_handles_most_https_certificates?
+      # The system Subversion is too old for some HTTPS certificates on
+      # older macOS versions.
+      MacOS.version >= :sierra
     end
   end
 end


### PR DESCRIPTION
The system Subversion doesn't handle new certificate authorities (e.g. Let's Encrypt) well enough for this check to be useful.