### PR TITLE
Fix handling of tap migrations to new cask names.

### DIFF
--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -122,6 +122,13 @@ class Migrator
   end
 
   def from_same_taps?
+    new_tap = if old_tap
+      if migrate_tap = old_tap.tap_migrations[formula.oldname]
+        new_tap_user, new_tap_repo, = migrate_tap.split("/")
+        "#{new_tap_user}/#{new_tap_repo}"
+      end
+    end
+
     if formula.tap == old_tap
       true
     # Homebrew didn't use to update tabs while performing tap-migrations,
@@ -129,7 +136,7 @@ class Migrator
     # so we check if there is an entry about oldname migrated to tap and if
     # newname's tap is the same as tap to which oldname migrated, then we
     # can perform migrations and the taps for oldname and newname are the same.
-    elsif formula.tap && old_tap && formula.tap == old_tap.tap_migrations[formula.oldname]
+    elsif formula.tap && old_tap && formula.tap == new_tap
       fix_tabs
       true
     else

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -105,10 +105,14 @@ module Homebrew
         message = nil
 
         Tap.each do |old_tap|
-          new_tap_name = old_tap.tap_migrations[name]
-          next unless new_tap_name
+          new_tap = old_tap.tap_migrations[name]
+          next unless new_tap
+
+          new_tap_user, new_tap_repo, = new_tap.split("/")
+          new_tap_name = "#{new_tap_user}/#{new_tap_repo}"
+
           message = <<-EOS.undent
-            It was migrated from #{old_tap} to #{new_tap_name}.
+            It was migrated from #{old_tap} to #{new_tap}.
             You can access it again by running:
               brew tap #{new_tap_name}
           EOS


### PR DESCRIPTION
Need to check for two `/`s rather than one.

References https://github.com/Homebrew/homebrew-core/issues/11656#issuecomment-289498649

CC @yurikoles