### PR TITLE
pull_spec: use stable, non-fork PR for patch expectation

### DIFF
--- a/Library/Homebrew/test/dev-cmd/pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pull_spec.rb
@@ -34,7 +34,7 @@ describe "brew pull", :integration_test do
       .and output(/Can only bump one changed formula/).to_stderr
       .and be_a_failure
 
-    expect { brew "pull", "https://github.com/Homebrew/homebrew-core/pull/1" }
+    expect { brew "pull", "https://github.com/Homebrew/brew/pull/1249" }
       .to output(/Fetching patch/).to_stdout
       .and output(/Patch failed to apply/).to_stderr
       .and be_a_failure


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Switch to using a stable, non-fork PR for the patch application expectation in `pull_spec.rb`.

This should fix the current error in https://github.com/Homebrew/homebrew-test-bot/pull/99.

cc @MikeMcQuaid as we have discussed this.