### PR TITLE
formula_cellar_checks: check_non_libraries only for new formulae

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -157,7 +157,7 @@ module FormulaCellarChecks
     problem_if_output(check_manpages)
     problem_if_output(check_infopages)
     problem_if_output(check_jars)
-    problem_if_output(check_non_libraries)
+    problem_if_output(check_non_libraries) if @new_formula
     problem_if_output(check_non_executables(formula.bin))
     problem_if_output(check_generic_executables(formula.bin))
     problem_if_output(check_non_executables(formula.sbin))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This check is overly opinionated and leads to audit failures no one cares to fix, so let's only run it for new formulae. For example, `tcl-tk` has failed this audit for years:

```
$ brew audit tcl-tk
tcl-tk:
  * Non-libraries were installed to "/usr/local/opt/tcl-tk/lib"
    Installing non-libraries to "lib" is discouraged.
    The offending files are:
      /usr/local/opt/tcl-tk/lib/Tk.icns
      /usr/local/opt/tcl-tk/lib/Tk.tiff
Error: 1 problem in 1 formula
```