### PR TITLE
missing_formula: no need to tap homebrew/core.

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -109,6 +109,10 @@ module Homebrew
 
           message = <<-EOS.undent
             It was migrated from #{old_tap} to #{new_tap}.
+          EOS
+          break if new_tap_name == CoreTap.instance.name
+
+          message += <<-EOS.undent
             You can access it again by running:
               brew tap #{new_tap_name}
           EOS


### PR DESCRIPTION
Avoiding printing the weird message e.g:
```
It was migrated from homebrew/science to homebrew/core.
You can access it again by running:
  brew tap homebrew/core
```