### PR TITLE
reinstall: remove partially installed keg.

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -66,6 +66,7 @@ module Homebrew
 
     return unless path.directory?
 
+    keg.rmtree if keg.exist?
     path.rename keg
     keg.link unless formula.keg_only?
   end


### PR DESCRIPTION
Previously if a `brew reinstall` was Ctrl-Cd after some files had been installed it wouldn't try to remove the partially installed keg and the renaming of the backed-up keg would fail. Alternatively, remove the partially installed keg as if it has been Ctrl-Cd or otherwise failed then it's not desirable to keep it.

Fixes #2643

CC @DomT4 for thoughts.