### PR TITLE
Fix and cleanup some PATH usage.

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -50,11 +50,6 @@ begin
   path = PATH.new(ENV["PATH"])
   homebrew_path = PATH.new(ENV["HOMEBREW_PATH"])
 
-  # Add contributed commands to PATH before checking.
-  tap_cmds = Pathname.glob(Tap::TAP_DIRECTORY/"*/*/cmd")
-  path.append(tap_cmds)
-  homebrew_path.append(tap_cmds)
-
   # Add SCM wrappers.
   path.append(HOMEBREW_SHIMS_PATH/"scm")
   homebrew_path.append(HOMEBREW_SHIMS_PATH/"scm")
@@ -93,8 +88,14 @@ begin
     system(HOMEBREW_BREW_FILE, "uninstall", "--force", "brew-cask")
   end
 
-  # External commands expect a normal PATH
-  ENV["PATH"] = homebrew_path unless internal_cmd
+  unless internal_cmd
+    # Add contributed commands to PATH before checking.
+    tap_cmds = Pathname.glob(Tap::TAP_DIRECTORY/"*/*/cmd")
+    homebrew_path.append(tap_cmds)
+
+    # External commands expect a normal PATH
+    ENV["PATH"] = homebrew_path
+  end
 
   if internal_cmd
     Homebrew.send cmd.to_s.tr("-", "_").downcase

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -94,6 +94,7 @@ class Requirement
     # PATH.
     parent = satisfied_result_parent
     return unless parent
+    return if ["#{HOMEBREW_PREFIX}/bin", "#{HOMEBREW_PREFIX}/bin"].include?(parent.to_s)
     return if PATH.new(ENV["PATH"]).include?(parent.to_s)
     ENV.prepend_path("PATH", parent)
   end

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -77,7 +77,11 @@ class Requirement
 
   def satisfied_result_parent
     return unless @satisfied_result.is_a?(Pathname)
-    @satisfied_result.resolved_path.parent
+    parent = @satisfied_result.resolved_path.parent
+    if parent.to_s =~ %r{^#{Regexp.escape(HOMEBREW_CELLAR)}/([\w+-.@]+)/[^/]+/(s?bin)/?$}
+      parent = HOMEBREW_PREFIX/"opt/#{Regexp.last_match(1)}/#{Regexp.last_match(2)}"
+    end
+    parent
   end
 
   # Overriding #modify_build_environment is deprecated.

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -95,7 +95,7 @@ class Requirement
     parent = satisfied_result_parent
     return unless parent
     return if PATH.new(ENV["PATH"]).include?(parent.to_s)
-    ENV.append_path("PATH", parent)
+    ENV.prepend_path("PATH", parent)
   end
 
   def env

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -138,7 +138,7 @@ describe Requirement do
       end
 
       it "infers path from #satisfy result" do
-        expect(ENV).to receive(:append_path).with("PATH", Pathname.new("/foo/bar"))
+        expect(ENV).to receive(:prepend_path).with("PATH", Pathname.new("/foo/bar"))
         subject.satisfied?
         subject.modify_build_environment
       end


### PR DESCRIPTION
- brew.rb: cleanup PATH setup. Avoid adding all the tap commands to the PATH when not necessary.
- requirement: convert Cellar path to opt path.
- requirement: prepend rather than append PATH. Otherwise this ends up behind e.g. `/usr/bin` so is pretty useless. Fixes #2875.