### PR TITLE
sandbox: allow write access to /dev/random

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -156,6 +156,7 @@ class Sandbox
           (literal "/dev/ptmx")
           (literal "/dev/dtracehelper")
           (literal "/dev/null")
+          (literal "/dev/random")
           (literal "/dev/zero")
           (regex #"^/dev/fd/[0-9]+$")
           (regex #"^/dev/ttys?[0-9]*$")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This avoids build failure for `root6`.

MacPorts currently avoids the failure with a patch, as their sandbox
doesn't yet allow write access to `/dev/random` either:
https://github.com/macports/macports-ports/blob/7792b2c5655f9d2adb979434a242cc3ac60fea40/science/root6/Portfile#L73-L75
https://github.com/macports/macports-ports/blob/7792b2c5655f9d2adb979434a242cc3ac60fea40/science/root6/files/patch-disable-hsimple-macro.diff

The relevant code where `/dev/random` is opened with `O_WRONLY` is here:
https://github.com/root-project/root/blob/15673deba5a0cb73d90ae8f36d7b010f65b5e96e/interpreter/cling/lib/Utils/PlatformPosix.cpp#L63-L82