### PR TITLE
missing_formula: warn when git-log takes very long

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -55,11 +55,10 @@ module Homebrew
             info_formula Formulary.find_with_priority(f)
           end
         rescue FormulaUnavailableError => e
+          ofail e.message
           # No formula with this name, try a missing formula lookup
           if (reason = Homebrew::MissingFormula.reason(f))
-            ofail "#{e.message}\n#{reason}"
-          else
-            ofail e.message
+            $stderr.puts reason
           end
         end
       end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -206,44 +206,47 @@ module Homebrew
       # formula was found, but there's a problem with its implementation).
       ofail e.message
     rescue FormulaUnavailableError => e
-      if (reason = Homebrew::MissingFormula.reason(e.name))
-        ofail "#{e.message}\n#{reason}"
-      elsif e.name == "updog"
+      if e.name == "updog"
         ofail "What's updog?"
+        return
+      end
+
+      ofail e.message
+      if (reason = Homebrew::MissingFormula.reason(e.name))
+        $stderr.puts reason
+        return
+      end
+
+      query = query_regexp(e.name)
+
+      ohai "Searching for similarly named formulae..."
+      formulae_search_results = search_formulae(query)
+      case formulae_search_results.length
+      when 0
+        ofail "No similarly named formulae found."
+      when 1
+        puts "This similarly named formula was found:"
+        puts formulae_search_results
+        puts "To install it, run:\n  brew install #{formulae_search_results.first}"
       else
-        ofail e.message
+        puts "These similarly named formulae were found:"
+        puts Formatter.columns(formulae_search_results)
+        puts "To install one of them, run (for example):\n  brew install #{formulae_search_results.first}"
+      end
 
-        query = query_regexp(e.name)
-
-        ohai "Searching for similarly named formulae..."
-        formulae_search_results = search_formulae(query)
-        case formulae_search_results.length
-        when 0
-          ofail "No similarly named formulae found."
-        when 1
-          puts "This similarly named formula was found:"
-          puts formulae_search_results
-          puts "To install it, run:\n  brew install #{formulae_search_results.first}"
-        else
-          puts "These similarly named formulae were found:"
-          puts Formatter.columns(formulae_search_results)
-          puts "To install one of them, run (for example):\n  brew install #{formulae_search_results.first}"
-        end
-
-        ohai "Searching taps..."
-        taps_search_results = search_taps(query)
-        case taps_search_results.length
-        when 0
-          ofail "No formulae found in taps."
-        when 1
-          puts "This formula was found in a tap:"
-          puts taps_search_results
-          puts "To install it, run:\n  brew install #{taps_search_results.first}"
-        else
-          puts "These formulae were found in taps:"
-          puts Formatter.columns(taps_search_results)
-          puts "To install one of them, run (for example):\n  brew install #{taps_search_results.first}"
-        end
+      ohai "Searching taps..."
+      taps_search_results = search_taps(query)
+      case taps_search_results.length
+      when 0
+        ofail "No formulae found in taps."
+      when 1
+        puts "This formula was found in a tap:"
+        puts taps_search_results
+        puts "To install it, run:\n  brew install #{taps_search_results.first}"
+      else
+        puts "These formulae were found in taps:"
+        puts Formatter.columns(taps_search_results)
+        puts "To install one of them, run (for example):\n  brew install #{taps_search_results.first}"
       end
     end
   end

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -67,7 +67,7 @@ module Homebrew
       if $stdout.tty?
         count = local_results.length + tap_results.length
 
-        if reason = Homebrew::MissingFormula.reason(query)
+        if reason = Homebrew::MissingFormula.reason(query, silent: true)
           if count > 0
             puts
             puts "If you meant #{query.inspect} specifically:"

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -5,8 +5,9 @@ require "utils"
 module Homebrew
   module MissingFormula
     class << self
-      def reason(name)
-        blacklisted_reason(name) || tap_migration_reason(name) || deleted_reason(name)
+      def reason(name, silent: false)
+        blacklisted_reason(name) || tap_migration_reason(name) ||
+          deleted_reason(name, silent: silent)
       end
 
       def blacklisted_reason(name)
@@ -117,7 +118,7 @@ module Homebrew
         message
       end
 
-      def deleted_reason(name)
+      def deleted_reason(name, silent: false)
         path = Formulary.path name
         return if File.exist? path
         tap = Tap.from_path(path)
@@ -125,25 +126,17 @@ module Homebrew
         relative_path = path.relative_path_from tap.path
 
         tap.path.cd do
-          begin
-            timer_pid = fork do
-              # Let the user know what's going on when the search goes on for
-              # more than two seconds.
-              sleep 2
-              opoo "Searching through git history. This may take a while..."
-            end
+          ohai "Searching for a previously deleted formula..." unless silent
 
-            # We know this may return incomplete results for shallow clones but
-            # we don't want to nag everyone with a shallow clone to unshallow it.
-            log_command = "git log --name-only --max-count=1 --format=%H\\\\n%h\\\\n%B -- #{relative_path}"
-            hash, short_hash, *commit_message, relative_path =
-              Utils.popen_read(log_command).gsub("\\n", "\n").lines.map(&:chomp)
-          ensure
-            Process.kill "TERM", timer_pid
-          end
+          # We know this may return incomplete results for shallow clones but
+          # we don't want to nag everyone with a shallow clone to unshallow it.
+          log_command = "git log --name-only --max-count=1 --format=%H\\\\n%h\\\\n%B -- #{relative_path}"
+          hash, short_hash, *commit_message, relative_path =
+            Utils.popen_read(log_command).gsub("\\n", "\n").lines.map(&:chomp)
 
           if hash.to_s.empty? || short_hash.to_s.empty? ||
              relative_path.to_s.empty?
+            ofail "No previously deleted formula found." unless silent
             return
           end
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -268,7 +268,6 @@ module GitHub
 
   def print_pull_requests_matching(query)
     return [] if ENV["HOMEBREW_NO_GITHUB_API"]
-    ohai "Searching pull requests..."
 
     open_or_closed_prs = issues_matching(query, type: "pr")
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Since #1732, trying to install or info a nonexistent formula that's neither blacklisted nor recorded in a tap migration database triggers a search through the entire git history, which could take very long (~10s on my machine) in a non-shallow core tap:

```zsh
$ time (brew info foo)  # nothing happens for ten seconds
Error: No available formula with the name "foo"
( brew info foo; )  8.97s user 0.65s system 96% cpu 9.990 total
```

This is confusing to users (users shouldn't encounter the output of `deleted_reason` until we drop homebrew/boneyard). Therefore, we should let users know what's going on behind the scenes if `git-log` goes on for too long. I'm setting the threshold to two seconds. After this PR:

```zsh
$ time (brew info foo)
Warning: Searching through git history. This may take a while...
Error: No available formula with the name "foo"
( brew info foo; )  9.01s user 0.66s system 98% cpu 9.859 total
```

An iTerm2 screenshot with timestamps on each output line:

<img width="958" alt="screen shot 2017-03-22 at 12 40 16 am" src="https://cloud.githubusercontent.com/assets/4149852/24182430/36831f60-0e98-11e7-8655-d664b186e3fe.png">
