### PR TITLE
tests: don't output seed multiple times.

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -5,6 +5,7 @@ require "rspec/wait"
 require "rubocop"
 require "rubocop/rspec/support"
 require "set"
+require "support/no_seed_progress_formatter"
 
 if ENV["HOMEBREW_TESTS_COVERAGE"]
   require "simplecov"

--- a/Library/Homebrew/test/support/no_seed_progress_formatter.rb
+++ b/Library/Homebrew/test/support/no_seed_progress_formatter.rb
@@ -1,0 +1,7 @@
+require "rspec/core/formatters/progress_formatter"
+
+class NoSeedProgressFormatter < RSpec::Core::Formatters::ProgressFormatter
+  RSpec::Core::Formatters.register self, :seed
+
+  def seed(notification); end
+end


### PR DESCRIPTION
This clutters up the output. Instead, hide it with a RSpec formatter and generate and output it ourselves.

CC @reitermarkus for RSpec expertise and thoughts; is it even useful to output the seed for parallel test runs?