### PR TITLE
Use stty instead of tput to get terminal width

### DIFF
--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -6,7 +6,7 @@ module Tty
   end
 
   def width
-    `/usr/bin/tput cols`.strip.to_i
+    (`/bin/stty size`.split[1] || 80).to_i
   end
 
   def truncate(string)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Fixes https://github.com/Homebrew/brew/issues/2707
tput searches terminfo file for terminal description capabilities to get cols, stty talks directly to the terminal. Also added fallback.