### PR TITLE
x11_requirement: remove custom minimum version.

### DIFF
--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -51,6 +51,15 @@ module OS
         end
       end
 
+      def minimum_version
+        version = guess_system_version
+        return version unless version == "dunno"
+
+        # Update this a little later than latest_version to give people
+        # time to upgrade.
+        "2.7.11"
+      end
+
       # https://xquartz.macosforge.org/trac/wiki
       # https://xquartz.macosforge.org/trac/wiki/Releases
       def latest_version

--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -2,7 +2,6 @@ require "requirement"
 
 class X11Requirement < Requirement
   include Comparable
-  attr_reader :min_version
 
   fatal true
   cask "xquartz"
@@ -12,36 +11,38 @@ class X11Requirement < Requirement
 
   def initialize(name = "x11", tags = [])
     @name = name
-    if /(\d\.)+\d/ =~ tags.first
-      @min_version = Version.create(tags.shift)
-      @min_version_string = " #{@min_version}"
-    else
-      @min_version = Version.create("0.0.0")
-      @min_version_string = ""
-    end
+    # no-op on version specified as a tag argument
+    tags.shift if /(\d\.)+\d/ =~ tags.first
     super(tags)
   end
 
+  def min_version
+    # TODO: remove in https://github.com/Homebrew/brew/pull/3483
+    return Version::NULL unless OS.mac?
+
+    MacOS::XQuartz.minimum_version
+  end
+
   satisfy build_env: false do
-    MacOS::XQuartz.installed? && min_version <= Version.create(MacOS::XQuartz.version)
+    # TODO: remove in https://github.com/Homebrew/brew/pull/3483
+    next false unless OS.mac?
+
+    next false unless MacOS::XQuartz.installed?
+    min_version <= MacOS::XQuartz.version
   end
 
   def message
-    s = "XQuartz#{@min_version_string} is required to install this formula."
+    s = "XQuartz #{min_version} (or newer) is required to install this formula."
     s += super
     s
   end
 
   def <=>(other)
     return unless other.is_a? X11Requirement
-    min_version <=> other.min_version
-  end
-
-  def eql?(other)
-    super && min_version == other.min_version
+    0
   end
 
   def inspect
-    "#<#{self.class.name}: #{name.inspect} #{tags.inspect} min_version=#{min_version}>"
+    "#<#{self.class.name}: #{name.inspect} #{tags.inspect}>"
   end
 end

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -49,9 +49,9 @@ describe DependencyCollector do
       expect(find_requirement(X11Requirement).tags).to be_empty
     end
 
-    specify "x11 with minimum version" do
+    specify "x11 with (ignored) minimum version" do
       subject.add x11: "2.5.1"
-      expect(find_requirement(X11Requirement).min_version.to_s).to eq("2.5.1")
+      expect(find_requirement(X11Requirement).min_version.to_s).to_not eq("2.5.1")
     end
 
     specify "x11 with tag" do
@@ -59,10 +59,10 @@ describe DependencyCollector do
       expect(find_requirement(X11Requirement)).to be_optional
     end
 
-    specify "x11 with minimum version and tag" do
+    specify "x11 with (ignored) minimum version and tag" do
       subject.add x11: ["2.5.1", :optional]
       dep = find_requirement(X11Requirement)
-      expect(dep.min_version.to_s).to eq("2.5.1")
+      expect(dep.min_version.to_s).to_not eq("2.5.1")
       expect(dep).to be_optional
     end
 

--- a/Library/Homebrew/test/x11_requirement_spec.rb
+++ b/Library/Homebrew/test/x11_requirement_spec.rb
@@ -19,11 +19,6 @@ describe X11Requirement do
       other = described_class.new("foo")
       expect(subject).not_to eql(other)
     end
-
-    it "returns false if the minimum version differs" do
-      other = described_class.new(default_name, ["2.5"])
-      expect(subject).not_to eql(other)
-    end
   end
 
   describe "#modify_build_environment" do


### PR DESCRIPTION
This isn't desired or needed. Ensure older code still works, though.