### PR TITLE
cmd/search: use new Fedora package search

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -34,7 +34,7 @@ module Homebrew
     elsif ARGV.include? "--opensuse"
       exec_browser "https://software.opensuse.org/search?q=#{ARGV.next}"
     elsif ARGV.include? "--fedora"
-      exec_browser "https://admin.fedoraproject.org/pkgdb/packages/%2A#{ARGV.next}%2A/"
+      exec_browser "https://apps.fedoraproject.org/packages/s/#{ARGV.next}"
     elsif ARGV.include? "--ubuntu"
       exec_browser "http://packages.ubuntu.com/search?keywords=#{ARGV.next}&searchon=names&suite=all&section=all"
     elsif ARGV.include? "--desc"

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -44,7 +44,7 @@ describe "brew search", :integration_test do
     "fink" => "http://pdb.finkproject.org/pdb/browse.php?summary=testball",
     "debian" => "https://packages.debian.org/search?keywords=testball&searchon=names&suite=all&section=all",
     "opensuse" => "https://software.opensuse.org/search?q=testball",
-    "fedora" => "https://admin.fedoraproject.org/pkgdb/packages/%2Atestball%2A/",
+    "fedora" => "https://apps.fedoraproject.org/packages/s/testball",
     "ubuntu" => "http://packages.ubuntu.com/search?keywords=testball&searchon=names&suite=all&section=all",
   }.each do |flag, url|
     specify "--#{flag}" do


### PR DESCRIPTION
pkgdb has been put into read-only mode,
so it won't be updated for new Fedora releases
going forward. Use apps.fedoraproject.org/packages instead.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

See https://fedoraproject.org/wiki/Infrastructure/WhatHappenedToPkgdb if you're interested in why it's getting decommissioned. 