### PR TITLE
rubocop: don’t allow %x.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -118,10 +118,6 @@ Style/BlockDelimiters:
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
 
-# percent-x is allowed for multiline
-Style/CommandLiteral:
-  EnforcedStyle: mixed
-
 # our current conditional style is established, clear and
 # requiring users to change that now would be confusing.
 Style/ConditionalAssignment:


### PR DESCRIPTION
It’s confusing for non-Rubyists (and some Rubyists) and that’s a major number of our current and future contributors.