### PR TITLE
sandbox: implement some read protections

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -40,6 +40,7 @@ module Homebrew
         sandbox.allow_write_log(formula)
         sandbox.allow_write_xcode
         sandbox.deny_write_homebrew_repository
+        sandbox.deny_read_broad_home
         sandbox.allow_write_cellar(formula)
         Keg::TOP_LEVEL_DIRECTORIES.each do |dir|
           sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -72,6 +72,7 @@ module Homebrew
             sandbox.allow_write_path(HOMEBREW_PREFIX/"var/cache")
             sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
             sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
+            sandbox.deny_read_broad_home
             sandbox.exec(*args)
           else
             exec(*args)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -669,7 +669,15 @@ class FormulaInstaller
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"build.sandbox.log")
-        sandbox.allow_write_path(ENV["HOME"]) if ARGV.interactive?
+
+        if ARGV.interactive?
+          # The allow_read here is superfluous for now.
+          sandbox.allow_read_path(ENV["HOME"])
+          sandbox.allow_write_path(ENV["HOME"])
+        else
+          sandbox.deny_read_broad_home
+        end
+
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_write_xcode

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -105,6 +105,34 @@ class Sandbox
     end
   end
 
+  def deny_read_shell_files
+    # Configuration.
+    # deny_read "/Users/#{ENV["USER"]}/.bash_profile"
+    # deny_read "/Users/#{ENV["USER"]}/.cshrc"
+    # deny_read "/Users/#{ENV["USER"]}/.config/fish/config.fish"
+    # deny_read "/Users/#{ENV["USER"]}/.kshrc"
+    # deny_read "/Users/#{ENV["USER"]}/.tcshrc"
+    # deny_read "/Users/#{ENV["USER"]}/.zshrc"
+
+    # Maybe this way is cleaner, although less explicit.
+    # Should this use a "/[^/]+/" regex instead of explicit USER to ensure
+    # we're not just protecting the active user on the machine but all of them?
+    %w[bash_profile cshrc config/fish/config.fish kshrc tcshrc zshrc].each do |s|
+      deny_read "/Users/#{ENV["USER"]}/.#{s}"
+    end
+
+    # Same as above. Seek review on preference.
+    # History.
+    # deny_read "/Users/#{ENV["USER"]}/.bash_history"
+    # deny_read "/Users/#{ENV["USER"]}/.zsh_history"
+    # deny_read "/Users/#{ENV["USER"]}/.config/fish/fish_history"
+    # deny_read "/Users/#{ENV["USER"]}/.sh_history"
+    # deny_read "/Users/#{ENV["USER"]}/.history"
+    %w[bash_history zsh_history config/fish/fish_history sh_history history].each do |s|
+      deny_read "/Users/#{ENV["USER"]}/.#{s}"
+    end
+  end
+
   def exec(*args)
     seatbelt = Tempfile.new(["homebrew", ".sb"], HOMEBREW_TEMP)
     seatbelt.write(@profile.dump)

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -134,8 +134,9 @@ class Sandbox
   end
 
   def deny_read_broad_home
-    # Limit this to protecting non-HOME installations for now.
-    if HOMEBREW_PREFIX.to_s != "/Users/#{ENV["USER"]}"
+    # Limit this to protecting non-HOME & human installations for now.
+    if HOMEBREW_PREFIX.to_s != "/Users/#{ENV["USER"]}" &&
+       HOMEBREW_REPOSITORY.to_s != "/Users/#{ENV["USER"]}" && !ENV["CI"]
       # Deny reading to everything under /Users/xyz.
       deny_read "^/Users/#{ENV["USER"]}/[^/]+", type: :regex
       # Don't deny read access to /Users/xyz itself.

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -134,12 +134,21 @@ class Sandbox
   end
 
   def deny_read_broad_home
+    # Limit this to protecting non-HOME installations for now.
     if HOMEBREW_PREFIX.to_s != "/Users/#{ENV["USER"]}"
-      deny_read_path "/Users/#{ENV["USER"]}"
+      # Deny reading to everything under /Users/xyz.
+      deny_read "^/Users/#{ENV["USER"]}/[^/]+", type: :regex
+      # Don't deny read access to /Users/xyz itself.
+      allow_read "/Users/#{ENV["USER"]}"
+      # Need to test this more, but Apple dumps things in here that may need reading.
       allow_read_path "/Users/#{ENV["USER"]}/Library"
-      allow_read_path "/Users/#{ENV["USER"]}/.gem" # Used by Homebrew
+      # Used by Homebrew.
+      allow_read_path "/Users/#{ENV["USER"]}/.gem"
+      # Used by the HEAD install_spec tests.
+      allow_read "/Users/#{ENV["USER"]}/.gitconfig"
+    else
+      deny_read_shell_files
     end
-    deny_read_shell_files
   end
 
   def exec(*args)

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -137,6 +137,7 @@ class Sandbox
     if HOMEBREW_PREFIX.to_s != "/Users/#{ENV["USER"]}"
       deny_read_path "/Users/#{ENV["USER"]}"
       allow_read_path "/Users/#{ENV["USER"]}/Library"
+      allow_read_path "/Users/#{ENV["USER"]}/.gem" # Used by Homebrew
     end
     deny_read_shell_files
   end

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -133,6 +133,14 @@ class Sandbox
     end
   end
 
+  def deny_read_broad_home
+    if HOMEBREW_PREFIX.to_s != "/Users/#{ENV["USER"]}"
+      deny_read_path "/Users/#{ENV["USER"]}"
+      allow_read_path "/Users/#{ENV["USER"]}/Library"
+    end
+    deny_read_shell_files
+  end
+
   def exec(*args)
     seatbelt = Tempfile.new(["homebrew", ".sb"], HOMEBREW_TEMP)
     seatbelt.write(@profile.dump)

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -56,6 +56,22 @@ class Sandbox
     deny_write path, type: :subpath
   end
 
+  def allow_read(path, options = {})
+    add_rule allow: true, operation: "file-read*", filter: path_filter(path, options[:type])
+  end
+
+  def allow_read_path(path)
+    allow_read path, type: :subpath
+  end
+
+  def deny_read(path, options = {})
+    add_rule allow: false, operation: "file-read*", filter: path_filter(path, options[:type])
+  end
+
+  def deny_read_path(path)
+    deny_read path, type: :subpath
+  end
+
   def allow_write_temp_and_cache
     allow_write_path "/private/tmp"
     allow_write_path "/private/var/tmp"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Way way way too many things still require you to enter passwords into the terminal & not do anything to mask that, which then gets stashed away in your shell history, as well as any servers you `ssh` into, etc. There's a lot of sensitive information in there, basically.

Since Homebrew doesn't police network usage during builds better to deny read completely & close the small loophole. In reality almost everything in `HOME` should be blocked off for reading during builds, but there's a bunch of people who prefer to put Homebrew in `HOME` which this would screw with if we went that broad. We should get there eventually but compatibility baby steps.

Also gets rid of this exceptionally annoying message when you debug builds:
```
zsh: locking failed for /Users/xyz/.zsh_history: operation not permitted: reading anyway
```