### PR TITLE
Tweak Gem vendoring.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -8,13 +8,13 @@ std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 RUBY_TWO = RUBY_VERSION.split(".").first.to_i >= 2
 raise "Homebrew must be run under Ruby 2!" unless RUBY_TWO
 
-homebrew_library_path = File.dirname(File.realpath(__FILE__))
-$:.unshift(homebrew_library_path)
-
-require_relative "#{homebrew_library_path}/vendor/bundler/setup"
-
 require "pathname"
-HOMEBREW_LIBRARY_PATH = Pathname.new(homebrew_library_path)
+HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
+$:.unshift(HOMEBREW_LIBRARY_PATH)
+
+load_path_before_bundler = $:.dup
+require_relative "#{HOMEBREW_LIBRARY_PATH}/vendor/bundler/setup"
+ENV["HOMEBREW_GEMS_LOAD_PATH"] = ($: - load_path_before_bundler).join(":")
 
 require "global"
 require "tap"
@@ -24,8 +24,6 @@ if ARGV == %w[--version] || ARGV == %w[-v]
   puts "Homebrew/homebrew-core #{CoreTap.instance.version_string}"
   exit 0
 end
-
-HOMEBREW_GEM_HOME = HOMEBREW_LIBRARY_PATH/"vendor/#{RUBY_ENGINE}/#{RUBY_VERSION}"
 
 def require?(path)
   require path
@@ -60,17 +58,20 @@ begin
   path.append(Pathname.glob(Tap::TAP_DIRECTORY/"*/*/cmd"))
 
   # Add RubyGems.
-  ENV["GEM_HOME"] = ENV["GEM_PATH"] = HOMEBREW_GEM_HOME
+  HOMEBREW_GEM_HOME = HOMEBREW_LIBRARY_PATH/"vendor/#{RUBY_ENGINE}/#{RUBY_VERSION}"
   path.append(HOMEBREW_GEM_HOME/"bin")
-
-  # Make RubyGems notice environment changes.
-  Gem.clear_paths
-  Gem::Specification.reset
 
   # Add SCM wrappers.
   path.append(HOMEBREW_SHIMS_PATH/"scm")
 
   ENV["PATH"] = path
+
+  # Setup RubyGems environment.
+  ENV["GEM_HOME"] = ENV["GEM_PATH"] = HOMEBREW_GEM_HOME
+  # Make RubyGems notice environment changes.
+  Gem.clear_paths
+  Gem::Specification.reset
+  Homebrew.run_bundler_if_needed! unless HOMEBREW_GEM_HOME.exist?
 
   if cmd
     internal_cmd = require? HOMEBREW_LIBRARY_PATH.join("cmd", cmd)

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -69,10 +69,6 @@ then
   odie "Cowardly refusing to continue at this prefix: $HOMEBREW_PREFIX"
 fi
 
-# Save value to use for installing gems
-export GEM_OLD_HOME="$GEM_HOME"
-export GEM_OLD_PATH="$GEM_PATH"
-
 # Users may have these set, pointing the system Ruby
 # at non-system gem paths
 unset GEM_HOME

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -46,5 +46,8 @@ unless defined? HOMEBREW_LIBRARY_PATH
   HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
 end
 
+# Load path to vendored gems used by Homebrew
+HOMEBREW_GEMS_LOAD_PATH = ENV["HOMEBREW_GEMS_LOAD_PATH"]
+
 # Load path used by standalone scripts to access the Homebrew code base
-HOMEBREW_LOAD_PATH = HOMEBREW_LIBRARY_PATH
+HOMEBREW_LOAD_PATH = [HOMEBREW_LIBRARY_PATH, *HOMEBREW_GEMS_LOAD_PATH].join(":")

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -1,10 +1,11 @@
-require "macho"
 require "os/mac/architecture_list"
 
 module MachOShim
   # @private
   def macho
     @macho ||= begin
+      require "macho"
+
       MachO.open(to_s)
     end
   end
@@ -12,6 +13,8 @@ module MachOShim
   # @private
   def mach_data
     @mach_data ||= begin
+      require "macho"
+
       machos = []
       mach_data = []
 

--- a/Library/Homebrew/test/support/lib/config.rb
+++ b/Library/Homebrew/test/support/lib/config.rb
@@ -14,9 +14,9 @@ TEST_TMPDIR = ENV.fetch("HOMEBREW_TEST_TMPDIR") do |k|
 end
 
 # Paths pointing into the Homebrew code base that persist across test runs
-HOMEBREW_LIBRARY_PATH  = Pathname.new(File.expand_path("../../../..", __FILE__))
-HOMEBREW_SHIMS_PATH    = HOMEBREW_LIBRARY_PATH.parent+"Homebrew/shims"
-HOMEBREW_LOAD_PATH     = [File.expand_path("..", __FILE__), HOMEBREW_LIBRARY_PATH].join(":")
+HOMEBREW_LIBRARY_PATH   = Pathname.new(File.expand_path("../../../..", __FILE__))
+HOMEBREW_SHIMS_PATH     = HOMEBREW_LIBRARY_PATH.parent+"Homebrew/shims"
+HOMEBREW_LOAD_PATH      = [File.expand_path("..", __FILE__), HOMEBREW_LIBRARY_PATH, ENV["HOMEBREW_GEMS_LOAD_PATH"]].join(":")
 
 # Paths redirected to a temporary directory and wiped at the end of the test run
 HOMEBREW_PREFIX        = Pathname.new(TEST_TMPDIR).join("prefix")


### PR DESCRIPTION
If people have `HOMEBREW_RUBY_PATH` set then things explode in a rather confusing fashion. Instead, run `bundle` for them with the arguments that they'd want.

Also, move `macho` requires into the module itself; it's a pain having to do everything for Bundler before requiring `pathname` which is a core Ruby class.

Fixes https://github.com/Homebrew/homebrew-core/issues/13347