### PR TITLE
linkage_checker: add a check for extraneous dependencies

### DIFF
--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -80,7 +80,7 @@ class LinkageChecker
     end
     extraneous_deps = declared_dep_names.reject do |full_name|
       name = full_name.split("/").last
-      @brewed_dylibs.keys.map { |x| x.split("/").last }.include? name
+      Formula[name].bin.directory? || @brewed_dylibs.keys.map { |x| x.split("/").last }.include?(name)
     end
     [undeclared_deps, extraneous_deps]
   end

--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -79,10 +79,10 @@ class LinkageChecker
       end
     end
     extraneous_deps = declared_dep_names.reject do |full_name|
-        name = full_name.split("/").last
-        @brewed_dylibs.keys.map{ |x| x.split("/").last }.include? name
+      name = full_name.split("/").last
+      @brewed_dylibs.keys.map { |x| x.split("/").last }.include? name
     end
-    return undeclared_deps, extraneous_deps
+    [undeclared_deps, extraneous_deps]
   end
 
   def display_normal_output

--- a/Library/Homebrew/os/mac/linkage_checker.rb
+++ b/Library/Homebrew/os/mac/linkage_checker.rb
@@ -5,7 +5,7 @@ require "formula"
 class LinkageChecker
   attr_reader :keg, :formula
   attr_reader :brewed_dylibs, :system_dylibs, :broken_dylibs, :variable_dylibs
-  attr_reader :undeclared_deps, :reverse_links
+  attr_reader :undeclared_deps, :extraneous_deps, :reverse_links
 
   def initialize(keg, formula = nil)
     @keg = keg
@@ -16,6 +16,7 @@ class LinkageChecker
     @variable_dylibs = Set.new
     @undeclared_deps = []
     @reverse_links = Hash.new { |h, k| h[k] = Set.new }
+    @extraneous_deps = []
     check_dylibs
   end
 
@@ -51,7 +52,7 @@ class LinkageChecker
       end
     end
 
-    @undeclared_deps = check_undeclared_deps if formula
+    @undeclared_deps, @extraneous_deps = check_undeclared_deps if formula
   end
 
   def check_undeclared_deps
@@ -77,6 +78,11 @@ class LinkageChecker
         a <=> b
       end
     end
+    extraneous_deps = declared_dep_names.reject do |full_name|
+        name = full_name.split("/").last
+        @brewed_dylibs.keys.map{ |x| x.split("/").last }.include? name
+    end
+    return undeclared_deps, extraneous_deps
   end
 
   def display_normal_output
@@ -85,6 +91,7 @@ class LinkageChecker
     display_items "Variable-referenced libraries", @variable_dylibs
     display_items "Missing libraries", @broken_dylibs
     display_items "Possible undeclared dependencies", @undeclared_deps
+    display_items "Possible extraneous dependencies", @extraneous_deps
   end
 
   def display_reverse_output
@@ -111,6 +118,10 @@ class LinkageChecker
 
   def undeclared_deps?
     !@undeclared_deps.empty?
+  end
+
+  def extraneous_deps?
+    !@extraneous_deps.empty?
   end
 
   private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Detect extraneous dependencies in formulae. Might be useful for new formulae.

- Have not written tests for my changes. Suggestions what tests to write are welcome
- `brew tests` fail for some other tests

