### PR TITLE
Explain how to reduce auto-updates if they're slow

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -284,6 +284,8 @@ setup-analytics
 update-preinstall-timer() {
   sleep 3
   echo 'Updating Homebrew...' >&2
+  sleep 3
+  echo '  (to do this less frequently, set $HOMEBREW_AUTO_UPDATE_SECS.)' >&2
 }
 
 update-preinstall() {


### PR DESCRIPTION
I'm in Ethiopia on mobile data most of the time, and my internet can get down to 50kbps with 2+-second pings. Even under the best conditions, a no-op `brew update --preinstall` takes 2.5+ seconds. It would have improved my life a lot if I'd learned about `HOMEBREW_AUTO_UPDATE_SECS` earlier :)

(Also, right now if you Google for "homebrew disable auto update" it takes some poking around to learn how to reduce the frequency instead of the less-safe option of completely disabling it--hopefully this will make that more discoverable.)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). _no--not sure how to test brew.sh, sorry!_
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
