### PR TITLE
post_install: use HOMEBREW_PATH.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -956,16 +956,13 @@ class Formula
     @prefix_returns_versioned_prefix = true
     build = self.build
     self.build = Tab.for_formula(self)
-    path_with_prefix = PATH.new(ENV["PATH"])
-                           .append(HOMEBREW_PREFIX/"bin")
-                           .append(HOMEBREW_PREFIX/"sbin")
 
     new_env = {
       "TMPDIR" => HOMEBREW_TEMP,
       "TEMP" => HOMEBREW_TEMP,
       "TMP" => HOMEBREW_TEMP,
       "HOMEBREW_PATH" => nil,
-      "PATH" => path_with_prefix,
+      "PATH" => ENV["HOMEBREW_PATH"],
     }
 
     with_env(new_env) do


### PR DESCRIPTION
Do this instead of appending the `HOMEBREW_PREFIX` as it's more reliable at finding e.g. keg-only and requirement PATH additions. It's not ideal as it overrides some environment filtering but the only real alternative is recreate the entire build environment by shelling out to `build.rb` in `formula_installer`.

CC @ilovezfs