### PR TITLE
add available languages to cask info command

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/info.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/info.rb
@@ -23,6 +23,7 @@ module Hbc
         installation_info(cask)
         repo_info(cask)
         name_info(cask)
+        language_info(cask)
         artifact_info(cask)
         Installer.print_caveats(cask)
       end
@@ -49,6 +50,13 @@ module Hbc
       def self.name_info(cask)
         ohai((cask.name.size > 1) ? "Names" : "Name")
         puts cask.name.empty? ? Formatter.error("None") : cask.name
+      end
+
+      def self.language_info(cask)
+        return if cask.languages.empty?
+
+        ohai "Languages"
+        puts cask.languages.join(", ")
       end
 
       def self.repo_info(cask)

--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -63,6 +63,7 @@ module Hbc
       :gpg,
       :homepage,
       :language,
+      :languages,
       :name,
       :sha256,
       :staged_path,
@@ -137,6 +138,12 @@ module Hbc
       end
 
       @language = @language_blocks.default.call
+    end
+
+    def languages
+      return [] if @language_blocks.nil?
+
+      @language_blocks.keys.flatten
     end
 
     def url(*args, &block)

--- a/Library/Homebrew/test/cask/cli/info_spec.rb
+++ b/Library/Homebrew/test/cask/cli/info_spec.rb
@@ -90,6 +90,38 @@ describe Hbc::CLI::Info, :cask do
     EOS
   end
 
+  it "should print languages if the Cask provided any" do
+    expect {
+      Hbc::CLI::Info.run("with-languages")
+    }.to output(<<-EOS.undent).to_stdout
+      with-languages: 1.2.3
+      http://example.com/local-caffeine
+      Not installed
+      From: https://github.com/caskroom/homebrew-spec/blob/master/Casks/with-languages.rb
+      ==> Name
+      None
+      ==> Languages
+      zh, en-US
+      ==> Artifacts
+      Caffeine.app (App)
+    EOS
+  end
+
+  it 'should not print "Languages" section divider if the languages block has no output' do
+    expect {
+      Hbc::CLI::Info.run("with-conditional-languages")
+    }.to output(<<-EOS.undent).to_stdout
+      with-conditional-languages: 1.2.3
+      http://example.com/local-caffeine
+      Not installed
+      From: https://github.com/caskroom/homebrew-spec/blob/master/Casks/with-conditional-languages.rb
+      ==> Name
+      None
+      ==> Artifacts
+      Caffeine.app (App)
+    EOS
+  end
+
   describe "when no Cask is specified" do
     it "raises an exception" do
       expect {

--- a/Library/Homebrew/test/cask/cli/info_spec.rb
+++ b/Library/Homebrew/test/cask/cli/info_spec.rb
@@ -90,7 +90,7 @@ describe Hbc::CLI::Info, :cask do
     EOS
   end
 
-  it "should print languages if the Cask provided any" do
+  it "prints languages specified in the Cask" do
     expect {
       Hbc::CLI::Info.run("with-languages")
     }.to output(<<-EOS.undent).to_stdout
@@ -107,14 +107,14 @@ describe Hbc::CLI::Info, :cask do
     EOS
   end
 
-  it 'should not print "Languages" section divider if the languages block has no output' do
+  it 'does not print "Languages" section divider if the languages block has no output' do
     expect {
-      Hbc::CLI::Info.run("with-conditional-languages")
+      Hbc::CLI::Info.run("without-languages")
     }.to output(<<-EOS.undent).to_stdout
-      with-conditional-languages: 1.2.3
+      without-languages: 1.2.3
       http://example.com/local-caffeine
       Not installed
-      From: https://github.com/caskroom/homebrew-spec/blob/master/Casks/with-conditional-languages.rb
+      From: https://github.com/caskroom/homebrew-spec/blob/master/Casks/without-languages.rb
       ==> Name
       None
       ==> Artifacts

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -178,7 +178,7 @@ describe Hbc::DSL, :cask do
       expect(cask.call.url.to_s).to eq("https://example.org/en-US.zip")
     end
 
-    it "returns empty array if no languages specified" do
+    it "returns an empty array if no languages are specified" do
       cask = lambda do
         Hbc::Cask.new("cask-with-apps") do
           url "https://example.org/file.zip"

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -177,6 +177,36 @@ describe Hbc::DSL, :cask do
       expect(cask.call.sha256).to eq("xyz789")
       expect(cask.call.url.to_s).to eq("https://example.org/en-US.zip")
     end
+
+    it "returns empty array if no languages specified" do
+      cask = lambda do
+        Hbc::Cask.new("cask-with-apps") do
+          url "https://example.org/file.zip"
+        end
+      end
+
+      expect(cask.call.languages).to be_empty
+    end
+
+    it "returns an array of available languages" do
+      cask = lambda do
+        Hbc::Cask.new("cask-with-apps") do
+          language "zh" do
+            sha256 "abc123"
+            "zh-CN"
+          end
+
+          language "en-US", default: true do
+            sha256 "xyz789"
+            "en-US"
+          end
+
+          url "https://example.org/file.zip"
+        end
+      end
+
+      expect(cask.call.languages).to eq(["zh", "en-US"])
+    end
   end
 
   describe "app stanza" do

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-languages.rb
@@ -1,0 +1,9 @@
+cask 'with-conditional-languages' do
+  version '1.2.3'
+  sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
+  
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage 'http://example.com/local-caffeine'
+ 
+  app 'Caffeine.app'
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -1,0 +1,18 @@
+cask 'with-languages' do
+  version '1.2.3'
+  
+  language "zh" do
+    sha256 "abc123"
+    "zh-CN"
+  end
+
+  language "en-US", default: true do
+    sha256 "xyz789"
+    "en-US"
+  end
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage 'http://example.com/local-caffeine'
+ 
+  app 'Caffeine.app'
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
@@ -1,4 +1,4 @@
-cask 'with-conditional-languages' do
+cask 'without-languages' do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
   


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is first ever OSS pull request to a real project, I figured it was a relatively small easy one.

This adds a new method to the DSL parsing to expose the languages specified in a cask, and a new section in the info output for available languages

```
-> brew cask info firefox
firefox: 55.0.3
https://www.mozilla.org/firefox/
Not installed
From: https://github.com/caskroom/homebrew-cask/blob/master/Casks/firefox.rb
==> Name
Mozilla Firefox
==> Languages
cs, de, en-GB, en, es-AR, es-CL, es-ES, fi, fr, gl, in, it, ja, nl, pl, pt, pt-BR, ru, uk, zh-TW, zh
==> Artifacts
Firefox.app (App)
```

The section does not show up if there are no languages specified in the cask

```
-> brew cask info 1password
1password: 6.8.2
https://1password.com/
Not installed
From: https://github.com/caskroom/homebrew-cask/blob/master/Casks/1password.rb
==> Name
1Password
==> Artifacts
1Password 6.app (App)
```

Fixes https://github.com/caskroom/homebrew-cask/issues/31128

I'm absolutely open to any help, suggestions, criticism. 

