### PR TITLE
brew.1: clarify Homebrew's Ruby isn't 2.0 now.

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -165,8 +165,8 @@ can take several different forms:
     system version.
 
   * `HOMEBREW_FORCE_VENDOR_RUBY`:
-    If set, Homebrew will always use its vendored, relocatable Ruby 2.0 version
-    even if the system version of Ruby is >=2.0.
+    If set, Homebrew will always use its vendored, relocatable Ruby version
+    even if the system version of Ruby is new enough.
 
   * `HOMEBREW_GIT`:
     When using Git, Homebrew will use `GIT` if set,

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1007,8 +1007,8 @@ can take several different forms:
     system version.
 
   * `HOMEBREW_FORCE_VENDOR_RUBY`:
-    If set, Homebrew will always use its vendored, relocatable Ruby 2.0 version
-    even if the system version of Ruby is >=2.0.
+    If set, Homebrew will always use its vendored, relocatable Ruby version
+    even if the system version of Ruby is new enough.
 
   * `HOMEBREW_GIT`:
     When using Git, Homebrew will use `GIT` if set,

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1033,7 +1033,7 @@ If set, Homebrew will use a Homebrew\-installed \fBcurl\fR rather than the syste
 .
 .TP
 \fBHOMEBREW_FORCE_VENDOR_RUBY\fR
-If set, Homebrew will always use its vendored, relocatable Ruby 2\.0 version even if the system version of Ruby is >=2\.0\.
+If set, Homebrew will always use its vendored, relocatable Ruby version even if the system version of Ruby is new enough\.
 .
 .TP
 \fBHOMEBREW_GIT\fR


### PR DESCRIPTION
Make this generic; it doesn't matter what version this is and this will future proof it.