### PR TITLE
audit: allow skipping audit methods.

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -67,7 +67,7 @@ module FormulaCellarChecks
     checker = LinkageChecker.new(keg, formula)
 
     return unless checker.broken_dylibs?
-    audit_check_output <<-EOS.undent
+    problem_if_output <<-EOS.undent
       The installation was broken.
       Broken dylib links found:
         #{checker.broken_dylibs.to_a * "\n          "}
@@ -76,9 +76,9 @@ module FormulaCellarChecks
 
   def audit_installed
     generic_audit_installed
-    audit_check_output(check_shadowed_headers)
-    audit_check_output(check_openssl_links)
-    audit_check_output(check_python_framework_links(formula.lib))
+    problem_if_output(check_shadowed_headers)
+    problem_if_output(check_openssl_links)
+    problem_if_output(check_python_framework_links(formula.lib))
     check_linkage
   end
 end

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -154,17 +154,17 @@ module FormulaCellarChecks
   end
 
   def audit_installed
-    audit_check_output(check_manpages)
-    audit_check_output(check_infopages)
-    audit_check_output(check_jars)
-    audit_check_output(check_non_libraries)
-    audit_check_output(check_non_executables(formula.bin))
-    audit_check_output(check_generic_executables(formula.bin))
-    audit_check_output(check_non_executables(formula.sbin))
-    audit_check_output(check_generic_executables(formula.sbin))
-    audit_check_output(check_easy_install_pth(formula.lib))
-    audit_check_output(check_elisp_dirname(formula.share, formula.name))
-    audit_check_output(check_elisp_root(formula.share, formula.name))
+    problem_if_output(check_manpages)
+    problem_if_output(check_infopages)
+    problem_if_output(check_jars)
+    problem_if_output(check_non_libraries)
+    problem_if_output(check_non_executables(formula.bin))
+    problem_if_output(check_generic_executables(formula.bin))
+    problem_if_output(check_non_executables(formula.sbin))
+    problem_if_output(check_generic_executables(formula.sbin))
+    problem_if_output(check_easy_install_pth(formula.lib))
+    problem_if_output(check_elisp_dirname(formula.share, formula.name))
+    problem_if_output(check_elisp_root(formula.share, formula.name))
   end
   alias generic_audit_installed audit_installed
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -858,15 +858,15 @@ class FormulaInstaller
     tab.write
   end
 
-  def audit_check_output(output)
+  def problem_if_output(output)
     return unless output
     opoo output
     @show_summary_heading = true
   end
 
   def audit_installed
-    audit_check_output(check_env_path(formula.bin))
-    audit_check_output(check_env_path(formula.sbin))
+    problem_if_output(check_env_path(formula.bin))
+    problem_if_output(check_env_path(formula.sbin))
     super
   end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -303,7 +303,7 @@ describe FormulaAuditor do
     end
   end
 
-  describe "#audit_line" do
+  describe "#line_problems" do
     specify "pkgshare" do
       fa = formula_auditor "foo", <<-EOS.undent, strict: true
         class Foo < Formula
@@ -311,25 +311,25 @@ describe FormulaAuditor do
         end
       EOS
 
-      fa.audit_line 'ohai "#{share}/foo"', 3
+      fa.line_problems 'ohai "#{share}/foo"', 3
       expect(fa.problems.shift).to eq("Use \#{pkgshare} instead of \#{share}/foo")
 
-      fa.audit_line 'ohai "#{share}/foo/bar"', 3
+      fa.line_problems 'ohai "#{share}/foo/bar"', 3
       expect(fa.problems.shift).to eq("Use \#{pkgshare} instead of \#{share}/foo")
 
-      fa.audit_line 'ohai share/"foo"', 3
+      fa.line_problems 'ohai share/"foo"', 3
       expect(fa.problems.shift).to eq('Use pkgshare instead of (share/"foo")')
 
-      fa.audit_line 'ohai share/"foo/bar"', 3
+      fa.line_problems 'ohai share/"foo/bar"', 3
       expect(fa.problems.shift).to eq('Use pkgshare instead of (share/"foo")')
 
-      fa.audit_line 'ohai "#{share}/foo-bar"', 3
+      fa.line_problems 'ohai "#{share}/foo-bar"', 3
       expect(fa.problems).to eq([])
 
-      fa.audit_line 'ohai share/"foo-bar"', 3
+      fa.line_problems 'ohai share/"foo-bar"', 3
       expect(fa.problems).to eq([])
 
-      fa.audit_line 'ohai share/"bar"', 3
+      fa.line_problems 'ohai share/"bar"', 3
       expect(fa.problems).to eq([])
     end
 
@@ -344,11 +344,11 @@ describe FormulaAuditor do
         end
       EOS
 
-      fa.audit_line 'ohai "#{share}/foolibc++"', 3
+      fa.line_problems 'ohai "#{share}/foolibc++"', 3
       expect(fa.problems.shift)
         .to eq("Use \#{pkgshare} instead of \#{share}/foolibc++")
 
-      fa.audit_line 'ohai share/"foolibc++"', 3
+      fa.line_problems 'ohai share/"foolibc++"', 3
       expect(fa.problems.shift)
         .to eq('Use pkgshare instead of (share/"foolibc++")')
     end
@@ -360,7 +360,7 @@ describe FormulaAuditor do
         end
       EOS
 
-      fa.audit_line "class Foo<Formula", 1
+      fa.line_problems "class Foo<Formula", 1
       expect(fa.problems.shift)
         .to eq("Use a space in class inheritance: class Foo < Formula")
     end
@@ -368,10 +368,10 @@ describe FormulaAuditor do
     specify "default template" do
       fa = formula_auditor "foo", "class Foo < Formula; url '/foo-1.0.tgz'; end"
 
-      fa.audit_line '# system "cmake", ".", *std_cmake_args', 3
+      fa.line_problems '# system "cmake", ".", *std_cmake_args', 3
       expect(fa.problems.shift).to eq("Commented cmake call found")
 
-      fa.audit_line "# PLEASE REMOVE", 3
+      fa.line_problems "# PLEASE REMOVE", 3
       expect(fa.problems.shift).to eq("Please remove default template comments")
     end
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -606,7 +606,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
 ## DEVELOPER COMMANDS
 
-  * `audit` [`--strict`] [`--fix`] [`--online`] [`--new-formula`] [`--display-cop-names`] [`--display-filename`] [`formulae`]:
+  * `audit` [`--strict`] [`--fix`] [`--online`] [`--new-formula`] [`--display-cop-names`] [`--display-filename`] [`--only=``method`|`--except=``method] [<formulae`]:
     Check `formulae` for Homebrew coding style violations. This should be
     run before submitting a new formula.
 
@@ -630,6 +630,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--display-filename` is passed, every line of output is prefixed with the
     name of the file or formula being audited, to make the output easy to grep.
+
+    If `--only` is passed, only the methods named `audit_`method`` will be run.
+
+    If `--except` is passed, the methods named `audit_`method`` will not be run.
 
     `audit` exits with a non-zero status if any errors are found. This is useful,
     for instance, for implementing pre-commit hooks.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -631,7 +631,7 @@ Print the version number of Homebrew to standard output and exit\.
 .SH "DEVELOPER COMMANDS"
 .
 .TP
-\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-fix\fR] [\fB\-\-online\fR] [\fB\-\-new\-formula\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-display\-filename\fR] [\fIformulae\fR]
+\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-fix\fR] [\fB\-\-online\fR] [\fB\-\-new\-formula\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-display\-filename\fR] [\fB\-\-only=\fR\fImethod\fR|\fB\-\-except=\fR\fImethod] [<formulae\fR]
 Check \fIformulae\fR for Homebrew coding style violations\. This should be run before submitting a new formula\.
 .
 .IP
@@ -654,6 +654,12 @@ If \fB\-\-display\-cop\-names\fR is passed, the RuboCop cop name for each violat
 .
 .IP
 If \fB\-\-display\-filename\fR is passed, every line of output is prefixed with the name of the file or formula being audited, to make the output easy to grep\.
+.
+.IP
+If \fB\-\-only\fR is passed, only the methods named \fBaudit_<method>\fR will be run\.
+.
+.IP
+If \fB\-\-except\fR is passed, the methods named \fBaudit_<method>\fR will not be run\.
 .
 .IP
 \fBaudit\fR exits with a non\-zero status if any errors are found\. This is useful, for instance, for implementing pre\-commit hooks\.


### PR DESCRIPTION
Add `--only` and `--except` methods which can be used to selectively enable or disable audit groups.

CC @ilovezfs is this what you had in mind? Is this useful to you?