### PR TITLE
Add node pattern methods to handle dependency audits in a better way

### DIFF
--- a/Library/Homebrew/test/rubocops/text_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_cop_spec.rb
@@ -7,6 +7,54 @@ describe RuboCop::Cop::FormulaAudit::Text do
   subject(:cop) { described_class.new }
 
   context "When auditing formula text" do
+    it "with both openssl and libressl optional dependencies" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url "http://example.com/foo-1.0.tgz"
+          homepage "http://example.com"
+
+          depends_on "openssl"
+          depends_on "libressl" => :optional
+        end
+      EOS
+
+      expected_offenses = [{  message: "Formulae should not depend on both OpenSSL and LibreSSL (even optionally).",
+                              severity: :convention,
+                              line: 6,
+                              column: 2,
+                              source: source }]
+
+      inspect_source(cop, source)
+
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+
+    it "with both openssl and libressl dependencies" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url "http://example.com/foo-1.0.tgz"
+          homepage "http://example.com"
+
+          depends_on "openssl"
+          depends_on "libressl"
+        end
+      EOS
+
+      expected_offenses = [{  message: "Formulae should not depend on both OpenSSL and LibreSSL (even optionally).",
+                              severity: :convention,
+                              line: 6,
+                              column: 2,
+                              source: source }]
+
+      inspect_source(cop, source)
+
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+
     it "When xcodebuild is called without SYMROOT" do
       source = <<-EOS.undent
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#569 and #2662 
RuboCop has pattern searching macros which simplify searching/matching nodes in AST. 
Found documentation for same in the source of [node_pattern.rb](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/node_pattern.rb)

This PR updates `depends_on` audits to use such pattern matching methods, so code becomes more readable and also fixes bug in previous code which wasn't detecting dependencies. 

(there is however one edge case where the value of a `depends_on` hash is an array, I know how exactly to implement that and will deal with that later)

**Edit:** How did I derive those patterns?  By running the below commands and looking at the AST.
`$ ruby-parse -e 'depends_on :x11 => optional'`
`$ ruby-parse -e 'depends_on "readline" => :recommended'`

cc @ilovezfs 