### PR TITLE
which_editor: Add MacVim to the default editors

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -334,8 +334,8 @@ def which_editor
               .first
   return editor if editor
 
-  # Find Atom, Sublime Text, Textmate, BBEdit / TextWrangler, or vim
-  editor = %w[atom subl mate edit vim].find do |candidate|
+  # Find Atom, Sublime Text, Textmate, BBEdit / TextWrangler, MacVim, or vim
+  editor = %w[atom subl mate edit mvim vim].find do |candidate|
     candidate if which(candidate, ENV["HOMEBREW_PATH"])
   end
   editor ||= "/usr/bin/vim"


### PR DESCRIPTION
MacVim may be installed with…
```sh
brew cask install macvim
```

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
