### PR TITLE
formula_installer: allow version mismatched python deps

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -182,6 +182,7 @@ class FormulaInstaller
     recursive_runtime_formulae.each do |f|
       name = f.name
       unversioned_name, = name.split("@")
+      next if unversioned_name == "python"
       version_hash[unversioned_name] ||= Set.new
       version_hash[unversioned_name] << name
       next if version_hash[unversioned_name].length < 2


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Dependency trees with both python@2 and python@3 are not inherently
problematic.

Goes together with https://github.com/Homebrew/homebrew-core/pull/22263.