### PR TITLE
search_remote_tap spec: fix test offline

### DIFF
--- a/Library/Homebrew/test/cmd/search_remote_tap_spec.rb
+++ b/Library/Homebrew/test/cmd/search_remote_tap_spec.rb
@@ -2,6 +2,9 @@ require "cmd/search"
 
 describe Homebrew do
   specify "#search_taps" do
+    # Otherwise the tested method returns [], regardless of our stub
+    ENV.delete("HOMEBREW_NO_GITHUB_API")
+
     json_response = {
       "items" => [
         {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As pointed out by @jcount, the method being tested always [returns `[]` immediately](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/search.rb#L106) if `HOMEBREW_NO_GITHUB_API` is set even though we stub the JSON response. As a result, we get an `expected [] to match ["homebrew/foo/some-formula"]` failure when `--online` isn't passed. Unsetting `HOMEBREW_NO_GITHUB_API` for this one test should be safe.