### PR TITLE
audit: Detect multiline and interpolated strings in formula desc cop

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -180,9 +180,10 @@ module RuboCop
         node.source_range.source_buffer
       end
 
-      # Returns the string representation if node is of type str
+      # Returns the string representation if node is of type str(plain) or dstr(interpolated)
       def string_content(node)
-        node.str_content if node.type == :str
+        return node.str_content if node.type == :str
+        node.each_child_node(:str).map(&:str_content).join("") if node.type == :dstr
       end
 
       # Returns printable component name

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -51,6 +51,31 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
       end
     end
 
+    it "When desc is multiline string" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url 'http://example.com/foo-1.0.tgz'
+          desc '#{"bar"*10}'\
+            '#{"foo"*21}'
+        end
+      EOS
+
+      msg = <<-EOS.undent
+        Description is too long. "name: desc" should be less than 80 characters.
+        Length is calculated as Foo + desc. (currently 98)
+      EOS
+      expected_offenses = [{ message: msg,
+                             severity: :convention,
+                             line: 3,
+                             column: 2,
+                             source: source }]
+
+      inspect_source(cop, source)
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+
     it "When wrong \"command-line\" usage in desc" do
       source = <<-EOS.undent
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes #2611 
*Note:* It assumes there is no expression/variables in the multiline string. Ex: `'#{var1} is a formula'` Although var1 can be substituted it doesn't make sense, as rubocop is a static analyser, so I'm ignoring that part of string .
Also does not support here document , let me know if it's necessary for formula `desc` 