### PR TITLE
docs/Node: mention homebrew-npm-noob

### DIFF
--- a/docs/Node-for-Formula-Authors.md
+++ b/docs/Node-for-Formula-Authors.md
@@ -113,3 +113,7 @@ end
 ```
 
 For examples using the `local_npm_install_args` method look at the  [`elixirscript`](https://github.com/Homebrew/homebrew-core/blob/ec1e40d37e81af63122a354f0101c377f6a4e66d/Formula/elixirscript.rb) or [`kibana`](https://github.com/Homebrew/homebrew-core/blob/c6202f91a129e2f994d904f299a308cc6fbd58e5/Formula/kibana.rb) formulae.
+
+## Tooling
+
+You can use [homebrew-npm-noob](https://github.com/zmwangx/homebrew-npm-noob) to automatically generate a formula like the example above for an npm package.


### PR DESCRIPTION
I found myself writing quite a few node-based formulae recently, so I wrote a formula generator for npm packages, [homebrew-npm-noob](https://github.com/zmwangx/homebrew-npm-noob) (which, as the name hints, is inspired by Tim's homebrew-pypi-poet; hats off). To try it, just

    brew install zmwangx/npm-noob/noob

or

    pip install homebrew-npm-noob

(Python 3.3+ required.) It generates formulae like

```rb
require "language/node"

class Svgo < Formula
  desc "Nodejs-based tool for optimizing SVG vector graphics files"
  homepage "https://github.com/svg/svgo"
  url "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
  version "0.7.2"
  sha256 "e4fdae5cebe896bc90ec66acd4199495e0b826e55d5e8631c4ba6a0bf968d2ca"

  depends_on "node"

  def install
    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
    bin.install_symlink Dir["#{libexec}/bin/*"]
  end

  test do
    raise "Test not implemented."
  end
end
```

or 

```rb
require "language/node"

class BabelCli < Formula
  desc "Babel command line"
  homepage "https://babeljs.io/"
  url "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz"
  version "6.24.1"
  sha256 "d69a00bdb4f35184cda1f5bfe8075cd4d569600b8e61d864d1f08e360367933b"

  devel do
    url "https://registry.npmjs.org/babel-cli/-/babel-cli-7.0.0-alpha.15.tgz"
    version "7.0.0-alpha.15"
    sha256 "e825b9fe8e578aa392a8b398950070d3816c4c75e99953adb07ccfe858aea454"
  end

  depends_on "node"

  def install
    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
    bin.install_symlink Dir["#{libexec}/bin/*"]
  end

  test do
    raise "Test not implemented."
  end
end
```

It would be nice to "advertise" it in brew's docs so that other developers won't need to manually figure out tarball URLs on the npm registry (not trivial) and write boilerplate code.