### PR TITLE
system_config: output most HOMEBREW_* variables.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -69,9 +69,15 @@ then
   odie "Cowardly refusing to continue at this prefix: $HOMEBREW_PREFIX"
 fi
 
-# Save value to use for installing gems
-export HOMEBREW_GEM_HOME="$GEM_HOME"
-export HOMEBREW_GEM_PATH="$GEM_PATH"
+# Save values to use for installing gems
+if [[ -n "$GEM_HOME" ]]
+then
+  export HOMEBREW_GEM_HOME="$GEM_HOME"
+fi
+if [[ -n "$GEM_PATH" ]]
+then
+  export HOMEBREW_GEM_PATH="$GEM_PATH"
+fi
 
 # Users may have these set, pointing the system Ruby
 # at non-system gem paths
@@ -308,9 +314,6 @@ update-preinstall() {
   [[ -z "$HOMEBREW_NO_AUTO_UPDATE" ]] || return
   [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]] || return
 
-  # Allow auto-update migration now we have a fix in place (below in this function).
-  export HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION="1"
-
   if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" || "$HOMEBREW_COMMAND" = "tap" ]]
   then
     if [[ -z "$HOMEBREW_VERBOSE" ]]
@@ -318,6 +321,9 @@ update-preinstall() {
       update-preinstall-timer &
       timer_pid=$!
     fi
+
+    # Allow auto-update migration now we have a fix in place (below in this function).
+    export HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION="1"
 
     brew update --preinstall
 

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -148,6 +148,15 @@ class SystemConfig
       "#{Utils.git_version} => #{Utils.git_path}"
     end
 
+    def describe_curl
+      curl_version_output = Utils.popen_read("#{curl_executable} --version", err: :close)
+      curl_version_output =~ /^curl ([\d\.]+)/
+      curl_version = Regexp.last_match(1)
+      "#{curl_version} => #{curl_executable}"
+    rescue
+      "N/A"
+    end
+
     def dump_verbose_config(f = $stdout)
       f.puts "HOMEBREW_VERSION: #{HOMEBREW_VERSION}"
       f.puts "ORIGIN: #{origin}"
@@ -170,6 +179,7 @@ class SystemConfig
       f.puts "GCC-4.2: build #{gcc_4_2}" unless gcc_4_2.null?
       f.puts "Clang: #{clang.null? ? "N/A" : "#{clang} build #{clang_build}"}"
       f.puts "Git: #{describe_git}"
+      f.puts "Curl: #{describe_curl}"
       f.puts "Perl: #{describe_perl}"
       f.puts "Python: #{describe_python}"
       f.puts "Ruby: #{describe_ruby}"

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -169,10 +169,47 @@ class SystemConfig
       else
         f.puts "Core tap: N/A"
       end
+      defaults_hash = {
+        HOMEBREW_PREFIX: "/usr/local",
+        HOMEBREW_REPOSITORY: "/usr/local/Homebrew",
+        HOMEBREW_CELLAR: "/usr/local/Cellar",
+        HOMEBREW_CACHE: "#{ENV["HOME"]}/Library/Caches/Homebrew",
+      }.freeze
+      boring_keys = %w[
+        HOMEBREW_BROWSER
+        HOMEBREW_EDITOR
+
+        HOMEBREW_ANALYTICS_ID
+        HOMEBREW_ANALYTICS_USER_UUID
+        HOMEBREW_BREW_FILE
+        HOMEBREW_COMMAND_DEPTH
+        HOMEBREW_CURL
+        HOMEBREW_LIBRARY
+        HOMEBREW_MACOS_VERSION
+        HOMEBREW_RUBY_PATH
+        HOMEBREW_SYSTEM
+        HOMEBREW_OS_VERSION
+        HOMEBREW_PATH
+        HOMEBREW_PROCESSOR
+        HOMEBREW_PRODUCT
+        HOMEBREW_USER_AGENT
+        HOMEBREW_USER_AGENT_CURL
+        HOMEBREW_VERSION
+      ].freeze
       f.puts "HOMEBREW_PREFIX: #{HOMEBREW_PREFIX}"
-      f.puts "HOMEBREW_REPOSITORY: #{HOMEBREW_REPOSITORY}"
-      f.puts "HOMEBREW_CELLAR: #{HOMEBREW_CELLAR}"
-      f.puts "HOMEBREW_BOTTLE_DOMAIN: #{BottleSpecification::DEFAULT_DOMAIN}"
+      if defaults_hash[:HOMEBREW_REPOSITORY] != HOMEBREW_REPOSITORY.to_s
+        f.puts "HOMEBREW_REPOSITORY: #{HOMEBREW_REPOSITORY}"
+      end
+      if defaults_hash[:HOMEBREW_CELLAR] != HOMEBREW_CELLAR.to_s
+        f.puts "HOMEBREW_CELLAR: #{HOMEBREW_CELLAR}"
+      end
+      ENV.sort.each do |key, value|
+        next unless key.start_with?("HOMEBREW_")
+        next if boring_keys.include?(key)
+        next if defaults_hash[key.to_sym] == value
+        value = "set" if key =~ /(cookie|key|token)/i
+        f.puts "#{key}: #{value}"
+      end
       f.puts hardware if hardware
       f.puts "Homebrew Ruby: #{describe_homebrew_ruby}"
       f.puts "GCC-4.0: build #{gcc_4_0}" unless gcc_4_0.null?

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -189,8 +189,11 @@ module Homebrew
 
   def install_gem_setup_path!(name, version = nil, executable = name)
     # Respect user's preferences for where gems should be installed.
-    ENV["GEM_HOME"] = ENV["HOMEBREW_GEM_HOME"].to_s
-    ENV["GEM_HOME"] = Gem.user_dir if ENV["GEM_HOME"].empty?
+    ENV["GEM_HOME"] = if ENV["HOMEBREW_GEM_HOME"].to_s.empty?
+      Gem.user_dir
+    else
+      ENV["HOMEBREW_GEM_HOME"]
+    end
     unless ENV["HOMEBREW_GEM_PATH"].to_s.empty?
       ENV["GEM_PATH"] = ENV["HOMEBREW_GEM_PATH"]
     end


### PR DESCRIPTION
Exclude the boring ones and exclude some that are already printed that are just using their default values. HOMEBREW_PREFIX is the only one where we’re always interested in the output to quickly communicate it.

Also:
- system_config: output curl path and version.
- utils: correctly handle empty user gem env.
- brew.sh: cleanup some environment pollution.