### PR TITLE
audit: Silence not notable on non-Homebrew taps

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -590,7 +590,8 @@ class FormulaAuditor
     return if metadata.nil?
 
     problem "GitHub fork (not canonical repository)" if metadata["fork"]
-    if (metadata["forks_count"] < 20) && (metadata["subscribers_count"] < 20) &&
+    if formula&.tap&.core_tap? &&
+       (metadata["forks_count"] < 20) && (metadata["subscribers_count"] < 20) &&
        (metadata["stargazers_count"] < 50)
       problem "GitHub repository not notable enough (<20 forks, <20 watchers and <50 stars)"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Silence the `brew audit` error message `GitHub repository not notable` for non-Homebrew taps.