### PR TITLE
git_spec.rb: use HTTPS for Git remote test

### DIFF
--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -130,7 +130,7 @@ describe Utils do
     context "when git is available" do
       it "returns true when git remote exists", :needs_network do
         git = HOMEBREW_SHIMS_PATH/"scm/git"
-        url = "http://github.com/Homebrew/homebrew.github.io"
+        url = "https://github.com/Homebrew/homebrew.github.io"
         repo = HOMEBREW_CACHE/"hey"
         repo.mkpath
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It seems more realistic to make tests via HTTPS, because this is how Git is used in most cases anyway.