### PR TITLE
Bump `rubocop-cask` version.

### DIFF
--- a/Library/Homebrew/constants.rb
+++ b/Library/Homebrew/constants.rb
@@ -1,3 +1,3 @@
 # RuboCop version used for `brew style` and `brew cask style`
 HOMEBREW_RUBOCOP_VERSION = "0.49.1".freeze
-HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.13.0".freeze # has to be updated when RuboCop version changes
+HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.13.1".freeze # has to be updated when RuboCop version changes

--- a/Library/Homebrew/test/cask/cli/style_spec.rb
+++ b/Library/Homebrew/test/cask/cli/style_spec.rb
@@ -57,18 +57,16 @@ describe Hbc::CLI::Style, :cask do
       end
     end
 
-    context "version" do
-      it "matches `HOMEBREW_RUBOCOP_VERSION`", :needs_network do
-        stdout, status = Open3.capture2("gem", "dependency", "rubocop-cask", "--version", HOMEBREW_RUBOCOP_CASK_VERSION, "--pipe", "--remote")
+    specify "`rubocop-cask` supports `HOMEBREW_RUBOCOP_VERSION`", :needs_network do
+      stdout, status = Open3.capture2("gem", "dependency", "rubocop-cask", "--version", HOMEBREW_RUBOCOP_CASK_VERSION, "--pipe", "--remote")
 
-        expect(status).to be_a_success
+      expect(status).to be_a_success
 
-        requirement = Gem::Requirement.new(stdout.scan(/rubocop --version '(.*)'/).flatten.first)
-        version = Gem::Version.new(HOMEBREW_RUBOCOP_VERSION)
+      requirement = Gem::Requirement.new(stdout.scan(/rubocop --version '(.*)'/).flatten.first)
+      version = Gem::Version.new(HOMEBREW_RUBOCOP_VERSION)
 
-        expect(requirement).not_to be_none
-        expect(requirement).to be_satisfied_by(version)
-      end
+      expect(requirement).not_to be_none
+      expect(requirement).to be_satisfied_by(version)
     end
   end
 


### PR DESCRIPTION
Bump `rubocop-cask` version and reword the spec.