### PR TITLE
Fix `plist` parser failing when encoded with ASCII.

### DIFF
--- a/Library/Homebrew/extend/io.rb
+++ b/Library/Homebrew/extend/io.rb
@@ -1,10 +1,17 @@
 class IO
   def readline_nonblock(sep = $INPUT_RECORD_SEPARATOR)
+    line = ""
     buffer = ""
-    buffer.concat(read_nonblock(1)) while buffer[-1] != sep
-    buffer
+
+    loop do
+      break if buffer == sep
+      read_nonblock(1, buffer)
+      line.concat(buffer)
+    end
+
+    line
   rescue IO::WaitReadable, EOFError => e
-    raise e if buffer.empty?
-    buffer
+    raise e if line.empty?
+    line
   end
 end

--- a/Library/Homebrew/vendor/plist/plist/parser.rb
+++ b/Library/Homebrew/vendor/plist/plist/parser.rb
@@ -69,6 +69,11 @@ module Plist
         @xml = plist_data_or_file
       end
 
+      # TODO: Update vendored `plist` parser when
+      #       https://github.com/patsplat/plist/pull/38
+      #       is merged.
+      @xml.force_encoding("UTF-8")
+
       @listener = listener
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

References https://github.com/patsplat/plist/pull/38.
Fixes https://github.com/caskroom/homebrew-cask/issues/32537.