### PR TITLE
audit: Fix cctools invocation check regular expression.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1185,7 +1185,7 @@ class FormulaAuditor
       problem "'fails_with :llvm' is now a no-op so should be removed"
     end
 
-    if line =~ /system\s+['"](otool)|(install_name_tool)|(lipo)/
+    if line =~ /system\s+['"](otool|install_name_tool|lipo)/ && formula.name != "cctools"
       problem "Use ruby-macho instead of calling #{$1}"
     end
 


### PR DESCRIPTION
Additionally, ignore the cctools formula itself, since it obviously needs to check cctools invocations.

Fixes #1828.

cc @ilovezfs 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
