### PR TITLE
fileutils: deprecate rake DSL

### DIFF
--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -78,4 +78,9 @@ class Formula
   def startup_plist
     odeprecated "Formula#startup_plist", "Formula#plist"
   end
+
+  def rake(*args)
+    # odeprecated "FileUtils#rake", "system \"rake\""
+    system "rake", *args
+  end
 end

--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -101,11 +101,6 @@ module FileUtils
     system Formulary.factory("scons").opt_bin/"scons", *args
   end
 
-  # Run the `rake` from the `ruby` Homebrew is using rather than whatever is in the `PATH`.
-  def rake(*args)
-    system RUBY_BIN/"rake", *args
-  end
-
   # Run `make` 3.81 or newer.
   # Uses the system make on Leopard and newer, and the
   # path to the actually-installed make on Tiger or older.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

superenv and the `:ruby` requirement make a `rake` DSL unnecessary.

Fixes https://github.com/Homebrew/brew/issues/3310.