### PR TITLE
formula_assertions: remove Ruby 2.0 compatibility.

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -3,11 +3,6 @@ module Homebrew
     require "test/unit/assertions"
     include ::Test::Unit::Assertions
 
-    # TODO: remove this when we no longer support Ruby 2.0.
-    unless defined?(Test::Unit::AssertionFailedError)
-      Test::Unit::AssertionFailedError = MiniTest::Assertion
-    end
-
     # Returns the output of running cmd, and asserts the exit status
     def shell_output(cmd, result = 0)
       ohai cmd


### PR DESCRIPTION
We only support Ruby 2.3, now.