### PR TITLE
Remove `existing` from PATH when adding `Gem.bindir`.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -189,14 +189,11 @@ module Homebrew
     Gem.clear_paths
     Gem::Specification.reset
 
-    # Create GEM_HOME which may not exist yet so it exists when creating PATH.
-    FileUtils.mkdir_p Gem.bindir
-
     # Add Gem binary directory and (if missing) Ruby binary directory to PATH.
     path = PATH.new(ENV["PATH"])
     path.prepend(RUBY_BIN) if which("ruby") != RUBY_PATH
     path.prepend(Gem.bindir)
-    ENV["PATH"] = path.existing
+    ENV["PATH"] = path
 
     if Gem::Specification.find_all_by_name(name, version).empty?
       ohai "Installing or updating '#{name}' gem"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?


This line didn't use `path_to_s` (predecessor of `PATH#existing`) before https://github.com/Homebrew/brew/pull/2560.