### PR TITLE
gpg: add GnuPG series 2.1.x to supported versions

### DIFF
--- a/Library/Homebrew/gpg.rb
+++ b/Library/Homebrew/gpg.rb
@@ -5,7 +5,9 @@ class Gpg
     which_all(executable).detect do |gpg|
       gpg_short_version = Utils.popen_read(gpg, "--version")[/\d\.\d/, 0]
       next unless gpg_short_version
-      Version.create(gpg_short_version.to_s) == Version.create("2.0")
+      gpg_version = Version.create(gpg_short_version.to_s)
+      gpg_version == Version.create("2.0") ||
+        gpg_version == Version.create("2.1")
     end
   end
 

--- a/Library/Homebrew/requirements/gpg2_requirement.rb
+++ b/Library/Homebrew/requirements/gpg2_requirement.rb
@@ -7,6 +7,6 @@ class GPG2Requirement < Requirement
 
   # MacGPG2/GPGTools installs GnuPG 2.0.x as a vanilla `gpg` symlink
   # pointing to `gpg2`, as do we. Ensure we're actually using a 2.0 `gpg`.
-  # Temporarily, only support 2.0.x rather than the 2.1.x "modern" series.
+  # Support both the 2.0.x "stable" and 2.1.x "modern" series.
   satisfy(build_env: false) { Gpg.gpg2 || Gpg.gpg }
 end

--- a/Library/Homebrew/requirements/gpg2_requirement.rb
+++ b/Library/Homebrew/requirements/gpg2_requirement.rb
@@ -3,7 +3,7 @@ require "gpg"
 
 class GPG2Requirement < Requirement
   fatal true
-  default_formula "gnupg2"
+  default_formula "gnupg"
 
   # MacGPG2/GPGTools installs GnuPG 2.0.x as a vanilla `gpg` symlink
   # pointing to `gpg2`, as do we. Ensure we're actually using a 2.0 `gpg`.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Now that the formula for GnuPG 2.1.x (`gnupg@2.1`) has been migrated to `homebrew/core`, extend the `gpg2_requirement` to support this branch as well. The actual substantive change is made in `gpg.rb` with the addition of "2.1" as a valid version.

CC @DomT4 