### PR TITLE
system_config: look for python formula binary.

### DIFF
--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -77,7 +77,14 @@ class SystemConfig
     end
 
     def describe_python
-      python = which "python"
+      python = begin
+        python_path = PATH.new(ENV["HOMEBREW_PATH"])
+                          .prepend(Formula["python"].opt_libexec/"bin")
+        which "python", python_path
+      rescue FormulaUnavailableError
+        which "python"
+      end
+
       return "N/A" if python.nil?
       python_binary = Utils.popen_read python, "-c", "import sys; sys.stdout.write(sys.executable)"
       python_binary = Pathname.new(python_binary).realpath


### PR DESCRIPTION
Now that Python has been renamed it's important that we still output which Python they are using for debugging purposes e.g.

```
Python: /usr/local/opt/python/libexec/bin/python => /usr/local/Cellar/python/2.7.13_1/Frameworks/Python.framework/Versions/2.7/bin/python2.7
```