### PR TITLE
Add `unverified` caveat to cask dsl

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/dsl/caveats.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/caveats.rb
@@ -111,6 +111,17 @@ module Hbc
 
         EOS
       end
+
+      def unverified(discussion_url)
+        puts <<-EOS.undent
+        #{@cask}'s sha256 was updated WITHOUT verification.
+
+        As with any app, use at your own risk.
+
+          #{Formatter.url("#{discussion_url}")}
+
+        EOS
+      end
     end
   end
 end

--- a/Library/Homebrew/cask/lib/hbc/dsl/caveats.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/caveats.rb
@@ -118,7 +118,7 @@ module Hbc
 
         As with any app, use at your own risk.
 
-          #{Formatter.url("#{discussion_url}")}
+          #{Formatter.url(discussion_url.to_s)}
 
         EOS
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/caskroom/homebrew-cask/issues/34584

Adds an `unverified` caveat to cask dsl `caveats.rb`