### PR TITLE
bash completion: add null completion where appropriate

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1,5 +1,10 @@
 # Bash completion script for brew(1)
 
+# Indicates there are no completions
+__brewcomp_null() {
+  COMPREPLY=""
+}
+
 __brewcomp_words_include() {
   local i=1
   while [[ "$i" -lt "$COMP_CWORD" ]]
@@ -399,6 +404,7 @@ _brew_search() {
       return
       ;;
   esac
+  __brewcomp_null
 }
 
 _brew_style() {


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *Nope - we don't test shell completion.*
- [X] Have you successfully run `brew tests` with your changes locally? 

-----

In some cases, in bash completion, there are no valid arguments discoverable from the command line. For example, with `brew search <tab><tab>`, it could take any string. (And, if #3625 is merged, `brew cask doctor <tab><tab>` has no valid completions.) In this case, I think we should supply no completions.

The current behavior is to fall back to completing on file names relative to the current directory. I think this is wrong, because those file names are not valid arguments in this context. Or at least, they're not expected to be relevant.

This PR changes the behavior to have it complete to nothing. (Unfortunately, adding a blank space on the command line, but I don't see a way around that.) I think that's more appropriate.
  