### PR TITLE
java_requirement: fix Java 9 version detection

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -11,7 +11,7 @@ class JavaRequirement < Requirement
   end
 
   def initialize(tags)
-    @version = tags.shift if /(\d\.)+\d/ =~ tags.first
+    @version = tags.shift if /(\d+\.)+\d/ =~ tags.first
     super
   end
 
@@ -103,7 +103,7 @@ class JavaRequirement < Requirement
   end
 
   def satisfies_version(java)
-    java_version_s = Utils.popen_read("#{java} -version 2>&1")[/1.\d/]
+    java_version_s = Utils.popen_read("#{java} -version 2>&1")[/\d+.\d/]
     return false unless java_version_s
     java_version = Version.create(java_version_s)
     needed_version = Version.create(version_without_plus)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I went for pretty much the most obvious possible fix here, so feel free to debate/request changes/etc as desired. We don't really need to consider post-period digit with Java 9 onwards, but retaining the existing behaviour there shouldn't cause issues with existing Java dependencies in core _(as far as I can see)_ because 9 > 1.

Obviously the `/(1|9)\.\d/` won't support Java 10 but that problem is likely several years away.

Closes https://github.com/Homebrew/brew/issues/3331.