### PR TITLE
brew: keep HOMEBREW_PREFIX/bin in PATH with HOMEBREW_ENV_FILTERING

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -60,7 +60,7 @@ done
 
 if [[ -n "$HOMEBREW_ENV_FILTERING" ]]
 then
-  PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+  PATH="$HOMEBREW_PREFIX/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
   FILTERED_ENV=()
   for VAR in HOME SHELL PATH TERM LOGNAME USER "${!HOMEBREW_@}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
**Yes, <a href="#fix">here</a>**
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
**Nope.** Please suggest tests.
- [ ] Have you successfully run `brew tests` with your changes locally?
**Nope** 

-----
<a name="fix"></a>
Fixes #2875.

Basically, with `HOMEBREW_ENV_FILTERING` enabled, Homebrew filters out everything, including its own `bin` directory from PATH. This PR brings peace of mind to those who do `HOMEBREW_ENV_FILTERING` stuff occasionally.

```
$ export HOMEBREW_ENV_FILTERING=1
$ brew install subversion --with-python
$ ls -1 /usr/local/Cellar/subversion/1.9.7/lib/perl5/site_perl/
5.26.0
$ unset HOMEBREW_ENV_FILTERING
$ brew reinstall subversion
$ ls -1 /usr/local/Cellar/subversion/1.9.7/lib/perl5/site_perl/
5.26.0
```
