### PR TITLE
link: tell users of `brew link --force` about opt.

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -44,6 +44,7 @@ module Homebrew
       elsif keg_only && !ARGV.force?
         opoo "#{keg.name} is keg-only and must be linked with --force"
         puts "Note that doing so can interfere with building software."
+        puts_keg_only_path_message(keg)
         next
       elsif mode.dry_run && mode.overwrite
         puts "Would remove:"
@@ -53,6 +54,7 @@ module Homebrew
       elsif mode.dry_run
         puts "Would link:"
         keg.link(mode)
+        puts_keg_only_path_message(keg) if keg_only
 
         next
       end
@@ -69,8 +71,23 @@ module Homebrew
         else
           puts "#{n} symlinks created"
         end
+
+        if keg_only && !ARGV.homebrew_developer?
+          puts_keg_only_path_message(keg)
+        end
       end
     end
+  end
+
+  def puts_keg_only_path_message(keg)
+    bin = keg/"bin"
+    sbin = keg/"sbin"
+    return if !bin.directory? && !sbin.directory?
+
+    opt = HOMEBREW_PREFIX/"opt/#{keg.name}"
+    puts "\nIf you need to have this software first in your PATH instead consider running:"
+    puts "  #{Utils::Shell.prepend_path_in_shell_profile(opt)}/bin"  if bin.directory?
+    puts "  #{Utils::Shell.prepend_path_in_shell_profile(opt)}/sbin" if sbin.directory?
   end
 
   def keg_only?(rack)


### PR DESCRIPTION
If people are force-linking keg-only things they should probably be told that they can add the opt prefix to their PATH instead.