### PR TITLE
mac/hardware/cpu: recognise Kaby Lake

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -50,6 +50,8 @@ module Hardware
             :broadwell
           when 0x37fc219f # Skylake
             :skylake
+          when 0x0f817246 # Kaby Lake
+            :kabylake
           else
             :dunno
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The 2017 MacBook Pro line shipped with Kaby Lake CPUs. Suspect this is what is causing the `dunno` in https://github.com/Homebrew/homebrew-core/issues/14418#issuecomment-327043548.