### PR TITLE
test: fix tests with a shallow clone.

### DIFF
--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -1,7 +1,7 @@
 describe "brew config", :integration_test do
   it "prints information about the current Homebrew configuration" do
     expect { brew "config" }
-      .to output(/HOMEBREW_VERSION: #{HOMEBREW_VERSION}/).to_stdout
+      .to output(/HOMEBREW_VERSION: #{Regexp.escape HOMEBREW_VERSION}/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -18,7 +18,7 @@ describe Tab do
 
   subject {
     described_class.new(
-      "homebrew_version" => HOMEBREW_VERSION,
+      "homebrew_version"     => HOMEBREW_VERSION,
       "used_options"         => used_options.as_flags,
       "unused_options"       => unused_options.as_flags,
       "built_as_bottle"      => false,
@@ -51,6 +51,9 @@ describe Tab do
   let(:f_tab_content) { (TEST_FIXTURE_DIR/"receipt.json").read }
 
   specify "defaults" do
+    # < 1.1.7 runtime_dependencies were wrong so are ignored
+    stub_const("HOMEBREW_VERSION", "1.1.7")
+
     tab = described_class.empty
 
     expect(tab.homebrew_version).to eq(HOMEBREW_VERSION)
@@ -199,6 +202,9 @@ describe Tab do
 
   describe "::create" do
     it "creates a Tab" do
+      # < 1.1.7 runtime dependencies were wrong so are ignored
+      stub_const("HOMEBREW_VERSION", "1.1.7")
+
       f = formula do
         url "foo-1.0"
         depends_on "bar"
@@ -223,8 +229,8 @@ describe Tab do
         { "full_name" => "bar", "version" => "2.0" },
         { "full_name" => "user/repo/from_tap", "version" => "1.0" },
       ]
-
       expect(tab.runtime_dependencies).to eq(runtime_dependencies)
+
       expect(tab.source["path"]).to eq(f.path.to_s)
     end
 


### PR DESCRIPTION
In this case `HOMEBREW_VERSION` is `>1.1.0 (no git repository)` so these tests failed. This was the cause of the Homebrew/homebrew-test-bot Linux CI failures as it was testing a shallow clone.

CC @alyssais because this partially relates to the previous `runtime_dependencies` stuff and I'm not totally happy with my fix here and am open to other suggestions.