### PR TITLE
travis: fast finish builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
     - $HOME/Library/Caches/Homebrew/tests
 
 matrix:
+  fast_finish: true
   include:
     - os: osx
       osx_image: xcode8.3


### PR DESCRIPTION
Show failing Linux builds (which run much more quickly) before the macOS
build has completed.

https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing