### PR TITLE
Revert "Fix `IO#select` blocking."

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/system_command.rb
+++ b/Library/Homebrew/cask/lib/hbc/system_command.rb
@@ -92,25 +92,17 @@ module Hbc
 
     def each_line_from(sources)
       loop do
-        selected_sources = IO.select(sources, [], [], 10)
-
-        break if selected_sources.nil?
-
-        readable_sources = selected_sources[0].delete_if(&:eof?)
-
-        readable_sources.each do |source|
+        readable_sources = IO.select(sources)[0]
+        readable_sources.delete_if(&:eof?).first(1).each do |source|
           type = (source == sources[0] ? :stdout : :stderr)
-
           begin
             yield(type, source.readline_nonblock || "")
           rescue IO::WaitReadable, EOFError
             next
           end
         end
-
         break if readable_sources.empty?
       end
-
       sources.each(&:close_read)
     end
 


### PR DESCRIPTION
Reverts Homebrew/brew#2517

This may cause some timeout problems on slow machines or big casks. See caskroom/homebrew-cask#33116 and caskroom/homebrew-cask#32830