### PR TITLE
formula_desc_cop: Whitelist "etc." and fix the full stop autocorrect

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -103,7 +103,7 @@ module RuboCop
             correction.gsub!(/(^|[^a-z])#{@formula_name}([^a-z]|$)/i, "\\1\\2")
             correction.gsub!(/^(['"]?)\s+/, "\\1")
             correction.gsub!(/\s+(['"]?)$/, "\\1")
-            correction.gsub!(/\.$/, "")
+            correction.gsub!(/\.(['"]?)$/, "\\1")
             corrector.insert_before(node.source_range, correction)
             corrector.remove(node.source_range)
           end

--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -40,7 +40,7 @@ module RuboCop
       # - Checks for correct usage of `command-line` in `desc`
       # - Checks description starts with a capital letter
       # - Checks if `desc` contains the formula name
-      # - Checks if `desc` ends with a full stop
+      # - Checks if `desc` ends with a full stop (apart from in the case of "etc.")
       class Desc < FormulaCop
         VALID_LOWERCASE_WORDS = %w[
           ex
@@ -83,8 +83,8 @@ module RuboCop
             problem "Description shouldn't start with the formula name"
           end
 
-          # Check if a full stop is used at the end of a formula's desc
-          return unless regex_match_group(desc, /\.$/)
+          # Check if a full stop is used at the end of a formula's desc (apart from in the case of "etc.")
+          return unless regex_match_group(desc, /\.$/) && !string_content(desc).end_with?("etc.")
           problem "Description shouldn't end with a full stop"
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [] Have you successfully run `brew tests` with your changes locally?

-----

As per https://github.com/Homebrew/brew/pull/2795#issuecomment-340287453, here's a PR to whitelist "etc." only in the full stop format_desc_cop, and fix the autocorrect so it works with quotes at the end of the line too. I ran a `brew audit --strict` and it stopped complaining about formulae with `etc.` at the end.