### PR TITLE
lock.sh: suppress error output when looking for flock

### DIFF
--- a/Library/Homebrew/utils/lock.sh
+++ b/Library/Homebrew/utils/lock.sh
@@ -45,7 +45,7 @@ _create_lock() {
   if [[ -x "$ruby" ]] && "$ruby" -e "exit(RUBY_VERSION >= '1.8.7')"
   then
     "$ruby" -e "File.new($lock_fd).flock(File::LOCK_EX | File::LOCK_NB) || exit(1)"
-  elif [[ -x "$(which flock)" ]]
+  elif [[ -x "$(which flock 2>/dev/null)" ]]
   then
     flock -n "$lock_fd"
   elif [[ -x "$python" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes (on centos6):
> which: no flock in (/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)

The checks for ruby and python at the same location have already their error message suppressed, so I think it makes sense to suppress that one too.

cc @sjackman 