### PR TITLE
OS: use RbConfig instead of RUBY_PLATFORM

### DIFF
--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -1,12 +1,14 @@
+require "rbconfig"
+
 module OS
   def self.mac?
     return false if ENV["HOMEBREW_TEST_GENERIC_OS"]
-    RUBY_PLATFORM.to_s.downcase.include? "darwin"
+    RbConfig::CONFIG["host_os"].include? "darwin"
   end
 
   def self.linux?
     return false if ENV["HOMEBREW_TEST_GENERIC_OS"]
-    RUBY_PLATFORM.to_s.downcase.include? "linux"
+    RbConfig::CONFIG["host_os"].include? "linux"
   end
 
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`RUBY_PLATFORM` is always `"java"` when running JRuby, no matter what the underlying platform is. Using `RbConfig` fixes that (see https://github.com/pry/pry/issues/386).