### PR TITLE
brew.sh: update no git repository message.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -23,7 +23,7 @@ HOMEBREW_VERSION="$(git -C "$HOMEBREW_REPOSITORY" describe --tags --dirty --abbr
 HOMEBREW_USER_AGENT_VERSION="$HOMEBREW_VERSION"
 if [[ -z "$HOMEBREW_VERSION" ]]
 then
-  HOMEBREW_VERSION=">1.2.0 (no git repository)"
+  HOMEBREW_VERSION=">1.2.0 (shallow or no git repository)"
   HOMEBREW_USER_AGENT_VERSION="1.X.Y"
 fi
 


### PR DESCRIPTION
Clarify that this message doesn’t only trigger when there’s no Git repository but also when there’s no tags that `git describe` can use.

Fixes https://github.com/Homebrew/brew/issues/3187