### PR TITLE
audit: fix full versioned alias name resolution in taps

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -323,6 +323,10 @@ class FormulaAuditor
       end
       valid_alias_names = [alias_name_major, alias_name_major_minor]
 
+      if formula.tap
+        valid_alias_names.map! { |a| "#{formula.tap}/#{a}" }
+      end
+
       valid_versioned_aliases = versioned_aliases & valid_alias_names
       invalid_versioned_aliases = versioned_aliases - valid_alias_names
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This fixes an issue where audit would prompt for the creation
of an already existing versioned alias while at the same time
declaring the existing alias invalid.

This can be done in one line, but it seemed less readable. I am happy to change it, however.

cc @MikeMcQuaid as this is a slight fix to his PR: https://github.com/Homebrew/brew/pull/2619.

Fixes #2650.