### PR TITLE
Don't fail to migrate repo because of empty dir

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -203,6 +203,7 @@ module Homebrew
     end
 
     new_homebrew_repository = Pathname.new "/usr/local/Homebrew"
+    new_homebrew_repository.rmdir_if_possible
     if new_homebrew_repository.exist?
       ofail <<-EOS.undent
         #{new_homebrew_repository} already exists.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I just ran into an issue where a colleague's Homebrew couldn't update. It seems to have been because it failed once just after the new repo directory was created. Since there was nothing in this directory, there really isn't any reason for us to fail here, so to avoid this problem in the future, try to `rmdir` the directory before failing because it already exists.