### PR TITLE
Allow external commands display usage instructions with help flag

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -60,6 +60,10 @@ begin
     internal_cmd = require? HOMEBREW_LIBRARY_PATH.join("cmd", cmd)
 
     unless internal_cmd
+      internal_cmd = HOMEBREW_LIBRARY_PATH.join("cmd", "#{cmd}.sh").exist?
+    end
+
+    unless internal_cmd
       internal_cmd = require? HOMEBREW_LIBRARY_PATH.join("dev-cmd", cmd)
       if internal_cmd && !ARGV.homebrew_developer?
         system "git", "config", "--file=#{HOMEBREW_REPOSITORY}/.git/config",

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -77,7 +77,7 @@ begin
   # - a help flag is passed AND a command is matched
   # - a help flag is passed AND there is no command specified
   # - no arguments are passed
-  if empty_argv || help_flag
+  if empty_argv || (help_flag && internal_cmd)
     require "cmd/help"
     Homebrew.help cmd, empty_argv: empty_argv
     # `Homebrew.help` never returns, except for external/unknown commands.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR allows external commands display usage instructions with help flag, and fixes #2390.
