### PR TITLE
travis.yml: only build the master branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ cache:
     - $HOME/.gem/ruby
     - $HOME/Library/Caches/Homebrew/style
     - $HOME/Library/Caches/Homebrew/tests
-
+branches:
+  only:
+    - master
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
This avoid two weird things:

- scary messages when building tags fails
- two builds being run instead of one when people create a PR and a branch on the Homebrew/brew repo (rather than their fork).