### PR TITLE
formula_installer: avoid irrelevant build deps.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -417,8 +417,9 @@ class FormulaInstaller
     raise UnsatisfiedRequirements, fatals
   end
 
-  def install_requirement_formula?(req_dependency, req, install_bottle_for_dependent)
+  def install_requirement_formula?(req_dependency, req, dependent, install_bottle_for_dependent)
     return false unless req_dependency
+    return false if req.build? && dependent.installed?
     return true unless req.satisfied?
     return false if req.run?
     return true if build_bottle?
@@ -451,7 +452,7 @@ class FormulaInstaller
           Requirement.prune
         elsif req.build? && use_default_formula && req_dependency.installed?
           Requirement.prune
-        elsif install_requirement_formula?(req_dependency, req, install_bottle_for_dependent)
+        elsif install_requirement_formula?(req_dependency, req, dependent, install_bottle_for_dependent)
           deps.unshift(req_dependency)
           formulae.unshift(req_dependency.to_formula)
           Requirement.prune
@@ -484,6 +485,8 @@ class FormulaInstaller
       if (dep.optional? || dep.recommended?) && build.without?(dep)
         Dependency.prune
       elsif dep.build? && install_bottle_for?(dependent, build)
+        Dependency.prune
+      elsif dep.build? && dependent.installed?
         Dependency.prune
       elsif dep.satisfied?(inherited_options[dep.name])
         Dependency.skip

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -140,19 +140,22 @@ describe FormulaInstaller do
       @install_bottle_for_dependent = false
       allow(@requirement).to receive(:satisfied?).and_return(satisfied?)
       allow(@requirement).to receive(:satisfied_by_formula?).and_return(satisfied_by_formula?)
+      allow(@requirement).to receive(:build?).and_return(build?)
       @dependent = formula do
         url "foo"
         version "0.1"
         depends_on :python3
       end
+      allow(@dependent).to receive(:installed?).and_return(installed?)
       @fi = FormulaInstaller.new(@dependent)
     end
 
-    subject { @fi.install_requirement_formula?(@requirement_dependency, @requirement, @install_bottle_for_dependent) }
+    subject { @fi.install_requirement_formula?(@requirement_dependency, @requirement, @dependent, @install_bottle_for_dependent) }
 
     context "it returns false when requirement is satisfied" do
       let(:satisfied?) { true }
       let(:satisfied_by_formula?) { false }
+      let(:build?) { false }
       let(:installed?) { false }
       it { is_expected.to be false }
     end
@@ -160,6 +163,15 @@ describe FormulaInstaller do
     context "it returns false when requirement is satisfied but default formula is installed" do
       let(:satisfied?) { true }
       let(:satisfied_by_formula?) { false }
+      let(:build?) { false }
+      let(:installed?) { false }
+      it { is_expected.to be false }
+    end
+
+    context "it returns false when requirement is :build and dependent is installed" do
+      let(:satisfied?) { false }
+      let(:satisfied_by_formula?) { false }
+      let(:build?) { true }
       let(:installed?) { true }
       it { is_expected.to be false }
     end
@@ -167,6 +179,7 @@ describe FormulaInstaller do
     context "it returns true when requirement isn't satisfied" do
       let(:satisfied?) { false }
       let(:satisfied_by_formula?) { false }
+      let(:build?) { false }
       let(:installed?) { false }
       it { is_expected.to be true }
     end
@@ -174,6 +187,7 @@ describe FormulaInstaller do
     context "it returns true when requirement is satisfied by a formula" do
       let(:satisfied?) { true }
       let(:satisfied_by_formula?) { true }
+      let(:build?) { false }
       let(:installed?) { false }
       it { is_expected.to be true }
     end


### PR DESCRIPTION
If dependents are already installed ensure their build dependencies (and
requirements) don't end up in the dependency/requirement tree.

CC @DomT4 @ilovezfs

Fixes #3033.