### PR TITLE
formulary: don't redeclare namespace modules

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -15,13 +15,20 @@ module Formulary
     FORMULAE.fetch(path)
   end
 
+  def self.namespace_module(namespace)
+    if const_defined?(namespace)
+      const_get(namespace)
+    else
+      Module.new.tap { |m| const_set(namespace, m) }
+    end
+  end
+
   def self.load_formula(name, path, contents, namespace)
     if ENV["HOMEBREW_DISABLE_LOAD_FORMULA"]
       raise "Formula loading disabled by HOMEBREW_DISABLE_LOAD_FORMULA!"
     end
 
-    mod = Module.new
-    const_set(namespace, mod)
+    mod = namespace_module(namespace)
     begin
       mod.module_eval(contents, path)
     rescue ScriptError => e


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This has been happening since #2601, and generates a warning. I don't _think_ there's any reason to worry about using the same module, but someone taking a second look would be nice.

@reitermarkus any idea why 330307b01 would have caused this to suddenly start happening?