### PR TITLE
audit: Run style violations check when `--new-formula` is passed

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -88,9 +88,9 @@ module Homebrew
       options[:only_cops] = only_cops
       ARGV.push("--only=style")
     elsif new_formula
-      options[:only_cops] = [:FormulaAudit, :FormulaAuditStrict, :NewFormulaAudit]
+      nil
     elsif strict
-      options[:only_cops] = [:FormulaAudit, :FormulaAuditStrict]
+      options[:except_cops] = [:NewFormulaAudit]
     elsif !except_cops.empty?
       options[:except_cops] = except_cops
     elsif !strict


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR restores the original `brew audit --new-formula` functionality : _all style checks are run._

[Test bot code](https://github.com/Homebrew/homebrew-test-bot/blob/master/cmd/brew-test-bot.rb#L834-L836) assumes that style checks are run for new formula once `brew audit --new-formula foo` is executed which WAS true and everything was fine. 

My PR #2905 , however changed that behaviour by introducing this [code](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/audit.rb#L90-L91) . This translates to rubocop running with `--only=FormulaAudit,FormulaAuditStrict,NewFormulaAudit` , so no other RuboCop style checks are run , and this makes testbot skip regular style checks for new formulae. This PR fixes that.

Similarly I also changed [line 93](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/audit.rb#L93) to preserve original audit functionality

Thanks to @ilovezfs  and @JCount for pointing this out. 