### PR TITLE
Allow optionally using Homebrew's curl

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -110,16 +110,18 @@ then
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X $HOMEBREW_MACOS_VERSION"
 
+  # The system Curl is too old for some modern HTTPS certificates on
+  # older macOS versions.
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
   if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101000" ]]
   then
     HOMEBREW_SYSTEM_CURL_TOO_OLD="1"
+    HOMEBREW_FORCE_BREWED_CURL="1"
   fi
 
-  # The system Curl is too old for some modern HTTPS certificates on
-  # older macOS versions.
-  if [[ -n "$HOMEBREW_SYSTEM_CURL_TOO_OLD" &&
-        -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
+  if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
+        -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]] &&
+           "$HOMEBREW_PREFIX/opt/curl/bin/curl" --version >/dev/null
   then
     HOMEBREW_CURL="$HOMEBREW_PREFIX/opt/curl/bin/curl"
   fi

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -383,14 +383,15 @@ user account:
 EOS
   fi
 
+  # we may want to use a Homebrew curl
+  if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
+      ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
+  then
+    brew install curl
+  fi
+
   if ! git --version >/dev/null 2>&1
   then
-    # we need a new enough curl to install git
-    if [[ -n "$HOMEBREW_SYSTEM_CURL_TOO_OLD" &&
-        ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
-    then
-      brew install curl
-    fi
     # we cannot install brewed git if homebrew/core is unavailable.
     [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git
     unset GIT_EXECUTABLE

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "October 2017" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "November 2017" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "October 2017" "Homebrew" "brew"
+.TH "BREW" "1" "November 2017" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS


### PR DESCRIPTION
If `HOMEBREW_FORCE_BREWED_CURL` is set then allow it to be used instead of the system `curl`.

Closes #3480.