### PR TITLE
Fixes querying Cask commands' help

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -32,7 +32,7 @@ begin
 
   empty_argv = ARGV.empty?
   help_flag_list = %w[-h --help --usage -?]
-  help_flag = false
+  help_flag = !ENV["HOMEBREW_HELP"].nil?
   internal_cmd = true
   cmd = nil
 
@@ -119,8 +119,16 @@ begin
     if Process.uid.zero? && !brew_uid.zero?
       tap_commands += %W[/usr/bin/sudo -u ##{brew_uid}]
     end
+    if help_flag
+      # Unset HOMEBREW_HELP to avoid confusing the tap
+      ENV["HOMEBREW_HELP"] = nil
+    end
     tap_commands += %W[#{HOMEBREW_BREW_FILE} tap #{possible_tap}]
     safe_system(*tap_commands)
+    if help_flag
+      # Restore HOMEBREW_HELP after the tap
+      ENV["HOMEBREW_HELP"] = 1
+    end
     exec HOMEBREW_BREW_FILE, cmd, *ARGV
   end
 rescue UsageError => e

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -80,7 +80,13 @@ begin
   # - no arguments are passed
   if empty_argv || help_flag
     require "cmd/help"
-    Homebrew.help cmd, empty_argv: empty_argv
+    if cmd == "cask"
+      # Let Cask handle the help command
+      Homebrew.send cmd.to_s.tr("-", "_").downcase
+      exit 0
+    else
+      Homebrew.help cmd, empty_argv: empty_argv
+    end
     # `Homebrew.help` never returns, except for external/unknown commands.
   end
 

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -44,9 +44,6 @@ begin
       help_flag = true
     elsif !cmd && !help_flag_list.include?(arg)
       cmd = ARGV.delete_at(i)
-    elsif help_flag_list.include?(arg) && cmd
-      # cmd determined, and it needs help
-      help_flag = true
     end
   end
 
@@ -121,13 +118,13 @@ begin
     end
     if help_flag
       # Unset HOMEBREW_HELP to avoid confusing the tap
-      ENV["HOMEBREW_HELP"] = nil
+      ENV.delete("HOMEBREW_HELP")
     end
     tap_commands += %W[#{HOMEBREW_BREW_FILE} tap #{possible_tap}]
     safe_system(*tap_commands)
     if help_flag
       # Restore HOMEBREW_HELP after the tap
-      ENV["HOMEBREW_HELP"] = 1
+      ENV["HOMEBREW_HELP"] = "1"
     end
     exec HOMEBREW_BREW_FILE, cmd, *ARGV
   end

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -44,7 +44,7 @@ begin
       help_flag = true
     elsif !cmd && !help_flag_list.include?(arg)
       cmd = ARGV.delete_at(i)
-    elsif help_flag_list.include?(arg) & cmd
+    elsif help_flag_list.include?(arg) && cmd
       # cmd determined, and it needs help
       help_flag = true
     end

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -78,15 +78,10 @@ begin
   # - a help flag is passed AND a command is matched
   # - a help flag is passed AND there is no command specified
   # - no arguments are passed
-  if empty_argv || help_flag
+  # - if cmd is Cask, let Cask handle the help command instead
+  if (empty_argv || help_flag ) && cmd != "cask"
     require "cmd/help"
-    if cmd == "cask"
-      # Let Cask handle the help command
-      Homebrew.send cmd.to_s.tr("-", "_").downcase
-      exit 0
-    else
-      Homebrew.help cmd, empty_argv: empty_argv
-    end
+    Homebrew.help cmd, empty_argv: empty_argv
     # `Homebrew.help` never returns, except for external/unknown commands.
   end
 

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -32,7 +32,7 @@ begin
 
   empty_argv = ARGV.empty?
   help_flag_list = %w[-h --help --usage -?]
-  help_flag = !ENV["HOMEBREW_HELP"].nil?
+  help_flag = false
   internal_cmd = true
   cmd = nil
 
@@ -44,6 +44,9 @@ begin
       help_flag = true
     elsif !cmd && !help_flag_list.include?(arg)
       cmd = ARGV.delete_at(i)
+    elsif help_flag_list.include?(arg) & cmd
+      # cmd determined, and it needs help
+      help_flag = true
     end
   end
 

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -78,8 +78,8 @@ begin
   # - a help flag is passed AND a command is matched
   # - a help flag is passed AND there is no command specified
   # - no arguments are passed
-  # - if cmd is Cask, let Cask handle the help command instead
-  if (empty_argv || help_flag ) && cmd != "cask"
+  # - if cmd is Cask, let Cask handle the help command instead
+  if (empty_argv || help_flag) && cmd != "cask"
     require "cmd/help"
     Homebrew.help cmd, empty_argv: empty_argv
     # `Homebrew.help` never returns, except for external/unknown commands.

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -116,16 +116,11 @@ begin
     if Process.uid.zero? && !brew_uid.zero?
       tap_commands += %W[/usr/bin/sudo -u ##{brew_uid}]
     end
-    if help_flag
-      # Unset HOMEBREW_HELP to avoid confusing the tap
-      ENV.delete("HOMEBREW_HELP")
-    end
+    # Unset HOMEBREW_HELP to avoid confusing the tap
+    ENV.delete("HOMEBREW_HELP") if help_flag
     tap_commands += %W[#{HOMEBREW_BREW_FILE} tap #{possible_tap}]
     safe_system(*tap_commands)
-    if help_flag
-      # Restore HOMEBREW_HELP after the tap
-      ENV["HOMEBREW_HELP"] = "1"
-    end
+    ENV["HOMEBREW_HELP"] = "1" if help_flag
     exec HOMEBREW_BREW_FILE, cmd, *ARGV
   end
 rescue UsageError => e

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -230,7 +230,8 @@ module Hbc
 
         return if @command == "help" && @args.empty?
 
-        raise ArgumentError, "Unknown command: #{@command} #{@args.join(" ")}"
+        unknown_command = @command == "help" ? @args.first : @command
+        raise ArgumentError, "Unknown command: #{unknown_command}"
       end
 
       def purpose

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -230,7 +230,6 @@ module Hbc
 
         return if @command == "help" && @args.empty?
 
-        unknown_command = @args.empty? ? @command : @args.first
         raise ArgumentError, "Unknown command: #{@command} #{@args.join(" ")}"
       end
 

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -154,7 +154,7 @@ module Hbc
     def run
       command_name, *args = detect_command_and_arguments(*@args)
       command = if help?
-        args.unshift(command_name) if !command_name.nil?
+        args.unshift(command_name) unless command_name.nil
         "help"
       else
         self.class.lookup_command(command_name)
@@ -230,7 +230,7 @@ module Hbc
 
         return if @command == "help" && @args.empty?
 
-        raise ArgumentError, "help does not take arguments"
+        raise ArgumentError, "help does not take arguments."
       end
 
       def purpose

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -154,7 +154,7 @@ module Hbc
     def run
       command_name, *args = detect_command_and_arguments(*@args)
       command = if help?
-        args.unshift(command_name) unless command_name.nil
+        args.unshift(command_name) unless command_name.nil?
         "help"
       else
         self.class.lookup_command(command_name)

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -154,7 +154,7 @@ module Hbc
     def run
       command_name, *args = detect_command_and_arguments(*@args)
       command = if help?
-        args.unshift(command_name)
+        args.unshift(command_name) if !command_name.nil?
         "help"
       else
         self.class.lookup_command(command_name)
@@ -230,8 +230,7 @@ module Hbc
 
         return if @command == "help" && @args.empty?
 
-        unknown_command = (@command == "help") ? @args.first : @command
-        raise ArgumentError, "Unknown command: #{unknown_command}"
+        raise ArgumentError, "help does not take arguments"
       end
 
       def purpose

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -231,7 +231,7 @@ module Hbc
         return if @command == "help" && @args.empty?
 
         unknown_command = @args.empty? ? @command : @args.first
-        raise ArgumentError, "Unknown command: #{unknown_command}"
+        raise ArgumentError, "Unknown command: #{@command} #{@args.join(" ")}"
       end
 
       def purpose

--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -230,7 +230,7 @@ module Hbc
 
         return if @command == "help" && @args.empty?
 
-        unknown_command = @command == "help" ? @args.first : @command
+        unknown_command = (@command == "help") ? @args.first : @command
         raise ArgumentError, "Unknown command: #{unknown_command}"
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
-----

In caskroom/homebrew-cask#28977, two bugs were discovered (quote from my comment).

The first one:
> That last option is being “stolen” by Homebrew itself. Try something like brew cask example --help and you’ll get their help, not even ours.

It's a bug in Cask's `cli.rb`:
https://github.com/Homebrew/brew/blob/56458f03fcc68ef6d8ee3ee4a7c1d16021aa5800/Library/Homebrew/cask/lib/hbc/cli.rb#L227-L235
Line 234 specifies that it should print the first argument if available, which the example script does (instead of `example`, which doesn't exist as a command!)

The second one:
> And this looks like a bug, but I just tried brew services --help and my terminal is filled with the (correct) instructions. I then cannot leave/do anything until I <kbd>ctrl</kbd><kbd>C</kbd>.

This one only happens *if homebrew/services has not been previously tapped*, because in this case the help request is redirected to the `tap` command, which *always returns the help text without actually tapping the cask* 🤦‍♀️ .
The execution flow is roughly like this:

`brew services --help`
 - `help.rb` [does not find the command](https://github.com/Homebrew/brew/blob/021729e1646212d47d3f52c0b29034e7da97693b/Library/Homebrew/cmd/help.rb#L69) and so returns
 - now `brew.rb` tests [whether it belongs to a Tap](https://github.com/Homebrew/brew/blob/b488a89b5d2bd9c96e3128f598221fed1c3c1911/Library/Homebrew/brew.rb#L103-L107)
 - it does, so `brew tap homebrew/services` [is triggered](https://github.com/Homebrew/brew/blob/b488a89b5d2bd9c96e3128f598221fed1c3c1911/Library/Homebrew/brew.rb#L113-L115)
 -  ***because the `HOMEBREW_HELP` environment variable is still set, `help.rb` sets the `help_flag`, [and attempts to print `tap` help instead](https://github.com/Homebrew/brew/blob/021729e1646212d47d3f52c0b29034e7da97693b/Library/Homebrew/cmd/help.rb#L72-L73)***
 -  now, `puts(command_help(path))` does the job, but after doing so `exit 0` returns _from the "tap"_
 - [we execute `brew services --help` again](https://github.com/Homebrew/brew/blob/b488a89b5d2bd9c96e3128f598221fed1c3c1911/Library/Homebrew/brew.rb#L115), and since the tap didn't clone the repo but merely printed the help text, this triggers the loop.

The bug lies in the remarked step: if a tap is required, it should *not* obey the `HOMEBREW_HELP` environment variable.

I've fixed the first bug by specifying all `args` to be printed along with the offending command, and the second by forcing `brew.rb` to ignore the shell's `HOMEBREW_HELP` variable and verify that the help text was actually requested.

Fixes caskroom/homebrew-cask#28977
