### PR TITLE
determine_path: Fix tests FormulaUnavailableError

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -111,16 +111,16 @@ module Superenv
 
     # Homebrew's apple-gcc42 will be outside the PATH in superenv,
     # so xcrun may not be able to find it
-    case homebrew_cc
-    when "gcc-4.2"
-      begin
-        apple_gcc42 = Formulary.factory("apple-gcc42")
-      rescue FormulaUnavailableError
+    begin
+      case homebrew_cc
+      when "gcc-4.2"
+        paths << Formulary.factory("apple-gcc42").opt_bin
+      when GNU_GCC_REGEXP
+        paths << gcc_version_formula($&).opt_bin
       end
-      paths << apple_gcc42.opt_bin.to_s if apple_gcc42
-    when GNU_GCC_REGEXP
-      gcc_formula = gcc_version_formula($&)
-      paths << gcc_formula.opt_bin.to_s
+    rescue FormulaUnavailableError
+      # Don't fail and don't add these formulae to the path if they don't exist.
+      nil
     end
 
     paths.to_path_s


### PR DESCRIPTION
Fix the brew tests error on Linux by paralleling the code directly above for `apple_gcc42`:
```
InstallTests#test_a_basic_install:
FormulaUnavailableError: No available formula with the name "gcc"
Library/Homebrew/formulary.rb:231:in `get_formula'
Library/Homebrew/formulary.rb:259:in `factory'
Library/Homebrew/extend/ENV/shared.rb:287:in `gcc_version_formula'
Library/Homebrew/extend/ENV/super.rb:124:in `determine_path'
Library/Homebrew/extend/ENV/super.rb:44:in `setup_build_environment'
Library/Homebrew/build.rb:87:in `install'
Library/Homebrew/build.rb:201:in `<main>'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
