### PR TITLE
format_desc_cop: whitelist more lowercase words

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -38,8 +38,13 @@ module RuboCop
       # - Checks if `desc` contains the formula name
       class Desc < FormulaCop
         VALID_LOWERCASE_WORDS = %w[
+          ex
+          eXtensible
           iOS
           macOS
+          malloc
+          ooc
+          preexec
           xUnit
         ].freeze
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- From `homebrew-core` PR 14229, we decided to whitelist more words so
  that reordering to appease "description must start with a capital
  letter" wasn't so clunky.