### PR TITLE
Tests: override HOME

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -86,6 +86,9 @@ RSpec.configure do |config|
       @__argv = ARGV.dup
       @__env = ENV.to_hash # dup doesn't work on ENV
 
+      # Makes sure config files for git, svn, etc. aren't read
+      ENV["HOME"] = HOMEBREW_CACHE.to_s
+
       unless example.metadata.key?(:focus) || ENV.key?("VERBOSE_TESTS")
         @__stdout = $stdout.clone
         @__stderr = $stderr.clone


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is an alternate fix for #2197.

This prevents tools like git and svn from reading their configuration in the user's home directory. This is useful, for example, if the user has git configured to GPG sign every commit, which would cause every place we `git commit` in the tests to fail.

I chose `HOMEBREW_CACHE` over `TEST_TMPDIR` in order to avoid introducing file leakage from newly-written dotfiles. We clear out `HOMEBREW_CACHE` before checking for leakage.

cc @alyssais, @woodruffw 