### PR TITLE
Fix `bump-formula-pr` when working with a shallow git clone

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -286,8 +286,11 @@ module Homebrew
 
     formula.path.parent.cd do
       branch = "#{formula.name}-#{new_formula_version}"
+      git_dir = Utils.popen_read("git rev-parse --git-dir")
+      shallow = !git_dir.empty? && File.exist?("#{git_dir}/shallow")
+
       if ARGV.dry_run?
-        ohai "git fetch --unshallow origin"
+        ohai "git fetch --unshallow origin" if shallow
         ohai "git checkout --no-track -b #{branch} origin/master"
         ohai "git commit --no-edit --verbose --message='#{formula.name} #{new_formula_version}#{devel_message}' -- #{formula.path}"
         ohai "hub fork --no-remote"
@@ -297,7 +300,7 @@ module Homebrew
         ohai "hub pull-request --browse -m '#{formula.name} #{new_formula_version}#{devel_message}'"
         ohai "git checkout -"
       else
-        safe_system "git", "fetch", "--unshallow", "origin"
+        safe_system "git", "fetch", "--unshallow", "origin" if shallow
         safe_system "git", "checkout", "--no-track", "-b", branch, "origin/master"
         safe_system "git", "commit", "--no-edit", "--verbose",
           "--message=#{formula.name} #{new_formula_version}#{devel_message}",

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -287,6 +287,7 @@ module Homebrew
     formula.path.parent.cd do
       branch = "#{formula.name}-#{new_formula_version}"
       if ARGV.dry_run?
+        ohai "git fetch --unshallow origin"
         ohai "git checkout --no-track -b #{branch} origin/master"
         ohai "git commit --no-edit --verbose --message='#{formula.name} #{new_formula_version}#{devel_message}' -- #{formula.path}"
         ohai "hub fork --no-remote"
@@ -296,6 +297,7 @@ module Homebrew
         ohai "hub pull-request --browse -m '#{formula.name} #{new_formula_version}#{devel_message}'"
         ohai "git checkout -"
       else
+        safe_system "git", "fetch", "--unshallow", "origin"
         safe_system "git", "checkout", "--no-track", "-b", branch, "origin/master"
         safe_system "git", "commit", "--no-edit", "--verbose",
           "--message=#{formula.name} #{new_formula_version}#{devel_message}",

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -286,7 +286,7 @@ module Homebrew
 
     formula.path.parent.cd do
       branch = "#{formula.name}-#{new_formula_version}"
-      git_dir = Utils.popen_read("git rev-parse --git-dir")
+      git_dir = Utils.popen_read("git rev-parse --git-dir").chomp
       shallow = !git_dir.empty? && File.exist?("#{git_dir}/shallow")
 
       if ARGV.dry_run?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Creating a fork and pushing to it doesn't work when the repository in question is a shallow clone. By default, Homebrew clones all taps in shallow mode unless `--full` was passed or $HOMEBREW_DEVELOPER was set.

/cc @mikemcquaid