### PR TITLE
Use hgpath instead of "hg" to fix --HEAD hg builds

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1005,11 +1005,11 @@ class MercurialDownloadStrategy < VCSDownloadStrategy
   end
 
   def source_modified_time
-    Time.parse Utils.popen_read("hg", "tip", "--template", "{date|isodate}", "-R", cached_location.to_s)
+    Time.parse Utils.popen_read(hgpath, "tip", "--template", "{date|isodate}", "-R", cached_location.to_s)
   end
 
   def last_commit
-    Utils.popen_read("hg", "parent", "--template", "{node|short}", "-R", cached_location.to_s)
+    Utils.popen_read(hgpath, "parent", "--template", "{node|short}", "-R", cached_location.to_s)
   end
 
   private


### PR DESCRIPTION
Fixes #3628.
With environment filtering, hg was no longer in the path, so make sure to provide the path when calling hg commands (the other functions in download_strategy use hgpath). `last_commit` was the source of the problem in #3628, but I fixed `source_modified_time` as well since it had the same problem. I didn't see any other functions using "hg".

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----

  