### PR TITLE
sandbox: stop printing message.

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -29,8 +29,6 @@ module Homebrew
       args << "--devel"
     end
 
-    Sandbox.print_sandbox_message if Sandbox.formula?(formula)
-
     Utils.safe_fork do
       if Sandbox.formula?(formula)
         sandbox = Sandbox.new

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -65,8 +65,6 @@ module Homebrew
           args << "--devel"
         end
 
-        Sandbox.print_sandbox_message if Sandbox.test?
-
         Utils.safe_fork do
           if Sandbox.test?
             sandbox = Sandbox.new

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -679,8 +679,6 @@ class FormulaInstaller
       #{formula.specified_path}
     ].concat(build_argv)
 
-    Sandbox.print_sandbox_message if Sandbox.formula?(formula)
-
     Utils.safe_fork do
       # Invalidate the current sudo timestamp in case a build script calls sudo.
       # Travis CI's Linux sudoless workers have a weird sudo that fails here.

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -18,12 +18,6 @@ class Sandbox
     !ARGV.no_sandbox?
   end
 
-  def self.print_sandbox_message
-    return if @printed_sandbox_message
-    ohai "Using the sandbox"
-    @printed_sandbox_message = true
-  end
-
   def initialize
     @profile = SandboxProfile.new
   end


### PR DESCRIPTION
We’re always using the sandbox where possible now so this is just noise for the vast majority of our users.