### PR TITLE
Fix cached download file extension for certain URLs

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -306,7 +306,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     url_pathname = Pathname.new(@url)
     until ext = url_pathname.extname[/[^?]+/]
       url_pathname = url_pathname.dirname
-      return if url_pathname.to_s == "."
+      return if url_pathname.to_s == "." || url_pathname.to_s == "/"
     end
     ext
   end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -306,6 +306,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     url_pathname = Pathname.new(@url)
     until ext = url_pathname.extname[/[^?]+/]
       url_pathname = url_pathname.dirname
+      return if url_pathname.to_s == "."
     end
     ext
   end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -303,12 +303,11 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     # We can't use basename_without_params, because given a URL like
     #   https://example.com/download.php?file=foo-1.0.tar.gz
     # the extension we want is ".tar.gz", not ".php".
-    url_pathname = Pathname.new(@url)
-    until ext = url_pathname.extname[/[^?]+/]
-      url_pathname = url_pathname.dirname
-      return if url_pathname.to_s == "." || url_pathname.to_s == "/"
+    Pathname.new(@url).ascend do |path|
+      ext = path.extname[/[^?]+/]
+      return ext if ext
     end
-    ext
+    nil
   end
 end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -303,7 +303,11 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     # We can't use basename_without_params, because given a URL like
     #   https://example.com/download.php?file=foo-1.0.tar.gz
     # the extension we want is ".tar.gz", not ".php".
-    Pathname.new(@url).extname[/[^?]+/]
+    url_pathname = Pathname.new(@url)
+    while !ext = url_pathname.extname[/[^?]+/]
+      url_pathname = url_pathname.dirname
+    end
+    ext
   end
 end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -304,7 +304,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     #   https://example.com/download.php?file=foo-1.0.tar.gz
     # the extension we want is ".tar.gz", not ".php".
     url_pathname = Pathname.new(@url)
-    while !ext = url_pathname.extname[/[^?]+/]
+    until ext = url_pathname.extname[/[^?]+/]
       url_pathname = url_pathname.dirname
     end
     ext

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -209,6 +209,19 @@ describe CurlDownloadStrategy do
   it "parses the opts and sets the corresponding args" do
     expect(subject.send(:_curl_opts)).to eq(["--user", "download:123456"])
   end
+
+  describe "#tarball_path" do
+    subject { described_class.new(name, resource).tarball_path }
+
+    context "when URL ends with file" do
+      it { is_expected.to eq(HOMEBREW_CACHE/"foo-.tar.gz") }
+    end
+
+    context "when URL file is in middle" do
+      let(:url) { "http://example.com/foo.tar.gz/from/this/mirror" }
+      it { is_expected.to eq(HOMEBREW_CACHE/"foo-.tar.gz") }
+    end
+  end
 end
 
 describe DownloadStrategyDetector do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----
PHP URLs have the downloadable file in the middle of the pathname. If no extension is detected, continue up the pathname. Ex: `https://php.net/get/php-7.2.1.tar.xz/from/this/mirror` should cache to `php-7.2.1.tar.xz`.