### PR TITLE
add -n flag for curl ( check .netrc for basic auth )

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -38,7 +38,7 @@ def curl(*args)
 end
 
 def curl_download(*args, to: nil, continue_at: "-", **options)
-  curl("--location", "--remote-time", "--continue-at", continue_at.to_s, "--output", to, *args, **options)
+  curl("-n", "--location", "--remote-time", "--continue-at", continue_at.to_s, "--output", to, *args, **options)
 rescue ErrorDuringExecution
   # `curl` error 33: HTTP server doesn't seem to support byte ranges. Cannot resume.
   if $CHILD_STATUS.exitstatus == 33 && continue_at == "-"


### PR DESCRIPTION
some cdm provider requires basic authentication or token authentication.
it is easy to provide them via ~/.netrc
with extending the curl download flags by -n, curl will try to automatically find the best fit for authentication. 