### PR TITLE
upgrade: skip formula if upgrade fails due to unsatisfied requirement.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -89,10 +89,14 @@ module Homebrew
 
     formulae_to_install.each do |f|
       Migrator.migrate_if_needed(f)
-      upgrade_formula(f)
-      next unless ARGV.include?("--cleanup")
-      next unless f.installed?
-      Homebrew::Cleanup.cleanup_formula f
+      begin
+        upgrade_formula(f)
+        next unless ARGV.include?("--cleanup")
+        next unless f.installed?
+        Homebrew::Cleanup.cleanup_formula f
+      rescue UnsatisfiedRequirements => e
+        onoe "#{f}: #{e}"
+      end
     end
   end
 


### PR DESCRIPTION
Rather than blocking the rest of the formulae from being installed by `brew upgrade` print the requirement failure messages (already done) and an error stating requirements weren't satisfied and then continue to upgrade the rest of the formulae.