### PR TITLE
whitelisting additional SentinelOne dylib pattern

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -180,6 +180,7 @@ module Homebrew
           "libecomlodr.dylib", # Symantec Endpoint Protection
           "libsymsea*.dylib", # Symantec Endpoint Protection
           "sentinel.dylib", # SentinelOne
+          "sentinel-*.dylib", # SentinelOne
         ]
 
         __check_stray_files "/usr/local/lib", "*.dylib", white_list, <<~EOS


### PR DESCRIPTION
It seems like SentinelOne is now using dylibs that include a number, possibly randomized in some way.
This causes brew doctor to give a warning, but it should probably be ignored like the previous versions of the sentinel dylib.  (It was originally whitelisted here https://github.com/Homebrew/brew/pull/1440) 

updating `diagnostic.rb` to include a new pattern to ignore dylibs of the form `sentinel-*.dylib`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
