### PR TITLE
build-environment: OS-specific environment keys

### DIFF
--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -34,7 +34,7 @@ end
 module Homebrew
   module_function
 
-  def build_env_keys(env)
+  def common_build_env_keys
     %w[
       CC CXX LD OBJC OBJCXX
       HOMEBREW_CC HOMEBREW_CXX
@@ -46,7 +46,13 @@ module Homebrew
       HOMEBREW_SDKROOT HOMEBREW_BUILD_FROM_SOURCE
       MAKE GIT CPP
       ACLOCAL_PATH PATH CPATH
-    ].select { |key| env.key?(key) }
+    ]
+  end
+
+  def os_specific_build_env_keys; end
+
+  def build_env_keys(env)
+    (common_build_env_keys + os_specific_build_env_keys).select { |key| env.key?(key) }
   end
 
   def dump_build_env(env, f = $stdout)
@@ -64,3 +70,5 @@ module Homebrew
     end
   end
 end
+
+require "extend/os/build_environment"

--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -49,7 +49,9 @@ module Homebrew
     ]
   end
 
-  def os_specific_build_env_keys; end
+  def os_specific_build_env_keys
+    []
+  end
 
   def build_env_keys(env)
     (common_build_env_keys + os_specific_build_env_keys).select { |key| env.key?(key) }

--- a/Library/Homebrew/extend/os/build_environment.rb
+++ b/Library/Homebrew/extend/os/build_environment.rb
@@ -1,0 +1,5 @@
+if OS.mac?
+  require "extend/os/mac/build_environment"
+elsif OS.linux?
+  require "extend/os/linux/build_environment"
+end

--- a/Library/Homebrew/extend/os/linux/build_environment.rb
+++ b/Library/Homebrew/extend/os/linux/build_environment.rb
@@ -1,0 +1,7 @@
+module Homebrew
+  module_function
+
+  def os_specific_build_env_keys
+    %w[LD_LIBRARY_PATH LD_RUN_PATH LD_PRELOAD LIBRARY_PATH]
+  end
+end

--- a/Library/Homebrew/extend/os/mac/build_environment.rb
+++ b/Library/Homebrew/extend/os/mac/build_environment.rb
@@ -1,0 +1,7 @@
+module Homebrew
+  module_function
+
+  def os_specific_build_env_keys
+    []
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

CC @sjackman 

Provide a way to deal with OS-specific build environment variables. On Linux, those are: LD_LIBRARY_PATH, LD_RUN_PATH, LD_PRELOAD, LIBRARY_PATH.