### PR TITLE
List cask full-names

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cask.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask.rb
@@ -41,6 +41,14 @@ module Hbc
                           .reverse
     end
 
+    def full_name
+      if @tap.nil? || @tap == Hbc.default_tap
+        token
+      else
+        "#{@tap}/#{token}"
+      end
+    end
+
     def installed?
       !versions.empty?
     end

--- a/Library/Homebrew/cask/lib/hbc/cli/list.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/list.rb
@@ -3,6 +3,7 @@ module Hbc
     class List < AbstractCommand
       option "-1", :one, false
       option "--versions", :versions, false
+      option "--full-name", :full_name, false
 
       option "-l", (lambda do |*|
         one = true # rubocop:disable Lint/UselessAssignment
@@ -42,6 +43,8 @@ module Hbc
           puts installed_casks.map(&:to_s)
         elsif versions?
           puts installed_casks.map(&self.class.method(:format_versioned))
+        elsif full_name?
+          puts installed_casks.map(&:full_name).sort &tap_and_name_comparison
         elsif !installed_casks.empty?
           puts Formatter.columns(installed_casks.map(&:to_s))
         end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -39,15 +39,7 @@ module Homebrew
       filtered_list
     elsif ARGV.named.empty?
       if ARGV.include? "--full-name"
-        full_names = Formula.installed.map(&:full_name).sort do |a, b|
-          if a.include?("/") && !b.include?("/")
-            1
-          elsif !a.include?("/") && b.include?("/")
-            -1
-          else
-            a <=> b
-          end
-        end
+        full_names = Formula.installed.map(&:full_name).sort &tap_and_name_comparison
         return if full_names.empty?
         puts Formatter.columns(full_names)
       else

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -171,4 +171,38 @@ describe Hbc::Cask, :cask do
       end
     end
   end
+
+  describe "full_name" do
+    context "when it is a core cask" do
+      it "is the cask token" do
+        c = Hbc::CaskLoader.load("local-caffeine")
+        expect(c.full_name).to eq("local-caffeine")
+      end
+    end
+
+    context "when it is from a non-core tap" do
+      it "returns the fully-qualified name of the cask" do
+        c = Hbc::CaskLoader.load("third-party/tap/third-party-cask")
+        expect(c.full_name).to eq("third-party/tap/third-party-cask")
+      end
+    end
+
+    context "when it is from no known tap" do
+      it "retuns the cask token" do
+        file = Tempfile.new(%w[tapless-cask .rb])
+
+        begin
+          cask_name = File.basename(file.path, ".rb")
+          file.write "cask '#{cask_name}'"
+          file.close
+
+          c = Hbc::CaskLoader.load(file.path)
+          expect(c.full_name).to eq(cask_name)
+        ensure
+          file.close
+          file.unlink
+        end
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test/cask/cli/list_spec.rb
+++ b/Library/Homebrew/test/cask/cli/list_spec.rb
@@ -14,6 +14,26 @@ describe Hbc::CLI::List, :cask do
     EOS
   end
 
+  it "lists full names" do
+    casks = %w[
+      local-caffeine
+      third-party/tap/third-party-cask
+      local-transmission
+    ].map { |c| Hbc::CaskLoader.load(c) }
+
+    casks.each do |c|
+      InstallHelper.install_with_caskfile(c)
+    end
+
+    expect {
+      Hbc::CLI::List.run("--full-name")
+    }.to output(<<-EOS.undent).to_stdout
+      local-caffeine
+      local-transmission
+      third-party/tap/third-party-cask
+    EOS
+  end
+
   describe "lists versions" do
     let(:casks) { ["local-caffeine", "local-transmission"] }
     let(:expected_output) {

--- a/Library/Homebrew/test/support/fixtures/third-party/Casks/third-party-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/third-party/Casks/third-party-cask.rb
@@ -1,0 +1,9 @@
+cask 'third-party-cask' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url 'http://example.com/ThirdParty.dmg'
+  homepage 'http://example.com/'
+
+  app 'ThirdParty.app'
+end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -18,6 +18,7 @@ HOMEBREW_CASK_DIRS = [
 
 RSpec.shared_context "Homebrew-Cask" do
   around(:each) do |example|
+    third_party_tap = Tap.fetch("third-party", "tap")
     begin
       dirs = HOMEBREW_CASK_DIRS.map do |dir|
         Pathname.new(TEST_TMPDIR).join("cask-#{dir}").tap do |path|
@@ -31,11 +32,18 @@ RSpec.shared_context "Homebrew-Cask" do
         FileUtils.ln_sf TEST_FIXTURE_DIR.join("cask"), tap.path
       end
 
+      third_party_tap.tap do |tap|
+        FileUtils.mkdir_p tap.path.dirname
+        FileUtils.ln_sf TEST_FIXTURE_DIR.join("third-party"), tap.path
+      end
+
       example.run
     ensure
       FileUtils.rm_rf dirs
       Hbc.default_tap.path.unlink
       FileUtils.rm_rf Hbc.default_tap.path.parent
+      third_party_tap.path.unlink
+      FileUtils.rm_rf third_party_tap.path.parent
     end
   end
 end

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -296,4 +296,33 @@ describe "globally-scoped helper methods" do
       expect(ENV["PATH"]).not_to eq("/bin")
     end
   end
+
+  describe "#tap_and_name_comparison" do
+    describe "both strings are only names" do
+      it "alphabetizes the strings" do
+        expect(%w[a b].sort(&tap_and_name_comparison)).to eq(%w[a b])
+        expect(%w[b a].sort(&tap_and_name_comparison)).to eq(%w[a b])
+      end
+    end
+
+    describe "both strings include tap" do
+      it "alphabetizes the strings" do
+        expect(%w[a/z/z b/z/z].sort(&tap_and_name_comparison)).to eq(%w[a/z/z b/z/z])
+        expect(%w[b/z/z a/z/z].sort(&tap_and_name_comparison)).to eq(%w[a/z/z b/z/z])
+
+        expect(%w[z/a/z z/b/z].sort(&tap_and_name_comparison)).to eq(%w[z/a/z z/b/z])
+        expect(%w[z/b/z z/a/z].sort(&tap_and_name_comparison)).to eq(%w[z/a/z z/b/z])
+
+        expect(%w[z/z/a z/z/b].sort(&tap_and_name_comparison)).to eq(%w[z/z/a z/z/b])
+        expect(%w[z/z/b z/z/a].sort(&tap_and_name_comparison)).to eq(%w[z/z/a z/z/b])
+      end
+    end
+
+    describe "only one string includes tap" do
+      it "prefers the string without tap" do
+        expect(%w[a/z/z z].sort(&tap_and_name_comparison)).to eq(%w[z a/z/z])
+        expect(%w[z a/z/z].sort(&tap_and_name_comparison)).to eq(%w[z a/z/z])
+      end
+    end
+  end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -560,3 +560,15 @@ end
 def shell_profile
   Utils::Shell.profile
 end
+
+def tap_and_name_comparison
+  proc do |a, b|
+    if a.include?("/") && !b.include?("/")
+      1
+    elsif !a.include?("/") && b.include?("/")
+      -1
+    else
+      a <=> b
+    end
+  end
+end


### PR DESCRIPTION
`brew cask list` supports the `--full-name` flag which will include the tap name for casks not part of the core caskroom/cask tap. For example, if cask "foo-beta" is installed from the caskroom/versions cask, `brew cask list --full-name` will report the name as "caskroom/versions/foo-beta".

This will be especially helpful with `brew bundle cleanup`, which currently cannot correctly identify a cask installed from a non-core tap.