### PR TITLE
audit: flip GNU mirror preference.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1417,8 +1417,8 @@ class ResourceAuditor
 
   def audit_urls
     # Check GNU urls; doesn't apply to mirrors
-    if url =~ %r{^(?:https?|ftp)://(?!alpha).+/gnu/}
-      problem "Please use \"https://ftpmirror.gnu.org\" instead of #{url}."
+    if url =~ %r{^(?:https?|ftp)://ftpmirror.gnu.org/(.*)}
+      problem "Please use \"https://ftp.gnu.org/gnu/#{$1}\" instead of #{url}."
     end
 
     if mirrors.include?(url)


### PR DESCRIPTION
Now that both the primary and mirror URLs use HTTPS we can flip these around so the primary URL is the primary URL and we don't have problems with waiting for mirror propagation.

Discussed with @ilovezfs on Slack but CC @DomT4 and @vszakats to check I've understood this.