### PR TITLE
Do not specify absolute paths to utilities

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -85,7 +85,7 @@ case "$HOMEBREW_SYSTEM" in
   Linux)  HOMEBREW_LINUX="1" ;;
 esac
 
-HOMEBREW_CURL="/usr/bin/curl"
+HOMEBREW_CURL="curl"
 if [[ -n "$HOMEBREW_MACOS" ]]
 then
   HOMEBREW_PROCESSOR="$(uname -p)"
@@ -136,7 +136,7 @@ else
   fi
 fi
 HOMEBREW_USER_AGENT="$HOMEBREW_PRODUCT/$HOMEBREW_USER_AGENT_VERSION ($HOMEBREW_SYSTEM; $HOMEBREW_PROCESSOR $HOMEBREW_OS_USER_AGENT_VERSION)"
-HOMEBREW_CURL_VERSION="$("$HOMEBREW_CURL" --version 2>/dev/null | head -n1 | /usr/bin/awk '{print $1"/"$2}')"
+HOMEBREW_CURL_VERSION="$("$HOMEBREW_CURL" --version 2>/dev/null | head -n1 | awk '{print $1"/"$2}')"
 HOMEBREW_USER_AGENT_CURL="$HOMEBREW_USER_AGENT $HOMEBREW_CURL_VERSION"
 
 # Declared in bin/brew

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -217,12 +217,12 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
   def stage
     case type = cached_location.compression_type
     when :zip
-      with_system_path { quiet_safe_system "unzip", "-qq", cached_location }
+      quiet_safe_system "unzip", "-qq", cached_location
       chdir
     when :gzip_only
-      with_system_path { buffered_write("gunzip") }
+      buffered_write "gunzip"
     when :bzip2_only
-      with_system_path { buffered_write("bunzip2") }
+      buffered_write "bunzip2"
     when :gzip, :bzip2, :xz, :compress, :tar
       tar_flags = "x"
       if type == :gzip
@@ -233,16 +233,14 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
         tar_flags << "J"
       end
       tar_flags << "f"
-      with_system_path do
-        if type == :xz && DependencyCollector.tar_needs_xz_dependency?
-          pipe_to_tar(xzpath)
-        else
-          safe_system "tar", tar_flags, cached_location
-        end
+      if type == :xz && DependencyCollector.tar_needs_xz_dependency?
+        pipe_to_tar xzpath
+      else
+        safe_system "tar", tar_flags, cached_location
       end
       chdir
     when :lzip
-      with_system_path { pipe_to_tar(lzippath) }
+      pipe_to_tar lzippath
       chdir
     when :lha
       safe_system lhapath, "x", cached_location

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -96,7 +96,7 @@ class Keg
   alias generic_recursive_fgrep_args recursive_fgrep_args
 
   def each_unique_file_matching(string)
-    Utils.popen_read("/usr/bin/fgrep", recursive_fgrep_args, string, to_s) do |io|
+    Utils.popen_read("fgrep", recursive_fgrep_args, string, to_s) do |io|
       hardlinks = Set.new
 
       until io.eof?
@@ -113,7 +113,7 @@ class Keg
 
   def text_files
     text_files = []
-    return text_files unless File.exist?("/usr/bin/file")
+    return text_files unless which("file") && which("xargs")
 
     # file has known issues with reading files on other locales. Has
     # been fixed upstream for some time, but a sufficiently new enough
@@ -132,7 +132,7 @@ class Keg
         end
         false
       }
-      output, _status = Open3.capture2("/usr/bin/xargs -0 /usr/bin/file --no-dereference --print0",
+      output, _status = Open3.capture2("xargs -0 file --no-dereference --print0",
                                        stdin_data: files.to_a.join("\0"))
       # `file` output sometimes contains data from the file, which may include
       # invalid UTF-8 entities, so tell Ruby this is just a bytestring

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -344,7 +344,7 @@ def which_editor
   editor = %w[atom subl mate edit vim].find do |candidate|
     candidate if which(candidate, ENV["HOMEBREW_PATH"])
   end
-  editor ||= "/usr/bin/vim"
+  editor ||= "vim"
 
   opoo <<~EOS
     Using #{editor} because no editor was set in the environment.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -267,12 +267,6 @@ module Homebrew
   # rubocop:enable Style/GlobalVars
 end
 
-def with_system_path
-  with_env(PATH: PATH.new("/usr/bin", "/bin")) do
-    yield
-  end
-end
-
 def with_homebrew_path
   with_env(PATH: PATH.new(ENV["HOMEBREW_PATH"])) do
     yield
@@ -376,7 +370,7 @@ end
 # GZips the given paths, and returns the gzipped paths
 def gzip(*paths)
   paths.collect do |path|
-    with_system_path { safe_system "gzip", path }
+    safe_system "gzip", path
     Pathname.new("#{path}.gz")
   end
 end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -3,7 +3,7 @@ require "open3"
 
 def curl_executable
   curl = Pathname.new ENV["HOMEBREW_CURL"]
-  curl = Pathname.new "/usr/bin/curl" unless curl.exist?
+  curl = which("curl") unless curl.exist?
   return curl if curl.executable?
   raise "#{curl} is not executable"
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Specifying an absolute path to utilities is no longer needed, since environment filtering uses a default PATH.