### PR TITLE
tty: handle non-tty stdin.

### DIFF
--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -6,7 +6,10 @@ module Tty
   end
 
   def width
-    (`/bin/stty size`.split[1] || 80).to_i
+    width = `/bin/stty size 2>/dev/null`.split[1]
+    width ||= `/usr/bin/tput cols 2>/dev/null`.split[0]
+    width ||= 80
+    width.to_i
   end
 
   def truncate(string)


### PR DESCRIPTION
When stdin is not a tty then the message `stty: stdin isn't a terminal` will be produced. Silence this message and fall back to `tput` when it fails and default to 80 if we get no results at all.

Follow-up from #2714.
References https://github.com/Homebrew/homebrew-core/issues/14324.
Fixes #2742.