### PR TITLE
diagnostic: check if Xcode needs CLT installed.

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -19,6 +19,7 @@ module Homebrew
         %w[
           check_xcode_minimum_version
           check_clt_minimum_version
+          check_if_xcode_needs_clt_installed
         ].freeze
       end
 
@@ -121,6 +122,15 @@ module Homebrew
         <<~EOS
           Your Command Line Tools are too outdated.
           #{MacOS::CLT.update_instructions}
+        EOS
+      end
+
+      def check_if_xcode_needs_clt_installed
+        return unless MacOS::Xcode.needs_clt_installed?
+
+        <<~EOS
+          Xcode alone is not sufficient on #{MacOS.version.pretty_name}.
+          #{DevelopmentTools.installation_instructions}
         EOS
       end
 

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -9,7 +9,7 @@ module Superenv
   end
 
   def effective_sysroot
-    MacOS::Xcode.without_clt? ? MacOS.sdk_path.to_s : nil
+    MacOS.sdk_path.to_s if MacOS::Xcode.without_clt?
   end
 
   def homebrew_extra_paths
@@ -91,10 +91,8 @@ module Superenv
     generic_setup_build_environment(formula)
     self["HOMEBREW_SDKROOT"] = effective_sysroot
 
-    if MacOS::Xcode.without_clt? || MacOS::Xcode.version.to_i >= 7
-      self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
-      self["SDKROOT"] = MacOS.sdk_path
-    end
+    self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
+    self["SDKROOT"] = MacOS.sdk_path if MacOS::Xcode.without_clt?
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -31,14 +31,23 @@ module OS
       @version = nil
     end
 
-    def prerelease?
-      # TODO: bump version when new OS is released
-      version >= "10.14"
+    def latest_sdk_version
+      # TODO: bump version when new Xcode macOS SDK is released
+      Version.new "10.13"
+    end
+
+    def latest_stable_version
+      # TODO: bump version when new macOS is released
+      Version.new "10.13"
     end
 
     def outdated_release?
-      # TODO: bump version when new OS is released
+      # TODO: bump version when new macOS is released
       version < "10.11"
+    end
+
+    def prerelease?
+      version > latest_stable_version
     end
 
     def cat

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -40,6 +40,15 @@ module OS
         version < minimum_version
       end
 
+      def latest_sdk_version?
+        OS::Mac.version == OS::Mac.latest_sdk_version
+      end
+
+      def needs_clt_installed?
+        return false if latest_sdk_version?
+        without_clt?
+      end
+
       def outdated?
         return false unless installed?
         version < latest_version


### PR DESCRIPTION
Require the CLT on all but the latest version of macOS to avoid the continuous workarounds for SDK weirdness.