### PR TITLE
Make `--official-cmd-taps` imply `--online`.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -15,7 +15,7 @@
 #:    If `--online` is passed, include tests that use the GitHub API.
 #:
 #:    If `--official-cmd-taps` is passed, include tests that use any of the
-#:    taps for official external commands.
+#:    taps for official external commands (implies `--online`).
 
 require "fileutils"
 require "tap"
@@ -34,7 +34,7 @@ module Homebrew
       ENV["HOMEBREW_NO_COMPAT"] = "1" if ARGV.include? "--no-compat"
       ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if ARGV.include? "--generic"
 
-      if ARGV.include? "--online"
+      if ARGV.include?("--online") || ARGV.include?("--official-cmd-taps")
         ENV["HOMEBREW_TEST_ONLINE"] = "1"
       else
         ENV["HOMEBREW_NO_GITHUB_API"] = "1"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Tests that need a network connection aren't currently run on CI, but tests that use official command taps (i.e. also require a network connection) are, which is inconsistent.