### PR TITLE
In 'readall.rb', replaced multi-step 'each' loop with one-line method chain of Ruby enumerator methods

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -39,7 +39,7 @@ module Homebrew
       filtered_list
     elsif ARGV.named.empty?
       if ARGV.include? "--full-name"
-        full_names = Formula.installed.map(&:full_name).sort &tap_and_name_comparison
+        full_names = Formula.installed.map(&:full_name).sort(&tap_and_name_comparison)
         return if full_names.empty?
         puts Formatter.columns(full_names)
       else

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -13,16 +13,8 @@ module Homebrew
 
   def readall
     if ARGV.include?("--syntax")
-      ruby_files = []
-      scan_files = %W[
-        #{HOMEBREW_LIBRARY}/*.rb
-        #{HOMEBREW_LIBRARY}/Homebrew/**/*.rb
-      ]
-      Dir.glob(scan_files).each do |rb|
-        next if rb.include?("/vendor/")
-        next if rb.include?("/cask/")
-        ruby_files << rb
-      end
+      scan_files = "#{HOMEBREW_LIBRARY}/Homebrew/**/*.rb"
+      ruby_files = Dir.glob(scan_files).reject{|file| file =~ /vendor|cask/ }
 
       Homebrew.failed = true unless Readall.valid_ruby_syntax?(ruby_files)
     end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -14,7 +14,7 @@ module Homebrew
   def readall
     if ARGV.include?("--syntax")
       scan_files = "#{HOMEBREW_LIBRARY_PATH}/**/*.rb"
-      ruby_files = Dir.glob(scan_files).reject{|file| file =~ /vendor|cask/ }
+      ruby_files = Dir.glob(scan_files).reject { |file| file =~ /vendor|cask/ }
 
       Homebrew.failed = true unless Readall.valid_ruby_syntax?(ruby_files)
     end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -13,8 +13,8 @@ module Homebrew
 
   def readall
     if ARGV.include?("--syntax")
-      scan_files = "#{HOMEBREW_LIBRARY}/Homebrew/**/*.rb"
-      ruby_files = Dir.glob(scan_files).reject{|file| file.include? '/vendor/' }
+      scan_files = "#{HOMEBREW_LIBRARY_PATH}/**/*.rb"
+      ruby_files = Dir.glob(scan_files).reject{|file| file =~ /vendor|cask/ }
 
       Homebrew.failed = true unless Readall.valid_ruby_syntax?(ruby_files)
     end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -14,7 +14,7 @@ module Homebrew
   def readall
     if ARGV.include?("--syntax")
       scan_files = "#{HOMEBREW_LIBRARY}/Homebrew/**/*.rb"
-      ruby_files = Dir.glob(scan_files).reject{|file| file =~ /vendor|cask/ }
+      ruby_files = Dir.glob(scan_files).reject{|file| file.include? '/vendor/' }
 
       Homebrew.failed = true unless Readall.valid_ruby_syntax?(ruby_files)
     end

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -14,7 +14,7 @@ module Homebrew
   def readall
     if ARGV.include?("--syntax")
       scan_files = "#{HOMEBREW_LIBRARY_PATH}/**/*.rb"
-      ruby_files = Dir.glob(scan_files).reject { |file| file =~ /vendor|cask/ }
+      ruby_files = Dir.glob(scan_files).reject { |file| file =~ %r{/(vendor|cask)/} }
 
       Homebrew.failed = true unless Readall.valid_ruby_syntax?(ruby_files)
     end

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -54,14 +54,11 @@ module Homebrew
     end
     ignores << "recommended?" if ARGV.include? "--skip-recommended"
 
-    memo = {}
     uses = formulae.select do |f|
       used_formulae.all? do |ff|
         begin
           if recursive
             deps = f.recursive_dependencies do |dependent, dep|
-              memo_key = [dependent, dep].to_s
-              next if memo[memo_key]
               if dep.recommended?
                 Dependency.prune if ignores.include?("recommended?") || dependent.build.without?(dep)
               elsif dep.optional?
@@ -75,7 +72,6 @@ module Homebrew
               if dep.is_a?(TapDependency) && !dep.tap.installed?
                 Dependency.keep_but_prune_recursive_deps
               end
-              memo[memo_key] = true
             end
 
             dep_formulae = deps.flat_map do |dep|

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -54,11 +54,14 @@ module Homebrew
     end
     ignores << "recommended?" if ARGV.include? "--skip-recommended"
 
+    memo = {}
     uses = formulae.select do |f|
       used_formulae.all? do |ff|
         begin
           if recursive
             deps = f.recursive_dependencies do |dependent, dep|
+              memo_key = [dependent, dep].to_s
+              next if memo[memo_key]
               if dep.recommended?
                 Dependency.prune if ignores.include?("recommended?") || dependent.build.without?(dep)
               elsif dep.optional?
@@ -72,6 +75,7 @@ module Homebrew
               if dep.is_a?(TapDependency) && !dep.tap.installed?
                 Dependency.keep_but_prune_recursive_deps
               end
+              memo[memo_key] = true
             end
 
             dep_formulae = deps.flat_map do |dep|


### PR DESCRIPTION
Combine the two RegExp calls that are performed on each filename in `readall.rb`, reducing the # of checks performed by 50%.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
_**N/A (refactoring only; no new functionality; existing test suite passes)**_
- [X] Have you successfully run `brew tests` with your changes locally?

-----

