### PR TITLE
bin/brew: don't set empty, unfiltered variables.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -91,6 +91,9 @@ then
   for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do
+    # Skip if variable value is empty.
+    [[ -z "${!VAR}" ]] && continue
+
     FILTERED_ENV+=( "${VAR}=${!VAR}" )
   done
 


### PR DESCRIPTION
Otherwise we unconditionally set e.g. `CI`, `TRAVIS`.