### PR TITLE
scm/git: hide prefix cd failure warning.

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -92,11 +92,11 @@ case "$(lowercase "$SCM_FILE")" in
     ;;
 esac
 
-brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../../bin" && pwd -P)/$SCM_FILE"
-safe_exec "$brew_version" "$@"
+brew_prefix_version="$(quiet_safe_cd "$SCM_DIR/../../../../../bin" 2>/dev/null && pwd -P)/$SCM_FILE"
+safe_exec "$brew_prefix_version" "$@"
 
-brew_version="$(quiet_safe_cd "$SCM_DIR/../../../../bin" && pwd -P)/$SCM_FILE"
-safe_exec "$brew_version" "$@"
+brew_repo_version="$(quiet_safe_cd "$SCM_DIR/../../../../bin" && pwd -P)/$SCM_FILE"
+safe_exec "$brew_repo_version" "$@"
 
 IFS=$'\n'
 for path in $(/usr/bin/which -a "$SCM_FILE" 2>/dev/null)


### PR DESCRIPTION
This may happen with certain checkout configurations (such as on our CI boxes).

Also, rename the variables to be clearer about what they reference.

CC @ilovezfs