### PR TITLE
Specifies which errant version of Ruby is used in raise.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -9,7 +9,7 @@ RUBY_VERSION_SPLIT = RUBY_VERSION.split "."
 RUBY_X = RUBY_VERSION_SPLIT[0].to_i
 RUBY_Y = RUBY_VERSION_SPLIT[1].to_i
 if RUBY_X < 2 || (RUBY_X == 2 && RUBY_Y < 3)
-  raise "Homebrew must be run under Ruby 2.3!"
+  raise "Homebrew must be run under Ruby 2.3! You're running #{RUBY_VERSION}."
 end
 
 require "pathname"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As [discussed here](https://github.com/Homebrew/brew/pull/3240/files#r145185621), it would be helpful to display which version of Ruby is actually being used in the error message when used in non-2.3 environments. This is especially useful when running commands remotely, such as on CI.

Regarding testing: I didn't see any existing tests (I don't think it'd be easy to test this, as the code is executed at the top level) but if you point me in the right direction I'm sure I could figure it out.