### PR TITLE
Whitelist keg-only `ncurses` for `brew audit`

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -450,7 +450,7 @@ class FormulaAuditor
         end
 
         if @new_formula && dep_f.keg_only_reason &&
-           !["openssl", "apr", "apr-util"].include?(dep.name) &&
+           !["apr", "apr-util", "ncurses", "openssl"].include?(dep.name) &&
            [:provided_by_macos, :provided_by_osx].include?(dep_f.keg_only_reason.reason)
           problem "Dependency '#{dep.name}' may be unnecessary as it is provided by macOS; try to build this formula without it."
         end


### PR DESCRIPTION
With regards to `brew audit`, this PR whitelists the `ncurses` formula, which is tagged `keg_only :provided_by_macos`.

This tag had caused `brew audit --new-formula sc-im` to fail with the following error message:

> Dependency 'ncurses' may be unnecessary as it is provided by
> macOS; try to build this formula without it.

However, the [new formula](https://github.com/Homebrew/homebrew-core/pull/14067) `sc-im` depends on the GNU ncurses library in a recent version, just like the one Homebrew provides as a separate formula.

Because the macOS-provided ncurses is no drop-in replacement, this PR whitelists ncurses in `audit.rb`.

See also: https://github.com/Homebrew/homebrew-core/pull/14067#issuecomment-335046151
