### PR TITLE
audit: fix swapped audit messages

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1100,11 +1100,11 @@ class FormulaAuditor
     end
 
     if line =~ /(not\s|!)\s*build\.with?\?/
-      problem "Don't negate 'build.without?': use 'build.with?'"
+      problem "Don't negate 'build.with?': use 'build.without?'"
     end
 
     if line =~ /(not\s|!)\s*build\.without?\?/
-      problem "Don't negate 'build.with?': use 'build.without?'"
+      problem "Don't negate 'build.without?': use 'build.with?'"
     end
 
     if line =~ /ARGV\.(?!(debug\?|verbose\?|value[\(\s]))/


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

While preparing https://github.com/Homebrew/homebrew-core/pull/12636, I noticed that some audit messages are switched. I think they make sense this way.