### PR TITLE
Added no_proxy to filtered env

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -251,8 +251,14 @@ can take several different forms:
     Sets the FTP proxy to be used by `curl`, `git` and `svn` when downloading
     through Homebrew.
 
+  * `no_proxy`:
+    Sets the comma-separated list of hostnames and domain names that should be excluded from proxying
+    by `curl`, `git` and `svn` when downloading through Homebrew.
+
 ## USING HOMEBREW BEHIND A PROXY
-Use the `http_proxy`, `https_proxy` and/or `ftp_proxy` documented above. For example for an unauthenticated HTTP proxy:
+Use the `http_proxy`, `https_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
+
+For example for an unauthenticated HTTP proxy:
 
     export http_proxy=http://<host>:<port>
 

--- a/bin/brew
+++ b/bin/brew
@@ -67,7 +67,7 @@ then
   FILTERED_ENV=()
   # Filter all but the specific variables.
   for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
-             http_proxy https_proxy ftp_proxy HTTPS_PROXY FTP_PROXY \
+             http_proxy https_proxy ftp_proxy no_proxy HTTPS_PROXY FTP_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}" "${!JENKINS_@}"
   do
     # Skip if variable value is empty.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1096,8 +1096,14 @@ can take several different forms:
     Sets the FTP proxy to be used by `curl`, `git` and `svn` when downloading
     through Homebrew.
 
+  * `no_proxy`:
+    Sets the comma-separated list of hostnames and domain names that should be excluded from proxying
+    by `curl`, `git` and `svn` when downloading through Homebrew.
+
 ## USING HOMEBREW BEHIND A PROXY
-Use the `http_proxy`, `https_proxy` and/or `ftp_proxy` documented above. For example for an unauthenticated HTTP proxy:
+Use the `http_proxy`, `https_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
+
+For example for an unauthenticated HTTP proxy:
 
     export http_proxy=http://`host`:`port`
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1120,8 +1120,15 @@ Sets the HTTPS proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when down
 \fBftp_proxy\fR
 Sets the FTP proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
 .
+.TP
+\fBno_proxy\fR
+Sets the comma\-separated list of hostnames and domain names that should be excluded from proxying by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
+.
 .SH "USING HOMEBREW BEHIND A PROXY"
-Use the \fBhttp_proxy\fR, \fBhttps_proxy\fR and/or \fBftp_proxy\fR documented above\. For example for an unauthenticated HTTP proxy:
+Use the \fBhttp_proxy\fR, \fBhttps_proxy\fR, \fBno_proxy\fR and/or \fBftp_proxy\fR documented above\.
+.
+.P
+For example for an unauthenticated HTTP proxy:
 .
 .IP "" 4
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

no_proxy was requested in #3500 but was not included in #3501 
The additions of other proxy environment variables causes brew update to use proxy for a private tap host which causes the operation to fail.