### PR TITLE
update-test: tweak more edge cases.

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -36,8 +36,12 @@ module Homebrew
       tags = Utils.popen_read("git", "tag", "--list", "--sort=-version:refname")
       previous_tag = tags.lines[1]
       previous_tag ||= begin
-        safe_system "git", "fetch", "--tags", "--depth=1"
-        tags = Utils.popen_read("git", "tag", "--list", "--sort=-version:refname")
+        if (HOMEBREW_REPOSITORY/".git/shallow").exist?
+          safe_system "git", "fetch", "--tags", "--depth=1"
+          tags = Utils.popen_read("git", "tag", "--list", "--sort=-version:refname")
+        elsif OS.linux?
+          tags = Utils.popen_read("git tag --list | sort -rV")
+        end
         tags.lines[1]
       end
       previous_tag = previous_tag.to_s.chomp


### PR DESCRIPTION
Don't try to `fetch --depth=1` unless we've confirmed the repository is already shallow. Otherwise this can discard history from a full clone.

Additionally, if the repository wasn't shallow but there's no tags found assume that Git is too old and try a naive sort if on Linux where `sort` is able to sort versions.