### PR TITLE
brew info: report if no kegs are linked

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -143,6 +143,7 @@ module Homebrew
         tab = Tab.for_keg(keg).to_s
         puts "  #{tab}" unless tab.empty?
       end
+      puts "No linked kegs found!" unless kegs.map(&:linked?).any?
     end
 
     puts "From: #{Formatter.url(github_info(f))}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them? **(see below)**
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

**Purpose**: Instruct `brew info <formulae>` to print a message `No linked kegs found!` for every (installed) formula that has no linked kegs.

Currently, `brew` marks linked kegs with an asterisk (`*`). The absence of an asterisk signifies that there are no linked kegs. However, this is rather cryptic. This PR makes the absence of linked kegs obvious.

Related to `brew test <formula>` because formulae with no linked kegs fail tests.