### PR TITLE
audit: check for more universal usage.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1049,6 +1049,14 @@ class FormulaAuditor
       problem "Use ENV instead of invoking '#{$1}' to modify the environment"
     end
 
+    if formula.name != "wine" && line =~ /ENV\.universal_binary/
+      problem "macOS has been 64-bit only since 10.6 so ENV.universal_binary is deprecated."
+    end
+
+    if line =~ /build\.universal\?/
+      problem "macOS has been 64-bit only so build.universal? is deprecated."
+    end
+
     if line =~ /version == ['"]HEAD['"]/
       problem "Use 'build.head?' instead of inspecting 'version'"
     end


### PR DESCRIPTION
Also check for `ENV.universal_binary` and `build.universal?`. The prior is still required for `wine` and the latter should never be required any longer.