### PR TITLE
formula_installer: tweak req formula additions.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -415,7 +415,7 @@ class FormulaInstaller
     return true unless req.satisfied?
     return false if req.run?
     return true if build_bottle?
-    return true unless req_dependency.installed?
+    return true if req.satisfied_by_formula?
     install_bottle_for?(dependent, build)
   end
 

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -125,6 +125,10 @@ class Requirement
     @formula || self.class.default_formula
   end
 
+  def satisfied_by_formula?
+    !@formula.nil?
+  end
+
   def to_dependency
     if formula =~ HOMEBREW_TAP_FORMULA_REGEX
       TapDependency.new(formula, tags, method(:modify_build_environment), name)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -134,4 +134,43 @@ describe FormulaInstaller do
       fi.check_install_sanity
     }.to raise_error(CannotInstallFormulaError)
   end
+
+  describe "#install_requirement_formula?" do
+    before do
+      @requirement = Python3Requirement.new
+      allow(@requirement).to receive(:satisfied?).and_return(satisfied?)
+      allow(@requirement).to receive(:satisfied_by_formula?).and_return(satisfied_by_formula?)
+      allow_any_instance_of(Dependency).to receive(:installed?).and_return(installed?)
+      @dependent = formula do
+        url "foo"
+        version "0.1"
+        depends_on :python3
+      end
+      @build = BuildOptions.new [], []
+      @fi = FormulaInstaller.new(@dependent)
+    end
+
+    subject { @fi.install_requirement_formula?(@requirement, @dependent, @build) }
+
+    context "it returns false when requirement is satisfied" do
+      let(:satisfied?) { true }
+      let(:satisfied_by_formula?) { false }
+      let(:installed?) { false }
+      it { is_expected.to be false }
+    end
+
+    context "it returns true when requirement isn't satisfied" do
+      let(:satisfied?) { false }
+      let(:satisfied_by_formula?) { false }
+      let(:installed?) { false }
+      it { is_expected.to be true }
+    end
+
+    context "it returns true when requirement is satisfied by a formula" do
+      let(:satisfied?) { true }
+      let(:satisfied_by_formula?) { true }
+      let(:installed?) { false }
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
Rather than just checking if a requirement's dependency is installed or not check if the requirement was actually satisfied by a particular formula rather than e.g. just having a `default_formula` defined.

Closes #2302.
Closes #2388.
Closes https://github.com/Homebrew/homebrew-core/issues/11523.