### PR TITLE
audit: check system dupe deps on new formulae.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -472,6 +472,12 @@ class FormulaAuditor
           problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
         end
 
+        if @new_formula && dep_f.keg_only_reason &&
+           !["openssl", "apr", "apr-util"].include?(dep.name) &&
+           [:provided_by_macos, :provided_by_osx].include?(dep_f.keg_only_reason.reason)
+          problem "Dependency '#{dep.name}' may be unnecessary as it is provided by macOS; try to build this formula without it."
+        end
+
         dep.options.reject do |opt|
           next true if dep_f.option_defined?(opt)
           dep_f.requirements.detect do |r|

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -4,6 +4,8 @@ FormulaConflict = Struct.new(:name, :reason)
 # Used to annotate formulae that duplicate macOS provided software
 # or cause conflicts when linked in.
 class KegOnlyReason
+  attr_reader :reason
+
   def initialize(reason, explanation)
     @reason = reason
     @explanation = explanation


### PR DESCRIPTION
Provide a gentle nudge to users to check if these dependencies are definitely required.