### PR TITLE
test: require non-keg-only formulae to be linked.

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -39,6 +39,12 @@ module Homebrew
         next
       end
 
+      # Don't test unlinked formulae
+      if !ARGV.force? && !f.keg_only? && !f.linked?
+        ofail "#{f.full_name} is not linked"
+        next
+      end
+
       puts "Testing #{f.full_name}"
 
       env = ENV.to_hash


### PR DESCRIPTION
This can be overridden with `--force`.

As mentioned in:
https://github.com/Homebrew/homebrew-core/pull/14525#issuecomment-307838164