### PR TITLE
Preserve link status on reinstall/upgrade.

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -23,6 +23,7 @@ module Homebrew
   def reinstall_formula(f)
     if f.opt_prefix.directory?
       keg = Keg.new(f.opt_prefix.resolved_path)
+      keg_was_linked = keg.linked?
       backup keg
     end
 
@@ -37,6 +38,7 @@ module Homebrew
     fi.build_bottle         = ARGV.build_bottle? || (!f.bottled? && f.build.bottle?)
     fi.interactive          = ARGV.interactive?
     fi.git                  = ARGV.git?
+    fi.keg_was_linked       = keg_was_linked
     fi.prelude
 
     oh1 "Reinstalling #{f.full_name} #{options.to_a.join " "}"
@@ -46,7 +48,7 @@ module Homebrew
   rescue FormulaInstallationAlreadyAttemptedError
     # next
   rescue Exception
-    ignore_interrupts { restore_backup(keg, f) }
+    ignore_interrupts { restore_backup(keg, keg_was_linked) }
     raise
   else
     backup_path(keg).rmtree if backup_path(keg).exist?
@@ -57,7 +59,7 @@ module Homebrew
     keg.rename backup_path(keg)
   end
 
-  def restore_backup(keg, formula)
+  def restore_backup(keg, keg_was_linked)
     path = backup_path(keg)
 
     return unless path.directory?
@@ -65,7 +67,7 @@ module Homebrew
     Pathname.new(keg).rmtree if keg.exist?
 
     path.rename keg
-    keg.link unless formula.keg_only?
+    keg.link if keg_was_linked
   end
 
   def backup_path(path)

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -106,6 +106,7 @@ module Homebrew
                     .map(&:linked_keg)
                     .select(&:directory?)
                     .map { |k| Keg.new(k.resolved_path) }
+    linked_kegs = outdated_kegs.select(&:linked?)
 
     if f.opt_prefix.directory?
       keg = Keg.new(f.opt_prefix.resolved_path)
@@ -153,7 +154,7 @@ module Homebrew
   ensure
     # restore previous installation state if build failed
     begin
-      outdated_kegs.each(&:link) unless f.installed?
+      linked_kegs.each(&:link) unless f.installed?
     rescue
       nil
     end

--- a/Library/Homebrew/test/bottle_hooks_spec.rb
+++ b/Library/Homebrew/test/bottle_hooks_spec.rb
@@ -12,6 +12,8 @@ describe Homebrew::Hooks::Bottles do
       local_bottle_path: nil,
       bottle_disabled?: false,
       some_random_method: true,
+      linked_keg: Pathname("foo"),
+      rack: Pathname("bar"),
     )
   end
 


### PR DESCRIPTION
This means if a user has manually `brew unlink` or `brew link --force`d something then that status will be preserved after they `brew upgrade` or `brew reinstall` that formula.

This generally should make things that are keg-only by default easier to swallow.