### PR TITLE
cmd/reinstall: Fix reinstallation of formulae without bottles

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -34,7 +34,7 @@ module Homebrew
     fi = FormulaInstaller.new(f)
     fi.options              = options
     fi.invalid_option_names = build_options.invalid_option_names
-    fi.build_bottle         = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
+    fi.build_bottle         = ARGV.build_bottle? || (!f.bottled? && f.build.bottle?)
     fi.build_from_source    = ARGV.build_from_source? || ARGV.build_all_from_source?
     fi.force_bottle         = ARGV.force_bottle?
     fi.interactive          = ARGV.interactive?


### PR DESCRIPTION
Reinstallation of non-bottled formulae was failing because it
used a deprecated method.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Running `brew reinstall` on a formula which
a) was not already installed AND
b) does not have a bottle
would fail because it used a deprecated method.

Note that this issue is reproducible on macOS, but it's way easier to reproduce on Linux because so few formulae lack Mac bottles.