### PR TITLE
Skip search_remote on cask search when HOMEBREW_NO_GITHUB_API is set

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -15,6 +15,7 @@ module Hbc
       end
 
       def self.search_remote(query)
+        return [] if ENV["HOMEBREW_NO_GITHUB_API"]
         matches = GitHub.search_code(user: "caskroom", path: "Casks",
                                      filename: query, extension: "rb")
         matches.map do |match|


### PR DESCRIPTION
Fixes #3069.