### PR TITLE
Use File.join for join '.'

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -737,7 +737,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
   def stage
     super
-    cp_r cached_location/".", Dir.pwd, preserve: true
+    cp_r File.join(cached_location,"."), Dir.pwd, preserve: true
   end
 
   def source_modified_time
@@ -977,7 +977,7 @@ class CVSDownloadStrategy < VCSDownloadStrategy
   end
 
   def stage
-    cp_r cached_location/".", Dir.pwd, preserve: true
+    cp_r File.join(cached_location,"."), Dir.pwd, preserve: true
   end
 
   private
@@ -1066,7 +1066,7 @@ class BazaarDownloadStrategy < VCSDownloadStrategy
   def stage
     # The export command doesn't work on checkouts
     # See https://bugs.launchpad.net/bzr/+bug/897511
-    cp_r cached_location/".", Dir.pwd, preserve: true
+    cp_r File.join(cached_location,"."), Dir.pwd, preserve: true
     rm_r ".bzr"
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -737,7 +737,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
 
   def stage
     super
-    cp_r File.join(cached_location,"."), Dir.pwd, preserve: true
+    cp_r File.join(cached_location, "."), Dir.pwd, preserve: true
   end
 
   def source_modified_time
@@ -977,7 +977,7 @@ class CVSDownloadStrategy < VCSDownloadStrategy
   end
 
   def stage
-    cp_r File.join(cached_location,"."), Dir.pwd, preserve: true
+    cp_r File.join(cached_location, "."), Dir.pwd, preserve: true
   end
 
   private
@@ -1066,7 +1066,7 @@ class BazaarDownloadStrategy < VCSDownloadStrategy
   def stage
     # The export command doesn't work on checkouts
     # See https://bugs.launchpad.net/bzr/+bug/897511
-    cp_r File.join(cached_location,"."), Dir.pwd, preserve: true
+    cp_r File.join(cached_location, "."), Dir.pwd, preserve: true
     rm_r ".bzr"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The behavior of `cached_location/"."` is not same as `File.join(cached_location,".")`, which breaks formula installation for HEAD, e.g. https://github.com/neovim/homebrew-neovim/issues/217
