### PR TITLE
os/mac: ignore apps found in Time Machine backups.

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -229,7 +229,9 @@ module OS
     end
 
     def app_with_bundle_id(*ids)
-      path = mdfind(*ids).first
+      path = mdfind(*ids)
+             .reject { |p| p.include?("/Backups.backupdb/") }
+             .first
       Pathname.new(path) unless path.nil? || path.empty?
     end
 


### PR DESCRIPTION
These can introduce confusion on e.g. outdated Xcode versions when they are the only (or first) versions that are found.