### PR TITLE
search: use single HTTP call for tap searches.

### DIFF
--- a/Library/Homebrew/test/cmd/search_remote_tap_spec.rb
+++ b/Library/Homebrew/test/cmd/search_remote_tap_spec.rb
@@ -1,19 +1,24 @@
 require "cmd/search"
 
 describe Homebrew do
-  specify "#search_tap" do
+  specify "#search_taps" do
     json_response = {
-      "tree" => [
+      "items" => [
         {
-          "path" => "Formula/not-a-formula.rb",
-          "type" => "blob",
+          "path" => "Formula/some-formula.rb",
+          "repository" => {
+            "name" => "homebrew-foo",
+            "owner" => {
+              "login" => "Homebrew",
+            },
+          },
         },
       ],
     }
 
     allow(GitHub).to receive(:open).and_yield(json_response)
 
-    expect(described_class.search_tap("homebrew", "not-a-tap", "not-a-formula"))
-      .to eq(["homebrew/not-a-tap/not-a-formula"])
+    expect(described_class.search_taps("some-formula"))
+      .to match(["homebrew/foo/some-formula"])
   end
 end


### PR DESCRIPTION
Use GitHub's code search API to search using the filename based on the search query. This means we only need a single HTTP call and no more multithreading madness. This also means we're able to search everything in the Homebrew and Caskroom organisation by default without having to maintain a list of things to search (and not) in here.

CC @reitermarkus as we talked about this in #2254.