### PR TITLE
superenv: help Autotools with 10.13 SDK on 10.12

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -96,9 +96,12 @@ module Superenv
       self["SDKROOT"] = MacOS.sdk_path
     end
 
-    # Filter out symbols known not to be defined on 10.11 since GNU Autotools
-    # can't reliably figure this out with Xcode 8 on its own yet.
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    # Filter out symbols known not to be defined since GNU Autotools can't
+    # reliably figure this out with Xcode 8 and above.
+    if MacOS.version == "10.12" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "9.0"
+      ENV["ac_cv_func_futimens"] = "no"
+      ENV["ac_cv_func_utimensat"] = "no"
+    elsif MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
       %w[basename_r clock_getres clock_gettime clock_settime dirname_r
          getentropy mkostemp mkostemps timingsafe_bcmp].each do |s|
         ENV["ac_cv_func_#{s}"] = "no"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The GNU Autotools tests for whether futimens and utimensat are available reliably come to incorrect conclusions on 10.12 with the 10.13 SDK in Xcode 9. This overrides its decisions by forcing the right answer in superenv using ac_cv_func_* environment variables and setting them to "no" on 10.12.