### PR TITLE
Remove more uses of EOS.undent.

### DIFF
--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -221,7 +221,7 @@ describe FormulaAuditor do
     describe "a dependency on a macOS-provided keg-only formula" do
       describe "which is whitelisted" do
         let(:fa) do
-          formula_auditor "foo", <<-EOS.undent, new_formula: true
+          formula_auditor "foo", <<~EOS, new_formula: true
             class Foo < Formula
               url "http://example.com/foo-1.0.tgz"
               homepage "http://example.com"
@@ -253,7 +253,7 @@ describe FormulaAuditor do
 
       describe "which is not whitelisted" do
         let(:fa) do
-          formula_auditor "foo", <<-EOS.undent, new_formula: true
+          formula_auditor "foo", <<~EOS, new_formula: true
             class Foo < Formula
               url "http://example.com/foo-1.0.tgz"
               homepage "http://example.com"

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -553,7 +553,7 @@ Sometimes a package fails to build when using a certain compiler. Since recent [
 ```ruby
 fails_with :llvm do
   build 2335
-  cause <<-EOS.undent
+  cause <<~EOS
     The "cause" field should include a short summary of the error. Include
     the URLs of any relevant information, such as upstream bug reports. Wrap
     the text at a sensible boundary (~72-80 characters), but do not break


### PR DESCRIPTION
Some for consistency, some to fix the Linux build.