### PR TITLE
# ADD zh_TW.UTF-8 support.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -3,7 +3,7 @@ case "$(locale | grep LANG= | sed 's/LANG=//')" in
   *UTF-8*)
     LC_ALL=$(locale | grep LANG= | sed 's/LANG=//')
     ;;
-  default)
+  *)
 	LC_ALL="en_US.UTF-8"
 	;;
 esac

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -1,8 +1,13 @@
 # Force UTF-8 to avoid encoding issues for users with broken locale settings.
-if [[ "$(locale charmap 2>/dev/null)" != "UTF-8" ]]
-then
-  export LC_ALL="en_US.UTF-8"
-fi
+case "$(locale | grep LANG= | sed 's/LANG=//')" in 
+  *UTF-8*)
+    LC_ALL=$(locale | grep LANG= | sed 's/LANG=//')
+    ;;
+  default)
+	LC_ALL="en_US.UTF-8"
+	;;
+esac
+
 
 # Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
 # for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.


### PR DESCRIPTION
Before Change :
```
 bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```
After Change : 
```
No more warning
```
- [v ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?

- [v ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?

- [v ] Have you added an explanation of what your changes do and why you'd like us to include them?
## To add zh_TW.UTF-8 support and remove annoying warning from bash

- [x ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

- [v ] Have you successfully run `brew tests` with your changes locally?
## Yes, warning message removed in both en_US.UTF-8 and zh_TW.UTF-8
