### PR TITLE
utils: create GEM_HOME when installing Gems.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -189,6 +189,9 @@ module Homebrew
     Gem.clear_paths
     Gem::Specification.reset
 
+    # Create GEM_HOME which may not exist yet so it exists when creating PATH.
+    FileUtils.mkdir_p Gem.bindir
+
     # Add Gem binary directory and (if missing) Ruby binary directory to PATH.
     path = PATH.new(ENV["PATH"])
     path.prepend(RUBY_BIN) if which("ruby") != RUBY_PATH


### PR DESCRIPTION
It may not exist before Gem installation which means that the resulting installed gem will not be found in the PATH.

CC @reitermarkus as this was a regression from #2560. Can you go through the diff there and check all the other uses of `.existing` don't exhibit similar behaviour. Similarly, `.existing` may want to skip relative directories like `bin` in the `PATH` (i.e. add them unconditionally) as the `.existing` check will add them or not based on the current directory which may not be the directory used at `which`-time.