### PR TITLE
formula_desc_cop: ensure no full stops at the end of desc

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -40,6 +40,7 @@ module RuboCop
       # - Checks for correct usage of `command-line` in `desc`
       # - Checks description starts with a capital letter
       # - Checks if `desc` contains the formula name
+      # - Checks if `desc` ends with a full stop
       class Desc < FormulaCop
         VALID_LOWERCASE_WORDS = %w[
           ex
@@ -78,8 +79,13 @@ module RuboCop
           end
 
           # Check if formula's desc starts with formula's name
-          return unless regex_match_group(desc, /^#{@formula_name} /i)
-          problem "Description shouldn't start with the formula name"
+          if regex_match_group(desc, /^#{@formula_name} /i)
+            problem "Description shouldn't start with the formula name"
+          end
+
+          # Check if a full stop is used at the end of a formula's desc
+          return unless regex_match_group(desc, /\.$/)
+          problem "Description shouldn't end with a full stop"
         end
 
         private
@@ -97,6 +103,7 @@ module RuboCop
             correction.gsub!(/(^|[^a-z])#{@formula_name}([^a-z]|$)/i, "\\1\\2")
             correction.gsub!(/^(['"]?)\s+/, "\\1")
             correction.gsub!(/\s+(['"]?)$/, "\\1")
+            correction.gsub!(/\.$/, "")
             corrector.insert_before(node.source_range, correction)
             corrector.remove(node.source_range)
           end

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -91,6 +91,16 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
       RUBY
     end
 
+    it "When the description ends with a full stop" do
+      expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          url 'http://example.com/foo-1.0.tgz'
+          desc 'Description with a full stop at the end.'
+                                                       ^ Description shouldn\'t end with a full stop
+        end
+      RUBY
+    end
+
     it "autocorrects all rules" do
       source = <<~EOS
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was a suggestion by Mike McQuaid in my `homebrew-core` audit
  description PR. Currently, no formulae do have full stops at the
  end of descriptions (based on `ack "desc\b" *.rb | ack "\.$" *.rb`),
  but in the interests of future-proofing and consistency, we should
  check for this anyway?