### PR TITLE
popen: Do not suppress stderr when HOMEBREW_STDERR

### DIFF
--- a/Library/Homebrew/extend/os/mac/development_tools.rb
+++ b/Library/Homebrew/extend/os/mac/development_tools.rb
@@ -9,7 +9,7 @@ class DevelopmentTools
         @locate[key] = if (located_tool = original_locate(tool))
           located_tool
         elsif MacOS.version > :tiger
-          path = Utils.popen_read("/usr/bin/xcrun", "-no-cache", "-find", tool).chomp
+          path = Utils.popen_read("/usr/bin/xcrun", "-no-cache", "-find", tool, err: :close).chomp
           Pathname.new(path) if File.executable?(path)
         end
       end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -134,7 +134,7 @@ class SystemConfig
       # java_home doesn't exist on all macOSs; it might be missing on older versions.
       return "N/A" unless File.executable? "/usr/libexec/java_home"
 
-      java_xml = Utils.popen_read("/usr/libexec/java_home", "--xml", "--failfast")
+      java_xml = Utils.popen_read("/usr/libexec/java_home", "--xml", "--failfast", err: :close)
       return "N/A" unless $CHILD_STATUS.success?
       javas = []
       REXML::XPath.each(REXML::Document.new(java_xml), "//key[text()='JVMVersion']/following-sibling::string") do |item|

--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -13,7 +13,7 @@ module Utils
         return pipe.read unless block_given?
         yield pipe
       else
-        options[:err] ||= :close
+        options[:err] ||= :close unless ENV["HOMEBREW_STDERR"]
         exec(*args, options)
       end
     end

--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -1,20 +1,20 @@
 module Utils
-  def self.popen_read(*args, &block)
-    popen(args, "rb", &block)
+  def self.popen_read(*args, **options, &block)
+    popen(args, "rb", options, &block)
   end
 
-  def self.popen_write(*args, &block)
-    popen(args, "wb", &block)
+  def self.popen_write(*args, **options, &block)
+    popen(args, "wb", options, &block)
   end
 
-  def self.popen(args, mode)
+  def self.popen(args, mode, options = {})
     IO.popen("-", mode) do |pipe|
       if pipe
         return pipe.read unless block_given?
         yield pipe
       else
-        $stderr.reopen("/dev/null", "w")
-        exec(*args)
+        options[:err] ||= :close
+        exec(*args, options)
       end
     end
   end


### PR DESCRIPTION
Suppress the error message:
```
xcrun: error: unable to find utility "gcc-4.0", not a developer tool or in PATH
```

popen: Add an `options` argument. Useful for closing stderr, for example.
```ruby
popen_read("foo", err: :close)
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?