### PR TITLE
[WIP] language/node: fix prepublish scripts

### DIFF
--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -6,6 +6,16 @@ module Language
       "cache=#{HOMEBREW_CACHE}/npm_cache"
     end
 
+    def self.node_system(cmd, *args)
+      ohai "#{cmd} #{args * " "}"
+      if ARGV.verbose?
+        safe_system(cmd, *args)
+      else
+        quiet_system(cmd, *args)
+        raise ErrorDuringExecution.new(cmd, args) unless $CHILD_STATUS.exitstatus.zero?
+      end
+    end
+
     # Read https://gist.github.com/chrmoritz/34e4c4d7779d72b549e2fc41f77c365c
     # for a complete overview of the edge cases this method has to handle.
     def self.pack_for_installation(prepare_required: false)
@@ -27,7 +37,7 @@ module Language
       # so that we can continue to `npm pack` with `--ignore-scripts`.
       install_args = local_npm_install_args
       install_args << "--production" unless prepare_required
-      safe_system "npm", "install", *install_args
+      node_system "npm", "install", *install_args
 
       # Homebrew assumes the buildpath/testpath will always be disposable
       # and from npm 5.0.0 the logic changed so that when a directory is

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -6,24 +6,28 @@ module Language
       "cache=#{HOMEBREW_CACHE}/npm_cache"
     end
 
+    # Read https://gist.github.com/chrmoritz/34e4c4d7779d72b549e2fc41f77c365c
+    # for a complete overview of the edge cases this method has to handle.
     def self.pack_for_installation(prepare_required: false)
-      # Read https://gist.github.com/chrmoritz/34e4c4d7779d72b549e2fc41f77c365c
-      # for a complete overview of the edge cases this method has to handle.
-      if prepare_required
-        # Rewrites the package.json so that npm pack will bundle all deps
-        # into a self-contained package, so that we avoid installing them a
-        # second time during the final installation of the package to libexec.
-        pkg_json = JSON.parse(IO.read("package.json"))
-        if pkg_json["dependencies"]
-          pkg_json["bundledDependencies"] = pkg_json["dependencies"].keys
-          IO.write("package.json", JSON.pretty_generate(pkg_json))
-        end
-
-        # We have to already install all deps here before npm pack, because the
-        # prepare script could require them. This already executes the prepare
-        # script to, so that we can continue to npm pack with --ignore-scripts.
-        safe_system "npm", "install", *local_npm_install_args
+      # Rewrites the package.json so that npm pack will bundle all deps
+      # into a self-contained package, so that we avoid installing them a
+      # second time during the final installation of the package to libexec.
+      pkg_json = JSON.parse(IO.read("package.json"))
+      if pkg_json["dependencies"]
+        pkg_json["bundledDependencies"] = pkg_json["dependencies"].keys
+        IO.write("package.json", JSON.pretty_generate(pkg_json))
       end
+
+      # If `prepare_required` is false we pass `--production` to install all
+      # production deps (no devDeps) for bundling them into the pack and also
+      # to prevent the toplevel prepare / prepublish script from being executed
+      # while still executing all lifecycle scripts for the deps.
+      # Otherwise we omit `--production` to install all deps (devDeps might be
+      # required in `prepare`). This already executes the prepare script too,
+      # so that we can continue to `npm pack` with `--ignore-scripts`.
+      install_args = local_npm_install_args
+      install_args << "--production" unless prepare_required
+      safe_system "npm", "install", *install_args
 
       # Homebrew assumes the buildpath/testpath will always be disposable
       # and from npm 5.0.0 the logic changed so that when a directory is

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -28,7 +28,7 @@ describe Language::Node do
 
     it "raises error with non zero npm pack exitstatus" do
       allow(IO).to receive(:read).and_return("{}")
-      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd", "--build-from-source",
+      allow(Language::Node).to receive(:node_system).with("npm", "install", "-ddd", "--build-from-source",
         "--cache=#{HOMEBREW_CACHE}/npm_cache", "--production") { `true` }
       allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `false` }
       expect { subject.std_npm_install_args(npm_install_arg) }.to \
@@ -37,7 +37,7 @@ describe Language::Node do
 
     it "raises error with empty npm pack output" do
       allow(IO).to receive(:read).and_return("{}")
-      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd", "--build-from-source",
+      allow(Language::Node).to receive(:node_system).with("npm", "install", "-ddd", "--build-from-source",
         "--cache=#{HOMEBREW_CACHE}/npm_cache", "--production") { `true` }
       allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `false` }
       expect { subject.std_npm_install_args(npm_install_arg) }.to \
@@ -46,7 +46,7 @@ describe Language::Node do
 
     it "does not raise error with a zero npm pack exitstatus" do
       allow(IO).to receive(:read).and_return("{}")
-      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd", "--build-from-source",
+      allow(Language::Node).to receive(:node_system).with("npm", "install", "-ddd", "--build-from-source",
         "--cache=#{HOMEBREW_CACHE}/npm_cache", "--production") { `true` }
       allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `echo pack.tgz` }
       resp = subject.std_npm_install_args(npm_install_arg)
@@ -59,7 +59,7 @@ describe Language::Node do
                       '"bundledDependencies":["foo","bar"]}'
       expected_json = JSON.pretty_generate(JSON.parse(expected_json))
       allow(IO).to receive(:write).with("package.json", expected_json) { `true` }
-      allow(Language::Node).to receive(:safe_system)
+      allow(Language::Node).to receive(:node_system)
         .with("npm", "install", "-ddd", "--build-from-source", "--cache=#{HOMEBREW_CACHE}/npm_cache") { `true` }
       allow(Utils).to receive(:popen_read).with("npm pack --ignore-scripts") { `echo pack.tgz` }
       resp = subject.std_npm_install_args(npm_install_arg, prepare_required: true)
@@ -68,7 +68,7 @@ describe Language::Node do
 
     it "raises error with non zero local npm install exitstatus" do
       allow(IO).to receive(:read).and_return("{}")
-      allow(Language::Node).to receive(:safe_system).and_raise("Failure while executing: npm install -ddd")
+      allow(Language::Node).to receive(:node_system).and_raise("Failure while executing: npm install -ddd")
       expect { subject.std_npm_install_args(npm_install_arg, prepare_required: true) }.to \
         raise_error("Failure while executing: npm install -ddd")
     end

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -26,19 +26,28 @@ describe Language::Node do
     npm_install_arg = "libexec"
     npm_pack_cmd = "npm pack --ignore-scripts"
 
-    it "raises error with non zero exitstatus" do
+    it "raises error with non zero npm pack exitstatus" do
+      allow(IO).to receive(:read).and_return("{}")
+      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd", "--build-from-source",
+        "--cache=#{HOMEBREW_CACHE}/npm_cache", "--production") { `true` }
       allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `false` }
       expect { subject.std_npm_install_args(npm_install_arg) }.to \
         raise_error("npm failed to pack #{Dir.pwd}")
     end
 
     it "raises error with empty npm pack output" do
-      allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `true` }
+      allow(IO).to receive(:read).and_return("{}")
+      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd", "--build-from-source",
+        "--cache=#{HOMEBREW_CACHE}/npm_cache", "--production") { `true` }
+      allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `false` }
       expect { subject.std_npm_install_args(npm_install_arg) }.to \
         raise_error("npm failed to pack #{Dir.pwd}")
     end
 
-    it "does not raise error with a zero exitstatus" do
+    it "does not raise error with a zero npm pack exitstatus" do
+      allow(IO).to receive(:read).and_return("{}")
+      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd", "--build-from-source",
+        "--cache=#{HOMEBREW_CACHE}/npm_cache", "--production") { `true` }
       allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `echo pack.tgz` }
       resp = subject.std_npm_install_args(npm_install_arg)
       expect(resp).to include("--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
@@ -57,9 +66,8 @@ describe Language::Node do
       expect(resp).to include("--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
     end
 
-    it "raises error with non zero exitstatus with prepare_required set" do
+    it "raises error with non zero local npm install exitstatus" do
       allow(IO).to receive(:read).and_return("{}")
-      allow(IO).to receive(:write).with("package.json", "{}") { `true` }
       allow(Language::Node).to receive(:safe_system).and_raise("Failure while executing: npm install -ddd")
       expect { subject.std_npm_install_args(npm_install_arg, prepare_required: true) }.to \
         raise_error("Failure while executing: npm install -ddd")

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -42,6 +42,20 @@ describe Language::Node do
       resp = subject.std_npm_install_args(npm_install_arg)
       expect(resp).to include("--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
     end
+
+    it "does not raise error with prepublish_required set" do
+      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd")
+      allow(Utils).to receive(:popen_read).with("npm pack").and_return("pack.tgz")
+      resp = subject.std_npm_install_args(npm_install_arg, prepublish_required: true)
+      expect(resp).to include("--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
+    end
+
+    it "raises error with non zero exitstatus with prepublish_required set" do
+      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd")\
+        .and_raise("Failure while executing: npm install -ddd")
+      expect { subject.std_npm_install_args(npm_install_arg, prepublish_required: true) }.to \
+        raise_error("Failure while executing: npm install -ddd")
+    end
   end
 
   specify "#local_npm_install_args" do

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -1,4 +1,5 @@
 require "language/node"
+require "json"
 
 describe Language::Node do
   describe "#setup_npm_environment" do
@@ -43,17 +44,24 @@ describe Language::Node do
       expect(resp).to include("--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
     end
 
-    it "does not raise error with prepublish_required set" do
-      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd")
-      allow(Utils).to receive(:popen_read).with("npm pack").and_return("pack.tgz")
-      resp = subject.std_npm_install_args(npm_install_arg, prepublish_required: true)
+    it "does not raise error with prepare_required set" do
+      allow(IO).to receive(:read).and_return('{"name":"example","dependencies":{"foo":"1.2.3","bar":"4.5.6"}}')
+      expected_json = '{"name":"example","dependencies":{"foo":"1.2.3","bar":"4.5.6"},'\
+                      '"bundledDependencies":["foo","bar"]}'
+      expected_json = JSON.pretty_generate(JSON.parse(expected_json))
+      allow(IO).to receive(:write).with("package.json", expected_json) { `true` }
+      allow(Language::Node).to receive(:safe_system)
+        .with("npm", "install", "-ddd", "--build-from-source", "--cache=#{HOMEBREW_CACHE}/npm_cache") { `true` }
+      allow(Utils).to receive(:popen_read).with("npm pack --ignore-scripts") { `echo pack.tgz` }
+      resp = subject.std_npm_install_args(npm_install_arg, prepare_required: true)
       expect(resp).to include("--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
     end
 
-    it "raises error with non zero exitstatus with prepublish_required set" do
-      allow(Language::Node).to receive(:safe_system).with("npm", "install", "-ddd")\
-        .and_raise("Failure while executing: npm install -ddd")
-      expect { subject.std_npm_install_args(npm_install_arg, prepublish_required: true) }.to \
+    it "raises error with non zero exitstatus with prepare_required set" do
+      allow(IO).to receive(:read).and_return("{}")
+      allow(IO).to receive(:write).with("package.json", "{}") { `true` }
+      allow(Language::Node).to receive(:safe_system).and_raise("Failure while executing: npm install -ddd")
+      expect { subject.std_npm_install_args(npm_install_arg, prepare_required: true) }.to \
         raise_error("Failure while executing: npm install -ddd")
     end
   end

--- a/docs/Node-for-Formula-Authors.md
+++ b/docs/Node-for-Formula-Authors.md
@@ -72,13 +72,15 @@ This will install your Node module in npm's global module style with a custom pr
 bin.install_symlink Dir["#{libexec}/bin/*"]
 ```
 
-**Note:** If your Node module requires a prepublish step (e.g. for transpiling sources) it is recommended to use a npm registry tarball (which is already prepublished) as the download url. If this is not possible, you have to pass `prepublish_required: true` to `std_npm_install_args` like in:
+**Note:** If your Node module requires a prepare or prepublish step (e.g. for transpiling sources) it is recommended to use a npm registry tarball (which is already prepared/ prepublished) as the download url. If this is not possible, you have to pass `prepare_required: true` to `std_npm_install_args` like in:
 
 ```ruby
-system "npm", "install", *Language::Node.std_npm_install_args(libexec, prepublish_required: true)
+system "npm", "install", *Language::Node.std_npm_install_args(libexec, prepare_required: true)
 ```
 
-This will run the `prepublish` script before we pack the module internally for installation with the overhead of installing all it's dependencies beforehand an additional time.
+This will run the `prepare` and `prepublish` scripts of your module before we pack the module and it's dependencies internally for installation.
+
+Not passing `prepare_required: true` will prevent the `prepare` and `prepublish` scripts of your top-level module from being executed, but all lifecycle scripts from it's dependencies are still executed as normal.
 
 ### Installing module dependencies locally with `local_npm_install_args`
 

--- a/docs/Node-for-Formula-Authors.md
+++ b/docs/Node-for-Formula-Authors.md
@@ -72,7 +72,13 @@ This will install your Node module in npm's global module style with a custom pr
 bin.install_symlink Dir["#{libexec}/bin/*"]
 ```
 
-**Note:** Because of a required workaround for `npm@5` calling `npm pack` we currently don't support installing modules (from non-npm registry tarballs), which require a prepublish step (e.g. for transpiling sources). See [Homebrew/brew#2820](https://github.com/Homebrew/brew/pull/2820) for more information.
+**Note:** If your Node module requires a prepublish step (e.g. for transpiling sources) it is recommended to use a npm registry tarball (which is already prepublished) as the download url. If this is not possible, you have to pass `prepublish_required: true` to `std_npm_install_args` like in:
+
+```ruby
+system "npm", "install", *Language::Node.std_npm_install_args(libexec, prepublish_required: true)
+```
+
+This will run the `prepublish` script before we pack the module internally for installation with the overhead of installing all it's dependencies beforehand an additional time.
 
 ### Installing module dependencies locally with `local_npm_install_args`
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Refs: https://github.com/Homebrew/homebrew-core/pull/14827

This PR adds support for installing node modules with a prepublish step, which requires the execution of some of it's (dev)dependencies. This is required for adding the `now-cli` formula to homebrew-core (see: https://github.com/Homebrew/homebrew-core/pull/14827).

The current implementation of `pack_for_installation` is based on the assumption that the module we want to pack is self-contained. Unfortunately this is not always the case and some modules require a prepublish step, which is executed before (=at the beginning of) every `npm pack` run (and it was even executed during our old pre npm@5 way of installing modules, but there we had all dependencies in place).
Unfortunately prepublish scripts are likely trying to execute at least some of their dev(dependencies), so we have to install them a second (or first?) time before executing `npm pack`. I did made this an opt-in, so that we don't have the overhead of installing all dependencies twice in the majority of formulas for node modules without such prepublish steps.

cc @ilovezfs

I was able to successfully install `now-cli` and `coffeescript` with this PR.