### PR TITLE
Clear Formulary::FORMULAE between test runs

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -97,6 +97,7 @@ RSpec.configure do |config|
     ensure
       ARGV.replace(@__argv)
       ENV.replace(@__env)
+      Formulary::FORMULAE.clear
 
       unless example.metadata.key?(:focus) || ENV.key?("VERBOSE_TESTS")
         $stdout.reopen(@__stdout)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Potential fix for #3113. A possible cause for that one was the Formulary cache causing a different formula by the same name to be loaded if it had happened to have been loaded in the past by a different test.