### PR TITLE
version: improve devel spec version parsing

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -453,6 +453,17 @@ describe Version do
         .to be_detected_from("https://example.com/dada-v2017-04-17.tar.gz")
     end
 
+    specify "devel spec version style" do
+      expect(Version.create("1.3.0-beta.1"))
+        .to be_detected_from("https://registry.npmjs.org/@angular/cli/-/cli-1.3.0-beta.1.tgz")
+      expect(Version.create("2.074.0-beta1"))
+        .to be_detected_from("https://github.com/dlang/dmd/archive/v2.074.0-beta1.tar.gz")
+      expect(Version.create("2.074.0-rc1"))
+        .to be_detected_from("https://github.com/dlang/dmd/archive/v2.074.0-rc1.tar.gz")
+      expect(Version.create("5.0.0-alpha10"))
+        .to be_detected_from("https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-src.zip")
+    end
+
     specify "jenkins version style" do
       expect(Version.create("1.486"))
         .to be_detected_from("http://mirrors.jenkins-ci.org/war/1.486/jenkins.war")
@@ -479,6 +490,12 @@ describe Version do
     specify "dash version style" do
       expect(Version.create("3.4"))
         .to be_detected_from("http://www.antlr.org/download/antlr-3.4-complete.jar")
+      expect(Version.create("9.2"))
+        .to be_detected_from("https://cdn.nuxeo.com/nuxeo-9.2/nuxeo-server-9.2-tomcat.zip")
+      expect(Version.create("0.181"))
+        .to be_detected_from("https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.181/presto-cli-0.181-executable.jar")
+      expect(Version.create("1.2.3"))
+        .to be_detected_from("https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/1.2.3/orc-tools-1.2.3-uber.jar")
     end
 
     specify "apache version style" do

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -406,12 +406,29 @@ class Version
     m = /[-_](\d+\.\d+(?:\.\d+)?(?:-\d+)?)[-_.](?:i[36]86|x86|x64(?:[-_](?:32|64))?)$/.match(stem)
     return m.captures.first unless m.nil?
 
+    # devel spec
+    # e.g. https://registry.npmjs.org/@angular/cli/-/cli-1.3.0-beta.1.tgz
+    # e.g. https://github.com/dlang/dmd/archive/v2.074.0-beta1.tar.gz
+    # e.g. https://github.com/dlang/dmd/archive/v2.074.0-rc1.tar.gz
+    # e.g. https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-src.zip
+    m = /[-.vV]?((?:\d+\.)+\d+[-_.]?(?i:alpha|beta|pre|rc)\.?\d{,2})/.match(stem)
+    return m.captures.first unless m.nil?
+
     # e.g. foobar4.5.1
     m = /((?:\d+\.)*\d+)$/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. foobar-4.5.0-bin
     m = /-((?:\d+\.)+\d+[abc]?)[-._](?:bin|dist|stable|src|sources?)$/.match(stem)
+    return m.captures.first unless m.nil?
+
+    # dash version style
+    # e.g. http://www.antlr.org/download/antlr-3.4-complete.jar
+    # e.g. https://cdn.nuxeo.com/nuxeo-9.2/nuxeo-server-9.2-tomcat.zip
+    # e.g. https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.181/presto-cli-0.181-executable.jar
+    # e.g. https://search.maven.org/remotecontent?filepath=org/fusesource/fuse-extra/fusemq-apollo-mqtt/1.3/fusemq-apollo-mqtt-1.3-uber.jar
+    # e.g. https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/1.2.3/orc-tools-1.2.3-uber.jar
+    m = /-((?:\d+\.)+\d+)-/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. dash_0.5.5.1.orig.tar.gz (Debian style)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
term this 'devel spec version style';
also improve dash version style parsing

This adds regex specifically aimed at matching common non-release styles used, to better cover automatic version detection in the devel spec. Consequently, I gave it the name of **'devel spec version style'** to try make this intent clear within the code.

I additionally created a specific regex for the **'dash version style'** because before these were simply being matched by the regex aimed at `OpenSSL`, leading to erroneous automatic version detections that had to be manually corrected.