### PR TITLE
formula: handle missing deps when formula missing.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1555,6 +1555,8 @@ class Formula
       hide.include?(d.name) || d.installed_prefixes.empty?
     end
     missing_dependencies
+  rescue FormulaUnavailableError
+    []
   end
 
   # @private


### PR DESCRIPTION
We could try and get a partial result but given it'll also be wrong it
feels simpler to just return an empty array.

Fixes #1928.
Fixes #2027.
Closes #2058.
Fixes https://github.com/Homebrew/homebrew-core/issues/11827.