### PR TITLE
bump-formula-pr: always use HOMEBREW_PATH.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -109,6 +109,10 @@ module Homebrew
   end
 
   def bump_formula_pr
+    # As this command is simplifying user run commands then let's just use a
+    # user path, too.
+    ENV["PATH"] = ENV["HOMEBREW_PATH"]
+
     formula = ARGV.formulae.first
 
     if formula


### PR DESCRIPTION
Fixes this when using environment filtering.