### PR TITLE
tap-new: bump Xcode to 8.3.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -47,7 +47,7 @@ module Homebrew
       language: ruby
       os: osx
       env: OSX=10.12
-      osx_image: xcode8.1
+      osx_image: xcode8.3
       rvm: system
 
       before_install:


### PR DESCRIPTION
Update this to the current latest Travis CI supports (which we're using).