### PR TITLE
tap_constants: support caskroom/* Tap

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -80,7 +80,7 @@ module Homebrew
     unless ARGV.force?
       ARGV.named.each do |name|
         next if File.exist?(name)
-        if name !~ HOMEBREW_TAP_FORMULA_REGEX && name !~ HOMEBREW_CASK_TAP_CASK_REGEX
+        if name !~ HOMEBREW_TAP_FORMULA_REGEX
           next
         end
         tap = Tap.fetch(Regexp.last_match(1), Regexp.last_match(2))
@@ -90,18 +90,6 @@ module Homebrew
 
     begin
       formulae = []
-
-      unless ARGV.casks.empty?
-        args = []
-        args << "--force" if ARGV.force?
-        args << "--debug" if ARGV.debug?
-        args << "--verbose" if ARGV.verbose?
-
-        ARGV.casks.each do |c|
-          ohai "brew cask install #{c} #{args.join " "}"
-          system("#{HOMEBREW_PREFIX}/bin/brew", "cask", "install", c, *args)
-        end
-      end
 
       # if the user's flags will prevent bottle only-installations when no
       # developer tools are available, we need to stop them early on

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -84,10 +84,6 @@ module HomebrewArgvExtension
     end.uniq(&:name)
   end
 
-  def casks
-    @casks ||= downcased_unique_named.grep HOMEBREW_CASK_TAP_CASK_REGEX
-  end
-
   def kegs
     require "keg"
     require "formula"

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -6,5 +6,3 @@ HOMEBREW_TAP_CASK_REGEX = %r{^([\w-]+)/([\w-]+)/([a-z0-9\-]+)$}
 HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY)}/Taps/(?<user>[\w-]+)/(?<repo>[\w-]+)}
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula
 HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
-# match the default and the versions brew-cask tap e.g. Caskroom/cask or Caskroom/versions
-HOMEBREW_CASK_TAP_CASK_REGEX = %r{^([Cc]askroom)/([\w]+)/([\w+-.]+)$}

--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -7,4 +7,4 @@ HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY)}/Taps/(?<user>[\w-
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula
 HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
 # match the default and the versions brew-cask tap e.g. Caskroom/cask or Caskroom/versions
-HOMEBREW_CASK_TAP_CASK_REGEX = %r{^([Cc]askroom)/(cask|versions)/([\w+-.]+)$}
+HOMEBREW_CASK_TAP_CASK_REGEX = %r{^([Cc]askroom)/([\w]+)/([\w+-.]+)$}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hi, caskroom repository has [fonts](https://github.com/caskroom/homebrew-fonts), [versions](https://github.com/caskroom/homebrew-versions) and [more](https://github.com/caskroom).

So, bellow command is not working:
- brew install Caskroom/versions/google-chrome-canary 
- brew install Caskroom/fonts/font-source-code-pro
