### PR TITLE
keg_relocate: treat .lai files as libtool files.

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -156,7 +156,7 @@ class Keg
     libtool_files = []
 
     path.find do |pn|
-      next if pn.symlink? || pn.directory? || pn.extname != ".la"
+      next if pn.symlink? || pn.directory? || ![".la", ".lai"].include?(pn.extname)
       libtool_files << pn
     end
     libtool_files


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Previously .lai files only had their locations replaced with
placeholders if /usr/bin/file recognized them as ASCII files, which is
only the case on macOS Sierra and above.