### PR TITLE
audit: ask for full_index patches

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -819,6 +819,13 @@ class FormulaAuditor
 
   def patch_problems(patch)
     case patch.url
+    when %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
+      unless patch.url =~ /\?full_index=\w+$/
+        problem <<-EOS.undent
+          GitHub patches should use the full_index parameter:
+            #{patch.url}?full_index=1
+        EOS
+      end
     when /raw\.github\.com/, %r{gist\.github\.com/raw}, %r{gist\.github\.com/.+/raw},
       %r{gist\.githubusercontent\.com/.+/raw}
       unless patch.url =~ /[a-fA-F0-9]{40}/
@@ -827,7 +834,7 @@ class FormulaAuditor
     when %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}
       problem <<-EOS.undent
         use GitHub pull request URLs:
-          https://github.com/#{Regexp.last_match(1)}/#{Regexp.last_match(2)}/pull/#{Regexp.last_match(3)}.patch
+          https://github.com/#{Regexp.last_match(1)}/#{Regexp.last_match(2)}/pull/#{Regexp.last_match(3)}.patch?full_index=1
         Rather than patch-diff:
           #{patch.url}
       EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This configures audit to recommend the new `?full_index=1` option for patch URLs. This option uses unabbreviated git refs, which aren't subject to change like abbreviated refs are. (See https://github.com/Homebrew/homebrew-core/pull/13792#issuecomment-302973700 for an example of large numbers of patches changing at once for this reason.)

This will cause `audit` to start flagging lots of existing formulae. Do we want to mass-migrate these in batches?