### PR TITLE
Check req.satisfied? before req formula install

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -436,11 +436,11 @@ class FormulaInstaller
           Requirement.prune
         elsif req.build? && install_bottle_for_dependent
           Requirement.prune
+        elsif req.satisfied?
+          Requirement.prune
         elsif install_requirement_formula?(req_dependency, req, install_bottle_for_dependent)
           deps.unshift(req_dependency)
           formulae.unshift(req_dependency.to_formula)
-          Requirement.prune
-        elsif req.satisfied?
           Requirement.prune
         elsif !runtime_requirements.include?(req) && install_bottle_for_dependent
           Requirement.prune


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This changes the order of logic in `FormulaInstaller::expand_requirements` so that we check if a requirement is already satisfied before trying to install a formula to satisfy it.

This fixed #3159 for me.

cc @dpo 