### PR TITLE
caveats.rb: empty method on Linux

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -161,49 +161,7 @@ class Caveats
     EOS
   end
 
-  def plist_caveats
-    s = []
-    if f.plist || (keg&.plist_installed?)
-      plist_domain = f.plist_path.basename(".plist")
-
-      # we readlink because this path probably doesn't exist since caveats
-      # occurs before the link step of installation
-      # Yosemite security measures mildly tighter rules:
-      # https://github.com/Homebrew/legacy-homebrew/issues/33815
-      if !plist_path.file? || !plist_path.symlink?
-        if f.plist_startup
-          s << "To have launchd start #{f.full_name} now and restart at startup:"
-          s << "  sudo brew services start #{f.full_name}"
-        else
-          s << "To have launchd start #{f.full_name} now and restart at login:"
-          s << "  brew services start #{f.full_name}"
-        end
-      # For startup plists, we cannot tell whether it's running on launchd,
-      # as it requires for `sudo launchctl list` to get real result.
-      elsif f.plist_startup
-        s << "To restart #{f.full_name} after an upgrade:"
-        s << "  sudo brew services restart #{f.full_name}"
-      elsif Kernel.system "/bin/launchctl list #{plist_domain} &>/dev/null"
-        s << "To restart #{f.full_name} after an upgrade:"
-        s << "  brew services restart #{f.full_name}"
-      else
-        s << "To start #{f.full_name}:"
-        s << "  brew services start #{f.full_name}"
-      end
-
-      if f.plist_manual
-        s << "Or, if you don't want/need a background service you can just run:"
-        s << "  #{f.plist_manual}"
-      end
-
-      # pbpaste is the system clipboard tool on macOS and fails with `tmux` by default
-      # check if this is being run under `tmux` to avoid failing
-      if ENV["TMUX"] && !quiet_system("/usr/bin/pbpaste")
-        s << "" << "WARNING: brew services will fail when run under tmux."
-      end
-    end
-    s.join("\n") + "\n" unless s.empty?
-  end
+  def plist_caveats; end
 
   def plist_path
     destination = if f.plist_startup
@@ -222,3 +180,5 @@ class Caveats
     destination_path/plist_filename
   end
 end
+
+require "extend/os/caveats"

--- a/Library/Homebrew/extend/os/caveats.rb
+++ b/Library/Homebrew/extend/os/caveats.rb
@@ -1,0 +1,1 @@
+require "extend/os/mac/caveats" if OS.mac?

--- a/Library/Homebrew/extend/os/linux/caveats.rb
+++ b/Library/Homebrew/extend/os/linux/caveats.rb
@@ -1,0 +1,3 @@
+class Caveats
+  def plist_caveats; end
+end

--- a/Library/Homebrew/extend/os/linux/caveats.rb
+++ b/Library/Homebrew/extend/os/linux/caveats.rb
@@ -1,3 +1,0 @@
-class Caveats
-  def plist_caveats; end
-end

--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -1,0 +1,46 @@
+class Caveats
+  def plist_caveats
+    s = []
+    if f.plist || (keg&.plist_installed?)
+      plist_domain = f.plist_path.basename(".plist")
+
+      # we readlink because this path probably doesn't exist since caveats
+      # occurs before the link step of installation
+      # Yosemite security measures mildly tighter rules:
+      # https://github.com/Homebrew/legacy-homebrew/issues/33815
+      if !plist_path.file? || !plist_path.symlink?
+        if f.plist_startup
+          s << "To have launchd start #{f.full_name} now and restart at startup:"
+          s << "  sudo brew services start #{f.full_name}"
+        else
+          s << "To have launchd start #{f.full_name} now and restart at login:"
+          s << "  brew services start #{f.full_name}"
+        end
+      # For startup plists, we cannot tell whether it's running on launchd,
+      # as it requires for `sudo launchctl list` to get real result.
+      elsif f.plist_startup
+        s << "To restart #{f.full_name} after an upgrade:"
+        s << "  sudo brew services restart #{f.full_name}"
+      elsif Kernel.system "/bin/launchctl list #{plist_domain} &>/dev/null"
+        s << "To restart #{f.full_name} after an upgrade:"
+        s << "  brew services restart #{f.full_name}"
+      else
+        s << "To start #{f.full_name}:"
+        s << "  brew services start #{f.full_name}"
+      end
+
+      if f.plist_manual
+        s << "Or, if you don't want/need a background service you can just run:"
+        s << "  #{f.plist_manual}"
+      end
+
+      # pbpaste is the system clipboard tool on macOS and fails with `tmux` by default
+      # check if this is being run under `tmux` to avoid failing
+      if ENV["TMUX"] && !quiet_system("/usr/bin/pbpaste")
+        s << "" << "WARNING: brew services will fail when run under tmux."
+      end
+    end
+    s.join("\n") + "\n" unless s.empty?
+  end
+
+end

--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -42,5 +42,4 @@ class Caveats
     end
     s.join("\n") + "\n" unless s.empty?
   end
-
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`plist_caveats` does not apply to Linux so we have to override it to an empty method.