### PR TITLE
utils: tweak with_env.

### DIFF
--- a/Library/Homebrew/extend/fileutils.rb
+++ b/Library/Homebrew/extend/fileutils.rb
@@ -134,9 +134,9 @@ module FileUtils
 
   # Run `xcodebuild` without Homebrew's compiler environment variables set.
   def xcodebuild(*args)
-    removed = ENV.remove_cc_etc
-    system "xcodebuild", *args
-  ensure
-    ENV.update(removed)
+    with_env(ENV.to_hash) do
+      ENV.remove_cc_etc
+      system "xcodebuild", *args
+    end
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -547,7 +547,7 @@ def with_env(hash)
 
     yield if block_given?
   ensure
-    ENV.update(old_values)
+    ENV.replace(old_values)
   end
 end
 


### PR DESCRIPTION
Tweak `with_env` to use `ENV.replace` instead of `ENV.update` to undo any other environment variables that are changed in the block. Also, use this for `brew test` and for the `xcodebuild` helper.