### PR TITLE
python_virtualenv_constants: update virtualenv to 15.1.0

### DIFF
--- a/Library/Homebrew/language/python_virtualenv_constants.rb
+++ b/Library/Homebrew/language/python_virtualenv_constants.rb
@@ -1,2 +1,2 @@
-PYTHON_VIRTUALENV_URL = "https://files.pythonhosted.org/packages/5c/79/5dae7494b9f5ed061cff9a8ab8d6e1f02db352f3facf907d9eb614fb80e9/virtualenv-15.0.2.tar.gz".freeze
-PYTHON_VIRTUALENV_SHA256 = "fab40f32d9ad298fba04a260f3073505a16d52539a84843cf8c8369d4fd17167".freeze
+PYTHON_VIRTUALENV_URL = "https://files.pythonhosted.org/packages/d4/0c/9840c08189e030873387a73b90ada981885010dd9aea134d6de30cd24cb8/virtualenv-15.1.0.tar.gz".freeze
+PYTHON_VIRTUALENV_SHA256 = "02f8102c2436bb03b3ee6dede1919d1dac8a427541652e5ec95171ec8adbc93a".freeze


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This release adds support for Python 3.6, the current python3
version in homebrew/core.

While the current version of virtualenv being used hasn't been causing any overt errors or showing signs of issues when used with python3, it might still be worth making the update sooner rather than later.

cc @tdsmith @ilovezfs @MikeMcQuaid