### PR TITLE
Preserve HOMEBREW_CELLAR if already specified

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -5,8 +5,12 @@ then
 fi
 
 # Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
-# for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.
-if [[ -d "$HOMEBREW_REPOSITORY/Cellar" ]]
+# for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY or the
+# cellar is already defined via HOMEBREW_CELLAR.
+if [[ -n "$HOMEBREW_CELLAR" ]]
+then
+  :
+elif [[ -d "$HOMEBREW_REPOSITORY/Cellar" ]]
 then
   HOMEBREW_CELLAR="$HOMEBREW_REPOSITORY/Cellar"
 else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Currently, users can freely choose HOMEBREW_PREFIX (based on where the symlink is located) and HOMEBREW_REPOSITORY (based on the location of the repository/where the symlink points) but cannot specify HOMEBREW_CELLAR. This provides an easy way to make that specifiable by users.