### PR TITLE
Support `brew pull --bottle` for taps in organizations other than Homebrew

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -73,6 +73,8 @@ Metrics/CyclomaticComplexity:
 
 Metrics/LineLength:
   Max: 324
+  # ignore manpage comments
+  IgnoredPatterns: ['#: ']
 
 Metrics/MethodLength:
   Max: 222

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -58,6 +58,18 @@ require "tap"
 require "version"
 require "pkg_version"
 
+module GitHub
+  module_function
+
+  # Return the corresponding test-bot user name for the given GitHub organization.
+  def test_bot_user(user)
+    test_bot = ARGV.value "test-bot-user"
+    return test_bot if test_bot
+    return "BrewTestBot" if user.casecmp("homebrew").zero?
+    "#{user.capitalize}TestBot"
+  end
+end
+
 module Homebrew
   module_function
 
@@ -231,7 +243,7 @@ module Homebrew
           url
         else
           bottle_branch = "pull-bottle-#{issue}"
-          "https://github.com/#{test_bot_user user}/homebrew-#{tap.repo}/compare/#{user}:master...pr-#{issue}"
+          "https://github.com/#{GitHub.test_bot_user user}/homebrew-#{tap.repo}/compare/#{user}:master...pr-#{issue}"
         end
 
         curl "--silent", "--fail", "--output", "/dev/null", "--head", bottle_commit_url
@@ -257,13 +269,6 @@ module Homebrew
     # Verify bintray publishing after all patches have been applied
     bintray_published_formulae.uniq!
     verify_bintray_published(bintray_published_formulae)
-  end
-
-  def test_bot_user(user)
-    test_bot = ARGV.value "test-bot-user"
-    return test_bot if test_bot
-    return "BrewTestBot" if user.casecmp("homebrew").zero?
-    "#{user.capitalize}TestBot"
   end
 
   def force_utf8!(str)

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -1,4 +1,4 @@
-#:  * `pull` [`--bottle`] [`--bump`] [`--clean`] [`--ignore-whitespace`] [`--resolve`] [`--branch-okay`] [`--no-pbcopy`] [`--no-publish`] [`--warn-on-publish-failure`] [`--bintray-org=`<bintray-org>] <patch-source> [<patch-source>]:
+#:  * `pull` [`--bottle`] [`--bump`] [`--clean`] [`--ignore-whitespace`] [`--resolve`] [`--branch-okay`] [`--no-pbcopy`] [`--no-publish`] [`--warn-on-publish-failure`] [`--bintray-org=`<bintray-org>] [`--test-bot-user=`<test-bot-user>] <patch-source> [<patch-source>]:
 #:
 #:    Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
 #:    Optionally, installs the formulae changed by the patch.
@@ -44,6 +44,9 @@
 #:
 #:    If `--bintray-org=`<bintray-org> is passed, publish at the given Bintray
 #:    organisation.
+#:
+#:    If `--test-bot-user=`<test-bot-user> is passed, pull the bottle block
+#:    commit from the specified user on GitHub.
 
 require "net/http"
 require "net/https"
@@ -228,7 +231,7 @@ module Homebrew
           url
         else
           bottle_branch = "pull-bottle-#{issue}"
-          "https://github.com/BrewTestBot/homebrew-#{tap.repo}/compare/homebrew:master...pr-#{issue}"
+          "https://github.com/#{test_bot_user user}/homebrew-#{tap.repo}/compare/#{user}:master...pr-#{issue}"
         end
 
         curl "--silent", "--fail", "--output", "/dev/null", "--head", bottle_commit_url
@@ -254,6 +257,13 @@ module Homebrew
     # Verify bintray publishing after all patches have been applied
     bintray_published_formulae.uniq!
     verify_bintray_published(bintray_published_formulae)
+  end
+
+  def test_bot_user(user)
+    test_bot = ARGV.value "test-bot-user"
+    return test_bot if test_bot
+    return "BrewTestBot" if user.casecmp("homebrew").zero?
+    "#{user.capitalize}TestBot"
   end
 
   def force_utf8!(str)

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -770,7 +770,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Additionally, the date used in new manpages will match those in the existing
     manpages (to allow comparison without factoring in the date).
 
-  * `pull` [`--bottle`] [`--bump`] [`--clean`] [`--ignore-whitespace`] [`--resolve`] [`--branch-okay`] [`--no-pbcopy`] [`--no-publish`] [`--warn-on-publish-failure`] `patch-source` [`patch-source`]:
+  * `pull` [`--bottle`] [`--bump`] [`--clean`] [`--ignore-whitespace`] [`--resolve`] [`--branch-okay`] [`--no-pbcopy`] [`--no-publish`] [`--warn-on-publish-failure`] [`--bintray-org=``bintray-org`] [`--test-bot-user=``test-bot-user`] `patch-source` [`patch-source`]:
 
     Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
     Optionally, installs the formulae changed by the patch.
@@ -813,6 +813,12 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--warn-on-publish-failure` was passed, do not exit if there's a
     failure publishing bottles on Bintray.
+
+    If `--bintray-org=``bintray-org` is passed, publish at the given Bintray
+    organisation.
+
+    If `--test-bot-user=``test-bot-user` is passed, pull the bottle block
+    commit from the specified user on GitHub.
 
   * `release-notes` [`--markdown`] [`previous_tag`] [`end_ref`]:
     Output the merged pull requests on Homebrew/brew between two Git refs.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -797,7 +797,7 @@ Generate Homebrew\'s manpages\.
 If \fB\-\-fail\-if\-changed\fR is passed, the command will return a failing status code if changes are detected in the manpage outputs\. This can be used for CI to be notified when the manpages are out of date\. Additionally, the date used in new manpages will match those in the existing manpages (to allow comparison without factoring in the date)\.
 .
 .TP
-\fBpull\fR [\fB\-\-bottle\fR] [\fB\-\-bump\fR] [\fB\-\-clean\fR] [\fB\-\-ignore\-whitespace\fR] [\fB\-\-resolve\fR] [\fB\-\-branch\-okay\fR] [\fB\-\-no\-pbcopy\fR] [\fB\-\-no\-publish\fR] [\fB\-\-warn\-on\-publish\-failure\fR] \fIpatch\-source\fR [\fIpatch\-source\fR]:
+\fBpull\fR [\fB\-\-bottle\fR] [\fB\-\-bump\fR] [\fB\-\-clean\fR] [\fB\-\-ignore\-whitespace\fR] [\fB\-\-resolve\fR] [\fB\-\-branch\-okay\fR] [\fB\-\-no\-pbcopy\fR] [\fB\-\-no\-publish\fR] [\fB\-\-warn\-on\-publish\-failure\fR] [\fB\-\-bintray\-org=\fR\fIbintray\-org\fR] [\fB\-\-test\-bot\-user=\fR\fItest\-bot\-user\fR] \fIpatch\-source\fR [\fIpatch\-source\fR]:
 .
 .IP
 Gets a patch from a GitHub commit or pull request and applies it to Homebrew\. Optionally, installs the formulae changed by the patch\.
@@ -843,6 +843,12 @@ If \fB\-\-no\-publish\fR is passed, do not publish bottles to Bintray\.
 .
 .IP
 If \fB\-\-warn\-on\-publish\-failure\fR was passed, do not exit if there\'s a failure publishing bottles on Bintray\.
+.
+.IP
+If \fB\-\-bintray\-org=\fR\fIbintray\-org\fR is passed, publish at the given Bintray organisation\.
+.
+.IP
+If \fB\-\-test\-bot\-user=\fR\fItest\-bot\-user\fR is passed, pull the bottle block commit from the specified user on GitHub\.
 .
 .TP
 \fBrelease\-notes\fR [\fB\-\-markdown\fR] [\fIprevious_tag\fR] [\fIend_ref\fR]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Infer the name of the Bintray organization and test-bot GitHub user if either is not provided.
If the GitHub organization is Homebrew, infer that the Bintray organization is homebrew, and the GitHub test-bot user is BrewTestBot.
Otherwise, if the GitHub organization is Foo, infer that the Bintray organization is foo, and the GitHub test-bot user is FooTestBot.
Add options `--bintray-org` and `--test-bot-user` to override these inferences.