### PR TITLE
style: Don't run FormulaAuditStrict cops when `brew style foo` cmd is executed

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -46,6 +46,8 @@ module Homebrew
       options[:only_cops] = only_cops
     elsif !except_cops.empty?
       options[:except_cops] = except_cops
+    elsif only_cops.empty? && except_cops.empty?
+      options[:except_cops] = %w[FormulaAuditStrict FormulaAudit]
     end
 
     Homebrew.failed = check_style_and_print(target, options)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#2847 
cc @ilovezfs @JCount  @MikeMcQuaid 
This basically disables `FormulaAuditStrict` cops when `brew style` is ran on some formula and neither `--only-cops` nor `--except-cops` is passed as cmd line options. 

Also means, `brew style some_new_formula` wouldn't run the strict checks, but I'm assuming `brew audit --strict` would run those? 
Let me know if this code behaviour is acceptable. 