### PR TITLE
Add cmd/strip

### DIFF
--- a/Library/Homebrew/cmd/strip.rb
+++ b/Library/Homebrew/cmd/strip.rb
@@ -1,0 +1,60 @@
+#:  * `strip` [`--all`]
+#:    Strip binary executables and libraries to reduce their size.
+#:
+#:    If `--all` is passed, strip all installed formulae.
+
+module Homebrew
+  module_function
+
+  def binary_object?(file)
+    f = Pathname.new file
+    return false unless f.file?
+    return true if f.extname == ".a"
+    if OS.mac?
+      f.dylib? || f.mach_o_executable? || f.mach_o_bundle?
+    else
+      false
+    end
+  end
+
+  def strip_keg(keg)
+    binaries = Dir[keg/"**/*"].select do |f|
+      !File.symlink?(f) && binary_object?(f)
+    end
+    return if binaries.empty?
+
+    puts "  #{keg} (#{keg.abv})"
+    not_writable = binaries.reject { |f| File.writable? f }
+    keg.lock do
+      begin
+        safe_system "chmod", "u+w", *not_writable unless not_writable.empty?
+        args = ["--strip-unneeded", "--preserve-dates"] unless OS.mac?
+        system "strip", *args, *binaries, err: (:close unless ARGV.verbose?)
+      ensure
+        system "chmod", "u-w", *not_writable unless not_writable.empty?
+      end
+    end
+    puts "  #{keg} (#{keg.abv})"
+  end
+
+  def strip_formula(formula)
+    kegs = formula.installed_kegs
+    return ofail "Formula not installed: #{formula.full_name}" if kegs.empty?
+    ohai "Stripping #{formula.full_name}..."
+    kegs.each { |keg| strip_keg keg }
+  end
+
+  def strip_formulae(formulae)
+    formulae.each { |f| strip_formula f }
+  end
+
+  def strip
+    odie "Command not found: strip" unless which "strip"
+    if ARGV.include?("--all") || ARGV.include?("--installed")
+      strip_formulae Formula.installed.sort
+    else
+      raise FormulaUnspecifiedError if ARGV.named.empty?
+      strip_formulae ARGV.resolved_formulae.sort
+    end
+  end
+end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -167,12 +167,12 @@ end
 module Homebrew
   module_function
 
-  def _system(cmd, *args)
+  def _system(cmd, *args, **options)
     pid = fork do
       yield if block_given?
       args.collect!(&:to_s)
       begin
-        exec(cmd, *args)
+        exec(cmd, *args, **options)
       rescue
         nil
       end
@@ -182,9 +182,9 @@ module Homebrew
     $CHILD_STATUS.success?
   end
 
-  def system(cmd, *args)
+  def system(cmd, *args, **options)
     puts "#{cmd} #{args * " "}" if ARGV.verbose?
-    _system(cmd, *args)
+    _system(cmd, *args, **options)
   end
 
   def install_gem_setup_path!(name, version = nil, executable = name)


### PR DESCRIPTION
Strip binary executables and libraries to reduce their size.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----


```
❯❯❯ brew strip gcc
==> Stripping gcc...
  /usr/local/Cellar/gcc/7.2.0 (1,486 files, 289.8MB)
  /usr/local/Cellar/gcc/7.2.0 (1,486 files, 257.4MB)
```