### PR TITLE
Fix internal links on the manpage

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -2,7 +2,7 @@
 #:    Upload logs for a failed build of <formula> to a new Gist.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
-#:    in several different ways. See [SPECIFYING FORMULAE][].
+#:    in several different ways. See [SPECIFYING FORMULAE](#specifying-formulae).
 #:
 #:    If `--new-issue` is passed, automatically create a new issue in the appropriate
 #:    GitHub repository as well as creating the Gist.

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -2,7 +2,7 @@
 #:    Install <formula>.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
-#:    in several different ways. See [SPECIFYING FORMULAE][].
+#:    in several different ways. See [SPECIFYING FORMULAE](#specifying-formulae).
 #:
 #:    If `--debug` (or `-d`) is passed and brewing fails, open an interactive debugging
 #:    session with access to IRB or a shell inside the temporary build directory.

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -24,7 +24,7 @@ didn't include with macOS.
 
 ## ESSENTIAL COMMANDS
 
-For the full command list, see the [COMMANDS][] section.
+For the full command list, see the [COMMANDS](#commands) section.
 
 With `--verbose` or `-v`, many commands print extra debugging information. Note that these flags should only appear after a command.
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -167,7 +167,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Upload logs for a failed build of `formula` to a new Gist.
 
     `formula` is usually the name of the formula to install, but it can be specified
-    in several different ways. See [SPECIFYING FORMULAE][].
+    in several different ways. See [SPECIFYING FORMULAE][#specifying-formulae].
 
     If `--new-issue` is passed, automatically create a new issue in the appropriate
     GitHub repository as well as creating the Gist.
@@ -202,7 +202,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified
-    in several different ways. See [SPECIFYING FORMULAE][].
+    in several different ways. See [SPECIFYING FORMULAE][#specifying-formulae].
 
     If `--debug` (or `-d`) is passed and brewing fails, open an interactive debugging
     session with access to IRB or a shell inside the temporary build directory.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -13,7 +13,7 @@ didn't include with macOS.
 
 ## ESSENTIAL COMMANDS
 
-For the full command list, see the [COMMANDS][] section.
+For the full command list, see the [COMMANDS](#commands) section.
 
 With `--verbose` or `-v`, many commands print extra debugging information. Note that these flags should only appear after a command.
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -167,7 +167,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Upload logs for a failed build of `formula` to a new Gist.
 
     `formula` is usually the name of the formula to install, but it can be specified
-    in several different ways. See [SPECIFYING FORMULAE][#specifying-formulae].
+    in several different ways. See [SPECIFYING FORMULAE](#specifying-formulae).
 
     If `--new-issue` is passed, automatically create a new issue in the appropriate
     GitHub repository as well as creating the Gist.
@@ -202,7 +202,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified
-    in several different ways. See [SPECIFYING FORMULAE][#specifying-formulae].
+    in several different ways. See [SPECIFYING FORMULAE](#specifying-formulae).
 
     If `--debug` (or `-d`) is passed and brewing fails, open an interactive debugging
     session with access to IRB or a shell inside the temporary build directory.

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "May 2017" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "June 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "May 2017" "Homebrew" "brew"
+.TH "BREW" "1" "June 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS


### PR DESCRIPTION
Similar to #2494, but a different page. The markdown formatting isn't correct, and within page links don't go to the right place (wrong case).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
