### PR TITLE
Remove unused command_args

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/utils.rb
+++ b/Library/Homebrew/cask/lib/hbc/utils.rb
@@ -43,7 +43,7 @@ module Hbc
             p.rmtree
           else
             command.run("/bin/rm",
-                        args: command_args + ["-r", "-f", "--", p],
+                        args: ["-r", "-f", "--", p],
                         sudo: true)
           end
         end


### PR DESCRIPTION
Extra command_args in gain_permissions_remove caused silent failure and path never gets deleted.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
