### PR TITLE
portable-ruby: fix installation on Leopard.

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -45,6 +45,11 @@ fetch() {
     curl_args[${#curl_args[*]}]="--progress-bar"
   fi
 
+  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "100600" ]]
+  then
+    curl_args[${#curl_args[*]}]="--insecure"
+  fi
+
   temporary_path="$CACHED_LOCATION.incomplete"
 
   mkdir -p "$HOMEBREW_CACHE"

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -12,6 +12,7 @@ module OS
         mountain_lion: "10.8",
         lion: "10.7",
         snow_leopard: "10.6",
+        leopard_64: "10.5",
         leopard: "10.5",
         tiger: "10.4",
       }.freeze

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -37,7 +37,7 @@ setup-ruby-path() {
 
       if [[ -n "$HOMEBREW_RUBY_PATH" ]]
       then
-        ruby_old_version="$("$HOMEBREW_RUBY_PATH" -e "puts Gem::Version.new('$minimum_ruby_version') > Gem::Version.new(RUBY_VERSION)")"
+        ruby_old_version="$("$HOMEBREW_RUBY_PATH" -rrubygems -e "puts Gem::Version.new('$minimum_ruby_version') > Gem::Version.new(RUBY_VERSION)")"
       fi
 
       if [[ "$ruby_old_version" == "true" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" ]]


### PR DESCRIPTION
Download it insecurely there and require `rubygems` for `Gem::Version`.