### PR TITLE
formulary: handle unreadable bottle formula.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -124,7 +124,15 @@ module Formulary
 
     def get_formula(spec, **)
       contents = Utils::Bottles.formula_contents @bottle_filename, name: name
-      formula = Formulary.from_contents name, @bottle_filename, contents, spec
+      formula = begin
+        Formulary.from_contents name, @bottle_filename, contents, spec
+      rescue FormulaUnreadableError => e
+        opoo <<-EOS.undent
+          Unreadable formula in #{@bottle_filename}:
+          #{e}
+        EOS
+        super
+      end
       formula.local_bottle_path = @bottle_filename
       formula
     end


### PR DESCRIPTION
This occurs for any formulae that use relative `require` to files that are inside of e.g. a tap to use abstract formulae.

CC @sjackman FYI that https://github.com/Homebrew/brew/pull/3176 broke Homebrew/php CI
CC @javian as this will fix your issue (but I'd love an issue filed on GitHub next time :wink:)