### PR TITLE
python2: Added missing pip sub-command in docs

### DIFF
--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -24,7 +24,7 @@ The Python formulae install [pip](http://www.pip-installer.org) (as `pip2` or `p
 Setuptools can be updated via pip, without having to re-brew Python:
 
 ```sh
-python2 -m pip --upgrade setuptools
+python2 -m pip install --upgrade setuptools
 ```
 
 Similarly, pip can be used to upgrade itself via:


### PR DESCRIPTION
This is to add missing `install` sub-command to `pip` invocation in docs.
