### PR TITLE
audit: Allow skipping/selective running of cops and cops refactor

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -8,10 +8,10 @@ AllCops:
 
 require: ./Homebrew/rubocops.rb
 
-Homebrew/CorrectBottleBlock:
+FormulaAuditStrict/CorrectBottleBlock:
   Enabled: true
 
-Homebrew/FormulaDesc:
+FormulaAuditStrict/FormulaDesc:
   Enabled: true
 
 Homebrew/FormulaComponentsOrder:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -8,16 +8,16 @@ AllCops:
 
 require: ./Homebrew/rubocops.rb
 
-FormulaAuditStrict/CorrectBottleBlock:
+FormulaAuditStrict/BottleBlock:
   Enabled: true
 
-FormulaAuditStrict/FormulaDesc:
+FormulaAuditStrict/Desc:
   Enabled: true
 
-Homebrew/FormulaComponentsOrder:
+FormulaAuditStrict/ComponentsOrder:
   Enabled: true
 
-Homebrew/ComponentsRedundancy:
+FormulaAuditStrict/ComponentsRedundancy:
   Enabled: true
 
 Metrics/AbcSize:

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -15,6 +15,8 @@
 
 require "utils"
 require "json"
+require "rubocop"
+require_relative "../rubocops"
 
 module Homebrew
   module_function
@@ -53,6 +55,10 @@ module Homebrew
       --force-exclusion
     ]
     args << "--auto-correct" if fix
+
+    if options[:only]
+      args << "--only" << RuboCop::Cop::Cop.registry.with_department(options[:only]).names.join(" ")
+    end
 
     if files.nil?
       args << "--config" << HOMEBREW_LIBRARY_PATH/".rubocop.yml"

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -1,4 +1,4 @@
-#:  * `style` [`--fix`] [`--display-cop-names`] [<files>|<taps>|<formulae>]:
+#:  * `style` [`--fix`] [`--display-cop-names`] [`--only-cops=`[COP1,COP2..]|`--except-cops=`[COP1,COP2..]] [<files>|<taps>|<formulae>]:
 #:    Check formulae or files for conformance to Homebrew style guidelines.
 #:
 #:    <formulae> and <files> may not be combined. If both are omitted, style will run
@@ -10,6 +10,10 @@
 #:
 #:    If `--display-cop-names` is passed, the RuboCop cop name for each violation
 #:    is included in the output.
+#:
+#:    If `--only-cops` is passed, only the given Rubocop cop(s)' violations would be checked.
+#:
+#:    If `--except-cops` is passed, the given Rubocop cop(s)' checks would be skipped.
 #:
 #:    Exits with a non-zero status if any style violations are found.
 
@@ -32,7 +36,20 @@ module Homebrew
       ARGV.formulae.map(&:path)
     end
 
-    Homebrew.failed = check_style_and_print(target, fix: ARGV.flag?("--fix"))
+    only_cops = ARGV.value("only-cops").to_s.split(",")
+    except_cops = ARGV.value("except-cops").to_s.split(",")
+    if !only_cops.empty? && !except_cops.empty?
+      odie "--only-cops and --except-cops cannot be used simultaneously!"
+    end
+
+    options = { fix: ARGV.flag?("--fix") }
+    if !only_cops.empty?
+      options[:only_cops] = only_cops
+    elsif !except_cops.empty?
+      options[:except_cops] = except_cops
+    end
+
+    Homebrew.failed = check_style_and_print(target, options)
   end
 
   # Checks style for a list of files, printing simple RuboCop output.
@@ -56,18 +73,22 @@ module Homebrew
     ]
     args << "--auto-correct" if fix
 
-    if options[:exclude].eql?(:FormulaAuditStrict) && !(options.key?(:except) || options.key?(:only))
-      args << "--except" << :FormulaAuditStrict
-    end
+    if options[:except_cops]
+      options[:except_cops].map! { |cop| RuboCop::Cop::Cop.registry.qualified_cop_name(cop, "") }
+      cops_to_exclude = options[:except_cops].select do |cop|
+        RuboCop::Cop::Cop.registry.names.include?(cop) ||
+          RuboCop::Cop::Cop.registry.departments.include?(cop.to_sym)
+      end
 
-    if options[:except]
-      cops_to_exclude = options[:except].select { |cop| RuboCop::Cop::Cop.registry.names.include?(cop) }
-      args << "--except" << cops_to_exclude.join(" ") unless cops_to_exclude.empty?
-    end
+      args << "--except" << cops_to_exclude.join(",") unless cops_to_exclude.empty?
+    elsif options[:only_cops]
+      options[:only_cops].map! { |cop| RuboCop::Cop::Cop.registry.qualified_cop_name(cop, "") }
+      cops_to_include = options[:only_cops].select do |cop|
+        RuboCop::Cop::Cop.registry.names.include?(cop) ||
+          RuboCop::Cop::Cop.registry.departments.include?(cop.to_sym)
+      end
 
-    if options[:only]
-      cops_to_include = options[:only].select { |cop| RuboCop::Cop::Cop.registry.names.include?(cop) }
-      args << "--only" << cops_to_include.join(" ") unless cops_to_include.empty?
+      args << "--only" << cops_to_include.join(",") unless cops_to_include.empty?
     end
 
     if files.nil?

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -56,8 +56,18 @@ module Homebrew
     ]
     args << "--auto-correct" if fix
 
+    if options[:exclude].eql?(:FormulaAuditStrict) && !(options.key?(:except) || options.key?(:only))
+      args << "--except" << :FormulaAuditStrict
+    end
+
+    if options[:except]
+      cops_to_exclude = options[:except].select { |cop| RuboCop::Cop::Cop.registry.names.include?(cop) }
+      args << "--except" << cops_to_exclude.join(" ") unless cops_to_exclude.empty?
+    end
+
     if options[:only]
-      args << "--only" << RuboCop::Cop::Cop.registry.with_department(options[:only]).names.join(" ")
+      cops_to_include = options[:only].select { |cop| RuboCop::Cop::Cop.registry.names.include?(cop) }
+      args << "--only" << cops_to_include.join(" ") unless cops_to_include.empty?
     end
 
     if files.nil?

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -75,9 +75,14 @@ module Homebrew
       style_results = check_style_json(files, options)
     end
 
+    if !strict
+      options = { fix: ARGV.flag?("--fix"), realpath: true, only: :Homebrew }
+      style_results = check_style_json(files, options)
+    end
+
     ff.each do |f|
       options = { new_formula: new_formula, strict: strict, online: online }
-      options[:style_offenses] = style_results.file_offenses(f.path) if strict
+      options[:style_offenses] = style_results.file_offenses(f.path)
       fa = FormulaAuditor.new(f, options)
       fa.audit
 

--- a/Library/Homebrew/rubocops/bottle_block_cop.rb
+++ b/Library/Homebrew/rubocops/bottle_block_cop.rb
@@ -7,7 +7,7 @@ module RuboCop
       #
       # - `rebuild` should be used instead of `revision` in `bottle` block
 
-      class CorrectBottleBlock < FormulaCop
+      class BottleBlock < FormulaCop
         MSG = "Use rebuild instead of revision in bottle block".freeze
 
         def audit_formula(_node, _class_node, _parent_class_node, formula_class_body_node)

--- a/Library/Homebrew/rubocops/bottle_block_cop.rb
+++ b/Library/Homebrew/rubocops/bottle_block_cop.rb
@@ -2,7 +2,7 @@ require_relative "./extend/formula_cop"
 
 module RuboCop
   module Cop
-    module Homebrew
+    module FormulaAuditStrict
       # This cop audits `bottle` block in Formulae
       #
       # - `rebuild` should be used instead of `revision` in `bottle` block

--- a/Library/Homebrew/rubocops/components_order_cop.rb
+++ b/Library/Homebrew/rubocops/components_order_cop.rb
@@ -2,12 +2,12 @@ require_relative "./extend/formula_cop"
 
 module RuboCop
   module Cop
-    module Homebrew
+    module FormulaAuditStrict
       # This cop checks for correct order of components in a Formula
       #
       # - component_precedence_list has component hierarchy in a nested list
       #   where each sub array contains components' details which are at same precedence level
-      class FormulaComponentsOrder < FormulaCop
+      class ComponentsOrder < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, formula_class_body_node)
           component_precedence_list = [
             [{ name: :include,  type: :method_call }],

--- a/Library/Homebrew/rubocops/components_redundancy_cop.rb
+++ b/Library/Homebrew/rubocops/components_redundancy_cop.rb
@@ -2,7 +2,7 @@ require_relative "./extend/formula_cop"
 
 module RuboCop
   module Cop
-    module Homebrew
+    module FormulaAuditStrict
       # This cop checks if redundant components are present and other component errors
       #
       # - `url|checksum|mirror` should be inside `stable` block

--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -1,213 +1,211 @@
 module RuboCop
   module Cop
-    module Homebrew
-      class FormulaCop < Cop
-        @registry = Cop.registry
+    class FormulaCop < Cop
+      @registry = Cop.registry
 
-        # This method is called by RuboCop and is the main entry point
-        def on_class(node)
-          file_path = processed_source.buffer.name
-          return unless file_path_allowed?(file_path)
-          class_node, parent_class_node, body = *node
-          return unless formula_class?(parent_class_node)
-          return unless respond_to?(:audit_formula)
-          @formula_name = class_name(class_node)
-          audit_formula(node, class_node, parent_class_node, body)
+      # This method is called by RuboCop and is the main entry point
+      def on_class(node)
+        file_path = processed_source.buffer.name
+        return unless file_path_allowed?(file_path)
+        class_node, parent_class_node, body = *node
+        return unless formula_class?(parent_class_node)
+        return unless respond_to?(:audit_formula)
+        @formula_name = class_name(class_node)
+        audit_formula(node, class_node, parent_class_node, body)
+      end
+
+      # Checks for regex match of pattern in the node and
+      # Sets the appropriate instance variables to report the match
+      def regex_match_group(node, pattern)
+        string_repr = string_content(node)
+        match_object = string_repr.match(pattern)
+        return unless match_object
+        node_begin_pos = start_column(node)
+        line_begin_pos = line_start_column(node)
+        @column = node_begin_pos + match_object.begin(0) - line_begin_pos + 1
+        @length = match_object.to_s.length
+        @line_no = line_number(node)
+        @source_buf = source_buffer(node)
+        @offense_source_range = source_range(@source_buf, @line_no, @column, @length)
+        @offensive_node = node
+        match_object
+      end
+
+      # Returns method_node matching method_name
+      def find_node_method_by_name(node, method_name)
+        return if node.nil?
+        node.each_child_node(:send) do |method_node|
+          next unless method_node.method_name == method_name
+          @offensive_node = method_node
+          @offense_source_range = method_node.source_range
+          return method_node
         end
+        # If not found then, parent node becomes the offensive node
+        @offensive_node = node.parent
+        @offense_source_range = node.parent.source_range
+        nil
+      end
 
-        # Checks for regex match of pattern in the node and
-        # Sets the appropriate instance variables to report the match
-        def regex_match_group(node, pattern)
-          string_repr = string_content(node)
-          match_object = string_repr.match(pattern)
-          return unless match_object
-          node_begin_pos = start_column(node)
-          line_begin_pos = line_start_column(node)
-          @column = node_begin_pos + match_object.begin(0) - line_begin_pos + 1
-          @length = match_object.to_s.length
-          @line_no = line_number(node)
-          @source_buf = source_buffer(node)
-          @offense_source_range = source_range(@source_buf, @line_no, @column, @length)
-          @offensive_node = node
-          match_object
+      # Returns an array of method call nodes matching method_name inside node
+      def find_method_calls_by_name(node, method_name)
+        return if node.nil?
+        node.each_child_node(:send).select { |method_node| method_name == method_node.method_name }
+      end
+
+      # Returns a block named block_name inside node
+      def find_block(node, block_name)
+        return if node.nil?
+        node.each_child_node(:block) do |block_node|
+          next if block_node.method_name != block_name
+          @offensive_node = block_node
+          @offense_source_range = block_node.source_range
+          return block_node
         end
+        # If not found then, parent node becomes the offensive node
+        @offensive_node = node.parent
+        @offense_source_range = node.parent.source_range
+        nil
+      end
 
-        # Returns method_node matching method_name
-        def find_node_method_by_name(node, method_name)
-          return if node.nil?
-          node.each_child_node(:send) do |method_node|
-            next unless method_node.method_name == method_name
-            @offensive_node = method_node
-            @offense_source_range = method_node.source_range
-            return method_node
-          end
-          # If not found then, parent node becomes the offensive node
-          @offensive_node = node.parent
-          @offense_source_range = node.parent.source_range
-          nil
+      # Returns an array of block nodes named block_name inside node
+      def find_blocks(node, block_name)
+        return if node.nil?
+        node.each_child_node(:block).select { |block_node| block_name == block_node.method_name }
+      end
+
+      # Returns a method definition node with method_name
+      def find_method_def(node, method_name)
+        return if node.nil?
+        node.each_child_node(:def) do |def_node|
+          def_method_name = method_name(def_node)
+          next unless method_name == def_method_name
+          @offensive_node = def_node
+          @offense_source_range = def_node.source_range
+          return def_node
         end
+        # If not found then, parent node becomes the offensive node
+        @offensive_node = node.parent
+        @offense_source_range = node.parent.source_range
+        nil
+      end
 
-        # Returns an array of method call nodes matching method_name inside node
-        def find_method_calls_by_name(node, method_name)
-          return if node.nil?
-          node.each_child_node(:send).select { |method_node| method_name == method_node.method_name }
+      # Check if a method is called inside a block
+      def method_called_in_block?(node, method_name)
+        block_body = node.children[2]
+        block_body.each_child_node(:send) do |call_node|
+          next unless call_node.method_name == method_name
+          @offensive_node = call_node
+          @offense_source_range = call_node.source_range
+          return true
         end
+        false
+      end
 
-        # Returns a block named block_name inside node
-        def find_block(node, block_name)
-          return if node.nil?
-          node.each_child_node(:block) do |block_node|
-            next if block_node.method_name != block_name
-            @offensive_node = block_node
-            @offense_source_range = block_node.source_range
-            return block_node
-          end
-          # If not found then, parent node becomes the offensive node
-          @offensive_node = node.parent
-          @offense_source_range = node.parent.source_range
-          nil
+      # Check if method_name is called among the direct children nodes in the given node
+      def method_called?(node, method_name)
+        node.each_child_node(:send) do |call_node|
+          next unless call_node.method_name == method_name
+          @offensive_node = call_node
+          @offense_source_range = call_node.source_range
+          return true
         end
+        false
+      end
 
-        # Returns an array of block nodes named block_name inside node
-        def find_blocks(node, block_name)
-          return if node.nil?
-          node.each_child_node(:block).select { |block_node| block_name == block_node.method_name }
-        end
-
-        # Returns a method definition node with method_name
-        def find_method_def(node, method_name)
-          return if node.nil?
-          node.each_child_node(:def) do |def_node|
-            def_method_name = method_name(def_node)
-            next unless method_name == def_method_name
-            @offensive_node = def_node
-            @offense_source_range = def_node.source_range
-            return def_node
-          end
-          # If not found then, parent node becomes the offensive node
-          @offensive_node = node.parent
-          @offense_source_range = node.parent.source_range
-          nil
-        end
-
-        # Check if a method is called inside a block
-        def method_called_in_block?(node, method_name)
-          block_body = node.children[2]
-          block_body.each_child_node(:send) do |call_node|
-            next unless call_node.method_name == method_name
-            @offensive_node = call_node
-            @offense_source_range = call_node.source_range
-            return true
-          end
-          false
-        end
-
-        # Check if method_name is called among the direct children nodes in the given node
-        def method_called?(node, method_name)
-          node.each_child_node(:send) do |call_node|
-            next unless call_node.method_name == method_name
-            @offensive_node = call_node
-            @offense_source_range = call_node.source_range
-            return true
-          end
-          false
-        end
-
-        # Checks for precedence, returns the first pair of precedence violating nodes
-        def check_precedence(first_nodes, next_nodes)
-          next_nodes.each do |each_next_node|
-            first_nodes.each do |each_first_node|
-              if component_precedes?(each_first_node, each_next_node)
-                return [each_first_node, each_next_node]
-              end
+      # Checks for precedence, returns the first pair of precedence violating nodes
+      def check_precedence(first_nodes, next_nodes)
+        next_nodes.each do |each_next_node|
+          first_nodes.each do |each_first_node|
+            if component_precedes?(each_first_node, each_next_node)
+              return [each_first_node, each_next_node]
             end
           end
-          nil
         end
+        nil
+      end
 
-        # If first node does not precede next_node, sets appropriate instance variables for reporting
-        def component_precedes?(first_node, next_node)
-          return false if line_number(first_node) < line_number(next_node)
-          @offense_source_range = first_node.source_range
-          @offensive_node = first_node
-          true
-        end
+      # If first node does not precede next_node, sets appropriate instance variables for reporting
+      def component_precedes?(first_node, next_node)
+        return false if line_number(first_node) < line_number(next_node)
+        @offense_source_range = first_node.source_range
+        @offensive_node = first_node
+        true
+      end
 
-        # Returns the array of arguments of the method_node
-        def parameters(method_node)
-          return unless method_node.send_type?
-          method_node.method_args
-        end
+      # Returns the array of arguments of the method_node
+      def parameters(method_node)
+        return unless method_node.send_type?
+        method_node.method_args
+      end
 
-        # Returns the begin position of the node's line in source code
-        def line_start_column(node)
-          node.source_range.source_buffer.line_range(node.loc.line).begin_pos
-        end
+      # Returns the begin position of the node's line in source code
+      def line_start_column(node)
+        node.source_range.source_buffer.line_range(node.loc.line).begin_pos
+      end
 
-        # Returns the begin position of the node in source code
-        def start_column(node)
-          node.source_range.begin_pos
-        end
+      # Returns the begin position of the node in source code
+      def start_column(node)
+        node.source_range.begin_pos
+      end
 
-        # Returns the line number of the node
-        def line_number(node)
-          node.loc.line
-        end
+      # Returns the line number of the node
+      def line_number(node)
+        node.loc.line
+      end
 
-        # Returns the class node's name, nil if not a class node
-        def class_name(node)
-          @offensive_node = node
-          @offense_source_range = node.source_range
-          node.const_name
-        end
+      # Returns the class node's name, nil if not a class node
+      def class_name(node)
+        @offensive_node = node
+        @offense_source_range = node.source_range
+        node.const_name
+      end
 
-        # Returns the method name for a def node
-        def method_name(node)
-          node.children[0] if node.def_type?
-        end
+      # Returns the method name for a def node
+      def method_name(node)
+        node.children[0] if node.def_type?
+      end
 
-        # Returns the node size in the source code
-        def size(node)
-          node.source_range.size
-        end
+      # Returns the node size in the source code
+      def size(node)
+        node.source_range.size
+      end
 
-        # Returns the block length of the block node
-        def block_size(block)
-          block_length(block)
-        end
+      # Returns the block length of the block node
+      def block_size(block)
+        block_length(block)
+      end
 
-        # Source buffer is required as an argument to report style violations
-        def source_buffer(node)
-          node.source_range.source_buffer
-        end
+      # Source buffer is required as an argument to report style violations
+      def source_buffer(node)
+        node.source_range.source_buffer
+      end
 
-        # Returns the string representation if node is of type str
-        def string_content(node)
-          node.str_content if node.type == :str
-        end
+      # Returns the string representation if node is of type str
+      def string_content(node)
+        node.str_content if node.type == :str
+      end
 
-        # Returns printable component name
-        def format_component(component_node)
-          return component_node.method_name if component_node.send_type? || component_node.block_type?
-          method_name(component_node) if component_node.def_type?
-        end
+      # Returns printable component name
+      def format_component(component_node)
+        return component_node.method_name if component_node.send_type? || component_node.block_type?
+        method_name(component_node) if component_node.def_type?
+      end
 
-        def problem(msg)
-          add_offense(@offensive_node, @offense_source_range, msg)
-        end
+      def problem(msg)
+        add_offense(@offensive_node, @offense_source_range, msg)
+      end
 
-        private
+      private
 
-        def formula_class?(parent_class_node)
-          parent_class_node && parent_class_node.const_name == "Formula"
-        end
+      def formula_class?(parent_class_node)
+        parent_class_node && parent_class_node.const_name == "Formula"
+      end
 
-        def file_path_allowed?(file_path)
-          paths_to_exclude = [%r{/Library/Homebrew/compat/},
-                              %r{/Library/Homebrew/test/}]
-          return true if file_path.nil? # file_path is nil when source is directly passed to the cop eg., in specs
-          file_path !~ Regexp.union(paths_to_exclude)
-        end
+      def file_path_allowed?(file_path)
+        paths_to_exclude = [%r{/Library/Homebrew/compat/},
+                            %r{/Library/Homebrew/test/}]
+        return true if file_path.nil? # file_path is nil when source is directly passed to the cop eg., in specs
+        file_path !~ Regexp.union(paths_to_exclude)
       end
     end
   end

--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -11,7 +11,7 @@ module RuboCop
       # - Checks if `desc` begins with an article
       # - Checks for correct usage of `command-line` in `desc`
       # - Checks if `desc` contains the formula name
-      class FormulaDesc < FormulaCop
+      class Desc < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body)
           desc_call = find_node_method_by_name(body, :desc)
 

--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -3,7 +3,7 @@ require_relative "../extend/string"
 
 module RuboCop
   module Cop
-    module Homebrew
+    module FormulaAuditStrict
       # This cop audits `desc` in Formulae
       #
       # - Checks for existence of `desc`

--- a/Library/Homebrew/test/rubocops/bottle_block_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle_block_cop_spec.rb
@@ -3,7 +3,7 @@ require "rubocop/rspec/support"
 require_relative "../../extend/string"
 require_relative "../../rubocops/bottle_block_cop"
 
-describe RuboCop::Cop::FormulaAuditStrict::CorrectBottleBlock do
+describe RuboCop::Cop::FormulaAuditStrict::BottleBlock do
   subject(:cop) { described_class.new }
 
   context "When auditing Bottle Block" do

--- a/Library/Homebrew/test/rubocops/bottle_block_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle_block_cop_spec.rb
@@ -3,7 +3,7 @@ require "rubocop/rspec/support"
 require_relative "../../extend/string"
 require_relative "../../rubocops/bottle_block_cop"
 
-describe RuboCop::Cop::Homebrew::CorrectBottleBlock do
+describe RuboCop::Cop::FormulaAuditStrict::CorrectBottleBlock do
   subject(:cop) { described_class.new }
 
   context "When auditing Bottle Block" do

--- a/Library/Homebrew/test/rubocops/components_order_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_cop_spec.rb
@@ -3,7 +3,7 @@ require "rubocop/rspec/support"
 require_relative "../../extend/string"
 require_relative "../../rubocops/components_order_cop"
 
-describe RuboCop::Cop::Homebrew::FormulaComponentsOrder do
+describe RuboCop::Cop::FormulaAuditStrict::ComponentsOrder do
   subject(:cop) { described_class.new }
 
   context "When auditing formula components order" do

--- a/Library/Homebrew/test/rubocops/components_redundancy_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_cop_spec.rb
@@ -3,7 +3,7 @@ require "rubocop/rspec/support"
 require_relative "../../extend/string"
 require_relative "../../rubocops/components_redundancy_cop"
 
-describe RuboCop::Cop::Homebrew::ComponentsRedundancy do
+describe RuboCop::Cop::FormulaAuditStrict::ComponentsRedundancy do
   subject(:cop) { described_class.new }
 
   context "When auditing formula components common errors" do

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -3,7 +3,7 @@ require "rubocop/rspec/support"
 require_relative "../../extend/string"
 require_relative "../../rubocops/formula_desc_cop"
 
-describe RuboCop::Cop::Homebrew::FormulaDesc do
+describe RuboCop::Cop::FormulaAuditStrict::FormulaDesc do
   subject(:cop) { described_class.new }
 
   context "When auditing formula desc" do

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -3,7 +3,7 @@ require "rubocop/rspec/support"
 require_relative "../../extend/string"
 require_relative "../../rubocops/formula_desc_cop"
 
-describe RuboCop::Cop::FormulaAuditStrict::FormulaDesc do
+describe RuboCop::Cop::FormulaAuditStrict::Desc do
   subject(:cop) { described_class.new }
 
   context "When auditing formula desc" do

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -402,7 +402,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--env=std` is passed, use the standard `PATH` instead of superenv's.
 
-  * `style` [`--fix`] [`--display-cop-names`] [`files`|`taps`|`formulae`]:
+  * `style` [`--fix`] [`--display-cop-names`] [`--only-cops=`[COP1,COP2..]|`--except-cops=`[COP1,COP2..]] [`files`|`taps`|`formulae`]:
     Check formulae or files for conformance to Homebrew style guidelines.
 
     `formulae` and `files` may not be combined. If both are omitted, style will run
@@ -414,6 +414,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--display-cop-names` is passed, the RuboCop cop name for each violation
     is included in the output.
+
+    If `--only-cops` is passed, only the given Rubocop cop(s)' violations would be checked.
+
+    If `--except-cops` is passed, the given Rubocop cop(s)' checks would be skipped.
 
     Exits with a non-zero status if any style violations are found.
 
@@ -606,7 +610,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
 ## DEVELOPER COMMANDS
 
-  * `audit` [`--strict`] [`--fix`] [`--online`] [`--new-formula`] [`--display-cop-names`] [`--display-filename`] [`--only=``method`|`--except=``method] [<formulae`]:
+  * `audit` [`--strict`] [`--fix`] [`--online`] [`--new-formula`] [`--display-cop-names`] [`--display-filename`] [`--only=``method`|`--except=``method`] [`--only-cops=`[COP1,COP2..]|`--except-cops=`[COP1,COP2..]] [`formulae`]:
     Check `formulae` for Homebrew coding style violations. This should be
     run before submitting a new formula.
 
@@ -635,9 +639,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--except` is passed, the methods named `audit_`method`` will not be run.
 
-    If `--only-cops` is passed, only the mentioned cops' violations would be checked.
+    If `--only-cops` is passed, only the given Rubocop cop(s)' violations would be checked.
 
-    If `--except-cops` is passed, the mentioned cops' checks would be skipped.
+    If `--except-cops` is passed, the given Rubocop cop(s)' checks would be skipped.
 
     `audit` exits with a non-zero status if any errors are found. This is useful,
     for instance, for implementing pre-commit hooks.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -635,6 +635,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--except` is passed, the methods named `audit_`method`` will not be run.
 
+    If `--only-cops` is passed, only the mentioned cops' violations would be checked.
+
+    If `--except-cops` is passed, the mentioned cops' checks would be skipped.
+
     `audit` exits with a non-zero status if any errors are found. This is useful,
     for instance, for implementing pre-commit hooks.
 

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "April 2017" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "May 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "April 2017" "Homebrew" "brew"
+.TH "BREW" "1" "May 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -415,7 +415,7 @@ Start a Homebrew build environment shell\. Uses our years\-battle\-hardened Home
 If \fB\-\-env=std\fR is passed, use the standard \fBPATH\fR instead of superenv\'s\.
 .
 .TP
-\fBstyle\fR [\fB\-\-fix\fR] [\fB\-\-display\-cop\-names\fR] [\fIfiles\fR|\fItaps\fR|\fIformulae\fR]
+\fBstyle\fR [\fB\-\-fix\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-only\-cops=\fR[COP1,COP2\.\.]|\fB\-\-except\-cops=\fR[COP1,COP2\.\.]] [\fIfiles\fR|\fItaps\fR|\fIformulae\fR]
 Check formulae or files for conformance to Homebrew style guidelines\.
 .
 .IP
@@ -426,6 +426,12 @@ If \fB\-\-fix\fR is passed, style violations will be automatically fixed using R
 .
 .IP
 If \fB\-\-display\-cop\-names\fR is passed, the RuboCop cop name for each violation is included in the output\.
+.
+.IP
+If \fB\-\-only\-cops\fR is passed, only the given Rubocop cop(s)\' violations would be checked\.
+.
+.IP
+If \fB\-\-except\-cops\fR is passed, the given Rubocop cop(s)\' checks would be skipped\.
 .
 .IP
 Exits with a non\-zero status if any style violations are found\.
@@ -631,7 +637,7 @@ Print the version number of Homebrew to standard output and exit\.
 .SH "DEVELOPER COMMANDS"
 .
 .TP
-\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-fix\fR] [\fB\-\-online\fR] [\fB\-\-new\-formula\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-display\-filename\fR] [\fB\-\-only=\fR\fImethod\fR|\fB\-\-except=\fR\fImethod] [<formulae\fR]
+\fBaudit\fR [\fB\-\-strict\fR] [\fB\-\-fix\fR] [\fB\-\-online\fR] [\fB\-\-new\-formula\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-display\-filename\fR] [\fB\-\-only=\fR\fImethod\fR|\fB\-\-except=\fR\fImethod\fR] [\fB\-\-only\-cops=\fR[COP1,COP2\.\.]|\fB\-\-except\-cops=\fR[COP1,COP2\.\.]] [\fIformulae\fR]
 Check \fIformulae\fR for Homebrew coding style violations\. This should be run before submitting a new formula\.
 .
 .IP
@@ -662,10 +668,10 @@ If \fB\-\-only\fR is passed, only the methods named \fBaudit_<method>\fR will be
 If \fB\-\-except\fR is passed, the methods named \fBaudit_<method>\fR will not be run\.
 .
 .IP
-If \fB\-\-only\-cops\fR is passed, only the mentioned cops\' violations would be checked\.
+If \fB\-\-only\-cops\fR is passed, only the given Rubocop cop(s)\' violations would be checked\.
 .
 .IP
-If \fB\-\-except\-cops\fR is passed, the mentioned cops\' checks would be skipped\.
+If \fB\-\-except\-cops\fR is passed, the given Rubocop cop(s)\' checks would be skipped\.
 .
 .IP
 \fBaudit\fR exits with a non\-zero status if any errors are found\. This is useful, for instance, for implementing pre\-commit hooks\.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -662,6 +662,12 @@ If \fB\-\-only\fR is passed, only the methods named \fBaudit_<method>\fR will be
 If \fB\-\-except\fR is passed, the methods named \fBaudit_<method>\fR will not be run\.
 .
 .IP
+If \fB\-\-only\-cops\fR is passed, only the mentioned cops\' violations would be checked\.
+.
+.IP
+If \fB\-\-except\-cops\fR is passed, the mentioned cops\' checks would be skipped\.
+.
+.IP
 \fBaudit\fR exits with a non\-zero status if any errors are found\. This is useful, for instance, for implementing pre\-commit hooks\.
 .
 .TP


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
As discussed in #2478 , this PR implements `--only` , `--except` kind of functionality for RuboCop Cops and also refactors existing cops into two "departments" viz., `FormulaAudit` and `FormulaAuditStrict` to separate analogous audit rules.
Please suggest better names if the current naming conventions are not acceptable. I could also probably write integration tests for the new options? 

Example commands:
`brew audit --only-cops=Desc,CompentsOrder nrpe`
`brew audit --except-cops=BottleBlock`
