### PR TITLE
audit: prefer assert/refute_predicate over File.exist?

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -967,6 +967,14 @@ class FormulaAuditor
       problem "Use `assert_match` instead of `assert ...include?`"
     end
 
+    if line =~ /(assert File\.exist\?|File\.exist\?)/
+      problem "Use `assert_predicate <path_to_file>, :exist?` instead of `#{Regexp.last_match(1)}`"
+    end
+
+    if line =~ /(assert !File\.exist\?|!File\.exist\?)/
+      problem "Use `refute_predicate <path_to_file>, :exist?` instead of `#{Regexp.last_match(1)}`"
+    end
+
     return unless @strict
 
     problem "`#{Regexp.last_match(1)}` in formulae is deprecated" if line =~ /(env :(std|userpaths))/


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`assert_predicate` and `refute_predicate` fail in a much clearer way than `File.exist?` does, and we've slowly started switching them over but @ilovezfs suggested `audit` was the way to go for consistency, so, here's a PR for him.

Before:
```
Error: minisign: failed
<false> is not true.
```
After:
```
Error: minisign: failed
<#<Pathname:/tmp/minisign-test-20171005-74992-3xoky/minisignb.pub>>.exist? is true value expected but was
<false>
```