### PR TITLE
enhance write_jar_script to launch specified java version

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -436,11 +436,12 @@ class Pathname
   end
 
   # Writes an exec script that invokes a java jar
-  def write_jar_script(target_jar, script_name, java_opts = "")
+  def write_jar_script(target_jar, script_name, java_opts = "", java_version = "")
     mkpath
+    launcher = java_version.empty? ? "java" : "/usr/libexec/java_home -v #{java_version} --exec java"
     join(script_name).write <<~EOS
       #!/bin/bash
-      exec java #{java_opts} -jar #{target_jar} "$@"
+      exec #{launcher} #{java_opts} -jar #{target_jar} "$@"
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Certain java apps require a specific java version, meanwhile the current java version from `$PATH` could be another incompatible version,  e.g. one might have installed both java 8 and java 9,
 meanwhile [**Jenkins**][1] only works with java 8.

[1]: https://issues.jenkins-ci.org/browse/JENKINS-40689

This change improves the `bin.write_jar_script`, so that it takes one more optional argument `java_version`, once specified, it use `/usr/libexec/java_home` to launch the specified java version.