### PR TITLE
python: handle env filtering on pth check

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -35,7 +35,7 @@ module Language
       probe_file = homebrew_site_packages(version)/"homebrew-pth-probe.pth"
       begin
         probe_file.atomic_write("import site; site.homebrew_was_here = True")
-        quiet_system python, "-c", "import site; assert(site.homebrew_was_here)"
+        with_homebrew_path { quiet_system python, "-c", "import site; assert(site.homebrew_was_here)" }
       ensure
         probe_file.unlink if probe_file.exist?
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since ENV filtering became the default this has been chucking erroneous warnings from both `brew doctor` and things like `brew install pygobject` about needing to run:
```
echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /Users/xyz/Library/Python/2.7/lib/python/site-packages/homebrew.pth
```
even though I had Homebrew's `python` installed.