### PR TITLE
keg: correctly cleanup old aliases.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -383,7 +383,9 @@ class Formula
   # All of aliases for the formula
   def aliases
     @aliases ||= if tap
-      tap.alias_reverse_table[full_name] || []
+      tap.alias_reverse_table[full_name].to_a.map do |a|
+        a.split("/")[-1]
+      end
     else
       []
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -863,6 +863,7 @@ class FormulaInstaller
     tab.source["path"] = formula.specified_path.to_s
     tab.installed_as_dependency = installed_as_dependency
     tab.installed_on_request = installed_on_request
+    tab.aliases = formula.aliases
     tab.write
   end
 

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -237,13 +237,37 @@ class Keg
     opt_record.symlink? && path == opt_record.resolved_path
   end
 
-  def remove_opt_record
-    opt_record.unlink
-    aliases.each do |a|
-      alias_symlink = opt_record.parent/a
-      next if !alias_symlink.symlink? && !alias_symlink.exist?
+  def remove_old_aliases
+    opt = opt_record.parent
+
+    tap = begin
+      to_formula.tap
+    rescue FormulaUnavailableError, TapFormulaAmbiguityError,
+           TapFormulaWithOldnameAmbiguityError
+      # If the formula can't be found, just ignore aliases for now.
+      nil
+    end
+
+    if tap
+      bad_tap_opt = opt/tap.user
+      FileUtils.rm_rf bad_tap_opt if bad_tap_opt.directory?
+    end
+
+    Pathname.glob("#{opt_record}@*").each do |a|
+      a = a.basename
+      next if aliases.include?(a)
+
+      alias_symlink = opt/a
+      if alias_symlink.symlink? && alias_symlink.exist?
+        next if rack != alias_symlink.realpath.parent
+      end
+
       alias_symlink.delete
     end
+  end
+
+  def remove_opt_record
+    opt_record.unlink
     opt_record.parent.rmdir_if_possible
   end
 
@@ -251,6 +275,7 @@ class Keg
     path.rmtree
     path.parent.rmdir_if_possible
     remove_opt_record if optlinked?
+    remove_old_aliases
     remove_oldname_opt_record
   end
 
@@ -277,6 +302,7 @@ class Keg
 
         dst.uninstall_info if dst.to_s =~ INFOFILE_RX
         dst.unlink
+        remove_old_aliases
         Find.prune if src.directory?
       end
     end
@@ -468,12 +494,7 @@ class Keg
   end
 
   def aliases
-    formula = Formulary.from_rack(rack)
-    aliases = formula.aliases
-    return aliases if formula.stable?
-    aliases.reject { |a| a.include?("@") }
-  rescue FormulaUnavailableError
-    []
+    Tab.for_keg(self).aliases || []
   end
 
   def optlink(mode = OpenStruct.new)

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -33,6 +33,7 @@ class Tab < OpenStruct
       "HEAD" => HOMEBREW_REPOSITORY.git_head,
       "compiler" => compiler,
       "stdlib" => stdlib,
+      "aliases" => formula.aliases,
       "runtime_dependencies" => formula.runtime_dependencies.map do |dep|
         f = dep.to_formula
         { "full_name" => f.full_name, "version" => f.version.to_s }
@@ -185,6 +186,7 @@ class Tab < OpenStruct
       "HEAD" => nil,
       "stdlib" => nil,
       "compiler" => DevelopmentTools.default_compiler,
+      "aliases" => [],
       "runtime_dependencies" => [],
       "source" => {
         "path" => nil,
@@ -328,6 +330,7 @@ class Tab < OpenStruct
       "HEAD" => self.HEAD,
       "stdlib" => (stdlib.to_s if stdlib),
       "compiler" => (compiler.to_s if compiler),
+      "aliases" => aliases,
       "runtime_dependencies" => runtime_dependencies,
       "source" => source,
     }


### PR DESCRIPTION
Cleanup old, versioned aliases and tap aliases folders when unlinking or uninstalling a keg.

Also:
- Include aliases in the tab to allow e.g. `brew switch` to correctly handle switching between different keg’s aliases.
- Ensure aliases don’t include full names (aliases that include `/`s end up creating directories and this is bad).

Fixes #2937 