### PR TITLE
add zsh completion for switch <formula> <version>

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -592,8 +592,14 @@ _brew_style() {
 
 # brew switch name version:
 _brew_switch() {
-  _message "name version"
-  return 1
+  local -a versions
+  if [[ -n ${words[2]} ]]; then
+    versions=(${$(brew ls "${words[2]}" --versions)#${words[2]}})
+  fi
+  _arguments -S \
+    '1::formula:__brew_formulae' \
+    "2:: :(${versions[*]})" \
+    && ret=0
 }
 
 # brew tap:


### PR DESCRIPTION
I assume there aren't tests for completions...

Adds formula name and version ZSH completion for `brew switch`.

```
% brew switch go<tab>
go                     go@1.6
go@1.4                 go@1.7
go@1.5                 go@1.8

% brew switch go 1.<tab>
1.7.4_1  1.9
```