### PR TITLE
mac/xcode: compare with existing Version class.

### DIFF
--- a/Library/Homebrew/compat/macos.rb
+++ b/Library/Homebrew/compat/macos.rb
@@ -1,5 +1,10 @@
 require "development_tools"
 
+if OS.mac?
+  MACOS_FULL_VERSION = OS::Mac.full_version.to_s.freeze
+  MACOS_VERSION = OS::Mac.version.to_s.freeze
+end
+
 module OS
   module Mac
     module_function

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -50,7 +50,6 @@ module Homebrew
       end
 
       def check_xcode_up_to_date
-        return unless MacOS::Xcode.installed?
         return unless MacOS::Xcode.outdated?
 
         # Travis CI images are going to end up outdated so don't complain when
@@ -78,7 +77,6 @@ module Homebrew
       end
 
       def check_clt_up_to_date
-        return unless MacOS::CLT.installed?
         return unless MacOS::CLT.outdated?
 
         # Travis CI images are going to end up outdated so don't complain when
@@ -108,7 +106,6 @@ module Homebrew
       end
 
       def check_xcode_minimum_version
-        return unless MacOS::Xcode.installed?
         return unless MacOS::Xcode.below_minimum_version?
 
         <<~EOS
@@ -119,7 +116,6 @@ module Homebrew
       end
 
       def check_clt_minimum_version
-        return unless MacOS::CLT.installed?
         return unless MacOS::CLT.below_minimum_version?
 
         <<~EOS
@@ -281,13 +277,8 @@ module Homebrew
         EOS
       end
 
-      def check_for_latest_xquartz
-        return unless MacOS::XQuartz.version
-        return if MacOS::XQuartz.provided_by_apple?
-
-        installed_version = Version.create(MacOS::XQuartz.version)
-        latest_version = Version.create(MacOS::XQuartz.latest_version)
-        return if installed_version >= latest_version
+      def check_xquartz_up_to_date
+        return unless MacOS::XQuartz.outdated?
 
         <<~EOS
           Your XQuartz (#{installed_version}) is outdated.
@@ -298,8 +289,7 @@ module Homebrew
       end
 
       def check_for_beta_xquartz
-        return unless MacOS::XQuartz.version
-        return unless MacOS::XQuartz.version.include? "beta"
+        return unless MacOS::XQuartz.version.to_s.include?("beta")
 
         <<~EOS
           The following beta release of XQuartz is installed: #{MacOS::XQuartz.version}

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -91,18 +91,18 @@ module Superenv
     generic_setup_build_environment(formula)
     self["HOMEBREW_SDKROOT"] = effective_sysroot
 
-    if MacOS::Xcode.without_clt? || (MacOS::Xcode.installed? && MacOS::Xcode.version.to_i >= 7)
+    if MacOS::Xcode.without_clt? || MacOS::Xcode.version.to_i >= 7
       self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
       self["SDKROOT"] = MacOS.sdk_path
     end
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.
-    if MacOS.version == "10.12" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "9.0"
+    if MacOS.version == "10.12" && MacOS::Xcode.version >= "9.0"
       %w[fmemopen futimens open_memstream utimensat].each do |s|
         ENV["ac_cv_func_#{s}"] = "no"
       end
-    elsif MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    elsif MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       %w[basename_r clock_getres clock_gettime clock_settime dirname_r
          getentropy mkostemp mkostemps timingsafe_bcmp].each do |s|
         ENV["ac_cv_func_#{s}"] = "no"

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -4,7 +4,7 @@ class SystemConfig
       if instance_variable_defined?(:@xcode)
         @xcode
       elsif MacOS::Xcode.installed?
-        @xcode = MacOS::Xcode.version
+        @xcode = MacOS::Xcode.version.to_s
         @xcode += " => #{MacOS::Xcode.prefix}" unless MacOS::Xcode.default_prefix?
         @xcode
       end

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -20,9 +20,6 @@ module OS
       ISSUES_URL = "https://docs.brew.sh/Troubleshooting.html".freeze
     end
     PATH_OPEN = "/usr/bin/open".freeze
-    # compatibility
-    ::MACOS_FULL_VERSION = OS::Mac.full_version.to_s.freeze
-    ::MACOS_VERSION = OS::Mac.version.to_s.freeze
   elsif OS.linux?
     ISSUES_URL = "https://github.com/Linuxbrew/brew/wiki/troubleshooting".freeze
     PATH_OPEN = "xdg-open".freeze

--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -34,7 +34,11 @@ module OS
       # The X11.app distributed by Apple is also XQuartz, and therefore covered
       # by this method.
       def version
-        @version ||= detect_version
+        if @version ||= detect_version
+          ::Version.new @version
+        else
+          ::Version::NULL
+        end
       end
 
       def detect_version
@@ -115,7 +119,13 @@ module OS
       end
 
       def installed?
-        !version.nil? && !prefix.nil?
+        !version.null? && !prefix.nil?
+      end
+
+      def outdated?
+        return false unless installed?
+        return false if provided_by_apple?
+        version < latest_version
       end
 
       # If XQuartz and/or the CLT are installed, headers will be found under

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -431,6 +431,10 @@ class Version
     version.to_f
   end
 
+  def to_i
+    version.to_i
+  end
+
   def to_s
     version.dup
   end


### PR DESCRIPTION
Additionally, return null versions when it makes sense to do so. This means that comparisons on the Xcode/CLT version do not need to be guarded on whether Xcode/CLT is installed.

Also, while we're here do the same thing for `mac/xquartz`, move `MACOS_*VERSION` to compat and simplify and fix up code accordingly for these changes.

Requested by @ilovezfs and @DomT4 in https://github.com/Homebrew/homebrew-core/pull/20059