### PR TITLE
cd tap-new: fix symlink creation.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -60,6 +60,7 @@ module Homebrew
         - git -C "$HOMEBREW_REPOSITORY" reset --hard origin/master
         - brew update || brew update
         - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"
+        - mkdir -p "$HOMEBREW_TAP_DIR"
         - rm -rf "$HOMEBREW_TAP_DIR"
         - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
         - export HOMEBREW_DEVELOPER="1"


### PR DESCRIPTION
Ensure the full HOMEBREW_TAP_DIR path is created before deleting and creating the symlink for it. This ensures that non-`homebrew` taps will have the necessary username/organisation folder created.


Fixes #2378.