### PR TITLE
xcode: update Sierra CLT version to 802.0.42

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -213,7 +213,7 @@ module OS
         # on the older supported platform for that Xcode release, i.e there's no
         # CLT package for 10.11 that contains the Clang version from Xcode 8.
         case MacOS.version
-        when "10.12" then "802.0.38"
+        when "10.12" then "802.0.42"
         when "10.11" then "800.0.42.1"
         when "10.10" then "700.1.81"
         when "10.9"  then "600.0.57"


### PR DESCRIPTION
update Sierra CLT version to 802.0.42