### PR TITLE
shims: fix detecting Homebrew Git

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -75,7 +75,6 @@ safe_exec() {
 
 SCM_FILE="${0##*/}"
 SCM_REAL="$(realpath "$0")"
-SCM_DIR="$(quiet_safe_cd "${SCM_REAL%/*}/" && pwd -P)"
 
 if [[ "$1" = --homebrew=* ]]
 then
@@ -92,7 +91,7 @@ case "$(lowercase "$SCM_FILE")" in
     ;;
 esac
 
-brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../bin" && pwd -P)/$SCM_FILE"
+brew_version="$(quiet_safe_cd "$HOMEBREW_PREFIX/bin" && pwd -P)/$SCM_FILE"
 safe_exec "$brew_version" "$@"
 
 IFS=$'\n'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Basing `brew_version`'s assumed location on the location of the shim file meant that it was looking for a `bin/git` executable at the root of Homebrew's _repository_, rather than the _prefix_. This meant that
Homebrew's Git wasn't always detected correctly when these weren't the same. This is the case for the vast majority of our users, who have /usr/local as the prefix, but /usr/local/Homebrew as the repository. In that case, the Git shim would look for /usr/local/Homebrew/bin/git, which of course would never exist no matter whether Homebrew Git was installed.

In most cases, this didn't have a noticeable effect, because the shim would fall through to selecting the first "git" executable in the user's `PATH`, which would be Homebrew's Git anyway.

In some cases, though  (i.e. when superenv was active), this would lead to Homebrew ignoring its own Git and using system Git if available, or producing a very confusing failure message intructing the user to install Git with Homebrew if not.

At first glance, this sounds like it could lead to a pretty nasty security problem: if Homebrew had mistakenly used a non-Homebrew Git when Homebrew Git was installed (and so expected to be used), it could have ended up exposing a vulnerable older version of Git to the network unexpectedly. However, due to a fortunate quirk of Homebrew's build system, there would be no way for a malicious formula to actually do this in practice:

- Tapping a repository through `depends_on` statement couldn't expose Git to a malicious server because only GitHub repositories can be specified in this way.
- Cloning a repository through a formula resource (including through a `url` statement or similar) wouldn't incorrectly use a non-Homebrew Git because if such a Git were installed, Homebrew's build system would interpret its presence as meaning it should include Homebrew's Git installation in `PATH`.

Additionally, even if Homebrew did expose a vulnerable Git version, it would only be exploitable through either a malicious formula or some malicious package code. Both of these things could be exploited to exactly the same extent much more easily without involving Git in the first place.

So, the only actual problem this bug could cause is that, if Homebrew's prefix and repository are different, and Homebrew's Git is installed but no system Git is installed, Homebrew will incorrectly claim that Git is not installed and will instruct the user to install it using Homebrew, forever.