### PR TITLE
sandbox: sandbox all taps by default.

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -3,18 +3,14 @@ require "tempfile"
 
 class Sandbox
   SANDBOX_EXEC = "/usr/bin/sandbox-exec".freeze
-  SANDBOXED_TAPS = %w[
-    homebrew/core
-  ].freeze
 
   def self.available?
     OS.mac? && OS::Mac.version >= "10.6" && File.executable?(SANDBOX_EXEC)
   end
 
-  def self.formula?(formula)
+  def self.formula?(_formula)
     return false unless available?
-    return false if ARGV.no_sandbox?
-    ARGV.sandbox? || SANDBOXED_TAPS.include?(formula.tap.to_s)
+    !ARGV.no_sandbox?
   end
 
   def self.test?

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -12,15 +12,7 @@ describe Sandbox do
 
   specify "#formula?" do
     f = formula { url "foo-1.0" }
-    f2 = formula { url "bar-1.0" }
-    allow(f2).to receive(:tap).and_return(Tap.fetch("test/tap"))
-
-    ENV["HOMEBREW_SANDBOX"] = "1"
-    expect(described_class).to be_formula(f), "Formulae should be sandboxed if --sandbox was passed."
-
-    ENV.delete("HOMEBREW_SANDBOX")
-    expect(described_class).to be_formula(f), "Formulae should be sandboxed if in a sandboxed tap."
-    expect(described_class).not_to be_formula(f2), "Formulae should not be sandboxed if not in a sandboxed tap."
+    expect(described_class).to be_formula(f), "Formulae should be sandboxed."
   end
 
   specify "#test?" do


### PR DESCRIPTION
We've been doing this in `brew test-bot`, for our CI and for homebrew/core long enough that this is a reasonable default that provides more protection to our users of non-homebrew/core taps.