### PR TITLE
audit: don't output when searching taps.

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -102,11 +102,13 @@ module Homebrew
     odie "#{query} is not a valid regex"
   end
 
-  def search_taps(query)
+  def search_taps(query, silent: false)
     return [] if ENV["HOMEBREW_NO_GITHUB_API"]
 
     # Use stderr to avoid breaking parsed output
-    $stderr.puts Formatter.headline("Searching taps on GitHub...", color: :blue)
+    unless silent
+      $stderr.puts Formatter.headline("Searching taps on GitHub...", color: :blue)
+    end
 
     valid_dirnames = ["Formula", "HomebrewFormula", "Casks", "."].freeze
     matches = GitHub.search_code(user: ["Homebrew", "caskroom"], filename: query, extension: "rb")

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -412,7 +412,7 @@ class FormulaAuditor
     same_name_tap_formulae = @@local_official_taps_name_map[name] || []
 
     if @online
-      Homebrew.search_taps(name).each do |tap_formula_full_name|
+      Homebrew.search_taps(name, silent: true).each do |tap_formula_full_name|
         tap_formula_name = tap_formula_full_name.split("/").last
         next if tap_formula_name != name
         same_name_tap_formulae << tap_formula_full_name


### PR DESCRIPTION
This messaging was added for the `brew search` command and having it in audit is annoying: (https://github.com/Homebrew/brew/pull/3059#issuecomment-323638672)

As a side note: this is why randomly including `cmd/*` is a bad idea.