### PR TITLE
readall: by default, process homebrew/core tap only

### DIFF
--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -29,7 +29,7 @@ module Homebrew
 
     options = { aliases: ARGV.include?("--aliases") }
     taps = if ARGV.named.empty?
-      Tap
+      [Tap.fetch("homebrew/core")]
     else
       [Tap.fetch(ARGV.named.first)]
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

There is a discrepancy between the description in `cmd/readall.rb` and what it actually does:
currently, `brew readall` reads all taps, not only the `homebrew/core` one. 

Steps to see the effect
1. Add `ohai tap` before `Homebrew.failed = true unless Readall.valid_tap?(tap, options)` in the `taps.each` loop in `Library/Homebrew/cmd/readall.rb`
2. Call `brew readall`

BEFORE (with the above debug information):
```
$ brew readall
==> jmhobbs/parrot
==> linuxbrew/developer
==> homebrew/science
==> homebrew/core
==> homebrew/dev-tools
==> homebrew/test-bot
==> caskroom/cask
```

AFTER:
```
$ brew readall
==> homebrew/core
```