### PR TITLE
Remove unused writer methods for `Hbc.caskroom` and `Hbc.cache`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/locations.rb
+++ b/Library/Homebrew/cask/lib/hbc/locations.rb
@@ -7,13 +7,9 @@ module Hbc
     end
 
     module ClassMethods
-      attr_writer :caskroom
-
       def caskroom
         @caskroom ||= HOMEBREW_PREFIX.join("Caskroom")
       end
-
-      attr_writer :cache
 
       def cache
         @cache ||= HOMEBREW_CACHE.join("Cask")

--- a/Library/Homebrew/cask/lib/hbc/locations.rb
+++ b/Library/Homebrew/cask/lib/hbc/locations.rb
@@ -57,8 +57,6 @@ module Hbc
         @servicedir ||= Pathname.new("~/Library/Services").expand_path
       end
 
-      attr_writer :binarydir
-
       def binarydir
         @binarydir ||= HOMEBREW_PREFIX.join("bin")
       end

--- a/Library/Homebrew/compat/hbc/cli.rb
+++ b/Library/Homebrew/compat/hbc/cli.rb
@@ -12,8 +12,7 @@ module Hbc
     end)
 
     option "--caskroom=PATH", (lambda do |value|
-      Hbc.caskroom = value
-      odeprecated "`brew cask` with the `--caskroom` flag", disable_on: Time.utc(2017, 10, 31)
+      odisabled "`brew cask` with the `--caskroom` flag"
     end)
   end
 end

--- a/Library/Homebrew/compat/hbc/cli.rb
+++ b/Library/Homebrew/compat/hbc/cli.rb
@@ -11,7 +11,7 @@ module Hbc
       EOS
     end)
 
-    option "--caskroom=PATH", (lambda do |value|
+    option "--caskroom=PATH", (lambda do |*|
       odisabled "`brew cask` with the `--caskroom` flag"
     end)
   end

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -7,10 +7,6 @@ describe Hbc::Artifact::Binary, :cask do
   let(:artifacts) { cask.artifacts.select { |a| a.is_a?(described_class) } }
   let(:expected_path) { Hbc.binarydir.join("binary") }
 
-  before(:each) do
-    Hbc.binarydir.mkpath
-  end
-
   after(:each) do
     FileUtils.rm expected_path if expected_path.exist?
   end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -11,14 +11,13 @@ HOMEBREW_CASK_DIRS = [
   :prefpanedir,
   :qlplugindir,
   :servicedir,
-  :binarydir,
 ].freeze
 
 RSpec.shared_context "Homebrew-Cask" do
   around(:each) do |example|
     third_party_tap = Tap.fetch("third-party", "tap")
     begin
-      [Hbc.caskroom, Hbc.cache].each(&:mkpath)
+      [Hbc.binarydir, Hbc.caskroom, Hbc.cache].each(&:mkpath)
 
       dirs = HOMEBREW_CASK_DIRS.map do |dir|
         Pathname.new(TEST_TMPDIR).join("cask-#{dir}").tap do |path|
@@ -40,7 +39,7 @@ RSpec.shared_context "Homebrew-Cask" do
       example.run
     ensure
       FileUtils.rm_rf dirs
-      FileUtils.rm_rf Hbc.caskroom, Hbc.cache
+      FileUtils.rm_rf [Hbc.binarydir, Hbc.caskroom, Hbc.cache]
       Hbc.default_tap.path.unlink
       FileUtils.rm_rf Hbc.default_tap.path.parent
       third_party_tap.path.unlink

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -8,8 +8,6 @@ require "test/support/helper/cask/never_sudo_system_command"
 
 HOMEBREW_CASK_DIRS = [
   :appdir,
-  :caskroom,
-  :cache,
   :prefpanedir,
   :qlplugindir,
   :servicedir,
@@ -20,6 +18,8 @@ RSpec.shared_context "Homebrew-Cask" do
   around(:each) do |example|
     third_party_tap = Tap.fetch("third-party", "tap")
     begin
+      [Hbc.caskroom, Hbc.cache].each(&:mkpath)
+
       dirs = HOMEBREW_CASK_DIRS.map do |dir|
         Pathname.new(TEST_TMPDIR).join("cask-#{dir}").tap do |path|
           path.mkpath
@@ -40,6 +40,7 @@ RSpec.shared_context "Homebrew-Cask" do
       example.run
     ensure
       FileUtils.rm_rf dirs
+      FileUtils.rm_rf Hbc.caskroom, Hbc.cache
       Hbc.default_tap.path.unlink
       FileUtils.rm_rf Hbc.default_tap.path.parent
       third_party_tap.path.unlink


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Writer methods are now unused since the `--caskroom` flag was disabled.