### PR TITLE
diagnostic: increase minimum git version to 1.8.5

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -753,13 +753,14 @@ module Homebrew
       def check_git_version
         # https://help.github.com/articles/https-cloning-errors
         return unless Utils.git_available?
-        return unless Version.create(Utils.git_version) < Version.create("1.7.10")
+        return unless Version.create(Utils.git_version) < Version.create("1.8.5")
 
         git = Formula["git"]
         git_upgrade_cmd = git.any_version_installed? ? "upgrade" : "install"
         <<-EOS.undent
           An outdated version (#{Utils.git_version}) of Git was detected in your PATH.
-          Git 1.7.10 or newer is required to perform checkouts over HTTPS from GitHub.
+          Git 1.8.5 or newer is required to perform checkouts over HTTPS from GitHub and
+          to support the 'git -C <path>' option.
           Please upgrade:
             brew #{git_upgrade_cmd} git
         EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally? (except for `Gpg::create_test_key` failure)

-----
older versions do not support the `git -C <path>` option

this is necessary for #2398

cc @MikeMcQuaid