### PR TITLE
Match the "formula name in description" on word boundaries

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -40,7 +40,7 @@ module RuboCop
           end
 
           # Check if formula's name is used in formula's desc
-          problem "Description shouldn't include the formula name" if regex_match_group(desc, /^#{@formula_name}/i)
+          problem "Description shouldn't include the formula name" if regex_match_group(desc, /^#{@formula_name}\b/i)
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -120,7 +120,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
       source = <<-EOS.undent
         class Foo < Formula
           url 'http://example.com/foo-1.0.tgz'
-          desc 'Foo'
+          desc 'Foo: foobar'
         end
       EOS
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The regexp for the "check if formula name is used in formula's
  description" cop matches every instance of the formula name if it
  exists, whether it's in a word or not.
- For example, the formula `mon` has the description "Monitor
  hosts/services/whatever and alert about problems". This makes
  `brew audit --strict` complain because it matches "Monitor",
  which isn't the formula name! The formula `pass` has the description
  "Password manager".  Again, the strict audit matches "Password",
  which isn't an issue.
- Instead, this change matches on a word boundary, so it will match
  `mon:`, or `mon `, but not "Monitor", or, for example, "harmony".
- I've changed the tests to account for this change.