### PR TITLE
Always output when tapping core

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -124,7 +124,7 @@ module Homebrew
     return if ENV["HOMEBREW_UPDATE_TEST"]
     core_tap = CoreTap.instance
     return if core_tap.installed?
-    CoreTap.ensure_installed! quiet: false
+    CoreTap.ensure_installed!
     revision = core_tap.git_head
     ENV["HOMEBREW_UPDATE_BEFORE_HOMEBREW_HOMEBREW_CORE"] = revision
     ENV["HOMEBREW_UPDATE_AFTER_HOMEBREW_HOMEBREW_CORE"] = revision

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -551,11 +551,9 @@ class CoreTap < Tap
     @instance ||= new
   end
 
-  def self.ensure_installed!(options = {})
+  def self.ensure_installed!
     return if instance.installed?
-    args = ["tap", instance.name]
-    args << "-q" if options.fetch(:quiet, true)
-    safe_system HOMEBREW_BREW_FILE, *args
+    safe_system HOMEBREW_BREW_FILE, "tap", instance.name
   end
 
   # @private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hiding all output makes it look like Homebrew is hanging while the tap operation (which can take a long time!) is running.

Closes #3053.