### PR TITLE
FileUtils.make: don't bypass superenv

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -108,13 +108,13 @@ module FileUtils
 
   # Run `make` 3.81 or newer.
   # Uses the system make on Leopard and newer, and the
-  # path to the actually-installed make on Tiger or older.
+  # name of the actually-installed make on Tiger or older.
   def make(*args)
     if Utils.popen_read("/usr/bin/make", "--version").match(/Make (\d\.\d+)/)[1] > "3.80"
-      system "/usr/bin/make", *args
+      system "make", *args
     else
       make = Formula["make"].opt_bin/"make"
-      make_path = make.exist? ? make.to_s : (Formula["make"].opt_bin/"gmake").to_s
+      make_path = make.exist? ? "make" : "gmake"
       system make_path, *args
     end
   end

--- a/Library/Homebrew/shims/super/make
+++ b/Library/Homebrew/shims/super/make
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
-exec xcrun make "$@"
+exec xcrun $0 "$@"


### PR DESCRIPTION
The intention here was to make sure that `make` or `gmake` is called as appropriate; as long as paths are set up right, superenv shims should call through to the Homebrew copy as appropriate. This should also work in stdenv (e.g., Tiger).

Fixes Homebrew/homebrew-portable#31.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

cc @xu-cheng 