### PR TITLE
Tap.each: return an enumerable when no block given

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -486,6 +486,8 @@ class Tap
   def self.each
     return unless TAP_DIRECTORY.directory?
 
+    return to_enum unless block_given?
+
     TAP_DIRECTORY.subdirs.each do |user|
       user.subdirs.each do |repo|
         yield fetch(user.basename.to_s, repo.basename.to_s)

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -297,6 +297,12 @@ describe Tap do
     subject.config["foo"] = nil
     expect(subject.config["foo"]).to be nil
   end
+
+  describe "#each" do
+    it "returns an enumerator if no block is passed" do
+      expect(described_class.each).to be_an_instance_of(Enumerator)
+    end
+  end
 end
 
 describe CoreTap do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Tap` is an enumerable which iterates over instances of itself. It was missing a `to_enum` call, however, which meant that `Tap.each` didn't return a chainable enumerable. We don't currently need this, but it's standard for Ruby enumerables.