### PR TITLE
audit: pass explicit sort to handle APFS

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -102,7 +102,7 @@ module Homebrew
     # Check style in a single batch run up front for performance
     style_results = check_style_json(files, options)
 
-    ff.each do |f|
+    ff.sort.each do |f|
       options = { new_formula: new_formula, strict: strict, online: online }
       options[:style_offenses] = style_results.file_offenses(f.path)
       fa = FormulaAuditor.new(f, options)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
https://github.com/Homebrew/brew/issues/3311
```
$ brew audit
apcupsd:
  * C: 29: col 66: "#{prefix}/Lib" should be "#{lib}"
azure-cli:
  * C: 16: col 3: :python3 is deprecated. Usage should be "python3".
ib:
  * C: 14: col 3: :python is deprecated. Usage should be "python".
pyqt:
  * C: 21: col 3: :python is deprecated. Usage should be "python".
you-get:
  * C: 17: col 3: :python3 is deprecated. Usage should be "python3".
hdf5@1.8:
  * C: 23: col 3: :fortran is deprecated. Usage should be "gcc".
arpack:
  * C: 19: col 3: :fortran is deprecated. Usage should be "gcc".
```
```
$ brew audit
abyss:
  * C: 23: col 3: 'needs :openmp' should be replaced with 'depends_on "gcc"'
apcupsd:
  * C: 29: col 66: "#{prefix}/Lib" should be "#{lib}"
arpack:
  * C: 19: col 3: :fortran is deprecated. Usage should be "gcc".
asciinema:
  * C: 16: col 3: :python3 is deprecated. Usage should be "python3".
awscli:
  * C: 20: col 3: :python3 is deprecated. Usage should be "python3".
azure-cli:
  * C: 16: col 3: :python3 is deprecated. Usage should be "python3".
bandcamp-dl:
  * C: 18: col 3: :python3 is deprecated. Usage should be "python3".
beast:
  * C: 15: col 3: :ant is deprecated. Usage should be "ant".
```