### PR TITLE
Add Python 3 path in brew config

### DIFF
--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -76,8 +76,8 @@ class SystemConfig
       describe_path(which("perl"))
     end
 
-    def describe_python
-      python = which "python"
+    def describe_python(version)
+      python = which "python#{version}"
       return "N/A" if python.nil?
       python_binary = Utils.popen_read python, "-c", "import sys; sys.stdout.write(sys.executable)"
       python_binary = Pathname.new(python_binary).realpath
@@ -164,7 +164,8 @@ class SystemConfig
       f.puts "Clang: #{clang.null? ? "N/A" : "#{clang} build #{clang_build}"}"
       f.puts "Git: #{describe_git}"
       f.puts "Perl: #{describe_perl}"
-      f.puts "Python: #{describe_python}"
+      f.puts "Python 2: #{describe_python("2")}"
+      f.puts "Python 3: #{describe_python("3")}"
       f.puts "Ruby: #{describe_ruby}"
       f.puts "Java: #{describe_java}"
     end


### PR DESCRIPTION
This is useful when debugging user issues for
formulae using Python 3.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
