### PR TITLE
audit: deprecate language module requirements.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1021,6 +1021,10 @@ class FormulaAuditor
       problem ":tex is deprecated."
     end
 
+    if line =~ /depends_on\s+['"].+['"]\s+=>\s+:(lua|perl|python|ruby)(\d*)/
+      problem "Formulae should vendor #{$1} modules rather than use `depends_on ... => :#{$1}#{$2}`."
+    end
+
     # Commented-out depends_on
     problem "Commented-out dep #{$1}" if line =~ /#\s*depends_on\s+(.+)\s*$/
 


### PR DESCRIPTION
Make `brew audit` complain about language module requirements because they provide a crappy user experience compared to vendoring and we’re not really fixing bugs in them any more.

CC @ilovezfs as we discussed this.