### PR TITLE
Replace `FileUtils.chmod` with `/bin/chmod` for cask binaries.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/artifact/binary.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/binary.rb
@@ -9,7 +9,12 @@ module Hbc
 
       def link
         super
-        FileUtils.chmod "+x", source
+        return if source.executable?
+        if source.writable?
+          FileUtils.chmod "+x", source
+        else
+          @command.run!.run("/bin/chmod", args: ["+x", source], sudo: true)
+        end
       end
     end
   end

--- a/Library/Homebrew/cask/lib/hbc/artifact/binary.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/binary.rb
@@ -13,7 +13,7 @@ module Hbc
         if source.writable?
           FileUtils.chmod "+x", source
         else
-          @command.run!.run("/bin/chmod", args: ["+x", source], sudo: true)
+          @command.run!("/bin/chmod", args: ["+x", source], sudo: true)
         end
       end
     end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
@@ -1,0 +1,9 @@
+cask 'with-non-executable-binary' do
+  version '1.2.3'
+  sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/naked_non_executable"
+  homepage 'http://example.com/with-binary'
+
+  binary "naked_non_executable"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/naked_non_executable
+++ b/Library/Homebrew/test/support/fixtures/cask/naked_non_executable
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Hello Homebrew maintainers, this is my first PR here, apologies for it being incomplete at this stage.

Currently when creating cask binary symlinks `FileUtils.chmod` fails with some casks.

This fixes https://github.com/caskroom/homebrew-cask/issues/31874.

This is a WIP as `binary_spec.rb` is not included in this PR so tests will fail.

CC @reitermarkus 