### PR TITLE
formula_installer: allow version mismatched build deps

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -151,6 +151,8 @@ class FormulaInstaller
 
     recursive_deps = formula.recursive_dependencies
     recursive_formulae = recursive_deps.map(&:to_formula)
+    recursive_runtime_deps = formula.recursive_dependencies.reject(&:build?)
+    recursive_runtime_formulae = recursive_runtime_deps.map(&:to_formula)
 
     recursive_dependencies = []
     recursive_formulae.each do |dep|
@@ -176,7 +178,7 @@ class FormulaInstaller
 
     version_hash = {}
     version_conflicts = Set.new
-    recursive_formulae.each do |f|
+    recursive_runtime_formulae.each do |f|
       name = f.name
       unversioned_name, = name.split("@")
       version_hash[unversioned_name] ||= Set.new


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Only check runtime dependencies for version conflicts to avoid
having to create unnecessary duplicate formulae.

For example, a formula that needs to be built with ghc@8.0 should still
be allowed to have a build-time dependency on a cabal-install that was
itself built with ghc@8.2.