### PR TITLE
Formula#keg_only should be a boolean

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -33,6 +33,10 @@ Style/BlockDelimiters:
   Exclude:
     - '**/*_spec.rb'
 
+# used idiomatically to return boolean values
+Style/DoubleNegation:
+  Enabled: false
+
 # so many of these in formulae but none in here
 Style/GuardClause:
   Enabled: true

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -33,10 +33,6 @@ Style/BlockDelimiters:
   Exclude:
     - '**/*_spec.rb'
 
-# used idiomatically to return boolean values
-Style/DoubleNegation:
-  Enabled: false
-
 # so many of these in formulae but none in here
 Style/GuardClause:
   Enabled: true

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1008,7 +1008,8 @@ class Formula
   # rarely, you don't want your library symlinked into the main prefix
   # see gettext.rb for an example
   def keg_only?
-    !!keg_only_reason && keg_only_reason.valid?
+    return false unless keg_only_reason
+    keg_only_reason.valid?
   end
 
   # @private

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1008,7 +1008,7 @@ class Formula
   # rarely, you don't want your library symlinked into the main prefix
   # see gettext.rb for an example
   def keg_only?
-    keg_only_reason && keg_only_reason.valid?
+    !!keg_only_reason && keg_only_reason.valid?
   end
 
   # @private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since the left half of this conditional is false if `keg_only_reason` is nil, this was returning `nil` or `true` instead of `false` or `true`. Noticed this via the JSON output, where this value is exposed publicly.

Before:
```json
    "linked_keg": "8.27",
    "pinned": false,
    "outdated": false,
    "keg_only": null,
```

After:

```json
    "linked_keg": "8.27",
    "pinned": false,
    "outdated": false,
    "keg_only": false,
```

Rubocop doesn't like `!!`, but it feels like the most natural solution in this case. It's not like #2699 where there was a more natural method to use.

```
Library/Homebrew/formula.rb:1011:5: C: Avoid the use of double negation (!!).
    !!keg_only_reason && keg_only_reason.valid?
    ^
```

-----

This was originally opened at #2862, which was accidentally pushed to `origin` rather than my fork.