### PR TITLE
lines_cop: Fix detection of negated expression

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -316,8 +316,10 @@ module RuboCop
       end
 
       # Check if negation is present in the given node
-      def negated?(node)
-        method_called?(node, :!)
+      def expression_negated?(node)
+        return false if node.parent.nil?
+        return false unless node.parent.method_name.equal?(:!)
+        offending_node(node.parent)
       end
 
       # Return all the caveats' string nodes in an array

--- a/Library/Homebrew/rubocops/lines_cop.rb
+++ b/Library/Homebrew/rubocops/lines_cop.rb
@@ -94,12 +94,12 @@ module RuboCop
           end
 
           find_instance_method_call(body_node, :build, :with?) do |method|
-            next unless negated?(method.parent)
+            next unless expression_negated?(method)
             problem "Don't negate 'build.with?': use 'build.without?'"
           end
 
           find_instance_method_call(body_node, :build, :without?) do |method|
-            next unless negated?(method.parent)
+            next unless expression_negated?(method)
             problem "Don't negate 'build.without?': use 'build.with?'"
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
In chained conditional statements if any one condition is negated, false positives were being raised. 
Example: `build.with?("libcxx") || !MacOS::CLT.installed?` in `llvm` formula