### PR TITLE
Add check for build from source

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -99,7 +99,7 @@ module Homebrew
       end
 
       def check_build_from_source
-        return unless ENV.key?("HOMEBREW_BUILD_FROM_SOURCE")
+        return unless ENV("HOMEBREW_BUILD_FROM_SOURCE")
 
         <<-EOS.undent
           You have HOMEBREW_BUILD_FROM_SOURCE set. This environment variable is

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -98,6 +98,17 @@ module Homebrew
         EOS
       end
 
+      def check_build_from_source
+        return if !ENV.has_key?("HOMEBREW_BUILD_FROM_SOURCE")
+
+        <<-EOS.undent
+          You have HOMEBREW_BUILD_FROM_SOURCE set. This environment variable is
+          intended for use by Homebrew developers. If you are encountering errors,
+          please try unsetting this. Please do not file issues if you encounter
+          errors when using this environment variable.
+        EOS
+      end
+
       # See https://github.com/Homebrew/legacy-homebrew/pull/9986
       def check_path_for_trailing_slashes
         bad_paths = PATH.new(ENV["HOMEBREW_PATH"]).select { |p| p.end_with?("/") }

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -99,7 +99,7 @@ module Homebrew
       end
 
       def check_build_from_source
-        return if !ENV.has_key?("HOMEBREW_BUILD_FROM_SOURCE")
+        return unless ENV.key?("HOMEBREW_BUILD_FROM_SOURCE")
 
         <<-EOS.undent
           You have HOMEBREW_BUILD_FROM_SOURCE set. This environment variable is

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -99,7 +99,7 @@ module Homebrew
       end
 
       def check_build_from_source
-        return unless ENV("HOMEBREW_BUILD_FROM_SOURCE")
+        return unless ENV["HOMEBREW_BUILD_FROM_SOURCE"]
 
         <<-EOS.undent
           You have HOMEBREW_BUILD_FROM_SOURCE set. This environment variable is

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -12,6 +12,12 @@ describe Homebrew::Diagnostic::Checks do
       .to match("Some directories in your path end in a slash")
   end
 
+  specify "#check_build_from_source" do
+    ENV["HOMEBREW_BUILD_FROM_SOURCE"] = "1"
+    expect(subject.check_build_from_source)
+      .to match("You have HOMEBREW_BUILD_FROM_SOURCE set.")
+  end
+
   specify "#check_for_anaconda" do
     mktmpdir do |path|
       anaconda = "#{path}/anaconda"

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -89,6 +89,8 @@ following conditions:
 will use a bottled version of the formula, but
 `brew install <formula> --enable-bar` will trigger a source build.
 * The `--build-from-source` option is invoked.
+* The environment variable `HOMEBREW_BUILD_FROM_SOURCE` is set
+(intended for developers only).
 * The machine is not running a supported version of macOS as all
 bottled builds are generated only for supported macOS versions.
 * Homebrew is installed to a prefix other than the standard

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -89,15 +89,10 @@ following conditions:
 will use a bottled version of the formula, but
 `brew install <formula> --enable-bar` will trigger a source build.
 * The `--build-from-source` option is invoked.
-* The environment variable `HOMEBREW_BUILD_FROM_SOURCE` is set.
 * The machine is not running a supported version of macOS as all
 bottled builds are generated only for supported macOS versions.
 * Homebrew is installed to a prefix other than the standard
 `/usr/local` (although some bottles support this).
-
-In order to completely disable bottled builds, simply add a value for
-the environment variable `HOMEBREW_BUILD_FROM_SOURCE` to
-your profile.
 
 We aim to bottle everything.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a simple change to add a warning to `brew doctor` if the unsupported environment variable `HOMEBREW_BUILD_FROM_SOURCE` is set. I believe they would be beneficial for older `brew` users (myself included) that have this set (I wasn't aware it was unsupported until recently).