### PR TITLE
Don’t output Caskroom creation messages on non-TTY.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/caskroom.rb
+++ b/Library/Homebrew/cask/lib/hbc/caskroom.rb
@@ -5,10 +5,10 @@ module Hbc
     def ensure_caskroom_exists
       return if Hbc.caskroom.exist?
 
-      ohai "Creating Caskroom at #{Hbc.caskroom}"
+      ohai "Creating Caskroom at #{Hbc.caskroom}" if $stdout.tty?
       sudo = !Hbc.caskroom.parent.writable?
 
-      ohai "We'll set permissions properly so we won't need sudo in the future" if sudo
+      ohai "We'll set permissions properly so we won't need sudo in the future" if $stdout.tty? && sudo
 
       SystemCommand.run("/bin/mkdir", args: ["-p", Hbc.caskroom], sudo: sudo)
       SystemCommand.run("/bin/chmod", args: ["g+rwx", Hbc.caskroom], sudo: sudo)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This breaks `brew cask list` in a sub-shell when the caskroom doesn't exist yet.