### PR TITLE
Replace search_tap with search_taps

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -48,7 +48,8 @@ module Homebrew
         result = Formulary.factory(query).name
         results = Array(result)
       rescue FormulaUnavailableError
-        results = search_taps(query.split('/')[-1])
+        _, _, name = query.split("/", 3)
+        results = search_taps(name)
       end
 
       puts Formatter.columns(results) unless results.empty?

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -48,7 +48,7 @@ module Homebrew
         result = Formulary.factory(query).name
         results = Array(result)
       rescue FormulaUnavailableError
-        results = search_taps(query)
+        results = search_taps(query.split('/')[-1])
       end
 
       puts Formatter.columns(results) unless results.empty?

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -43,15 +43,14 @@ module Homebrew
       Descriptions.search(regex, :desc).print
     elsif ARGV.first =~ HOMEBREW_TAP_FORMULA_REGEX
       query = ARGV.first
-      user, repo, name = query.split("/", 3)
 
       begin
         result = Formulary.factory(query).name
+        results = Array(result)
       rescue FormulaUnavailableError
-        result = search_tap(user, repo, name)
+        results = search_taps(query)
       end
 
-      results = Array(result)
       puts Formatter.columns(results) unless results.empty?
     else
       query = ARGV.first

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,6 +1,7 @@
 describe "brew search", :integration_test do
   before(:each) do
     setup_test_formula "testball"
+    setup_remote_tap "caskroom/cask/test"
   end
 
   it "lists all available Formulae when no argument is given" do
@@ -20,6 +21,13 @@ describe "brew search", :integration_test do
   it "supports searching a fully-qualified name " do
     expect { brew "search", "homebrew/homebrew-core/testball" }
       .to output(/testball/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "falls back to a tap search when no formula is found" do
+    expect { brew "search", "caskroom/cask/firefox" }
+      .to output(/firefox/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,7 +1,7 @@
 describe "brew search", :integration_test do
   before(:each) do
     setup_test_formula "testball"
-    setup_remote_tap "caskroom/cask/test"
+    setup_remote_tap "caskroom/cask"
   end
 
   it "lists all available Formulae when no argument is given" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Seems like this method call was missed in https://github.com/Homebrew/brew/pull/2548/files

I got this error earlier:

```bash
$ brew search caskroom/cask/jet
Error: undefined method `search_tap' for Homebrew:Module
/usr/local/Homebrew/Library/Homebrew/compat/global.rb:9:in `method_missing'
/usr/local/Homebrew/Library/Homebrew/cmd/search.rb:51:in `rescue in search'
/usr/local/Homebrew/Library/Homebrew/cmd/search.rb:48:in `search'
/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in `<main>'
```

And a google search took me to that PR

~~Tests coming soon!~~ Done!