### PR TITLE
Use Python's flock instead of Ruby's

### DIFF
--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -42,13 +42,13 @@ _create_lock() {
   [[ -x "$ruby" ]] || ruby="$(which ruby 2>/dev/null)"
   [[ -x "$python" ]] || python="$(which python 2>/dev/null)"
 
-  if [[ -n "$ruby" && $("$ruby" -e "puts RUBY_VERSION >= '1.8.7' ? 0 : 1") = 0 ]]
+  if [[ -x "$ruby" && $("$ruby" -e "puts RUBY_VERSION >= '1.8.7' ? 0 : 1") = 0 ]]
   then
     "$ruby" -e "File.new($lock_fd).flock(File::LOCK_EX | File::LOCK_NB) || exit(1)"
-  elif [[ -n "$(which flock)" ]]
+  elif [[ -x "$(which flock)" ]]
   then
     flock -n "$lock_fd"
-  elif [[ -n "$python" ]]
+  elif [[ -x "$python" ]]
   then
     "$python" -c "import fcntl; fcntl.flock($lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)"
   else

--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -42,7 +42,7 @@ _create_lock() {
   [[ -x "$ruby" ]] || ruby="$(which ruby 2>/dev/null)"
   [[ -x "$python" ]] || python="$(which python 2>/dev/null)"
 
-  if [[ -x "$ruby" && $("$ruby" -e "puts RUBY_VERSION >= '1.8.7' ? 0 : 1") = 0 ]]
+  if [[ -x "$ruby" ]] && "$ruby" -e "exit(RUBY_VERSION >= '1.8.7')"
   then
     "$ruby" -e "File.new($lock_fd).flock(File::LOCK_EX | File::LOCK_NB) || exit(1)"
   elif [[ -x "$(which flock)" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I'm currently in the process of adding vendored Ruby support to Tigerbrew (https://github.com/mistydemeo/tigerbrew/pull/510). One of the roadblocks I ran into was that the flock shell script doesn't work. Ruby first gained flock in 1.8.7, which is a problem since we're using this lock utility in `vendor-install` in order to install a newer Ruby. Catch-22!

Fortunately, Python 2.3(!) has flock support. Should work anywhere from ancient Pythons to modern OS X.