### PR TITLE
tap: warn on tapping deprecated, official taps.

### DIFF
--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -15,3 +15,19 @@ OFFICIAL_CMD_TAPS = {
   "homebrew/test-bot" => ["test-bot"],
   "homebrew/services" => ["services"],
 }.freeze
+
+DEPRECATED_OFFICIAL_TAPS = %w[
+  binary
+  completions
+  devel-only
+  dupes
+  emacs
+  fuse
+  games
+  gui
+  head-only
+  python
+  tex
+  versions
+  x11
+].freeze

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -201,6 +201,10 @@ class Tap
     quiet = options.fetch(:quiet, false)
     requested_remote = options[:clone_target] || default_remote
 
+    if official? && DEPRECATED_OFFICIAL_TAPS.include?(repo)
+      opoo "#{name} was deprecated. This tap is now empty as all its formulae were migrated."
+    end
+
     if installed?
       raise TapAlreadyTappedError, name unless full_clone
       raise TapAlreadyUnshallowError, name unless shallow?


### PR DESCRIPTION
They don't contain any formulae so tapping them will add pointless clutter.