### PR TITLE
updating the exception for "kibana" for the "@" naming scheme. File changed: audit.rb

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1176,8 +1176,8 @@ class FormulaAuditor
       problem "Use `assert_match` instead of `assert ...include?`"
     end
 
-    if line.include?('system "npm", "install"') && !line.include?("Language::Node")\
-      && formula.name !~ /^kibana(\@\d+(\.\d+)?)?$/
+    if line.include?('system "npm", "install"') && !line.include?("Language::Node") &&
+      formula.name !~ /^kibana(\@\d+(\.\d+)?)?$/
       problem "Use Language::Node for npm install args"
     end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1176,7 +1176,8 @@ class FormulaAuditor
       problem "Use `assert_match` instead of `assert ...include?`"
     end
 
-    if line.include?('system "npm", "install"') && !line.include?("Language::Node") && formula.name !~ /^kibana(\d{2})?$/
+    if line.include?('system "npm", "install"') && !line.include?("Language::Node")\
+      && formula.name !~ /^kibana(\@\d+(\.\d+)?)?$/
       problem "Use Language::Node for npm install args"
     end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1177,7 +1177,7 @@ class FormulaAuditor
     end
 
     if line.include?('system "npm", "install"') && !line.include?("Language::Node") &&
-      formula.name !~ /^kibana(\@\d+(\.\d+)?)?$/
+       formula.name !~ /^kibana(\@\d+(\.\d+)?)?$/
       problem "Use Language::Node for npm install args"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
In the PR https://github.com/Homebrew/homebrew-core/pull/11562, the project maintainer @ilovezfs  suggested that we update the regex in ``` audit.rb ``` reflecting the updated versions formulae with the ``` @ ``` naming scheme. This PR updates that regex. 
Before this change, the regex would not recognize these names:
``` kibana@4.1 ``` and ``` kibana@4.4 ```

The current regex recognizes these names:
``` kibana ``` and ``` kibana@4.1 ``` and ``` kibana@4.4 ```, 
but will not recognize these names:
``` kibana@ ``` and ``` kibana41 ``` (correctly so I believe)

If there are some changes that need to be made or some use cases that you think I should also cater to, please do tell me. I will be happy to make further changes.

Thanks.