### PR TITLE
Java: deprecate ENV.java_cache in favour of setting it by default.

### DIFF
--- a/Library/Homebrew/compat/ENV/shared.rb
+++ b/Library/Homebrew/compat/ENV/shared.rb
@@ -3,4 +3,8 @@ module SharedEnvExtension
     odeprecated "ENV.j1", "ENV.deparallelize"
     deparallelize
   end
+
+  def java_cache
+    # odeprecated "ENV.java_cache"
+  end
 end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -869,6 +869,10 @@ class FormulaAuditor
       problem "Use \"depends_on :x11\" instead of \"ENV.x11\""
     end
 
+    if line.include?("ENV.java_cache")
+      problem "In-formula ENV.java_cache usage has been deprecated & should be removed."
+    end
+
     # Avoid hard-coding compilers
     if line =~ %r{(system|ENV\[.+\]\s?=)\s?['"](/usr/bin/)?(gcc|llvm-gcc|clang)['" ]}
       problem "Use \"\#{ENV.cc}\" instead of hard-coding \"#{Regexp.last_match(3)}\""

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -260,10 +260,6 @@ module SharedEnvExtension
     set_cpu_flags(flags)
   end
 
-  def java_cache
-    append "_JAVA_OPTIONS", "-Duser.home=#{HOMEBREW_CACHE}/java_cache"
-  end
-
   # ld64 is a newer linker provided for Xcode 2.5
   # @private
   def ld64

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1613,6 +1613,7 @@ class Formula
   def run_test
     @prefix_returns_versioned_prefix = true
     old_home = ENV["HOME"]
+    old_java_opts = ENV["_JAVA_OPTIONS"]
     old_curl_home = ENV["CURL_HOME"]
     old_tmpdir = ENV["TMPDIR"]
     old_temp = ENV["TEMP"]
@@ -1626,6 +1627,7 @@ class Formula
     ENV["TERM"] = "dumb"
     ENV["PATH"] = PATH.new(old_path).append(HOMEBREW_PREFIX/"bin")
     ENV["HOMEBREW_PATH"] = nil
+    ENV["_JAVA_OPTIONS"] = "#{old_java_opts} -Duser.home=#{HOMEBREW_CACHE}/java_cache"
 
     ENV.clear_sensitive_environment!
 
@@ -1646,6 +1648,7 @@ class Formula
   ensure
     @testpath = nil
     ENV["HOME"] = old_home
+    ENV["_JAVA_OPTIONS"] = old_java_opts
     ENV["CURL_HOME"] = old_curl_home
     ENV["TMPDIR"] = old_tmpdir
     ENV["TEMP"] = old_temp
@@ -1888,11 +1891,13 @@ class Formula
       mkdir_p env_home
 
       old_home = ENV["HOME"]
+      old_java_opts = ENV["_JAVA_OPTIONS"]
       old_curl_home = ENV["CURL_HOME"]
       old_path = ENV["HOMEBREW_PATH"]
 
       unless ARGV.interactive?
         ENV["HOME"] = env_home
+        ENV["_JAVA_OPTIONS"] = "#{old_java_opts} -Duser.home=#{HOMEBREW_CACHE}/java_cache"
         ENV["CURL_HOME"] = old_curl_home || old_home
       end
       ENV["HOMEBREW_PATH"] = nil
@@ -1907,6 +1912,7 @@ class Formula
         @buildpath = nil
         unless ARGV.interactive?
           ENV["HOME"] = old_home
+          ENV["_JAVA_OPTIONS"] = old_java_opts
           ENV["CURL_HOME"] = old_curl_home
         end
         ENV["HOMEBREW_PATH"] = old_path


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-----

https://github.com/Homebrew/homebrew-core/issues/17376 made me realise it's quite confusing we still permit this to be optional given the sandbox is now mandatory unless you pass an explicit flag.

`brew tests` still fails with the unrelated:
```
Failures:

  1) Homebrew #search_taps
     Failure/Error:
       expect(described_class.search_taps("some-formula"))
         .to match(["homebrew/foo/some-formula"])

       expected [] to match ["homebrew/foo/some-formula"]
     # ./test/cmd/search_remote_tap_spec.rb:18:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:96:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

Finished in 1 minute 12.21 seconds (files took 3.43 seconds to load)
311 examples, 1 failure
```