### PR TITLE
Add autocorrect method for ComponentsOrder rubocop and tests

### DIFF
--- a/Library/Homebrew/test/rubocops/components_order_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_cop_spec.rb
@@ -113,4 +113,51 @@ describe RuboCop::Cop::FormulaAuditStrict::ComponentsOrder do
       expect(actual.column).to eq(expected[:column])
     end
   end
+
+  context "When auditing formula components order with autocorrect" do
+    it "When url precedes homepage" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url "http://example.com/foo-1.0.tgz"
+          homepage "http://example.com"
+        end
+      EOS
+      correct_source = <<-EOS.undent
+        class Foo < Formula
+          homepage "http://example.com"
+          url "http://example.com/foo-1.0.tgz"
+        end
+      EOS
+
+      corrected_source = autocorrect_source(cop, source)
+      expect(corrected_source).to eq(correct_source)
+    end
+
+    it "When `resource` precedes `depends_on`" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url "https://example.com/foo-1.0.tgz"
+
+          resource "foo2" do
+            url "https://example.com/foo-2.0.tgz"
+          end
+
+          depends_on "openssl"
+        end
+      EOS
+      correct_source = <<-EOS.undent
+        class Foo < Formula
+          url "https://example.com/foo-1.0.tgz"
+
+          depends_on "openssl"
+
+          resource "foo2" do
+            url "https://example.com/foo-2.0.tgz"
+          end
+        end
+      EOS
+      corrected_source = autocorrect_source(cop, source)
+      expect(corrected_source).to eq(correct_source)
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Can fix components' order using to `brew audit --fix`, 

But please note that `autocorrect` is called just after `problem` is called, ~~and `autocorrect` works by swapping those two components in the source~~

Edit: `autocorrect` doesn't swap anymore, rather reorders the components.  


 During the re order (only for the components out of precedence order ) 
 -  linebreaks, and grouping of components are taken into account. ( A Multi line 
 component is surrounded by line breaks, while components of same type are placed together) 
 - First 8 components i.e., upto `version_scheme` are grouped together. 