### PR TITLE
 lines_cop: add ENV.universal_binary audit exemption for wine

### DIFF
--- a/Library/Homebrew/rubocops/lines_cop.rb
+++ b/Library/Homebrew/rubocops/lines_cop.rb
@@ -121,6 +121,7 @@ module RuboCop
           end
 
           find_instance_method_call(body_node, "ENV", :universal_binary) do
+            next if @formula_name == "wine"
             problem "macOS has been 64-bit only since 10.6 so ENV.universal_binary is deprecated."
           end
 

--- a/Library/Homebrew/test/rubocops/lines_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_cop_spec.rb
@@ -419,7 +419,22 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       end
     end
 
-    it "with ENV.universal_binary" do
+    it "with ENV.universal_binary exempted formula" do
+      source = <<-EOS.undent
+        class Wine < Formula
+          desc "foo"
+          url 'http://example.com/foo-1.0.tgz'
+          if build?
+             ENV.universal_binary
+          end
+        end
+      EOS
+
+      inspect_source(source, "/homebrew-core/Formula/wine.rb")
+      expect(cop.offenses).to eq([])
+    end
+
+    it "with ENV.x11" do
       source = <<-EOS.undent
         class Foo < Formula
           desc "foo"

--- a/Library/Homebrew/test/rubocops/lines_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_cop_spec.rb
@@ -82,7 +82,7 @@ end
 describe RuboCop::Cop::FormulaAudit::Comments do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula" do
+  context "When auditing formulae" do
     it "with commented cmake call" do
       source = <<-EOS.undent
         class Foo < Formula
@@ -154,7 +154,7 @@ end
 describe RuboCop::Cop::FormulaAudit::Miscellaneous do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula" do
+  context "When auditing formulae" do
     it "with FileUtils" do
       source = <<-EOS.undent
         class Foo < Formula
@@ -380,7 +380,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       end
     end
 
-    it "with build.universal? exempted formula" do
+    it "with a build.universal? exemption reports no offenses" do
       source = <<-EOS.undent
         class Wine < Formula
           desc "foo"
@@ -392,7 +392,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       EOS
 
       inspect_source(source, "/homebrew-core/Formula/wine.rb")
-      expect(cop.offenses).to eq([])
+      expect(cop.offenses).to be_empty
     end
 
     it "with ENV.universal_binary" do
@@ -419,7 +419,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       end
     end
 
-    it "with ENV.universal_binary exempted formula" do
+    it "with an ENV.universal_binary exemption reports no offenses" do
       source = <<-EOS.undent
         class Wine < Formula
           desc "foo"
@@ -431,7 +431,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       EOS
 
       inspect_source(source, "/homebrew-core/Formula/wine.rb")
-      expect(cop.offenses).to eq([])
+      expect(cop.offenses).to be_empty
     end
 
     it "with ENV.x11" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
add ENV.universal_binary audit exception for wine and corresponding test coverage