### PR TITLE
gpg_spec test add 2.1.x compatibility

### DIFF
--- a/Library/Homebrew/gpg.rb
+++ b/Library/Homebrew/gpg.rb
@@ -6,6 +6,7 @@ class Gpg
       gpg_short_version = Utils.popen_read(gpg, "--version")[/\d\.\d/, 0]
       next unless gpg_short_version
       gpg_version = Version.create(gpg_short_version.to_s)
+      @version = gpg_version
       gpg_version == Version.create("2.0") ||
         gpg_version == Version.create("2.1")
     end
@@ -23,6 +24,10 @@ class Gpg
 
   def self.available?
     File.executable?(GPG_EXECUTABLE.to_s)
+  end
+
+  def self.version
+    @version if available?
   end
 
   def self.create_test_key(path)

--- a/Library/Homebrew/test/gpg2_requirement_spec.rb
+++ b/Library/Homebrew/test/gpg2_requirement_spec.rb
@@ -9,7 +9,7 @@ describe GPG2Requirement do
       ENV["PATH"] = dir/"bin"
       (dir/"bin/gpg").write <<-EOS.undent
         #!/bin/bash
-        echo 2.0.30
+        echo 2.1.20
       EOS
       FileUtils.chmod 0755, dir/"bin/gpg"
 

--- a/Library/Homebrew/test/gpg_spec.rb
+++ b/Library/Homebrew/test/gpg_spec.rb
@@ -13,7 +13,12 @@ describe Gpg do
         shutup do
           subject.create_test_key(dir)
         end
-        expect(dir/".gnupg/secring.gpg").to exist
+
+        begin
+          expect(dir/".gnupg/pubring.kbx").to be_file
+        rescue RSpec::Expectations::ExpectationNotMetError
+          expect(dir/".gnupg/secring.gpg").to be_file
+        end
       end
     end
   end

--- a/Library/Homebrew/test/gpg_spec.rb
+++ b/Library/Homebrew/test/gpg_spec.rb
@@ -12,14 +12,12 @@ describe Gpg do
 
         shutup do
           subject.create_test_key(dir)
-          gpg = subject::GPG_EXECUTABLE
-          @version = Utils.popen_read(gpg, "--version")[/\d\.\d/, 0]
         end
 
-        if @version.to_s.start_with?("2.1")
-          expect(dir/".gnupg/pubring.kbx").to be_file
+        if subject.version == Version.create("2.0")
+          expect(dir/".gnupg/secring.gpg").to be_a_file
         else
-          expect(dir/".gnupg/secring.gpg").to be_file
+          expect(dir/".gnupg/pubring.kbx").to be_a_file
         end
       end
     end

--- a/Library/Homebrew/test/gpg_spec.rb
+++ b/Library/Homebrew/test/gpg_spec.rb
@@ -12,11 +12,13 @@ describe Gpg do
 
         shutup do
           subject.create_test_key(dir)
+          gpg = subject::GPG_EXECUTABLE
+          @version = Utils.popen_read(gpg, "--version")[/\d\.\d/, 0]
         end
 
-        begin
+        if @version.to_s.start_with?("2.1")
           expect(dir/".gnupg/pubring.kbx").to be_file
-        rescue RSpec::Expectations::ExpectationNotMetError
+        else
           expect(dir/".gnupg/secring.gpg").to be_file
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is meant to update the tests so that they do not begin failing once `GnuPG 2.1.x` is the default. Backwards compatibility for `2.0.x` has been maintained for now in `gpg_spec` because the binary is fetched directly from the path.