### PR TITLE
rubocop: don’t allow Perl regex backrefs.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -176,10 +176,6 @@ Style/PercentLiteralDelimiters:
     '%W': '[]'
     '%x': '()'
 
-# we prefer Perl-style regex back references
-Style/PerlBackrefs:
-  Enabled: false
-
 Style/RaiseArgs:
   EnforcedStyle: exploded
 

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -79,7 +79,7 @@ module Homebrew
 
   def github_remote_path(remote, path)
     if remote =~ %r{^(?:https?://|git(?:@|://))github\.com[:/](.+)/(.+?)(?:\.git)?$}
-      "https://github.com/#{$1}/#{$2}/blob/master/#{path}"
+      "https://github.com/#{Regexp.last_match(1)}/#{Regexp.last_match(2)}/blob/master/#{path}"
     else
       "#{remote}/#{path}"
     end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -80,7 +80,7 @@ module Homebrew
         if name !~ HOMEBREW_TAP_FORMULA_REGEX && name !~ HOMEBREW_CASK_TAP_CASK_REGEX
           next
         end
-        tap = Tap.fetch($1, $2)
+        tap = Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))
         tap.install unless tap.installed?
       end
     end

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -93,7 +93,7 @@ module Homebrew
 
   def query_regexp(query)
     case query
-    when %r{^/(.*)/$} then Regexp.new($1)
+    when %r{^/(.*)/$} then Regexp.new(Regexp.last_match(1))
     else /.*#{Regexp.escape(query)}.*/i
     end
   rescue RegexpError

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -101,13 +101,13 @@ class FormulaCreator
     if @name.nil?
       case url
       when %r{github\.com/(\S+)/(\S+)\.git}
-        @user = $1
-        @name = $2
+        @user = Regexp.last_match(1)
+        @name = Regexp.last_match(2)
         @head = true
         @github = true
       when %r{github\.com/(\S+)/(\S+)/(archive|releases)/}
-        @user = $1
-        @name = $2
+        @user = Regexp.last_match(1)
+        @name = Regexp.last_match(2)
         @github = true
       else
         @name = path.basename.to_s[/(.*?)[-_.]?#{Regexp.escape(path.version.to_s)}/, 1]

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -87,7 +87,7 @@ module Homebrew
     date = if ARGV.include?("--fail-if-changed") &&
               target.extname == ".1" && target.exist?
       /"(\d{1,2})" "([A-Z][a-z]+) (\d{4})" "#{organisation}" "#{manual}"/ =~ target.read
-      Date.parse("#{$1} #{$2} #{$3}")
+      Date.parse("#{Regexp.last_match(1)} #{Regexp.last_match(2)} #{Regexp.last_match(3)}")
     else
       Date.today
     end

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -347,7 +347,7 @@ module Homebrew
     formulae = []
     others = []
     File.foreach(patchfile) do |line|
-      files << $1 if line =~ %r{^\+\+\+ b/(.*)}
+      files << Regexp.last_match(1) if line =~ %r{^\+\+\+ b/(.*)}
     end
     files.each do |file|
       if tap && tap.formula_file?(file)

--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -33,7 +33,7 @@ module Homebrew
     if ARGV.include?("--markdown")
       output.map! do |s|
         /(.*\d)+ \(@(.+)\) - (.*)/ =~ s
-        "- [#{$3}](#{$1}) (@#{$2})"
+        "- [#{Regexp.last_match(3)}](#{Regexp.last_match(1)}) (@#{Regexp.last_match(2)})"
       end
     end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -49,7 +49,7 @@ module Homebrew
             case line.chomp
               # regex matches: /dev/disk0s2   489562928 440803616  48247312    91%    /
             when /^.+\s+[0-9]+\s+[0-9]+\s+[0-9]+\s+[0-9]{1,3}%\s+(.+)/
-              vols << $1
+              vols << Regexp.last_match(1)
             end
           end
         end
@@ -919,11 +919,11 @@ module Homebrew
         return unless which "python"
         `python -V 2>&1` =~ /Python (\d+)\./
         # This won't be the right warning if we matched nothing at all
-        return if $1.nil?
-        return if $1 == "2"
+        return if Regexp.last_match(1).nil?
+        return if Regexp.last_match(1) == "2"
 
         <<-EOS.undent
-          python is symlinked to python#{$1}
+          python is symlinked to python#{Regexp.last_match(1)}
           This will confuse build scripts and in general lead to subtle breakage.
         EOS
       end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -517,8 +517,8 @@ class S3DownloadStrategy < CurlDownloadStrategy
     if @url !~ %r{^https?://([^.].*)\.s3\.amazonaws\.com/(.+)$}
       raise "Bad S3 URL: " + @url
     end
-    bucket = $1
-    key = $2
+    bucket = Regexp.last_match(1)
+    key = Regexp.last_match(2)
 
     ENV["AWS_ACCESS_KEY_ID"] = ENV["HOMEBREW_AWS_ACCESS_KEY_ID"]
     ENV["AWS_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_AWS_SECRET_ACCESS_KEY"]

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -182,7 +182,7 @@ class TapFormulaAmbiguityError < RuntimeError
     @paths = paths
     @formulae = paths.map do |path|
       path.to_s =~ HOMEBREW_TAP_PATH_REGEX
-      "#{Tap.fetch($1, $2)}/#{path.basename(".rb")}"
+      "#{Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))}/#{path.basename(".rb")}"
     end
 
     super <<-EOS.undent
@@ -202,7 +202,7 @@ class TapFormulaWithOldnameAmbiguityError < RuntimeError
 
     @taps = possible_tap_newname_formulae.map do |newname|
       newname =~ HOMEBREW_TAP_FORMULA_REGEX
-      "#{$1}/#{$2}"
+      "#{Regexp.last_match(1)}/#{Regexp.last_match(2)}"
     end
 
     super <<-EOS.undent
@@ -504,7 +504,7 @@ class CurlDownloadStrategyError < RuntimeError
   def initialize(url)
     case url
     when %r{^file://(.+)}
-      super "File does not exist: #{$1}"
+      super "File does not exist: #{Regexp.last_match(1)}"
     else
       super "Download failed: #{url}"
     end

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -200,7 +200,7 @@ module Stdenv
   # @private
   def set_cpu_flags(flags, default = DEFAULT_FLAGS, map = Hardware::CPU.optimization_flags)
     cflags =~ /(-Xarch_#{Hardware::CPU.arch_32_bit} )-march=/
-    xarch = $1.to_s
+    xarch = Regexp.last_match(1).to_s
     remove flags, /(-Xarch_#{Hardware::CPU.arch_32_bit} )?-march=\S*/
     remove flags, /( -Xclang \S+)+/
     remove flags, /-mssse3/

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -266,7 +266,7 @@ module Superenv
 
   def make_jobs
     self["MAKEFLAGS"] =~ /-\w*j(\d+)/
-    [$1.to_i, 1].max
+    [Regexp.last_match(1).to_i, 1].max
   end
 
   def universal_binary

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -32,7 +32,7 @@ module Utils
       # :tiger_g4, :tiger_g5, etc.
       def find_altivec_tag(tag)
         return unless tag.to_s =~ /(\w+)_(g4|g4e|g5)$/
-        altivec_tag = "#{$1}_altivec".to_sym
+        altivec_tag = "#{Regexp.last_match(1)}_altivec".to_sym
         altivec_tag if key?(altivec_tag)
       end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -177,7 +177,7 @@ class Formula
     @tap = if path == Formulary.core_path(name)
       CoreTap.instance
     elsif path.to_s =~ HOMEBREW_TAP_PATH_REGEX
-      Tap.fetch($1, $2)
+      Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))
     end
 
     @full_name = full_name_with_optional_tap(name)

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -59,7 +59,7 @@ module Formulary
 
   def self.class_s(name)
     class_name = name.capitalize
-    class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { $1.upcase }
+    class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
     class_name.tr!("+", "x")
     class_name.sub!(/(.)@(\d)/, "\\1AT\\2")
     class_name
@@ -168,7 +168,7 @@ module Formulary
       super
     rescue MethodDeprecatedError => e
       if url =~ %r{github.com/([\w-]+)/homebrew-([\w-]+)/}
-        e.issues_url = "https://github.com/#{$1}/homebrew-#{$2}/issues/new"
+        e.issues_url = "https://github.com/#{Regexp.last_match(1)}/homebrew-#{Regexp.last_match(2)}/issues/new"
       end
       raise
     end

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -61,7 +61,7 @@ class Requirement
 
     if parent = satisfied_result_parent
       parent.to_s =~ %r{(#{Regexp.escape(HOMEBREW_CELLAR)}|#{Regexp.escape(HOMEBREW_PREFIX)}/opt)/([\w+-.@]+)}
-      @formula = $2
+      @formula = Regexp.last_match(2)
     end
 
     true

--- a/Library/Homebrew/rubocops/homepage_cop.rb
+++ b/Library/Homebrew/rubocops/homepage_cop.rb
@@ -54,7 +54,7 @@ module RuboCop
             problem "Please use https:// for #{homepage}"
 
           when %r{^http://([^/]*)\.(sf|sourceforge)\.net(/|$)}
-            problem "#{homepage} should be `https://#{$1}.sourceforge.io/`"
+            problem "#{homepage} should be `https://#{Regexp.last_match(1)}.sourceforge.io/`"
 
           # There's an auto-redirect here, but this mistake is incredibly common too.
           # Only applies to the homepage and subdomains for now, not the FTP URLs.

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -43,8 +43,8 @@ class Tap
 
   def self.from_path(path)
     path.to_s =~ HOMEBREW_TAP_PATH_REGEX
-    raise "Invalid tap path '#{path}'" unless $1
-    fetch($1, $2)
+    raise "Invalid tap path '#{path}'" unless Regexp.last_match(1)
+    fetch(Regexp.last_match(1), Regexp.last_match(2))
   rescue
     # No need to error as a nil tap is sufficient to show failure.
     nil

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -76,7 +76,7 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
   tap_message = nil
   caller_message = backtrace.detect do |line|
     next unless line =~ %r{^#{Regexp.escape(HOMEBREW_LIBRARY)}/Taps/([^/]+/[^/]+)/}
-    tap = Tap.fetch $1
+    tap = Tap.fetch Regexp.last_match(1)
     tap_message = "\nPlease report this to the #{tap} tap!"
     true
   end


### PR DESCRIPTION
Even if shell/perl users recognise these variables the explicit versions are significantly more readable for everyone.