### PR TITLE
caveats: fix a message showing the wrong version

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -108,7 +108,8 @@ class Caveats
     return unless keg.python_site_packages_installed?
 
     s = nil
-    homebrew_site_packages = Language::Python.homebrew_site_packages
+    version = Language::Python.major_minor_version "python"
+    homebrew_site_packages = Language::Python.homebrew_site_packages version
     user_site_packages = Language::Python.user_site_packages "python"
     pth_file = user_site_packages/"homebrew.pth"
     instructions = <<-EOS.undent.gsub(/^/, "  ")
@@ -117,7 +118,7 @@ class Caveats
     EOS
 
     if f.keg_only?
-      keg_site_packages = f.opt_prefix/"lib/python2.7/site-packages"
+      keg_site_packages = f.opt_prefix/"lib/python#{version}/site-packages"
       unless Language::Python.in_sys_path?("python", keg_site_packages)
         s = <<-EOS.undent
           If you need Python to find bindings for this keg-only formula, run:

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -237,8 +237,9 @@ describe Caveats do
           keg_only "some reason"
         end
         caveats = described_class.new(f).caveats
-        homebrew_site_packages = Language::Python.homebrew_site_packages
-        expect(caveats).to include("echo #{f.opt_prefix}/lib/python2.7/site-packages >> #{homebrew_site_packages/f.name}.pth")
+        version = Language::Python.major_minor_version "python"
+        homebrew_site_packages = Language::Python.homebrew_site_packages version
+        expect(caveats).to include("echo #{f.opt_prefix}/lib/python#{version}/site-packages >> #{homebrew_site_packages/f.name}.pth")
       end
     end
   end


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When Homebrew's site-packages is not in your Python sys.path, it tells
to add `site-packages` of the only version `2.7`.

for example:

```
...
please run:
  mkdir -p /MY/LOCAL/.local/lib/python3.4/site-packages
  echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /MY/LOCAL/.local/lib/python3.4/site-packages/homebrew.pth
```

