### PR TITLE
test.rb: test all installed formulae with the new --installed flag

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -29,7 +29,7 @@ module Homebrew
     raise FormulaUnspecifiedError if ARGV.named.empty? && !ARGV.include?("--installed")
     raise "Specifying formulae together with '--installed' flag is not supported " if !ARGV.named.empty? && ARGV.include?("--installed")
 
-    if ARGV.named.empty?
+    if ARGV.include?("--installed")
       enum = Formula.installed.each
     else
       enum = ARGV.resolved_formulae.each

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -26,17 +26,15 @@ module Homebrew
   module_function
 
   def test
-    raise FormulaUnspecifiedError if ARGV.named.empty? && !ARGV.include?("--installed")
-    raise "Specifying formulae together with '--installed' flag is not supported " if !ARGV.named.empty? && ARGV.include?("--installed")
-
-    if ARGV.include?("--installed")
-      enum = Formula.installed.each
+    if ARGV.named.empty?
+      raise FormulaUnspecifiedError unless ARGV.include?("--installed")
+      formulae = Formula.installed
     else
-      enum = ARGV.resolved_formulae.each
+      raise "Can not specify formulae and '--installed' flag." unless ARGV.named.empty?
+      formulae = ARGV.resolved_formulae
     end
 
-    loop do
-      f = enum.next
+    formulae.each do |f|
       # Cannot test uninstalled formulae
       unless f.installed?
         ofail "Testing requires the latest version of #{f.full_name}"

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -30,7 +30,7 @@ module Homebrew
       raise FormulaUnspecifiedError unless ARGV.include?("--installed")
       formulae = Formula.installed
     else
-      raise "Can not specify formulae and '--installed' flag." unless ARGV.named.empty?
+      raise "Can not specify formulae and '--installed' flag." if ARGV.include?("--installed")
       formulae = ARGV.resolved_formulae
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? **(see below)**
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

provide an easy way to run tests for all installed formulae with the new `--installed` flag for the `test` command.