### PR TITLE
rubocop: don't always care about module length.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -40,6 +40,11 @@ Metrics/MethodLength:
 
 Metrics/ModuleLength:
   CountComments: false
+  Exclude:
+    - '**/bin/**/*'
+    - '**/cmd/**/*'
+    - '**/lib/**/*'
+    - '**/spec/**/*'
 
 Metrics/PerceivedComplexity:
   Enabled: false


### PR DESCRIPTION
We don't care about this in external taps as this is more about code
architecture than code style.