### PR TITLE
Bugfix/pkgconfiglibdir

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -138,7 +138,6 @@ module Superenv
 
   def determine_pkg_config_libdir
     PATH.new(
-      "/usr/lib/pkgconfig",
       homebrew_extra_pkg_config_paths,
     ).existing
   end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -29,6 +29,7 @@ module Superenv
   def homebrew_extra_pkg_config_paths
     paths = \
       ["#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
+    paths << "/usr/lib/pkg-config"
     paths << "#{MacOS::X11.lib}/pkgconfig" << "#{MacOS::X11.share}/pkgconfig" if x11?
     paths
   end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -28,8 +28,7 @@ module Superenv
   # @private
   def homebrew_extra_pkg_config_paths
     paths = \
-      ["#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
-    paths << "/usr/lib/pkg-config"
+      ["/usr/lib/pkg-config", "#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
     paths << "#{MacOS::X11.lib}/pkgconfig" << "#{MacOS::X11.share}/pkgconfig" if x11?
     paths
   end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -28,7 +28,7 @@ module Superenv
   # @private
   def homebrew_extra_pkg_config_paths
     paths = \
-      ["/usr/lib/pkg-config", "#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
+      ["/usr/lib/pkgconfig", "#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.version}"]
     paths << "#{MacOS::X11.lib}/pkgconfig" << "#{MacOS::X11.share}/pkgconfig" if x11?
     paths
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Hi. I'm proposing these changes after an error was found trying to compile graphviz on a Linux machine (see Linuxbrew/homebrew-core#3366. The inclusion of `/usr/lib/pkg-config` in `determine_pkg_config_libdir` from `ENV/super.rb` meant a system install GD library was compiled into graphviz instead of the brew installed GD library.

As asked by @sjackman I've created this PR to enact the changes he proposed to move the declaration to `os/mac/ENV/super.rb` and `homebrew_extra_pkg_config_paths`. Order of pkg-config has been retained during the move.