### PR TITLE
More environment filtering tweaks

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -100,7 +100,7 @@ module Homebrew
 
       # See https://github.com/Homebrew/legacy-homebrew/pull/9986
       def check_path_for_trailing_slashes
-        bad_paths = PATH.new(ENV["PATH"]).select { |p| p.end_with?("/") }
+        bad_paths = PATH.new(ENV["HOMEBREW_PATH"]).select { |p| p.end_with?("/") }
         return if bad_paths.empty?
 
         inject_file_list bad_paths, <<-EOS.undent

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -520,6 +520,9 @@ class S3DownloadStrategy < CurlDownloadStrategy
     bucket = $1
     key = $2
 
+    ENV["AWS_ACCESS_KEY_ID"] = ENV["HOMEBREW_AWS_ACCESS_KEY_ID"]
+    ENV["AWS_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_AWS_SECRET_ACCESS_KEY"]
+
     obj = AWS::S3.new.buckets[bucket].objects[key]
     begin
       s3url = obj.url_for(:get)

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -98,31 +98,6 @@ can take several different forms:
     The formula file will be cached for later use.
 
 ## ENVIRONMENT
-
-  * `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`:
-    When using the `S3` download strategy, Homebrew will look in
-    these variables for access credentials (see
-    <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment>
-    to retrieve these access credentials from AWS).  If they are not set,
-    the `S3` download strategy will download with a public
-    (unsigned) URL.
-
-  * `BROWSER`:
-    If set, and `HOMEBREW_BROWSER` is not, use `BROWSER` as the web browser
-    when opening project homepages.
-
-  * `EDITOR`:
-    If set, and `HOMEBREW_EDITOR` and `VISUAL` are not, use `EDITOR` as the text editor.
-
-  * `GIT`:
-    When using Git, Homebrew will use `GIT` if set,
-    a Homebrew-built Git if installed, or the system-provided binary.
-
-    Set this to force Homebrew to use a particular git binary.
-
-  * `HOMEBREW_BOTTLE_DOMAIN`:
-    If set, instructs Homebrew to use the given URL as a download mirror for bottles.
-
   * `HOMEBREW_ARTIFACT_DOMAIN`:
     If set, instructs Homebrew to use the given URL as a download mirror for bottles and binaries.
 
@@ -130,6 +105,17 @@ can take several different forms:
     If set, Homebrew will only check for autoupdates once per this seconds interval.
 
     *Default:* `60`.
+
+  * `HOMEBREW_AWS_ACCESS_KEY_ID`, `HOMEBREW_AWS_SECRET_ACCESS_KEY`:
+    When using the `S3` download strategy, Homebrew will look in
+    these variables for access credentials (see
+    <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment>
+    to retrieve these access credentials from AWS).  If they are not set,
+    the `S3` download strategy will download with a public
+    (unsigned) URL.
+
+  * `HOMEBREW_BOTTLE_DOMAIN`:
+    If set, instructs Homebrew to use the given URL as a download mirror for bottles.
 
   * `HOMEBREW_BROWSER`:
     If set, uses this setting as the browser when opening project homepages,
@@ -177,6 +163,12 @@ can take several different forms:
   * `HOMEBREW_FORCE_VENDOR_RUBY`:
     If set, Homebrew will always use its vendored, relocatable Ruby 2.0 version
     even if the system version of Ruby is >=2.0.
+
+  * `HOMEBREW_GIT`:
+    When using Git, Homebrew will use `GIT` if set,
+    a Homebrew-built Git if installed, or the system-provided binary.
+
+    Set this to force Homebrew to use a particular git binary.
 
   * `HOMEBREW_GITHUB_API_TOKEN`:
     A personal access token for the GitHub API, which you can create at
@@ -242,9 +234,6 @@ can take several different forms:
 
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.
-
-  * `VISUAL`:
-    If set, and `HOMEBREW_EDITOR` is not, use `VISUAL` as the text editor.
 
 ## USING HOMEBREW BEHIND A PROXY
 

--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -86,7 +86,6 @@ fi
 case "$(lowercase "$SCM_FILE")" in
   git)
     [[ -n "$HOMEBREW_GIT" ]] && safe_exec "$(which "$HOMEBREW_GIT")" "$@"
-    [[ -n "$GIT" ]] && safe_exec "$(which "$GIT")" "$@"
     ;;
   svn)
     [[ -n "$HOMEBREW_SVN" ]] && safe_exec "$(which "$HOMEBREW_SVN")" "$@"

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -7,7 +7,7 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_path_for_trailing_slashes" do
-    ENV["PATH"] += File::PATH_SEPARATOR + "/foo/bar/"
+    ENV["HOMEBREW_PATH"] += File::PATH_SEPARATOR + "/foo/bar/"
     expect(subject.check_path_for_trailing_slashes)
       .to match("Some directories in your path end in a slash")
   end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -320,7 +320,7 @@ def which_all(cmd, path = ENV["PATH"])
 end
 
 def which_editor
-  editor = ENV.values_at("HOMEBREW_EDITOR", "VISUAL").compact.reject(&:empty?).first
+  editor = ENV.values_at("HOMEBREW_EDITOR", "HOMEBREW_VISUAL").compact.reject(&:empty?).first
   if editor
     editor_name, _, editor_args = editor.partition " "
     editor_path = which(editor_name, ENV["HOMEBREW_PATH"])
@@ -356,7 +356,7 @@ def exec_editor(*args)
 end
 
 def exec_browser(*args)
-  browser = ENV["HOMEBREW_BROWSER"] || ENV["BROWSER"]
+  browser = ENV["HOMEBREW_BROWSER"]
   browser ||= OS::PATH_OPEN if defined?(OS::PATH_OPEN)
   return unless browser
   safe_exec(browser, *args)

--- a/bin/brew
+++ b/bin/brew
@@ -44,7 +44,10 @@ fi
 
 HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 
-for VAR in EDITOR PATH BINTRAY_USER BINTRAY_KEY
+# Whitelist and copy to HOMEBREW_* all variables previously mentioned in
+# manpage or used elsewhere by Homebrew.
+for VAR in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BINTRAY_USER BINTRAY_KEY \
+           BROWSER EDITOR GIT PATH VISUAL
 do
   VAR_NEW="HOMEBREW_${VAR}"
   [[ -n "${!VAR_NEW}" ]] && continue

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -910,31 +910,6 @@ can take several different forms:
     The formula file will be cached for later use.
 
 ## ENVIRONMENT
-
-  * `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`:
-    When using the `S3` download strategy, Homebrew will look in
-    these variables for access credentials (see
-    <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment>
-    to retrieve these access credentials from AWS).  If they are not set,
-    the `S3` download strategy will download with a public
-    (unsigned) URL.
-
-  * `BROWSER`:
-    If set, and `HOMEBREW_BROWSER` is not, use `BROWSER` as the web browser
-    when opening project homepages.
-
-  * `EDITOR`:
-    If set, and `HOMEBREW_EDITOR` and `VISUAL` are not, use `EDITOR` as the text editor.
-
-  * `GIT`:
-    When using Git, Homebrew will use `GIT` if set,
-    a Homebrew-built Git if installed, or the system-provided binary.
-
-    Set this to force Homebrew to use a particular git binary.
-
-  * `HOMEBREW_BOTTLE_DOMAIN`:
-    If set, instructs Homebrew to use the given URL as a download mirror for bottles.
-
   * `HOMEBREW_ARTIFACT_DOMAIN`:
     If set, instructs Homebrew to use the given URL as a download mirror for bottles and binaries.
 
@@ -942,6 +917,17 @@ can take several different forms:
     If set, Homebrew will only check for autoupdates once per this seconds interval.
 
     *Default:* `60`.
+
+  * `HOMEBREW_AWS_ACCESS_KEY_ID`, `HOMEBREW_AWS_SECRET_ACCESS_KEY`:
+    When using the `S3` download strategy, Homebrew will look in
+    these variables for access credentials (see
+    <https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment>
+    to retrieve these access credentials from AWS).  If they are not set,
+    the `S3` download strategy will download with a public
+    (unsigned) URL.
+
+  * `HOMEBREW_BOTTLE_DOMAIN`:
+    If set, instructs Homebrew to use the given URL as a download mirror for bottles.
 
   * `HOMEBREW_BROWSER`:
     If set, uses this setting as the browser when opening project homepages,
@@ -989,6 +975,12 @@ can take several different forms:
   * `HOMEBREW_FORCE_VENDOR_RUBY`:
     If set, Homebrew will always use its vendored, relocatable Ruby 2.0 version
     even if the system version of Ruby is >=2.0.
+
+  * `HOMEBREW_GIT`:
+    When using Git, Homebrew will use `GIT` if set,
+    a Homebrew-built Git if installed, or the system-provided binary.
+
+    Set this to force Homebrew to use a particular git binary.
 
   * `HOMEBREW_GITHUB_API_TOKEN`:
     A personal access token for the GitHub API, which you can create at
@@ -1054,9 +1046,6 @@ can take several different forms:
 
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.
-
-  * `VISUAL`:
-    If set, and `HOMEBREW_EDITOR` is not, use `VISUAL` as the text editor.
 
 ## USING HOMEBREW BEHIND A PROXY
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -941,29 +941,6 @@ Homebrew can install formulae via URL, e\.g\. \fBhttps://raw\.github\.com/Homebr
 .SH "ENVIRONMENT"
 .
 .TP
-\fBAWS_ACCESS_KEY_ID\fR, \fBAWS_SECRET_ACCESS_KEY\fR
-When using the \fBS3\fR download strategy, Homebrew will look in these variables for access credentials (see \fIhttps://docs\.aws\.amazon\.com/cli/latest/userguide/cli\-chap\-getting\-started\.html#cli\-environment\fR to retrieve these access credentials from AWS)\. If they are not set, the \fBS3\fR download strategy will download with a public (unsigned) URL\.
-.
-.TP
-\fBBROWSER\fR
-If set, and \fBHOMEBREW_BROWSER\fR is not, use \fBBROWSER\fR as the web browser when opening project homepages\.
-.
-.TP
-\fBEDITOR\fR
-If set, and \fBHOMEBREW_EDITOR\fR and \fBVISUAL\fR are not, use \fBEDITOR\fR as the text editor\.
-.
-.TP
-\fBGIT\fR
-When using Git, Homebrew will use \fBGIT\fR if set, a Homebrew\-built Git if installed, or the system\-provided binary\.
-.
-.IP
-Set this to force Homebrew to use a particular git binary\.
-.
-.TP
-\fBHOMEBREW_BOTTLE_DOMAIN\fR
-If set, instructs Homebrew to use the given URL as a download mirror for bottles\.
-.
-.TP
 \fBHOMEBREW_ARTIFACT_DOMAIN\fR
 If set, instructs Homebrew to use the given URL as a download mirror for bottles and binaries\.
 .
@@ -973,6 +950,14 @@ If set, Homebrew will only check for autoupdates once per this seconds interval\
 .
 .IP
 \fIDefault:\fR \fB60\fR\.
+.
+.TP
+\fBHOMEBREW_AWS_ACCESS_KEY_ID\fR, \fBHOMEBREW_AWS_SECRET_ACCESS_KEY\fR
+When using the \fBS3\fR download strategy, Homebrew will look in these variables for access credentials (see \fIhttps://docs\.aws\.amazon\.com/cli/latest/userguide/cli\-chap\-getting\-started\.html#cli\-environment\fR to retrieve these access credentials from AWS)\. If they are not set, the \fBS3\fR download strategy will download with a public (unsigned) URL\.
+.
+.TP
+\fBHOMEBREW_BOTTLE_DOMAIN\fR
+If set, instructs Homebrew to use the given URL as a download mirror for bottles\.
 .
 .TP
 \fBHOMEBREW_BROWSER\fR
@@ -1019,6 +1004,13 @@ If set, Homebrew will use this editor when editing a single formula, or several 
 .TP
 \fBHOMEBREW_FORCE_VENDOR_RUBY\fR
 If set, Homebrew will always use its vendored, relocatable Ruby 2\.0 version even if the system version of Ruby is >=2\.0\.
+.
+.TP
+\fBHOMEBREW_GIT\fR
+When using Git, Homebrew will use \fBGIT\fR if set, a Homebrew\-built Git if installed, or the system\-provided binary\.
+.
+.IP
+Set this to force Homebrew to use a particular git binary\.
 .
 .TP
 \fBHOMEBREW_GITHUB_API_TOKEN\fR
@@ -1085,10 +1077,6 @@ This issue typically occurs when using FileVault or custom SSD configurations\.
 .TP
 \fBHOMEBREW_VERBOSE\fR
 If set, Homebrew always assumes \fB\-\-verbose\fR when running commands\.
-.
-.TP
-\fBVISUAL\fR
-If set, and \fBHOMEBREW_EDITOR\fR is not, use \fBVISUAL\fR as the text editor\.
 .
 .SH "USING HOMEBREW BEHIND A PROXY"
 Homebrew uses several commands for downloading files (e\.g\. \fBcurl\fR, \fBgit\fR, \fBsvn\fR)\. Many of these tools can download via a proxy\. It\'s common for these tools to read proxy parameters from environment variables\.


### PR DESCRIPTION
- only document HOMEBREW_* variables in the manpage (although still
  read from all the original environment variables).
- resort manpage environment variables in alphabetical order
- check the original path for trailing slashes