### PR TITLE
os/mac/diagnostic: allow custom Ruby for devs.

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -197,6 +197,7 @@ module Homebrew
       def check_ruby_version
         ruby_version = "2.0"
         return if RUBY_VERSION[/\d\.\d/] == ruby_version
+        return if ARGV.homebrew_developer? && OS::Mac.prerelease?
 
         <<-EOS.undent
           Ruby version #{RUBY_VERSION} is unsupported on #{MacOS.version}. Homebrew

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -47,15 +47,10 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_ruby_version" do
-    allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.13"))
-    stub_const("RUBY_VERSION", "2.3.3p222")
+    allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.12"))
+    stub_const("RUBY_VERSION", "1.8.6")
 
     expect(subject.check_ruby_version)
-      .to match <<-EOS.undent
-      Ruby version 2.3.3p222 is unsupported on 10.13. Homebrew
-      is developed and tested on Ruby 2.0, and may not work correctly
-      on other Rubies. Patches are accepted as long as they don't cause breakage
-      on supported Rubies.
-    EOS
+      .to match "Ruby version 1.8.6 is unsupported on 10.12"
   end
 end


### PR DESCRIPTION
This avoids `brew doctor` warnings on High Sierra but in general this is a good idea for future versions and to allow Homebrew developers to test things out with different versions of Ruby.