### PR TITLE
Document that Xcode CLT is auto installed by standard install script

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -12,7 +12,7 @@ it does it too. And you have to confirm everything it will do before it starts.
 ## Requirements
 * An Intel CPU <sup>[1](#1)</sup>
 * OS X 10.10 or higher <sup>[2](#2)</sup>
-* Command Line Tools (CLT) for Xcode: `xcode-select --install`,
+* Command Line Tools (CLT) for Xcode (automatically installed by standard script if not present): `xcode-select --install`,
   [developer.apple.com/downloads](https://developer.apple.com/downloads) or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
 * A Bourne-compatible shell for installation (e.g. bash or zsh) <sup>[4](#4)</sup>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).~~ N/A
- [x] ~~Have you successfully run `brew tests` with your changes locally?~~ N/A

-----

As per title: it would be nice to know that this will be done for me if I install on a fresh macOS installation.