### PR TITLE
formula_desc_cop: add 'x86' to VALID_LOWERCASE_WORDS

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -45,6 +45,7 @@ module RuboCop
           malloc
           ooc
           preexec
+          x86
           xUnit
         ].freeze
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
add `x86` to `VALID_LOWERCASE_WORDS`

-----
This is a perfectly valid "word" to use at the beginning of a formula's description that should not be capitalized. A current example of a formula that fails a strict audit because of this is [qemu](https://github.com/Homebrew/homebrew-core/blob/master/Formula/qemu.rb).

(Should `x86-64` be added as well? My personal opinion is that it is probably unnecessary.)