### PR TITLE
bin/brew: don't set blank HOMEBREW_* variables.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -49,7 +49,11 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 for VAR in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BINTRAY_USER BINTRAY_KEY \
            BROWSER EDITOR GIT PATH VISUAL
 do
+  # Skip if variable value is empty.
+  [[ -z "${!VAR}" ]] && continue
+
   VAR_NEW="HOMEBREW_${VAR}"
+  # Skip if existing HOMEBREW_* variable is set.
   [[ -n "${!VAR_NEW}" ]] && continue
   export "$VAR_NEW"="${!VAR}"
 done


### PR DESCRIPTION
When creating the necessary HOMEBREW_* variables ensure that they aren't set if their value would be empty.

Fixes #2633.

Thanks to @chdiza for the extremely clear reproduction instructions.