### PR TITLE
formula_installer: fix default formula prune.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -449,7 +449,7 @@ class FormulaInstaller
 
         if (req.optional? || req.recommended?) && build.without?(req)
           Requirement.prune
-        elsif req.build? && use_default_formula
+        elsif req.build? && use_default_formula && req_dependency.installed?
           Requirement.prune
         elsif install_requirement_formula?(req_dependency, req, install_bottle_for_dependent)
           deps.unshift(req_dependency)


### PR DESCRIPTION
Only prune it if it's not already installed.

Fixes bug with https://github.com/Homebrew/brew/pull/3479
Closes https://github.com/Homebrew/brew/pull/3535.

CC @ilovezfs