### PR TITLE
Require more HTTP mirrors for old OS X versions.

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -47,7 +47,7 @@ PowerPC and Tiger branches from other users in the fork network. See
 [Interesting Taps and Forks](Interesting-Taps-and-Forks.md).
 
 <a name="2"><sup>2</sup></a> 10.10 or higher is recommended. 10.5–10.9 are
-supported on a best-effort basis. For 10.4 and 10.5, see
+supported on a best-effort basis. For 10.4 see
 [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
 <a name="3"><sup>3</sup></a> Most formulae require a compiler. A handful


### PR DESCRIPTION
This allows the bootstrap of `curl`, `openssl` and `git` on versions of Mac OS X that cannot reliably download from HTTPS servers any longer. Once these are both installed users are able to update Homebrew and download files securely.

Also, as we're doing this, don't point 10.5 users to Tigerbrew as they are already given caveats for using Homebrew itself.