### PR TITLE
diagnostic_spec.rb: assertion in check_access_lock_dir test

### DIFF
--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -43,8 +43,10 @@ describe Homebrew::Diagnostic::Checks do
 
   specify "#check_access_lock_dir" do
     begin
+      prev_mode = HOMEBREW_LOCK_DIR.stat.mode
       mode = HOMEBREW_LOCK_DIR.stat.mode & 0777
       HOMEBREW_LOCK_DIR.chmod 0555
+      expect(HOMEBREW_LOCK_DIR.stat.mode).not_to eq(prev_mode)
 
       expect(subject.check_access_lock_dir)
         .to match("#{HOMEBREW_LOCK_DIR} isn't writable.")


### PR DESCRIPTION
Added assertion to check `HOMEBREW_LOCK_DIR.stat.mode` changes after `HOMEBREW_LOCK_DIR.chmod 0555`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
