### PR TITLE
Pull Request: add a link to quickly jump to the explanation section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,11 @@
 - [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
-- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
+- [ ] Have you added [an explanation](#explanation) of what your changes do and why you'd like us to include them?
 - [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
 - [ ] Have you successfully run `brew tests` with your changes locally?
 
 -----
+
+**<a name="explanation"></a>Explanation of changes**:
+
+_[change me]_


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added [an explanation](#explanation) of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

**<a name="explanation"></a>Explanation of changes**:

This PR adds an empty ("hidden") link to the section with explanations of changes making it possible to quickly jump to it from anywhere in the discussion (like [so](#explanation)).