### PR TITLE
Check that a single uninstall_* and zap stanza is defined

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/audit.rb
+++ b/Library/Homebrew/cask/lib/hbc/audit.rb
@@ -53,21 +53,33 @@ module Hbc
     def check_single_pre_postflight
       odebug "Auditing preflight and postflight stanzas"
 
-      add_warning "only a single preflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.key?(:preflight) } > 1
+      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.key?(:preflight) } > 1
+        add_warning "only a single preflight stanza is allowed"
+      end
 
-      add_warning "only a single postflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:postflight) } > 1
+      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:postflight) } > 1
+        add_warning "only a single postflight stanza is allowed"
+      end
     end
 
     def check_single_uninstall_zap
       odebug "Auditing single uninstall_* and zap stanzas"
 
-      add_warning "only a single uninstall stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Uninstall) } > 1
+      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Uninstall) } > 1
+        add_warning "only a single uninstall stanza is allowed"
+      end
 
-      add_warning "only a single uninstall_preflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.key?(:uninstall_preflight) } > 1
+      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.key?(:uninstall_preflight) } > 1
+        add_warning "only a single uninstall_preflight stanza is allowed"
+      end
 
-      add_warning "only a single uninstall_postflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:uninstall_postflight) } > 1
+      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:uninstall_postflight) } > 1
+        add_warning "only a single uninstall_postflight stanza is allowed"
+      end
 
-      add_warning "only a single zap stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Zap) } > 1
+      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Zap) } > 1
+        add_warning "only a single zap stanza is allowed"
+      end
     end
 
     def check_required_stanzas

--- a/Library/Homebrew/cask/lib/hbc/audit.rb
+++ b/Library/Homebrew/cask/lib/hbc/audit.rb
@@ -31,6 +31,7 @@ module Hbc
       check_generic_artifacts
       check_token_conflicts
       check_download
+      check_single_pre_postflight
       check_single_uninstall_zap
       self
     rescue StandardError => e
@@ -49,20 +50,24 @@ module Hbc
 
     private
 
+    def check_single_pre_postflight
+      odebug "Auditing preflight and postflight stanzas"
+
+      add_warning "only a single preflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.key?(:preflight) } > 1
+
+      add_warning "only a single postflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:postflight) } > 1
+    end
+
     def check_single_uninstall_zap
       odebug "Auditing single uninstall_* and zap stanzas"
 
-      uninstalls = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::Uninstall) }
-      add_warning "there should be a single uninstall stanza" unless uninstalls.size <= 1
+      add_warning "only a single uninstall stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Uninstall) } > 1
 
-      uninstalls_preflight = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.keys.include?("uninstall_preflight") }
-      add_warning "there should be a single uninstall_preflight stanza" unless uninstalls_preflight.size <= 1
+      add_warning "only a single uninstall_preflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.key?(:uninstall_preflight) } > 1
 
-      uninstalls_postflight = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.keys.include?("uninstall_postflight") }
-      add_warning "there should be a single uninstall_postflight stanza" unless uninstalls_postflight.size <= 1
+      add_warning "only a single uninstall_postflight stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:uninstall_postflight) } > 1
 
-      zaps = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::Zap) }
-      add_warning "there should be a single zap stanza" unless zaps.size <= 1
+      add_warning "only a single zap stanza is allowed" if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Zap) } > 1
     end
 
     def check_required_stanzas

--- a/Library/Homebrew/cask/lib/hbc/audit.rb
+++ b/Library/Homebrew/cask/lib/hbc/audit.rb
@@ -31,6 +31,7 @@ module Hbc
       check_generic_artifacts
       check_token_conflicts
       check_download
+      check_single_uninstall_zap
       self
     rescue StandardError => e
       odebug "#{e.message}\n#{e.backtrace.join("\n")}"
@@ -47,6 +48,22 @@ module Hbc
     end
 
     private
+
+    def check_single_uninstall_zap
+      odebug "Auditing single uninstall_* and zap stanzas"
+
+      uninstalls = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::Uninstall) }
+      add_warning "there should be a single uninstall stanza" unless uninstalls.size <= 1
+
+      uninstalls_preflight = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::PreflightBlock) && k.directives.keys.include?("uninstall_preflight") }
+      add_warning "there should be a single uninstall_preflight stanza" unless uninstalls_preflight.size <= 1
+
+      uninstalls_postflight = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.keys.include?("uninstall_postflight") }
+      add_warning "there should be a single uninstall_postflight stanza" unless uninstalls_postflight.size <= 1
+
+      zaps = cask.artifacts.find_all { |k| k.is_a?(Hbc::Artifact::Zap) }
+      add_warning "there should be a single zap stanza" unless zaps.size <= 1
+    end
 
     def check_required_stanzas
       odebug "Auditing required stanzas"

--- a/Library/Homebrew/cask/lib/hbc/audit.rb
+++ b/Library/Homebrew/cask/lib/hbc/audit.rb
@@ -57,9 +57,8 @@ module Hbc
         add_warning "only a single preflight stanza is allowed"
       end
 
-      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:postflight) } > 1
-        add_warning "only a single postflight stanza is allowed"
-      end
+      return unless cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::PostflightBlock) && k.directives.key?(:postflight) } > 1
+      add_warning "only a single postflight stanza is allowed"
     end
 
     def check_single_uninstall_zap
@@ -77,9 +76,8 @@ module Hbc
         add_warning "only a single uninstall_postflight stanza is allowed"
       end
 
-      if cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Zap) } > 1
-        add_warning "only a single zap stanza is allowed"
-      end
+      return unless cask.artifacts.count { |k| k.is_a?(Hbc::Artifact::Zap) } > 1
+      add_warning "only a single zap stanza is allowed"
     end
 
     def check_required_stanzas

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -91,6 +91,120 @@ describe Hbc::Audit, :cask do
       end
     end
 
+    describe "preflight stanza checks" do
+      let(:error_msg) { "only a single preflight stanza is allowed" }
+
+      context "when the cask has no preflight stanza" do
+        let(:cask_token) { "with-zap-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has only one preflight stanza" do
+        let(:cask_token) { "with-preflight" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has multiple preflight stanzas" do
+        let(:cask_token) { "with-preflight-multi" }
+        it { is_expected.to warn_with(error_msg) }
+      end
+    end
+
+    describe "uninstall_postflight stanza checks" do
+      let(:error_msg) { "only a single postflight stanza is allowed" }
+
+      context "when the cask has no postflight stanza" do
+        let(:cask_token) { "with-zap-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has only one postflight stanza" do
+        let(:cask_token) { "with-postflight" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has multiple postflight stanzas" do
+        let(:cask_token) { "with-postflight-multi" }
+        it { is_expected.to warn_with(error_msg) }
+      end
+    end
+
+    describe "uninstall stanza checks" do
+      let(:error_msg) { "only a single uninstall stanza is allowed" }
+
+      context "when the cask has no uninstall stanza" do
+        let(:cask_token) { "with-zap-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has only one uninstall stanza" do
+        let(:cask_token) { "with-uninstall-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has multiple uninstall stanzas" do
+        let(:cask_token) { "with-uninstall-multi" }
+        it { is_expected.to warn_with(error_msg) }
+      end
+    end
+
+    describe "uninstall_preflight stanza checks" do
+      let(:error_msg) { "only a single uninstall_preflight stanza is allowed" }
+
+      context "when the cask has no uninstall_preflight stanza" do
+        let(:cask_token) { "with-zap-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has only one uninstall_preflight stanza" do
+        let(:cask_token) { "with-uninstall-preflight" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has multiple uninstall_preflight stanzas" do
+        let(:cask_token) { "with-uninstall-preflight-multi" }
+        it { is_expected.to warn_with(error_msg) }
+      end
+    end
+
+    describe "uninstall_postflight stanza checks" do
+      let(:error_msg) { "only a single uninstall_postflight stanza is allowed" }
+
+      context "when the cask has no uninstall_postflight stanza" do
+        let(:cask_token) { "with-zap-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has only one uninstall_postflight stanza" do
+        let(:cask_token) { "with-uninstall-postflight" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has multiple uninstall_postflight stanzas" do
+        let(:cask_token) { "with-uninstall-postflight-multi" }
+        it { is_expected.to warn_with(error_msg) }
+      end
+    end
+
+    describe "zap stanza checks" do
+      let(:error_msg) { "only a single zap stanza is allowed" }
+
+      context "when the cask has no zap stanza" do
+        let(:cask_token) { "with-uninstall-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has only one zap stanza" do
+        let(:cask_token) { "with-zap-rmdir" }
+        it { should_not warn_with(error_msg) }
+      end
+
+      context "when the cask has multiple zap stanzas" do
+        let(:cask_token) { "with-zap-multi" }
+        it { is_expected.to warn_with(error_msg) }
+      end
+    end
+
     describe "version checks" do
       let(:error_msg) { "you should use version :latest instead of version 'latest'" }
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
@@ -7,7 +7,9 @@ cask 'with-postflight-multi' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  postflight do end
+  postflight do
+  end
 
-  postflight do end
+  postflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
@@ -1,0 +1,13 @@
+cask 'with-postflight-multi' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  postflight do end
+
+  postflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
@@ -1,0 +1,11 @@
+cask 'with-postflight' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  postflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
@@ -7,5 +7,6 @@ cask 'with-postflight' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  postflight do end
+  postflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
@@ -7,7 +7,9 @@ cask 'with-preflight-multi' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  preflight do end
+  preflight do
+  end
 
-  preflight do end
+  preflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
@@ -1,0 +1,13 @@
+cask 'with-preflight-multi' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  preflight do end
+
+  preflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
@@ -7,5 +7,6 @@ cask 'with-preflight' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  preflight do end
+  preflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
@@ -1,0 +1,11 @@
+cask 'with-preflight' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  preflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
@@ -1,0 +1,13 @@
+cask 'with-uninstall-multi' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  uninstall rmdir: "#{TEST_TMPDIR}/empty_directory_path"
+
+  uninstall delete: "#{TEST_TMPDIR}/empty_directory_path"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
@@ -7,7 +7,9 @@ cask 'with-uninstall-postflight-multi' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  uninstall_postflight do end
+  uninstall_postflight do
+  end
 
-  uninstall_postflight do end
+  uninstall_postflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
@@ -1,0 +1,13 @@
+cask 'with-uninstall-postflight-multi' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  uninstall_postflight do end
+
+  uninstall_postflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
@@ -7,5 +7,6 @@ cask 'with-uninstall-postflight' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  uninstall_postflight do end
+  uninstall_postflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
@@ -1,0 +1,11 @@
+cask 'with-uninstall-postflight' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  uninstall_postflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
@@ -7,7 +7,9 @@ cask 'with-uninstall-preflight-multi' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  uninstall_preflight do end
+  uninstall_preflight do
+  end
 
-  uninstall_preflight do end
+  uninstall_preflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
@@ -1,0 +1,13 @@
+cask 'with-uninstall-preflight-multi' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  uninstall_preflight do end
+
+  uninstall_preflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
@@ -7,5 +7,6 @@ cask 'with-uninstall-preflight' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  uninstall_preflight do end
+  uninstall_preflight do
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
@@ -1,0 +1,11 @@
+cask 'with-uninstall-preflight' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  uninstall_preflight do end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
@@ -1,0 +1,13 @@
+cask 'with-zap-multi' do
+  version '1.2.3'
+  sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  homepage 'http://example.com/fancy-pkg'
+
+  pkg 'MyFancyPkg/Fancy.pkg'
+
+  zap rmdir: "#{TEST_TMPDIR}/empty_directory_path"
+
+  zap delete: "#{TEST_TMPDIR}/empty_directory_path"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This pull requests fixes caskroom/homebrew-cask#23885 by checking that only a single `uninstall` and `zap` stanza is present in the Cask. I've also extended it to check the `*preflight` and `*postflight` stanzas as well.
~I don't yet know how to write Ruby tests, so I've not attached any.~ Tests have been included for all stanzas.

Please review, and thanks for your comments!
