### PR TITLE
spec_helper: add focus support.

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -41,6 +41,8 @@ TEST_DIRECTORIES = [
 RSpec.configure do |config|
   config.order = :random
 
+  config.filter_run_when_matching :focus
+
   config.include(Test::Helper::Shutup)
   config.include(Test::Helper::Fixtures)
   config.include(Test::Helper::Formula)


### PR DESCRIPTION
When adding `, :focus` as a trailing argument to a `describe` or `it` this allows you to only run that single test.