### PR TITLE
audit: fix bug where `brew audit foo` runs every style check.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -94,7 +94,7 @@ module Homebrew
     elsif !except_cops.empty?
       options[:except_cops] = except_cops
     elsif !strict
-      options[:except_cops] = [:FormulaAuditStrict, :NewFormulaAudit]
+      options[:only_cops] = [:FormulaAudit]
     end
 
     # Check style in a single batch run up front for performance


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR fixes bug, where every style check is ran when `brew audit <some_formula>` is executed which is not the expected behaviour.

Style checks are done only when `--strict` or `--new-formula` is passed to `brew audit`.
Without `--strict` or `--new-formula` , only RuboCop Custom Cops' style checks belonging to `FormulaAudit` department have to be checked. 

cc and Thanks @ilovezfs 