### PR TITLE
formula_installer: prevent endless loop in some cases

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -449,11 +449,11 @@ class FormulaInstaller
           Requirement.prune
         elsif req.build? && use_default_formula && req_dependency&.installed?
           Requirement.prune
+        elsif req.satisfied?
+          Requirement.prune
         elsif install_requirement_formula?(req_dependency, req, dependent, install_bottle_for_dependent)
           deps.unshift(req_dependency)
           formulae.unshift(req_dependency.to_formula)
-          Requirement.prune
-        elsif req.satisfied?
           Requirement.prune
         elsif !runtime_requirements.include?(req) && install_bottle_for_dependent
           Requirement.prune


### PR DESCRIPTION
This fixes an endless loop, where the xorg requirement
was added to the formulae array, and looped
over again and again. If the requirement is satisfied,
we can bail out earlier.

This fixes the endless loop you got when calling:
brew install python3 --with-tcl-tk

See https://github.com/Linuxbrew/homebrew-core/issues/5218
for the initial bug report. Adding @sjackman as cc.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
