### PR TITLE
caveats: tweak keg_only wording

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -44,8 +44,10 @@ class Caveats
   def keg_only_text
     return unless f.keg_only?
 
-    s = "This formula is keg-only, which means it was not symlinked into #{HOMEBREW_PREFIX}."
-    s << "\n\n#{f.keg_only_reason}\n"
+    s = <<-EOS.undent
+      This formula is keg-only, which means it was not symlinked into #{HOMEBREW_PREFIX},
+      because #{f.keg_only_reason}.
+    EOS
     if f.bin.directory? || f.sbin.directory?
       s << "\nIf you need to have this software first in your PATH run:\n"
       if f.bin.directory?

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -32,30 +32,30 @@ class KegOnlyReason
     return @explanation unless @explanation.empty?
     case @reason
     when :versioned_formula then <<-EOS.undent
-      This is an alternate version of another formula.
+      this is an alternate version of another formula
     EOS
     when :provided_by_macos, :provided_by_osx then <<-EOS.undent
       macOS already provides this software and installing another version in
-      parallel can cause all kinds of trouble.
+      parallel can cause all kinds of trouble
     EOS
     when :shadowed_by_macos, :shadowed_by_osx then <<-EOS.undent
       macOS provides similar software and installing this software in
-      parallel can cause all kinds of trouble.
+      parallel can cause all kinds of trouble
     EOS
     when :provided_pre_mountain_lion then <<-EOS.undent
-      macOS already provides this software in versions before Mountain Lion.
+      macOS already provides this software in versions before Mountain Lion
     EOS
     when :provided_pre_mavericks then <<-EOS.undent
-      macOS already provides this software in versions before Mavericks.
+      macOS already provides this software in versions before Mavericks
     EOS
     when :provided_pre_el_capitan then <<-EOS.undent
-      macOS already provides this software in versions before El Capitan.
+      macOS already provides this software in versions before El Capitan
     EOS
     when :provided_until_xcode43 then <<-EOS.undent
-      Xcode provides this software prior to version 4.3.
+      Xcode provides this software prior to version 4.3
     EOS
     when :provided_until_xcode5 then <<-EOS.undent
-      Xcode provides this software prior to version 5.
+      Xcode provides this software prior to version 5
     EOS
     else
       @reason


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Talked about this with Mike quite a few times, but I also went through a considerable period where I wasn't happy to submit PRs to the `brew` side of Homebrew because of reasons, but nonetheless, let's try this thing.

Current:
```
This formula is keg-only, which means it was not symlinked into /usr/local.

Qt 5 has CMake issues when linked
```

```
This formula is keg-only, which means it was not symlinked into /usr/local.

Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries
```

After:
```
This formula is keg-only, which means it was not symlinked into /usr/local,
because Qt 5 has CMake issues when linked
```

```
This formula is keg-only, which means it was not symlinked into /usr/local,
because Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries
```
