### PR TITLE
Offline cask search and listing all available casks 

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -23,14 +23,13 @@ module Hbc
           user: "caskroom",
           path: "Casks",
           filename: query,
-          extension: "rb"
+          extension: "rb",
         )
-        rescue Exception => e
+        rescue StandardError => e
           onoe e
           $stderr.puts e.backtrace
           []
         end
-        
         matches.map do |match|
           tap = Tap.fetch(match["repository"]["full_name"])
           next if tap.installed?

--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -19,12 +19,13 @@ module Hbc
       end
 
       def self.search_remote(query)
-        matches = begin GitHub.search_code(
-          user: "caskroom",
-          path: "Casks",
-          filename: query,
-          extension: "rb",
-        )
+        matches = begin
+          GitHub.search_code(
+            user: "caskroom",
+            path: "Casks",
+            filename: query,
+            extension: "rb",
+          )
         rescue StandardError => e
           onoe e
           $stderr.puts e.backtrace

--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -27,7 +27,7 @@ module Hbc
             extension: "rb",
           )
         rescue GitHub::Error => error
-          opoo "Online search failed: #{error}\n"
+          opoo "Error searching on GitHub: #{error}\n"
           []
         end
         matches.map do |match|

--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -26,9 +26,8 @@ module Hbc
             filename: query,
             extension: "rb",
           )
-        rescue GitHub::Error => e
-          onoe e
-          $stderr.puts e.backtrace
+        rescue GitHub::Error => error
+          opoo "Online search failed: #{error}\n"
           []
         end
         matches.map do |match|

--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -19,8 +19,18 @@ module Hbc
       end
 
       def self.search_remote(query)
-        matches = GitHub.search_code(user: "caskroom", path: "Casks",
-                                     filename: query, extension: "rb")
+        matches = begin GitHub.search_code(
+          user: "caskroom",
+          path: "Casks",
+          filename: query,
+          extension: "rb"
+        )
+        rescue Exception => e
+          onoe e
+          $stderr.puts e.backtrace
+          []
+        end
+        
         matches.map do |match|
           tap = Tap.fetch(match["repository"]["full_name"])
           next if tap.installed?

--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -2,8 +2,12 @@ module Hbc
   class CLI
     class Search < AbstractCommand
       def run
-        results = self.class.search(*args)
-        self.class.render_results(*results)
+        if args.empty?
+          puts Formatter.columns(CLI.nice_listing(Hbc.all_tokens))
+        else
+          results = self.class.search(*args)
+          self.class.render_results(*results)
+        end
       end
 
       def self.extract_regexp(string)

--- a/Library/Homebrew/cask/lib/hbc/cli/search.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/search.rb
@@ -26,7 +26,7 @@ module Hbc
             filename: query,
             extension: "rb",
           )
-        rescue StandardError => e
+        rescue GitHub::Error => e
           onoe e
           $stderr.puts e.backtrace
           []

--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -1,5 +1,5 @@
 brew-cask(1) - a friendly binary installer for macOS
-========================================================
+====================================================
 
 ## SYNOPSIS
 
@@ -85,7 +85,7 @@ names, and other aspects of this manual are still subject to change.
 
     If <token> is given, summarize the staged files associated with the
     given Cask.
-    
+
   * `outdated` [--greedy] [--verbose|--quiet] [ <token> ...]:
     Without token arguments, display all the installed Casks that have newer
     versions available in the tap; otherwise check only the tokens given
@@ -101,9 +101,10 @@ names, and other aspects of this manual are still subject to change.
     Reinstall the given Cask.
 
   * `search` or `-S` [<text> | /<regexp>/]:
-    Without an argument, display all Casks available for install; otherwise
-    perform a substring search of known Cask tokens for <text> or, if the
-    text is delimited by slashes (/<regexp>/), it is interpreted as a
+    Without an argument, display all locally available Casks for install; no
+    online search is performed.
+    Otherwise perform a substring search of known Cask tokens for <text> or,
+    if the text is delimited by slashes (/<regexp>/), it is interpreted as a
     Ruby regular expression.
 
   * `style` [--fix] [ <token> ... ]:
@@ -255,7 +256,7 @@ Environment variables specific to Homebrew-Cask:
                export HOMEBREW_CASK_OPTS='--appdir=~/Applications --fontdir=/Library/Fonts'
 
 Other environment variables:
-           
+
   * `SUDO_ASKPASS`:
     When this variable is set, Homebrew-Cask will call `sudo`(8) with the `-A` option.
 

--- a/Library/Homebrew/test/cask/cli/search_spec.rb
+++ b/Library/Homebrew/test/cask/cli/search_spec.rb
@@ -30,7 +30,7 @@ describe Hbc::CLI::Search, :cask do
       local-caffeine
       local-transmission
     EOS
-    .and output(/^Warning: Online search failed: reason/).to_stderr
+    .and output(/^Warning: Error searching on GitHub: reason/).to_stderr
   end
 
   it "shows that there are no Casks matching a search term that did not result in anything" do

--- a/Library/Homebrew/test/cask/cli/search_spec.rb
+++ b/Library/Homebrew/test/cask/cli/search_spec.rb
@@ -42,18 +42,16 @@ describe Hbc::CLI::Search, :cask do
   end
 
   it "doesn't output anything to non-TTY stdout when there are no matches" do
-    expect {
-      Hbc::CLI::Search.run("foo-bar-baz")
-    }.to not_to_output.to_stdout
-    .and not_to_output.to_stderr
+    expect { Hbc::CLI::Search.run("foo-bar-baz") }
+      .to not_to_output.to_stdout
+      .and not_to_output.to_stderr
   end
 
   it "lists all Casks available offline with no search term" do
     allow(GitHub).to receive(:search_code).and_raise(GitHub::Error.new("reason"))
-    expect {
-      Hbc::CLI::Search.run
-    }.to output(/local-caffeine/).to_stdout.as_tty
-    .and not_to_output.to_stderr
+    expect { Hbc::CLI::Search.run }
+      .to output(/local-caffeine/).to_stdout.as_tty
+      .and not_to_output.to_stderr
   end
 
   it "ignores hyphens in search terms" do

--- a/Library/Homebrew/test/cask/cli/search_spec.rb
+++ b/Library/Homebrew/test/cask/cli/search_spec.rb
@@ -36,7 +36,9 @@ describe Hbc::CLI::Search, :cask do
   it "shows that there are no Casks matching a search term that did not result in anything" do
     expect {
       Hbc::CLI::Search.run("foo-bar-baz")
-    }.to output("No Cask found for \"foo-bar-baz\".\n").to_stdout.as_tty
+    }.to output(<<-EOS.undent).to_stdout.as_tty
+      No Cask found for "foo-bar-baz".
+    EOS
   end
 
   it "lists all Casks available offline with no search term" do
@@ -68,19 +70,29 @@ describe Hbc::CLI::Search, :cask do
   it "accepts a regexp argument" do
     expect {
       Hbc::CLI::Search.run("/^local-c[a-z]ffeine$/")
-    }.to output("==> Regexp Matches\nlocal-caffeine\n").to_stdout.as_tty
+    }.to output(<<-EOS.undent).to_stdout.as_tty
+      ==> Regexp Matches
+      local-caffeine
+    EOS
   end
 
-  it "Returns both exact and partial matches" do
+  it "returns both exact and partial matches" do
     expect {
       Hbc::CLI::Search.run("test-opera")
-    }.to output(/^==> Exact Match\ntest-opera\n==> Partial Matches\ntest-opera-mail/).to_stdout.as_tty
+    }.to output(<<-EOS.undent).to_stdout.as_tty
+      ==> Exact Match
+      test-opera
+      ==> Partial Matches
+      test-opera-mail
+    EOS
   end
 
   it "does not search the Tap name" do
     expect {
       Hbc::CLI::Search.run("caskroom")
-    }.to output(/^No Cask found for "caskroom"\.\n/).to_stdout.as_tty
+    }.to output(<<-EOS.undent).to_stdout.as_tty
+      No Cask found for "caskroom".
+    EOS
   end
 
   it "doesn't highlight packages that aren't installed" do

--- a/Library/Homebrew/test/cask/cli/search_spec.rb
+++ b/Library/Homebrew/test/cask/cli/search_spec.rb
@@ -30,7 +30,7 @@ describe Hbc::CLI::Search, :cask do
       local-caffeine
       local-transmission
     EOS
-    .and output(/^Error: reason\n/).to_stderr
+    .and output(/^Warning: Online search failed: reason/).to_stderr
   end
 
   it "shows that there are no Casks matching a search term that did not result in anything" do

--- a/Library/Homebrew/test/cask/cli/search_spec.rb
+++ b/Library/Homebrew/test/cask/cli/search_spec.rb
@@ -41,6 +41,13 @@ describe Hbc::CLI::Search, :cask do
     EOS
   end
 
+  it "doesn't output anything to non-TTY stdout when there are no matches" do
+    expect {
+      Hbc::CLI::Search.run("foo-bar-baz")
+    }.to not_to_output.to_stdout
+    .and not_to_output.to_stderr
+  end
+
   it "lists all Casks available offline with no search term" do
     allow(GitHub).to receive(:search_code).and_raise(GitHub::Error.new("reason"))
     expect {

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -103,7 +103,7 @@ Reinstall the given Cask\.
 .
 .TP
 \fBsearch\fR or \fB\-S\fR [\fItext\fR | /\fIregexp\fR/]
-Without an argument, display all Casks available for install; otherwise perform a substring search of known Cask tokens for \fItext\fR or, if the text is delimited by slashes (/\fIregexp\fR/), it is interpreted as a Ruby regular expression\.
+Without an argument, display all locally available Casks for install; no online search is performed\. Otherwise perform a substring search of known Cask tokens for \fItext\fR or, if the text is delimited by slashes (/\fIregexp\fR/), it is interpreted as a Ruby regular expression\.
 .
 .TP
 \fBstyle\fR [\-\-fix] [ \fItoken\fR \.\.\. ]


### PR DESCRIPTION
Fixes #3080 

---- 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
  _See below_
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Here are two changes for fixing #3080:
* a5640fd handles Github request failure, so that the whole search doesn't fail and returns empty "remote matches" instead
* 00803b1 makes `brew cask search` to output the list of all cask tokens without performing any search (analogously to `brew search`)

I tried to improve tests, but I have some problems with it and decided to submit a WIP pull-request and ask for help here:

1. I noticed that there was already a test for the expected behaviour described in #3080: ["lists all available Casks with no search term"](https://github.com/Homebrew/brew/blob/a5640fdfeeea7347e51c14abac481f4b210527ab/Library/Homebrew/test/cask/cli/search_spec.rb#L31-L35). But it fails **only** when I run tests with `--online` _and_ turned off network connection. I don't really understand why it passes without `--online` and no network. Are any network requests silently ignored without `--online` flag?
2. I noticed usage of `:needs_network` in other tests, but I don't know how to use it here: there should be tests both with and without network
3. Is there a way to specify that a test has to run successfully _without_ network? `:doesnt_need_network`? or a way to mock such situation?

