### PR TITLE
audit: whitelist bash-completion@* to use conflicts_with

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -532,7 +532,7 @@ class FormulaAuditor
       end
     end
 
-    versioned_conflicts_whitelist = %w[node@ bash-completion@]
+    versioned_conflicts_whitelist = %w[node@ bash-completion@].freeze
 
     return unless formula.conflicts.any? && formula.versioned_formula?
     return if formula.name.start_with?(*versioned_conflicts_whitelist)

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -532,8 +532,11 @@ class FormulaAuditor
       end
     end
 
+    versioned_conflicts_whitelist = %w[node@ bash-completion@]
+
     return unless formula.conflicts.any? && formula.versioned_formula?
-    return if formula.name.start_with? "node@"
+    versioned_conflicts_whitelist.each { |c|
+      return if formula.name.start_with? c }
     problem <<-EOS
       Versioned formulae should not use `conflicts_with`.
       Use `keg_only :versioned_formula` instead.

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -535,8 +535,7 @@ class FormulaAuditor
     versioned_conflicts_whitelist = %w[node@ bash-completion@]
 
     return unless formula.conflicts.any? && formula.versioned_formula?
-    versioned_conflicts_whitelist.each { |c|
-      return if formula.name.start_with? c }
+    return if formula.name.start_with?(*versioned_conflicts_whitelist)
     problem <<-EOS
       Versioned formulae should not use `conflicts_with`.
       Use `keg_only :versioned_formula` instead.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
this is necessary because they install conflicting scripts into HOMEBREW_PREFIX/etc/profile.d

I changed how the whitelisted formulae are stored, both to improve readability and to make it easier to potentially add more formulae in the future if necessary. I tried to make the return conditional compact, but I am a bit uncertain if it conforms to the style of the rest of the code, so any feedback there would be welcome.

bash-completion@2 PR this is meant to address: https://github.com/Homebrew/homebrew-core/pull/10594