### PR TITLE
Revert "formula_installer: force fewer default formulae"

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -449,7 +449,7 @@ class FormulaInstaller
 
         if (req.optional? || req.recommended?) && build.without?(req)
           Requirement.prune
-        elsif req.build? && use_default_formula
+        elsif req.build? && install_bottle_for_dependent
           Requirement.prune
         elsif install_requirement_formula?(req_dependency, req, install_bottle_for_dependent)
           deps.unshift(req_dependency)


### PR DESCRIPTION
Reverts Homebrew/brew#3479

This broke `depends_on :python3 => :build`

See https://github.com/Homebrew/homebrew-core/pull/21389
https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/14196/version=high_sierra/