### PR TITLE
Tweak troubleshooting docs and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,10 @@
 # Please always follow these steps:
-- [ ] Confirmed this is a problem with Homebrew/brew and not one or more formulae? If it's a formulae-specific problem please file this issue at https://github.com/Homebrew/homebrew-core/issues/new
+- [ ] Confirmed this is a problem with running a `brew` command and just `brew install`ing one or more formulae? If it's a formulae-specific problem please file this issue at https://github.com/Homebrew/homebrew-core/issues/new
 - [ ] Ran `brew update` and retried your prior step?
-- [ ] Ran `brew doctor`, fixed as many issues as possible and retried your prior step?
+- [ ] Ran `brew doctor`, fixed all issues and retried your prior step?
 - [ ] Ran `brew config` and `brew doctor` and included their output with your issue?
+
+**Please note we may immediately close your issue without comment if you delete or do not fill out the issue checklist and provide ALL the requested information.**
 
 To help us debug your issue please explain:
 - What you were trying to do (and why)
@@ -10,8 +12,6 @@ To help us debug your issue please explain:
 - What you expected to happen
 - Step-by-step reproduction instructions (by running `brew` commands)
 
-**Please note we may immediately close your issue without comment if you do not fill out the issue template and provide ALL the requested information.**
-
 # Or propose a feature:
-Please replace this section with a detailed description of your proposed feature, the motivation for it and alternatives considered.
+Please replace this section with a detailed description of your proposed feature, the motivation for it, how it would be relevant to at least 90% of Homebrew users and alternatives considered.
 Please note we may close this issue or ask you to create a pull-request if it's something we're not actively planning to work on.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -13,12 +13,11 @@ Follow these steps to fix common problems:
 * Check that **Command Line Tools for Xcode (CLT)** and **Xcode** are up to date.
 * If commands fail with permissions errors, check the permissions of `/usr/local`'s subdirectories. If you’re unsure what to do, you can run `cd /usr/local && sudo chown -R $(whoami) bin etc include lib sbin share var Frameworks`.
 * Read through the [Common Issues](Common-Issues.md).
-* If you’re installing something Java-related, make sure you have installed Java (you can run `brew cask install java`).
 
 ## Check to see if the issue has been reported
 
 * Search the [issue tracker](https://github.com/Homebrew/homebrew-core/issues) to see if someone else has already reported the same issue.
-* Make sure you search issues on the correct repository. If a formula that has failed to build is part of a tap like [homebrew/science](https://github.com/Homebrew/homebrew-science/issues) or [homebrew/dupes](https://github.com/Homebrew/homebrew-dupes/issues) check those issue trackers instead.
+* Make sure you search issues on the correct repository. If a formula that has failed to build is part of a tap like [homebrew/science](https://github.com/Homebrew/homebrew-science/issues) or a cask is part of [caskroom/cask](https://github.com/caskroom/homebrew-cask/issues) check those issue trackers instead.
 
 ## Create an issue
 


### PR DESCRIPTION
- Note that Homebrew Cask issues should be filed elsewhere.
- Make `brew`/homebrew-core issue differential in simpler language
- Tell people to fix all `brew doctor` issues
- Refer to the issue checklist and make it even more clear and prominent
  that we may close it out immediately if they don't use it.
- Note that proposed new issues should be widely relevant.
- Don't tell people they need to `brew cask install java`; we handle
  this in most places with a Java requirement and probably want issues
  filed where we don't.
- Remove reference to Homebrew Dupes and replace with reference to
  Homebrew Cask to try and get people filing stuff there instead.

Fixes #2608