### PR TITLE
download_strategy: docstring typo Gtthub -> Github

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -538,7 +538,7 @@ end
 # your formula. This download strategy uses GitHub access tokens (in the
 # environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.  This
 # strategy is suitable for corporate use just like S3DownloadStrategy, because
-# it lets you use a private GttHub repository for internal distribution.  It
+# it lets you use a private GitHub repository for internal distribution.  It
 # works with public one, but in that case simply use CurlDownloadStrategy.
 class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   require "utils/formatter"


### PR DESCRIPTION
I hope this is the right source for the generated doc at 
http://www.rubydoc.info/github/Homebrew/brew/master/GitHubPrivateRepositoryDownloadStrategy

It's a small typo but it does affect searching so it's worth fixing.