### PR TITLE
Revert "formula_installer: need up to date requirement formulae."

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -410,13 +410,10 @@ class FormulaInstaller
   end
 
   def install_requirement_formula?(req, dependent, build)
-    req_dependency = req.to_dependency
-    return false unless req_dependency
+    return false unless req.to_dependency
     return true unless req.satisfied?
     return false if req.run?
-    return true if build_bottle?
-    return true unless req_dependency.installed?
-    install_bottle_for?(dependent, build)
+    install_bottle_for?(dependent, build) || build_bottle?
   end
 
   def expand_requirements


### PR DESCRIPTION
Reverts Homebrew/brew#2348

This has broken the requirements system, effectively converting all requirements into

```
depends_on "#{default_formula}"
```