### PR TITLE
audit: Port audit_options rules for new formulae to rubocop and add test

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -27,6 +27,9 @@ FormulaAudit/Options:
 FormulaAuditStrict/Options:
   Enabled: true
 
+NewFormulaAudit/Options:
+  Enabled: true
+
 FormulaAuditStrict/BottleBlock:
   Enabled: true
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -87,10 +87,14 @@ module Homebrew
     if !only_cops.empty?
       options[:only_cops] = only_cops
       ARGV.push("--only=style")
+    elsif new_formula
+      options[:only_cops] = [:FormulaAudit, :FormulaAuditStrict, :NewFormulaAudit]
+    elsif strict
+      options[:only_cops] = [:FormulaAudit, :FormulaAuditStrict]
     elsif !except_cops.empty?
       options[:except_cops] = except_cops
     elsif !strict
-      options[:except_cops] = [:FormulaAuditStrict]
+      options[:except_cops] = [:FormulaAuditStrict, :NewFormulaAudit]
     end
 
     # Check style in a single batch run up front for performance
@@ -551,13 +555,6 @@ class FormulaAuditor
 
     return unless reason.end_with?(".")
     problem "keg_only reason should not end with a period."
-  end
-
-  def audit_options
-    return unless @new_formula
-    return if formula.deprecated_options.empty?
-    return if formula.versioned_formula?
-    problem "New formulae should not use `deprecated_option`."
   end
 
   def audit_homepage

--- a/Library/Homebrew/rubocops/options_cop.rb
+++ b/Library/Homebrew/rubocops/options_cop.rb
@@ -43,5 +43,16 @@ module RuboCop
         end
       end
     end
+
+    module NewFormulaAudit
+      class Options < FormulaCop
+        MSG = "New Formula should not use `deprecated_option`".freeze
+
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          return if versioned_formula?
+          problem MSG if method_called_ever?(body_node, :deprecated_option)
+        end
+      end
+    end
   end
 end

--- a/Library/Homebrew/test/rubocops/options_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_cop_spec.rb
@@ -103,3 +103,30 @@ describe RuboCop::Cop::FormulaAuditStrict::Options do
     end
   end
 end
+
+describe RuboCop::Cop::NewFormulaAudit::Options do
+  subject(:cop) { described_class.new }
+
+  context "When auditing options for a new formula" do
+    it "with deprecated options" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url 'http://example.com/foo-1.0.tgz'
+          deprecated_option "examples" => "with-examples"
+        end
+      EOS
+
+      expected_offenses = [{  message: described_class::MSG,
+                              severity: :convention,
+                              line: 3,
+                              column: 2,
+                              source: source }]
+
+      inspect_source(cop, source)
+
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#569 
Continuation of #2879 and #2901 . This PR finishes porting of `audit_options` method completely from `audit.rb` to rubocop. 
This also introduces a new department of cops `NewFormulaAudit` as the name suggests, cops which execute when `--new-formula` flag is passed to audit. 