### PR TITLE
install.rb: stop early when there are no formulae to be installed

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -219,6 +219,7 @@ module Homebrew
         end
       end
 
+      return if formulae.empty?
       perform_preinstall_checks
 
       formulae.each do |f|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR makes so that Homebrew exists early when there are no formulae to be installed.

I've added some debugging info to demonstrate what this PR does:

**BEFORE:**
```
 $ brew install gdm
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:show_summary_heading, :show_header]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:build_from_source, :force_bottle]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:ignore_deps, :only_deps, :interactive, :git]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:verbose, :debug, :quieter, :link_keg]
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: install
Warning: gdm 1.4 is already installed
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: perform_preinstall_checks
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_ppc
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_writable_install_location
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_development_tools
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_cellar
$
```

**AFTER**
```
$ brew install gdm
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:show_summary_heading, :show_header]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:build_from_source, :force_bottle]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:ignore_deps, :only_deps, :interactive, :git]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:verbose, :debug, :quieter, :link_keg]
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: install
Warning: gdm 1.4 is already installed
$
```

This PR does not break building multiple formulae:

```
$ brew install gdbm gdm
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:show_summary_heading, :show_header]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:build_from_source, :force_bottle]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:ignore_deps, :only_deps, :interactive, :git]
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: mode_attr_accessor
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: names = [:verbose, :debug, :quieter, :link_keg]
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: install
Warning: gdm 1.4 is already installed
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: perform_preinstall_checks
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_ppc
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_writable_install_location
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_development_tools
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: check_cellar
DEBUG [/usr/local/Homebrew/Library/Homebrew/cmd/install.rb]: install_formula
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: initialize
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: formula = gdbm
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: prelude
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: verify_deps_exist
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: compute_dependencies
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: expand_requirements
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: runtime_requirements
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: formula = gdbm
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: check_requirements
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: req_map = {}
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: expand_dependencies
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: deps = []
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: lock
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: check_install_sanity
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: install
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: check_conflicts
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_bottle?
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: compute_dependencies
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: expand_requirements
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: runtime_requirements
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: formula = gdbm
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: check_requirements
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: req_map = {}
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: expand_dependencies
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: deps = []
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_bottle?
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: install_dependencies
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: deps = []
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_bottle?
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: display_options
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: formula = gdbm
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_bottle?
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: pour
==> Downloading https://homebrew.bintray.com/bottles/gdbm-1.13.sierra.bottle.tar.gz
Already downloaded: /Users/mbelkin/Library/Caches/Homebrew/gdbm-1.13.sierra.bottle.tar.gz
==> Pouring gdbm-1.13.sierra.bottle.tar.gz
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: puts_requirement_messages
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_bottle?
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_bottle?
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: finish
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: install_plist
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: link
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: keg = /usr/local/Cellar/gdbm/1.13
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: fix_dynamic_linkage
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: keg = /usr/local/Cellar/gdbm/1.13
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_bottle?
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: post_install
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: caveats
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: summary
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: build_time
🍺  /usr/local/Cellar/gdbm/1.13: 19 files, 554.4KB
DEBUG [/usr/local/Homebrew/Library/Homebrew/formula_installer.rb]: unlock
```