### PR TITLE
xcode: update to Xcode 9.0.1 on 10.12 and 10.13

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -201,6 +201,7 @@ module OS
       "8.3.2" => { clang: "8.1", clang_build: 802 },
       "8.3.3" => { clang: "8.1", clang_build: 802 },
       "9.0"   => { clang: "9.0", clang_build: 900 },
+      "9.0.1" => { clang: "9.0", clang_build: 900 },
     }.freeze
 
     def compilers_standard?

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -17,13 +17,13 @@ module OS
         when "10.9"  then "6.2"
         when "10.10" then "7.2.1"
         when "10.11" then "8.2.1"
-        when "10.12" then "8.3.3"
-        when "10.13" then "9.0"
+        when "10.12" then "9.0.1"
+        when "10.13" then "9.0.1"
         else
           raise "macOS '#{MacOS.version}' is invalid" unless OS::Mac.prerelease?
 
           # Default to newest known version of Xcode for unreleased macOS versions.
-          "9.0"
+          "9.0.1"
         end
       end
 
@@ -216,8 +216,8 @@ module OS
         # on the older supported platform for that Xcode release, i.e there's no
         # CLT package for 10.11 that contains the Clang version from Xcode 8.
         case MacOS.version
-        when "10.13" then "900.0.37"
-        when "10.12" then "802.0.42"
+        when "10.13" then "900.0.38"
+        when "10.12" then "900.0.38"
         when "10.11" then "800.0.42.1"
         when "10.10" then "700.1.81"
         when "10.9"  then "600.0.57"

--- a/docs/Xcode.md
+++ b/docs/Xcode.md
@@ -12,7 +12,8 @@ Tools available for your platform:
 | 10.9  | 6.2   | 6.2                |
 | 10.10 | 7.2.1 | 7.2                |
 | 10.11 | 8.2.1 | 8.2                |
-| 10.12 | 8.3.3 | 8.3                |
+| 10.12 | 9.0.1 | 9.0.1              |
+| 10.13 | 9.0.1 | 9.0.1              |
 
 ## Compiler version database
 
@@ -73,6 +74,8 @@ Tools available for your platform:
 | 8.3.1 | —       | —       | —            | —          | 8.1 (802.0.41)  | —          |
 | 8.3.2 | —       | —       | —            | —          | 8.1 (802.0.42)  | —          |
 | 8.3.3 | —       | —       | —            | —          | 8.1 (802.0.42)  | —          |
+| 9.0.0 | —       | —       | —            | —          | 9.0 (900.0.37)  | —          |
+| 9.0.1 | —       | —       | —            | —          | 9.0 (900.0.38)  | —          |
 
 ## References to Xcode and compiler versions in code
 When a new Xcode release is made, the following things need to be


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Xcode 9.0.1 and the 9.0.1 CLT are out for both 10.12 and 10.13.