### PR TITLE
audit: fix core formula alias check.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -476,7 +476,7 @@ class FormulaAuditor
         end
 
         if @@aliases.include?(dep.name) &&
-           (core_formula? || !dep_f.versioned_formula?)
+           (dep_f.core_formula? || !dep_f.versioned_formula?)
           problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
         end
 


### PR DESCRIPTION
Was missing a formula object being passed.

Closes #2449.