### PR TITLE
utils: stop debug exploding when zsh is used

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -154,6 +154,7 @@ def interactive_shell(f = nil)
   end
 
   if ENV["SHELL"].include?("zsh") && ENV["HOME"].start_with?(HOMEBREW_TEMP.resolved_path.to_s)
+    FileUtils.mkdir_p ENV["HOME"]
     FileUtils.touch "#{ENV["HOME"]}/.zshrc"
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I'm not actually completely sure what's going on here, to be honest, other than this fixes it. It seems like it's trying to touch `.zshrc` _before_ Homebrew creates the `HOME` directory inside `buildpath` or `testpath` but I have no idea why this has started recently.

This is the existing failure:
```
==> make install
^C/usr/local/Homebrew/Library/Homebrew/formula.rb:1762:in `gets'
Interrupt:
1. raise
2. backtrace
3. shell
Choose an action: 3
When you exit this shell, you will return to the menu.
==> Kept temporary files
Temporary files retained at /tmp/gopass-20171223-39548-16u43i1
Error: No such file or directory @ rb_sysopen - /private/tmp/gopass-20171223-39548-16u43i1/gopass-1.6.6/.brew_home/.zshrc
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:1157:in `initialize'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:1157:in `open'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:1157:in `rescue in block in touch'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:1153:in `block in touch'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:1151:in `each'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/fileutils.rb:1151:in `touch'
/usr/local/Homebrew/Library/Homebrew/utils.rb:157:in `interactive_shell'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:135:in `block (3 levels) in debug'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:73:in `choose'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:112:in `block in debug'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:111:in `loop'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:111:in `debug'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:96:in `rescue in debrew'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:99:in `debrew'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:22:in `install'
/usr/local/Homebrew/Library/Homebrew/build.rb:143:in `block (2 levels) in install'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1095:in `block in brew'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1901:in `block (2 levels) in stage'
/usr/local/Homebrew/Library/Homebrew/utils.rb:548:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1900:in `block in stage'
/usr/local/Homebrew/Library/Homebrew/resource.rb:97:in `block in unpack'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:14:in `block in mktemp'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `block in run'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `chdir'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:74:in `run'
/usr/local/Homebrew/Library/Homebrew/extend/fileutils.rb:13:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/resource.rb:93:in `unpack'
/usr/local/Homebrew/Library/Homebrew/resource.rb:85:in `stage'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1878:in `stage'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1090:in `brew'
/usr/local/Homebrew/Library/Homebrew/build.rb:114:in `block in install'
/usr/local/Homebrew/Library/Homebrew/utils.rb:548:in `with_env'
/usr/local/Homebrew/Library/Homebrew/build.rb:111:in `install'
/usr/local/Homebrew/Library/Homebrew/build.rb:192:in `<main>'
```