### PR TITLE
integration_test: try tests on Gem load failure.

### DIFF
--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -89,8 +89,14 @@ RSpec.shared_context "integration test" do
       ]
       if ENV["HOMEBREW_TESTS_COVERAGE"]
         simplecov_spec = Gem.loaded_specs["simplecov"]
-        specs = simplecov_spec.runtime_dependencies.flat_map(&:to_specs)
-        specs << simplecov_spec
+        specs = [simplecov_spec]
+        simplecov_spec.runtime_dependencies.each do |dep|
+          begin
+            specs += dep.to_specs
+          rescue Gem::LoadError => e
+            onoe e
+          end
+        end
         libs = specs.flat_map do |spec|
           full_gem_path = spec.full_gem_path
           # full_require_paths isn't available in RubyGems < 2.2.


### PR DESCRIPTION
This should help with debugging `Gem::LoadError`s (e.g. for https://github.com/Homebrew/homebrew-test-bot/pull/111).