### PR TITLE
install: do not search taps when a qualified formula is missing

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -241,7 +241,7 @@ module Homebrew
       end
 
       # Do not search taps if the formula name is qualified
-      return if e.name =~ %r{/}
+      return if e.name.include?("/")
       ohai "Searching taps..."
       taps_search_results = search_taps(query)
       case taps_search_results.length

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -240,6 +240,8 @@ module Homebrew
         puts "To install one of them, run (for example):\n  brew install #{formulae_search_results.first}"
       end
 
+      # Do not search taps if the formula name is qualified
+      return if e.name =~ %r{/}
       ohai "Searching taps..."
       taps_search_results = search_taps(query)
       case taps_search_results.length


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

You won't find the formula in another tap when it's already qualified.

Ref: https://github.com/Homebrew/brew/issues/2497#issuecomment-294317628.