### PR TITLE
formula_installer: need up to date requirement formulae.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -410,10 +410,13 @@ class FormulaInstaller
   end
 
   def install_requirement_formula?(req, dependent, build)
-    return false unless req.to_dependency
+    req_dependency = req.to_dependency
+    return false unless req_dependency
     return true unless req.satisfied?
     return false if req.run?
-    install_bottle_for?(dependent, build) || build_bottle?
+    return true if build_bottle?
+    return true unless req_dependency.installed?
+    install_bottle_for?(dependent, build)
   end
 
   def expand_requirements


### PR DESCRIPTION
This makes them behave consistently to other dependencies. Otherwise
other checks for them being `installed?` will fail.

CC @iMichka @ilovezfs 

Fixes #2333
Closes #2302
Fixes https://github.com/Homebrew/homebrew-science/issues/5247