### PR TITLE
BottleLoader: Fix installing a bottle from an URL

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -108,7 +108,8 @@ module Formulary
       case bottle_name
       when %r{(https?|ftp|file)://}
         # The name of the formula is found between the last slash and the last hyphen.
-        resource = Resource.new bottle_name[%r{([^/]+)-}, 1] { url bottle_name }
+        formula_name = File.basename(bottle_name)[/(.+)-/, 1]
+        resource = Resource.new(formula_name) { url bottle_name }
         downloader = CurlBottleDownloadStrategy.new resource.name, resource
         @bottle_filename = downloader.cached_location
         cached = @bottle_filename.exist?


### PR DESCRIPTION
The name of the formula is not extracted correctly when the URL includes a hyphen.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
