### PR TITLE
Remove "*instal" aliases from bash completion

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -563,7 +563,7 @@ _brew() {
 
   if [[ "$i" -eq "$COMP_CWORD" ]]
   then
-    # Do not auto-complete "*instal" abbreviations for "*install" commands.
+    # Do not auto-complete "*instal" or "*uninstal" aliases for "*install" commands.
     # Prefix newline to prevent not checking the first command.
     local cmds=$'\n'"$(brew commands --quiet --include-aliases | grep -v instal$)"
     __brewcomp "${cmds}"

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -563,10 +563,10 @@ _brew() {
 
   if [[ "$i" -eq "$COMP_CWORD" ]]
   then
-    # Do not auto-complete "instal" abbreviation for "install" command.
+    # Do not auto-complete "*instal" abbreviations for "*install" commands.
     # Prefix newline to prevent not checking the first command.
-    local cmds=$'\n'"$(brew commands --quiet --include-aliases)"
-    __brewcomp "${cmds/$'\n'instal$'\n'/$'\n'}"
+    local cmds=$'\n'"$(brew commands --quiet --include-aliases | grep -v instal$)"
+    __brewcomp "${cmds}"
     return
   fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Remove all command aliases ending in "instal" (single letter L) from the bash completion. This has the practical effect of removing the aliases "instal" and "uninstal" from bash completion, allowing "install" and "uninstall" to be auto completed once the first three characters of each "ins" or "uni" are typed in.

This makes bash completion for "uninstall" complete with a following space on the first tab instead of offering two different versions of the same command.

Addresses #3051