### PR TITLE
More environment filtering fixes

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -80,6 +80,14 @@ module Homebrew
       odie "This command requires at least one argument containing a URL or pull request number"
     end
 
+    # Passthrough Git environment variables for e.g. git am
+    if ENV["HOMEBREW_GIT_NAME"]
+      ENV["GIT_COMMITTER_NAME"] = ENV["HOMEBREW_GIT_NAME"]
+    end
+    if ENV["HOMEBREW_GIT_EMAIL"]
+      ENV["GIT_COMMITTER_EMAIL"] = ENV["HOMEBREW_GIT_EMAIL"]
+    end
+
     do_bump = ARGV.include?("--bump") && !ARGV.include?("--clean")
 
     # Formulae with affected bottles that were published

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -57,7 +57,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI provider
         # Homebrew/brew is currently using.
-        return if ENV["HOMEBREW_TRAVIS"]
+        return if ENV["TRAVIS"]
 
         message = <<~EOS
           Your Xcode (#{MacOS::Xcode.version}) is outdated.
@@ -84,7 +84,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI provider
         # Homebrew/brew is currently using.
-        return if ENV["HOMEBREW_TRAVIS"]
+        return if ENV["TRAVIS"]
 
         <<~EOS
           A newer Command Line Tools release is available.

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -495,7 +495,7 @@ module ObserverPathnameExtension
     MAXIMUM_VERBOSE_OUTPUT = 100
 
     def verbose?
-      return ARGV.verbose? unless ENV["HOMEBREW_TRAVIS"]
+      return ARGV.verbose? unless ENV["TRAVIS"]
       return false unless ARGV.verbose?
 
       if total < MAXIMUM_VERBOSE_OUTPUT

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -702,7 +702,7 @@ class FormulaInstaller
     Utils.safe_fork do
       # Invalidate the current sudo timestamp in case a build script calls sudo.
       # Travis CI's Linux sudoless workers have a weird sudo that fails here.
-      system "/usr/bin/sudo", "-k" unless ENV["HOMEBREW_TRAVIS_SUDO"] == "false"
+      system "/usr/bin/sudo", "-k" unless ENV["TRAVIS_SUDO"] == "false"
 
       if Sandbox.formula?(formula)
         sandbox = Sandbox.new

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -9,7 +9,7 @@ require "set"
 if ENV["HOMEBREW_TESTS_COVERAGE"]
   require "simplecov"
 
-  if ENV["CODECOV_TOKEN"] || ENV["HOMEBREW_TRAVIS"]
+  if ENV["CODECOV_TOKEN"] || ENV["TRAVIS"]
     require "codecov"
     SimpleCov.formatter = SimpleCov::Formatter::Codecov
   end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -27,7 +27,7 @@ def curl_args(*extra_args, show_output: false, user_agent: :default)
     args << "--fail"
     args << "--progress-bar" unless ARGV.verbose?
     args << "--verbose" if ENV["HOMEBREW_CURL_VERBOSE"]
-    args << "--silent" if !$stdout.tty? || ENV["HOMEBREW_TRAVIS"]
+    args << "--silent" if !$stdout.tty? || ENV["TRAVIS"]
   end
 
   args + extra_args

--- a/bin/brew
+++ b/bin/brew
@@ -47,7 +47,7 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 # Whitelist and copy to HOMEBREW_* all variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
 for VAR in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BINTRAY_USER BINTRAY_KEY \
-           BROWSER EDITOR GIT PATH VISUAL TRAVIS TRAVIS_SUDO \
+           BROWSER EDITOR GIT PATH VISUAL \
            GITHUB_USER GITHUB_PASSWORD GITHUB_TOKEN
 do
   # Skip if variable value is empty.
@@ -65,7 +65,8 @@ then
   PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
   FILTERED_ENV=()
-  for VAR in HOME SHELL PATH TERM LOGNAME USER CI "${!HOMEBREW_@}"
+  for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS \
+             "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do
     FILTERED_ENV+=( "${VAR}=${!VAR}" )
   done


### PR DESCRIPTION
- Make `brew pull` pass through Git environment variables (thanks @scpeters)
- Whitelist all `TRAVIS_` variables.

Fixes #3476