### PR TITLE
Handle missing receipt on `brew install`.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -194,8 +194,10 @@ module Homebrew
         next unless f.opt_prefix.directory?
         keg = Keg.new(f.opt_prefix.resolved_path)
         tab = Tab.for_keg(keg)
-        tab.installed_on_request = true
-        tab.write
+        unless tab.installed_on_request
+          tab.installed_on_request = true
+          tab.write
+        end
       end
 
       perform_preinstall_checks

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -100,11 +100,14 @@ class Tab < OpenStruct
   def self.for_keg(keg)
     path = keg.join(FILENAME)
 
-    if path.exist?
+    tab = if path.exist?
       from_file(path)
     else
       empty
     end
+
+    tab["tabfile"] = path
+    tab
   end
 
   # Returns a tab for the named formula's installation,

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -258,7 +258,7 @@ describe Tab do
     it "can create a Tab for a non-existant Keg" do
       f.prefix.mkpath
 
-      expect(subject.tabfile).to be nil
+      expect(subject.tabfile).to eq(f_tab_path)
     end
   end
 


### PR DESCRIPTION
For example if this is for a really old keg, keg where a user has manually removed stuff or used `brew diy`.

Fixes #2436.