### PR TITLE
Migrator: various rename fixes

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -199,7 +199,10 @@ module Homebrew
 
       perform_preinstall_checks
 
-      formulae.each { |f| install_formula(f) }
+      formulae.each do |f|
+        Migrator.migrate_if_needed(f)
+        install_formula(f)
+      end
     rescue FormulaClassUnavailableError => e
       # Need to rescue before `FormulaUnavailableError` (superclass of this)
       # is handled, as searching for a formula doesn't make sense here (the

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -15,6 +15,7 @@ module Homebrew
         onoe "#{f.full_name} is pinned. You must unpin it to reinstall."
         next
       end
+      Migrator.migrate_if_needed(f)
       reinstall_formula(f)
     end
   end

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -525,12 +525,7 @@ class Reporter
         next
       end
 
-      begin
-        migrator = Migrator.new(f, force: true)
-        migrator.migrate
-      rescue Exception => e
-        onoe e
-      end
+      Migrator.migrate_if_needed(f)
     end
   end
 

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -502,12 +502,18 @@ class Reporter
   end
 
   def migrate_formula_rename
-    Formula.installed.map(&:oldname).compact.each do |old_name|
-      old_name_dir = HOMEBREW_CELLAR/old_name
-      next if old_name_dir.symlink?
-      next unless old_name_dir.directory? && !old_name_dir.subdirs.empty?
+    Formula.installed.each do |formula|
+      next unless Migrator.needs_migration?(formula)
 
-      new_name = tap.formula_renames[old_name]
+      oldname = formula.oldname
+      oldname_rack = HOMEBREW_CELLAR/oldname
+
+      if oldname_rack.subdirs.empty?
+        oldname_rack.rmdir_if_possible
+        next
+      end
+
+      new_name = tap.formula_renames[oldname]
       next unless new_name
 
       new_full_name = "#{tap}/#{new_name}"
@@ -520,9 +526,8 @@ class Reporter
       end
 
       begin
-        migrator = Migrator.new(f)
+        migrator = Migrator.new(f, force: true)
         migrator.migrate
-      rescue Migrator::MigratorDifferentTapsError
       rescue Exception => e
         onoe e
       end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -88,6 +88,7 @@ module Homebrew
     end
 
     formulae_to_install.each do |f|
+      Migrator.migrate_if_needed(f)
       upgrade_formula(f)
       next unless ARGV.include?("--cleanup")
       next unless f.installed?

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -77,6 +77,9 @@ class Migrator
   # path to newname cellar according to new name
   attr_reader :new_cellar
 
+  # true if new cellar existed at initialization time
+  attr_reader :new_cellar_existed
+
   # path to newname pin
   attr_reader :new_pin_record
 
@@ -119,6 +122,7 @@ class Migrator
     end
 
     @new_cellar = HOMEBREW_CELLAR/formula.name
+    @new_cellar_existed = @new_cellar.exist?
 
     if @old_linked_keg = linked_old_linked_keg
       @old_linked_keg_record = old_linked_keg.linked_keg_record if old_linked_keg.linked?
@@ -368,7 +372,7 @@ class Migrator
       new_cellar.subdirs.each do |d|
         newname_keg = Keg.new(d)
         newname_keg.unlink
-        newname_keg.uninstall
+        newname_keg.uninstall if new_cellar_existed
       end
     end
 

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -164,7 +164,10 @@ class Migrator
   end
 
   def linked_old_linked_keg
-    kegs = old_cellar.subdirs.map { |d| Keg.new(d) }
+    keg_dirs = []
+    keg_dirs += new_cellar.subdirs if new_cellar.exist?
+    keg_dirs += old_cellar.subdirs
+    kegs = keg_dirs.map { |d| Keg.new(d) }
     kegs.detect(&:linked?) || kegs.detect(&:optlinked?)
   end
 

--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -217,7 +217,7 @@ class Migrator
       end
     end
 
-    puts "Moving to: #{new_cellar}"
+    oh1 "Moving #{Formatter.identifier(oldname)} children"
     if new_cellar.exist?
       FileUtils.mv(old_cellar.children, new_cellar)
     else


### PR DESCRIPTION
Remove those that are either unnecessary (as they have no children) or duplicated (because there's two copies of the same version).

This will also serve to make mass migrations more robust.