### PR TITLE
tests: unset HOMEBREW_TEMP

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -28,6 +28,7 @@ module Homebrew
       ENV.delete("HOMEBREW_VERBOSE")
       ENV.delete("VERBOSE")
       ENV.delete("HOMEBREW_CASK_OPTS")
+      ENV.delete("HOMEBREW_TEMP")
       ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
       ENV["HOMEBREW_DEVELOPER"] = "1"
       ENV["HOMEBREW_NO_COMPAT"] = "1" if ARGV.include? "--no-compat"


### PR DESCRIPTION
Setting `HOMEBREW_TEMP` env. var [currently] breaks tests. Although this behavior looks like a bug, the solution is straightforward: unset `HOMEBREW_TEMP`.