### PR TITLE
Documentation improvements

### DIFF
--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -65,7 +65,9 @@ module Homebrew
     readme = HOMEBREW_REPOSITORY/"README.md"
     variables[:lead_maintainer] = readme.read[/(Homebrew's lead maintainer .*\.)/, 1]
                                         .gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
-    variables[:maintainers] = readme.read[/(Homebrew's current maintainers .*\.)/, 1]
+    variables[:core_maintainer] = readme.read[%r{(Homebrew/homebrew-core's lead maintainer .*\.)}, 1]
+                                        .gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
+    variables[:maintainers] = readme.read[/(Homebrew's other current maintainers .*\.)/, 1]
                                     .gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
     variables[:former_maintainers] = readme.read[/(Former maintainers .*\.)/, 1]
                                            .gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -260,6 +260,8 @@ Homebrew Documentation: <https://github.com/Homebrew/brew/blob/master/docs/>
 
 <%= lead_maintainer.concat("\n") %>
 
+<%= core_maintainer.concat("\n") %>
+
 <%= maintainers.concat("\n") %>
 
 <%= former_maintainers.concat("\n") %>

--- a/Library/README.md
+++ b/Library/README.md
@@ -1,0 +1,3 @@
+# Library
+
+This directory contains all the code run by the official `brew` and `brew cask` commands in `Homebrew` and all formulae (package descriptions) in taps (repositories containing formulae) in `Taps` subdirectories.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 
 Features, usage and installation instructions are [summarised on the homepage](https://brew.sh). Terminology (e.g. the difference between a Cellar, Tap, Cask and so forth) is [explained here](docs/Formula-Cookbook.md#homebrew-terminology).
 
-## Update Bug
-If Homebrew was updated on Aug 10-11th 2016 and `brew update` always says `Already up-to-date.` you need to run:
-```bash
-cd "$(brew --repo)" && git fetch && git reset --hard origin/master && brew update
-```
-
 ## What Packages Are Available?
 1. Type `brew search` for a list.
 2. Or visit [braumeister.org](http://braumeister.org) to browse packages online.
@@ -40,7 +34,9 @@ Please report security issues to our [HackerOne](https://hackerone.com/homebrew/
 ## Who Are You?
 Homebrew's lead maintainer is [Mike McQuaid](https://github.com/mikemcquaid).
 
-Homebrew's current maintainers are [Alyssa Ross](https://github.com/alyssais), [Andrew Janke](https://github.com/apjanke), [Alex Dunn](https://github.com/dunn), [FX Coudert](https://github.com/fxcoudert), [ilovezfs](https://github.com/ilovezfs), [Josh Hagins](https://github.com/jawshooah), [JCount](https://github.com/jcount), [Misty De Meo](https://github.com/mistydemeo), [neutric](https://github.com/neutric), [Tomasz Pajor](https://github.com/nijikon), [Markus Reiter](https://github.com/reitermarkus), [Tim Smith](https://github.com/tdsmith), [Tom Schoonjans](https://github.com/tschoonj), [Uladzislau Shablinski](https://github.com/vladshablinsky) and [William Woodruff](https://github.com/woodruffw).
+Homebrew/homebrew-core's lead maintainer is [ilovezfs](https://github.com/ilovezfs).
+
+Homebrew's other current maintainers are [Alyssa Ross](https://github.com/alyssais), [Andrew Janke](https://github.com/apjanke), [Alex Dunn](https://github.com/dunn), [FX Coudert](https://github.com/fxcoudert), [Josh Hagins](https://github.com/jawshooah), [JCount](https://github.com/jcount), [Misty De Meo](https://github.com/mistydemeo), [neutric](https://github.com/neutric), [Tomasz Pajor](https://github.com/nijikon), [Markus Reiter](https://github.com/reitermarkus), [Tim Smith](https://github.com/tdsmith), [Tom Schoonjans](https://github.com/tschoonj), [Uladzislau Shablinski](https://github.com/vladshablinsky) and [William Woodruff](https://github.com/woodruffw).
 
 Former maintainers with significant contributions include [Baptiste Fontaine](https://github.com/bfontaine), [Xu Cheng](https://github.com/xu-cheng), [Martin Afanasjew](https://github.com/UniqMartin), [Dominyk Tiller](https://github.com/DomT4), [Brett Koonce](https://github.com/asparagui), [Charlie Sharpsteen](https://github.com/Sharpie), [Jack Nagel](https://github.com/jacknagel), [Adam Vandenberg](https://github.com/adamv) and Homebrew's creator: [Max Howell](https://github.com/mxcl).
 

--- a/completions/README.md
+++ b/completions/README.md
@@ -1,0 +1,2 @@
+# Completions
+This directory contains subdirectories for `brew`'s tab completions for `bash` and `zsh`.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1072,7 +1072,9 @@ Homebrew Documentation: <https://github.com/Homebrew/brew/blob/master/docs/>
 
 Homebrew's lead maintainer is Mike McQuaid.
 
-Homebrew's current maintainers are Alyssa Ross, Andrew Janke, Alex Dunn, FX Coudert, ilovezfs, Josh Hagins, JCount, Misty De Meo, neutric, Tomasz Pajor, Markus Reiter, Tim Smith, Tom Schoonjans, Uladzislau Shablinski and William Woodruff.
+Homebrew/homebrew-core's lead maintainer is ilovezfs.
+
+Homebrew's other current maintainers are Alyssa Ross, Andrew Janke, Alex Dunn, FX Coudert, Josh Hagins, JCount, Misty De Meo, neutric, Tomasz Pajor, Markus Reiter, Tim Smith, Tom Schoonjans, Uladzislau Shablinski and William Woodruff.
 
 Former maintainers with significant contributions include Baptiste Fontaine, Xu Cheng, Martin Afanasjew, Dominyk Tiller, Brett Koonce, Charlie Sharpsteen, Jack Nagel, Adam Vandenberg and Homebrew's creator: Max Howell.
 

--- a/manpages/README.md
+++ b/manpages/README.md
@@ -1,0 +1,3 @@
+# Manual pages
+
+This directory contains the generated Homebrew man pages from the `brew man` command. This command creates the output from `#:` comments in files, sections extracted from the repository's `README.md` and `brew.1.md.erb`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1117,7 +1117,10 @@ Homebrew Documentation: \fIhttps://github\.com/Homebrew/brew/blob/master/docs/\f
 Homebrew\'s lead maintainer is Mike McQuaid\.
 .
 .P
-Homebrew\'s current maintainers are Alyssa Ross, Andrew Janke, Alex Dunn, FX Coudert, ilovezfs, Josh Hagins, JCount, Misty De Meo, neutric, Tomasz Pajor, Markus Reiter, Tim Smith, Tom Schoonjans, Uladzislau Shablinski and William Woodruff\.
+Homebrew/homebrew\-core\'s lead maintainer is ilovezfs\.
+.
+.P
+Homebrew\'s other current maintainers are Alyssa Ross, Andrew Janke, Alex Dunn, FX Coudert, Josh Hagins, JCount, Misty De Meo, neutric, Tomasz Pajor, Markus Reiter, Tim Smith, Tom Schoonjans, Uladzislau Shablinski and William Woodruff\.
 .
 .P
 Former maintainers with significant contributions include Baptiste Fontaine, Xu Cheng, Martin Afanasjew, Dominyk Tiller, Brett Koonce, Charlie Sharpsteen, Jack Nagel, Adam Vandenberg and Homebrew\'s creator: Max Howell\.


### PR DESCRIPTION
- Document @ilovezfs as the official lead maintainer of Homebrew/homebrew-core. This is a role he's been doing unofficially (and brilliantly) for a while and explicit documentation of power  structures makes it easier for non-Homebrew-maintainers to understand.
- Document the contents of some of Homebrew's subdirectories for people clicking around in the GitHub UI looking to contribute.
- Remove update bug mention from README. Enough time has passed that we can remove this disappointment.