### PR TITLE
Allow --interactive to access HOME

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1943,8 +1943,10 @@ class Formula
       old_curl_home = ENV["CURL_HOME"]
       old_path = ENV["HOMEBREW_PATH"]
 
-      ENV["HOME"] = env_home
-      ENV["CURL_HOME"] = old_curl_home || old_home
+      unless ARGV.interactive?
+        ENV["HOME"] = env_home
+        ENV["CURL_HOME"] = old_curl_home || old_home
+      end
       ENV["HOMEBREW_PATH"] = nil
 
       setup_home env_home
@@ -1955,8 +1957,10 @@ class Formula
         yield staging
       ensure
         @buildpath = nil
-        ENV["HOME"] = old_home
-        ENV["CURL_HOME"] = old_curl_home
+        unless ARGV.interactive?
+          ENV["HOME"] = old_home
+          ENV["CURL_HOME"] = old_curl_home
+        end
         ENV["HOMEBREW_PATH"] = old_path
       end
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -664,6 +664,7 @@ class FormulaInstaller
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"build.sandbox.log")
+        sandbox.allow_write_path(ENV["HOME"]) if ARGV.interactive?
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_write_xcode

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -5,10 +5,6 @@ class Sandbox
   SANDBOX_EXEC = "/usr/bin/sandbox-exec".freeze
   SANDBOXED_TAPS = %w[
     homebrew/core
-    homebrew/dupes
-    homebrew/fuse
-    homebrew/devel-only
-    homebrew/tex
   ].freeze
 
   def self.available?


### PR DESCRIPTION
This may result in a slightly varied build but it’s generally just far
less annoying to be able to access all your e.g. shell configuration.