### PR TITLE
linkage_checker: Whitelist another harmless dylib

### DIFF
--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -118,9 +118,12 @@ class LinkageChecker
   # Whether or not dylib is a harmless broken link, meaning that it's
   # okay to skip (and not report) as broken.
   def harmless_broken_link?(dylib)
-    # libgcc_s_ppc64 is referenced by programs that use the Java Service Wrapper,
+    # libgcc_s_* is referenced by programs that use the Java Service Wrapper,
     # and is harmless on x86(_64) machines
-    ["/usr/lib/libgcc_s_ppc64.1.dylib"].include?(dylib)
+    [
+      "/usr/lib/libgcc_s_ppc64.1.dylib",
+      "/opt/local/lib/libgcc/libgcc_s.1.dylib",
+    ].include?(dylib)
   end
 
   # Display a list of things.


### PR DESCRIPTION
libgcc_s.1.dylib is a variation on libgcc_s_ppc64.1.dylib.

See #2085, https://github.com/Homebrew/homebrew-core/pull/15787

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
