### PR TITLE
keg: cleanup aliases correctly.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -253,6 +253,11 @@ class Keg
       FileUtils.rm_rf bad_tap_opt if bad_tap_opt.directory?
     end
 
+    aliases.each do |a|
+      alias_symlink = opt/a
+      alias_symlink.delete if alias_symlink.symlink? || alias_symlink.exist?
+    end
+
     Pathname.glob("#{opt_record}@*").each do |a|
       a = a.basename
       next if aliases.include?(a)


### PR DESCRIPTION
This was missed when I was focused on cleaning up versioned aliases.

Fixes #2992.