### PR TITLE
Allow passing hash to system

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -111,10 +111,18 @@ module FileUtils
   # path to the actually-installed make on Tiger or older.
   def make(*args)
     if Utils.popen_read("/usr/bin/make", "--version").match(/Make (\d\.\d+)/)[1] > "3.80"
-      system "/usr/bin/make", *args
+      make_path = "/usr/bin/make"
     else
       make = Formula["make"].opt_bin/"make"
       make_path = make.exist? ? make.to_s : (Formula["make"].opt_bin/"gmake").to_s
+    end
+
+    if superenv?
+      make_name = File.basename(make_path)
+      with_env "HOMEBREW_MAKE" => make_name do
+        system "make", *args
+      end
+    else
       system make_path, *args
     end
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -955,30 +955,27 @@ class Formula
     build = self.build
     self.build = Tab.for_formula(self)
 
-    old_tmpdir = ENV["TMPDIR"]
-    old_temp = ENV["TEMP"]
-    old_tmp = ENV["TMP"]
-    old_path = ENV["HOMEBREW_PATH"]
+    new_env = {
+      "TMPDIR" => HOMEBREW_TEMP,
+      "TEMP" => HOMEBREW_TEMP,
+      "TMP" => HOMEBREW_TEMP,
+      "HOMEBREW_PATH" => nil,
+    }
 
-    ENV["TMPDIR"] = ENV["TEMP"] = ENV["TMP"] = HOMEBREW_TEMP
-    ENV["HOMEBREW_PATH"] = nil
+    with_env(new_env) do
+      ENV.clear_sensitive_environment!
 
-    ENV.clear_sensitive_environment!
+      Pathname.glob("#{bottle_prefix}/{etc,var}/**/*") do |path|
+        path.extend(InstallRenamed)
+        path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
+      end
 
-    Pathname.glob("#{bottle_prefix}/{etc,var}/**/*") do |path|
-      path.extend(InstallRenamed)
-      path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
-    end
-
-    with_logging("post_install") do
-      post_install
+      with_logging("post_install") do
+        post_install
+      end
     end
   ensure
     self.build = build
-    ENV["TMPDIR"] = old_tmpdir
-    ENV["TEMP"] = old_temp
-    ENV["TMP"] = old_tmp
-    ENV["HOMEBREW_PATH"] = old_path
     @prefix_returns_versioned_prefix = false
   end
 

--- a/Library/Homebrew/shims/super/make
+++ b/Library/Homebrew/shims/super/make
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+export MAKE=${HOMEBREW_MAKE:-make}
 export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
-exec xcrun make "$@"
+exec xcrun $MAKE "$@"

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -270,4 +270,30 @@ describe "globally-scoped helper methods" do
       }.to raise_error(MethodDeprecatedError, %r{method.*replacement.*homebrew/homebrew-core.*homebrew/core}m)
     end
   end
+
+  describe "#with_env" do
+    it "sets environment variables within the block" do
+      expect(ENV["PATH"]).not_to eq("/bin")
+      with_env "PATH" => "/bin" do
+        expect(ENV["PATH"]).to eq("/bin")
+      end
+    end
+
+    it "restores ENV after the block" do
+      with_env "PATH" => "/bin" do
+        expect(ENV["PATH"]).to eq("/bin")
+      end
+      expect(ENV["PATH"]).not_to eq("/bin")
+    end
+
+    it "restores ENV if an exception is raised" do
+      expect {
+        with_env "PATH" => "/bin" do
+          raise StandardError, "boom"
+        end
+      }.to raise_error(StandardError)
+
+      expect(ENV["PATH"]).not_to eq("/bin")
+    end
+  end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -287,10 +287,9 @@ ensure
 end
 
 def run_as_not_developer(&_block)
-  old = ENV.delete "HOMEBREW_DEVELOPER"
-  yield
-ensure
-  ENV["HOMEBREW_DEVELOPER"] = old
+  with_env "HOMEBREW_DEVELOPER" => nil do
+    yield
+  end
 end
 
 # Kernel.system but with exceptions

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -533,3 +533,27 @@ def migrate_legacy_keg_symlinks_if_necessary
   end
   FileUtils.rm_rf legacy_pinned_kegs
 end
+
+# Calls the given block with the passed environment variables
+# added to ENV, then restores ENV afterwards.
+# Example:
+# with_env "PATH" => "/bin" do
+#   system "echo $PATH"
+# end
+#
+# Note that this method is *not* thread-safe - other threads
+# which happen to be scheduled during the block will also
+# see these environment variables.
+def with_env(hash)
+  old_values = {}
+  begin
+    hash.each do |key, value|
+      old_values[key] = ENV.delete(key)
+      ENV[key] = value
+    end
+
+    yield if block_given?
+  ensure
+    ENV.update(old_values)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds support for passing an env hash to `Formula#system` and `Homebrew.system`. This syntax is supported by the language methods we're shadowing. The env hash is combined with the system env, so it allows passing extra environment variables or overriding environment variables in individual `system`/`exec` calls.

I missed this in #2877, which makes use of this syntax.