### PR TITLE
diagnostic: fix paths usage.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -434,7 +434,7 @@ module Homebrew
 
         message = ""
 
-        paths(ENV["HOMEBREW_PATH"]).each do |p|
+        paths.each do |p|
           case p
           when "/usr/bin"
             unless @seen_prefix_bin
@@ -577,7 +577,7 @@ module Homebrew
           /Applications/Server.app/Contents/ServerRoot/usr/sbin
         ].map(&:downcase)
 
-        paths(ENV["HOMEBREW_PATH"]).each do |p|
+        paths.each do |p|
           next if whitelist.include?(p.downcase) || !File.directory?(p)
 
           realpath = Pathname.new(p).realpath.to_s
@@ -1045,7 +1045,7 @@ module Homebrew
       end
 
       def check_for_external_cmd_name_conflict
-        cmds = paths.flat_map { |p| Dir["#{p}/brew-*"] }.uniq
+        cmds = Tap.cmd_directories.flat_map { |p| Dir["#{p}/brew-*"] }.uniq
         cmds = cmds.select { |cmd| File.file?(cmd) && File.executable?(cmd) }
         cmd_map = {}
         cmds.each do |cmd|

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -194,7 +194,7 @@ describe Homebrew::Diagnostic::Checks do
           FileUtils.chmod 0755, cmd
         end
 
-        ENV["PATH"] = [path1, path2, ENV["PATH"]].join File::PATH_SEPARATOR
+        allow(Tap).to receive(:cmd_directories).and_return([path1, path2])
 
         expect(subject.check_for_external_cmd_name_conflict)
           .to match("brew-foo")

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -420,8 +420,8 @@ def nostdout
   end
 end
 
-def paths(env_path = ENV["PATH"])
-  @paths ||= PATH.new(env_path).collect do |p|
+def paths
+  @paths ||= PATH.new(ENV["HOMEBREW_PATH"]).collect do |p|
     begin
       File.expand_path(p).chomp("/")
     rescue ArgumentError


### PR DESCRIPTION
- Don't allow taking an argument. This doesn't work and never has as it caches the result regardless of the argument.
- Don't rely on the PATH to check for external commands.