### PR TITLE
linux: Use -march=native for optimization_flags

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -1,6 +1,16 @@
 module Hardware
   class CPU
     class << self
+      LINUX_OPTIMIZATION_FLAGS = {
+        core2: OPTIMIZATION_FLAGS[:core2],
+        core: OPTIMIZATION_FLAGS[:core],
+        dunno: "-march=native",
+      }.freeze
+
+      def optimization_flags
+        LINUX_OPTIMIZATION_FLAGS
+      end
+
       def universal_archs
         [].extend ArchitectureListExtension
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Linuxbrew uses `-march=native` by default and `-march=core2` for 64-bit Linux bottles as on Homebrew.

See https://github.com/Linuxbrew/brew#257