### PR TITLE
Revert "audit: exempt wine's deps from the universal deprecation"

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -548,7 +548,7 @@ class FormulaAuditor
 
       next unless @strict
 
-      if o.name == "universal" && !Formula["wine"].recursive_dependencies.map(&:name).include?(formula.name)
+      if o.name == "universal"
         problem "macOS has been 64-bit only since 10.6 so universal options are deprecated."
       end
 


### PR DESCRIPTION
Reverts Homebrew/brew#1877

All universal wine dependencies were vendored in https://github.com/Homebrew/homebrew-core/pull/10532 so the audit exemption is no longer needed.