### PR TITLE
keg_relocate: use correct number of arguments in call to change_install_name

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -16,7 +16,7 @@ class Keg
           new_name = fixed_name(file, bad_name)
 
           @require_relocation = true
-          file.change_install_name(bad_name, new_name, file)
+          file.change_install_name(bad_name, new_name)
         end
       end
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

During the refactoring of macho file relocation in #3101, #3138, and #3139,
the number of arguments to the `mach::change_install_name` function changed from 3 to 2, but there was still an instance of the function being called with the wrong number of arguments.

I noticed this while building a high_sierra bottle for [osrf/simulation/simbody](https://github.com/osrf/homebrew-simulation/blob/master/simbody.rb) and received a `Error: Failed to fix install linkage` in the jenkins console output and saw the following when building with `--debug`:

~~~
==> wrong number of arguments (given 3, expected 2)
/usr/local/Homebrew/Library/Homebrew/os/mac/mach.rb:78:in `change_install_name'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:19:in `block (3 levels) in fix_dynamic_linkage'
~~~

more context:

~~~
...
Fixing /usr/local/Cellar/simbody/3.5.4_2/lib/simbody/examples/UserGuide permissions from 755 to 555
Fixing /usr/local/Cellar/simbody/3.5.4_2/lib/simbody/examples/UserGuideLimits permissions from 755 to 555
Changing dylib ID of /usr/local/Cellar/simbody/3.5.4_2/lib/libSimTKcommon.3.5.dylib
  from libSimTKcommon.3.5.dylib
    to /usr/local/opt/simbody/lib/libSimTKcommon.3.5.dylib
Changing dylib ID of /usr/local/Cellar/simbody/3.5.4_2/lib/libSimTKmath.3.5.dylib
  from libSimTKmath.3.5.dylib
    to /usr/local/opt/simbody/lib/libSimTKmath.3.5.dylib
Error: Failed to fix install linkage
The formula built, but you may encounter issues using it or linking other
formula against it.
==> wrong number of arguments (given 3, expected 2)
/usr/local/Homebrew/Library/Homebrew/os/mac/mach.rb:78:in `change_install_name'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:19:in `block (3 levels) in fix_dynamic_linkage'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:91:in `each'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:91:in `each_install_name_for'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:10:in `block (2 levels) in fix_dynamic_linkage'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:381:in `ensure_writable'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:4:in `block in fix_dynamic_linkage'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:3:in `each'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/keg_relocate.rb:3:in `fix_dynamic_linkage'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:811:in `fix_dynamic_linkage'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:589:in `finish'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:337:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:226:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:224:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:224:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:95:in `<main>'
/usr/local/Homebrew/Library/Homebrew/postinstall.rb (Formulary::FromPathLoader): loading /usr/local/Homebrew/Library/Taps/osrf/homebrew-simulation/simbody.rb
~~~

Just removing the `file` argument allows my formula to build successfully. I think this isn't a controversial change.