### PR TITLE
check_install_sanity: Use formula.runtime_dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -149,7 +149,7 @@ class FormulaInstaller
 
     recursive_deps = formula.recursive_dependencies
     recursive_formulae = recursive_deps.map(&:to_formula)
-    recursive_runtime_deps = formula.recursive_dependencies.reject(&:build?)
+    recursive_runtime_deps = formula.runtime_dependencies
     recursive_runtime_formulae = recursive_runtime_deps.map(&:to_formula)
 
     recursive_dependencies = []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix…
```
$ brew install wget
Error: wget contains conflicting version recursive dependencies:
openssl, openssl@1.1
View these with `brew deps --tree wget`.
$ brew deps --tree wget
wget
├── libidn2
│ └── libunistring
├── openssl@1.1
│ └── perl
│ ├── gdbm
│ ├── berkeley-db
│ └── expat
│ └── libbsd
└── util-linux
└── ncurses
```

On Linux, `libidn2` has no linkage to `gettext` and so is a `:build` dependency rather than a run-time dependency. `libintl` is a header-only and provided by `glibc` rather than by `gettext`, as it is on macOS.