### PR TITLE
check_non_libraries: fix false positive subdirectory reports

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -62,7 +62,7 @@ module FormulaCellarChecks
     valid_extensions = %w[.a .dylib .framework .jnilib .la .o .so
                           .jar .prl .pm .sh]
     non_libraries = formula.lib.children.reject do |g|
-      next if g.directory?
+      next true if g.directory?
       valid_extensions.include? g.extname
     end
     return if non_libraries.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a bug introduced in 7a38bab333c6808022fe53aac2be9ca2e329cd53. Since `check_non_libraries` now uses `reject` instead of `select`, the value returned for the `g.directory?` check has to be inverted too; otherwise, non-directories stay in the array and will be reported as inappropriately-installed files.

Fixes warnings like this one:

```
Non-libraries were installed to "/usr/local/opt/imagemagick/lib"
Installing non-libraries to "lib" is discouraged.
The offending files are:
  /usr/local/opt/imagemagick/lib/ImageMagick
  /usr/local/opt/imagemagick/lib/pkgconfig
```