### PR TITLE
Fix curl invocation in Hbc::DSL::Appcast

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/dsl/appcast.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/appcast.rb
@@ -12,7 +12,7 @@ module Hbc
       end
 
       def calculate_checkpoint
-        result = SystemCommand.run("/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", URL::FAKE_USER_AGENT, @uri], print_stderr: false)
+        result = SystemCommand.run("/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", URL::FAKE_USER_AGENT, "--fail", @uri], print_stderr: false)
 
         checkpoint = if result.success?
           processed_appcast_text = result.stdout.gsub(%r{<pubDate>[^<]*</pubDate>}m, "")

--- a/Library/Homebrew/test/cask/dsl/appcast_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/appcast_spec.rb
@@ -1,0 +1,74 @@
+require "cmd/cask"
+
+describe Hbc::DSL::Appcast do
+  subject { described_class.new(url, params) }
+
+  let(:url) { "http://example.com" }
+  let(:uri) { Hbc::UnderscoreSupportingURI.parse(url) }
+  let(:params) { {} }
+
+  describe "#to_s" do
+    it "returns the parsed URI string" do
+      expect(subject.to_s).to eq("http://example.com")
+    end
+  end
+
+  describe "#to_yaml" do
+    let(:yaml) { [uri, params].to_yaml }
+
+    context "with empty parameters" do
+      it "returns an YAML serialized array composed of the URI and parameters" do
+        expect(subject.to_yaml).to eq(yaml)
+      end
+    end
+
+    context "with checkpoint in parameters" do
+      let(:params) { { checkpoint: "abc123" } }
+
+      it "returns an YAML serialized array composed of the URI and parameters" do
+        expect(subject.to_yaml).to eq(yaml)
+      end
+    end
+  end
+
+  describe "#calculate_checkpoint" do
+    before do
+      expect(Hbc::SystemCommand).to receive(:run).with(*cmd_args).and_return(cmd_result)
+      allow(cmd_result).to receive(:success?).and_return(cmd_success)
+      allow(cmd_result).to receive(:stdout).and_return(cmd_stdout)
+    end
+
+    context "when server returns a successful HTTP status" do
+      let(:cmd_args) { ["/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", Hbc::URL::FAKE_USER_AGENT, "--fail", uri], print_stderr: false] }
+      let(:cmd_result) { double("Hbc::SystemCommand::Result") }
+      let(:cmd_success) { true }
+      let(:cmd_stdout) { "hello world" }
+
+      it "generates the content digest hash and returns a hash with the command result and the digest hash for the checkpoint" do
+        expected_digest = Digest::SHA2.hexdigest(cmd_stdout)
+        expected_result = {
+          checkpoint: expected_digest,
+          command_result: cmd_result,
+        }
+
+        expect(subject.calculate_checkpoint).to eq(expected_result)
+      end
+    end
+
+    context "when server returns a non-successful HTTP status" do
+      let(:cmd_args) { ["/usr/bin/curl", args: ["--compressed", "--location", "--user-agent", Hbc::URL::FAKE_USER_AGENT, "--fail", uri], print_stderr: false] }
+      let(:cmd_result) { double("Hbc::SystemCommand::Result") }
+      let(:cmd_success) { false }
+      let(:cmd_stdout) { "some error message from the server" }
+
+      it "returns a hash with the command result and nil for the checkpoint" do
+        expected_result = {
+          checkpoint: nil,
+          command_result: cmd_result,
+        }
+
+        expect(subject.calculate_checkpoint).to eq(expected_result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

Explained in #2592 

- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

`cask/lib/hbc/dsl/appcast.rb` didn't have any specs, so I created.

- [ ] Have you successfully run `brew tests` with your changes locally?

`appcast_spec.rb` passes, but I got errors from gpg specs:

```
rspec ./test/gpg_spec.rb:7 # Gpg::create_test_key creates a test key in the home directory
```

-----

Fixes #2592