### PR TITLE
cask manpage: Fix section header link for Environment

### DIFF
--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -145,7 +145,7 @@ names, and other aspects of this manual are still subject to change.
 
 ## OPTIONS
 
-To make these options persistent, see the [ENVIRONMENT][] section, below.
+To make these options persistent, see the [ENVIRONMENT](#environment) section, below.
 
 Some of these (such as `--prefpanedir`) may be subject to removal
 in a future version.

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "April 2017" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "May 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "April 2017" "Homebrew" "brew"
+.TH "BREW" "1" "May 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS


### PR DESCRIPTION
Currently the second bracket is square instead of round, and it's empty, so it displays as plaintext brackets instead of an actual link.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
