### PR TITLE
formula_installer: remove feature flags.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -173,34 +173,22 @@ class FormulaInstaller
       EOS
     end
 
-    if ENV["HOMEBREW_CHECK_RECURSIVE_VERSION_DEPENDENCIES"]
-      version_hash = {}
-      version_conflicts = Set.new
-      recursive_formulae.each do |f|
-        name = f.name
-        unversioned_name, = name.split("@")
-        version_hash[unversioned_name] ||= Set.new
-        version_hash[unversioned_name] << name
-        next if version_hash[unversioned_name].length < 2
-        version_conflicts += version_hash[unversioned_name]
-      end
-      unless version_conflicts.empty?
-        raise CannotInstallFormulaError, <<-EOS.undent
-          #{formula.full_name} contains conflicting version recursive dependencies:
-            #{version_conflicts.to_a.join ", "}
-          View these with `brew deps --tree #{formula.full_name}`.
-        EOS
-      end
+    version_hash = {}
+    version_conflicts = Set.new
+    recursive_formulae.each do |f|
+      name = f.name
+      unversioned_name, = name.split("@")
+      version_hash[unversioned_name] ||= Set.new
+      version_hash[unversioned_name] << name
+      next if version_hash[unversioned_name].length < 2
+      version_conflicts += version_hash[unversioned_name]
     end
-
-    unless ENV["HOMEBREW_NO_CHECK_UNLINKED_DEPENDENCIES"]
-      unlinked_deps = recursive_formulae.select do |dep|
-        dep.installed? && !dep.keg_only? && !dep.linked_keg.directory?
-      end
-
-      unless unlinked_deps.empty?
-        raise CannotInstallFormulaError, "You must `brew link #{unlinked_deps*" "}` before #{formula.full_name} can be installed"
-      end
+    unless version_conflicts.empty?
+      raise CannotInstallFormulaError, <<-EOS.undent
+        #{formula.full_name} contains conflicting version recursive dependencies:
+          #{version_conflicts.to_a.join ", "}
+        View these with `brew deps --tree #{formula.full_name}`.
+      EOS
     end
 
     pinned_unsatisfied_deps = recursive_deps.select do |dep|


### PR DESCRIPTION
We've been testing the recursive dependency check and allowing unlinked dependencies in CI for a while with no adverse consequences so enable them globally now for all users.