### PR TITLE
cpu: fix SSE3 detection on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -84,9 +84,14 @@ module Hardware
         @features ||= flags[1..-1].map(&:intern)
       end
 
-      %w[aes altivec avx avx2 lm sse3 ssse3 sse4 sse4_2].each do |flag|
+      %w[aes altivec avx avx2 lm ssse3 sse4 sse4_2].each do |flag|
         define_method(flag + "?") { flags.include? flag }
       end
+
+      def sse3?
+        flags.include?("pni") || flags.include?("sse3")
+      end
+
       alias is_64_bit? lm?
 
       def bits


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

For exciting historical reasons, `/proc/cpuinfo` (sometimes?) lists the SSE3 instructions feature as PNI (Prescott New Instructions). My Haswell test machine (which certainly supports SSE3 instructions) doesn't have `sse3` listed but does have `pni` listed.

c.f. https://github.com/Homebrew/homebrew-science/issues/5920