### PR TITLE
gpg: use with_homebrew_path

### DIFF
--- a/Library/Homebrew/gpg.rb
+++ b/Library/Homebrew/gpg.rb
@@ -4,7 +4,7 @@ module Gpg
   module_function
 
   def executable
-    which "gpg"
+    with_homebrew_path { which("gpg") }
   end
 
   def available?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes calling things like `Gpg.available?` in `brew irb`, etc. Or anywhere that uses the protected `PATH`, really.