### PR TITLE
gpg: minor search priority tweaks

### DIFF
--- a/Library/Homebrew/gpg.rb
+++ b/Library/Homebrew/gpg.rb
@@ -7,8 +7,8 @@ class Gpg
       next unless gpg_short_version
       gpg_version = Version.create(gpg_short_version.to_s)
       @version = gpg_version
-      gpg_version == Version.create("2.0") ||
-        gpg_version == Version.create("2.1")
+      gpg_version == Version.create("2.1") ||
+        gpg_version == Version.create("2.0")
     end
   end
 
@@ -20,7 +20,7 @@ class Gpg
     find_gpg("gpg2")
   end
 
-  GPG_EXECUTABLE = gpg2 || gpg
+  GPG_EXECUTABLE = gpg || gpg2
 
   def self.available?
     File.executable?(GPG_EXECUTABLE.to_s)

--- a/Library/Homebrew/requirements/gpg2_requirement.rb
+++ b/Library/Homebrew/requirements/gpg2_requirement.rb
@@ -5,8 +5,8 @@ class GPG2Requirement < Requirement
   fatal true
   default_formula "gnupg"
 
-  # MacGPG2/GPGTools installs GnuPG 2.0.x as a vanilla `gpg` symlink
-  # pointing to `gpg2`, as do we. Ensure we're actually using a 2.0 `gpg`.
-  # Support both the 2.0.x "stable" and 2.1.x "modern" series.
-  satisfy(build_env: false) { Gpg.gpg2 || Gpg.gpg }
+  # GPGTools installs GnuPG 2.0.x as a vanilla `gpg` symlink
+  # pointing to `gpg2`. Homebrew install 2.1.x as a non-symlink `gpg`.
+  # We support both the 2.0.x "stable" and 2.1.x "modern" series here.
+  satisfy(build_env: false) { Gpg.gpg || Gpg.gpg2 }
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Makes more sense this way around now Homebrew has migrated across to 2.1.x & the latest version of that doesn't install as `gpg2` any more.

Doesn't need to be merged before this PR but for the sake of referencing the PR introducing the upstream death of the `gpg2` executable is: Homebrew/homebrew-core#16580