### PR TITLE
postinstall: add HOMEBREW_PREFIX/{,s}bin to PATH.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -956,12 +956,16 @@ class Formula
     @prefix_returns_versioned_prefix = true
     build = self.build
     self.build = Tab.for_formula(self)
+    path_with_prefix = PATH.new(ENV["PATH"])
+                           .append(HOMEBREW_PREFIX/"bin")
+                           .append(HOMEBREW_PREFIX/"sbin")
 
     new_env = {
       "TMPDIR" => HOMEBREW_TEMP,
       "TEMP" => HOMEBREW_TEMP,
       "TMP" => HOMEBREW_TEMP,
       "HOMEBREW_PATH" => nil,
+      "PATH" => path_with_prefix,
     }
 
     with_env(new_env) do


### PR DESCRIPTION
This avoids the need for workarounds such as https://github.com/Homebrew/homebrew-core/pull/21688