### PR TITLE
create: use GitHub metadata where available.

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -709,7 +709,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--meson` is passed, create a basic template for a Meson-style build.
 
     If `--no-fetch` is passed, Homebrew will not download `URL` to the cache and
-    will thus not add the SHA256 to the formula for you.
+    will thus not add the SHA256 to the formula for you. It will also not check
+    the GitHub API for GitHub projects (to fill out the description and homepage).
 
     The options `--set-name` and `--set-version` each take an argument and allow
     you to explicitly set the name and version of the package you are creating.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -729,7 +729,7 @@ Generate a formula for the downloadable file at \fIURL\fR and open it in the edi
 If \fB\-\-autotools\fR is passed, create a basic template for an Autotools\-style build\. If \fB\-\-cmake\fR is passed, create a basic template for a CMake\-style build\. If \fB\-\-meson\fR is passed, create a basic template for a Meson\-style build\.
 .
 .IP
-If \fB\-\-no\-fetch\fR is passed, Homebrew will not download \fIURL\fR to the cache and will thus not add the SHA256 to the formula for you\.
+If \fB\-\-no\-fetch\fR is passed, Homebrew will not download \fIURL\fR to the cache and will thus not add the SHA256 to the formula for you\. It will also not check the GitHub API for GitHub projects (to fill out the description and homepage)\.
 .
 .IP
 The options \fB\-\-set\-name\fR and \fB\-\-set\-version\fR each take an argument and allow you to explicitly set the name and version of the package you are creating\.


### PR DESCRIPTION
GitHub provides a description and homepage field so let `brew create` use them where possible. Also, detect GitHub repositories based on `releases` as well as `archive`s.