### PR TITLE
bump-formula-pr: forward compatibility with `hub fork`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -296,9 +296,7 @@ module Homebrew
         ohai "git fetch --unshallow origin" if shallow
         ohai "git checkout --no-track -b #{branch} origin/master"
         ohai "git commit --no-edit --verbose --message='#{formula.name} #{new_formula_version}#{devel_message}' -- #{formula.path}"
-        ohai "hub fork --no-remote"
-        ohai "hub fork"
-        ohai "hub fork (to read $HUB_REMOTE)"
+        ohai "hub fork # read $HUB_REMOTE"
         ohai "git push --set-upstream $HUB_REMOTE #{branch}:#{branch}"
         ohai "hub pull-request --browse -m '#{formula.name} #{new_formula_version}#{devel_message}'"
         ohai "git checkout -"
@@ -308,9 +306,9 @@ module Homebrew
         safe_system "git", "commit", "--no-edit", "--verbose",
           "--message=#{formula.name} #{new_formula_version}#{devel_message}",
           "--", formula.path
-        safe_system "hub", "fork", "--no-remote"
-        quiet_system "hub", "fork"
-        remote = Utils.popen_read("hub fork 2>&1")[/fatal: remote (.+) already exists\./, 1]
+        remote = Utils.popen_read("hub fork 2>&1")[/remote:? (\S+)/, 1]
+        # repeat for hub 2.2 backwards compatibility:
+        remote = Utils.popen_read("hub fork 2>&1")[/remote:? (\S+)/, 1] if remote.to_s.empty?
         odie "cannot get remote from 'hub'!" if remote.to_s.empty?
         safe_system "git", "push", "--set-upstream", remote, "#{branch}:#{branch}"
         pr_message = <<-EOS.undent


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Due to limitations of `hub fork` in hub 2.2, scripts had to repeat the command at least two times; the 2nd time was to read the fork name from the "fatal: remote MYNAME already exists" message output from git.

In upcoming hub 2.3, the `hub fork` command is improved to always output the remote name, regardless of whether one already existed or not. With this approach, only one `hub fork` call will ever be necessary when hub is up to date.

/cc @e-beach https://github.com/github/hub/pull/1535