### PR TITLE
audit: deprecate depends_on :tex.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1036,6 +1036,10 @@ class FormulaAuditor
       problem ":apr is deprecated. Usage should be \"apr-util\""
     end
 
+    if line =~ /depends_on :tex/
+      problem ":tex is deprecated."
+    end
+
     # Commented-out depends_on
     problem "Commented-out dep #{$1}" if line =~ /#\s*depends_on\s+(.+)\s*$/
 


### PR DESCRIPTION
This has known issues with our `ghostscript` formula, we can't test it on CI and is a ludicrously heavy dependency that in many cases can be avoided by upstream providing prebuilt documentation.