### PR TITLE
Partly revert “Fix `uninstall :pkgutil` leaving empty `.app` directories.”.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/pkg.rb
+++ b/Library/Homebrew/cask/lib/hbc/pkg.rb
@@ -63,7 +63,10 @@ module Hbc
     end
 
     def pkgutil_bom_all
-      @pkgutil_bom_all ||= info.fetch("paths").keys.map { |p| root.join(p) }
+      @pkgutil_bom_all ||= @command.run!("/usr/sbin/pkgutil", args: ["--files", package_id])
+                                   .stdout
+                                   .split("\n")
+                                   .map { |path| root.join(path) }
     end
 
     def root
@@ -71,7 +74,7 @@ module Hbc
     end
 
     def info
-      @info ||= @command.run!("/usr/sbin/pkgutil", args: ["--export-plist", package_id])
+      @info ||= @command.run!("/usr/sbin/pkgutil", args: ["--pkg-info-plist", package_id])
                         .plist
     end
 

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -36,7 +36,12 @@ describe Hbc::Pkg, :cask do
       it "forgets the pkg" do
         allow(fake_system_command).to receive(:run!).with(
           "/usr/sbin/pkgutil",
-          args: ["--export-plist", "my.fake.pkg"],
+          args: ["--pkg-info-plist", "my.fake.pkg"],
+        ).and_return(empty_response)
+
+        expect(fake_system_command).to receive(:run!).with(
+          "/usr/sbin/pkgutil",
+          args: ["--files", "my.fake.pkg"],
         ).and_return(empty_response)
 
         expect(fake_system_command).to receive(:run!).with(
@@ -139,7 +144,7 @@ describe Hbc::Pkg, :cask do
 
       expect(fake_system_command).to receive(:run!).with(
         "/usr/sbin/pkgutil",
-      args: ["--export-plist", pkg_id],
+      args: ["--pkg-info-plist", pkg_id],
       ).and_return(
         Hbc::SystemCommand::Result.new(nil, pkg_info_plist, nil, 0),
       )


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`pkgutil --export-plist org.tug.mactex.texlive2016` seems to be so huge (154227 files) that it just hangs, but `pkgutil --files org.tug.mactex.texlive2016` returns fine.
