### PR TITLE
Xcode: update supported versions & download URLs for 8.3

### DIFF
--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -31,13 +31,13 @@ class DevelopmentTools
       elsif MacOS.version == "10.8" || MacOS.version == "10.7"
         <<-EOS.undent
           Install the Command Line Tools from
-            https://developer.apple.com/downloads/
+            https://developer.apple.com/download/more/
           or via Xcode's preferences.
         EOS
       else
         <<-EOS.undent
           Install Xcode from
-            https://developer.apple.com/xcode/downloads/
+            https://developer.apple.com/download/more/
         EOS
       end
     end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -81,6 +81,12 @@ module Homebrew
         return unless MacOS::CLT.installed?
         return unless MacOS::CLT.outdated?
 
+        # Travis CI images are going to end up outdated so don't complain when
+        # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
+        # repository. This only needs to support whatever CI provider
+        # Homebrew/brew is currently using.
+        return if ENV["TRAVIS"]
+
         <<-EOS.undent
           A newer Command Line Tools release is available.
           #{MacOS::CLT.update_instructions}

--- a/Library/Homebrew/extend/os/mac/missing_formula.rb
+++ b/Library/Homebrew/extend/os/mac/missing_formula.rb
@@ -10,7 +10,7 @@ module Homebrew
             EOS
           else
             <<-EOS.undent
-            Xcode can be installed from #{Formatter.url("https://developer.apple.com/xcode/downloads/")}.
+            Xcode can be installed from #{Formatter.url("https://developer.apple.com/download/more/")}.
             EOS
           end
         else

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -201,6 +201,10 @@ module OS
       "7.3"   => { clang: "7.3", clang_build: 703 },
       "7.3.1" => { clang: "7.3", clang_build: 703 },
       "8.0"   => { clang: "8.0", clang_build: 800 },
+      "8.1"   => { clang: "8.0", clang_build: 800 },
+      "8.2"   => { clang: "8.0", clang_build: 800 },
+      "8.2.1" => { clang: "8.0", clang_build: 800 },
+      "8.3"   => { clang: "8.1", clang_build: 802 },
     }.freeze
 
     def compilers_standard?

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -90,7 +90,7 @@ module OS
         else
           <<-EOS.undent
             Xcode can be updated from
-              https://developer.apple.com/xcode/downloads/
+              https://developer.apple.com/download/more/
           EOS
         end
       end
@@ -202,7 +202,7 @@ module OS
         elsif MacOS.version == "10.8" || MacOS.version == "10.7"
           <<-EOS.undent
             The standalone package can be obtained from
-              https://developer.apple.com/downloads
+              https://developer.apple.com/download/more/
             or it can be installed via Xcode's preferences.
           EOS
         end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -16,13 +16,13 @@ module OS
         when "10.8"  then "5.1.1"
         when "10.9"  then "6.2"
         when "10.10" then "7.2.1"
-        when "10.11" then "8.2"
-        when "10.12" then "8.2"
+        when "10.11" then "8.2.1"
+        when "10.12" then "8.3"
         else
           raise "macOS '#{MacOS.version}' is invalid" unless OS::Mac.prerelease?
 
           # Default to newest known version of Xcode for unreleased macOS versions.
-          "8.2"
+          "8.3"
         end
       end
 
@@ -152,7 +152,8 @@ module OS
         when 70      then "7.0"
         when 73      then "7.3"
         when 80      then "8.0"
-        else "8.0"
+        when 81      then "8.3"
+        else "8.3"
         end
       end
 
@@ -213,8 +214,8 @@ module OS
         # on the older supported platform for that Xcode release, i.e there's no
         # CLT package for 10.11 that contains the Clang version from Xcode 8.
         case MacOS.version
-        when "10.12" then "800.0.42.1"
-        when "10.11" then "703.0.31"
+        when "10.12" then "802.0.38"
+        when "10.11" then "800.0.42.1"
         when "10.10" then "700.1.81"
         when "10.9"  then "600.0.57"
         when "10.8"  then "503.0.40"

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -43,7 +43,7 @@ class XcodeRequirement < Requirement
       EOS
     else
       message + <<-EOS.undent
-        Xcode can be installed from #{Formatter.url("https://developer.apple.com/xcode/downloads/")}
+        Xcode can be installed from #{Formatter.url("https://developer.apple.com/download/more/")}.
       EOS
     end
   end

--- a/docs/Xcode.md
+++ b/docs/Xcode.md
@@ -11,8 +11,8 @@ Tools available for your platform:
 | 10.8  | 5.1.1 | April 2014         |
 | 10.9  | 6.2   | 6.2                |
 | 10.10 | 7.2.1 | 7.2                |
-| 10.11 | 8.0   | 7.3                |
-| 10.12 | 8.0   | 8.0                |
+| 10.11 | 8.2.1 | 8.2                |
+| 10.12 | 8.3   | 8.3                |
 
 ## Compiler version database
 
@@ -66,6 +66,10 @@ Tools available for your platform:
 | 7.3   | —       | —       | —            | —          | 7.3 (703.0.29)  | —          |
 | 7.3.1 | —       | —       | —            | —          | 7.3 (703.0.31)  | —          |
 | 8.0   | —       | —       | —            | —          | 8.0 (800.0.38)  | —          |
+| 8.1   | —       | —       | —            | —          | 8.0 (800.0.42.1)| —          |
+| 8.2   | —       | —       | —            | —          | 8.0 (800.0.42.1)| —          |
+| 8.2.1 | —       | —       | —            | —          | 8.0 (800.0.42.1)| —          |
+| 8.3   | —       | —       | —            | —          | 8.1 (802.0.38)  | —          |
 
 ## References to Xcode and compiler versions in code
 When a new Xcode release is made, the following things need to be


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Now that Xcode 8.3 is finalized, adds support for it to `MacOS`. Also updates suggested URLs for downloading older Xcode and CLT versions, all of which are now found only at https://developer.apple.com/download/more/. 