### PR TITLE
Revert "formula_installer: tweak dependent requirements."

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -404,8 +404,8 @@ class FormulaInstaller
     fatals = []
 
     req_map.each_pair do |dependent, reqs|
-      next if dependent.installed?
       reqs.each do |req|
+        next if dependent.installed? && req.name == "maximummacos"
         @requirement_messages << "#{dependent}: #{req.message}"
         fatals << req if req.fatal?
       end


### PR DESCRIPTION
This reverts commit cc752e97f6dcfb3e58c9e753262926672edeb571.

Fixes #1585.

I will open a new issue for the actual underlying bug here (that requirements aren't being handled correctly based on the stable/devel spec used at installation time).