### PR TITLE
keg: skip opt versioned aliases for devel/head.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -468,7 +468,10 @@ class Keg
   end
 
   def aliases
-    Formulary.from_rack(rack).aliases
+    formula = Formulary.from_rack(rack)
+    aliases = formula.aliases
+    return aliases if formula.stable?
+    aliases.reject { |a| a.include?("@") }
   rescue FormulaUnavailableError
     []
   end


### PR DESCRIPTION
These versioned aliases don’t correspond to the correct version if not
Installed from stable.

Fixes #2596.