### PR TITLE
java_requirement.rb: use HTTPS in Java Platform URL

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -2,7 +2,7 @@ require "language/java"
 
 class JavaRequirement < Requirement
   fatal true
-  download "http://www.oracle.com/technetwork/java/javase/downloads/index.html"
+  download "https://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
   satisfy build_env: false do
     setup_java


### PR DESCRIPTION
It's redirected to cleartext, though this URL will be opened
in a browser so it won't be something hidden, and maybe
Oracle will fix this in the future.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Tested the updated URL in a Safari browser on Sierra.