### PR TITLE
Python requirements: Remove casks

### DIFF
--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -3,7 +3,6 @@ require "language/python"
 class PythonRequirement < Requirement
   fatal true
   default_formula "python"
-  cask "python"
 
   satisfy build_env: false do
     python = which_python
@@ -56,7 +55,6 @@ end
 class Python3Requirement < PythonRequirement
   fatal true
   default_formula "python3"
-  cask "python3"
 
   satisfy(build_env: false) { which_python }
 


### PR DESCRIPTION
Neither python nor python3 are available from Caskroom.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

