### PR TITLE
utils_spec: fix #which_editor test

### DIFF
--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -195,7 +195,7 @@ describe "globally-scoped helper methods" do
     FileUtils.touch editor
     FileUtils.chmod 0755, editor
 
-    expect(which_editor).to eql editor
+    expect(which_editor).to eql editor.to_s
   end
 
   specify "#gzip" do


### PR DESCRIPTION
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?
        (Yes, with the changes from @MikeMcQuaid's PR)

-----
Expect a string instead of a Pathname,
goes with the changes to Utils#which_editor in #2534