### PR TITLE
Display formula conflict reasons

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -124,8 +124,8 @@ module Homebrew
     puts Formatter.url(f.homepage) if f.homepage
 
     conflicts = f.conflicts.map do |c|
-      c.name +
-        (c.reason ? " (because #{c.reason})" : "")
+      reason = " (because #{c.reason})" if c.reason
+      "#{c.name}#{reason}"
     end.sort!
     msg="Conflicts with: "
     puts msg+conflicts*(",\n"+" "*msg.length) unless conflicts.empty?

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -127,8 +127,12 @@ module Homebrew
       reason = " (because #{c.reason})" if c.reason
       "#{c.name}#{reason}"
     end.sort!
-    msg="Conflicts with: "
-    puts msg+conflicts*(",\n"+" "*msg.length) unless conflicts.empty?
+    unless conflicts.empty?
+      puts <<-EOS.undent
+        Conflicts with:
+          #{conflicts.join("  \n")}
+      EOS
+    end
 
     kegs = f.installed_kegs.sort_by(&:version)
     if kegs.empty?

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -123,10 +123,10 @@ module Homebrew
     puts f.desc if f.desc
     puts Formatter.url(f.homepage) if f.homepage
 
-    conflicts = f.conflicts.map{ |f|
-      f.name +
-      if f.reason then " (because #{f.reason})" else "" end
-    }.sort!
+    conflicts = f.conflicts.map do |c|
+      c.name +
+        (c.reason ? " (because #{c.reason})" : "")
+    end.sort!
     msg="Conflicts with: "
     puts msg+conflicts*(",\n"+" "*msg.length) unless conflicts.empty?
 

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -123,8 +123,12 @@ module Homebrew
     puts f.desc if f.desc
     puts Formatter.url(f.homepage) if f.homepage
 
-    conflicts = f.conflicts.map(&:name).sort!
-    puts "Conflicts with: #{conflicts*", "}" unless conflicts.empty?
+    conflicts = f.conflicts.map{ |f|
+      f.name +
+      if f.reason then " (because #{f.reason})" else "" end
+    }.sort!
+    msg="Conflicts with: "
+    puts msg+conflicts*(",\n"+" "*msg.length) unless conflicts.empty?
 
     kegs = f.installed_kegs.sort_by(&:version)
     if kegs.empty?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2340,7 +2340,7 @@ class Formula
     end
 
     # If this formula conflicts with another one.
-    # <pre>conflicts_with "imagemagick", :because => "because this is just a stupid example"</pre>
+    # <pre>conflicts_with "imagemagick", :because => "because both install 'convert' binaries"</pre>
     def conflicts_with(*names)
       opts = names.last.is_a?(Hash) ? names.pop : {}
       names.each { |name| conflicts << FormulaConflict.new(name, opts[:because]) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

## Scenario

The enduser story for dealing with formula conflicts is not very good right now.
For instance, this morning I wanted a `sed` with better regexp support than the stock OSX version. `brew search sed` told me `gnu-sed` existed, and so of course I reviewed `brew info gnu-sed` first to see what I was getting:

```
pb3:Homebrew jhawk$ brew info gnu-sed
gnu-sed: stable 4.4 (bottled)
GNU implementation of the famous stream editor
https://www.gnu.org/software/sed/
Conflicts with: ssed
``` 

Hrmm. It conflicts with `ssed`? Why is that, and also, maybe I should be looking more closely at `ssed` too... `brew info ssed` is no help:

```
pb3:extractor jhawk$ brew info ssed
ssed: stable 3.62 (bottled)
Super sed stream editor
https://sed.sourceforge.io/grabbag/ssed/
Conflicts with: gnu-sed
```

If I were willing to review the formula source code, I would find:

```
  conflicts_with "ssed", :because => "both install share/info/sed.info"
  conflicts_with "gnu-sed", :because => "both install share/info/sed.info"
```

but that's not a reasonable thing for endusers to do. And also, if I have already installed `gnu-sed` and try to install `ssed`, the installation will fail and tell me why:

```
pb3:Homebrew jhawk$ brew install ssed
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (caskroom/cask, homebrew/core).
No changes to formulae.

Error: Cannot install ssed because conflicting formulae are installed.

  gnu-sed: because both install share/info/sed.info
```

But this also can't be the answer -- if I don't know why 2 formulas conflict, I should not have to install one in order to read the conflict message from the other. I should be able to figure this out nondestructively without installing formulas.

## Solution

`brew info` should show me conflict information, ala:

```
pb3:Formula jhawk$ brew info gnu-sed
gnu-sed: stable 4.4 (bottled)
GNU implementation of the famous stream editor
https://www.gnu.org/software/sed/
Conflicts with: ssed (because both install share/info/sed.info)
/usr/local/Cellar/gnu-sed/4.4 (12 files, 491.5KB) *
```

Here's an example with a formula with multiple conflicts:

```
pb3:Formula jhawk$ brew info app-engine-go-32
Unsetting PERL5LIB to protect you from yourself
app-engine-go-32: stable 1.9.46
Google App Engine SDK for Go (i386)
https://cloud.google.com/appengine/docs/go/
Conflicts.with: app-engine-go-64 (because both install the same binaries),
                app-engine-python (because both install the same binaries)
Not installed
```

And here's one that doesn't specify a reason (is that a bug?):

```
pb3:Formula jhawk$ brew info watch
watch: stable 3.3.12 (bottled), HEAD
Executes a program periodically, showing output fullscreen
https://gitlab.com/procps-ng/procps
Conflicts.with: visionmedia-watch
Not installed
```

And while we're here, the documentation for `conflicts_with` has a particularly poor example; improve it.

### Tests

> - [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

I'm not sure what sort of test would be appropriate here? Should I add a faux `conflicts_with` to `Library/Homebrew/test/support/fixtures/testball.rb` and then change `cmd/info_spec.rb`? I don't see any examples that care about the specifity of command output to this degree.