### PR TITLE
Fix the 'export PATH' message in `link` for a keg-only formula

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -86,8 +86,8 @@ module Homebrew
 
     opt = HOMEBREW_PREFIX/"opt/#{keg.name}"
     puts "\nIf you need to have this software first in your PATH instead consider running:"
-    puts "  #{Utils::Shell.prepend_path_in_shell_profile(opt)}/bin"  if bin.directory?
-    puts "  #{Utils::Shell.prepend_path_in_shell_profile(opt)}/sbin" if sbin.directory?
+    puts "  #{Utils::Shell.prepend_path_in_shell_profile(opt/"bin")}"  if bin.directory?
+    puts "  #{Utils::Shell.prepend_path_in_shell_profile(opt/"sbin")}" if sbin.directory?
   end
 
   def keg_only?(rack)

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -48,9 +48,11 @@ describe "brew link", :integration_test do
       expect { brew "install", "testball1" }.to be_a_success
     end
 
-    expect { brew "link", "testball1" }
+    expect { brew "link", "testball1", "SHELL" => "/bin/zsh" }
       .to output(/testball1 is keg-only/).to_stderr
-      .and output(/Note that doing so can interfere with building software\./).to_stdout
+      .and output(a_string_matching(/Note that doing so can interfere with building software\./)
+        .and(matching("If you need to have this software first in your PATH instead consider running:")
+        .and(including("echo 'export PATH=\"#{HOMEBREW_PREFIX}/opt/testball1/bin:$PATH\"' >> ~/.zshrc")))).to_stdout
       .and be_a_success
   end
 end


### PR DESCRIPTION
Commit 4cae6a724e6d684eb157dd6d7328755694f228b2 introduced the message,
but it printed the wrong path, e.g. for `brew link sqlite`:

```
If you need to have this software first in your PATH instead consider running:
  echo 'export PATH="/usr/local/opt/sqlite:$PATH"' >> ~/.zshrc/bin
```

where `/bin` is appended at the end, but should be inserted before
`:$PATH`: `echo 'export PATH="/usr/local/opt/sqlite/bin:$PATH"' >> ~/.zshrc`.
This patch fixes that and updates a test to verify it.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally? *

-----

\* i've run all the tests (`brew tests`) on this branch locally and one test fails, and that also happens in current `master`:

```
Failures:

  1) brew install can install HEAD Formulae
     Failure/Error:
       expect { brew "install", "testball1", "--HEAD", "--ignore-dependencies" }
         .to output(%r{#{HOMEBREW_CELLAR}/testball1/HEAD\-d5eb689}).to_stdout
         .and output(/Cloning into/).to_stderr
         .and be_a_success

          expected block to output /\/tmp\/homebrew-tests-20170401-27263-1hvud8u\/cellar\/testball1\/HEAD\-d5eb689/ to stdout, but output "==> Using the sandbox\n==> Cloning file:///tmp/homebrew-tests-20170401-27263-1hvud8u/cache/repo\n==> Checking out branch master\n"

       ...and:

          expected #<Proc:0x007ffe65988eb8@/usr/local/Homebrew/Library/Homebrew/test/cmd/install_spec.rb:182> to be a success
     # ./test/cmd/install_spec.rb:182:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:44:in `block (2 levels) .in <top (required)>'
     # ./test/spec_helper.rb:75:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.0.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```