### PR TITLE
shims/scm/git: Fix the search for brewed git

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -92,6 +92,9 @@ case "$(lowercase "$SCM_FILE")" in
     ;;
 esac
 
+brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../../bin" && pwd -P)/$SCM_FILE"
+safe_exec "$brew_version" "$@"
+
 brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../bin" && pwd -P)/$SCM_FILE"
 safe_exec "$brew_version" "$@"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Search for brewed git in both locations:
```
$HOMEBREW_PREFIX/Homebrew/Library/Homebrew/shims/scm/../../../../../bin/git
$HOMEBREW_PREFIX/Library/Homebrew/shims/scm/../../../../bin/git
```

It previously searched only the latter location.