### PR TITLE
audit: Use version pinned by brew while executing rubocop cli

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -119,10 +119,10 @@ module Homebrew
     when :print
       args << "--display-cop-names" if ARGV.include? "--display-cop-names"
       args << "--format" << "simple" if files
-      system(cache_env, "rubocop", *args)
+      system(cache_env, "rubocop", "_#{HOMEBREW_RUBOCOP_VERSION}_", *args)
       !$CHILD_STATUS.success?
     when :json
-      json, _, status = Open3.capture3(cache_env, "rubocop", "--format", "json", *args)
+      json, _, status = Open3.capture3(cache_env, "rubocop", "_#{HOMEBREW_RUBOCOP_VERSION}_", "--format", "json", *args)
       # exit status of 1 just means violations were found; other numbers mean
       # execution errors.
       # exitstatus can also be nil if RuboCop process crashes, e.g. due to


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
If the user has a newer `rubocop` version than that of `HOMEBREW_RUBOCOP_VERSION` , then it leads to unexpected https://github.com/Homebrew/homebrew-core/pull/18324#issue-258999783

This change ensures that rubocop version intended by `brew` is executed using an undocumented feature as described here https://stackoverflow.com/questions/4061596/how-can-i-call-an-older-version-of-a-gem-from-the-commandline

cc @ilovezfs 