### PR TITLE
test: simplify minitest inclusion.

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -83,7 +83,7 @@ module Homebrew
             exec(*args)
           end
         end
-      rescue Assertions::FailedAssertion => e
+      rescue MiniTest::Assertion => e
         ofail "#{f.full_name}: failed"
         puts e.message
       rescue Exception => e

--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -1,26 +1,6 @@
 module Homebrew
   module Assertions
-    if defined?(Gem)
-      begin
-        gem "minitest", "< 5.0.0"
-      rescue Gem::LoadError
-        require "test/unit/assertions"
-      else
-        require "minitest/unit"
-        require "test/unit/assertions"
-      end
-    else
-      require "test/unit/assertions"
-    end
-
-    if defined?(MiniTest::Assertion)
-      FailedAssertion = MiniTest::Assertion
-    elsif defined?(Minitest::Assertion)
-      FailedAssertion = Minitest::Assertion
-    else
-      FailedAssertion = Test::Unit::AssertionFailedError
-    end
-
+    require "test/unit/assertions"
     include ::Test::Unit::Assertions
 
     # Returns the output of running cmd, and asserts the exit status


### PR DESCRIPTION
The previous version seems needlessly complicated given we only support a single Ruby version. It was also blowing up on Bundler 1.15.X.