### PR TITLE
brew unlink: fix short option

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -711,7 +711,7 @@ _brew_uninstall() {
 # brew unlink [--dry-run] formula:
 _brew_unlink() {
   _arguments \
-    '(--dry-run =n)'{--dry-run,=n}'[don''t unlink or delete any files]' \
+    '(--dry-run -n)'{--dry-run,-n}'[don''t unlink or delete any files]' \
     ':formula:__brew_installed_formulae'
 }
 
@@ -719,7 +719,7 @@ _brew_unlink() {
 _brew_unlinkapps() {
   _arguments \
     '(--local)--local[remove symlinks from ~/Applications instead of the system directory]' \
-    '(--dry-run =n)'{--dry-run,-n}'[don''t unlink or delete any files]' \
+    '(--dry-run -n)'{--dry-run,-n}'[don''t unlink or delete any files]' \
     ':formula:__brew_installed_formulae'
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?
(2239 examples, 0 failures, 10 pendings)
-----

Fixes completion error on `brew unlink`
```
$brew unlink ...
_arguments:comparguments:319: invalid argument: (--dry-run =n)=n[dont unlink or delete any files]
_arguments:comparguments:319: invalid argument: (--dry-run =n)=n[dont unlink or delete any files]
_arguments:compa -- no matches found --
```