### PR TITLE
Revert "Revert "shims/scm/git: Fix the search for brewed git""

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -92,6 +92,9 @@ case "$(lowercase "$SCM_FILE")" in
     ;;
 esac
 
+brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../../bin" && pwd -P)/$SCM_FILE"
+safe_exec "$brew_version" "$@"
+
 brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../bin" && pwd -P)/$SCM_FILE"
 safe_exec "$brew_version" "$@"
 


### PR DESCRIPTION
Reverts Homebrew/brew#3594

#3589 should be OK now that https://github.com/Homebrew/homebrew-core/pull/22071 is merged.