### PR TITLE
brew config: Report physical CPU cores on macOS

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -72,7 +72,7 @@ module Hardware
 
       def cores
         return @cores if @cores
-        @cores = Utils.popen_read("getconf", "_NPROCESSORS_ONLN").chomp.to_i
+        @cores = Utils.popen_read("sysctl", "-n", "hw.physicalcpu").chomp.to_i
         @cores = 1 unless $CHILD_STATUS.success?
         @cores
       end


### PR DESCRIPTION
Per https://github.com/Homebrew/brew/issues/3473#issuecomment-346895927

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No: That's hard to do without changing the architecture to make mocking the hardware detection possible.*
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR changes `brew config`, at least on macOS, to report the number of physical cores in the current machine. Fixes #3473.

Leaves the Linux code alone, so that's probably still reporting virtual cores.