### PR TITLE
Improve some `brew install` messaging.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -146,8 +146,17 @@ module Homebrew
           # linked to opt, because installing without any warnings can break
           # dependencies. Therefore before performing other checks we need to be
           # sure --force flag is passed.
-          opoo "#{f.full_name} is a keg-only and another version is linked to opt."
-          puts "Use `brew install --force` if you want to install this version"
+          if f.outdated?
+            optlinked_version = Keg.for(f.opt_prefix).version
+            onoe <<-EOS.undent
+              #{f.full_name} #{optlinked_version} is already installed
+              To upgrade to #{f.version}, run `brew upgrade #{f.name}`
+            EOS
+          else
+            opoo <<-EOS.undent
+              #{f.full_name} #{f.pkg_version} is already installed
+            EOS
+          end
         elsif (ARGV.build_head? && new_head_installed) || prefix_installed
           # After we're sure that --force flag is passed for linked to opt
           # keg-only we need to be sure that the version we're attempting to
@@ -159,30 +168,38 @@ module Homebrew
             f.pkg_version
           end
 
-          msg = "#{f.full_name}-#{installed_version} already installed"
+          msg = "#{f.full_name} #{installed_version} is already installed"
           linked_not_equals_installed = f.linked_version != installed_version
           if f.linked? && linked_not_equals_installed
-            msg << ", however linked version is #{f.linked_version}"
-            opoo msg
-            puts "You can use `brew switch #{f} #{installed_version}` to link this version."
+            msg = <<-EOS.undent
+              #{msg}
+              The currently linked version is #{f.linked_version}
+              You can use `brew switch #{f} #{installed_version}` to link this version.
+            EOS
           elsif !f.linked? || f.keg_only?
-            msg << ", it's just not linked."
-            opoo msg
-          else
-            opoo msg
+            msg = <<-EOS.undent
+              #{msg}, it's just not linked.
+              You can use `brew link #{f}` to link this version.
+            EOS
           end
+          opoo msg
         elsif !f.any_version_installed? && old_formula = f.old_installed_formulae.first
-          msg = "#{old_formula.full_name}-#{old_formula.installed_version} already installed"
+          msg = "#{old_formula.full_name} #{old_formula.installed_version} already installed"
           if !old_formula.linked? && !old_formula.keg_only?
-            msg << ", it's just not linked."
+            msg = <<-EOS.undent
+              #{msg}, it's just not linked.
+              You can use `brew link #{old_formula.full_name}` to link this version.
+            EOS
           end
           opoo msg
         elsif f.migration_needed? && !ARGV.force?
           # Check if the formula we try to install is the same as installed
           # but not migrated one. If --force passed then install anyway.
-          opoo "#{f.oldname} already installed, it's just not migrated"
-          puts "You can migrate formula with `brew migrate #{f}`"
-          puts "Or you can force install it with `brew install #{f} --force`"
+          opoo <<-EOS.undent
+            #{f.oldname} already installed, it's just not migrated
+            You can migrate formula with `brew migrate #{f}`
+            Or you can force install it with `brew install #{f} --force`
+          EOS
         else
           # If none of the above is true and the formula is linked, then
           # FormulaInstaller will handle this case.

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -325,7 +325,7 @@ class FormulaConflictError < RuntimeError
 
   def message
     message = []
-    message << "Cannot install #{formula.full_name} because conflicting formulae are installed.\n"
+    message << "Cannot install #{formula.full_name} because conflicting formulae are installed."
     message.concat conflicts.map { |c| conflict_message(c) } << ""
     message << <<-EOS.undent
       Please `brew unlink #{conflicts.map(&:name)*" "}` before continuing.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1588,7 +1588,7 @@ class Formula
       "revision" => revision,
       "version_scheme" => version_scheme,
       "installed" => [],
-      "linked_keg" => (linked_keg.resolved_path.basename.to_s if linked_keg.exist?),
+      "linked_keg" => (linked_version.to_s if linked_keg.exist?),
       "pinned" => pinned?,
       "outdated" => outdated?,
       "keg_only" => keg_only?,

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -218,7 +218,7 @@ class FormulaInstaller
     # relink the active keg if possible (because it is slow).
     if formula.linked_keg.directory?
       message = <<-EOS.undent
-        #{formula.name} #{formula.linked_keg.resolved_path.basename} is already installed
+        #{formula.name} #{formula.linked_version} is already installed
       EOS
       message += if formula.outdated? && !formula.head?
         <<-EOS.undent

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -23,7 +23,7 @@ describe "brew install", :integration_test do
       .and be_a_success
 
     expect { brew "install", "testball1" }
-      .to output(/testball1\-0\.1 already installed/).to_stderr
+      .to output(/testball1\ 0\.1 is already installed/).to_stderr
       .and not_to_output.to_stdout
       .and be_a_success
 
@@ -51,7 +51,7 @@ describe "brew install", :integration_test do
     install_and_rename_coretap_formula "testball1", "testball2"
     expect { brew "install", "testball2" }
       .to output(/testball1 already installed, it's just not migrated/).to_stderr
-      .and output(/You can migrate formula with `brew migrate testball2`/).to_stdout
+      .and not_to_output.to_stdout
       .and be_a_success
   end
 
@@ -106,8 +106,8 @@ describe "brew install", :integration_test do
     end
 
     expect { brew "install", "testball1" }
-      .to output(/already installed, however linked version is/).to_stderr
-      .and output(/`brew switch testball1 2.0`/).to_stdout
+      .to output(/2.0 is already installed/).to_stderr
+      .and not_to_output.to_stdout
       .and be_a_success
 
     expect { brew "unlink", "testball1" }
@@ -141,8 +141,8 @@ describe "brew install", :integration_test do
     EOS
 
     expect { brew "install", "testball1" }
-      .to output(/keg-only and another version is linked to opt/).to_stderr
-      .and output(/Use `brew install --force`/).to_stdout
+      .to output(/testball1 1.0 is already installed/).to_stderr
+      .and not_to_output.to_stdout
       .and be_a_success
 
     expect { brew "install", "testball1", "--force" }
@@ -185,7 +185,7 @@ describe "brew install", :integration_test do
       .and be_a_success
 
     expect { brew "install", "testball1", "--HEAD", "--ignore-dependencies" }
-      .to output(/testball1\-HEAD\-d5eb689 already installed/).to_stderr
+      .to output(/testball1 HEAD\-d5eb689 is already installed/).to_stderr
       .and not_to_output.to_stdout
       .and be_a_success
 


### PR DESCRIPTION
Improve the messaging around `brew install` when there's a possible user
action such as an `upgrade` or `link` and don't tell people to
`install --force` when it's unnecessary.

While I did this, tweak the output and function usage in a couple of
related places.

Some example output before this change:
```
Warning: openssl is a keg-only and another version is linked to opt.
Use `brew install --force` if you want to install this version
Warning: mysql@5.6 is a keg-only and another version is linked to opt.
Use `brew install --force` if you want to install this version
Warning: analog-6.0_1 already installed
Warning: bash-completion@2-2.5 already installed, it's just not linked.
```

Some example output after this change:
```
Error: openssl 1.0.2k is already installed
To upgrade to 1.0.2l, run `brew upgrade openssl`
Warning: mysql@5.6 5.6.36_1 is already installed
Warning: analog 6.0_1 is already installed
Warning: bash-completion@2 2.5 is already installed, it's just not linked.
You can use `brew link bash-completion@2` to link this version.
```

Fixes the issue described in https://discourse.brew.sh/t/error-in-version-detection/792/4 CC @franklinyu
Fixes #2676 CC @pjvandehaar 