### PR TITLE
audit: fix subversion remote check logic.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1233,7 +1233,7 @@ class ResourceAuditor
       elsif strategy <= SubversionDownloadStrategy
         next unless DevelopmentTools.subversion_handles_most_https_certificates?
         next unless Utils.svn_available?
-        if Utils.svn_remote_exists url
+        unless Utils.svn_remote_exists url
           problem "The URL #{url} is not a valid svn URL"
         end
       end


### PR DESCRIPTION
Stop flagging invalid URLs as valid and vice-versa.

Fixes #3118.