### PR TITLE
Unify proxy documentation.

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -235,20 +235,26 @@ can take several different forms:
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.
 
+  * `http_proxy`:
+    Sets the HTTP proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
+  * `https_proxy`:
+    Sets the HTTPS proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
+  * `ftp_proxy`:
+    Sets the FTP proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
 ## USING HOMEBREW BEHIND A PROXY
+Use the `http_proxy`, `https_proxy` and/or `ftp_proxy` documented above. For example for an unauthenticated HTTP proxy:
 
-Homebrew uses several commands for downloading files (e.g. `curl`, `git`, `svn`).
-Many of these tools can download via a proxy. It's common for these tools
-to read proxy parameters from environment variables.
+    export http_proxy=http://<host>:<port>
 
-For the majority of cases setting `http_proxy` is enough. You can set this in
-your shell profile, or you can use it before a brew command:
+And for an authenticated HTTP proxy:
 
-    http_proxy=http://<host>:<port> brew install foo
-
-If your proxy requires authentication:
-
-    http_proxy=http://<user>:<password>@<host>:<port> brew install foo
+    export http_proxy=http://<user>:<password>@<host>:<port>
 
 ## SEE ALSO
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1077,20 +1077,26 @@ can take several different forms:
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.
 
+  * `http_proxy`:
+    Sets the HTTP proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
+  * `https_proxy`:
+    Sets the HTTPS proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
+  * `ftp_proxy`:
+    Sets the FTP proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
 ## USING HOMEBREW BEHIND A PROXY
+Use the `http_proxy`, `https_proxy` and/or `ftp_proxy` documented above. For example for an unauthenticated HTTP proxy:
 
-Homebrew uses several commands for downloading files (e.g. `curl`, `git`, `svn`).
-Many of these tools can download via a proxy. It's common for these tools
-to read proxy parameters from environment variables.
+    export http_proxy=http://`host`:`port`
 
-For the majority of cases setting `http_proxy` is enough. You can set this in
-your shell profile, or you can use it before a brew command:
+And for an authenticated HTTP proxy:
 
-    http_proxy=http://`host`:`port` brew install foo
-
-If your proxy requires authentication:
-
-    http_proxy=http://`user`:`password`@`host`:`port` brew install foo
+    export http_proxy=http://`user`:`password`@`host`:`port`
 
 ## SEE ALSO
 

--- a/docs/Tips-N'-Tricks.md
+++ b/docs/Tips-N'-Tricks.md
@@ -55,23 +55,6 @@ run `mv the_tarball $(brew --cache -s <formula>)`.
 
 You can also pre-cache the download by using the command `brew fetch formula` which also displays the SHA-256 hash. This can be useful for updating formulae to new versions.
 
-## Using Homebrew behind a proxy
-Behind the scenes, Homebrew uses several commands for downloading files (e.g. `curl`, `git`, `svn`).  Many of these tools can download via a proxy.  It's a common (though not universal) convention for these command-line tools to observe getting the proxy parameters from environment variables (e.g. `http_proxy`).  Unfortunately, most tools are inconsistent in their use of these environment parameters (e.g. `curl` supports `http_proxy`, `HTTPS_PROXY`, `FTP_PROXY`, `GOPHER_PROXY`, `ALL_PROXY`, `NO_PROXY`).
-
-Luckily, for the majority of cases setting `http_proxy` is enough.
-You can set this environment variable in several ways (search on the
-internet for details), including at runtime:
-
-```sh
-http_proxy=http://<proxyhost>:<proxyport> brew install <formula>
-```
-
-To use proxy authentication:
-
-```sh
-http_proxy=http://<user>:<password>@<proxyhost>:<proxyport>  brew install <formula>
-```
-
 ## Installing stuff without the Xcode CLT
 
 ```sh

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1104,30 +1104,39 @@ This issue typically occurs when using FileVault or custom SSD configurations\.
 \fBHOMEBREW_VERBOSE\fR
 If set, Homebrew always assumes \fB\-\-verbose\fR when running commands\.
 .
-.SH "USING HOMEBREW BEHIND A PROXY"
-Homebrew uses several commands for downloading files (e\.g\. \fBcurl\fR, \fBgit\fR, \fBsvn\fR)\. Many of these tools can download via a proxy\. It\'s common for these tools to read proxy parameters from environment variables\.
+.TP
+\fBhttp_proxy\fR
+Sets the HTTP proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
 .
-.P
-For the majority of cases setting \fBhttp_proxy\fR is enough\. You can set this in your shell profile, or you can use it before a brew command:
+.TP
+\fBhttps_proxy\fR
+Sets the HTTPS proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
+.
+.TP
+\fBftp_proxy\fR
+Sets the FTP proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
+.
+.SH "USING HOMEBREW BEHIND A PROXY"
+Use the \fBhttp_proxy\fR, \fBhttps_proxy\fR and/or \fBftp_proxy\fR documented above\. For example for an unauthenticated HTTP proxy:
 .
 .IP "" 4
 .
 .nf
 
-http_proxy=http://<host>:<port> brew install foo
+export http_proxy=http://<host>:<port>
 .
 .fi
 .
 .IP "" 0
 .
 .P
-If your proxy requires authentication:
+And for an authenticated HTTP proxy:
 .
 .IP "" 4
 .
 .nf
 
-http_proxy=http://<user>:<password>@<host>:<port> brew install foo
+export http_proxy=http://<user>:<password>@<host>:<port>
 .
 .fi
 .


### PR DESCRIPTION
Specify under the list of environment variables how to set each of those that we passthrough and use.