### PR TITLE
audit: Add some heuristics to https upgrade checks

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -240,26 +240,25 @@ class FormulaAuditor
       return "The URL #{url} could use HTTPS rather than HTTP"
     end
 
-    if type == "homepage"
+    return if type != "homepage"
 
-      details[:file] = details[:file].gsub(/https?:\\?\/\\?\//, '/')
-      secure_details[:file] = secure_details[:file].gsub(/https?:\\?\/\\?\//, '/')
+    details[:file] = details[:file].gsub(%r{https?:\\?\/\\?\/}, "/")
+    secure_details[:file] = secure_details[:file].gsub(%r{https?:\\?\/\\?\/}, "/")
 
-      # Same content after normalization
-      if details[:file] == secure_details[:file]
-        return "The URL #{url} could use HTTPS rather than HTTP"
-      end
+    # Same content after normalization
+    if details[:file] == secure_details[:file]
+      return "The URL #{url} could use HTTPS rather than HTTP"
+    end
 
-      # Same size, different content after normalization
-      # (typical causes: Generated ID, Timestamp, Unix time)
-      if details[:file].length == secure_details[:file].length
-        return "The URL #{url} could use HTTPS rather than HTTP"
-      end
+    # Same size, different content after normalization
+    # (typical causes: Generated ID, Timestamp, Unix time)
+    if details[:file].length == secure_details[:file].length
+      return "The URL #{url} could use HTTPS rather than HTTP"
+    end
 
-      lenratio = (100 * secure_details[:file].length / details[:file].length).to_i
-      if lenratio >= 90 && lenratio <= 120
-        return "The URL #{url} may be able to use HTTPS rather than HTTP. Please verify it in a browser."
-      end
+    lenratio = (100 * secure_details[:file].length / details[:file].length).to_i
+    if lenratio >= 90 && lenratio <= 120
+      return "The URL #{url} may be able to use HTTPS rather than HTTP. Please verify it in a browser."
     end
   end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -260,7 +260,7 @@ class FormulaAuditor
     end
 
     lenratio = (100 * secure_details[:file].length / details[:file].length).to_i
-    return if lenratio < 90 || lenratio > 110
+    return unless (90..110).cover?(lenratio)
     "The URL #{url} may be able to use HTTPS rather than HTTP. Please verify it in a browser."
   end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -260,7 +260,7 @@ class FormulaAuditor
     end
 
     lenratio = (100 * secure_details[:file].length / details[:file].length).to_i
-    return if lenratio < 90 || lenratio > 120
+    return if lenratio < 90 || lenratio > 110
     "The URL #{url} may be able to use HTTPS rather than HTTP. Please verify it in a browser."
   end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -201,7 +201,7 @@ class FormulaAuditor
     @specs = %w[stable devel head].map { |s| formula.send(s) }.compact
   end
 
-  def self.check_http_content(url, name, user_agents: [:default], check_content: false)
+  def self.check_http_content(url, name, user_agents: [:default], check_content: false, strict: false)
     return unless url.start_with? "http"
 
     details = nil
@@ -250,6 +250,8 @@ class FormulaAuditor
     if details[:file] == secure_details[:file]
       return "The URL #{url} should use HTTPS rather than HTTP"
     end
+
+    return unless strict
 
     # Same size, different content after normalization
     # (typical causes: Generated ID, Timestamp, Unix time)
@@ -590,7 +592,8 @@ class FormulaAuditor
     if http_content_problem = FormulaAuditor.check_http_content(homepage,
                                                formula.name,
                                                user_agents: [:browser, :default],
-                                               check_content: true)
+                                               check_content: true,
+                                               strict: @strict)
       problem http_content_problem
     end
   end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -257,9 +257,8 @@ class FormulaAuditor
     end
 
     lenratio = (100 * secure_details[:file].length / details[:file].length).to_i
-    if lenratio >= 90 && lenratio <= 120
-      return "The URL #{url} may be able to use HTTPS rather than HTTP. Please verify it in a browser."
-    end
+    return if lenratio < 90 || lenratio > 120
+    "The URL #{url} may be able to use HTTPS rather than HTTP. Please verify it in a browser."
   end
 
   def self.http_content_headers_and_checksum(url, hash_needed: false, user_agent: :default)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Following up on https://github.com/Homebrew/homebrew-core/pull/17181#issuecomment-325120973, this patch tries to extend HTTPS-upgrade audit checks to detect additional cases that may allow an upgrade. The logic was borrowed from this [project](https://github.com/vszakats/https-check).
