### PR TITLE
Ignore out-of-date XCode on CircleCI

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -53,11 +53,10 @@ module Homebrew
         return unless MacOS::Xcode.installed?
         return unless MacOS::Xcode.outdated?
 
-        # Travis CI images are going to end up outdated so don't complain when
+        # CI images are going to end up outdated so don't complain when
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
-        # repository. This only needs to support whatever CI provider
-        # Homebrew/brew is currently using.
-        return if ENV["TRAVIS"]
+        # repository.
+        return if ENV["CIRCLECI"] || ENV["TRAVIS"]
 
         message = <<~EOS
           Your Xcode (#{MacOS::Xcode.version}) is outdated.
@@ -81,11 +80,10 @@ module Homebrew
         return unless MacOS::CLT.installed?
         return unless MacOS::CLT.outdated?
 
-        # Travis CI images are going to end up outdated so don't complain when
+        # CI images are going to end up outdated so don't complain when
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
-        # repository. This only needs to support whatever CI provider
-        # Homebrew/brew is currently using.
-        return if ENV["TRAVIS"]
+        # repository.
+        return if ENV["CIRCLECI"] || ENV["TRAVIS"]
 
         <<~EOS
           A newer Command Line Tools release is available.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Do not check for out-of-date XCode or CLT on CircleCI.
Suppress the error:
```
Warning: Your Xcode (9.0) is outdated.
Please update to Xcode 9.0.1 (or delete it).
```