### PR TITLE
missing_formula: fix undefined method `path` for nil:NilClass

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -122,7 +122,7 @@ module Homebrew
         path = Formulary.path name
         return if File.exist? path
         tap = Tap.from_path(path)
-        return unless File.exist? tap.path
+        return if tap.nil? || !File.exist?(tap.path)
         relative_path = path.relative_path_from tap.path
 
         tap.path.cd do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This check for a nil `tap` is necessary because `Tap.from_path(path)`
will simply return a `nil` value in the event the tap path is invalid

Should fix https://github.com/Homebrew/homebrew-core/issues/12288

CC @ilovezfs @MikeMcQuaid