### PR TITLE
java_requirement: Add newline to failure message

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -18,7 +18,7 @@ class JavaRequirement < Requirement
   def message
     version_string = " #{@version}" if @version
 
-    s = "Java#{version_string} is required to install this formula."
+    s = "Java#{version_string} is required to install this formula.\n"
     s += super
     s
   end


### PR DESCRIPTION
Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The existing error output is kind of unattractive (`Java#{version_string} is required to install this formula.JavaRequirement failed!`); this just makes it a little nicer to read. You're not likely to see it since in most cases the Cask or the JDK formula will just get installed automatically, but no reason to leave it like this.