### PR TITLE
upgrade: keg_only before non-keg_only formulae

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -75,6 +75,18 @@ module Homebrew
       puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 
+    # Sort keg_only before non-keg_only formulae to avoid any needless conflicts
+    # with outdated, non-keg_only versions of formulae being upgraded.
+    formulae_to_install.sort! do |a, b|
+      if !a.keg_only? && b.keg_only?
+        1
+      elsif a.keg_only? && !b.keg_only?
+        -1
+      else
+        0
+      end
+    end
+
     formulae_to_install.each do |f|
       upgrade_formula(f)
       next unless ARGV.include?("--cleanup")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Avoids unnecessary conflicts when a previously non-keg_only formula is
in the way by prioritizing keg_only before non-keg_only formulae.

This change is motivated by the upgrade of gnupg 2.0 to 2.1, since the
latter no longer depends on the gpg-agent formula, which, even if made
keg_only, still causes the link step to fail for 2.1, as gpg-agent's
non-keg version won't have been upgraded to the keg_only version at that
point (alphabetically gnupg precedes gpg-agent).