### PR TITLE
pull: fix bintray verification failing due to redirection

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -560,7 +560,7 @@ module Homebrew
             req = Net::HTTP::Head.new bottle_info.url
             req.initialize_http_header "User-Agent" => HOMEBREW_USER_AGENT_RUBY
             res = http.request req
-            break if res.is_a?(Net::HTTPSuccess)
+            break if res.is_a?(Net::HTTPSuccess) || res.code == "302"
 
             unless res.is_a?(Net::HTTPClientError)
               raise "Failed to find published #{f} bottle at #{url} (#{res.code} #{res.message})!"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When doing a `brew pull --bottle <n>` for the second time, the command tries to verify if the uploaded package is there and correct. This failed in my case with an error:
```
==> Verifying bottles published on Bintray
Verifying bottle: caddy-0.10.10.high_sierra.bottle.tar.gz
Error: Failed to find published caddy bottle at https://homebrew.bintray.com/bottles/caddy-0.10.10.high_sierra.bottle.tar.gz (302 )!
```
What happens here is that `brew pull` is attempting a pre-check of the bottle URL (before starting the full download), by using the `Net::HTTP` Ruby class. In this particular case though — and this well may depend on geolocation — the URL returns a **302 redirect** (to a valid CloudFront URL). 302 is then considered and error and the command bails out without continuing to the curl download to do the actual verification.

`Net::HTTP` doesn't have an option to follow redirects automatically and 302 is _likely_ satisfying the goal of the pre-check (its stated goal is to wait in a loop till the upload finishes to propagate/publish upstream), so this patch simply accepts `302` as a success and let it proceed to the actual download.
