### PR TITLE
Update to venv.pip_install_and_link in doc

### DIFF
--- a/docs/Python-for-Formula-Authors.md
+++ b/docs/Python-for-Formula-Authors.md
@@ -143,7 +143,7 @@ def install
   %w[six parsedatetime].each do |r|
     venv.pip_install resource(r)
   end
-  venv.link_scripts(bin) { venv.pip_install buildpath }
+  venv.pip_install_and_link buildpath
 end
 ```
 


### PR DESCRIPTION
`venv.link_scripts(bin) { venv.pip_install buildpath }` is now `venv.pip_install_and_link buildpath`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
