### PR TITLE
ENV: don't set MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -60,7 +60,6 @@ module Stdenv
     # previously added by macosxsdk
     version = version.to_s
     remove_from_cflags(/ ?-mmacosx-version-min=10\.\d+/)
-    delete("MACOSX_DEPLOYMENT_TARGET")
     delete("CPATH")
     remove "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 
@@ -83,7 +82,6 @@ module Stdenv
     remove_macosxsdk
     version = version.to_s
     append_to_cflags("-mmacosx-version-min=#{version}")
-    self["MACOSX_DEPLOYMENT_TARGET"] = version
     self["CPATH"] = "#{HOMEBREW_PREFIX}/include"
     prepend "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -90,8 +90,6 @@ module Superenv
   def setup_build_environment(formula = nil)
     generic_setup_build_environment(formula)
     self["HOMEBREW_SDKROOT"] = effective_sysroot
-
-    self["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s
     self["SDKROOT"] = MacOS.sdk_path if MacOS::Xcode.without_clt?
 
     # Filter out symbols known not to be defined since GNU Autotools can't


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

CMake tries to use Xcode if MACOSX_DEPLOYMENT_TARGET is set but that can
lead to build failures when SDKROOT isn't set. The CMake behavior at
minimum manifests as -isysroot spontaneously being set to the Xcode SDK,
which brew sometimes can't successfully fully unwind with its ENV hacks.