### PR TITLE
gpg: prevent pinentry from launching when creating test key

### DIFF
--- a/Library/Homebrew/gpg.rb
+++ b/Library/Homebrew/gpg.rb
@@ -38,6 +38,7 @@ class Gpg
       Key-Length: 2048
       Subkey-Type: RSA
       Subkey-Length: 2048
+      Passphrase: ''
       Name-Real: Testing
       Name-Email: testing@foo.bar
       Expire-Date: 1d


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
-----
Prevent pinentry from launching when creating test key.
This is accomplished by setting an empty password in the `gnupg` batch input file.