### PR TITLE
audit: ensure default dependencies don't use options.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1028,11 +1028,15 @@ class FormulaAuditor
     end
 
     if line =~ /depends_on :tex/
-      problem ":tex is deprecated."
+      problem ":tex is deprecated"
     end
 
-    if line =~ /depends_on\s+['"].+['"]\s+=>\s+:(lua|perl|python|ruby)(\d*)/
-      problem "Formulae should vendor #{$1} modules rather than use `depends_on ... => :#{$1}#{$2}`."
+    if line =~ /depends_on\s+['"](.+)['"]\s+=>\s+:(lua|perl|python|ruby)(\d*)/
+      problem "#{$2} modules should be vendored rather than use deprecated `depends_on \"#{$1}\" => :#{$2}#{$3}`"
+    end
+
+    if line =~ /depends_on\s+['"](.+)['"]\s+=>\s+.*['"](.+)['"]/
+      problem "Dependency #{$1} should not use option #{$2}"
     end
 
     # Commented-out depends_on


### PR DESCRIPTION
Default option dependencies are nasty as they cause unnecessary builds from source.