### PR TITLE
travis.yml: cache Bundler output.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: ruby
+cache:
+  directories:
+    - $HOME/.gem/ruby
+    - Library/Homebrew/vendor/bundle
 
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.1
+      osx_image: xcode8.3
       rvm: system
     - os: linux
       rvm: 2.0.0

--- a/Library/Homebrew/test/.bundle/config
+++ b/Library/Homebrew/test/.bundle/config
@@ -1,3 +1,4 @@
 ---
 BUNDLE_PATH: "../vendor/bundle"
 BUNDLE_DISABLE_SHARED_GEMS: "true"
+BUNDLE_BIN: "../bin"


### PR DESCRIPTION
Travis needs some coaxing to find where we put it. This should improve build reliability due to network issues.