### PR TITLE
cli : Add basic arg parser and use it for parsing `brew audit` args

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -1,0 +1,55 @@
+require "optparse"
+require "ostruct"
+
+module Homebrew
+  module CLI
+    class Parser
+      def initialize(&block)
+        @parser = OptionParser.new
+        @parsed_args = OpenStruct.new
+        instance_eval(&block)
+      end
+
+      def switch(*names, description: nil)
+        description = option_to_description(*names) if description.nil?
+        @parser.on(*names, description) do
+          names.each do |name|
+            @parsed_args["#{option_to_name(name)}?"] = true
+          end
+        end
+      end
+
+      def comma_array(name, description: nil)
+        description = option_to_description(name) if description.nil?
+        @parser.on(name, OptionParser::REQUIRED_ARGUMENT, Array, description) do |list|
+          @parsed_args[option_to_name(name)] = list
+        end
+      end
+
+      def flag(name, description: nil, required: false)
+        if required
+          option_required = OptionParser::REQUIRED_ARGUMENT
+        else
+          option_required = OptionParser::OPTIONAL_ARGUMENT
+        end
+        description = option_to_description(name) if description.nil?
+        @parser.on(name, description, option_required) do |option_value|
+          @parsed_args[option_to_name(name)] = option_value
+        end
+      end
+
+      def option_to_name(name)
+        name.sub(/\A--?/, "").tr("-", "_")
+      end
+
+      def option_to_description(*names)
+        names.map { |name| name.sub(/\A--?/, "").tr("-", " ") }.sort.last
+      end
+
+      def parse(cmdline_args = ARGV)
+        @parser.parse!(cmdline_args)
+        @parsed_args
+      end
+    end
+  end
+end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -49,20 +49,34 @@ require "cmd/style"
 require "date"
 require "missing_formula"
 require "digest"
+require "cli_parser"
 
 module Homebrew
   module_function
 
   def audit
-    inject_dump_stats!(FormulaAuditor, /^audit_/) if ARGV.switch? "D"
+    args = Homebrew::CLI::Parser.new do
+      switch      "--strict"
+      switch      "--online"
+      switch      "--new-formula"
+      switch      "--fix"
+      switch      "--display-cop-names"
+      switch      "--display-filename"
+      switch      "-D", "--audit-debug", description: "Activates debugging and profiling"
+      comma_array "--only"
+      comma_array "--except"
+      comma_array "--only-cops"
+      comma_array "--except-cops"
+    end.parse
+
     Homebrew.auditing = true
+    inject_dump_stats!(FormulaAuditor, /^audit_/) if args.audit_debug?
 
     formula_count = 0
     problem_count = 0
-
-    new_formula = ARGV.include? "--new-formula"
-    strict = new_formula || ARGV.include?("--strict")
-    online = new_formula || ARGV.include?("--online")
+    new_formula = args.new_formula?
+    strict = new_formula || args.strict?
+    online = new_formula || args.online?
 
     ENV.activate_extensions!
     ENV.setup_build_environment
@@ -75,35 +89,36 @@ module Homebrew
       files = ARGV.resolved_formulae.map(&:path)
     end
 
-    only_cops = ARGV.value("only-cops").to_s.split(",")
-    except_cops = ARGV.value("except-cops").to_s.split(",")
+    only_cops = args.only_cops
+    except_cops = args.except_cops
 
-    if !only_cops.empty? && !except_cops.empty?
+    if only_cops && except_cops
       odie "--only-cops and --except-cops cannot be used simultaneously!"
-    elsif (!only_cops.empty? || !except_cops.empty?) && (strict || ARGV.value("only"))
+    elsif (only_cops || except_cops) && (strict || args.only)
       odie "--only-cops/--except-cops and --strict/--only cannot be used simultaneously"
     end
 
-    options = { fix: ARGV.flag?("--fix"), realpath: true }
+    options = { fix: args.fix?, realpath: true }
 
-    if !only_cops.empty?
+    if only_cops
       options[:only_cops] = only_cops
-      ARGV.push("--only=style")
-    elsif new_formula
+      args.only = ["style"]
+    elsif args.new_formula?
       nil
     elsif strict
       options[:except_cops] = [:NewFormulaAudit]
-    elsif !except_cops.empty?
+    elsif except_cops
       options[:except_cops] = except_cops
     elsif !strict
       options[:only_cops] = [:FormulaAudit]
     end
 
+    options[:display_cop_names] = args.display_cop_names?
     # Check style in a single batch run up front for performance
     style_results = check_style_json(files, options)
 
     ff.sort.each do |f|
-      options = { new_formula: new_formula, strict: strict, online: online }
+      options = { new_formula: new_formula, strict: strict, online: online, only: args.only, except: args.except }
       options[:style_offenses] = style_results.file_offenses(f.path)
       fa = FormulaAuditor.new(f, options)
       fa.audit
@@ -113,7 +128,7 @@ module Homebrew
       formula_count += 1
       problem_count += fa.problems.size
       problem_lines = fa.problems.map { |p| "* #{p.chomp.gsub("\n", "\n    ")}" }
-      if ARGV.include? "--display-filename"
+      if args.display_filename?
         puts problem_lines.map { |s| "#{f.path}: #{s}" }
       else
         puts "#{f.full_name}:", problem_lines.map { |s| "  #{s}" }
@@ -196,6 +211,9 @@ class FormulaAuditor
     @new_formula = options[:new_formula]
     @strict = options[:strict]
     @online = options[:online]
+    @display_cop_names = options[:display_cop_names]
+    @only = options[:only]
+    @except = options[:except]
     # Accept precomputed style offense results, for efficiency
     @style_offenses = options[:style_offenses]
     @problems = []
@@ -205,9 +223,8 @@ class FormulaAuditor
 
   def audit_style
     return unless @style_offenses
-    display_cop_names = ARGV.include?("--display-cop-names")
     @style_offenses.each do |offense|
-      problem offense.to_s(display_cop_name: display_cop_names)
+      problem offense.to_s(display_cop_name: @display_cop_names)
     end
   end
 
@@ -777,17 +794,17 @@ class FormulaAuditor
   end
 
   def audit
-    only_audits = ARGV.value("only").to_s.split(",")
-    except_audits = ARGV.value("except").to_s.split(",")
-    if !only_audits.empty? && !except_audits.empty?
+    only_audits = @only
+    except_audits = @except
+    if only_audits && except_audits
       odie "--only and --except cannot be used simultaneously!"
     end
 
     methods.map(&:to_s).grep(/^audit_/).each do |audit_method_name|
       name = audit_method_name.gsub(/^audit_/, "")
-      if !only_audits.empty?
+      if only_audits
         next unless only_audits.include?(name)
-      elsif !except_audits.empty?
+      elsif except_audits
         next if except_audits.include?(name)
       end
       send(audit_method_name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#1860 **Emit warnings for mistyped options**

This a very basic WIP PR,  to get feedback on its usability & to demonstrate DSL of the parser; 

**Requirements:** 
 - DSL should be in declarative way
 - Reduce number of places `ARGV` is used, abstract it in DSL

**Example Code:**

```ruby
args = Homebrew::CLI::Parser.new do
  switch       "--strict",      "description of strict"
  switch       "--online",      "description of online"
  switch       "--new-formula", "description of new-formula"
  comma_array  "--only-cops",   "description of only-cops"
end.parse
```
3 types are supported as of now.
1. `switch` 
  A switch is an option that does not take arguments. It is used to turn options on/off . It can be both long and short
  Ex: `--new-formula` , `-D`  

2. `flag` 
 Flags take arguments. Long form flags take arguments with equal sign and short form flags don't require equal sign
  Ex: `--log-level=DEBUG` 

3. `comma_array` 
 Custom "flag" option type for Homebrew, which can take comma separated arguments
  Ex: `--only-cops=FormulaAudit,FormulaAuditStrict` 

**`Usage:`** 
**Example 1:** (All valid args)
`$ brew audit --new-formula wget` would result `args` to be as follows

`> p args` 
`> #<OpenStruct new_formula?=true>`

**Example 2:** (wrong args)

`$ brew audit --unknown-arg wget` would result in

`Error invalid option: --unknown-arg`

To start with, I have replaced usages of `ARGV` in `audit.rb` with this implementation.