### PR TITLE
hardware: use march=native for generic module.

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -12,7 +12,7 @@ module Hardware
         penryn: "-march=core2 -msse4.1",
         core2: "-march=core2",
         core: "-march=prescott",
-        dunno: "",
+        dunno: "-march=native",
       }.freeze
 
       def optimization_flags


### PR DESCRIPTION
This matches Linux where this behaviour was original imported from.

CC @sjackman