### PR TITLE
vendor-install: use full shasum PATH.

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -81,9 +81,9 @@ fetch() {
     trap - SIGINT
   fi
 
-  if [[ -x "$(which shasum)" ]]
+  if [[ -x "/usr/bin/shasum" ]]
   then
-    sha="$(shasum -a 256 "$CACHED_LOCATION" | cut -d' ' -f1)"
+    sha="$(/usr/bin/shasum -a 256 "$CACHED_LOCATION" | cut -d' ' -f1)"
   elif [[ -x "$(which sha256sum)" ]]
   then
     sha="$(sha256sum "$CACHED_LOCATION" | cut -d' ' -f1)"


### PR DESCRIPTION
Otherwise things can explode if there's a random `shasum`.

See #3281.