### PR TITLE
Add more deprecations, disable some existing ones.

### DIFF
--- a/Library/Homebrew/compat/ARGV.rb
+++ b/Library/Homebrew/compat/ARGV.rb
@@ -1,6 +1,5 @@
 module HomebrewArgvExtension
   def build_32_bit?
-    odeprecated "ARGV.build_32_bit?"
-    include? "--32-bit"
+    odisabled "ARGV.build_32_bit?"
   end
 end

--- a/Library/Homebrew/compat/ENV/shared.rb
+++ b/Library/Homebrew/compat/ENV/shared.rb
@@ -5,6 +5,6 @@ module SharedEnvExtension
   end
 
   def java_cache
-    # odeprecated "ENV.java_cache"
+    odeprecated "ENV.java_cache"
   end
 end

--- a/Library/Homebrew/compat/build_options.rb
+++ b/Library/Homebrew/compat/build_options.rb
@@ -1,11 +1,9 @@
 class BuildOptions
   def build_32_bit?
-    odeprecated "build.build_32_bit?"
-    include?("32-bit") && option_defined?("32-bit")
+    odisabled "build.build_32_bit?"
   end
 
   def build_bottle?
-    odeprecated "build.build_bottle?", "build.bottle?"
-    bottle?
+    odisabled "build.build_bottle?", "build.bottle?"
   end
 end

--- a/Library/Homebrew/compat/dependency_collector.rb
+++ b/Library/Homebrew/compat/dependency_collector.rb
@@ -10,6 +10,7 @@ class DependencyCollector
 
   def parse_string_spec(spec, tags)
     if (tag = tags.first) && LANGUAGE_MODULES.include?(tag)
+      odeprecated "'depends_on :#{tag}'"
       LanguageModuleRequirement.new(tag, spec, tags[1])
     else
       _parse_string_spec(spec, tags)
@@ -23,7 +24,7 @@ class DependencyCollector
     when :clt
       odeprecated "'depends_on :clt'"
     when :tex
-      # odeprecated "'depends_on :tex'"
+      odeprecated "'depends_on :tex'"
       TeXRequirement.new(tags)
     when :autoconf, :automake, :bsdmake, :libtool
       output_deprecation(spec, tags)
@@ -39,7 +40,7 @@ class DependencyCollector
       output_deprecation("libtool", tags)
       Dependency.new("libtool", tags)
     when :apr
-      # output_deprecation(spec, tags, "apr-util")
+      output_deprecation(spec, tags, "apr-util")
       Dependency.new("apr-util", tags)
     when :fortran
       # output_deprecation(spec, tags, "gcc")

--- a/Library/Homebrew/compat/fails_with_llvm.rb
+++ b/Library/Homebrew/compat/fails_with_llvm.rb
@@ -1,9 +1,9 @@
 class Formula
   def fails_with_llvm(_msg = nil, _data = nil)
-    odeprecated "Formula#fails_with_llvm in install"
+    odisabled "Formula#fails_with_llvm in install"
   end
 
   def self.fails_with_llvm(_msg = nil, _data = {})
-    odeprecated "Formula.fails_with_llvm"
+    odisabled "Formula.fails_with_llvm"
   end
 end

--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -1,12 +1,10 @@
 module FormulaCompat
   def x11_installed?
-    odeprecated "Formula#x11_installed?", "MacOS::X11.installed?"
-    MacOS::X11.installed?
+    odisabled "Formula#x11_installed?", "MacOS::X11.installed?"
   end
 
   def snow_leopard_64?
-    odeprecated "Formula#snow_leopard_64?", "MacOS.prefer_64_bit?"
-    MacOS.prefer_64_bit?
+    odisabled "Formula#snow_leopard_64?", "MacOS.prefer_64_bit?"
   end
 end
 
@@ -15,48 +13,40 @@ class Formula
   extend FormulaCompat
 
   def std_cmake_parameters
-    odeprecated "Formula#std_cmake_parameters", "Formula#std_cmake_args"
-    "-DCMAKE_INSTALL_PREFIX='#{prefix}' -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -Wno-dev"
+    odisabled "Formula#std_cmake_parameters", "Formula#std_cmake_args"
   end
 
-  def cxxstdlib_check(check_type)
-    odeprecated "Formula#cxxstdlib_check in install",
-                "Formula.cxxstdlib_check outside install"
-    self.class.cxxstdlib_check check_type
+  def cxxstdlib_check(_)
+    odisabled "Formula#cxxstdlib_check in install",
+              "Formula.cxxstdlib_check outside install"
   end
 
   def self.bottle_sha1(*)
-    odeprecated "Formula.bottle_sha1"
+    odisabled "Formula.bottle_sha1"
   end
 
   def self.all
-    odeprecated "Formula.all", "Formula.map"
-    map
+    odisabled "Formula.all", "Formula.map"
   end
 
-  def self.canonical_name(name)
-    odeprecated "Formula.canonical_name", "Formulary.canonical_name"
-    Formulary.canonical_name(name)
+  def self.canonical_name(_)
+    odisabled "Formula.canonical_name", "Formulary.canonical_name"
   end
 
-  def self.class_s(name)
-    odeprecated "Formula.class_s", "Formulary.class_s"
-    Formulary.class_s(name)
+  def self.class_s(_)
+    odisabled "Formula.class_s", "Formulary.class_s"
   end
 
-  def self.factory(name)
-    odeprecated "Formula.factory", "Formulary.factory"
-    Formulary.factory(name)
+  def self.factory(_)
+    odisabled "Formula.factory", "Formulary.factory"
   end
 
   def self.require_universal_deps
-    odeprecated "Formula.require_universal_deps"
-    define_method(:require_universal_deps?) { true }
+    odisabled "Formula.require_universal_deps"
   end
 
-  def self.path(name)
-    odeprecated "Formula.path", "Formulary.core_path"
-    Formulary.core_path(name)
+  def self.path(_)
+    odisabled "Formula.path", "Formulary.core_path"
   end
 
   DATA = :DATA
@@ -67,20 +57,18 @@ class Formula
     {}
   end
 
-  def python(_options = {}, &_block)
-    odeprecated "Formula#python"
-    yield if block_given?
-    PythonRequirement.new
+  def python(_options = {}, &_)
+    odisabled "Formula#python"
   end
   alias python2 python
   alias python3 python
 
   def startup_plist
-    odeprecated "Formula#startup_plist", "Formula#plist"
+    odisabled "Formula#startup_plist", "Formula#plist"
   end
 
   def rake(*args)
-    # odeprecated "FileUtils#rake", "system \"rake\""
+    odeprecated "FileUtils#rake", "system \"rake\""
     system "rake", *args
   end
 end

--- a/Library/Homebrew/compat/formula_specialties.rb
+++ b/Library/Homebrew/compat/formula_specialties.rb
@@ -1,47 +1,23 @@
 class ScriptFileFormula < Formula
   def install
-    odeprecated "ScriptFileFormula#install", "Formula#install"
-    bin.install Dir["*"]
+    odisabled "ScriptFileFormula#install", "Formula#install"
   end
 end
 
 class GithubGistFormula < ScriptFileFormula
-  def self.url(val)
-    odeprecated "GithubGistFormula.url", "Formula.url"
-    super
-    version File.basename(File.dirname(val))[0, 6]
+  def self.url(_val)
+    odisabled "GithubGistFormula.url", "Formula.url"
   end
 end
 
-# This formula serves as the base class for several very similar
-# formulae for Amazon Web Services related tools.
 class AmazonWebServicesFormula < Formula
-  # Use this method to perform a standard install for Java-based tools,
-  # keeping the .jars out of HOMEBREW_PREFIX/lib
   def install
-    odeprecated "AmazonWebServicesFormula#install", "Formula#install"
-
-    rm Dir["bin/*.cmd"] # Remove Windows versions
-    libexec.install Dir["*"]
-    bin.install_symlink Dir["#{libexec}/bin/*"] - ["#{libexec}/bin/service"]
+    odisabled "AmazonWebServicesFormula#install", "Formula#install"
   end
   alias standard_install install
 
   # Use this method to generate standard caveats.
-  def standard_instructions(home_name, home_value = libexec)
-    odeprecated "AmazonWebServicesFormula#standard_instructions", "Formula#caveats"
-
-    <<~EOS
-      Before you can use these tools you must export some variables to your $SHELL.
-
-      To export the needed variables, add them to your dotfiles.
-       * On Bash, add them to `~/.bash_profile`.
-       * On Zsh, add them to `~/.zprofile` instead.
-
-      export JAVA_HOME="$(/usr/libexec/java_home)"
-      export AWS_ACCESS_KEY="<Your AWS Access ID>"
-      export AWS_SECRET_KEY="<Your AWS Secret Key>"
-      export #{home_name}="#{home_value}"
-    EOS
+  def standard_instructions(_, _)
+    odisabled "AmazonWebServicesFormula#standard_instructions", "Formula#caveats"
   end
 end

--- a/Library/Homebrew/compat/global.rb
+++ b/Library/Homebrew/compat/global.rb
@@ -3,8 +3,7 @@ module Homebrew
 
   def method_missing(method, *args, &block)
     if instance_methods.include?(method)
-      odeprecated "#{self}##{method}", "'module_function' or 'def self.#{method}' to convert it to a class method"
-      return instance_method(method).bind(self).call(*args, &block)
+      odisabled "#{self}##{method}", "'module_function' or 'def self.#{method}' to convert it to a class method"
     end
     super
   end

--- a/Library/Homebrew/compat/gpg.rb
+++ b/Library/Homebrew/compat/gpg.rb
@@ -4,46 +4,24 @@ module Gpg
   module_function
 
   def executable
+    odeprecated "Gpg.executable", 'which "gpg"'
     which "gpg"
   end
 
   def available?
+    odeprecated "Gpg.available?", 'which "gpg"'
     File.executable?(executable.to_s)
   end
 
-  def create_test_key(path)
-    odie "No GPG present to test against!" unless available?
-
-    (path/"batch.gpg").write <<~EOS
-      Key-Type: RSA
-      Key-Length: 2048
-      Subkey-Type: RSA
-      Subkey-Length: 2048
-      Name-Real: Testing
-      Name-Email: testing@foo.bar
-      Expire-Date: 1d
-      %no-protection
-      %commit
-    EOS
-    system executable, "--batch", "--gen-key", "batch.gpg"
+  def create_test_key(_)
+    odeprecated "Gpg.create_test_key"
   end
 
   def cleanup_test_processes!
-    odie "No GPG present to test against!" unless available?
-
-    gpgconf = Pathname.new(executable).parent/"gpgconf"
-
-    system gpgconf, "--kill", "gpg-agent"
-    system gpgconf, "--homedir", "keyrings/live", "--kill",
-                                 "gpg-agent"
+    odeprecated "Gpg.cleanup_test_processes!"
   end
 
-  def test(path)
-    create_test_key(path)
-    begin
-      yield
-    ensure
-      cleanup_test_processes!
-    end
+  def test(_)
+    odeprecated "Gpg.test"
   end
 end

--- a/Library/Homebrew/compat/hardware.rb
+++ b/Library/Homebrew/compat/hardware.rb
@@ -1,43 +1,35 @@
 module Hardware
   class << self
     def is_32_bit?
-      odeprecated "Hardware.is_32_bit?", "Hardware::CPU.is_32_bit?"
-      !CPU.is_64_bit?
+      odisabled "Hardware.is_32_bit?", "Hardware::CPU.is_32_bit?"
     end
 
     def is_64_bit?
-      odeprecated "Hardware.is_64_bit?", "Hardware::CPU.is_64_bit?"
-      CPU.is_64_bit?
+      odisabled "Hardware.is_64_bit?", "Hardware::CPU.is_64_bit?"
     end
 
     def bits
-      odeprecated "Hardware.bits", "Hardware::CPU.bits"
-      Hardware::CPU.bits
+      odisabled "Hardware.bits", "Hardware::CPU.bits"
     end
 
     def cpu_type
-      odeprecated "Hardware.cpu_type", "Hardware::CPU.type"
-      Hardware::CPU.type
+      odisabled "Hardware.cpu_type", "Hardware::CPU.type"
     end
 
     def cpu_family
-      odeprecated "Hardware.cpu_family", "Hardware::CPU.family"
-      Hardware::CPU.family
+      odisabled "Hardware.cpu_family", "Hardware::CPU.family"
     end
 
     def intel_family
-      odeprecated "Hardware.intel_family", "Hardware::CPU.family"
-      Hardware::CPU.family
+      odisabled "Hardware.intel_family", "Hardware::CPU.family"
     end
 
     def ppc_family
-      odeprecated "Hardware.ppc_family", "Hardware::CPU.family"
-      Hardware::CPU.family
+      odisabled "Hardware.ppc_family", "Hardware::CPU.family"
     end
 
     def processor_count
-      odeprecated "Hardware.processor_count", "Hardware::CPU.cores"
-      Hardware::CPU.cores
+      odisabled "Hardware.processor_count", "Hardware::CPU.cores"
     end
   end
 end

--- a/Library/Homebrew/compat/json.rb
+++ b/Library/Homebrew/compat/json.rb
@@ -4,34 +4,16 @@ module Utils
   module JSON
     module_function
 
-    Error = Class.new(StandardError)
-
-    def load(str)
-      odeprecated "Utils::JSON.load", "JSON.parse"
-      ::JSON.parse(str)
-    rescue ::JSON::ParserError => e
-      raise Error, e.message
+    def load(_)
+      odisabled "Utils::JSON.load", "JSON.parse"
     end
 
-    def dump(obj)
-      odeprecated "Utils::JSON.dump", "JSON.generate"
-      ::JSON.generate(obj)
+    def dump(_)
+      odisabled "Utils::JSON.dump", "JSON.generate"
     end
 
-    def stringify_keys(obj)
-      odeprecated "Utils::JSON.stringify_keys"
-      case obj
-      when Array
-        obj.map { |val| stringify_keys(val) }
-      when Hash
-        obj.inject({}) do |result, (key, val)|
-          key = key.respond_to?(:to_s) ? key.to_s : key
-          val = stringify_keys(val)
-          result.merge!(key => val)
-        end
-      else
-        obj
-      end
+    def stringify_keys(_)
+      odisabled "Utils::JSON.stringify_keys"
     end
   end
 end

--- a/Library/Homebrew/compat/keg.rb
+++ b/Library/Homebrew/compat/keg.rb
@@ -1,6 +1,5 @@
 class Keg
   def fname
-    odeprecated "Keg#fname", "Keg#name"
-    name
+    odisabled "Keg#fname", "Keg#name"
   end
 end

--- a/Library/Homebrew/compat/macos.rb
+++ b/Library/Homebrew/compat/macos.rb
@@ -10,142 +10,115 @@ module OS
     module_function
 
     def xcode_folder
-      odeprecated "MacOS.xcode_folder", "MacOS::Xcode.folder"
-      Xcode.folder
+      odisabled "MacOS.xcode_folder", "MacOS::Xcode.folder"
     end
 
     def xcode_prefix
-      odeprecated "MacOS.xcode_prefix", "MacOS::Xcode.prefix"
-      Xcode.prefix
+      odisabled "MacOS.xcode_prefix", "MacOS::Xcode.prefix"
     end
 
     def xcode_installed?
-      odeprecated "MacOS.xcode_installed?", "MacOS::Xcode.installed?"
-      Xcode.installed?
+      odisabled "MacOS.xcode_installed?", "MacOS::Xcode.installed?"
     end
 
     def xcode_version
-      odeprecated "MacOS.xcode_version", "MacOS::Xcode.version"
-      Xcode.version
+      odisabled "MacOS.xcode_version", "MacOS::Xcode.version"
     end
 
     def clt_installed?
-      odeprecated "MacOS.clt_installed?", "MacOS::CLT.installed?"
-      CLT.installed?
+      odisabled "MacOS.clt_installed?", "MacOS::CLT.installed?"
     end
 
     def clt_version?
-      odeprecated "MacOS.clt_version?", "MacOS::CLT.version"
-      CLT.version
+      odisabled "MacOS.clt_version?", "MacOS::CLT.version"
     end
 
     def x11_installed?
-      odeprecated "MacOS.x11_installed?", "MacOS::X11.installed?"
-      X11.installed?
+      odisabled "MacOS.x11_installed?", "MacOS::X11.installed?"
     end
 
     def x11_prefix
-      odeprecated "MacOS.x11_prefix", "MacOS::X11.prefix"
-      X11.prefix
+      odisabled "MacOS.x11_prefix", "MacOS::X11.prefix"
     end
 
     def leopard?
-      odeprecated "MacOS.leopard?", "'MacOS.version == :leopard'"
-      version == :leopard
+      odisabled "MacOS.leopard?", "'MacOS.version == :leopard'"
     end
 
     def snow_leopard?
-      odeprecated "MacOS.snow_leopard?", "'MacOS.version >= :snow_leopard'"
-      version >= :snow_leopard
+      odisabled "MacOS.snow_leopard?", "'MacOS.version >= :snow_leopard'"
     end
 
     def snow_leopard_or_newer?
-      odeprecated "MacOS.snow_leopard_or_newer?", "'MacOS.version >= :snow_leopard'"
-      version >= :snow_leopard
+      odisabled "MacOS.snow_leopard_or_newer?", "'MacOS.version >= :snow_leopard'"
     end
 
     def lion?
-      odeprecated "MacOS.lion?", "'MacOS.version >= :lion'"
-      version >= :lion
+      odisabled "MacOS.lion?", "'MacOS.version >= :lion'"
     end
 
     def lion_or_newer?
-      odeprecated "MacOS.lion_or_newer?", "'MacOS.version >= :lion'"
-      version >= :lion
+      odisabled "MacOS.lion_or_newer?", "'MacOS.version >= :lion'"
     end
 
     def mountain_lion?
-      odeprecated "MacOS.mountain_lion?", "'MacOS.version >= :mountain_lion'"
-      version >= :mountain_lion
+      odisabled "MacOS.mountain_lion?", "'MacOS.version >= :mountain_lion'"
     end
 
     def mountain_lion_or_newer?
-      odeprecated "MacOS.mountain_lion_or_newer?", "'MacOS.version >= :mountain_lion'"
-      version >= :mountain_lion
+      odisabled "MacOS.mountain_lion_or_newer?", "'MacOS.version >= :mountain_lion'"
     end
 
     def macports_or_fink_installed?
-      odeprecated "MacOS.macports_or_fink_installed?", "!MacOS.macports_or_fink.empty?"
-      !macports_or_fink.empty?
+      odisabled "MacOS.macports_or_fink_installed?", "!MacOS.macports_or_fink.empty?"
     end
 
-    def locate(tool)
-      odeprecated "MacOS.locate", "DevelopmentTools.locate"
-      DevelopmentTools.locate(tool)
+    def locate(_)
+      odisabled "MacOS.locate", "DevelopmentTools.locate"
     end
 
     def default_cc
-      odeprecated "MacOS.default_cc", "DevelopmentTools.default_cc"
-      DevelopmentTools.default_cc
+      odisabled "MacOS.default_cc", "DevelopmentTools.default_cc"
     end
 
     def default_compiler
-      odeprecated "MacOS.default_compiler", "DevelopmentTools.default_compiler"
-      DevelopmentTools.default_compiler
+      odisabled "MacOS.default_compiler", "DevelopmentTools.default_compiler"
     end
 
     def gcc_40_build_version
-      odeprecated "MacOS.gcc_40_build_version", "DevelopmentTools.gcc_4_0_build_version"
-      DevelopmentTools.gcc_4_0_build_version
+      odisabled "MacOS.gcc_40_build_version", "DevelopmentTools.gcc_4_0_build_version"
     end
 
     def gcc_4_0_build_version
-      odeprecated "MacOS.gcc_4_0_build_version", "DevelopmentTools.gcc_4_0_build_version"
-      DevelopmentTools.gcc_4_0_build_version
+      odisabled "MacOS.gcc_4_0_build_version", "DevelopmentTools.gcc_4_0_build_version"
     end
 
     def gcc_42_build_version
-      odeprecated "MacOS.gcc_42_build_version", "DevelopmentTools.gcc_4_2_build_version"
-      DevelopmentTools.gcc_4_2_build_version
+      odisabled "MacOS.gcc_42_build_version", "DevelopmentTools.gcc_4_2_build_version"
     end
 
     def gcc_build_version
-      odeprecated "MacOS.gcc_build_version", "DevelopmentTools.gcc_4_2_build_version"
-      DevelopmentTools.gcc_4_2_build_version
+      odisabled "MacOS.gcc_build_version", "DevelopmentTools.gcc_4_2_build_version"
     end
 
     def llvm_build_version
-      odeprecated "MacOS.llvm_build_version"
+      odisabled "MacOS.llvm_build_version"
     end
 
     def clang_version
-      odeprecated "MacOS.clang_version", "DevelopmentTools.clang_version"
-      DevelopmentTools.clang_version
+      odisabled "MacOS.clang_version", "DevelopmentTools.clang_version"
     end
 
     def clang_build_version
-      odeprecated "MacOS.clang_build_version", "DevelopmentTools.clang_build_version"
-      DevelopmentTools.clang_build_version
+      odisabled "MacOS.clang_build_version", "DevelopmentTools.clang_build_version"
     end
 
     def has_apple_developer_tools?
-      odeprecated "MacOS.has_apple_developer_tools?", "DevelopmentTools.installed?"
-      DevelopmentTools.installed?
+      odisabled "MacOS.has_apple_developer_tools?", "DevelopmentTools.installed?"
     end
 
     def release
-      odeprecated "MacOS.release", "MacOS.version"
-      version
+      odisabled "MacOS.release", "MacOS.version"
     end
   end
 end

--- a/Library/Homebrew/compat/pathname.rb
+++ b/Library/Homebrew/compat/pathname.rb
@@ -1,17 +1,9 @@
 class Pathname
-  def cp(dst)
-    odeprecated "Pathname#cp", "FileUtils.cp"
-    if file?
-      FileUtils.cp to_s, dst
-    else
-      FileUtils.cp_r to_s, dst
-    end
-    dst
+  def cp(_)
+    odisabled "Pathname#cp", "FileUtils.cp"
   end
 
-  def chmod_R(perms)
-    odeprecated "Pathname#chmod_R", "FileUtils.chmod_R"
-    require "fileutils"
-    FileUtils.chmod_R perms, to_s
+  def chmod_R(_)
+    odisabled "Pathname#chmod_R", "FileUtils.chmod_R"
   end
 end

--- a/Library/Homebrew/compat/software_spec.rb
+++ b/Library/Homebrew/compat/software_spec.rb
@@ -1,6 +1,5 @@
 class BottleSpecification
-  def revision(*args)
-    odeprecated "BottleSpecification.revision", "BottleSpecification.rebuild"
-    rebuild(*args)
+  def revision(*)
+    odisabled "BottleSpecification.revision", "BottleSpecification.rebuild"
   end
 end

--- a/Library/Homebrew/compat/tab.rb
+++ b/Library/Homebrew/compat/tab.rb
@@ -1,6 +1,5 @@
 class Tab < OpenStruct
   def build_32_bit?
-    odeprecated "Tab.build_32_bit?"
-    include?("32-bit")
+    odisabled "Tab.build_32_bit?"
   end
 end

--- a/Library/Homebrew/compat/tap.rb
+++ b/Library/Homebrew/compat/tap.rb
@@ -2,7 +2,6 @@ require "tap"
 
 class Tap
   def core_formula_repository?
-    odeprecated "Tap#core_formula_repository?", "Tap#core_tap?"
-    core_tap?
+    odisabled "Tap#core_formula_repository?", "Tap#core_tap?"
   end
 end

--- a/Library/Homebrew/compat/utils.rb
+++ b/Library/Homebrew/compat/utils.rb
@@ -2,17 +2,14 @@ module Tty
   module_function
 
   def white
-    odeprecated "Tty.white", "Tty.reset.bold"
-    reset.bold
+    odisabled "Tty.white", "Tty.reset.bold"
   end
 end
 
-def puts_columns(items)
-  odeprecated "puts_columns", "puts Formatter.columns"
-  puts Formatter.columns(items)
+def puts_columns(_)
+  odisabled "puts_columns", "puts Formatter.columns"
 end
 
-def plural(n, s = "s")
-  odeprecated "#plural", "Formatter.pluralize"
-  (n == 1) ? "" : s
+def plural(_, _)
+  odisabled "#plural", "Formatter.pluralize"
 end

--- a/Library/Homebrew/compat/version.rb
+++ b/Library/Homebrew/compat/version.rb
@@ -1,6 +1,5 @@
 class Version
-  def slice(*args)
-    odeprecated "Version#slice", "Version#to_s.slice"
-    to_s.slice(*args)
+  def slice(*)
+    odisabled "Version#slice", "Version#to_s.slice"
   end
 end

--- a/Library/Homebrew/compat/xcode.rb
+++ b/Library/Homebrew/compat/xcode.rb
@@ -4,8 +4,7 @@ module OS
       module_function
 
       def provides_autotools?
-        odeprecated "OS::Mac::Xcode.provides_autotools?"
-        version < "4.3"
+        odisabled "OS::Mac::Xcode.provides_autotools?"
       end
     end
   end


### PR DESCRIPTION
Add more `odeprecated` calls to places that have been deprecated for a while in the wild and move some of the existing `odeprecated` calls to be `odisabled` to allow deleting the compatibility code.