### PR TITLE
Rescue from multiple installation attempts for dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -531,6 +531,9 @@ class FormulaInstaller
     oh1 "Installing #{formula.full_name} dependency: #{Formatter.identifier(dep.name)}"
     fi.install
     fi.finish
+  rescue FormulaInstallationAlreadyAttemptedError
+    # We already attempted to install df as part of the dependency tree of
+    # another formula. In that case, don't generate an error, just move on.
   rescue Exception
     ignore_interrupts do
       tmp_keg.rename(installed_keg) if tmp_keg && !installed_keg.directory?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -534,6 +534,7 @@ class FormulaInstaller
   rescue FormulaInstallationAlreadyAttemptedError
     # We already attempted to install df as part of the dependency tree of
     # another formula. In that case, don't generate an error, just move on.
+    nil
   rescue Exception
     ignore_interrupts do
       tmp_keg.rename(installed_keg) if tmp_keg && !installed_keg.directory?


### PR DESCRIPTION
This fixes an early termination of brew install when a dependency tree includes a formula twice, such as the original formula and an alias.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I maintain a tap that has a formula that depends on `qt5`. I noticed that the `qt5` (alias `qt`) was renamed to `qt` (alias `qt5`) in https://github.com/Homebrew/homebrew-core/pull/8334. There's now an audit warning to change our dependency to the new name `qt` instead of the alias, which is a helpful notice. I'll do that soon and rebuild our bottles.

There is, however, some weird behavior when installing a formula like `osrf/simulation/gazebo8` that hasn't yet been updated to use the new dependency name. This is because `gazebo8` also depends on `qwt` in core, which depends on `qt`. So `brew deps` shows `gazebo8` depending on both `qt` and `qt5`:

~~~
$ brew deps osrf/simulation/gazebo8 | grep ^q
qt
qt5
qwt
~~~

Then when I `brew install gazebo8` on a fresh system, it installs the dependencies up until `qt`, then just stops, without an error code. So it installs `qt5` first, then it attempts to install `qt` and a `FormulaInstallationAlreadyAttemptedError` exception is raised. That exception is explicitly rescued in [cmd/install.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/install.rb#L321-L323) (see 5c799ef8c8720306a9dfb4db1e47f647e06f9857 and https://github.com/Homebrew/legacy-homebrew/issues/16957), so installation of `gazebo8` is terminated and considered successful at that point. Invoking `brew install gazebo8` once more will resume where it left off and successfully complete the installation.

This PR adds a rescue for that same exception to `install_dependency` so that installation can continue the first time. It currently allows it to just proceed. We could consider printing an appropriate console message and raising a different exception that wouldn't be rescued by `cmd/install.rb` if you'd rather not sweep this behavior under the rug.