### PR TITLE
Include SSH_AUTH_SOCK in filtered environment

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -88,7 +88,7 @@ then
   PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
   FILTERED_ENV=()
-  for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy HTTPS_PROXY FTP_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}" "${!JENKINS_@}"
   do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?
-----
So my situation may not be very common, but `brew update` broke for me after b26a0d4a911ba400f306ccc8bdc8cee42dd302bb because I have the following in my .gitconfig:
```
[url "git@github.com:"]
	insteadOf = https://github.com/
```
which forces all GitHub connections to use SSH. With `SSH_AUTH_SOCK` removed from the environment git is no longer able to find my SSH agent and I get:
```
Permission denied (publickey).
fatal: Could not read from remote repository.
```
for each of my taps. Copying `SSH_AUTH_SOCK` into the filtered environment fixed the problem.

Fixes https://github.com/Homebrew/brew/issues/3503