### PR TITLE
Hide sensitive tokens from install/test/post.

### DIFF
--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -8,10 +8,10 @@ module Homebrew
   def mirror
     odie "This command requires at least formula argument!" if ARGV.named.empty?
 
-    bintray_user = ENV["BINTRAY_USER"]
-    bintray_key = ENV["BINTRAY_KEY"]
+    bintray_user = ENV["HOMEBREW_BINTRAY_USER"]
+    bintray_key = ENV["HOMEBREW_BINTRAY_KEY"]
     if !bintray_user || !bintray_key
-      raise "Missing BINTRAY_USER or BINTRAY_KEY variables!"
+      raise "Missing HOMEBREW_BINTRAY_USER or HOMEBREW_BINTRAY_KEY variables!"
     end
 
     ARGV.formulae.each do |f|

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -263,7 +263,7 @@ module Homebrew
     end
 
     published = []
-    bintray_creds = { user: ENV["BINTRAY_USER"], key: ENV["BINTRAY_KEY"] }
+    bintray_creds = { user: ENV["HOMEBREW_BINTRAY_USER"], key: ENV["HOMEBREW_BINTRAY_KEY"] }
     if bintray_creds[:user] && bintray_creds[:key]
       changed_formulae_names.each do |name|
         f = Formula[name]
@@ -272,7 +272,7 @@ module Homebrew
         published << f.full_name
       end
     else
-      opoo "You must set BINTRAY_USER and BINTRAY_KEY to add or update bottles on Bintray!"
+      opoo "You must set HOMEBREW_BINTRAY_USER and HOMEBREW_BINTRAY_KEY to add or update bottles on Bintray!"
     end
     published
   end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -439,7 +439,7 @@ module Homebrew
 
         message = ""
 
-        paths.each do |p|
+        paths(ENV["HOMEBREW_PATH"]).each do |p|
           case p
           when "/usr/bin"
             unless $seen_prefix_bin
@@ -609,7 +609,7 @@ module Homebrew
           /Applications/Server.app/Contents/ServerRoot/usr/sbin
         ].map(&:downcase)
 
-        paths.each do |p|
+        paths(ENV["HOMEBREW_PATH"]).each do |p|
           next if whitelist.include?(p.downcase) || !File.directory?(p)
 
           realpath = Pathname.new(p).realpath.to_s

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -26,6 +26,13 @@ module EnvActivation
   ensure
     replace(old_env)
   end
+
+  def clear_sensitive_environment!
+    ENV.keys.each do |key|
+      next unless /(cookie|key|token)/i =~ key
+      ENV.delete key
+    end
+  end
 end
 
 ENV.extend(EnvActivation)

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -53,7 +53,7 @@ HOMEBREW_PULL_OR_COMMIT_URL_REGEX = %r[https://github\.com/([\w-]+)/([\w-]+)?/(?
 
 require "compat" unless ARGV.include?("--no-compat") || ENV["HOMEBREW_NO_COMPAT"]
 
-ORIGINAL_PATHS = ENV["PATH"].split(File::PATH_SEPARATOR).map do |p|
+ORIGINAL_PATHS = ENV["HOMEBREW_PATH"].split(File::PATH_SEPARATOR).map do |p|
   begin
     Pathname.new(p).expand_path
   rescue

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -122,8 +122,9 @@ describe Homebrew::Diagnostic::Checks do
   specify "#check_user_path_3" do
     begin
       sbin = HOMEBREW_PREFIX/"sbin"
-      ENV["PATH"] = "#{HOMEBREW_PREFIX}/bin#{File::PATH_SEPARATOR}" +
-                    ENV["PATH"].gsub(/(?:^|#{Regexp.escape(File::PATH_SEPARATOR)})#{Regexp.escape(sbin)}/, "")
+      ENV["HOMEBREW_PATH"] =
+        "#{HOMEBREW_PREFIX}/bin#{File::PATH_SEPARATOR}" +
+        ENV["HOMEBREW_PATH"].gsub(/(?:^|#{Regexp.escape(File::PATH_SEPARATOR)})#{Regexp.escape(sbin)}/, "")
       (sbin/"something").mkpath
 
       expect(subject.check_user_path_1).to be nil
@@ -149,7 +150,9 @@ describe Homebrew::Diagnostic::Checks do
       file = "#{path}/foo-config"
       FileUtils.touch file
       FileUtils.chmod 0755, file
-      ENV["PATH"] = "#{path}#{File::PATH_SEPARATOR}#{ENV["PATH"]}"
+      ENV["HOMEBREW_PATH"] =
+        ENV["PATH"] =
+          "#{path}#{File::PATH_SEPARATOR}#{ENV["PATH"]}"
 
       expect(subject.check_for_config_scripts)
         .to match('"config" scripts exist')

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -72,6 +72,7 @@ RSpec.shared_context "integration test" do
 
     env.merge!(
       "PATH" => path,
+      "HOMEBREW_PATH" => path,
       "HOMEBREW_BREW_FILE" => HOMEBREW_PREFIX/"bin/brew",
       "HOMEBREW_INTEGRATION_TEST" => command_id_from_args(args),
       "HOMEBREW_TEST_TMPDIR" => TEST_TMPDIR,

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -406,8 +406,8 @@ def nostdout
   end
 end
 
-def paths
-  @paths ||= ENV["PATH"].split(File::PATH_SEPARATOR).collect do |p|
+def paths(env_path = ENV["PATH"])
+  @paths ||= env_path.split(File::PATH_SEPARATOR).collect do |p|
     begin
       File.expand_path(p).chomp("/")
     rescue ArgumentError


### PR DESCRIPTION
Hide these tokens to avoid malicious subprocesses e.g. sending them over the network. Also, support using these tokens with environment filtering and clear `HOMEBREW_PATH` from subprocesses to stop them sniffing it. Finally, use `HOMEBREW_PATH` to detect Homebrew’s user’s PATH for e.g. `brew doctor` etc.

Requires the changes from https://github.com/Homebrew/brew/pull/2476. Will be rebased to remove those changes when it is merged (before this PR is merged).