### PR TITLE
[WIP] resolve path when checking include dirs

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -224,7 +224,8 @@ class Cmd
       true
     else
       # ignore MacPorts, Boxen's Homebrew, X11, fink
-      !path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")
+      blacklist = ["/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11"]
+      blacklist.none?{|dir| above_symbolically?(dir, path)}
     end
   end
 
@@ -318,6 +319,10 @@ class Cmd
     path = Pathname.new(path)
     path = path.realpath if path.exist?
     path.to_s
+  end
+
+  def above_symbolically?(dir, path)
+    path.start_with?(dir) || canonical_path(path).start_with?(canonical_path(dir))
   end
 
   def path_flags(prefix, paths)

--- a/Library/Homebrew/test/shim/cc_spec.rb
+++ b/Library/Homebrew/test/shim/cc_spec.rb
@@ -1,0 +1,37 @@
+require "tempfile"
+
+# set up temporary file, strip the preamble
+# up to and including the #!/usr/bin/env ruby shebang
+raise "failure" unless File.exist?("shims/super/cc")
+script = Tempfile.new("CCShim").path
+raise "failure2" unless
+  system("<shims/super/cc awk '/^[#][!].usr.bin.env ruby/ {c=1; next} c==1 {print}' > '#{script}'")
+
+load script
+
+describe "Shims_Super_CC" do
+  class Cmd1 < Cmd
+    def initialize; end
+  end
+  describe "above_symbolically?" do
+    it "nonexistent path is strict prefix of itself" do
+      Cmd1.new.above_symbolically?("/aaaa", "/aaaa").should eql true
+    end
+
+    it "nonexistent path is under strict prefix of path" do
+      Cmd1.new.above_symbolically?("/aaaa", "/aaaa/bbbb").should eql true
+    end
+
+    it "nonexistent path is only under strict prefix of path" do
+      Cmd1.new.above_symbolically?("/aaaa", "/bbbb/bbbb").should eql false
+    end
+
+    it "file is under symbolic link to self" do
+      target = Tempfile.new("CcTestTarget").path
+      symlink = Tempfile.new("CcTestSymlink").path
+      system("rm '#{symlink}' ; ln -s '#{target}' '#{symlink}'")
+
+      Cmd1.new.above_symbolically?(target, symlink).should eql true
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

adds a new method, `above_symbolically?` to heuristically check whether a path is a parent of another path when symbolic references are considered. Currently we perform the heuristic check by first seeing if the directory is textually a prefix of the path, and then comparing the `realpath`s. This doesn't catch everything... I don't think there's a way to do that without walking the file system and seeing which paths are accessible from `dir` ... and that seems like overkill.

I hunted around for a way to test the code in shims and couldn't find one ... so I wrote a quick test that copies the shim source over to a temporary file without the shebang preamble and then loads it.

The shim tester is kind of a hack (and it leaks temporary files). Is there a better approach for testing this code?

I'm also open to suggestions about how to test a scenario that more closely resembles a conflict with macports or fink or X11 or w/e.

Context: https://github.com/Homebrew/brew/issues/1191