### PR TITLE
keg_relocate: Don't relocate duplicated Rust dylibs.

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -84,7 +84,16 @@ class Keg
     dylibs.each(&block)
   end
 
+  # Rust ships two copies of its libraries, one in lib/ and the other in lib/rustlib/.
+  # We need to avoid rewriting the second copy until
+  # https://github.com/rust-lang/rust/issues/39870 is fixed.
+  def rust_duplicate?(fn)
+    fn =~ %r{/lib/rustlib/}
+  end
+
   def dylib_id_for(file)
+    return file.dylib_id if rust_duplicate?(file.to_s)
+
     # The new dylib ID should have the same basename as the old dylib ID, not
     # the basename of the file itself.
     basename = File.basename(file.dylib_id)


### PR DESCRIPTION
This is a workaround for https://github.com/rust-lang/rust/issues/39870.

We could make the filename match even more restrictive, but I think that `/lib/rustlib/` will probably be exclusive enough.

cc @ilovezfs 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
