### PR TITLE
Preserve installed_on_request for dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -553,18 +553,18 @@ class FormulaInstaller
     end
 
     fi = FormulaInstaller.new(df)
-    fi.options           |= tab.used_options
-    fi.options           |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
-    fi.options           |= inherited_options
-    fi.options           &= df.options
-    fi.build_from_source  = ARGV.build_formula_from_source?(df)
-    fi.force_bottle       = false
-    fi.verbose            = verbose?
-    fi.quieter            = quieter?
-    fi.debug              = debug?
-    fi.link_keg           = keg_was_linked if keg_had_linked_keg
+    fi.options                |= tab.used_options
+    fi.options                |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
+    fi.options                |= inherited_options
+    fi.options                &= df.options
+    fi.build_from_source       = ARGV.build_formula_from_source?(df)
+    fi.force_bottle            = false
+    fi.verbose                 = verbose?
+    fi.quieter                 = quieter?
+    fi.debug                   = debug?
+    fi.link_keg                = keg_was_linked if keg_had_linked_keg
     fi.installed_as_dependency = true
-    fi.installed_on_request = false
+    fi.installed_on_request    = df.any_version_installed? && tab.installed_on_request
     fi.prelude
     oh1 "Installing #{formula.full_name} dependency: #{Formatter.identifier(dep.name)}"
     fi.install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/3642.

It would be nice if the `Tab` returned from `for_formula` when the formula isn't installed didn't look like a real one that had been installed on request…

## Test cases

dd5f216bfe7d8d186853f303fb68cb4c0ecbdba8 is the commit before libdvdcss was updated.

```sh
export HOMEBREW_BUILD_FROM_SOURCE=1
brew install libdvdread
jq .installed_on_request "$(brew --prefix libdvdcss)/INSTALL_RECEIPT.json"
# should be false
```

```sh
export HOMEBREW_BUILD_FROM_SOURCE=1
export HOMEBREW_NO_AUTO_UPDATE=1
git -C "$(brew --repo homebrew/core)" checkout dd5f216bfe7d8d186853f303fb68cb4c0ecbdba8
brew install libdvdcss
git -C "$(brew --repo homebrew/core)" checkout master
brew install libdvdread
jq .installed_on_request "$(brew --prefix libdvdcss)/INSTALL_RECEIPT.json"
# should be true (this is what is currently broken)
```

```sh
export HOMEBREW_BUILD_FROM_SOURCE=1
export HOMEBREW_NO_AUTO_UPDATE=1
git -C "$(brew --repo homebrew/core)" checkout dd5f216bfe7d8d186853f303fb68cb4c0ecbdba8
brew install libdvdread
brew uninstall libdvdread
git -C "$(brew --repo homebrew/core)" checkout master
brew install libdvdread
jq .installed_on_request "$(brew --prefix libdvdcss)/INSTALL_RECEIPT.json"
# should be true
```
  