### PR TITLE
Stdenv: Add ENV.libxml2 and ENV.x11 for Linux

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -210,6 +210,8 @@ module Stdenv
   end
   alias generic_set_cpu_flags set_cpu_flags
 
+  def x11; end
+
   # @private
   def effective_arch
     if ARGV.build_bottle?

--- a/Library/Homebrew/extend/os/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/extend/ENV/std.rb
@@ -1,2 +1,6 @@
 require "extend/ENV/std"
-require "extend/os/mac/extend/ENV/std" if OS.mac?
+if OS.mac?
+  require "extend/os/mac/extend/ENV/std"
+elsif OS.linux?
+  require "extend/os/linux/extend/ENV/std"
+end

--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -1,0 +1,7 @@
+module Stdenv
+  def libxml2
+    append "CPPFLAGS", "-I#{Formula["libxml2"].include/"libxml2"}"
+  rescue FormulaUnavailableError
+    nil
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add `ENV.libxml2` primarily for the use of `test do` blocks. Also add a dummy `ENV.x11` function.