### PR TITLE
Include the pinned version in brew outdated output for pinned formulae

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -64,7 +64,9 @@ module Homebrew
           "#{full_name} (#{kegs.map(&:version).join(", ")})"
         end.join(", ")
 
-        puts "#{outdated_versions} < #{current_version}"
+        pinned_version = " [pinned at #{f.pinned_version}]" if f.pinned?
+
+        puts "#{outdated_versions} < #{current_version}#{pinned_version}"
       else
         puts f.full_installed_specified_name
       end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -88,7 +88,9 @@ module Homebrew
 
       json << { name: f.full_name,
                 installed_versions: outdated_versions.collect(&:to_s),
-                current_version: current_version }
+                current_version: current_version,
+                pinned: f.pinned?,
+                pinned_version: f.pinned_version }
     end
     puts JSON.generate(json)
 

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -22,4 +22,20 @@ describe "brew outdated", :integration_test do
         .and be_a_success
     end
   end
+
+  context "pinned formula, verbose output" do
+    it "prints out the pinned version" do
+      setup_test_formula "testball"
+      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+
+      shutup do
+        expect { brew "pin", "testball" }.to be_a_success
+      end
+
+      expect { brew "outdated", "--verbose" }
+        .to output("testball (0.0.1) < 0.1 [pinned at 0.0.1]\n").to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
+  end
 end

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -38,4 +38,50 @@ describe "brew outdated", :integration_test do
         .and be_a_success
     end
   end
+
+  context "json output" do
+    it "includes pinned version in the json output" do
+      setup_test_formula "testball"
+      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+
+      shutup do
+        expect { brew "pin", "testball" }.to be_a_success
+      end
+
+      expected_json = [
+        {
+          name: "testball",
+          installed_versions: ["0.0.1"],
+          current_version: "0.1",
+          pinned: true,
+          pinned_version: "0.0.1",
+        },
+      ].to_json
+
+      expect { brew "outdated", "--json=v1" }
+        .to output(expected_json + "\n").to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
+
+    it "has no pinned version when the formula isn't pinned" do
+      setup_test_formula "testball"
+      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+
+      expected_json = [
+        {
+          name: "testball",
+          installed_versions: ["0.0.1"],
+          current_version: "0.1",
+          pinned: false,
+          pinned_version: nil,
+        },
+      ].to_json
+
+      expect { brew "outdated", "--json=v1" }
+        .to output(expected_json + "\n").to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
+  end
 end

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -1,11 +1,25 @@
 describe "brew outdated", :integration_test do
-  it "prints outdated Formulae" do
-    setup_test_formula "testball"
-    (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+  context "quiet output" do
+    it "prints outdated Formulae" do
+      setup_test_formula "testball"
+      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 
-    expect { brew "outdated" }
-      .to output("testball\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
+      expect { brew "outdated" }
+        .to output("testball\n").to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
+  end
+
+  context "verbose output" do
+    it "prints out the installed and newer versions" do
+      setup_test_formula "testball"
+      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+
+      expect { brew "outdated", "--verbose" }
+        .to output("testball (0.0.1) < 0.1\n").to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This pull request adds pinned versions to the output of the `brew outdated` command. The format of the output is similar to the output from `brew info` in that it appends `[pinned at __version__]` to pinned formulae. For the JSON output, 2 fields are added: `pinned` (`true`|`false`) and `pinned_version` ("the_version" or `null`).

This is mainly useful for the peace of mind when running `brew outdated` before a `brew upgrade` that Homebrew has definitely pinned a formula and it won't get upgraded, even though it's outdated.

In addition to the added output, I've added tests for the previous output (effectively verbose output)  for unpinned formulae. I've divided these tests into their own contexts which should hopefully aid readability of the tests.

Here's an example of the output:

```bash
 % brew outdated
terraform (0.8.8) < 0.9.1_1 [pinned at 0.8.8]
```