### PR TITLE
formula_installer: improve install/upgrade message

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -217,11 +217,20 @@ class FormulaInstaller
     # function but after instantiating this class so that it can avoid having to
     # relink the active keg if possible (because it is slow).
     if formula.linked_keg.directory?
-      # some other version is already installed *and* linked
-      raise CannotInstallFormulaError, <<-EOS.undent
-        #{formula.name}-#{formula.linked_keg.resolved_path.basename} already installed
-        To install this version, first `brew unlink #{formula.name}`
+      message = <<-EOS.undent
+        #{formula.name} #{formula.linked_keg.resolved_path.basename} is already installed
       EOS
+      message += if formula.outdated? && !formula.head?
+        <<-EOS.undent
+          To upgrade to #{formula.version}, run `brew upgrade #{formula.name}`
+        EOS
+      else
+        # some other version is already installed *and* linked
+        <<-EOS.undent
+          To install #{formula.version}, first run `brew unlink #{formula.name}`
+        EOS
+      end
+      raise CannotInstallFormulaError, message
     end
 
     check_conflicts

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -77,7 +77,7 @@ describe "brew install", :integration_test do
     EOS
 
     expect { brew "install", "testball1" }
-      .to output(/first `brew unlink testball1`/).to_stderr
+      .to output(/`brew upgrade testball1`/).to_stderr
       .and not_to_output.to_stdout
       .and be_a_failure
 


### PR DESCRIPTION
If you `brew install` a formula that's already installed you get:
>  Warning: ripgrep-0.5.1 already installed

If you `brew install` an outdated formula that's installed you get:
>  Error: ripgrep-0.5.1 already installed. To install this version, first `brew unlink ripgrep`

Instead, suggest that the user should `brew upgrade` in this case. If the formula isn't outdated use the previous  message.

CC @ilovezfs for thoughts.

Fixes #2543.