### PR TITLE
Fix issue where keychain github credentials wouldn't work

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -87,8 +87,8 @@ module GitHub
   def api_credentials_type
     token, username = api_credentials
     return :none if !token || token.empty?
-    return :keychain if !username || username.empty?
-    :environment
+    return :environment if !username || username.empty?
+    :keychain
   end
 
   def api_credentials_error_message(response_headers, needed_scopes)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). **N/A**
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This fixes #3363 

I would also suggest that lines 32-52 of `Library/Homebrew/utils/github.rb` be rewritten to use `:environment` and `:keychain` rather than re-reading the environment variable (as this would have avoided some of the confusion that this bug caused), although I could be missing something that would mean this wouldn't work. (I would be happy to either add that change to this this pull request or create a new one for the purpose as you see fit).