### PR TITLE
Fix: curl error when fetching GH issues from custom remote

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -10,4 +10,25 @@ describe GitHub do
       expect(results.first["path"]).to eq("README.md")
     end
   end
+
+  describe "::issues_for_formula" do
+    let(:tap) { Tap.new "user", "my-repo" }
+    before(:each) { allow(tap).to receive(:remote).and_return(remote) }
+
+    context "with custom_remote tap" do
+      let(:remote) { "https://github.com/user/my-custom-repo" }
+
+      it "returns []" do
+        expect(described_class.issues_for_formula("some-formula", tap: tap)).to be_empty
+      end
+    end
+
+    context "with GitHub Enterprise tap" do
+      let(:remote) { "https://github.my-org.com/user/homebrew-repo" }
+
+      it "returns []" do
+        expect(described_class.issues_for_formula("some-formula", tap: tap)).to be_empty
+      end
+    end
+  end
 end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -269,6 +269,7 @@ module GitHub
 
   def issues_for_formula(name, options = {})
     tap = options[:tap] || CoreTap.instance
+    return [] if tap.custom_remote?
     issues_matching(name, state: "open", repo: "#{tap.user}/homebrew-#{tap.repo}")
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #2733 (curl error when attempting to fetch issues from github for custom tap)

When a formula encounters an error, homebrew attempts to print out a list of open GitHub issues from that tap that might be related to that formula. However, if the formula belongs to a custom remote (ie, not homebrew-foo or not on github.com), then the GitHub API request fails. This results in _two_ error messages: the original error output from the formula error, and a second error from the failed GitHub API call.

This PR instructs `GitHub.issues_for_formula` to short-circuit (returning an empty array) if the formula belongs to a custom_remote.

Additionally, as a bit of subjective housekeeping, the `issues` and `fetch_issues` methods were moved from `BuildError` to `Formula` (since the issues are scoped to, and belong to, the formula for which they are open). I'll yank this out if undesired.


## Before:

```
$ brew install rock-runtime-node012 
==> Installing rock-runtime-node012 from rockstack/rock
==> Downloading https://nodejs.org/dist/latest-v0.12.x/node-v0.12.18.tar.gz
Already downloaded: /Users/jasonkarns/Library/Caches/Homebrew/rock-runtime-node012-0.12.18.tar.gz
==> ./configure --prefix=/usr/local/Cellar/rock-runtime-node012/0.12.18
==> make install
Last 15 lines from /Users/jasonkarns/Library/Logs/Homebrew/rock-runtime-node012/02.make:
[...]

If reporting this issue please do so to (not Homebrew/brew or Homebrew/core):
rockstack/rock

/usr/local/Homebrew/Library/Homebrew/utils/github.rb:226:in `raise_api_error': curl failed!  (GitHub::Error)
curl: (22) The requested URL returned error: 422 Unprocessable Entity
curl: (3) <url> malformed
	from /usr/local/Homebrew/Library/Homebrew/utils/github.rb:184:in `open'
	from /usr/local/Homebrew/Library/Homebrew/utils/github.rb:233:in `issues_matching'
	from /usr/local/Homebrew/Library/Homebrew/utils/github.rb:272:in `issues_for_formula'
	from /usr/local/Homebrew/Library/Homebrew/exceptions.rb:369:in `fetch_issues'
	from /usr/local/Homebrew/Library/Homebrew/exceptions.rb:365:in `issues'
	from /usr/local/Homebrew/Library/Homebrew/exceptions.rb:419:in `dump'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:131:in `rescue in <main>'
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:24:in `<main>'
```

## After

```
$ brew install rock-runtime-node012 
==> Installing rock-runtime-node012 from rockstack/rock
==> Downloading https://nodejs.org/dist/latest-v0.12.x/node-v0.12.18.tar.gz
Already downloaded: /Users/jasonkarns/Library/Caches/Homebrew/rock-runtime-node012-0.12.18.tar.gz
==> ./configure --prefix=/usr/local/Cellar/rock-runtime-node012/0.12.18
==> make install
Last 15 lines from /Users/jasonkarns/Library/Logs/Homebrew/rock-runtime-node012/02.make:
[...]

If reporting this issue please do so to (not Homebrew/brew or Homebrew/core):
rockstack/rock

```