### PR TITLE
tap: don't presume Formula/ if untapped

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -298,7 +298,7 @@ class Tap
 
   # path to the directory of all {Formula} files for this {Tap}.
   def formula_dir
-    @formula_dir ||= potential_formula_dirs.detect(&:directory?) || path/"Formula"
+    @formula_dir ||= potential_formula_dirs.detect(&:directory?)
   end
 
   def potential_formula_dirs


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I recently decided to switch from using our own version of `qt4` without webkit to the `cartr/qt4` tap, since they now have a version without webkit as well (https://github.com/osrf/homebrew-simulation/pull/240). I'm seeing errors when running `brew test-bot` (for example `brew test-bot gazebo7` on that branch):

~~~
$ brew test-bot gazebo7 --verbose
...
==> brew uses --recursive osrf/simulation/gazebo7
test-bot: Formulary.factory(osrf/simulation/gazebo7)
brew tap cartr/qt4
==> Tapping cartr/qt4
Cloning into '/usr/local/Homebrew/Library/Taps/cartr/homebrew-qt4'...
remote: Counting objects: 294, done.
remote: Total 294 (delta 0), reused 0 (delta 0), pack-reused 294
Receiving objects: 100% (294/294), 59.66 KiB | 0 bytes/s, done.
Resolving deltas: 100% (186/186), done.
Checking connectivity... done.
Tapped 21 formulae (46 files, 137.1KB)
Error: No available formula with the name "cartr/qt4/qt@4" 
~~~

With some sleuthing, I traced the failure to a line in `tap.rb` that was modified in #2325 (https://github.com/Homebrew/brew/pull/2325/commits/d1995dad4bf76b447d9c97f1c2db99c6b3854b51#diff-5f336a727e42d98a4d5125c8972b6c07R288) that seems to presume that a tap is keeping its formulae in a `Formula/` folder. Reverting this change allows `test-bot` to proceed for me.

I can think of two options, though there are quite possibly more:

1. Revert that one-line change by merging this PR. This may break other things.

2. Require that taps store their formulae in a `Formula/` folder. This would require work from many tap maintainers.

