### PR TITLE
language/node: add setup_yarn_environment

### DIFF
--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -48,4 +48,29 @@ describe Language::Node do
     resp = subject.local_npm_install_args
     expect(resp).to include("-ddd", "--build-from-source", "--cache=#{HOMEBREW_CACHE}/npm_cache")
   end
+
+  describe "#setup_yarn_environment" do
+    it "does nothing when .yarnrc exists" do
+      allow_any_instance_of(Pathname).to receive(:exist?).and_return(true)
+      expect(subject.setup_yarn_environment).to be_nil
+    end
+
+    it "calls prepend_path when node formula exists and yarnrc does not exist" do
+      node = formula "node" do
+        url "node-test"
+      end
+      stub_formula_loader(node)
+      allow_any_instance_of(Pathname).to receive(:exist?).and_return(false)
+      allow_any_instance_of(Pathname).to receive(:write)
+      expect(ENV).to receive(:prepend_path).twice
+      subject.setup_yarn_environment
+    end
+
+    it "does not call prepend_path when node formula does not exist but .yarnrc exists" do
+      allow_any_instance_of(Pathname).to receive(:exist?).and_return(false)
+      allow_any_instance_of(Pathname).to receive(:write)
+      expect(ENV).to receive(:prepend_path)
+      expect(subject.setup_yarn_environment).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a `setup_yarn_environment` helper method to `language/node`, which will be needed for the upcoming yarn v0.28 (currently in `brew install yarn --devel`) to be able to build some yarn depending formulae.

### What it does:
1. It writes a temporary `.yarnrc` to `.brew_home` to tell yarn too:
    * prefix: set's yarns global prefix to `.brew_home/.yarn/bin` so that global build tool installations won't fail because of brew sandbox restrictions (like auto installing `node-gyp` on demand)
    * cache-folder: changes yarn's cache folder to `HOMEBREW_CACHE/yarn_cache` (from `.brew_home/Library/Caches/Yarn`) similar to what we do for npm
    * build-from-source: compile native addons from source instead of downloading prebuild binaries
    * ignore-engines: in yarn 0.28+ installing with a different node version than specified in the modules `package.json` engine filed would fail otherwise (warning => error)
2. It adds said temporary global prefix to the $PATH
3. It adds the `node-gyp` copy of the homebrew managed npm to the $PATH as a workaround preventing yarn from having to globally install a temporary copy of `node-gyp` on demand (yarn default detecting `node-gyp` from npm code does not work because of homebrews-npm-installation-structure-oddness)