### PR TITLE
keg: Skip relocation when dylib ID/install name doesn't change.

### DIFF
--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -1,5 +1,6 @@
 class Keg
   def change_dylib_id(id, file)
+    return if file.dylib_id == id
     @require_relocation = true
     puts "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}" if ARGV.debug?
     MachO::Tools.change_dylib_id(file, id, strict: false)
@@ -13,6 +14,7 @@ class Keg
   end
 
   def change_install_name(old, new, file)
+    return if old == new
     @require_relocation = true
     puts "Changing install name in #{file}\n  from #{old}\n    to #{new}" if ARGV.debug?
     MachO::Tools.change_install_name(file, old, new, strict: false)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Our current relocation behavior is harmless, but also useless when the load command being rewritten doesn't actually change. 

cc @ilovezfs 