### PR TITLE
Define a custom assertion failure error for cross-version compat

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -83,7 +83,7 @@ module Homebrew
             exec(*args)
           end
         end
-      rescue MiniTest::Assertion => e
+      rescue Homebrew::Assertions::AssertionFailed => e
         ofail "#{f.full_name}: failed"
         puts e.message
       rescue Exception => e

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -83,7 +83,7 @@ module Homebrew
             exec(*args)
           end
         end
-      rescue Homebrew::Assertions::AssertionFailed => e
+      rescue ::Test::Unit::AssertionFailedError => e
         ofail "#{f.full_name}: failed"
         puts e.message
       rescue Exception => e

--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -3,6 +3,19 @@ module Homebrew
     require "test/unit/assertions"
     include ::Test::Unit::Assertions
 
+    # Custom name here for cross-version compatibility.
+    # In Ruby 2.0, Test::Unit::Assertions raise a MiniTest::Assertion,
+    # but they raise Test::Unit::AssertionFailedError in 2.3.
+    # If neither is defined, this might be a completely different
+    # version of Ruby.
+    if defined?(MiniTest::Assertion)
+      AssertionFailed = MiniTest::Assertion
+    elsif defined?(Test::Unit::AssertionFailedError)
+      AssertionFailed = Test::Unit::AssertionFailedError
+    else
+      raise NameError, "Unable to find an assertion class for this version of Ruby (#{RUBY_VERSION})"
+    end
+
     # Returns the output of running cmd, and asserts the exit status
     def shell_output(cmd, result = 0)
       ohai cmd

--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -3,17 +3,9 @@ module Homebrew
     require "test/unit/assertions"
     include ::Test::Unit::Assertions
 
-    # Custom name here for cross-version compatibility.
-    # In Ruby 2.0, Test::Unit::Assertions raise a MiniTest::Assertion,
-    # but they raise Test::Unit::AssertionFailedError in 2.3.
-    # If neither is defined, this might be a completely different
-    # version of Ruby.
-    if defined?(MiniTest::Assertion)
-      AssertionFailed = MiniTest::Assertion
-    elsif defined?(Test::Unit::AssertionFailedError)
-      AssertionFailed = Test::Unit::AssertionFailedError
-    else
-      raise NameError, "Unable to find an assertion class for this version of Ruby (#{RUBY_VERSION})"
+    # TODO: remove this when we no longer support Ruby 2.0.
+    unless defined?(Test::Unit::AssertionFailedError)
+      Test::Unit::AssertionFailedError = MiniTest::Assertion
     end
 
     # Returns the output of running cmd, and asserts the exit status


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #2840.

Note that this partially reverts c45cca8e36401f6d95d851befef35879a5629182 - it was unnecessary on Ruby 2.0, but turns out to be necessary for compatibility with the system Ruby 2.3 on OS X 10.13.