### PR TITLE
Deprecate Git, Subversion requirements.

### DIFF
--- a/Library/Homebrew/compat/requirements.rb
+++ b/Library/Homebrew/compat/requirements.rb
@@ -44,6 +44,18 @@ class GPG2Requirement < Requirement
   satisfy { which "gpg" }
 end
 
+class GitRequirement < Requirement
+  fatal true
+  default_formula "git"
+  satisfy { Utils.git_available? }
+end
+
+class SubversionRequirement < Requirement
+  fatal true
+  default_formula "subversion"
+  satisfy { Utils.svn_available? }
+end
+
 XcodeDependency            = XcodeRequirement
 MysqlDependency            = MysqlRequirement
 PostgresqlDependency       = PostgresqlRequirement

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -52,6 +52,16 @@ class DependencyCollector
     parse_spec(spec, Array(tags))
   end
 
+  def git_dep_if_needed(tags)
+    return if Utils.git_available?
+    Dependency.new("git", tags)
+  end
+
+  def subversion_dep_if_needed(tags)
+    return if Utils.svn_available?
+    Dependency.new("subversion", tags)
+  end
+
   def cvs_dep_if_needed(tags)
     Dependency.new("cvs", tags)
   end
@@ -126,9 +136,9 @@ class DependencyCollector
     if strategy <= CurlDownloadStrategy
       parse_url_spec(spec.url, tags)
     elsif strategy <= GitDownloadStrategy
-      GitRequirement.new(tags)
+      git_dep_if_needed(tags)
     elsif strategy <= SubversionDownloadStrategy
-      SubversionRequirement.new(tags)
+      subversion_dep_if_needed(tags)
     elsif strategy <= MercurialDownloadStrategy
       Dependency.new("mercurial", tags)
     elsif strategy <= FossilDownloadStrategy

--- a/Library/Homebrew/extend/os/mac/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/mac/dependency_collector.rb
@@ -1,6 +1,13 @@
 require "os/mac/ld64_dependency"
 
 class DependencyCollector
+  def git_dep_if_needed(tags)
+    return if MacOS.version >= :lion
+    Dependency.new("git", tags)
+  end
+
+  def subversion_dep_if_needed(tags); end
+
   def cvs_dep_if_needed(tags)
     return if MacOS.version < :lion
     Dependency.new("cvs", tags)

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -9,15 +9,3 @@ require "requirements/unsigned_kext_requirement"
 require "requirements/x11_requirement"
 require "requirements/arch_requirement"
 require "requirements/xcode_requirement"
-
-class GitRequirement < Requirement
-  fatal true
-  default_formula "git"
-  satisfy { Utils.git_available? }
-end
-
-class SubversionRequirement < Requirement
-  fatal true
-  default_formula "subversion"
-  satisfy { Utils.svn_available? }
-end

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -78,22 +78,10 @@ describe DependencyCollector do
       expect(spec).to eq(copy)
     end
 
-    it "creates a resource dependency from a '.git' URL" do
-      resource = Resource.new
-      resource.url("git://example.com/foo/bar.git")
-      expect(subject.add(resource)).to be_an_instance_of(GitRequirement)
-    end
-
     it "creates a resource dependency from a CVS URL" do
       resource = Resource.new
       resource.url(":pserver:anonymous:@example.com:/cvsroot/foo/bar", using: :cvs)
       expect(subject.add(resource)).to eq(Dependency.new("cvs", [:build]))
-    end
-
-    it "creates a resource dependency from a Subversion URL" do
-      resource = Resource.new
-      resource.url("svn://example.com/foo/bar")
-      expect(subject.add(resource)).to be_an_instance_of(SubversionRequirement)
     end
 
     it "creates a resource dependency from a '.7z' URL" do

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -35,4 +35,16 @@ describe DependencyCollector do
     resource.url("http://example.com/foo.tar.xz")
     expect(subject.add(resource)).to be nil
   end
+
+  specify "Resource dependency from a '.git' URL" do
+    resource = Resource.new
+    resource.url("git://example.com/foo/bar.git")
+    expect(subject.add(resource)).to be nil
+  end
+
+  specify "Resource dependency from a Subversion URL" do
+    resource = Resource.new
+    resource.url("svn://example.com/foo/bar")
+    expect(subject.add(resource)).to be nil
+  end
 end


### PR DESCRIPTION
These rely on `default_formula` to be useful and are better following the `*_dep_if_needed` pattern.