### PR TITLE
Vendor compatibility fixes

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -145,7 +145,7 @@ export HOMEBREW_MACOS_VERSION
 export HOMEBREW_USER_AGENT
 export HOMEBREW_USER_AGENT_CURL
 
-if [[ -n "$HOMEBREW_MACOS" ]]
+if [[ -n "$HOMEBREW_MACOS" && -x "/usr/bin/xcode-select" ]]
 then
   XCODE_SELECT_PATH=$('/usr/bin/xcode-select' --print-path 2>/dev/null)
   if [[ "$XCODE_SELECT_PATH" = "/" ]]

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -76,10 +76,10 @@ fetch() {
     trap - SIGINT
   fi
 
-  if [[ -n "$(which shasum)" ]]
+  if [[ -x "$(which shasum)" ]]
   then
     sha="$(shasum -a 256 "$CACHED_LOCATION" | cut -d' ' -f1)"
-  elif [[ -n "$(which sha256sum)" ]]
+  elif [[ -x "$(which sha256sum)" ]]
   then
     sha="$(sha256sum "$CACHED_LOCATION" | cut -d' ' -f1)"
   else

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -39,10 +39,10 @@ fetch() {
 
   if [[ -n "$HOMEBREW_QUIET" ]]
   then
-    curl_args+=(--silent)
+    curl_args[${#curl_args[*]}]="--silent"
   elif [[ -z "$HOMEBREW_VERBOSE" ]]
   then
-    curl_args+=(--progress-bar)
+    curl_args[${#curl_args[*]}]="--progress-bar"
   fi
 
   temporary_path="$CACHED_LOCATION.incomplete"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a few compatibility issues with very old versions of OS X.

* `xcode-select` was first shipped in 10.5; scope the `xcode-select` and `xcrun` checks to only run if `/usr/bin/xcode-select` exists.
* While bash arrays exist in bash 2.x, the `+=` syntax doesn't. Arrays need to be appended via `[]` indexing.
* A few `-n` checks on the output of `which` were changed to `-x` checks, since older versions of `which` return a string when no results are found.