### PR TITLE
options: no need for --installed

### DIFF
--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -5,8 +5,6 @@
 #:    spaces.
 #:
 #:    If `--all` is passed, show options for all formulae.
-#:
-#:    If `--installed` is passed, show options for all installed formulae.
 
 require "formula"
 require "options"
@@ -17,8 +15,6 @@ module Homebrew
   def options
     if ARGV.include? "--all"
       puts_options Formula.to_a
-    elsif ARGV.include? "--installed"
-      puts_options Formula.installed
     else
       raise FormulaUnspecifiedError if ARGV.named.empty?
       puts_options ARGV.formulae


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

@MikeMcQuaid 

`brew options --installed` accomplishes the same as `brew options $(brew list)`.
Removing this option from the list of options for `options` for consistency (https://github.com/Homebrew/brew/pull/3172#issuecomment-331548135).