### PR TITLE
caveats: combine completion and function messages

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -302,23 +302,24 @@ class Keg
     dir = case shell
     when :bash then path.join("etc", "bash_completion.d")
     when :zsh
-      dir = path.join("share", "zsh", "site-functions")
-      dir if dir && dir.directory? && dir.children.any? { |f| f.basename.to_s.start_with?("_") }
-    when :fish then path.join("share", "fish", "vendor_completions.d")
+      dir = path/"share/zsh/site-functions"
+      dir if dir.directory? && dir.children.any? { |f| f.basename.to_s.start_with?("_") }
+    when :fish then path/"share/fish/vendor_completions.d"
     end
     dir && dir.directory? && !dir.children.empty?
   end
 
-  def zsh_functions_installed?
-    # Check for non completion functions (i.e. files not started with an underscore),
-    # since those can be checked separately
-    dir = path.join("share", "zsh", "site-functions")
-    dir && dir.directory? && dir.children.any? { |f| !f.basename.to_s.start_with?("_") }
-  end
-
-  def fish_functions_installed?
-    dir = path.join("share", "fish", "vendor_functions.d")
-    dir && dir.directory? && !dir.children.empty?
+  def functions_installed?(shell)
+    case shell
+    when :fish
+      dir = path/"share/fish/vendor_functions.d"
+      dir.directory? && !dir.children.empty?
+    when :zsh
+      # Check for non completion functions (i.e. files not started with an underscore),
+      # since those can be checked separately
+      dir = path/"share/zsh/site-functions"
+      dir.directory? && dir.children.any? { |f| !f.basename.to_s.start_with?("_") }
+    end
   end
 
   def plist_installed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The caveats for zsh/fish completions and functions are so similar that it looks like Homebrew is printing the same thing twice unless you read carefully.

Fixes Homebrew/homebrew-core#10338.