### PR TITLE
lines_cop: flag `depends_on :perl => "1.0"`.

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -70,6 +70,7 @@ module Homebrew
   def check_style_impl(files, output_type, options = {})
     fix = options[:fix]
 
+    Homebrew.install_gem_setup_path! "parser", HOMEBREW_RUBOCOP_PARSER_VERSION, "ruby-parse"
     Homebrew.install_gem_setup_path! "rubocop", HOMEBREW_RUBOCOP_VERSION
     require "rubocop"
     require_relative "../rubocops"

--- a/Library/Homebrew/constants.rb
+++ b/Library/Homebrew/constants.rb
@@ -2,4 +2,5 @@
 
 # RuboCop version used for `brew style` and `brew cask style`
 HOMEBREW_RUBOCOP_VERSION = "0.51.0"
+HOMEBREW_RUBOCOP_PARSER_VERSION = "2.4.0.0" # for Ruby 2.3.3
 HOMEBREW_RUBOCOP_CASK_VERSION = "~> 0.15.1" # has to be updated when RuboCop version changes

--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -146,7 +146,7 @@ module RuboCop
       # Returns nil if does not depend on dependency_name
       # args: node - dependency_name - dependency's name
       def depends_on?(dependency_name, *types)
-        types = [:required, :build, :optional, :recommended, :run] if types.empty?
+        types = [:any] if types.empty?
         dependency_nodes = find_every_method_call_by_name(@body, :depends_on)
         idx = dependency_nodes.index do |n|
           types.any? { |type| depends_on_name_type?(n, dependency_name, type) }
@@ -168,14 +168,14 @@ module RuboCop
         case type
         when :required
           type_match = required_dependency?(node)
-          if type_match && !name_match
-            name_match = required_dependency_name?(node, name)
-          end
+          name_match ||= required_dependency_name?(node, name) if type_match
         when :build, :optional, :recommended, :run
           type_match = dependency_type_hash_match?(node, type)
-          if type_match && !name_match
-            name_match = dependency_name_hash_match?(node, name)
-          end
+          name_match ||= dependency_name_hash_match?(node, name) if type_match
+        when :any
+          type_match = true
+          name_match ||= required_dependency_name?(node, name)
+          name_match ||= dependency_name_hash_match?(node, name)
         else
           type_match = false
         end
@@ -214,7 +214,7 @@ module RuboCop
       EOS
 
       def_node_search :dependency_name_hash_match?, <<~EOS
-        (hash (pair ({str sym} %1) ({str sym} _)))
+        (hash (pair ({str sym} %1) ({str sym array} _)))
       EOS
 
       # To compare node with appropriate Ruby variable

--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -467,7 +467,7 @@ module RuboCop
       end
 
       def problem(msg)
-        add_offense(@offensive_node, @offense_source_range, msg)
+        add_offense(@offensive_node, location: @offense_source_range, message: msg)
       end
 
       private

--- a/Library/Homebrew/test/Gemfile
+++ b/Library/Homebrew/test/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 require_relative "../constants"
 
 gem "parallel_tests"
+gem "parser", HOMEBREW_RUBOCOP_PARSER_VERSION
 gem "rspec"
 gem "rspec-its", require: false
 gem "rspec-wait", require: false

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -58,6 +58,7 @@ PLATFORMS
 DEPENDENCIES
   codecov
   parallel_tests
+  parser (= 2.4.0.0)
   rspec
   rspec-its
   rspec-wait
@@ -65,4 +66,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
This requires ignoring the version argument with a new `:version` mode for this check.