### PR TITLE
search: don’t exclude Caskroom results even if tapped.

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -107,7 +107,7 @@ module Homebrew
       dirname, filename = File.split(match["path"])
       next unless valid_dirnames.include?(dirname)
       tap = Tap.fetch(match["repository"]["full_name"])
-      next if tap.installed?
+      next if tap.installed? && match["repository"]["owner"]["login"] != "caskroom"
       "#{tap.name}/#{File.basename(filename, ".rb")}"
     end.compact
   end


### PR DESCRIPTION
As they are not shown in the normal `brew search` output.

CC @reitermarkus for thoughts