### PR TITLE
docs: Clarify availability of analytics

### DIFF
--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -37,7 +37,9 @@ As far as we can tell it would be impossible for Google to match the randomly ge
 Homebrew's analytics are sent throughout Homebrew's execution to Google Analytics over HTTPS.
 
 ## Who?
-Homebrew's analytics are accessible to Homebrew's current maintainers. Contact @MikeMcQuaid if you are a maintainer and need access.
+Homebrew's detailed analytics are accessible to Homebrew's current maintainers. Contact @MikeMcQuaid if you are a maintainer and need access.
+
+Summaries of installation and error analytics are publicly available [here](https://brew.sh/analytics/).
 
 ## How?
 The code is viewable in [analytics.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/analytics.rb) and [analytics.sh](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/analytics.sh). They are done in a separate background process and fail fast to avoid delaying any execution. They will fail immediately and silently if you have no network connection.


### PR DESCRIPTION
This commit tweaks the language in Analytics.md to make it clear
that summaries of install/error data are publicly available,
while only Homebrew maintainers can access the full analytics
(as specified above in the document).

