### PR TITLE
linkage_checker: Add harmless dylibs check.

### DIFF
--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -36,6 +36,7 @@ class LinkageChecker
           rescue NotAKegError
             @system_dylibs << dylib
           rescue Errno::ENOENT
+            next if harmless_broken_link?(dylib)
             @broken_dylibs << dylib
           else
             tap = Tab.for_keg(owner).tap
@@ -113,6 +114,14 @@ class LinkageChecker
   end
 
   private
+
+  # Whether or not dylib is a harmless broken link, meaning that it's
+  # okay to skip (and not report) as broken.
+  def harmless_broken_link?(dylib)
+    # libgcc_s_ppc64 is referenced by programs that use the Java Service Wrapper,
+    # and is harmless on x86(_64) machines
+    ["/usr/lib/libgcc_s_ppc64.1.dylib"].include?(dylib)
+  end
 
   # Display a list of things.
   # Things may either be an array, or a hash of (label -> array)


### PR DESCRIPTION
While the linkage checker should normally report all broken links,
there are a few cases where broken links are harmless. One case
is when a the PPC slice of a program links to a PPC-only library
that no longer exists on x86_64 OS X. Since the PPC slice is never
loaded on modern OS X, inconsistencies within it do not need to
be reported.

This is a fix for https://github.com/Homebrew/homebrew-core/pull/14753,
as well as everything here: https://github.com/Homebrew/homebrew-core/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aclosed%20libgcc_s_ppc64.1.dylib

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
