### PR TITLE
Revert Xcode 9.2 check for CLT (#3560)

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -221,8 +221,8 @@ module OS
         # on the older supported platform for that Xcode release, i.e there's no
         # CLT package for 10.11 that contains the Clang version from Xcode 8.
         case MacOS.version
-        when "10.13" then "900.0.39.2"
-        when "10.12" then "900.0.39.2"
+        when "10.13" then "900.0.38"
+        when "10.12" then "900.0.38"
         when "10.11" then "800.0.42.1"
         when "10.10" then "700.1.81"
         when "10.9"  then "600.0.57"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

As reported in #3560, the command-line tools for xcode 9.2 don't seem to be available yet in the App Store, so `brew doctor` is failing for at least myself and the reporter of #3560, who have the CLT installed. This just reverts the version bump to the CLT clang version from #3542.

cc: @MikeMcQuaid 