### PR TITLE
Tweaks for older Mac OS X versions.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -105,7 +105,14 @@ then
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X $HOMEBREW_MACOS_VERSION"
 
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
-  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "100900" &&
+  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101000" ]]
+  then
+    HOMEBREW_SYSTEM_CURL_TOO_OLD="1"
+  fi
+
+  # The system Curl is too old for some modern HTTPS certificates on
+  # older macOS versions.
+  if [[ -n "$HOMEBREW_SYSTEM_CURL_TOO_OLD" &&
         -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
   then
     HOMEBREW_CURL="$HOMEBREW_PREFIX/opt/curl/bin/curl"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -385,6 +385,12 @@ EOS
 
   if ! git --version >/dev/null 2>&1
   then
+    # we need a new enough curl to install git
+    if [[ -n "$HOMEBREW_SYSTEM_CURL_TOO_OLD" &&
+        ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
+    then
+      brew install curl
+    fi
     # we cannot install brewed git if homebrew/core is unavailable.
     [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git
     unset GIT_EXECUTABLE

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -114,7 +114,7 @@ class DevelopmentTools
       @non_apple_gcc_version = {}
     end
 
-    def curl_handles_most_https_homepages?
+    def curl_handles_most_https_certificates?
       true
     end
 

--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -43,10 +43,15 @@ class DevelopmentTools
     end
 
     def custom_installation_instructions
-      if MacOS.version > :tiger
+      if MacOS.version > :leopard
         <<-EOS.undent
           Install GNU's GCC
             brew install gcc
+        EOS
+      elsif MacOS.version > :tiger
+        <<-EOS.undent
+          Install GNU's GCC
+            brew install gcc@4.6
         EOS
       else
         # Tiger doesn't ship with apple-gcc42, and this is required to build
@@ -55,7 +60,7 @@ class DevelopmentTools
           Install Apple's GCC
             brew install apple-gcc42
           or GNU's GCC
-            brew install gcc
+            brew install gcc@4.6
         EOS
       end
     end
@@ -77,10 +82,10 @@ class DevelopmentTools
       end
     end
 
-    def curl_handles_most_https_homepages?
-      # The system Curl is too old for some modern HTTPS homepages on
+    def curl_handles_most_https_certificates?
+      # The system Curl is too old for some modern HTTPS certificates on
       # older macOS versions.
-      MacOS.version >= :el_capitan
+      !ENV["HOMEBREW_SYSTEM_CURL_TOO_OLD"].nil?
     end
 
     def subversion_handles_most_https_certificates?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -603,6 +603,12 @@ class FormulaInstaller
 
     # let's reset Utils.git_available? if we just installed git
     Utils.clear_git_available_cache if formula.name == "git"
+
+    # use installed curl when it's needed and available
+    if formula.name == "curl" &&
+       !DevelopmentTools.curl_handles_most_https_certificates?
+      ENV["HOMEBREW_CURL"] = formula.opt_bin/"curl"
+    end
   ensure
     unlock
   end


### PR DESCRIPTION
- `brew update` should try to install `curl` before `git` on older versions of Mac OS X where it is needed for accessing modern SSL certificates.
- We don't need an HTTP mirror for `git` because `curl` will already be installed before it is downloaded.
- Don't recommend GCC on Mac OS X versions where it can't be built with the default system compiler.
- Start using the Homebrew `curl` on Mac OS X versions where it is needed as soon as it is installed.