### PR TITLE
portable-ruby: improve installation messaging.

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -135,7 +135,7 @@ install() {
   fi
 
   safe_cd "$VENDOR_DIR"
-  [[ -n "$HOMEBREW_QUIET" ]] || echo "==> Unpacking $(basename "$VENDOR_URL")"
+  [[ -n "$HOMEBREW_QUIET" ]] || echo "==> Pouring $(basename "$VENDOR_URL")"
   tar "$tar_args" "$CACHED_LOCATION"
   safe_cd "$VENDOR_DIR/portable-$VENDOR_NAME"
 

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -22,7 +22,7 @@ setup-ruby-path() {
 
       if [[ $(readlink "$vendor_ruby_current_version") != "$(<"$vendor_dir/portable-ruby-version")" ]]
       then
-        if ! brew vendor-install ruby --quiet
+        if ! brew vendor-install ruby
         then
           onoe "Failed to upgrade vendor Ruby."
         fi
@@ -42,7 +42,7 @@ setup-ruby-path() {
 
       if [[ "$ruby_old_version" == "true" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
       then
-        brew vendor-install ruby --quiet
+        brew vendor-install ruby
         if [[ ! -x "$vendor_ruby_path" ]]
         then
           odie "Failed to install vendor Ruby."


### PR DESCRIPTION
- Use “Pouring” to be more consistent with our normal messaging.
- Don’t be silent by default.

Fixes https://github.com/Homebrew/brew/issues/3184