### PR TITLE
audit: add additional php header ignore patterns

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -6,7 +6,7 @@ module FormulaCellarChecks
       formula.name.start_with?(formula_name)
     end
 
-    return if formula.name =~ /^php\d+$/
+    return if formula.name =~ /^php(@?\d+\.?\d*?)?$/
 
     return if MacOS.version < :mavericks && formula.name.start_with?("postgresql")
     return if MacOS.version < :yosemite  && formula.name.start_with?("memcached")


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----
Since https://github.com/Homebrew/homebrew-core/pull/16067 introduces a new php formula with the standard naming convention the header ignore rule needs to be updated for the formula to pass green in the CI. This new regexp should support the following formula names which ought to cover any future additions to the php formulas in core. The regexp should match
```
php (new Formula)
php@7.1 (new versioned formula, not yet exisiting)
php71 (convention used in the php tap)
```
