### PR TITLE
OPTIMIZATION_FLAGS: Use -march=native for Penryn

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -9,7 +9,6 @@ module Hardware
 
     class << self
       OPTIMIZATION_FLAGS = {
-        penryn: "-march=core2 -msse4.1",
         core2: "-march=core2",
         core: "-march=prescott",
         dunno: "-march=native",


### PR DESCRIPTION
Use `-march=native` for Penryn as for other systems rather than `-march=core2 -msse4.1`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?
