### PR TITLE
lines_cop: add missing e.g. clang++ regex SOL.

### DIFF
--- a/Library/Homebrew/rubocops/lines_cop.rb
+++ b/Library/Homebrew/rubocops/lines_cop.rb
@@ -178,7 +178,7 @@ module RuboCop
             param = parameters(method).first
             if match = regex_match_group(param, %r{^(/usr/bin/)?(gcc|llvm-gcc|clang)\s?})
               problem "Use \"\#{ENV.cc}\" instead of hard-coding \"#{match[2]}\""
-            elsif match = regex_match_group(param, %r{(/usr/bin/)?((g|llvm-g|clang)\+\+)\s?})
+            elsif match = regex_match_group(param, %r{^(/usr/bin/)?((g|llvm-g|clang)\+\+)\s?})
               problem "Use \"\#{ENV.cxx}\" instead of hard-coding \"#{match[2]}\""
             end
           end


### PR DESCRIPTION
You need a start of line check in this regex (like was added in the others) to allow things like `#{bin}/clang++`.

CC @ilovezfs @GauthamGoli