### PR TITLE
env: make prepend_path ignore system paths

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -87,7 +87,11 @@ module SharedEnvExtension
   # Is the formula struggling to find the pkgconfig file? Point it to it.
   # This is done automatically for `keg_only` formulae.
   # <pre>ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["glib"].opt_lib}/pkgconfig"</pre>
+  # Prepending a system path such as /usr/bin is a no-op so that requirements
+  # don't accidentally override superenv shims or formulae's `bin` directories
+  # (e.g. <pre>ENV.prepend_path "PATH", which("emacs").dirname</pre>)
   def prepend_path(key, path)
+    return if %w[/usr/bin /bin /usr/sbin /sbin].include? path.to_s
     prepend key, path, File::PATH_SEPARATOR if File.directory? path
   end
 

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -115,11 +115,11 @@ shared_examples EnvActivation do
 
   describe "#prepend_path" do
     it "prepends to a path" do
-      subject.prepend_path "FOO", "/usr/bin"
-      expect(subject["FOO"]).to eq("/usr/bin")
+      subject.prepend_path "FOO", "/usr/libexec"
+      expect(subject["FOO"]).to eq("/usr/libexec")
 
-      subject.prepend_path "FOO", "/bin"
-      expect(subject["FOO"]).to eq("/bin#{File::PATH_SEPARATOR}/usr/bin")
+      subject.prepend_path "FOO", "/usr"
+      expect(subject["FOO"]).to eq("/usr#{File::PATH_SEPARATOR}/usr/libexec")
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`ENV.prepend_path "PATH", which("emacs").dirname` in the emacs
requirement was causing us to end up invoking /usr/bin/clang instead
of /usr/local/Homebrew/Library/Homebrew/shims/super/clang.