### PR TITLE
audit: don't suggest non-stable versioned alias.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -309,7 +309,7 @@ class FormulaAuditor
         unversioned_name = unversioned_formula.basename(".rb")
         problem "#{formula} is versioned but no #{unversioned_name} formula exists"
       end
-    elsif ARGV.build_stable? &&
+    elsif ARGV.build_stable? && formula.stable? &&
           !(versioned_formulae = Dir[formula.path.to_s.gsub(/\.rb$/, "@*.rb")]).empty?
       versioned_aliases = formula.aliases.grep(/.@\d/)
       _, last_alias_version =


### PR DESCRIPTION
Additionally handle the case where a formula has been installed as devel/HEAD rather than just e.g. `brew audit --devel`.

As mentioned in https://github.com/Homebrew/homebrew-core/pull/14985.