### PR TITLE
travis.yml: tweak how we handle homebrew/test-bot.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,10 @@ before_install:
     else
       git fetch --unshallow;
       export PATH="$PWD/bin:$PATH";
-      rm -rf Library/Taps/homebrew/homebrew-test-bot/.git;
-      mv Library/Taps/homebrew/homebrew-test-bot Library/Taps/homebrew/homebrew-core;
+      HOMEBREW_CORE_TAP_DIR="$(brew --repo "homebrew/core")";
+      mkdir -p "$HOMEBREW_CORE_TAP_DIR";
+      HOMEBREW_TEST_BOT_TAP_DIR="$(brew --repo "homebrew/test-bot")";
+      ln -s "$HOMEBREW_TEST_BOT_TAP_DIR/.git" "$HOMEBREW_TEST_BOT_TAP_DIR/Formula" "$HOMEBREW_CORE_TAP_DIR";
       umask 022;
     fi
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -760,6 +760,8 @@ module Homebrew
               git -C "#{coretap_path}" remote add origin #{Formatter.url("https://github.com/Homebrew/homebrew-core.git")}
           EOS
         elsif origin !~ %r{Homebrew/homebrew-core(\.git|/)?$}
+          return if ENV["CI"] && origin.include?("Homebrew/homebrew-test-bot")
+
           <<-EOS.undent
             Suspicious #{CoreTap.instance} git origin remote found.
 
@@ -1026,6 +1028,11 @@ module Homebrew
         end
         cmd_map.reject! { |_cmd_name, cmd_paths| cmd_paths.size == 1 }
         return if cmd_map.empty?
+
+        if ENV["CI"] && cmd_map.keys.length == 1 &&
+           cmd_map.keys.first == "brew-test-bot"
+          return
+        end
 
         message = "You have external commands with conflicting names.\n"
         cmd_map.each do |cmd_name, cmd_paths|


### PR DESCRIPTION
On Linux this is currently blowing up for our tags so let's change the approach.