### PR TITLE
keg: resolve rack aliases correctly.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -466,7 +466,7 @@ class Keg
   end
 
   def aliases
-    Formula[rack.basename.to_s].aliases
+    Formulary.from_rack(rack).aliases
   rescue FormulaUnavailableError
     []
   end


### PR DESCRIPTION
Don't use the basename but instead use the Formulary logic for rack formula resolution.

CC @staticfloat

Fixes #2288.