### PR TITLE
install: fix cask install with env filtering.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -95,9 +95,8 @@ module Homebrew
         args << "--verbose" if ARGV.verbose?
 
         ARGV.casks.each do |c|
-          cmd = "brew", "cask", "install", c, *args
-          ohai cmd.join " "
-          system(*cmd)
+          ohai "brew cask install #{c} #{args.join " "}"
+          system("#{HOMEBREW_PREFIX}/bin/brew", "cask", "install", c, *args)
         end
       end
 


### PR DESCRIPTION
With `HOMEBREW_ENV_FILTERING` simply running `brew` is not sufficient to find `brew cask` so the full path needs to be passed.