### PR TITLE
Allow forcing Homebrew GitHub organisation.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -23,7 +23,7 @@ git() {
 }
 
 git_init_if_necessary() {
-  if [[ -n "$HOMEBREW_MACOS" ]]
+  if [[ -n "$HOMEBREW_MACOS" ]] || [[ -n "$HOMEBREW_FORCE_HOMEBREW_ORG" ]]
   then
     BREW_OFFICIAL_REMOTE="https://github.com/Homebrew/brew"
     CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/homebrew-core"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -526,13 +526,11 @@ end
 
 # A specialized {Tap} class for the core formulae
 class CoreTap < Tap
-  if OS.mac?
-    def default_remote
-      "https://github.com/Homebrew/homebrew-core"
-    end
-  else
-    def default_remote
-      "https://github.com/Linuxbrew/homebrew-core"
+  def default_remote
+    if OS.mac? || ENV["$HOMEBREW_FORCE_HOMEBREW_ORG"]
+      "https://github.com/Homebrew/homebrew-core".freeze
+    else
+      "https://github.com/Linuxbrew/homebrew-core".freeze
     end
   end
 


### PR DESCRIPTION
On Linux this defaults to Linuxbrew but in some cases (i.e. a Linux machine performing uploads for Homebrew) we want to allow this to be overridden back to the defaults.

Relies on https://github.com/Homebrew/homebrew-test-bot/pull/69