### PR TITLE
Update documentation of brew install syntax to match its actual behav…

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -1,4 +1,4 @@
-#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] <formula> [`install-options`]:
+#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] <formula> [<options> ...]:
 #:    Install <formula>.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
@@ -46,6 +46,9 @@
 #:
 #:    If `--build-bottle` is passed, prepare the formula for eventual bottling
 #:    during installation.
+#:
+#:    Installation options specific to <formula> may be appended to the command,
+#:    and can be listed with `brew options` <formula>.
 #:
 #:  * `install` `--interactive` [`--git`] <formula>:
 #:    If `--interactive` (or `-i`) is passed, download and patch <formula>, then

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -1,4 +1,4 @@
-#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] <formula>:
+#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] <formula> [`install-options`]:
 #:    Install <formula>.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -198,7 +198,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     See the docs for examples of using the JSON output:
     <http://docs.brew.sh/Querying-Brew.html>
 
-  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula` [`install-options`]:
+  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula` : [<`options`> ...]
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified
@@ -246,6 +246,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--build-bottle` is passed, prepare the formula for eventual bottling
     during installation.
+
+    Installation options specific to <formula> may be appended to the command,
+    and can be listed with `brew options` <formula>.
 
   * `install` `--interactive` [`--git`] `formula`:
     If `--interactive` (or `-i`) is passed, download and patch `formula`, then

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -198,7 +198,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     See the docs for examples of using the JSON output:
     <http://docs.brew.sh/Querying-Brew.html>
 
-  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula` [<`options`> ...]:
+  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula` [`options` ...]:
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified
@@ -248,7 +248,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     during installation.
 
     Installation options specific to `formula` may be appended to the command,
-    and can be listed with `brew options <formula>`.
+    and can be listed with `brew options` `formula`.
 
   * `install` `--interactive` [`--git`] `formula`:
     If `--interactive` (or `-i`) is passed, download and patch `formula`, then

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -198,7 +198,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     See the docs for examples of using the JSON output:
     <http://docs.brew.sh/Querying-Brew.html>
 
-  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula` : [<`options`> ...]
+  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula` [<`options`> ...]:
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified
@@ -247,8 +247,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--build-bottle` is passed, prepare the formula for eventual bottling
     during installation.
 
-    Installation options specific to <formula> may be appended to the command,
-    and can be listed with `brew options` <formula>.
+    Installation options specific to `formula` may be appended to the command,
+    and can be listed with `brew options <formula>`.
 
   * `install` `--interactive` [`--git`] `formula`:
     If `--interactive` (or `-i`) is passed, download and patch `formula`, then

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -198,7 +198,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     See the docs for examples of using the JSON output:
     <http://docs.brew.sh/Querying-Brew.html>
 
-  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula`:
+  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] `formula` [`install-options`]:
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "June 2017" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "July 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -216,7 +216,7 @@ Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to
 See the docs for examples of using the JSON output: \fIhttp://docs\.brew\.sh/Querying\-Brew\.html\fR
 .
 .TP
-\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] \fIformula\fR
+\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] \fIformula\fR [\fIinstall\-options\fR]
 Install \fIformula\fR\.
 .
 .IP

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -216,7 +216,7 @@ Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to
 See the docs for examples of using the JSON output: \fIhttp://docs\.brew\.sh/Querying\-Brew\.html\fR
 .
 .TP
-\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] \fIformula\fR [\fIinstall\-options\fR]
+\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] \fIformula\fR [\fIoptions\fR \.\.\.]
 Install \fIformula\fR\.
 .
 .IP
@@ -260,6 +260,9 @@ If \fB\-\-keep\-tmp\fR is passed, the temporary files created during installatio
 .
 .IP
 If \fB\-\-build\-bottle\fR is passed, prepare the formula for eventual bottling during installation\.
+.
+.IP
+Installation \fIoptions\fR specific to \fIformula\fR may be appended to the command, and can be listed with \fBbrew options <formula>\fR.
 .
 .TP
 \fBinstall\fR \fB\-\-interactive\fR [\fB\-\-git\fR] \fIformula\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "June 2017" "Homebrew" "brew"
+.TH "BREW" "1" "July 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -262,7 +262,7 @@ If \fB\-\-keep\-tmp\fR is passed, the temporary files created during installatio
 If \fB\-\-build\-bottle\fR is passed, prepare the formula for eventual bottling during installation\.
 .
 .IP
-Installation \fIoptions\fR specific to \fIformula\fR may be appended to the command, and can be listed with \fBbrew options <formula>\fR.
+Installation options specific to \fIformula\fR may be appended to the command, and can be listed with \fBbrew options\fR \fIformula\fR\.
 .
 .TP
 \fBinstall\fR \fB\-\-interactive\fR [\fB\-\-git\fR] \fIformula\fR


### PR DESCRIPTION
…ior.

- [OK] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [OK] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [OK] Have you added an explanation of what your changes do and why you'd like us to include them?

-----
As stated in  issue #1699, the documentation doesn't reflect the actual behavior of `brew install`. When using `brew install`, install options given by `brew options` can be added after the formula. For example, I can install ffmpeg with chromaprint support with `brew install ffmpeg --with-chromaprint`. Currently the documentation, doesn't reflect this. This patch update the documentation (man page, markdown, and `brew help install`) to match the actual behavior.
