### PR TITLE
ENV/std: fully extend from HOMEBREW_PATH.

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -9,14 +9,11 @@ module Stdenv
   SAFE_CFLAGS_FLAGS = "-w -pipe".freeze
   DEFAULT_FLAGS = "-march=core2 -msse4".freeze
 
-  def self.extended(base)
-    return if ORIGINAL_PATHS.include? HOMEBREW_PREFIX/"bin"
-    base.prepend_path "PATH", "#{HOMEBREW_PREFIX}/bin"
-  end
-
   # @private
   def setup_build_environment(formula = nil)
     super
+
+    PATH.new(ENV["HOMEBREW_PATH"]).each { |p| prepend_path "PATH", p }
 
     # Set the default pkg-config search path, overriding the built-in paths
     # Anything in PKG_CONFIG_PATH is searched before paths in this variable


### PR DESCRIPTION
Rather than just re-adding HOMEBREW_PREFIX/bin if it's missing re-add everything from HOMEBREW_PATH. This works well with or without environment filtering being enabled but with environment filtering it ensures that ENV/std just builds on the original user environment.