### PR TITLE
rubocops: refactor to use consistent _body_node parameter name

### DIFF
--- a/Library/Homebrew/rubocops/bottle_block_cop.rb
+++ b/Library/Homebrew/rubocops/bottle_block_cop.rb
@@ -10,8 +10,8 @@ module RuboCop
       class BottleBlock < FormulaCop
         MSG = "Use rebuild instead of revision in bottle block".freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, formula_class_body_node)
-          bottle = find_block(formula_class_body_node, :bottle)
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          bottle = find_block(body_node, :bottle)
           return if bottle.nil? || block_size(bottle).zero?
           problem "Use rebuild instead of revision in bottle block" if method_called_in_block?(bottle, :revision)
         end

--- a/Library/Homebrew/rubocops/components_order_cop.rb
+++ b/Library/Homebrew/rubocops/components_order_cop.rb
@@ -8,7 +8,7 @@ module RuboCop
       # - component_precedence_list has component hierarchy in a nested list
       #   where each sub array contains components' details which are at same precedence level
       class ComponentsOrder < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, formula_class_body_node)
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
           component_precedence_list = [
             [{ name: :include,  type: :method_call }],
             [{ name: :desc,     type: :method_call }],
@@ -41,11 +41,11 @@ module RuboCop
             components.each do |component|
               case component[:type]
               when :method_call
-                relevant_components += find_method_calls_by_name(formula_class_body_node, component[:name]).to_a
+                relevant_components += find_method_calls_by_name(body_node, component[:name]).to_a
               when :block_call
-                relevant_components += find_blocks(formula_class_body_node, component[:name]).to_a
+                relevant_components += find_blocks(body_node, component[:name]).to_a
               when :method_definition
-                relevant_components << find_method_def(formula_class_body_node, component[:name])
+                relevant_components << find_method_def(body_node, component[:name])
               end
             end
             relevant_components.delete_if(&:nil?)

--- a/Library/Homebrew/rubocops/components_redundancy_cop.rb
+++ b/Library/Homebrew/rubocops/components_redundancy_cop.rb
@@ -13,19 +13,19 @@ module RuboCop
         HEAD_MSG = "`head` and `head do` should not be simultaneously present".freeze
         BOTTLE_MSG = "`bottle :modifier` and `bottle do` should not be simultaneously present".freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, formula_class_body_node)
-          stable_block = find_block(formula_class_body_node, :stable)
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          stable_block = find_block(body_node, :stable)
           if stable_block
             [:url, :sha256, :mirror].each do |method_name|
-              problem "`#{method_name}` should be put inside `stable` block" if method_called?(formula_class_body_node, method_name)
+              problem "`#{method_name}` should be put inside `stable` block" if method_called?(body_node, method_name)
             end
           end
 
-          problem HEAD_MSG if method_called?(formula_class_body_node, :head) &&
-                              find_block(formula_class_body_node, :head)
+          problem HEAD_MSG if method_called?(body_node, :head) &&
+                              find_block(body_node, :head)
 
-          problem BOTTLE_MSG if method_called?(formula_class_body_node, :bottle) &&
-                                find_block(formula_class_body_node, :bottle)
+          problem BOTTLE_MSG if method_called?(body_node, :bottle) &&
+                                find_block(body_node, :bottle)
         end
       end
     end

--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -9,8 +9,8 @@ module RuboCop
       # - Checks for existence of `desc`
       # - Checks if size of `desc` > 80
       class DescLength < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body)
-          desc_call = find_node_method_by_name(body, :desc)
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          desc_call = find_node_method_by_name(body_node, :desc)
 
           # Check if a formula's desc is present
           if desc_call.nil?
@@ -48,8 +48,8 @@ module RuboCop
           xUnit
         ].freeze
 
-        def audit_formula(_node, _class_node, _parent_class_node, body)
-          desc_call = find_node_method_by_name(body, :desc)
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          desc_call = find_node_method_by_name(body_node, :desc)
           return if desc_call.nil?
 
           desc = parameters(desc_call).first

--- a/Library/Homebrew/rubocops/homepage_cop.rb
+++ b/Library/Homebrew/rubocops/homepage_cop.rb
@@ -5,8 +5,8 @@ module RuboCop
     module FormulaAudit
       # This cop audits `homepage` url in Formulae
       class Homepage < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, formula_class_body_node)
-          homepage_node = find_node_method_by_name(formula_class_body_node, :homepage)
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          homepage_node = find_node_method_by_name(body_node, :homepage)
           homepage = if homepage_node
             string_content(parameters(homepage_node).first)
           else


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No new tests needed because no functionality change.*
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The various FormulaCop classes use different names for their fourth parameter (`_body_node`/`body_node`/`body`/`formula_class_body_node`). This PR changes them all to `_body_node` for consistency. I chose the `_body_node` variant for consistency with the other parameter names, which all have leading underscores and include `_node`.

No functional changes.

<strike>If this is approved, then, #2776 should also switch to `_body_node`.</strike>

Also changes a hash to hash rocket syntax to quiet `brew style rubocops/*.rb`.