### PR TITLE
Custom commands can show help

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -69,6 +69,14 @@ begin
     end
   end
 
+  unless internal_cmd
+    # Add contributed commands to PATH before checking.
+    homebrew_path.append(Tap.cmd_directories)
+
+    # External commands expect a normal PATH
+    ENV["PATH"] = homebrew_path
+  end
+
   # Usage instructions should be displayed if and only if one of:
   # - a help flag is passed AND a command is matched
   # - a help flag is passed AND there is no command specified
@@ -86,14 +94,6 @@ begin
   # Uninstall old brew-cask if it's still around; we just use the tap now.
   if cmd == "cask" && (HOMEBREW_CELLAR/"brew-cask").exist?
     system(HOMEBREW_BREW_FILE, "uninstall", "--force", "brew-cask")
-  end
-
-  unless internal_cmd
-    # Add contributed commands to PATH before checking.
-    homebrew_path.append(Tap.cmd_directories)
-
-    # External commands expect a normal PATH
-    ENV["PATH"] = homebrew_path
   end
 
   if internal_cmd


### PR DESCRIPTION
#3385 introduced a change to path loading, and loads custom tap paths after trying to render help text. When trying to run something like `brew bundle --help`, the path is totally missed and bundle ends up getting called directly.

I tried to write an integration test for this in `custom-external-command_spec.rb`, but figuring out the interactions between the test, brew path loading, and the test fixture was too tough. I need to not specify a custom `PATH` in order to properly test the path recomposition in `brew.rb`, but I was unable to do that and still have my custom command detected. If you have guidance for this, I'll gladly update my PR.