### PR TITLE
python_requirement: add libexec/bin to PATH.

### DIFF
--- a/Library/Homebrew/requirements/python_requirement.rb
+++ b/Library/Homebrew/requirements/python_requirement.rb
@@ -21,6 +21,7 @@ class PythonRequirement < Requirement
     # Homebrew Python should take precedence over older Pythons in the PATH
     elsif short_version != Version.create("2.7")
       ENV.prepend_path "PATH", Formula["python"].opt_bin
+      ENV.prepend_path "PATH", Formula["python"].opt_libexec/"bin"
     end
 
     ENV["PYTHONPATH"] = "#{HOMEBREW_PREFIX}/lib/python#{short_version}/site-packages"


### PR DESCRIPTION
This avoids having to fix formulae that use `python` to make them use `python2`.

For when/if https://github.com/Homebrew/homebrew-core/pull/14408 gets merged.