### PR TITLE
audit: Port audit_options strict rules to rubocop and add tests

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -24,6 +24,9 @@ FormulaAudit/Conflicts:
 FormulaAudit/Options:
   Enabled: true
 
+FormulaAuditStrict/Options:
+  Enabled: true
+
 FormulaAuditStrict/BottleBlock:
   Enabled: true
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -554,23 +554,6 @@ class FormulaAuditor
   end
 
   def audit_options
-    formula.options.each do |o|
-      next unless @strict
-
-      if o.name == "universal"
-        problem "macOS has been 64-bit only since 10.6 so universal options are deprecated."
-      end
-
-      if o.name !~ /with(out)?-/ && o.name != "c++11" && o.name != "universal"
-        problem "Options should begin with with/without. Migrate '--#{o.name}' with `deprecated_option`."
-      end
-
-      next unless o.name =~ /^with(out)?-(?:checks?|tests)$/
-      unless formula.deps.any? { |d| d.name == "check" && (d.optional? || d.recommended?) }
-        problem "Use '--with#{Regexp.last_match(1)}-test' instead of '--#{o.name}'. Migrate '--#{o.name}' with `deprecated_option`."
-      end
-    end
-
     return unless @new_formula
     return if formula.deprecated_options.empty?
     return if formula.versioned_formula?

--- a/Library/Homebrew/rubocops/options_cop.rb
+++ b/Library/Homebrew/rubocops/options_cop.rb
@@ -16,5 +16,32 @@ module RuboCop
         end
       end
     end
+
+    module FormulaAuditStrict
+      class Options < FormulaCop
+        DEPRECATION_MSG = "macOS has been 64-bit only since 10.6 so universal options are deprecated.".freeze
+
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          option_call_nodes = find_every_method_call_by_name(body_node, :option)
+          option_call_nodes.each do |option_call|
+            offending_node(option_call)
+            option = string_content(parameters(option_call).first)
+            problem DEPRECATION_MSG if option == "universal"
+
+            if option !~ /with(out)?-/ &&
+               option != "cxx11" &&
+               option != "universal"
+              problem "Options should begin with with/without."\
+                      " Migrate '--#{option}' with `deprecated_option`."
+            end
+
+            next unless option =~ /^with(out)?-(?:checks?|tests)$/
+            next if depends_on?("check", :optional, :recommended)
+            problem "Use '--with#{Regexp.last_match(1)}-test' instead of '--#{option}'."\
+                    " Migrate '--#{option}' with `deprecated_option`."
+          end
+        end
+      end
+    end
   end
 end

--- a/Library/Homebrew/test/rubocops/options_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_cop_spec.rb
@@ -29,3 +29,77 @@ describe RuboCop::Cop::FormulaAudit::Options do
     end
   end
 end
+
+describe RuboCop::Cop::FormulaAuditStrict::Options do
+  subject(:cop) { described_class.new }
+
+  context "When auditing options strictly" do
+    it "with universal" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url 'http://example.com/foo-1.0.tgz'
+          option :universal
+        end
+      EOS
+
+      expected_offenses = [{  message: described_class::DEPRECATION_MSG,
+                              severity: :convention,
+                              line: 3,
+                              column: 2,
+                              source: source }]
+
+      inspect_source(cop, source)
+
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+
+    it "with deprecated options" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url 'http://example.com/foo-1.0.tgz'
+          option :cxx11
+          option "examples", "with-examples"
+        end
+      EOS
+
+      MSG_1 = "Options should begin with with/without."\
+              " Migrate '--examples' with `deprecated_option`.".freeze
+      expected_offenses = [{  message: MSG_1,
+                              severity: :convention,
+                              line: 4,
+                              column: 2,
+                              source: source }]
+
+      inspect_source(cop, source)
+
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+
+    it "with misc deprecated options" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url 'http://example.com/foo-1.0.tgz'
+          option "without-check"
+        end
+      EOS
+
+      MSG_2 = "Use '--without-test' instead of '--without-check'."\
+              " Migrate '--without-check' with `deprecated_option`.".freeze
+      expected_offenses = [{  message: MSG_2,
+                              severity: :convention,
+                              line: 3,
+                              column: 2,
+                              source: source }]
+
+      inspect_source(cop, source)
+
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#569 
Continuation of #2879 
Had to convert the option node to string ( [lines 27-28](https://github.com/GauthamGoli/brew/blob/cb2fb6fce9ef1cbd60f121a85883f9a3e4ad5acc/Library/Homebrew/rubocops/options_cop.rb#L27-L28) )  because there is a negative regex match, hence was not able to reuse `regex_match_group` method which takes the node itself as an argument and does the regex match but the method does not do negative regex match. Please suggest if you think there's a better way to do this. 
