### PR TITLE
bump-formula-pr: add --no-browse option.

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -726,6 +726,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--message=``message` is passed, append `message` to the default PR
     message.
 
+    If `--no-browse` is passed, don't pass the `--browse` argument to `hub`
+    which opens the pull request URL in a browser. Instead, output it to the
+    command line.
+
     Note that this command cannot be used to transition a formula from a
     URL-and-sha256 style specification into a tag-and-revision style
     specification, nor vice versa. It must use whichever style specification

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -757,6 +757,9 @@ If \fB\-\-version=\fR\fIversion\fR is passed, use the value to override the valu
 If \fB\-\-message=\fR\fImessage\fR is passed, append \fImessage\fR to the default PR message\.
 .
 .IP
+If \fB\-\-no\-browse\fR is passed, don\'t pass the \fB\-\-browse\fR argument to \fBhub\fR which opens the pull request URL in a browser\. Instead, output it to the command line\.
+.
+.IP
 Note that this command cannot be used to transition a formula from a URL\-and\-sha256 style specification into a tag\-and\-revision style specification, nor vice versa\. It must use whichever style specification the preexisting formula already uses\.
 .
 .TP


### PR DESCRIPTION
If `--no-browse` is passed, don't pass the `--browse` argument to `hub` which opens the pull request URL in a browser. Instead, output it to the command line.

Fixes #2468.