### PR TITLE
caveats: fix fish caveats under env filtering

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -76,7 +76,7 @@ class Caveats
 
   def function_completion_caveats(shell)
     return unless keg
-    return unless which(shell.to_s)
+    return unless which(shell.to_s, ENV["HOMEBREW_PATH"])
 
     completion_installed = keg.completion_installed?(shell)
     functions_installed = keg.functions_installed?(shell)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Missed this one when I fixed the `PKG_CONFIG_PATH` printing. Only a problem with `fish` here, as obviously both `bash` and `zsh` are available in the default `PATH`.