### PR TITLE
Update docs: homebrew/livecheck

### DIFF
--- a/docs/External-Commands.md
+++ b/docs/External-Commands.md
@@ -44,12 +44,12 @@ Note they are largely untested, and as always, be careful about running untested
 
 ### brew-livecheck
 Check if there is a new upstream version of a formula.
-See the [`README`](https://github.com/youtux/homebrew-livecheck/blob/master/README.md) for more info and usage.
+See the [`README`](https://github.com/Homebrew/homebrew-livecheck/blob/master/README.md) for more info and usage.
 
 Install using:
 
 ```sh
-brew tap youtux/livecheck
+brew tap homebrew/livecheck
 ```
 
 ### brew-gem


### PR DESCRIPTION
The docs are outdated, since live check has been moved to the Homebrew organization.