### PR TITLE
Remove puts_hash, require pp

### DIFF
--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -10,6 +10,7 @@ require "exceptions"
 require "set"
 require "rbconfig"
 require "official_taps"
+require "pp"
 
 ARGV.extend(HomebrewArgvExtension)
 

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -270,12 +270,4 @@ describe "globally-scoped helper methods" do
       }.to raise_error(MethodDeprecatedError, %r{method.*replacement.*homebrew/homebrew-core.*homebrew/core}m)
     end
   end
-
-  describe "#puts_hash" do
-    it "outputs a hash" do
-      expect {
-        puts_hash(a: 1, b: 2, c: [3, { "d"=>4 }])
-      }.to output("a: 1\nb: 2\nc: [3, {\"d\"=>4}]\n").to_stdout
-    end
-  end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -526,19 +526,3 @@ def migrate_legacy_keg_symlinks_if_necessary
   end
   FileUtils.rm_rf legacy_pinned_kegs
 end
-
-def puts_hash(hash, indent: 0)
-  return hash unless hash.is_a? Hash
-  hash.each do |key, value|
-    indent_spaces = " " * (indent * 2)
-    printf "#{indent_spaces}#{key}:"
-    if value.is_a? Hash
-      puts
-      puts_hash(value, indent: indent+1)
-    else
-      puts " #{value}"
-    end
-  end
-  hash
-end
-alias ph puts_hash


### PR DESCRIPTION
I wasn’t aware this existed when I created puts_hash so: may as well remove it.

Thanks to @alyssais for pointing this out.