### PR TITLE
linux: Add ARM to CPU.type

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -12,6 +12,8 @@ module Hardware
       def type
         @type ||= if cpuinfo =~ /Intel|AMD/
           :intel
+        elsif cpuinfo =~ /ARM|Marvell/
+          :arm
         else
           :dunno
         end
@@ -71,7 +73,7 @@ module Hardware
       end
 
       def flags
-        @flags ||= cpuinfo[/^flags.*/, 0].split
+        @flags ||= cpuinfo[/^(flags|Features).*/, 0].split
       end
 
       # Compatibility with Mac method, which returns lowercase symbols


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

--------

Detect the CPU on systems running Linux on an ARM processor, such as the Raspberry PI.
