### PR TITLE
Remove osmium from blacklisted formulas

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -64,10 +64,6 @@ module Homebrew
           and then follow the tutorial:
             #{Formatter.url("https://github.com/technomancy/leiningen/blob/stable/doc/TUTORIAL.md")}
           EOS
-        when "osmium" then <<-EOS.undent
-          The creator of Osmium requests that it not be packaged and that people
-          use the GitHub master branch instead.
-          EOS
         when "gfortran" then <<-EOS.undent
           GNU Fortran is now provided as part of GCC, and can be installed with:
             brew install gcc

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -88,14 +88,6 @@ describe Homebrew::MissingFormula do
       it { is_expected.to be_blacklisted }
     end
 
-    context "osmium" do
-      %w[osmium Osmium].each do |s|
-        subject { s }
-
-        it { is_expected.to be_blacklisted }
-      end
-    end
-
     context "gfortran" do
       subject { "gfortran" }
 


### PR DESCRIPTION
The author of the Osmium library says:

> That is from about 5 years back when Homebrew wanted to package the then existing osmium c++ lib. And they said they only can do that if i do proper released versions, which i didn't want to do at that time. Somehow they translated this into that sentence above. But i have proper releases for years now, and, as you mention, libosmium has been packaged.

So I guess we should unblacklist the Osmium library.