### PR TITLE
formula_desc_cop: empty string is not a valid desc

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -18,8 +18,14 @@ module RuboCop
             return
           end
 
-          # Check if a formula's desc is too long
+          # Check the formula's desc length. Should be >0 and <80 characters.
           desc = parameters(desc_call).first
+          pure_desc_length = string_content(desc).length
+          if pure_desc_length.zero?
+            problem "The desc (description) should not be an empty string."
+            return
+          end
+
           desc_length = "#{@formula_name}: #{string_content(desc)}".length
           max_desc_length = 80
           return if desc_length <= max_desc_length

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -27,6 +27,27 @@ describe RuboCop::Cop::FormulaAuditStrict::DescLength do
       end
     end
 
+    it "reports an offense when desc is an empty string" do
+      source = <<-EOS.undent
+        class Foo < Formula
+          url 'http://example.com/foo-1.0.tgz'
+          desc ''
+        end
+      EOS
+
+      msg = "The desc (description) should not be an empty string."
+      expected_offenses = [{ message: msg,
+                             severity: :convention,
+                             line: 3,
+                             column: 2,
+                             source: source }]
+
+      inspect_source(source, "/homebrew-core/Formula/foo.rb")
+      expected_offenses.zip(cop.offenses).each do |expected, actual|
+        expect_offense(expected, actual)
+      end
+    end
+
     it "When desc is too long" do
       source = <<-EOS.undent
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
-----

Just a slightly tweaked version of https://github.com/Homebrew/brew/issues/3286#issuecomment-334983011