### PR TITLE
Cask: require macOS

### DIFF
--- a/Library/Homebrew/cmd/cask.rb
+++ b/Library/Homebrew/cmd/cask.rb
@@ -5,6 +5,7 @@ module Homebrew
   module_function
 
   def cask
+    odie "The cask command requires macOS." unless OS.mac?
     Hbc::CLI.run(*ARGV)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

the hierarchy of `cask` commands requires macOS. Moving it under `extend/os` makes Homebrew/brew compatible with other Operating Systems.