### PR TITLE
diagnostic: Update whitelisted dylib used by Symantec

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -165,8 +165,7 @@ module Homebrew
           "libUFSDNTFS.dylib", # Paragon NTFS
           "libUFSDExtFS.dylib", # Paragon ExtFS
           "libecomlodr.dylib", # Symantec Endpoint Protection
-          "libsymsea.*.dylib", # Symantec Endpoint Protection
-          "libsymsea.dylib",   # Symantec Endpoint Protection
+          "libsymsea*.dylib", # Symantec Endpoint Protection
           "sentinel.dylib", # SentinelOne
         ]
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -166,6 +166,7 @@ module Homebrew
           "libUFSDExtFS.dylib", # Paragon ExtFS
           "libecomlodr.dylib", # Symantec Endpoint Protection
           "libsymsea.*.dylib", # Symantec Endpoint Protection
+          "libsymsea.dylib",   # Symantec Endpoint Protection
           "sentinel.dylib", # SentinelOne
         ]
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
  * This is to fix a `brew doctor` warning about unbrewed dylibs used by Symantec Endpoint Protection
  * Previously some dylibs and static libs have been added into white_list in [this pull request](https://github.com/Homebrew/brew/pull/1438)
- [x] ~~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).~~
- [x] Have you successfully run `brew tests` with your changes locally?

-----
