### PR TITLE
update-test: Use git fetch --tags --depth=1

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -36,7 +36,7 @@ module Homebrew
       previous_tag =
         Utils.popen_read("git", "tag", "--list", "--sort=-version:refname").lines[1]
       unless previous_tag
-        safe_system "git", "fetch", "--tags"
+        safe_system "git", "fetch", "--tags", "--depth=1"
         previous_tag =
           Utils.popen_read("git", "tag", "--list", "--sort=-version:refname").lines[1]
       end


### PR DESCRIPTION
Use `git fetch --tags --depth=1` to fetch fewer commits.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`git fetch --tags --depth=1` works equally well as `git fetch --tags` for the purpose of `update-test --to-tag` and fetches fewer unnecessary historical commits.

There's a second somewhat related error that `brew --version` may not work if the repo is shallow, if there are any commits missing between `previous_tag` and `master`. Those commits will not be fetched by `git fetch --tags`, so it's unaffected by whether the tags above are fetched shallow or not.

I haven't found a `git` command yet to fetch just those commits between `previous_tag` and `master`, unless you know exactly how many of them there are and use `git fetch --depth=N`, but theres'a 🐔 and :egg: problem there. That makes `git fetch --unshallow` necessary to ensure that `brew --version` works.