### PR TITLE
add audit rule to enforce slash after domain name

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -613,6 +613,10 @@ class FormulaAuditor
       problem "The homepage should start with http or https (URL is #{homepage})."
     end
 
+    unless homepage =~ %r{^(.+)://(.*)/(.*)}
+      problem "#{homepage} must have a slash after the domain name part."
+    end
+
     # Check for http:// GitHub homepage urls, https:// is preferred.
     # Note: only check homepages that are repo pages, not *.github.com hosts
     if homepage.start_with? "http://github.com/"

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -613,7 +613,7 @@ class FormulaAuditor
       problem "The homepage should start with http or https (URL is #{homepage})."
     end
 
-    unless homepage =~ %r{^(.+)://(.*)/(.*)}
+    if homepage =~ %r{^.+://[^/]+$}
       problem "#{homepage} must have a slash after the domain name part."
     end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -465,6 +465,8 @@ describe FormulaAuditor do
         "sf3" => "http://foo.sf.net/",
         "sf4" => "http://foo.sourceforge.io/",
         "waldo" => "http://www.gnu.org/waldo",
+        "sl1" => "http://example.com",
+        "sl2" => "http://example.com#section",
       }
 
       formula_homepages.each do |name, homepage|
@@ -476,7 +478,10 @@ describe FormulaAuditor do
         EOS
 
         fa.audit_homepage
-        if homepage =~ %r{http:\/\/www\.freedesktop\.org}
+        if name =~ /(sf2|sl)/
+          expect(fa.problems.first)
+            .to match("#{homepage} must have a slash after the domain name part.")
+        elsif homepage =~ %r{http:\/\/www\.freedesktop\.org}
           if homepage =~ /Software/
             expect(fa.problems.first).to match(
               "#{homepage} should be styled " \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently there is random variations of the same URLs (or the same group of URLs) in this regard, some of them have an ending slash added, some of them don't. While it's certainly not the end of the world, it doesn't look neat and presents an extra hurdle when searching/grepping/parsing this field. It's also general good practice to add it and may help servers to return the correct page on the first request.

Example:
```
$ grep 'sourceforge.io\"' *.rb | wc -l
      73
$ grep 'sourceforge.io/\"' *.rb | wc -l
     286
```