### PR TITLE
formula_support: add provided_pre_high_sierra keg_only

### DIFF
--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -19,6 +19,8 @@ class KegOnlyReason
       MacOS.version < :mavericks
     when :provided_pre_el_capitan
       MacOS.version < :el_capitan
+    when :provided_pre_high_sierra
+      MacOS.version < :high_sierra
     when :provided_until_xcode43
       MacOS::Xcode.installed? && MacOS::Xcode.version < "4.3"
     when :provided_until_xcode5
@@ -50,6 +52,9 @@ class KegOnlyReason
     EOS
     when :provided_pre_el_capitan then <<-EOS.undent
       macOS already provides this software in versions before El Capitan
+    EOS
+    when :provided_pre_high_sierra then <<-EOS.undent
+      macOS already provides this software in versions before High Sierra
     EOS
     when :provided_until_xcode43 then <<-EOS.undent
       Xcode provides this software prior to version 4.3


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Apple ditched at least `telnet` from High Sierra, and whilst I lean towards thinking PRs shouldn't be accepted for those things _before_ the High Sierra GM release if Homebrew is going to accept them it should probably provide this helper for messaging consistency & common-sense handling.

Ref: https://github.com/Homebrew/homebrew-core/pull/16208