### PR TITLE
Remove cask artifact `uninstall` sort

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/installer.rb
+++ b/Library/Homebrew/cask/lib/hbc/installer.rb
@@ -336,13 +336,7 @@ module Hbc
     def uninstall_artifacts
       odebug "Un-installing artifacts"
       artifacts = Artifact.for_cask(@cask, command: @command, force: force)
-
-      # Make sure the `uninstall` stanza is run first, as it
-      # may depend on other artifacts still being installed.
-      artifacts = artifacts.sort_by { |a| a.is_a?(Artifact::Uninstall) ? -1 : 1 }
-
       odebug "#{artifacts.length} artifact/s defined", artifacts
-
       artifacts.each do |artifact|
         next unless artifact.respond_to?(:uninstall_phase)
         odebug "Un-installing artifact of class #{artifact.class}"

--- a/Library/Homebrew/test/cask/cli/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/cli/uninstall_spec.rb
@@ -58,26 +58,6 @@ describe Hbc::CLI::Uninstall, :cask do
     expect(Hbc.appdir.join("Caffeine.app")).not_to exist
   end
 
-  it "calls `uninstall` before removing artifacts" do
-    cask = Hbc::CaskLoader.load_from_file(TEST_FIXTURE_DIR/"cask/Casks/with-uninstall-script-app.rb")
-
-    shutup do
-      Hbc::Installer.new(cask).install
-    end
-
-    expect(cask).to be_installed
-    expect(Hbc.appdir.join("MyFancyApp.app")).to exist
-
-    expect {
-      shutup do
-        Hbc::CLI::Uninstall.run("with-uninstall-script-app")
-      end
-    }.not_to raise_error
-
-    expect(cask).not_to be_installed
-    expect(Hbc.appdir.join("MyFancyApp.app")).not_to exist
-  end
-
   it "can uninstall Casks when the uninstall script is missing, but only when using `--force`" do
     cask = Hbc::CaskLoader.load_from_file(TEST_FIXTURE_DIR/"cask/Casks/with-uninstall-script-app.rb")
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently when casks are uninstalled, artifacts are sorted so that `uninstall_preflight` runs after `uninstall`.

Fixes https://github.com/caskroom/homebrew-cask/issues/32300

Partially reverts https://github.com/Homebrew/brew/pull/2033