### PR TITLE
rubocop: don’t allow special global variables.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -187,10 +187,6 @@ Style/RaiseArgs:
 Style/RegexpLiteral:
   EnforcedStyle: slashes
 
-# not a problem for typical shell users
-Style/SpecialGlobalVars:
-  Enabled: false
-
 # ruby style guide favorite
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -10,7 +10,8 @@ raise "Homebrew must be run under Ruby 2!" unless RUBY_TWO
 
 require "pathname"
 HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
-$:.unshift(HOMEBREW_LIBRARY_PATH.to_s)
+require "English"
+$LOAD_PATH.unshift(HOMEBREW_LIBRARY_PATH.to_s)
 require "global"
 require "tap"
 

--- a/Library/Homebrew/cask/lib/hbc/cli/style.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/style.rb
@@ -1,5 +1,3 @@
-require "English"
-
 module Hbc
   class CLI
     class Style < AbstractCommand

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -112,7 +112,7 @@ module Homebrew
       args << "--display-cop-names" if ARGV.include? "--display-cop-names"
       args << "--format" << "simple" if files
       system(cache_env, "rubocop", *args)
-      !$?.success?
+      !$CHILD_STATUS.success?
     when :json
       json, _, status = Open3.capture3(cache_env, "rubocop", "--format", "json", *args)
       # exit status of 1 just means violations were found; other numbers mean

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -265,10 +265,10 @@ module Homebrew
       failed_audit = false
       if ARGV.include? "--strict"
         system HOMEBREW_BREW_FILE, "audit", "--strict", formula.path
-        failed_audit = !$?.success?
+        failed_audit = !$CHILD_STATUS.success?
       elsif ARGV.include? "--audit"
         system HOMEBREW_BREW_FILE, "audit", formula.path
-        failed_audit = !$?.success?
+        failed_audit = !$CHILD_STATUS.success?
       end
       if failed_audit
         formula.path.atomic_write(backup_file)

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -459,7 +459,7 @@ module Homebrew
     def self.lookup(name)
       json = Utils.popen_read(HOMEBREW_BREW_FILE, "info", "--json=v1", name)
 
-      return nil unless $?.success?
+      return nil unless $CHILD_STATUS.success?
 
       Homebrew.force_utf8!(json)
       FormulaInfoFromJson.new(JSON.parse(json)[0])

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -111,7 +111,7 @@ module Homebrew
         system "bundle", "exec", "rspec", *args, "--", *files
       end
 
-      return if $?.success?
+      return if $CHILD_STATUS.success?
       Homebrew.failed = true
     end
   end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -338,7 +338,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       rescue ErrorDuringExecution
         # 33 == range not supported
         # try wiping the incomplete download and retrying once
-        unless $?.exitstatus == 33 && had_incomplete_download
+        unless $CHILD_STATUS.exitstatus == 33 && had_incomplete_download
           raise CurlDownloadStrategyError, @url
         end
 

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -271,7 +271,7 @@ module Homebrew
       def check_xcode_license_approved
         # If the user installs Xcode-only, they have to approve the
         # license or no "xc*" tool will work.
-        return unless `/usr/bin/xcrun clang 2>&1` =~ /license/ && !$?.success?
+        return unless `/usr/bin/xcrun clang 2>&1` =~ /license/ && !$CHILD_STATUS.success?
 
         <<-EOS.undent
           You have not agreed to the Xcode license.

--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -23,7 +23,7 @@ class JavaRequirement < Requirement
     args = %w[--failfast]
     args << "--version" << @version.to_s if @version
     java_home = Utils.popen_read("/usr/libexec/java_home", *args).chomp
-    return nil unless $?.success?
+    return nil unless $CHILD_STATUS.success?
     Pathname.new(java_home)/"bin/java"
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1836,7 +1836,7 @@ class Formula
 
       $stdout.flush
 
-      unless $?.success?
+      unless $CHILD_STATUS.success?
         log_lines = ENV["HOMEBREW_FAIL_LOG_LINES"]
         log_lines ||= "15"
 

--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -27,7 +27,7 @@ module Homebrew
     def shell_output(cmd, result = 0)
       ohai cmd
       output = `#{cmd}`
-      assert_equal result, $?.exitstatus
+      assert_equal result, $CHILD_STATUS.exitstatus
       output
     end
 
@@ -40,7 +40,7 @@ module Homebrew
         pipe.close_write
         pipe.read
       end
-      assert_equal result, $?.exitstatus unless result.nil?
+      assert_equal result, $CHILD_STATUS.exitstatus unless result.nil?
       output
     end
   end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -96,7 +96,7 @@ module Formulary
     private
 
     def load_file
-      $stderr.puts "#{$0} (#{self.class.name}): loading #{path}" if ARGV.debug?
+      $stderr.puts "#{$PROGRAM_NAME} (#{self.class.name}): loading #{path}" if ARGV.debug?
       raise FormulaUnavailableError, name unless path.file?
       Formulary.load_formula_from_path(name, path)
     end
@@ -258,7 +258,7 @@ module Formulary
     end
 
     def klass
-      $stderr.puts "#{$0} (#{self.class.name}): loading #{path}" if ARGV.debug?
+      $stderr.puts "#{$PROGRAM_NAME} (#{self.class.name}): loading #{path}" if ARGV.debug?
       namespace = "FormulaNamespace#{Digest::MD5.hexdigest(contents)}"
       Formulary.load_formula(name, path, contents, namespace)
     end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -12,6 +12,7 @@ require "set"
 require "rbconfig"
 require "official_taps"
 require "pp"
+require "English"
 
 ARGV.extend(HomebrewArgvExtension)
 

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -11,7 +11,7 @@ module Language
       # directory, consequently breaking that assumption. We require a tarball
       # because npm install creates a "real" installation when fed a tarball.
       output = Utils.popen_read("npm pack").chomp
-      raise "npm failed to pack #{Dir.pwd}" unless $?.exitstatus.zero?
+      raise "npm failed to pack #{Dir.pwd}" unless $CHILD_STATUS.exitstatus.zero?
       output
     end
 

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -118,7 +118,7 @@ module OS
         ].uniq.each do |xcodebuild_path|
           next unless File.executable? xcodebuild_path
           xcodebuild_output = Utils.popen_read(xcodebuild_path, "-version")
-          next unless $?.success?
+          next unless $CHILD_STATUS.success?
 
           xcode_version = xcodebuild_output[/Xcode (\d(\.\d)*)/, 1]
           return xcode_version if xcode_version

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -68,7 +68,7 @@ class EmbeddedPatch
     cmd = "/usr/bin/patch"
     args = %W[-g 0 -f -#{strip}]
     IO.popen("#{cmd} #{args.join(" ")}", "w") { |p| p.write(data) }
-    raise ErrorDuringExecution.new(cmd, args) unless $?.success?
+    raise ErrorDuringExecution.new(cmd, args) unless $CHILD_STATUS.success?
   end
 
   def inspect

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -82,7 +82,7 @@ module Readall
 
       # Only syntax errors result in a non-zero status code. To detect syntax
       # warnings we also need to inspect the output to `$stderr`.
-      !$?.success? || !messages.chomp.empty?
+      !$CHILD_STATUS.success? || !messages.chomp.empty?
     end
   end
 end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -128,7 +128,7 @@ class SystemConfig
       return "N/A" unless File.executable? "/usr/libexec/java_home"
 
       java_xml = Utils.popen_read("/usr/libexec/java_home", "--xml", "--failfast")
-      return "N/A" unless $?.success?
+      return "N/A" unless $CHILD_STATUS.success?
       javas = []
       REXML::XPath.each(REXML::Document.new(java_xml), "//key[text()='JVMVersion']/following-sibling::string") do |item|
         javas << item.text

--- a/Library/Homebrew/test/cask/cli/style_spec.rb
+++ b/Library/Homebrew/test/cask/cli/style_spec.rb
@@ -1,4 +1,3 @@
-require "English"
 require "open3"
 require "rubygems"
 

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -4,7 +4,7 @@ describe Utils do
   describe "::popen_read" do
     it "reads the standard output of a given command" do
       expect(subject.popen_read("sh", "-c", "echo success").chomp).to eq("success")
-      expect($?).to be_a_success
+      expect($CHILD_STATUS).to be_a_success
     end
 
     it "can be given a block to manually read from the pipe" do
@@ -13,7 +13,7 @@ describe Utils do
           pipe.read.chomp
         end,
       ).to eq("success")
-      expect($?).to be_a_success
+      expect($CHILD_STATUS).to be_a_success
     end
   end
 
@@ -22,7 +22,7 @@ describe Utils do
       subject.popen_write("grep", "-q", "success") do |pipe|
         pipe.write("success\n")
       end
-      expect($?).to be_a_success
+      expect($CHILD_STATUS).to be_a_success
     end
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -151,9 +151,9 @@ def interactive_shell(f = nil)
 
   Process.wait fork { exec ENV["SHELL"] }
 
-  return if $?.success?
-  raise "Aborted due to non-zero exit status (#{$?.exitstatus})" if $?.exited?
-  raise $?.inspect
+  return if $CHILD_STATUS.success?
+  raise "Aborted due to non-zero exit status (#{$CHILD_STATUS.exitstatus})" if $CHILD_STATUS.exited?
+  raise $CHILD_STATUS.inspect
 end
 
 module Homebrew
@@ -171,7 +171,7 @@ module Homebrew
       exit! 1 # never gets here unless exec failed
     end
     Process.wait(pid)
-    $?.success?
+    $CHILD_STATUS.success?
   end
 
   def system(cmd, *args)

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -37,8 +37,8 @@ module Utils
           read.close
           Process.wait(pid) unless socket.nil?
           raise Marshal.load(data) unless data.nil? || data.empty?
-          raise Interrupt if $?.exitstatus == 130
-          raise "Suspicious failure" unless $?.success?
+          raise Interrupt if $CHILD_STATUS.exitstatus == 130
+          raise "Suspicious failure" unless $CHILD_STATUS.success?
         end
       end
     end


### PR DESCRIPTION
Even if shell/perl users recognise these variables the English versions are significantly more readable for everyone.