### PR TITLE
Add check for HEAD ref in diagnostics

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -787,19 +787,13 @@ module Homebrew
         end
 
         head = coretap_path.git_head
-        return unless head && head !~ %r{refs/heads/master}
+        return if head.nil? || head =~ %r{refs/heads/master}
 
         <<-EOS.undent
-          Suspicious #{CoreTap.instance} git head found.
+          Homebrew/homebrew-core is not on the master branch
 
-          With a non-standard head, your local version of Homebrew might not
-          have all of the changes intended for the most recent release. The
-          current git head is:
-            #{head}
-
-          Unless you have compelling reasons, consider setting the head to
-          point at the master branch by running:
-            git checkout master
+          Check out the master branch by running:
+            git -C "$(brew --repo homebrew/core)" checkout master
         EOS
       end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -786,7 +786,7 @@ module Homebrew
           EOS
         end
 
-        head = coretap_path.head
+        head = coretap_path.git_head
         return unless head && head !~ %r{refs/heads/master}
 
         <<-EOS.undent

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -756,7 +756,7 @@ module Homebrew
         end
       end
 
-      def check_coretap_git_origin
+      def check_coretap_git_config
         coretap_path = CoreTap.instance.path
         return if !Utils.git_available? || !(coretap_path/".git").exist?
 
@@ -785,6 +785,22 @@ module Homebrew
               git -C "#{coretap_path}" remote set-url origin #{Formatter.url("https://github.com/Homebrew/homebrew-core.git")}
           EOS
         end
+
+        head = coretap_path.head
+        return unless head && head !~ %r{refs/heads/master}
+
+        <<-EOS.undent
+          Suspicious #{CoreTap.instance} git head found.
+
+          With a non-standard head, your local version of Homebrew might not
+          have all of the changes intended for the most recent release. The
+          current git head is:
+            #{head}
+
+          Unless you have compelling reasons, consider setting the head to
+          point at the master branch by running:
+            git checkout master
+        EOS
       end
 
       def __check_linked_brew(f)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Addresses this issue: https://github.com/Homebrew/brew/issues/3068 by extending a diagnostic check so that it adds a warning to the console if `.git/HEAD` is not set to `/refs/heads/master`

Any thoughts on how to test this? Are there patterns established for testing things that interact with the filesystem?