### PR TITLE
missing_formula: check deleted in the last month.

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -122,7 +122,7 @@ module Homebrew
 
         tap.path.cd do
           unless silent
-            ohai "Searching for a previously deleted formula..."
+            ohai "Searching for a previously deleted formula (in the last month)..."
             if (tap.path/".git/shallow").exist?
               opoo <<~EOS
                 #{tap} is shallow clone. To get complete history run:
@@ -132,7 +132,7 @@ module Homebrew
             end
           end
 
-          log_command = "git log --name-only --max-count=1 --format=%H\\\\n%h\\\\n%B -- #{relative_path}"
+          log_command = "git log --since='1 month ago' --diff-filter=D --name-only --max-count=1 --format=%H\\\\n%h\\\\n%B -- #{relative_path}"
           hash, short_hash, *commit_message, relative_path =
             Utils.popen_read(log_command).gsub("\\n", "\n").lines.map(&:chomp)
 

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -140,6 +140,8 @@ describe Homebrew::MissingFormula do
       tap_path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
       tap_path.mkpath
       (tap_path/"deleted-formula.rb").write "placeholder"
+      ENV.delete "GIT_AUTHOR_DATE"
+      ENV.delete "GIT_COMMITTER_DATE"
 
       tap_path.cd do
         system "git", "init"


### PR DESCRIPTION
This speeds things up pretty dramatically and handles the case that something was deleted recently and users haven't learned about it yet.

Fixes #3513.