### PR TITLE
High Sierra: more initial support

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/10.13/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/libcurl.pc
@@ -1,0 +1,39 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2004 - 2012, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at http://curl.haxx.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+###########################################################################
+
+# This should most probably benefit from getting a "Requires:" field added
+# dynamically by configure.
+#
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+supported_protocols="DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
+supported_features="AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz UnixSockets"
+
+Name: libcurl
+URL: https://curl.haxx.se/
+Description: Library to transfer files with ftp, http, etc.
+Version: 7.51.0
+Libs: -L${libdir} -lcurl
+Libs.private: -lldap -lz
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/libexslt.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+
+Name: libexslt
+Version: 0.8.17
+Description: EXSLT Extension library
+Requires: libxml-2.0
+Libs: -L${libdir} -lexslt -lxslt  -lxml2 -lz -lpthread -licucore -lm
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/libxml-2.0.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+modules=1
+
+Name: libXML
+Version: 2.9.4
+Description: libXML library version2.
+Requires:
+Libs: -L${libdir} -lxml2
+Libs.private: -lz -lpthread -licucore -lm
+Cflags: -I${includedir}/libxml2

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/libxslt.pc
@@ -1,0 +1,12 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+
+Name: libxslt
+Version: 1.1.29
+Description: XSLT library version 2.
+Requires: libxml-2.0
+Libs: -L${libdir} -lxslt  -lxml2 -lz -lpthread -licucore -lm
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/sqlite3.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: SQLite
+Description: SQL database engine
+Version: 3.18.0
+Libs: -L${libdir} -lsqlite3
+Libs.private:
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/zlib.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: zlib
+Description: zlib compression library
+Version: 1.2.8
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lz
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -216,6 +216,7 @@ module OS
         # on the older supported platform for that Xcode release, i.e there's no
         # CLT package for 10.11 that contains the Clang version from Xcode 8.
         case MacOS.version
+        when "10.13" then "900.0.22.8"
         when "10.12" then "802.0.42"
         when "10.11" then "800.0.42.1"
         when "10.10" then "700.1.81"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally? (On macOS 10.12, not 10.13)

-----

One small note:

I trimmed `Libs.private` in `libcurl.pc` because I'm pretty sure it's wildly outdated & has been for quite some time. In the 10.12 `libcurl.pc` for example we have things like `-lssl -lcrypto` which is almost certainly not true these days since `curl` links to macOS' `SecureTransport`.

Reading the `libcurl.pc` file from Homebrew's standard, non-option, bottle-poured `curl` I get `Libs.private: -lldap -lz` so that's what I've trimmed the line to 🤷‍♂️.