### PR TITLE
Install etc/var files on postinstall.

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -7,7 +7,10 @@ module Homebrew
   module_function
 
   def postinstall
-    ARGV.resolved_formulae.each { |f| run_post_install(f) if f.post_install_defined? }
+    ARGV.resolved_formulae.each do |f|
+      ohai "Postinstalling #{f}"
+      run_post_install(f)
+    end
   end
 
   def run_post_install(formula)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1005,11 +1005,6 @@ class Formula
   def post_install; end
 
   # @private
-  def post_install_defined?
-    method(:post_install).owner == self.class
-  end
-
-  # @private
   def run_post_install
     @prefix_returns_versioned_prefix = true
     build = self.build
@@ -1024,6 +1019,11 @@ class Formula
     ENV["HOMEBREW_PATH"] = nil
 
     ENV.clear_sensitive_environment!
+
+    Pathname.glob("#{bottle_prefix}/{etc,var}/**/*") do |path|
+      path.extend(InstallRenamed)
+      path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
+    end
 
     with_logging("post_install") do
       post_install

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -564,13 +564,11 @@ class FormulaInstaller
       fix_dynamic_linkage(keg)
     end
 
-    if formula.post_install_defined?
-      if build_bottle?
-        ohai "Not running post_install as we're building a bottle"
-        puts "You can run it manually using `brew postinstall #{formula.full_name}`"
-      else
-        post_install
-      end
+    if build_bottle?
+      ohai "Not running post_install as we're building a bottle"
+      puts "You can run it manually using `brew postinstall #{formula.full_name}`"
+    else
+      post_install
     end
 
     caveats
@@ -831,12 +829,6 @@ class FormulaInstaller
 
     skip_linkage = formula.bottle_specification.skip_relocation?
     keg.replace_placeholders_with_locations tab.changed_files, skip_linkage: skip_linkage
-
-    Pathname.glob("#{formula.bottle_prefix}/{etc,var}/**/*") do |path|
-      path.extend(InstallRenamed)
-      path.cp_path_sub(formula.bottle_prefix, HOMEBREW_PREFIX)
-    end
-    FileUtils.rm_rf formula.bottle_prefix
 
     tab = Tab.for_keg(keg)
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -10,7 +10,6 @@ RSpec::Matchers.alias_matcher :supersede_an_installed_formula, :be_supersedes_an
 RSpec::Matchers.alias_matcher :have_changed_alias, :be_alias_changed
 
 RSpec::Matchers.alias_matcher :have_option_defined, :be_option_defined
-RSpec::Matchers.alias_matcher :have_post_install_defined, :be_post_install_defined
 RSpec::Matchers.alias_matcher :have_test_defined, :be_test_defined
 RSpec::Matchers.alias_matcher :pour_bottle, :be_pour_bottle
 
@@ -622,23 +621,6 @@ describe Formula do
     end
 
     expect(f.desc).to eq("a formula")
-  end
-
-  specify "#post_install_defined?" do
-    f1 = formula do
-      url "foo-1.0"
-
-      def post_install
-        # do nothing
-      end
-    end
-
-    f2 = formula do
-      url "foo-1.0"
-    end
-
-    expect(f1).to have_post_install_defined
-    expect(f2).not_to have_post_install_defined
   end
 
   specify "#test_defined?" do


### PR DESCRIPTION
Also, don't delete them after that. This means that `brew postinstall` becomes a way to easily reinstall configuration files for any formula without needing any changes to any bottles or requiring a reinstall.