### PR TITLE
replace_text_in_files: Regex match is greedy

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -68,17 +68,7 @@ class Keg
         relocation.old_cellar => relocation.new_cellar,
         relocation.old_repository => relocation.new_repository,
       }
-
-      # Order matters here since `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are
-      # children of `HOMEBREW_PREFIX` by default.
-      regexp = Regexp.union(
-        relocation.old_cellar,
-        relocation.old_repository,
-        relocation.old_prefix,
-      )
-
-      changed = s.gsub!(regexp, replacements)
-
+      changed = s.gsub!(Regexp.union(replacements.keys), replacements)
       next unless changed
       changed_files += [first, *rest].map { |file| file.relative_path_from(path) }
 


### PR DESCRIPTION
The regex matches the longest possible string. Order does not matter.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
