### PR TITLE
Unhide readall and update-reset from manpage.

### DIFF
--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -1,11 +1,9 @@
-#: @hide_from_man_page
 #:  * `readall` [tap]:
-#:    Import all formulae from specified taps (defaults to
-#:    all installed taps).
+#:    Import all formulae from specified taps (defaults to all installed taps).
 #:
-#:    This can be useful for debugging issues across all formulae
-#:    when making significant changes to `formula.rb`,
-#:    or to determine if any current formulae have Ruby issues.
+#:    This can be useful for debugging issues across all formulae when making
+#:    significant changes to `formula.rb`, testing the performance of loading
+#:    all formulae or to determine if any current formulae have Ruby issues.
 
 require "readall"
 

--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -1,7 +1,7 @@
-#: @hide_from_man_page
 #:  * `update-reset`:
 #:    Fetches and resets Homebrew and all tap repositories using `git`(1) to
-#:    their latest `origin/master`.
+#:    their latest `origin/master`. Note this will destroy all your uncommitted
+#:    or committed changes.
 
 homebrew-update-reset() {
   local DIR

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -386,6 +386,13 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--dry-run` or `-n` is passed, show what would be removed, but do not
     actually remove anything.
 
+  * `readall` [tap]:
+    Import all formulae from specified taps (defaults to all installed taps).
+
+    This can be useful for debugging issues across all formulae when making
+    significant changes to `formula.rb`, testing the performance of loading
+    all formulae or to determine if any current formulae have Ruby issues.
+
   * `reinstall` `formula`:
     Uninstall and then install `formula`.
 
@@ -552,6 +559,11 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--force` (or `-f`) is specified then always do a slower, full update check even
     if unnecessary.
+
+  * `update-reset`:
+    Fetches and resets Homebrew and all tap repositories using `git`(1) to
+    their latest `origin/master`. Note this will destroy all your uncommitted
+    or committed changes.
 
   * `upgrade` [`install-options`] [`--cleanup`] [`--fetch-HEAD`] [`formulae`]:
     Upgrade outdated, unpinned brews.

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "September 2017" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "October 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "September 2017" "Homebrew" "brew"
+.TH "BREW" "1" "October 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -398,6 +398,13 @@ Remove dead symlinks from the Homebrew prefix\. This is generally not needed, bu
 If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, show what would be removed, but do not actually remove anything\.
 .
 .TP
+\fBreadall\fR [tap]
+Import all formulae from specified taps (defaults to all installed taps)\.
+.
+.IP
+This can be useful for debugging issues across all formulae when making significant changes to \fBformula\.rb\fR, testing the performance of loading all formulae or to determine if any current formulae have Ruby issues\.
+.
+.TP
 \fBreinstall\fR \fIformula\fR
 Uninstall and then install \fIformula\fR\.
 .
@@ -570,6 +577,10 @@ If \fB\-\-merge\fR is specified then \fBgit merge\fR is used to include updates 
 .
 .IP
 If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full update check even if unnecessary\.
+.
+.TP
+\fBupdate\-reset\fR
+Fetches and resets Homebrew and all tap repositories using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
 .TP
 \fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fIformulae\fR]


### PR DESCRIPTION
These are both tools that end-users can find useful on occasion so it doesn't make sense to hide them.

We may want to think about fleshing out or changing these descriptions if they are targeted at end-users.