### PR TITLE
WIP: Implement on-disk formula cache

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -32,6 +32,7 @@
 #:    List all pinned taps.
 
 require "tap"
+require "formula_store"
 
 module Homebrew
   module_function
@@ -52,6 +53,8 @@ module Homebrew
         tap.install clone_target: ARGV.named[1],
                     full_clone: full_clone?,
                     quiet: ARGV.quieter?
+
+        FormulaStore.store_tap tap
       rescue TapRemoteMismatchError => e
         odie e
       rescue TapAlreadyTappedError, TapAlreadyUnshallowError # rubocop:disable Lint/HandleExceptions

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -54,7 +54,7 @@ module Homebrew
                     full_clone: full_clone?,
                     quiet: ARGV.quieter?
 
-        FormulaStore.store_tap tap
+        FormulaStore.store_tap tap if ENV["HOMEBREW_EXPERIMENTAL_FORMULA_STORE"]
       rescue TapRemoteMismatchError => e
         odie e
       rescue TapAlreadyTappedError, TapAlreadyUnshallowError # rubocop:disable Lint/HandleExceptions

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -2,6 +2,7 @@
 #:    Remove a tapped repository.
 
 require "tap"
+require "formula_store"
 
 module Homebrew
   module_function
@@ -12,6 +13,7 @@ module Homebrew
     ARGV.named.each do |tapname|
       tap = Tap.fetch(tapname)
       raise "untapping #{tap} is not allowed" if tap.core_tap?
+      FormulaStore.unstore_tap tap
       tap.uninstall
     end
   end

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -13,7 +13,7 @@ module Homebrew
     ARGV.named.each do |tapname|
       tap = Tap.fetch(tapname)
       raise "untapping #{tap} is not allowed" if tap.core_tap?
-      FormulaStore.unstore_tap tap
+      FormulaStore.unstore_tap tap if ENV["HOMEBREW_EXPERIMENTAL_FORMULA_STORE"]
       tap.uninstall
     end
   end

--- a/Library/Homebrew/cmd/update-store.rb
+++ b/Library/Homebrew/cmd/update-store.rb
@@ -1,0 +1,22 @@
+#: @hide_from_man_page
+#:  * `update-store` [tap]:
+#:    Update formula store for all formulae in a tap (defaults to all taps).
+
+require "tap"
+require "formula_store"
+
+module Homebrew
+  module_function
+
+  def update_store
+    taps = if ARGV.named.empty?
+      Tap
+    else
+      [Tap.fetch(ARGV.named.first)]
+    end
+    taps.each do |tap|
+      FormulaStore.store_tap tap
+    end
+    FormulaStore.save_store
+  end
+end

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -571,6 +571,7 @@ EOS
         (-n "$HOMEBREW_DEVELOPER" && -z "$HOMEBREW_UPDATE_PREINSTALL") ]]
   then
     unset HOMEBREW_RUBY_PATH
+    brew update-store
     brew update-report "$@"
     return $?
   elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -571,7 +571,10 @@ EOS
         (-n "$HOMEBREW_DEVELOPER" && -z "$HOMEBREW_UPDATE_PREINSTALL") ]]
   then
     unset HOMEBREW_RUBY_PATH
-    brew update-store
+    if [[ -n "$HOMEBREW_EXPERIMENTAL_FORMULA_STORE" ]]
+    then
+        brew update-store
+    fi
     brew update-report "$@"
     return $?
   elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]]

--- a/Library/Homebrew/formula_store.rb
+++ b/Library/Homebrew/formula_store.rb
@@ -1,0 +1,73 @@
+module FormulaStore
+  class << self
+    STORE_FILE = Pathname.new HOMEBREW_CACHE/"formula_store.bin"
+
+    @_at_exit_registered = false
+
+    def _register_at_exit
+      at_exit { save_store }
+      @_at_exit_registered = true
+    end
+
+    def register_at_exit
+      _register_at_exit unless @_at_exit_registered
+    end
+
+    def load_store
+      return {} unless STORE_FILE.exist?
+      Marshal.load(File.binread(STORE_FILE))
+    end
+
+    def store
+      @store ||= load_store
+    end
+
+    def save_store
+      File.open(STORE_FILE, 'wb') {|f| f.write(Marshal.dump(store))}
+    end
+
+    def stored?(path)
+      store.has_key?(path.to_s)
+    end
+
+    def store_formula(path)
+      return store[path] if stored?(path) and store[path.to_s]["mtime"] == path.mtime.to_i
+
+      contents = path.open("r") { |f| Formulary.ensure_utf8_encoding(f).read }
+
+      parts = contents.split(/^__END__$/)
+      mod = <<-EOS
+        module FormulaNamespace#{Digest::MD5.hexdigest(path.to_s)}
+          #{parts[0]}
+        end
+      EOS
+
+      byte_code = RubyVM::InstructionSequence.new(mod, path.basename.to_s, path.realpath.to_s)
+
+      register_at_exit
+
+      store[path.realpath.to_s] = {
+        "byte_code" => byte_code.to_binary,
+        "extra_data" => parts[1],
+        "mtime" => path.mtime.to_i
+      }
+    end
+
+    def unstore_formula(path)
+      register_at_exit
+      store.delete path
+    end
+
+    def store_tap(tap)
+      tap.formula_files.each do |file|
+        store_formula file
+      end
+    end
+
+    def unstore_tap(tap)
+      tap.formula_files.each do |file|
+        unstore_formula file
+      end
+    end
+  end
+end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -51,7 +51,7 @@ module Formulary
       raise "Formula loading disabled by HOMEBREW_DISABLE_LOAD_FORMULA!"
     end
 
-    mod = if FormulaStore.stored?(path)
+    mod = if ENV["HOMEBREW_EXPERIMENTAL_FORMULA_STORE"] && FormulaStore.stored?(path)
       load_module_from_store(path, namespace)
     else
       load_module_from_file(name, path, contents, namespace)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This PR addresses issue #3007. One of the reasons commands like `brew uses` and `brew readall` may be slow is because they load all formulae in all installed taps. The slowness is a result of ruby having to open and interpret thousands of formulae. In order to speed this process up, this PR adds functionality which pre-compiles all formulae and stores the ruby byte code on-disk in a marshaled hash. 

The formula store is saved at `HOMEBREW_CACHE/formula_store.bin`. The format of the formula store is an on-disk marshaled hash with the following format:
```
{
  <path to formula1> => {
    "byte_code" => <bytecode of formula stored in binary>,
    "extra_data" => <formula data after the __END__>,
    "mtime" => <integer of modified time>
  },
  ...
  <path to formulaN> => {
    "byte_code" => <bytecode of formula stored in binary>,
    "extra_data" => <formula data after the __END__>,
    "mtime" => <integer of modified time>
  },
}
```

Potential cache invalidation issues have been solved by storing the modified time of each formula in the formula store. When loading formulae from the store, the modified time is compared with the modified time of the file. If they are different, the store is updated so it will be up-to-date during the next run. Additionally, the store is updated when `brew tap`, `brew untap`, or `brew update` are run. 

Local testing has shown an approximate 40% performance gain when running commands which iterate over all loaded formula. 

An additional command, `brew update-store`, was added for generating/updating the store.