### PR TITLE
Update jenkins.brew.sh links.

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -14,7 +14,7 @@
 #:
 #:      ~ The URL of a commit on GitHub
 #:
-#:      ~ A "https://bot.brew.sh/job/..." string specifying a testing job ID
+#:      ~ A "https://jenkins.brew.sh/job/..." string specifying a testing job ID
 #:
 #:    If `--bottle` is passed, handle bottles, pulling the bottle-update
 #:    commit and publishing files on Bintray.

--- a/Library/Homebrew/test/dev-cmd/pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pull_spec.rb
@@ -14,7 +14,7 @@ describe "brew pull", :integration_test do
       end
     end
 
-    expect { brew "pull", "https://bot.brew.sh/job/Homebrew\%20Testing/1028/" }
+    expect { brew "pull", "https://jenkins.brew.sh/job/Homebrew\%20Testing/1028/" }
       .to output(/Testing URLs require `\-\-bottle`!/).to_stderr
       .and not_to_output.to_stdout
       .and be_a_failure

--- a/docs/Brew-Test-Bot-For-Core-Contributors.md
+++ b/docs/Brew-Test-Bot-For-Core-Contributors.md
@@ -4,10 +4,10 @@ If a build has run and passed on `brew test-bot` then it can be used to quickly 
 
 There are two types of Jenkins jobs you will interact with:
 
-## [Homebrew Core Pull Requests](https://bot.brew.sh/job/Homebrew%20Core/)
+## [Homebrew Core Pull Requests](https://jenkins.brew.sh/job/Homebrew%20Core/)
 This job automatically builds any pull requests submitted to Homebrew/homebrew-core. On success or failure it updates the pull request status (see more details on the [main Brew Test Bot documentation page](Brew-Test-Bot.md)). On a successful build it automatically uploads bottles.
 
-## [Homebrew Testing](https://bot.brew.sh/job/Homebrew%20Testing/)
+## [Homebrew Testing](https://jenkins.brew.sh/job/Homebrew%20Testing/)
 This job is manually triggered to run [`brew test-bot`](https://github.com/Homebrew/homebrew-test-bot/blob/master/cmd/brew-test-bot.rb) with user-specified parameters. On a successful build it automatically uploads bottles.
 
 You can manually start this job with parameters to run [`brew test-bot`](https://github.com/Homebrew/homebrew-test-bot/blob/master/cmd/brew-test-bot.rb) with the same parameters. It's often useful to pass a pull request URL, a commit URL, a commit SHA-1 and/or formula names to have the Brew Test Bot test them, report the results and produce bottles.
@@ -22,5 +22,5 @@ To pull and bottle a pull request with `brew pull`:
 To bottle a test build:
 
 1. Ensure the job has already completed successfully.
-2. Run `brew pull --bottle https://bot.brew.sh/job/Homebrew%20Testing/1234/` where `https://bot.brew.sh/job/Homebrew%20Testing/1234/` is the testing build URL in Jenkins.
+2. Run `brew pull --bottle https://jenkins.brew.sh/job/Homebrew%20Testing/1234/` where `https://jenkins.brew.sh/job/Homebrew%20Testing/1234/` is the testing build URL in Jenkins.
 3. Run `git push` to push the commits.

--- a/docs/Brew-Test-Bot.md
+++ b/docs/Brew-Test-Bot.md
@@ -4,7 +4,7 @@
 by [our Kickstarter in 2013](https://www.kickstarter.com/projects/homebrew/brew-test-bot).
 
 It comprises four Mac Minis running in a data centre in England which host
-[a Jenkins instance at https://bot.brew.sh](https://bot.brew.sh) and run the
+[a Jenkins instance at https://jenkins.brew.sh](https://jenkins.brew.sh) and run the
 [`brew-test-bot.rb`](https://github.com/Homebrew/homebrew-test-bot/blob/master/cmd/brew-test-bot.rb)
 Ruby script to perform automated testing of commits to the master branch, pull
 requests and custom builds requested by maintainers.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -776,7 +776,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
       ~ The URL of a commit on GitHub
 
-      ~ A "https://bot.brew.sh/job/..." string specifying a testing job ID
+      ~ A "https://jenkins.brew.sh/job/..." string specifying a testing job ID
 
     If `--bottle` is passed, handle bottles, pulling the bottle-update
     commit and publishing files on Bintray.

--- a/docs/New-Maintainer-Checklist.md
+++ b/docs/New-Maintainer-Checklist.md
@@ -47,8 +47,8 @@ If they accept, follow a few steps to get them set up:
 
 - Invite them to the [**@Homebrew/maintainers** team](https://github.com/orgs/Homebrew/teams/maintainers) to give them write access to all repositories (but don't make them owners yet). They will need to enable [GitHub's Two Factor Authentication](https://help.github.com/articles/about-two-factor-authentication/).
 - Ask them to sign in to [Bintray](https://bintray.com) using their GitHub account and they should auto-sync to [Bintray's Homebrew organisation](https://bintray.com/homebrew/organization/edit/members) as a member so they can publish new bottles
-- Add them to the [Jenkins' GitHub Authorization Settings admin user names](https://bot.brew.sh/configureSecurity/) so they can adjust settings and restart jobs
-- Add them to the [Jenkins' GitHub Pull Request Builder admin list](https://bot.brew.sh/configure) to enable `@BrewTestBot test this please` for them
+- Add them to the [Jenkins' GitHub Authorization Settings admin user names](https://jenkins.brew.sh/configureSecurity/) so they can adjust settings and restart jobs
+- Add them to the [Jenkins' GitHub Pull Request Builder admin list](https://jenkins.brew.sh/configure) to enable `@BrewTestBot test this please` for them
 - Invite them to the [`homebrew-dev` private maintainers mailing list](https://groups.google.com/forum/#!managemembers/homebrew-dev/invite)
 - Invite them to the [`machomebrew` private maintainers Slack](https://machomebrew.slack.com/admin/invites)
 - Invite them to the [`homebrew` private maintainers 1Password](https://homebrew.1password.com/signin)

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -806,7 +806,7 @@ Each \fIpatch\-source\fR may be one of:
 ~ The URL of a commit on GitHub
 .
 .IP
-~ A "https://bot\.brew\.sh/job/\.\.\." string specifying a testing job ID
+~ A "https://jenkins\.brew\.sh/job/\.\.\." string specifying a testing job ID
 .
 .IP
 If \fB\-\-bottle\fR is passed, handle bottles, pulling the bottle\-update commit and publishing files on Bintray\.


### PR DESCRIPTION
These previously, incorrectly pointed to bot.brew.sh.

CC @DomT4 

Fixes #2703.