### PR TITLE
software_spec: rescue TapFormulaUnavailableError in recursive_dependencies

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -161,8 +161,17 @@ class SoftwareSpec
   end
 
   def recursive_dependencies
-    recursive_dependencies = deps
-    deps.map(&:to_formula).compact.uniq.each do |f|
+    deps_f = []
+    recursive_dependencies = deps.map do |dep|
+      begin
+        deps_f << dep.to_formula
+        dep
+      rescue TapFormulaUnavailableError
+        # Don't complain about missing cross-tap dependencies
+        next
+      end
+    end.compact.uniq
+    deps_f.compact.each do |f|
       f.recursive_dependencies.each do |dep|
         recursive_dependencies << dep unless recursive_dependencies.include?(dep)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Prevents CI failure when there are missing cross-tap dependencies.