### PR TITLE
pull: fix status code check in check_bintray_mirror

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -608,7 +608,7 @@ module Homebrew
   def check_bintray_mirror(name, url)
     headers = curl_output("--connect-timeout", "15", "--head", url)[0]
     status_code = headers.scan(%r{^HTTP\/.* (\d+)}).last.first
-    return if status_code.start_with?("3")
+    return if status_code.start_with?("2")
     opoo "The Bintray mirror #{url} is not reachable (HTTP status code #{status_code})."
     opoo "Do you need to upload it with `brew mirror #{name}`?"
   end


### PR DESCRIPTION
Fix an issue in #2252. [Report by @ilovezfs](https://github.com/Homebrew/brew/pull/2252#issuecomment-298151694):

```
Josephs-MacBook-Pro:~ joe$ brew pull https://github.com/Homebrew/homebrew-core/pull/12969
==> Fetching patch 
Patch: https://github.com/Homebrew/homebrew-core/pull/12969.patch
==> Applying patch
Applying: openssl: remove support for universal build
Warning: The Bintray mirror https://dl.bintray.com/homebrew/mirror/openssl-1.0.2k.tar.gz is not reachable (HTTP status code 200).
```

The status code of the last redirect should be 2xx to be deemed successful. I don't remember why I was checking for 3xx; most likely a typo.
