### PR TITLE
Revert "Raise an exception when double loading a formula"

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -20,8 +20,6 @@ module Formulary
       raise "Formula loading disabled by HOMEBREW_DISABLE_LOAD_FORMULA!"
     end
 
-    raise "Formula #{name} has already been loaded" if const_defined?(namespace)
-
     mod = Module.new
     const_set(namespace, mod)
     begin

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -27,16 +27,6 @@ describe Formulary do
   let(:bottle_dir) { Pathname.new("#{TEST_FIXTURE_DIR}/bottles") }
   let(:bottle) { bottle_dir/"testball_bottle-0.1.#{Utils::Bottles.tag}.bottle.tar.gz" }
 
-  describe "::load_formula" do
-    it "does not allow namespace repetition" do |example|
-      definition = "Foo = Class.new(Formula)"
-      namespace = "Test#{example.description.hash.abs}"
-      subject.load_formula("foo", "bar", definition, namespace)
-      expect { subject.load_formula("foo", "bar", definition, namespace) }
-        .to raise_error RuntimeError, /already.* loaded/
-    end
-  end
-
   describe "::class_s" do
     it "replaces '+' with 'x'" do
       expect(subject.class_s("foo++")).to eq("Fooxx")


### PR DESCRIPTION
Reverts Homebrew/brew#3046

Causing a failure here:
```
==> Installing or updating 'rubocop' gem
Building native extensions.  This could take a while...
Successfully installed rainbow-2.2.2
Successfully installed ast-2.3.0
Successfully installed parser-2.4.0.0
Successfully installed powerpack-0.1.1
Successfully installed ruby-progressbar-1.8.1
Successfully installed unicode-display_width-1.3.0
Successfully installed parallel-1.12.0
Successfully installed rubocop-0.49.1
8 gems installed
Error: Formula sane-backends has already been loaded

```
https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/6459/version=sierra/testReport/junit/brew-test-bot/sierra/audit_sane_backends___online/

CC @alyssais @reitermarkus 