### PR TITLE
audit: stop demanding a HTTP HEAD mirror for curl

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1237,7 +1237,7 @@ class ResourceAuditor
   def audit_urls
     urls = [url] + mirrors
 
-    if name == "curl" && !urls.find { |u| u.start_with?("http://") }
+    if name == "curl" && !urls.find { |u| u.start_with?("http://") } && url != Formula["curl"].head.url
       problem "should always include at least one HTTP url"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Not sure if this is how you want to handle it but having a HEAD mirror for `curl` is just silliness.

Ref: https://github.com/Homebrew/homebrew-core/commit/e36b95849ae38ade30605155d75cf6e731b4e38f