### PR TITLE
lines_cop: Convert ARGV audit to negative look ahead

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -127,6 +127,22 @@ module RuboCop
         end
       end
 
+      # Matches receiver part of method,
+      # EX: to match `ARGV.<whatever>()`
+      # call `find_instance_call(node, "ARGV")`
+      # yields to a block with parent node of receiver
+      def find_instance_call(node, name)
+        node.each_descendant(:send) do |method_node|
+          next if method_node.receiver.nil?
+          next if method_node.receiver.const_name != name &&
+                  method_node.receiver.method_name != name
+          @offense_source_range = method_node.receiver.source_range
+          @offensive_node = method_node.receiver
+          return true unless block_given?
+          yield method_node
+        end
+      end
+
       # Returns nil if does not depend on dependency_name
       # args: node - dependency_name - dependency's name
       def depends_on?(dependency_name, *types)

--- a/Library/Homebrew/rubocops/lines_cop.rb
+++ b/Library/Homebrew/rubocops/lines_cop.rb
@@ -162,10 +162,9 @@ module RuboCop
             end
           end
 
-          [:debug?, :verbose?, :value].each do |method_name|
-            find_instance_method_call(body_node, "ARGV", method_name) do
-              problem "Use build instead of ARGV to check options"
-            end
+          find_instance_call(body_node, "ARGV") do |method_node|
+            next if [:debug?, :verbose?, :value].index(method_node.method_name)
+            problem "Use build instead of ARGV to check options"
           end
 
           find_instance_method_call(body_node, :man, :+) do |method|

--- a/Library/Homebrew/test/rubocops/lines_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_cop_spec.rb
@@ -541,13 +541,12 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
     end
 
     it "Using ARGV to check options" do
-      expect_offense(<<~RUBY)
+      expect_no_offenses(<<~RUBY)
         class Foo < Formula
           desc "foo"
           url 'http://example.com/foo-1.0.tgz'
           def install
             verbose = ARGV.verbose?
-                      ^^^^^^^^^^^^^ Use build instead of ARGV to check options
           end
         end
       RUBY
@@ -739,6 +738,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           test do
             head = ARGV.include? "--HEAD"
                                   ^^^^^^ Use "if build.head?" instead
+                   ^^^^ Use build instead of ARGV to check options
           end
         end
       RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
https://github.com/Homebrew/homebrew-core/pull/18736#issuecomment-346739752

Original audit rule was a negative look ahead, where as the RuboCop audit was implemented as positive lookahead. This PR Fixes it. 

original audit rule:
```ruby
if line =~ /ARGV\.(?!(debug\?|verbose\?|value[\(\s]))/
   problem "Use build instead of ARGV to check options"
end
```

cc @ilovezfs 