### PR TITLE
Hardware cpu can run arch helper

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -80,6 +80,18 @@ module Hardware
       def feature?(name)
         features.include?(name)
       end
+
+      def can_run?(arch)
+        if is_32_bit?
+          arch_32_bit == arch
+        elsif intel?
+          [:i386, :x86_64].include? arch
+        elsif ppc?
+          [:ppc, :ppc64].include? arch
+        else
+          false
+        end
+      end
     end
   end
 

--- a/Library/Homebrew/test/hardware_spec.rb
+++ b/Library/Homebrew/test/hardware_spec.rb
@@ -36,5 +36,52 @@ module Hardware
         ).to include(described_class.family)
       end
     end
+
+    describe "::can_run?" do
+      it "reports that Intel machines can run Intel executables" do
+        allow(Hardware::CPU).to receive(:type).and_return :intel
+        allow(Hardware::CPU).to receive(:bits).and_return 64
+        expect(Hardware::CPU.can_run?(:i386)).to be true
+        expect(Hardware::CPU.can_run?(:x86_64)).to be true
+      end
+
+      it "reports that PowerPC machines can run PowerPC executables" do
+        allow(Hardware::CPU).to receive(:type).and_return :ppc
+        allow(Hardware::CPU).to receive(:bits).and_return 64
+        expect(Hardware::CPU.can_run?(:ppc)).to be true
+        expect(Hardware::CPU.can_run?(:ppc64)).to be true
+      end
+
+      it "reports that 32-bit Intel machines can't run x86_64 executables" do
+        allow(Hardware::CPU).to receive(:type).and_return :intel
+        allow(Hardware::CPU).to receive(:bits).and_return 32
+        expect(Hardware::CPU.can_run?(:x86_64)).to be false
+      end
+
+      it "reports that 32-bit PowerPC machines can't run ppc64 executables" do
+        allow(Hardware::CPU).to receive(:type).and_return :ppc
+        allow(Hardware::CPU).to receive(:bits).and_return 32
+        expect(Hardware::CPU.can_run?(:ppc64)).to be false
+      end
+
+      it "identifies that Intel and PowerPC machines can't run each others' executables" do
+        allow(Hardware::CPU).to receive(:type).and_return :ppc
+        expect(Hardware::CPU.can_run?(:i386)).to be false
+        expect(Hardware::CPU.can_run?(:x86_64)).to be false
+
+        allow(Hardware::CPU).to receive(:type).and_return :intel
+        expect(Hardware::CPU.can_run?(:ppc)).to be false
+        expect(Hardware::CPU.can_run?(:ppc64)).to be false
+      end
+
+      it "returns false for unknown CPU types" do
+        allow(Hardware::CPU).to receive(:type).and_return :dunno
+        expect(Hardware::CPU.can_run?(:i386)).to be false
+      end
+
+      it "returns false for unknown arches" do
+        expect(Hardware::CPU.can_run?(:blah)).to be false
+      end
+    end
   end
 end

--- a/Library/Homebrew/test/os/mac/hardware_spec.rb
+++ b/Library/Homebrew/test/os/mac/hardware_spec.rb
@@ -1,0 +1,56 @@
+require "hardware"
+require "extend/os/mac/hardware/cpu"
+
+describe Hardware::CPU do
+  describe "::can_run?" do
+    it "reports that Intel Macs can run Intel executables" do
+      allow(Hardware::CPU).to receive(:type).and_return :intel
+      allow(Hardware::CPU).to receive(:bits).and_return 64
+      expect(Hardware::CPU.can_run?(:i386)).to be true
+      expect(Hardware::CPU.can_run?(:x86_64)).to be true
+    end
+
+    it "reports that PowerPC Macs can run PowerPC executables" do
+      allow(Hardware::CPU).to receive(:type).and_return :ppc
+      allow(Hardware::CPU).to receive(:bits).and_return 64
+      expect(Hardware::CPU.can_run?(:ppc)).to be true
+      expect(Hardware::CPU.can_run?(:ppc64)).to be true
+    end
+
+    it "reports that 32-bit Intel Macs can't run x86_64 executables" do
+      allow(Hardware::CPU).to receive(:type).and_return :intel
+      allow(Hardware::CPU).to receive(:bits).and_return 32
+      expect(Hardware::CPU.can_run?(:x86_64)).to be false
+    end
+
+    it "reports that 32-bit PowerPC Macs can't run ppc64 executables" do
+      allow(Hardware::CPU).to receive(:type).and_return :ppc
+      allow(Hardware::CPU).to receive(:bits).and_return 32
+      expect(Hardware::CPU.can_run?(:ppc64)).to be false
+    end
+
+    it "reports that Intel Macs can only run 32-bit PowerPC executables on 10.6 and older" do
+      allow(Hardware::CPU).to receive(:type).and_return :intel
+      allow(OS::Mac).to receive(:version).and_return OS::Mac::Version.new "10.6"
+      expect(Hardware::CPU.can_run?(:ppc)).to be true
+
+      allow(OS::Mac).to receive(:version).and_return OS::Mac::Version.new "10.7"
+      expect(Hardware::CPU.can_run?(:ppc)).to be false
+    end
+
+    it "reports that PowerPC Macs can't run Intel executables" do
+      allow(Hardware::CPU).to receive(:type).and_return :ppc
+      expect(Hardware::CPU.can_run?(:i386)).to be false
+      expect(Hardware::CPU.can_run?(:x86_64)).to be false
+    end
+
+    it "returns false for unknown CPU types" do
+      allow(Hardware::CPU).to receive(:type).and_return :dunno
+      expect(Hardware::CPU.can_run?(:i386)).to be false
+    end
+
+    it "returns false for unknown arches" do
+      expect(Hardware::CPU.can_run?(:blah)).to be false
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a helper that returns whether or not the active CPU is capable of running an executable of a given architecture. This is useful for cross-compiling; for example, in homebrew-portable, we can end up building a library for an architecture the host CPU can't run, which prevents `make test` and similar things from failing. A practical example is building a universal portable-openssl on a PowerPC host: it can build Intel binaries, but `make test` will fail since it can't run them.

cc @xu-cheng 