### PR TITLE
dev-cmd/bump-formula-pr: search for tar

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -176,7 +176,10 @@ module Homebrew
       rsrc.version = forced_version if forced_version
       odie "No version specified!" unless rsrc.version
       rsrc_path = rsrc.fetch
-      if Utils.popen_read("/usr/bin/tar", "-tf", rsrc_path) =~ %r{/.*\.}
+      gnu_tar_gtar_path = HOMEBREW_PREFIX/"opt/gnu-tar/bin/gtar"
+      gnu_tar_gtar = gnu_tar_gtar_path if gnu_tar_gtar_path.executable?
+      tar = which("gtar") || gnu_tar_gtar || which("tar")
+      if Utils.popen_read(tar, "-tf", rsrc_path) =~ %r{/.*\.}
         new_hash = rsrc_path.sha256
       elsif new_url.include? ".tar"
         odie "#{formula}: no url/#{hash_type} specified!"


### PR DESCRIPTION
Certain Linux distros (eg. Ubuntu) have /bin/tar,
not /usr/bin/tar. Use the first tar in the path
to avoid bizarre failures on such distros.

macOS continues to use the hardcoded /usr/bin/tar.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The precise error message is:

```
==> replace nil with nil
Error: no implicit conversion of nil into String
/home/linuxbrew/.linuxbrew/Library/Homebrew/extend/string.rb:56:in `gsub!'
/home/linuxbrew/.linuxbrew/Library/Homebrew/extend/string.rb:56:in `gsub!'
/home/linuxbrew/.linuxbrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:50:in `block in inreplace_pairs'
/home/linuxbrew/.linuxbrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:46:in `each'
/home/linuxbrew/.linuxbrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:46:in `inreplace_pairs'
/home/linuxbrew/.linuxbrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:240:in `bump_formula_pr'
/home/linuxbrew/.linuxbrew/Library/Homebrew/brew.rb:95:in `<main>'
```