### PR TITLE
system: Forward the options hash to exec

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -167,12 +167,12 @@ end
 module Homebrew
   module_function
 
-  def _system(cmd, *args)
+  def _system(cmd, *args, **options)
     pid = fork do
       yield if block_given?
       args.collect!(&:to_s)
       begin
-        exec(cmd, *args)
+        exec(cmd, *args, **options)
       rescue
         nil
       end
@@ -182,9 +182,9 @@ module Homebrew
     $CHILD_STATUS.success?
   end
 
-  def system(cmd, *args)
+  def system(cmd, *args, **options)
     puts "#{cmd} #{args * " "}" if ARGV.verbose?
-    _system(cmd, *args)
+    _system(cmd, *args, **options)
   end
 
   def install_gem_setup_path!(name, version = nil, executable = name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Forward the options hash to `exec`. Useful to silence stderr with `stderr: :close`, for example.