### PR TITLE
Use local Curl to support ProxyChains-NG

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -110,16 +110,8 @@ then
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X $HOMEBREW_MACOS_VERSION"
 
-  printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
-  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101000" ]]
-  then
-    HOMEBREW_SYSTEM_CURL_TOO_OLD="1"
-  fi
-
-  # The system Curl is too old for some modern HTTPS certificates on
-  # older macOS versions.
-  if [[ -n "$HOMEBREW_SYSTEM_CURL_TOO_OLD" &&
-        -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
+  # Use local Curl by default to support ProxyChains-NG.
+  if [[ -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
   then
     HOMEBREW_CURL="$HOMEBREW_PREFIX/opt/curl/bin/curl"
   fi

--- a/Library/Homebrew/test/cask/dsl/appcast_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/appcast_spec.rb
@@ -34,7 +34,7 @@ describe Hbc::DSL::Appcast do
   describe "#calculate_checkpoint" do
     before do
       expect(Hbc::SystemCommand).to receive(:run) do |executable, **options|
-        expect(executable).to eq "/usr/bin/curl"
+        expect(executable).to eq("/usr/bin/curl").or eq("#{ENV["HOMEBREW_PREFIX"]}/opt/curl/bin/curl")
         expect(options[:args]).to include(*cmd_args)
         expect(options[:print_stderr]).to be false
         cmd_result


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Use local Curl by default to support ProxyChains-NG.

Reference:
https://github.com/rofl0r/proxychains-ng/issues/78