### PR TITLE
rubocop: don’t allow word arrays.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -217,4 +217,4 @@ Style/VariableNumber:
   Enabled: false
 
 Style/WordArray:
-  MinSize: 4
+  EnforcedStyle: brackets


### PR DESCRIPTION
These save a little syntax but they are more confusing to non-Rubyists and the previous, inconsistent rule isn’t helpful.

I realise I’ve changed my mind here. Sorry!

I've not fixed up the uses of this yet because there's a fair few, they can't all be autocorrected and I'd rather discuss this change first.