### PR TITLE
build_environment: add Linux-specific environment variables

### DIFF
--- a/Library/Homebrew/build_environment.rb
+++ b/Library/Homebrew/build_environment.rb
@@ -46,6 +46,7 @@ module Homebrew
       HOMEBREW_SDKROOT HOMEBREW_BUILD_FROM_SOURCE
       MAKE GIT CPP
       ACLOCAL_PATH PATH CPATH
+      LD_LIBRARY_PATH LD_RUN_PATH LD_PRELOAD LIBRARY_PATH
     ].select { |key| env.key?(key) }
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

supersedes #3341 

Add Linux-specific environment variables to `build_env_keys` method:

- `LD_LIBRARY_PATH`
- `LD_RUN_PATH`
- `LD_PRELOAD`
- `LIBRARY_PATH`

CC @sjackman @MikeMcQuaid 
