### PR TITLE
readall: allow readall-ing multiple taps at once

### DIFF
--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -1,6 +1,7 @@
 #: @hide_from_man_page
 #:  * `readall` [tap]:
-#:    Import all formulae in a tap (defaults to core tap).
+#:    Import all formulae from specified taps (defaults to
+#:    all installed taps).
 #:
 #:    This can be useful for debugging issues across all formulae
 #:    when making significant changes to `formula.rb`,

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -31,7 +31,7 @@ module Homebrew
     taps = if ARGV.named.empty?
       Tap
     else
-      [Tap.fetch(ARGV.named.first)]
+      ARGV.named.map { |t| Tap.fetch(t) }
     end
     taps.each do |tap|
       Homebrew.failed = true unless Readall.valid_tap?(tap, options)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Current behavior:
```
$ brew readall homebrew/core homebrew/dev-tools
```
processes `homebrew/core` only

This PR "improves" `readall`'s behavior so that all specified taps are processed