### PR TITLE
Add vendored sha256

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -82,6 +82,15 @@ fetch() {
   elif [[ -x "$(which sha256sum)" ]]
   then
     sha="$(sha256sum "$CACHED_LOCATION" | cut -d' ' -f1)"
+  elif [[ -x "$(which ruby)" ]]
+  then
+    sha="$(ruby <<EOSCRIPT
+            require 'digest/sha2'
+            digest = Digest::SHA256.new
+            File.open('$CACHED_LOCATION', 'rb') { |f| digest.update(f.read) }
+            puts digest.hexdigest
+EOSCRIPT
+)"
   else
     odie "Cannot verify the checksum ('shasum' or 'sha256sum' not found)!"
   fi

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -322,7 +322,7 @@ class Pathname
 
   def sha256
     require "digest/sha2"
-    incremental_hash(Digest::SHA2)
+    incremental_hash(Digest::SHA256)
   end
 
   def verify_checksum(expected)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a pure-Perl sha256 implementation, which is compatible with essentially any version of Perl released in the last 15 years. It's suitable for use on older versions of OS X, or Linuces which lack a `shasum` or `sha256sum`; this makes it very useful for installing a vendored Ruby.

This script was originally contributed to Tigerbrew by @geoff-codes.

cc @xu-cheng, @sjackman 