### PR TITLE
undefined local variable or method `ruby_version' on macOS 10.13 beta

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -195,7 +195,8 @@ module Homebrew
       end
 
       def check_ruby_version
-        return if RUBY_VERSION[/\d\.\d/] == "2.0"
+        ruby_version = "2.0"
+        return if RUBY_VERSION[/\d\.\d/] == ruby_version
 
         <<-EOS.undent
           Ruby version #{RUBY_VERSION} is unsupported on #{MacOS.version}. Homebrew

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -47,16 +47,15 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_ruby_version" do
-    expected_string = <<-EXPECTED
-Ruby version 2.3.3p222 is unsupported on 10.13. Homebrew
-is developed and tested on Ruby 2.0, and may not work correctly
-on other Rubies. Patches are accepted as long as they don't cause breakage
-on supported Rubies.
-    EXPECTED
     allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.13"))
     stub_const("RUBY_VERSION", "2.3.3p222")
 
     expect(subject.check_ruby_version)
-      .to match(expected_string)
+      .to match <<-EOS.undent
+      Ruby version 2.3.3p222 is unsupported on 10.13. Homebrew
+      is developed and tested on Ruby 2.0, and may not work correctly
+      on other Rubies. Patches are accepted as long as they don't cause breakage
+      on supported Rubies.
+    EOS
   end
 end

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -45,4 +45,18 @@ describe Homebrew::Diagnostic::Checks do
     expect(subject.check_homebrew_prefix)
       .to match("Your Homebrew's prefix is not /usr/local.")
   end
+
+  specify "#check_ruby_version" do
+    expected_string = <<-EXPECTED
+Ruby version 2.3.3p222 is unsupported on 10.13. Homebrew
+is developed and tested on Ruby 2.0, and may not work correctly
+on other Rubies. Patches are accepted as long as they don't cause breakage
+on supported Rubies.
+    EXPECTED
+    allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.13"))
+    stub_const("RUBY_VERSION", "2.3.3p222")
+
+    expect(subject.check_ruby_version)
+      .to match(expected_string)
+  end
 end


### PR DESCRIPTION
There is a bug in check_ruby_version. It occur on MacOS 10.13 beta because it ships with Ruby 2.3.3.

I didn't figure up how to make brew tests work, but i made some workarounds changes to check my code and it should to be work.

Fixes https://github.com/Homebrew/brew/issues/2737

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

-----