### PR TITLE
docs/brew-tap.md: Reference dunn's Emacs tap

### DIFF
--- a/docs/brew-tap.md
+++ b/docs/brew-tap.md
@@ -13,7 +13,7 @@ but the command isn't limited to any one location.
 $ brew tap
 homebrew/core
 mistydemeo/tigerbrew
-edavis/emacs
+dunn/emacs
 ```
 
 * `brew tap <user/repo>` makes a shallow clone of the repository at


### PR DESCRIPTION
edavis' repo currently points to homebrew/emacs,
which has since been moved to dunn/emacs.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?