### PR TITLE
enforce *.sourceforge.io and more for urls

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1431,7 +1431,9 @@ class ResourceAuditor
            %r{^http://hackage\.haskell\.org/},
            %r{^http://(?:[^/]*\.)?archive\.org},
            %r{^http://(?:[^/]*\.)?freedesktop\.org},
-           %r{^http://(?:[^/]*\.)?mirrorservice\.org/}
+           %r{^http://(?:[^/]*\.)?mirrorservice\.org/},
+           %r{^(http|git)://git\.code\.sf\.net/},
+           %r{^(http|svn)://svn\.code\.sf\.net/}
         problem "Please use https:// for #{p}"
       when %r{^http://search\.mcpan\.org/CPAN/(.*)}i
         problem "#{p} should be `https://cpan.metacpan.org/#{$1}`"
@@ -1439,6 +1441,18 @@ class ResourceAuditor
         problem "#{p} should be `https://download.gnome.org/#{$2}`"
       when %r{^git://anonscm\.debian\.org/users/(.*)}i
         problem "#{p} should be `https://anonscm.debian.org/git/users/#{$1}`"
+      when %r{^http://hg\.(sv|savannah)\.gnu\.org/(.*)}i
+        problem "#{p} should be `https://hg.savannah.gnu.org/#{$2}`"
+      when %r{^(http|git)://git\.(sv|savannah)\.gnu\.org/(.*)}i
+        problem "#{p} should be `https://git.savannah.gnu.org/#{$2}`"
+      when %r{^(http|svn)://svn\.(sv|savannah)\.gnu\.org/(.*)}i
+        problem "#{p} should be `https://svn.savannah.gnu.org/#{$2}`"
+      when %r{^(http|git)://([^/]*)\.git\.sourceforge\.net/gitroot/(.*)}i
+        problem "Please use https://git.code.sf.net/ for #{p}"
+      when %r{^(http|svn)://([^/]*)\.svn\.sourceforge\.net/svnroot/(.*)}i
+        problem "Please use https://svn.code.sf.net/ for #{p}"
+      when %r{^http://([^/]*)\.(sf|sourceforge)\.net/(.*)}i
+        problem "#{p} should be `https://#{$1}.sourceforge.io/#{$3}`"
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Add more URL checks to audit, following recent series of formula updates.

Alert will now go off for these URLs:
```
(http|git)://git.(savannah|sv).gnu.org/
(http|svn)://svn.(savannah|sv).gnu.org/
http://hg.(savannah|sv).gnu.org/
(http|git)://git.code.sf.net/
(http|svn)://svn.code.sf.net/
(http|git)://*.git.sourceforge.net/gitroot/
(http|svn)://*.svn.sourceforge.net/svnroot/
```

Plus, existing `*.sourceforge.io` homepage rule has been extended to `url` as well.
These will be redirected to insecure `.net` page unless the SourceForge project
maintainer enables HTTPS for these pages explicitly.
