### PR TITLE
cask: remove pre_bug_report links

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/utils.rb
+++ b/Library/Homebrew/cask/lib/hbc/utils.rb
@@ -4,8 +4,7 @@ require "stringio"
 
 require "hbc/utils/file"
 
-PREBUG_URL = "https://github.com/caskroom/homebrew-cask/blob/master/doc/reporting_bugs/pre_bug_report.md".freeze
-ISSUES_URL = "https://github.com/caskroom/homebrew-cask#reporting-bugs".freeze
+BUG_REPORTS_URL = "https://github.com/caskroom/homebrew-cask#reporting-bugs".freeze
 
 # monkeypatch Object - not a great idea
 class Object
@@ -96,11 +95,7 @@ module Hbc
     def self.error_message_with_suggestions
       <<-EOS.undent
         Follow the instructions here:
-          #{Formatter.url(PREBUG_URL)}
-
-        If this doesn’t fix the problem, please report this bug:
-          #{Formatter.url(ISSUES_URL)}
-
+          #{Formatter.url(BUG_REPORTS_URL)}
       EOS
     end
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -26,8 +26,6 @@ describe Hbc::DSL, :cask do
         .*
         Unexpected method 'future_feature' called on Cask unexpected-method-cask\\.
         .*
-        https://github.com/caskroom/homebrew-cask/blob/master/doc/reporting_bugs/pre_bug_report.md
-        .*
         https://github.com/caskroom/homebrew-cask#reporting-bugs
       EOS
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Companion to https://github.com/caskroom/homebrew-cask/pull/31717. That document might cease to exist, so this updates the messages.