### PR TITLE
Fix outdated `--repository` man documentation

### DIFF
--- a/Library/Homebrew/cmd/--repository.rb
+++ b/Library/Homebrew/cmd/--repository.rb
@@ -1,6 +1,5 @@
 #:  * `--repository`:
-#:    Display where Homebrew's `.git` directory is located. For standard installs,
-#:    the `prefix` and `repository` are the same directory.
+#:    Display where Homebrew's `.git` directory is located.
 #:
 #:  * `--repository` <user>`/`<repo>:
 #:    Display where tap <user>`/`<repo>'s directory is located.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -599,8 +599,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Display the location in the cellar where `formula` is or would be installed.
 
   * `--repository`:
-    Display where Homebrew's `.git` directory is located. For standard installs,
-    the `prefix` and `repository` are the same directory.
+    Display where Homebrew's `.git` directory is located.
 
   * `--repository` `user``/``repo`:
     Display where tap `user``/``repo`'s directory is located.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -624,7 +624,7 @@ Display the location in the cellar where \fIformula\fR is or would be installed\
 .
 .TP
 \fB\-\-repository\fR
-Display where Homebrew\'s \fB\.git\fR directory is located\. For standard installs, the \fBprefix\fR and \fBrepository\fR are the same directory\.
+Display where Homebrew\'s \fB\.git\fR directory is located\.
 .
 .TP
 \fB\-\-repository\fR \fIuser\fR\fB/\fR\fIrepo\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In a default installation, `brew --repository` is now "/usr/local/Homebrew" while `brew --prefix` is now "/usr/local".