### PR TITLE
doctor.rb: enable regular expressions

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -19,7 +19,7 @@ module Homebrew
       if ARGV.named.empty?
         puts checks.all.sort
       else
-        ARGV.named.each { |regex| puts checks.all.grep /#{regex}/ }
+        puts ARGV.named.flat_map { |na| checks.all.grep /#{na}/ }.uniq
       end
       exit
     end
@@ -32,7 +32,7 @@ module Homebrew
       ]
       methods = (checks.all.sort - slow_checks) + slow_checks
     else
-      methods = ARGV.named.map { |na| checks.all.grep /#{na}/ }.flatten.uniq
+      methods = ARGV.named.flat_map { |na| checks.all.grep /#{na}/ }.uniq
     end
 
     first_warning = true

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -16,7 +16,11 @@ module Homebrew
     checks = Diagnostic::Checks.new
 
     if ARGV.include? "--list-checks"
-      puts checks.all.sort
+      if ARGV.named.empty?
+        puts checks.all.sort
+      else
+        ARGV.named.each { |regex| puts checks.all.grep /#{regex}/ }
+      end
       exit
     end
 
@@ -28,7 +32,7 @@ module Homebrew
       ]
       methods = (checks.all.sort - slow_checks) + slow_checks
     else
-      methods = ARGV.named
+      methods = ARGV.named.map { |na| checks.all.grep /#{na}/ }.flatten.uniq
     end
 
     first_warning = true

--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -19,7 +19,7 @@ module Homebrew
       if ARGV.named.empty?
         puts checks.all.sort
       else
-        puts ARGV.named.flat_map { |na| checks.all.grep /#{na}/ }.uniq
+        puts ARGV.named.flat_map { |na| checks.all.grep(/#{na}/) }.uniq
       end
       exit
     end
@@ -32,7 +32,7 @@ module Homebrew
       ]
       methods = (checks.all.sort - slow_checks) + slow_checks
     else
-      methods = ARGV.named.flat_map { |na| checks.all.grep /#{na}/ }.uniq
+      methods = ARGV.named.flat_map { |na| checks.all.grep(/#{na}/) }.uniq
     end
 
     first_warning = true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR enables regular expressions to be used with `doctor`, e.g.:
```
$ brew doctor --list-checks xcode
check_xcode_up_to_date
check_xcode_8_without_clt_on_el_capitan
check_xcode_minimum_version
check_xcode_prefix
check_xcode_prefix_exists
check_xcode_select_path
check_xcode_license_approved

$ brew doctor xcode
Your system is ready to brew.

$ # whereas...
$ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry and just ignore them. Thanks!
...
```
