### PR TITLE
brew: handle Ruby 2.3 more gracefully.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -5,8 +5,12 @@ end
 std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 
 # check ruby version before requiring any modules.
-RUBY_TWO = RUBY_VERSION.split(".").first.to_i >= 2
-raise "Homebrew must be run under Ruby 2!" unless RUBY_TWO
+RUBY_VERSION_SPLIT = RUBY_VERSION.split "."
+RUBY_X = RUBY_VERSION_SPLIT[0].to_i
+RUBY_Y = RUBY_VERSION_SPLIT[1].to_i
+if RUBY_X < 2 || (RUBY_X == 2 && RUBY_Y < 3)
+  raise "Homebrew must be run under Ruby 2.3!"
+end
 
 require "pathname"
 HOMEBREW_LIBRARY_PATH = Pathname.new(__FILE__).realpath.parent

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -570,6 +570,7 @@ EOS
         -d "$HOMEBREW_LIBRARY/LinkedKegs" ||
         (-n "$HOMEBREW_DEVELOPER" && -z "$HOMEBREW_UPDATE_PREINSTALL") ]]
   then
+    unset HOMEBREW_RUBY_PATH
     brew update-report "$@"
     return $?
   elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]]

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -81,7 +81,7 @@ module Homebrew
       safe_system "git", "reset", "--hard", start_commit
 
       # update ENV["PATH"]
-      ENV["PATH"] = "#{curdir}/bin:/usr/local/bin:/usr/bin:/bin"
+      ENV["PATH"] = "#{curdir}/bin:#{ENV["PATH"]}"
 
       # run brew update
       oh1 "Running brew update..."


### PR DESCRIPTION
- `brew.rb` needed updated to fail unless on Ruby 2.3
- `brew update` should unset `HOMEBREW_RUBY_PATH` to ensure that this doesn't "stick" on a Ruby 2.0 version after a portable Ruby has been installed.

Fixes #3237 (may not fix that exact case because not reproducible but will at least make the error nicer and hopefully fix that case).