### PR TITLE
shims/super/cc: Fix c++ -xc++-header

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -43,6 +43,8 @@ class Cmd
       else
         :cc
       end
+    elsif @args.include?("-xc++-header") || @args.each_cons(2).include?(["-x", "c++-header"])
+      :cxx
     elsif @args.include? "-E"
       :ccE
     else


### PR DESCRIPTION
Compiling a precompiled header should be mode `:cxx` rather than `:cxxld`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

When compiling a precompiled header with `c++ -xc++-header`, `shims/super/cc` believes the mode is `:cxxld` and adds `cxxflags + args + cppflags + ldflags`, when it should be `cxxflags + args + cppflags`. `ldflags` should not be included when compiling a precompiled header.

This issue caused `brew install homebrew/science/opencv` to fail on Linux. See https://github.com/Homebrew/homebrew-science/pull/6092