### PR TITLE
Add a failure message to be_detected_from matcher

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -241,8 +241,18 @@ describe Version do
 
   describe "::detect" do
     matcher :be_detected_from do |url, specs = {}|
-      match do |version|
-        Version.detect(url, specs) == version
+      detected = Version.detect(url, specs)
+
+      match do |expected|
+        detected == expected
+      end
+
+      failure_message do |expected|
+        format = <<-EOS
+        expected: %s
+        detected: %s
+        EOS
+        format % [expected, detected]
       end
     end
 

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -248,11 +248,11 @@ describe Version do
       end
 
       failure_message do |expected|
-        format = <<-EOS
+        message = <<-EOS
         expected: %s
         detected: %s
         EOS
-        format % [expected, detected]
+        format(message, expected, detected)
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I added a failure message to `#be_detected_from` matcher because I was not sure what is wrong in tests.

### Before

```
Failures:

  1) Version::detect version all dots
     Failure/Error:
       expect(Version.create("1.13"))
         .to be_detected_from("http://example.com/foo.bar.la.1.14.zip")

       expected #<Version:0x00000101c18de0 @version="1.13", @tokens=[#<Version::NumericToken 1>, #<Version::NumericToken 13>]> to be detected from "http://example.com/foo.bar.la.1.14.zip"
```

### After

```
Failures:

  1) Version::detect version all dots
     Failure/Error:
       expect(Version.create("1.13"))
         .to be_detected_from("http://example.com/foo.bar.la.1.14.zip")

               expected: 1.13
               detected: 1.14
```