### PR TITLE
formula_installer: force fewer default formulae

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -449,7 +449,7 @@ class FormulaInstaller
 
         if (req.optional? || req.recommended?) && build.without?(req)
           Requirement.prune
-        elsif req.build? && install_bottle_for_dependent
+        elsif req.build? && use_default_formula
           Requirement.prune
         elsif install_requirement_formula?(req_dependency, req, install_bottle_for_dependent)
           deps.unshift(req_dependency)


### PR DESCRIPTION
Don't force a default formulae install if a requirement is satisfied if we're building a bottle and it's a build-time dependency.