### PR TITLE
java_requirement: support prompting users to install legacy Java casks

### DIFF
--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -1,12 +1,29 @@
 class JavaRequirement < Requirement
-  cask "java"
-
   env do
     env_java_common
     env_oracle_jdk || env_apple
   end
 
+  # A strict Java 8 requirement (1.8) should prompt the user to install
+  # the legacy java8 cask because the current version, Java 9, is not
+  # completely backwards compatible, and contains breaking changes such as
+  # strong encapsulation of JDK-internal APIs and a modified version scheme
+  # (9.0 not 1.9).
+  def cask
+    if @version.nil? || @version.to_s.end_with?("+") ||
+       @version.to_f >= JAVA_CASK_MAP.keys.max.to_f
+      JAVA_CASK_MAP.fetch(JAVA_CASK_MAP.keys.max)
+    else
+      JAVA_CASK_MAP.fetch("1.8")
+    end
+  end
+
   private
+
+  JAVA_CASK_MAP = {
+    "1.8" => "caskroom/versions/java8",
+    "9.0" => "java",
+  }.freeze
 
   def possible_javas
     javas = []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This adds support for prompting the user to install an older, "legacy" java cask when required.

Instead of always attempting to satisfy the requirement with the default java cask, currently Java 9, this prompts the user to install a specific java cask version as needed.