### PR TITLE
Shell escape printed commands when installing a formula

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1,3 +1,4 @@
+require "shellwords"
 require "formula_support"
 require "lock_file"
 require "formula_pin"
@@ -1732,7 +1733,7 @@ class Formula
         pretty_args[i] = "import setuptools..."
       end
     end
-    ohai "#{cmd} #{pretty_args * " "}".strip
+    ohai [cmd, *pretty_args].shelljoin
 
     @exec_count ||= 0
     @exec_count += 1

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1867,8 +1867,8 @@ class Formula
       ENV.refurbish_args if setup_py_in_args || setuptools_shim_in_args
     end
 
-    $stdout.reopen(out)
-    $stderr.reopen(out)
+    $stdout = out
+    $stderr = out
     out.close
     args.collect!(&:to_s)
     begin

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -763,6 +763,13 @@ describe Formula do
     expect(h["versions"]["bottle"]).to be_truthy
   end
 
+  describe "#system" do
+    it "escapes commands" do
+      f = formula { url "foo-1.0" }
+      expect { f.system("echo", "-n", "") }.to output("==> echo -n ''\n").to_stdout
+    end
+  end
+
   describe "#eligible_kegs_for_cleanup" do
     it "returns Kegs eligible for cleanup" do
       f1 = Class.new(Testball) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This means commands can be copy/pasted into a terminal, which is very useful, for example, when debugging formulae installs with `brew install --interactive`.