### PR TITLE
diagnostic: don't tap homebrew/core

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -942,6 +942,8 @@ module Homebrew
       end
 
       def check_for_non_prefixed_coreutils
+        return unless CoreTap.instance.installed?
+
         coreutils = Formula["coreutils"]
         return unless coreutils.any_version_installed?
 
@@ -955,6 +957,8 @@ module Homebrew
       end
 
       def check_for_non_prefixed_findutils
+        return unless CoreTap.instance.installed?
+
         findutils = Formula["findutils"]
         return unless findutils.any_version_installed?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Attempting to look up a formula when the core tap has not been set up yet made Homebrew silently clone it, which meant that `brew doctor` took a very long time with no indication of what was happening.

Since both of the diagnostic checks that caused this behaviour will only fail if a homebrew/core formula is installed, it seems a little silly to clone it just for the purpose of checking that.