### PR TITLE
version: improve url-only version parsing

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -438,16 +438,32 @@ describe Version do
         .to be_detected_from("https://example.com/dada-v2017-04-17.tar.gz")
     end
 
-    specify "dash version style" do
-      expect(Version.create("3.4"))
-        .to be_detected_from("http://www.antlr.org/download/antlr-3.4-complete.jar")
-    end
-
     specify "jenkins version style" do
       expect(Version.create("1.486"))
         .to be_detected_from("http://mirrors.jenkins-ci.org/war/1.486/jenkins.war")
       expect(Version.create("0.10.11"))
         .to be_detected_from("https://github.com/hechoendrupal/DrupalConsole/releases/download/0.10.11/drupal.phar")
+    end
+
+    specify "char prefixed, url-only version style" do
+      expect(Version.create("1.9.293"))
+        .to be_detected_from("https://github.com/clojure/clojurescript/releases/download/r1.9.293/cljs.jar")
+      expect(Version.create("0.6.1"))
+        .to be_detected_from("https://github.com/fibjs/fibjs/releases/download/v0.6.1/fullsrc.zip")
+      expect(Version.create("1.9"))
+        .to be_detected_from("https://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_1.9/E.tgz")
+    end
+
+    specify "w.x.y.z url-only version style" do
+      expect(Version.create("2.3.2.0"))
+        .to be_detected_from("https://github.com/JustArchi/ArchiSteamFarm/releases/download/2.3.2.0/ASF.zip")
+      expect(Version.create("1.7.5.2"))
+        .to be_detected_from("https://people.gnome.org/~newren/eg/download/1.7.5.2/eg")
+    end
+
+    specify "dash version style" do
+      expect(Version.create("3.4"))
+        .to be_detected_from("http://www.antlr.org/download/antlr-3.4-complete.jar")
     end
 
     specify "apache version style" do

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -407,8 +407,13 @@ class Version
 
     # e.g. http://mirrors.jenkins-ci.org/war/1.486/jenkins.war
     # e.g. https://github.com/foo/bar/releases/download/0.10.11/bar.phar
-    m = %r{/(\d\.\d+(\.\d+)?)}.match(spec_s)
-    return m.captures.first unless m.nil?
+    # e.g. https://github.com/clojure/clojurescript/releases/download/r1.9.293/cljs.jar
+    # e.g. https://github.com/fibjs/fibjs/releases/download/v0.6.1/fullsrc.zip
+    # e.g. https://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_1.9/E.tgz
+    # e.g. https://github.com/JustArchi/ArchiSteamFarm/releases/download/2.3.2.0/ASF.zip
+    # e.g. https://people.gnome.org/~newren/eg/download/1.7.5.2/eg
+    m = %r{/([rvV]_?)?(\d\.\d+(\.\d+){,2})}.match(spec_s)
+    return m.captures[1] unless m.nil?
 
     # e.g. http://www.ijg.org/files/jpegsrc.v8d.tar.gz
     m = /\.v(\d+[a-z]?)/.match(stem)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
add support for both styles prefixed with up to two characters,
and styles with four groups of digits, seperated by periods

I believe I made the regex sufficiently strict to prevent unwanted results, but if necessary it could be split into two or more pieces. Some of the regex syntax itself is also more esoteric so it may be desirable to modify them for that reason as well.

Originally begun as a fix for [homebrew/core#14957](https://github.com/Homebrew/homebrew-core/pull/14957#discussion_r124086480).

I added tests, which is good, but did I add too many?

cc @ilovezfs @dunn