### PR TITLE
Use `sudo` if parent path of `target` is not writable.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/utils.rb
+++ b/Library/Homebrew/cask/lib/hbc/utils.rb
@@ -39,7 +39,15 @@ module Hbc
   module Utils
     def self.gain_permissions_remove(path, command: SystemCommand)
       if path.respond_to?(:rmtree) && path.exist?
-        gain_permissions(path, ["-R"], command, &:rmtree)
+        gain_permissions(path, ["-R"], command) do |p|
+          if p.parent.writable?
+            p.rmtree
+          else
+            command.run("/bin/rm",
+                        args: command_args + ["-r", "-f", "--", p],
+                        sudo: true)
+          end
+        end
       elsif File.symlink?(path)
         gain_permissions(path, ["-h"], command, &FileUtils.method(:rm_f))
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently, when using `--qlplugin=/Library/QuickLook`, you get a “permission denied” error, because it is owned by `root:wheel` by default.


---

Fixes https://github.com/caskroom/homebrew-cask/issues/31692.