### PR TITLE
lines_cop: Add condition to prevent false positives

### DIFF
--- a/Library/Homebrew/rubocops/lines_cop.rb
+++ b/Library/Homebrew/rubocops/lines_cop.rb
@@ -331,6 +331,7 @@ module RuboCop
           end
 
           find_instance_method_call(body_node, "Dir", :[]) do |method|
+            next unless parameters(method).size == 1
             path = parameters(method).first
             next unless path.str_type?
             next unless match = regex_match_group(path, /^[^\*{},]+$/)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes this bug 
https://github.com/Homebrew/homebrew-core/pull/18736
https://github.com/Homebrew/homebrew-core/pull/18736#issuecomment-346739752

This was the original audit rule.
```ruby
if line =~ /(Dir\[("[^\*{},]+")\])/
      problem "#{Regexp.last_match(1)} is unnecessary; just use #{Regexp.last_match(2)}"
end
```
Issue:  I was just running the check on first argument without checking number of arguments but original rule I think doesn't match multiple arguments