### PR TITLE
Tty: if NO_COLOR env var is present, disable color

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -199,6 +199,9 @@ can take several different forms:
     If set, Homebrew will not auto-update before running `brew install`,
     `brew upgrade` or `brew tap`.
 
+  * `HOMEBREW_NO_COLOR`:
+    If set, Homebrew will not print text with color added.
+
   * `HOMEBREW_NO_EMOJI`:
     If set, Homebrew will not print the `HOMEBREW_INSTALL_BADGE` on a
     successful build.

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -75,6 +75,7 @@ describe Hbc::DSL, :cask do
 
       it "may use deprecated DSL version hash syntax" do
         allow(ENV).to receive(:[]).with("HOMEBREW_DEVELOPER").and_return(nil)
+        allow(ENV).to receive(:[]).with("HOMEBREW_NO_COLOR").and_return(nil)
 
         expect(cask.token).to eq("with-dsl-version")
         expect(cask.url.to_s).to eq("http://example.com/TestCask.dmg")

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -53,7 +53,7 @@ describe Tty do
       allow($stdout).to receive(:tty?).and_return(true)
     end
 
-    it "returns an empty string for all colors" do
+    it "returns ANSI escape codes for colors" do
       expect(subject.to_s).to eq("")
       expect(subject.red.to_s).to eq("\033[31m")
       expect(subject.green.to_s).to eq("\033[32m")
@@ -62,6 +62,18 @@ describe Tty do
       expect(subject.magenta.to_s).to eq("\033[35m")
       expect(subject.cyan.to_s).to eq("\033[36m")
       expect(subject.default.to_s).to eq("\033[39m")
+    end
+
+    it "returns an empty string for all colors when HOMEBREW_NO_COLOR is set" do
+      ENV["HOMEBREW_NO_COLOR"] = "1"
+      expect(subject.to_s).to eq("")
+      expect(subject.red.to_s).to eq("")
+      expect(subject.green.to_s).to eq("")
+      expect(subject.yellow.to_s).to eq("")
+      expect(subject.blue.to_s).to eq("")
+      expect(subject.magenta.to_s).to eq("")
+      expect(subject.cyan.to_s).to eq("")
+      expect(subject.default.to_s).to eq("")
     end
   end
 end

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -59,7 +59,9 @@ module Tty
   end
 
   def to_s
-    return "" unless $stdout.tty?
+    if ENV["HOMEBREW_NO_COLOR"] || !$stdout.tty?
+      return ""
+    end
     current_escape_sequence
   ensure
     reset_escape_sequence!

--- a/bin/brew
+++ b/bin/brew
@@ -47,7 +47,7 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 # Whitelist and copy to HOMEBREW_* all variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
 for VAR in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BINTRAY_USER BINTRAY_KEY \
-           BROWSER EDITOR GIT PATH VISUAL \
+           BROWSER EDITOR GIT NO_COLOR PATH VISUAL \
            GITHUB_USER GITHUB_PASSWORD GITHUB_TOKEN
 do
   # Skip if variable value is empty.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1037,6 +1037,9 @@ can take several different forms:
     If set, Homebrew will not auto-update before running `brew install`,
     `brew upgrade` or `brew tap`.
 
+  * `HOMEBREW_NO_COLOR`:
+    If set, Homebrew will not print text with color added.
+
   * `HOMEBREW_NO_EMOJI`:
     If set, Homebrew will not print the `HOMEBREW_INSTALL_BADGE` on a
     successful build.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1059,6 +1059,10 @@ If set, Homebrew will not send analytics\. See: \fIhttps://docs\.brew\.sh/Analyt
 If set, Homebrew will not auto\-update before running \fBbrew install\fR, \fBbrew upgrade\fR or \fBbrew tap\fR\.
 .
 .TP
+\fBHOMEBREW_NO_COLOR\fR
+If set, Homebrew will not print text with color added\.
+.
+.TP
 \fBHOMEBREW_NO_EMOJI\fR
 If set, Homebrew will not print the \fBHOMEBREW_INSTALL_BADGE\fR on a successful build\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If the [`NO_COLOR`](http://no-color.org/) environment variable is set, even with a valid TTY, disable color output.