### PR TITLE
shims/super/make: don't export MAKE=make.

### DIFF
--- a/Library/Homebrew/shims/super/make
+++ b/Library/Homebrew/shims/super/make
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-export MAKE=${HOMEBREW_MAKE:-make}
+if [[ -n "$HOMEBREW_MAKE" && "$HOMEBREW_MAKE" != "make" ]]
+then
+  export MAKE="$HOMEBREW_MAKE"
+else
+  MAKE="make"
+fi
 export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
-exec xcrun $MAKE "$@"
+exec xcrun "$MAKE" "$@"


### PR DESCRIPTION
This is redundant and breaks Handbrake:
https://github.com/HandBrake/HandBrake/issues/872
 
Changes part of https://github.com/Homebrew/brew/pull/2877

CC @ilovezfs, @xu-cheng and @mistydemeo FYI