### PR TITLE
Follow the XDG Base Directory specification for caching on Linux

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -123,7 +123,15 @@ HOMEBREW_USER_AGENT_CURL="$HOMEBREW_USER_AGENT $HOMEBREW_CURL_VERSION"
 
 if [[ -z "$HOMEBREW_CACHE" ]]
 then
-  HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"
+  if [[ -n "$HOMEBREW_MACOS" ]]
+  then
+    HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"
+  elif [[ -n "$XDG_CACHE_HOME" ]]
+  then
+    HOMEBREW_CACHE="$XDG_CACHE_HOME/Homebrew"
+  else
+    HOMEBREW_CACHE="$HOME/.cache/Homebrew"
+  fi
 fi
 
 # Declared in bin/brew


### PR DESCRIPTION
Prefer $XDG_CACHE_HOME if defined, falling back to $HOME/.cache.
The Mac cache location is not affected by this change.

Most Linux users won't have a ~/Library directory, and those who do probably use it for something very different than what macOS uses it for.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
