### PR TITLE
reinstall/upgrade: stop unlinked kegs being sticky

### DIFF
--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -39,7 +39,7 @@ module Homebrew
     fi.build_bottle         = ARGV.build_bottle? || (!f.bottled? && f.build.bottle?)
     fi.interactive          = ARGV.interactive?
     fi.git                  = ARGV.git?
-    fi.link_keg             = keg_was_linked if keg_had_linked_opt
+    fi.link_keg           ||= keg_was_linked if keg_had_linked_opt
     fi.prelude
 
     oh1 "Reinstalling #{f.full_name} #{options.to_a.join " "}"

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -133,7 +133,7 @@ module Homebrew
     fi.options = options
     fi.build_bottle = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
     fi.installed_on_request = !ARGV.named.empty?
-    fi.link_keg             = keg_was_linked if keg_had_linked_opt
+    fi.link_keg           ||= keg_was_linked if keg_had_linked_opt
     if tab
       fi.installed_as_dependency = tab.installed_as_dependency
       fi.installed_on_request  ||= tab.installed_on_request

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -32,11 +32,11 @@ class FormulaInstaller
 
   attr_reader :formula
   attr_accessor :options, :build_bottle, :invalid_option_names
-  attr_accessor :installed_as_dependency, :installed_on_request
+  attr_accessor :installed_as_dependency, :installed_on_request, :link_keg
   mode_attr_accessor :show_summary_heading, :show_header
   mode_attr_accessor :build_from_source, :force_bottle
   mode_attr_accessor :ignore_deps, :only_deps, :interactive, :git
-  mode_attr_accessor :verbose, :debug, :quieter, :link_keg
+  mode_attr_accessor :verbose, :debug, :quieter
 
   def initialize(formula)
     @formula = formula
@@ -562,7 +562,7 @@ class FormulaInstaller
     fi.verbose                 = verbose?
     fi.quieter                 = quieter?
     fi.debug                   = debug?
-    fi.link_keg                = keg_was_linked if keg_had_linked_keg
+    fi.link_keg              ||= keg_was_linked if keg_had_linked_keg
     fi.installed_as_dependency = true
     fi.installed_on_request    = df.any_version_installed? && tab.installed_on_request
     fi.prelude


### PR DESCRIPTION
It's not possible to determine the difference between a non-keg-only keg that failed to link and one that wasn't linked by us intentionally.

To avoid additional complexity of storing this logic in another place let's back out this relatively new functionality; sticky keg-only links is a better and more desirable behaviour anyway.