### PR TITLE
style: disable NewFormulaAudit cops' execution by default unless specified

### DIFF
--- a/Library/.auditcops.yml
+++ b/Library/.auditcops.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - ./.rubocop.yml
+
+NewFormulaAudit:
+  Enabled: true

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -6,47 +6,14 @@ AllCops:
 
 require: ./Homebrew/rubocops.rb
 
-FormulaAudit/Text:
+FormulaAudit:
   Enabled: true
 
-FormulaAudit/Caveats:
+FormulaAuditStrict:
   Enabled: true
 
-FormulaAudit/Checksum:
-  Enabled: true
-
-FormulaAudit/ChecksumCase:
-  Enabled: true
-
-FormulaAudit/Conflicts:
-  Enabled: true
-
-FormulaAudit/Options:
-  Enabled: true
-
-FormulaAuditStrict/Options:
-  Enabled: true
-
-NewFormulaAudit/Options:
-  Enabled: true 
-
-FormulaAuditStrict/BottleBlock:
-  Enabled: true
-
-FormulaAuditStrict/Desc:
-  Enabled: true
-
-FormulaAuditStrict/ComponentsOrder:
-  Enabled: true
-
-FormulaAuditStrict/ComponentsRedundancy:
-  Enabled: true
-
-FormulaAudit/Homepage:
-  Enabled: true
-
-FormulaAudit/LegacyPatches:
-  Enabled: true
+NewFormulaAudit:
+  Enabled: false
 
 # `system` is a special case and aligns on second argument
 Layout/AlignParameters:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -28,7 +28,7 @@ FormulaAuditStrict/Options:
   Enabled: true
 
 NewFormulaAudit/Options:
-  Enabled: false
+  Enabled: true 
 
 FormulaAuditStrict/BottleBlock:
   Enabled: true

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -109,7 +109,7 @@ module Homebrew
       args << "--config" << HOMEBREW_LIBRARY_PATH/".rubocop.yml"
       args << HOMEBREW_LIBRARY_PATH
     else
-      args << "--config" << HOMEBREW_LIBRARY/".rubocop.yml"
+      args << "--config" << HOMEBREW_LIBRARY/".auditcops.yml"
       args += files
     end
 

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -47,7 +47,9 @@ module Homebrew
     elsif !except_cops.empty?
       options[:except_cops] = except_cops
     elsif only_cops.empty? && except_cops.empty?
-      options[:except_cops] = %w[FormulaAuditStrict FormulaAudit]
+      options[:except_cops] = %w[FormulaAudit
+                                 FormulaAuditStrict
+                                 NewFormulaAudit]
     end
 
     Homebrew.failed = check_style_and_print(target, options)

--- a/Library/Homebrew/test/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cmd/style_spec.rb
@@ -4,12 +4,12 @@ describe "brew style" do
   around(:each) do |example|
     begin
       FileUtils.ln_s HOMEBREW_LIBRARY_PATH, HOMEBREW_LIBRARY/"Homebrew"
-      FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".rubocop.yml"
+      FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".auditcops.yml"
 
       example.run
     ensure
       FileUtils.rm_f HOMEBREW_LIBRARY/"Homebrew"
-      FileUtils.rm_f HOMEBREW_LIBRARY/".rubocop.yml"
+      FileUtils.rm_f HOMEBREW_LIBRARY/".auditcops.yml"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The `NewFormulaAudit` cop got enabled for all Formulae because I forgot to disable it for `brew style` ( I disabled for `brew audit` )  in #2905, This PR fixes that mistake. 
