### PR TITLE
audit: new formulae should not require patches.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -732,7 +732,10 @@ class FormulaAuditor
         }
       end
 
+      next if spec.patches.empty?
       spec.patches.each { |p| patch_problems(p) if p.external? }
+      next unless @new_formula
+      problem "New formulae should not require patches to build. Patches should be submitted and accepted upstream first."
     end
 
     %w[Stable Devel].each do |name|


### PR DESCRIPTION
We may under some circumstances accept these anyway but it's better to nudge people into the right behaviours on local `audit`s.