### PR TITLE
audit: fix false negative for formulae options.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -959,6 +959,7 @@ class FormulaAuditor
     if line =~ /depends_on\s+['"](.+)['"]\s+=>\s+(.*)/
       dep = $1
       $2.split(" ").map do |o|
+        break if ["if", "unless"].include?(o)
         next unless o =~ /^\[?['"](.*)['"]/
         problem "Dependency #{dep} should not use option #{$1}"
       end


### PR DESCRIPTION
Handle the case where an if/unless is detected and then write off this line for option handling.

CC @ilovezfs who has seen this a billion times.