### PR TITLE
Fix `brew tests` on High Sierra.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -11,7 +11,9 @@ raise "Homebrew must be run under Ruby 2!" unless RUBY_TWO
 require "pathname"
 HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent
 require "English"
-$LOAD_PATH.unshift(HOMEBREW_LIBRARY_PATH.to_s)
+unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
+  $LOAD_PATH.unshift(HOMEBREW_LIBRARY_PATH.to_s)
+end
 require "global"
 require "tap"
 

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -77,6 +77,7 @@ RSpec.shared_context "integration test" do
       "HOMEBREW_INTEGRATION_TEST" => command_id_from_args(args),
       "HOMEBREW_TEST_TMPDIR" => TEST_TMPDIR,
       "HOMEBREW_DEVELOPER" => ENV["HOMEBREW_DEVELOPER"],
+      "GEM_HOME" => nil,
     )
 
     ruby_args = [
@@ -89,7 +90,7 @@ RSpec.shared_context "integration test" do
     ruby_args << "-rtest/support/helper/integration_mocks"
     ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
 
-    Bundler.with_original_env do
+    Bundler.with_clean_env do
       stdout, stderr, status = Open3.capture3(env, RUBY_PATH, *ruby_args, *args)
       $stdout.print stdout
       $stderr.print stderr

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -80,18 +80,34 @@ RSpec.shared_context "integration test" do
       "GEM_HOME" => nil,
     )
 
-    ruby_args = [
-      "-W0",
-      "-I", "#{HOMEBREW_LIBRARY_PATH}/test/support/lib",
-      "-I", HOMEBREW_LIBRARY_PATH.to_s,
-      "-rconfig"
-    ]
-    ruby_args << "-rsimplecov" if ENV["HOMEBREW_TESTS_COVERAGE"]
-    ruby_args << "-rtest/support/helper/integration_mocks"
-    ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
+    @ruby_args ||= begin
+      ruby_args = [
+        "-W0",
+        "-I", "#{HOMEBREW_LIBRARY_PATH}/test/support/lib",
+        "-I", HOMEBREW_LIBRARY_PATH.to_s,
+        "-rconfig"
+      ]
+      if ENV["HOMEBREW_TESTS_COVERAGE"]
+        simplecov_spec = Gem.loaded_specs["simplecov"]
+        specs = simplecov_spec.runtime_dependencies.flat_map(&:to_specs)
+        specs << simplecov_spec
+        libs = specs.flat_map do |spec|
+          full_gem_path = spec.full_gem_path
+          # full_require_paths isn't available in RubyGems < 2.2.
+          spec.require_paths.map do |lib|
+            next lib if lib.include?(full_gem_path)
+            "#{full_gem_path}/#{lib}"
+          end
+        end
+        libs.each { |lib| ruby_args << "-I" << lib }
+        ruby_args << "-rsimplecov"
+      end
+      ruby_args << "-rtest/support/helper/integration_mocks"
+      ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
+    end
 
     Bundler.with_clean_env do
-      stdout, stderr, status = Open3.capture3(env, RUBY_PATH, *ruby_args, *args)
+      stdout, stderr, status = Open3.capture3(env, RUBY_PATH, *@ruby_args, *args)
       $stdout.print stdout
       $stderr.print stderr
       status


### PR DESCRIPTION
The `brew test` tests were failing as they were unable to include `test/unit/assertions`. This is because it's a gem and we were setting the `GEM_HOME` so system gems were being ignored.

While I was there and examining the `$LOAD_PATH`: reduce the number of things we add there by using `Bundler.with_clean_env` and only adding `HOMEBREW_LIBRARY_PATH` in the `$LOAD_PATH` if it isn't already there (which it always is [and has to be] for integration tests).

This also seems to have the side effect of speeding up integration tests from 1m26s to 1m8s on my machine.