### PR TITLE
docs: fix fallback fonts

### DIFF
--- a/docs/css/screen.scss
+++ b/docs/css/screen.scss
@@ -111,7 +111,7 @@ html {
   margin: 0;
   padding: 0;
   font-size: 62.5%;
-  font-family: "-apple-system", "BlinkMacSystemFont", "Helvetica Neue", "Roboto", "sans-serif";
+  font-family: "-apple-system", "BlinkMacSystemFont", "Helvetica Neue", "Roboto", sans-serif;
   height: 100%;
 }
 
@@ -176,7 +176,7 @@ pre {
   @include border-radius(0.4em);
   overflow-x: auto;
   code {
-    font-family: "Monaco", "Menlo", "monospace";
+    font-family: "Monaco", "Menlo", monospace;
     font-size: 11px;
     line-height: 1.6;
   }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

http://docs.brew.sh/ doesn't render well on Windows due to the CSS fallback fonts being quoted. (It will look for a font called "sans-serif" and doesn't find it). 

See below. Note that the browser default font Times New Roman (a serif font) was chosen instead of a sans-serif font for body text and a monospace font for the code block.

![Imgur](http://i.imgur.com/2HsbdOu.png)
