### PR TITLE
Create login shells

### DIFF
--- a/Library/Homebrew/cmd/sh.rb
+++ b/Library/Homebrew/cmd/sh.rb
@@ -36,6 +36,6 @@ module Homebrew
       When done, type `exit'.
     EOS
     $stdout.flush
-    exec ENV["SHELL"]
+    exec ENV["SHELL"], "--login"
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -157,7 +157,7 @@ def interactive_shell(f = nil)
     FileUtils.touch "#{ENV["HOME"]}/.zshrc"
   end
 
-  Process.wait fork { exec ENV["SHELL"] }
+  Process.wait fork { exec ENV["SHELL"], "--login" }
 
   return if $CHILD_STATUS.success?
   raise "Aborted due to non-zero exit status (#{$CHILD_STATUS.exitstatus})" if $CHILD_STATUS.exited?


### PR DESCRIPTION
This means that `brew sh`, `brew install -i` and `brew install -d` shells end up reading the same initialisation files by default as they do when opened in Terminal.app (which uses login shells).