### PR TITLE
formula_desc_cop: tweak some rules.

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -8,27 +8,46 @@ module RuboCop
       #
       # - Checks for existence of `desc`
       # - Checks if size of `desc` > 80
-      # - Checks if `desc` begins with an article
-      # - Checks for correct usage of `command-line` in `desc`
-      # - Checks if `desc` contains the formula name
-      class Desc < FormulaCop
+      class DescLength < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body)
           desc_call = find_node_method_by_name(body, :desc)
 
+          # Check if a formula's desc is present
           if desc_call.nil?
             problem "Formula should have a desc (Description)."
             return
           end
 
+          # Check if a formula's desc is too long
           desc = parameters(desc_call).first
           desc_length = "#{@formula_name}: #{string_content(desc)}".length
           max_desc_length = 80
-          if desc_length > max_desc_length
-            problem <<-EOS.undent
-              Description is too long. "name: desc" should be less than #{max_desc_length} characters.
-              Length is calculated as #{@formula_name} + desc. (currently #{desc_length})
-            EOS
-          end
+          return if desc_length <= max_desc_length
+          problem <<-EOS.undent
+            Description is too long. "name: desc" should be less than #{max_desc_length} characters.
+            Length is calculated as #{@formula_name} + desc. (currently #{desc_length})
+          EOS
+        end
+      end
+
+      # This cop audits `desc` in Formulae
+      #
+      # - Checks if `desc` begins with an article
+      # - Checks for correct usage of `command-line` in `desc`
+      # - Checks description starts with a capital letter
+      # - Checks if `desc` contains the formula name
+      class Desc < FormulaCop
+        VALID_LOWERCASE_WORDS = %w[
+          iOS
+          macOS
+          xUnit
+        ].freeze
+
+        def audit_formula(_node, _class_node, _parent_class_node, body)
+          desc_call = find_node_method_by_name(body, :desc)
+          return if desc_call.nil?
+
+          desc = parameters(desc_call).first
 
           # Check if command-line is wrongly used in formula's desc
           if match = regex_match_group(desc, /(command ?line)/i)
@@ -36,16 +55,41 @@ module RuboCop
             problem "Description should use \"#{c}ommand-line\" instead of \"#{match}\""
           end
 
+          # Check if a/an are used in a formula's desc
           if match = regex_match_group(desc, /^(an?)\s/i)
-            problem "Description shouldn't start with an indefinite article (#{match})"
+            problem "Description shouldn't start with an indefinite article i.e. \"#{match.to_s.strip}\""
           end
 
-          if regex_match_group(desc, /^[a-z]/)
+          # Check if invalid uppercase words are at the start of a
+          # formula's desc
+          if !VALID_LOWERCASE_WORDS.include?(string_content(desc).split.first) &&
+             regex_match_group(desc, /^[a-z]/)
             problem "Description should start with a capital letter"
           end
 
           # Check if formula's name is used in formula's desc
-          problem "Description shouldn't include the formula name" if regex_match_group(desc, /^#{@formula_name}\b/i)
+          return unless regex_match_group(desc, /(^|[^a-z])#{@formula_name}([^a-z]|$)/i)
+          problem "Description shouldn't include the formula name"
+        end
+
+        private
+
+        def autocorrect(node)
+          lambda do |corrector|
+            correction = node.source
+            first_word = string_content(node).split.first
+            unless VALID_LOWERCASE_WORDS.include?(first_word)
+              first_char = first_word.to_s.chars.first
+              correction.sub!(/^(['"]?)([a-z])/, "\\1#{first_char.upcase}")
+            end
+            correction.sub!(/^(['"]?)an?\s/i, "\\1")
+            correction.gsub!(/(ommand ?line)/i, "ommand-line")
+            correction.gsub!(/(^|[^a-z])#{@formula_name}([^a-z]|$)/i, "\\1\\2")
+            correction.gsub!(/^(['"]?)\s+/, "\\1")
+            correction.gsub!(/\s+(['"]?)$/, "\\1")
+            corrector.insert_before(node.source_range, correction)
+            corrector.remove(node.source_range)
+          end
         end
       end
     end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -23,6 +23,7 @@ require "test/support/helper/shutup"
 require "test/support/helper/fixtures"
 require "test/support/helper/formula"
 require "test/support/helper/mktmpdir"
+require "test/support/helper/rubocop"
 
 require "test/support/helper/spec/shared_context/homebrew_cask" if OS.mac?
 require "test/support/helper/spec/shared_context/integration_test"
@@ -44,6 +45,7 @@ RSpec.configure do |config|
   config.include(Test::Helper::Fixtures)
   config.include(Test::Helper::Formula)
   config.include(Test::Helper::MkTmpDir)
+  config.include(Test::Helper::RuboCop)
 
   config.before(:each, :needs_compat) do
     skip "Requires compatibility layer." if ENV["HOMEBREW_NO_COMPAT"]

--- a/Library/Homebrew/test/support/helper/rubocop.rb
+++ b/Library/Homebrew/test/support/helper/rubocop.rb
@@ -1,0 +1,13 @@
+module Test
+  module Helper
+    module RuboCop
+      def expect_offense(expected, actual)
+        expect(actual).to_not be_nil
+        expect(actual.message).to eq(expected[:message])
+        expect(actual.severity).to eq(expected[:severity])
+        expect(actual.line).to eq(expected[:line])
+        expect(actual.column).to eq(expected[:column])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow some specific lowercase words and provide an autocorrect for some of these rules.

As mentioned in https://github.com/Homebrew/brew/pull/2724.

CC @issyl0 as this was partly motivated by your PR.

CC @GauthamGoli for thoughts and review. Additionally, this did made me think we should probably have some of the stuff that can't be autocorrected as different rules otherwise RuboCop will think it's autocorrected them when it has not.