### PR TITLE
Fix version parsing

### DIFF
--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -4,7 +4,7 @@ describe Language::Node do
   describe "#setup_npm_environment" do
     it "calls prepend_path when node formula exists only during the first call" do
       node = formula "node" do
-        url "node-test"
+        url "https://nodejs.org/dist/v8.5.0/node-v8.5.0.tar.xz"
       end
       stub_formula_loader(node)
       expect(ENV).to receive(:prepend_path)

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -358,6 +358,11 @@ describe Version do
         .to be_detected_from("http://github.com/lloyd/yajl/tarball/v1.2.34")
     end
 
+    specify "version github releases" do
+      expect(Version.create("0.1.0"))
+        .to be_detected_from("https://github.com/foo/bar-baz/releases/download/0.1.0/bar-baz.tar.gz")
+    end
+
     specify "yet another version" do
       expect(Version.create("0.15.1b"))
         .to be_detected_from("http://example.com/mad-0.15.1b.tar.gz")

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -436,7 +436,7 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. https://www.openssl.org/source/openssl-0.9.8s.tar.gz
-    m = /-v?(\d+(?:\.\d+)*[^-]*)/.match(stem)
+    m = /-v?(\d+[^-]+)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. astyle_1.23_macosx.tar.gz

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -436,7 +436,7 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. https://www.openssl.org/source/openssl-0.9.8s.tar.gz
-    m = /-v?([^-]+)/.match(stem)
+    m = /-v?(\d+(?:\.\d+)*[^-]*)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. astyle_1.23_macosx.tar.gz


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I fixed version parsing. While I publish [naoty/git-misc](https://github.com/naoty/git-misc) from [naoty/homebrew-misc](https://github.com/naoty/homebrew-misc), I found that the upgrade of `git-misc` was failed because the name of Cache file is `git-misc-misc.tar.gz` and the version was missing.

When the download URL, https://github.com/naoty/git-misc/releases/download/0.2.0/git-misc.tar.gz, is parsed into a version, it is wrongly matched with [this line](https://github.com/Homebrew/brew/blob/b93fa96ec8b79bbe97253bc4a493c82ce1bb6d50/Library/Homebrew/version.rb#L439). So, I made this pattern more strict.

A change in `node_spec.rb` is needed to pass tests. It looks like a dummy text and so I fixed it to an actual download URL.