### PR TITLE
blacklist - remove clojure

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -55,15 +55,6 @@ module Homebrew
         when "gsutil" then <<-EOS.undent
           Install gsutil with `pip install gsutil`
           EOS
-        when "clojure" then <<-EOS.undent
-          Clojure isn't really a program but a library managed as part of a
-          project and Leiningen is the user interface to that library.
-
-          To install Clojure you should install Leiningen:
-            brew install leiningen
-          and then follow the tutorial:
-            #{Formatter.url("https://github.com/technomancy/leiningen/blob/stable/doc/TUTORIAL.md")}
-          EOS
         when "gfortran" then <<-EOS.undent
           GNU Fortran is now provided as part of GCC, and can be installed with:
             brew install gcc

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -82,12 +82,6 @@ describe Homebrew::MissingFormula do
       it { is_expected.to be_blacklisted }
     end
 
-    context "clojure" do
-      subject { "clojure" }
-
-      it { is_expected.to be_blacklisted }
-    end
-
     context "gfortran" do
       subject { "gfortran" }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently there is a blacklist entry for "clojure" (the language) that points you towards installing "leiningen" instead, which is the most popular Clojure build tool and the easiest path to a Clojure REPL, so this made good sense until now.

However, the next release of Clojure (1.9.0) will include a Clojure REPL tool (called `clj`). I am a member of the Clojure core team and I have a separate PR ready to submit with a formula for `clojure` that includes this tool, but the blacklist entry needs to be removed before that formula can be added.

This patch removes the blacklist for `clojure` and the test checking the blacklist for `clojure`.