### PR TITLE
Increment system command timeout to avoid problems installing some casks

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/system_command.rb
+++ b/Library/Homebrew/cask/lib/hbc/system_command.rb
@@ -92,7 +92,7 @@ module Hbc
 
     def each_line_from(sources)
       loop do
-        selected_sources = IO.select(sources, [], [], 10)
+        selected_sources = IO.select(sources, [], [], 50)
 
         break if selected_sources.nil?
 


### PR DESCRIPTION
Depending on the computer speed and the cask size, the former timeout
caused some problems installing some programs like Google Chrome,
Spotify, or LibreOffice.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This fixes https://github.com/caskroom/homebrew-cask/issues/33116 and https://github.com/caskroom/homebrew-cask/issues/32830