### PR TITLE
Let `curl_download` handle HTTP 416 error.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -331,20 +331,10 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     if cached_location.exist?
       puts "Already downloaded: #{cached_location}"
     else
-      had_incomplete_download = temporary_path.exist?
       begin
         _fetch
       rescue ErrorDuringExecution
-        # 33 == range not supported
-        # try wiping the incomplete download and retrying once
-        unless $CHILD_STATUS.exitstatus == 33 && had_incomplete_download
-          raise CurlDownloadStrategyError, @url
-        end
-
-        ohai "Trying a full download"
-        temporary_path.unlink
-        had_incomplete_download = false
-        retry
+        raise CurlDownloadStrategyError, @url
       end
       ignore_interrupts { temporary_path.rename(cached_location) }
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`curl_download` fails when the server returns 416, which was previously only checked implicitly in download strategies using `had_incomplete_download`.

---

Fixes https://github.com/caskroom/homebrew-cask/issues/38331.