### PR TITLE
gist-logs: use full path to brew.

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -27,7 +27,7 @@ module Homebrew
     # Dummy summary file, asciibetically first, to control display title of gist
     files["# #{f.name} - #{timestamp}.txt"] = { content: brief_build_info(f) }
     files["00.config.out"] = { content: s.string }
-    files["00.doctor.out"] = { content: `brew doctor 2>&1` }
+    files["00.doctor.out"] = { content: Utils.popen_read("#{HOMEBREW_PREFIX}/bin/brew", "doctor", err: :out) }
     unless f.core_formula?
       tap = <<~EOS
         Formula: #{f.name}

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -350,7 +350,7 @@ module Homebrew
         remote = reply[/remote:? (\S+)/, 1]
 
         # repeat for hub 2.2 backwards compatibility:
-        remote = Utils.popen_read("hub fork 2>&1")[/remote:? (\S+)/, 1] if remote.to_s.empty?
+        remote = Utils.popen_read("hub", "fork", err: :out)[/remote:? (\S+)/, 1] if remote.to_s.empty?
 
         if remote.to_s.empty?
           formula.path.atomic_write(backup_file) unless ARGV.dry_run?

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -103,7 +103,7 @@ class JavaRequirement < Requirement
   end
 
   def satisfies_version(java)
-    java_version_s = Utils.popen_read("#{java} -version 2>&1")[/\d+.\d/]
+    java_version_s = Utils.popen_read(java, "-version", err: :out)[/\d+.\d/]
     return false unless java_version_s
     java_version = Version.create(java_version_s)
     needed_version = Version.create(version_without_plus)


### PR DESCRIPTION
This fixes the command with environment filtering enabled. Also, while we're here, cleanup some `2>&1` usage in `java_requirement` and `bump-formula-pr`.