### PR TITLE
Tweak preserve link status on reinstall/upgrade.

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -23,6 +23,7 @@ module Homebrew
   def reinstall_formula(f)
     if f.opt_prefix.directory?
       keg = Keg.new(f.opt_prefix.resolved_path)
+      keg_had_linked_opt = true
       keg_was_linked = keg.linked?
       backup keg
     end
@@ -38,7 +39,7 @@ module Homebrew
     fi.build_bottle         = ARGV.build_bottle? || (!f.bottled? && f.build.bottle?)
     fi.interactive          = ARGV.interactive?
     fi.git                  = ARGV.git?
-    fi.keg_was_linked       = keg_was_linked
+    fi.link_keg             = keg_was_linked if keg_had_linked_opt
     fi.prelude
 
     oh1 "Reinstalling #{f.full_name} #{options.to_a.join " "}"

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -101,6 +101,12 @@ module Homebrew
   end
 
   def upgrade_formula(f)
+    if f.opt_prefix.directory?
+      keg = Keg.new(f.opt_prefix.resolved_path)
+      keg_had_linked_opt = true
+      keg_was_linked = keg.linked?
+    end
+
     formulae_maybe_with_kegs = [f] + f.old_installed_formulae
     outdated_kegs = formulae_maybe_with_kegs
                     .map(&:linked_keg)
@@ -118,6 +124,7 @@ module Homebrew
     fi.options &= f.options
     fi.build_bottle = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
     fi.installed_on_request = !ARGV.named.empty?
+    fi.link_keg             = keg_was_linked if keg_had_linked_opt
     if tab
       fi.installed_as_dependency = tab.installed_as_dependency
       fi.installed_on_request  ||= tab.installed_on_request

--- a/Library/Homebrew/test/bottle_hooks_spec.rb
+++ b/Library/Homebrew/test/bottle_hooks_spec.rb
@@ -12,8 +12,7 @@ describe Homebrew::Hooks::Bottles do
       local_bottle_path: nil,
       bottle_disabled?: false,
       some_random_method: true,
-      linked_keg: Pathname("foo"),
-      rack: Pathname("bar"),
+      keg_only?: false,
     )
   end
 


### PR DESCRIPTION
Treat a `brew install` command as normal i.e. link by default unless keg-only and only specify whether a keg should be linked when upgrading or reinstalling. Also, adjust the naming accordingly so it's more obvious that this is the case.