### PR TITLE
refactor: DRY up redundant formulations of {#user}/homebrew-{#repo}

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -64,6 +64,11 @@ class Tap
   # e.g. `user/repo`
   attr_reader :name
 
+  # The full name of this {Tap}, including the `homebrew-` prefix.
+  # It combines {#user} and 'homebrew-'-prefixed {#repo} with a slash.
+  # e.g. `user/homebrew-repo`
+  attr_reader :full_name
+
   # The local path to this {Tap}.
   # e.g. `/usr/local/Library/Taps/user/homebrew-repo`
   attr_reader :path
@@ -73,7 +78,8 @@ class Tap
     @user = user
     @repo = repo
     @name = "#{@user}/#{@repo}".downcase
-    @path = TAP_DIRECTORY/"#{@user}/homebrew-#{@repo}".downcase
+    @full_name = "#{@user}/homebrew-#{@repo}"
+    @path = TAP_DIRECTORY/@full_name.downcase
     @path.extend(GitRepositoryExtension)
   end
 
@@ -104,7 +110,7 @@ class Tap
 
   # The default remote path to this {Tap}.
   def default_remote
-    "https://github.com/#{user}/homebrew-#{repo}"
+    "https://github.com/#{full_name}"
   end
 
   # True if this {Tap} is a git repository.
@@ -140,7 +146,7 @@ class Tap
   # e.g. `https://github.com/user/homebrew-repo/issues`
   def issues_url
     return unless official? || !custom_remote?
-    "https://github.com/#{user}/homebrew-#{repo}/issues"
+    "#{default_remote}/issues"
   end
 
   def to_s
@@ -263,7 +269,7 @@ class Tap
       credentials each time you update, you can use git HTTP credential
       caching or issue the following command:
         cd #{path}
-        git remote set-url origin git@github.com:#{user}/homebrew-#{repo}.git
+        git remote set-url origin git@github.com:#{full_name}.git
     EOS
   end
 
@@ -513,7 +519,7 @@ class Tap
         if custom_remote?
           true
         else
-          GitHub.private_repo?(user, "homebrew-#{repo}")
+          GitHub.private_repo?(full_name)
         end
       rescue GitHub::HTTPNotFoundError
         true

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -291,8 +291,8 @@ module GitHub
     prs.each { |i| puts "#{i["title"]} (#{i["html_url"]})" }
   end
 
-  def private_repo?(user, repo)
-    uri = URI.parse("#{API_URL}/repos/#{user}/#{repo}")
+  def private_repo?(full_name)
+    uri = URI.parse("#{API_URL}/repos/#{full_name}")
     open(uri) { |json| json["private"] }
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Minor refactor to dry-up the redundant formulations of `{user}/homebrew-{repo}`. This coalesces the logic for how the `{#user}/homebrew-{#repo}` formulation is defined into a single location.

Open to better attribute names than `full_name`.

No tests yet included because I'm not sure if the `full_name` attribute should even be public. It's publicly-surfaceable information, but currently has no uses outside of the Tap itself.

If this tweak is welcome, the one last duplicate reference would be `GitHub.private_repo?(user, "homebrew-#{repo}")` at https://github.com/jasonkarns/brew/blob/dae9b9a8332f442036193c966095d06e4e6e7e68/Library/Homebrew/tap.rb#L522. More than happy to include that change in this PR.