### PR TITLE
formula: fix safe navigation bug

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1528,10 +1528,10 @@ class Formula
       "oldname" => oldname,
       "aliases" => aliases,
       "versions" => {
-        "stable" => stable&.version.to_s,
+        "stable" => stable&.version&.to_s,
         "bottle" => bottle ? true : false,
-        "devel" => devel&.version.to_s,
-        "head" => head&.version.to_s,
+        "devel" => devel&.version&.to_s,
+        "head" => head&.version&.to_s,
       },
       "revision" => revision,
       "version_scheme" => version_scheme,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Safe navigation needs to be chained to preserve equivalence.

Fixes a bug introduced by 01e9ec9a in #3183.

CC @MikeMcQuaid @woodruffw

The symptom here is
```
==> Fetching patch 
Patch: https://github.com/Homebrew/homebrew-core/pull/20175.patch
==> Applying patch
Applying: dmd 2.077.0
==> Patch closes issue #20175
Warning: Nonstandard bump subject: dmd 2.077.0
Warning: Subject should be: dmd 2.077.0,  (devel)
```

which occurs any time a devel block is removed.