### PR TITLE
cabextract: WARNING lines aren't fatal

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/container/cab.rb
+++ b/Library/Homebrew/cask/lib/hbc/container/cab.rb
@@ -6,11 +6,7 @@ module Hbc
   class Container
     class Cab < Base
       def self.me?(criteria)
-        cabextract = which("cabextract")
-
-        criteria.magic_number(/^(MSCF|MZ)/n) &&
-          !cabextract.nil? &&
-          criteria.command.run(cabextract, args: ["-t", "--", criteria.path.to_s]).stderr.empty?
+        criteria.magic_number(/^(MSCF|MZ)/n)
       end
 
       def extract


### PR DESCRIPTION
Fixes #2689.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As reported in #2689, it's possible for `cabextract` to issue non-fatal `WARNING`s to stderr. Right now cask's cab support treats that as an error, but it seems safe to filter that out. I confirmed the formula @joeyhoer was trying to install works with this patch.