### PR TITLE
Suppress alias expansion in bash completion script

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -51,7 +51,7 @@ __brewcomp() {
 __brew_complete_formulae() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   local formulas="$(brew search)"
-  local shortnames="$(echo "$formulas" | grep / | cut -d / -f 3)"
+  local shortnames="$(echo "$formulas" | \grep / | \cut -d / -f 3)"
   COMPREPLY=($(compgen -W "$formulas $shortnames" -- "$cur"))
 }
 
@@ -593,7 +593,7 @@ __brew_cask_complete_formulae ()
     local lib=$(brew --repository)/Library
     local taps=${lib}/Taps
     local casks=${lib}/Taps/caskroom/homebrew-cask/Casks
-    local ff=$(\ls ${casks} 2>/dev/null | sed 's/\.rb//g')
+    local ff=$(\ls ${casks} 2>/dev/null | \sed 's/\.rb//g')
 
     COMPREPLY=($(compgen -W "$ff" -- "$cur"))
 }
@@ -738,7 +738,7 @@ _brew() {
   then
     # Do not auto-complete "*instal" or "*uninstal" aliases for "*install" commands.
     # Prefix newline to prevent not checking the first command.
-    local cmds=$'\n'"$(brew commands --quiet --include-aliases | grep -v instal$)"
+    local cmds=$'\n'"$(brew commands --quiet --include-aliases | \grep -v instal$)"
     __brewcomp "${cmds}"
     return
   fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I have an alias that adds `--line-number` to each `grep` invocation. That cause the bash completion script to do this:

```
$brew<TAB>
10:abv                          27:diy                          44:linkage                      60:pull                         78:uninstall
11:analytics                    28:doctor                       45:linkapps                     61:readall                      79:unlink
12:aspell-dictionaries          29:dr                           46:list                         62:reinstall                    7:--repository
13:audit                        2:--cellar                      47:ln                           63:release-notes                80:unlinkapps
14:bottle                       30:edit                         48:log                          64:remove                       81:unpack
15:bump-formula-pr              31:environment                  49:ls                           65:rm                           82:unpin
16:bundle                       32:fetch                        4:--env                         66:search                       83:untap
17:cask                         33:formula                      50:man                          67:sh                           84:up
18:cat                          34:gist-logs                    51:migrate                      68:style                        85:update
19:cleanup                      35:help                         52:mirror                       69:switch                       86:update-report
1:--cache                       36:home                         53:missing                      6:--repo                        87:update-reset
20:command                      37:homepage                     54:options                      70:tap                          88:update-test
21:commands                     38:info                         55:outdated                     71:tap-info                     89:upgrade
22:config                       3:--config                      56:pin                          72:tap-new                      8:--version
23:configure                    40:install                      57:postgresql-upgrade-database  73:tap-pin                      90:uses
24:create                       41:irb                          58:postinstall                  74:tap-unpin                    91:vendor-install
25:deps                         42:leaves                       59:prune                        75:test                         9:-S
26:desc                         43:link                         5:--prefix                      76:tests
```

Alias expansion can be disabled by quoting any part of the aliased word. A common method is to add a leading `\` to the word. I skimmed the script and quoted a few other commands as well.