### PR TITLE
build: fix HOMEBREW_FORMULA_PREFIX for head

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -112,6 +112,10 @@ class Build
       formula.extend(Debrew::Formula) if ARGV.debug?
 
       formula.brew do |_formula, staging|
+        # For head builds, HOMEBREW_FORMULA_PREFIX should include the commit,
+        # which is not known until after the formula has been staged.
+        ENV["HOMEBREW_FORMULA_PREFIX"] = formula.prefix
+
         staging.retain! if ARGV.keep_tmp?
         formula.patch
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

so that it includes the commit.

This fixes the issue identified in https://github.com/Homebrew/homebrew-core/pull/15950#issuecomment-317501358 where includes and libraries installed in the formula's prefix (e.g. resources installed in `libexec`) cannot be used during a build because superenv is using an incorrect value for HOMEBREW_FORMULA_PREFIX that doesn't include the commit, which causes it to filter out anything in the actual prefix.