### PR TITLE
tests: install specific Bundler version.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -59,7 +59,10 @@ module Homebrew
         ENV["GIT_#{role}_DATE"]  = "Sun Jan 22 19:59:13 2017 +0000"
       end
 
-      Homebrew.install_gem_setup_path! "bundler"
+      # TODO: unpin this version when this error no longer shows:
+      # bundler-1.15.0/lib/bundler/shared_helpers.rb:25:
+      #   stack level too deep (SystemStackError)
+      Homebrew.install_gem_setup_path! "bundler", "1.14.6"
       system "bundle", "install" unless quiet_system("bundle", "check")
 
       parallel = true


### PR DESCRIPTION
Otherwise `brew tests` fails with the latest. See the failing Homebrew/homebrew-test-bot `master` build as an example.