### PR TITLE
Fix boolean types

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cask_loader.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask_loader.rb
@@ -54,7 +54,7 @@ module Hbc
 
     class FromURILoader < FromPathLoader
       def self.can_load?(ref)
-        ref.to_s =~ ::URI.regexp
+        ref.to_s.match?(::URI.regexp)
       end
 
       def initialize(url)
@@ -80,7 +80,7 @@ module Hbc
 
     class FromTapLoader < FromPathLoader
       def self.can_load?(ref)
-        ref.to_s =~ HOMEBREW_TAP_CASK_REGEX
+        ref.to_s.match?(HOMEBREW_TAP_CASK_REGEX)
       end
 
       def initialize(tapped_name)

--- a/Library/Homebrew/cask/lib/hbc/cli/abstract_command.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/abstract_command.rb
@@ -15,7 +15,7 @@ module Hbc
       end
 
       def self.abstract?
-        name.split("::").last =~ /^Abstract[^a-z]/
+        name.split("::").last.match?(/^Abstract[^a-z]/)
       end
 
       def self.visible

--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -1,3 +1,6 @@
+# Contains backports from newer versions of Ruby
+require_relative "../vendor/backports/string"
+
 class String
   def undent
     gsub(/^[ \t]{#{(slice(/^[ \t]+/) || '').length}}/, "")

--- a/Library/Homebrew/vendor/README.md
+++ b/Library/Homebrew/vendor/README.md
@@ -5,6 +5,8 @@ Vendored Dependencies
 
 * [ruby-macho](https://github.com/Homebrew/ruby-macho), version 1.1.0
 
+* [backports](https://github.com/marcandre/backports), version 3.8.0
+
 ## Licenses:
 
 ### plist
@@ -52,3 +54,27 @@ Vendored Dependencies
 > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 > THE SOFTWARE.
+
+### backports
+
+> Copyright (c) 2009 Marc-Andre Lafortune
+
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/Library/Homebrew/vendor/backports/string.rb
+++ b/Library/Homebrew/vendor/backports/string.rb
@@ -1,0 +1,12 @@
+# Taken from https://github.com/marcandre/backports/blob/v3.8.0/lib/backports/2.4.0/string/match.rb
+unless String.method_defined? :match?
+  class String
+    def match?(*args)
+      # Fiber to avoid setting $~
+      f = Fiber.new do
+        !match(*args).nil?
+      end
+      f.resume
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a few return types, which changed from `Boolean` to `~Fixnum` in 7a38bab333c6808022fe53aac2be9ca2e329cd53. `===` is not my favourite bit of Ruby syntax, but Rubocop likes it more than it likes `!!`.