### PR TITLE
Relocate virtualenv orig-prefix

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -133,6 +133,7 @@ class Keg
       files = Set.new path.find.reject { |pn|
         next true if pn.symlink?
         next true if pn.directory?
+        next false if pn.basename.to_s == "orig-prefix.txt" # for python virtualenvs
         next true if Metafiles::EXTENSIONS.include?(pn.extname)
         if pn.text_executable?
           text_files << pn


### PR DESCRIPTION
Virtualenvs remember the path to the stdlib in a file named
orig_prefix.txt. This file wasn't being relocated because Homebrew skips
files that look like they're intended for human consumption by matching
against the list of metafile extensions. This led to the bug described
in https://github.com/Homebrew/homebrew-core/issues/12869. This fixes
relocation by creating an exception for orig-prefix.txt.