### PR TITLE
Refactor command handling code

### DIFF
--- a/Library/Homebrew/cmd/command.rb
+++ b/Library/Homebrew/cmd/command.rb
@@ -8,15 +8,16 @@ module Homebrew
 
   def command
     abort "This command requires a command argument" if ARGV.empty?
-    cmd = ARGV.first
-    cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
 
-    if (path = Commands.path(cmd))
-      puts path
-    elsif (path = which("brew-#{cmd}") || which("brew-#{cmd}.rb"))
-      puts path
-    else
-      odie "Unknown command: #{cmd}"
-    end
+    cmd = HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(ARGV.first, ARGV.first)
+
+    path = Commands.path(cmd)
+
+    cmd_paths = PATH.new(ENV["PATH"]).append(Tap.cmd_directories) unless path
+    path ||= which("brew-#{cmd}", cmd_paths)
+    path ||= which("brew-#{cmd}.rb", cmd_paths)
+
+    odie "Unknown command: #{cmd}" unless path
+    puts path
   end
 end

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -1,13 +1,10 @@
 module Commands
   def self.path(cmd)
-    if File.exist?(HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.sh")
-      HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.sh"
-    elsif File.exist?(HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.sh")
-      HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.sh"
-    elsif File.exist?(HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.rb")
-      HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.rb"
-    elsif File.exist?(HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.rb")
-      HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.rb"
-    end
+    [
+      HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.sh",
+      HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.sh",
+      HOMEBREW_LIBRARY_PATH/"cmd/#{cmd}.rb",
+      HOMEBREW_LIBRARY_PATH/"dev-cmd/#{cmd}.rb",
+    ].find(&:exist?)
   end
 end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -503,6 +503,11 @@ class Tap
     map(&:name).sort
   end
 
+  # an array of all tap cmd directory {Pathname}s
+  def self.cmd_directories
+    Pathname.glob TAP_DIRECTORY/"*/*/cmd"
+  end
+
   # @private
   def formula_file_to_name(file)
     "#{name}/#{file.basename(".rb")}"


### PR DESCRIPTION
Don’t rely on having external commands always present in the PATH in order to find them. Instead, provide an accessory method to Tap so they can be added and used when needed.

While we’re here, do some general refactoring and cleanup of the command code in these places.

Fixes #3421.