### PR TITLE
Don't auto-tap caskroom/cask in ZSH completion

### DIFF
--- a/completions/zsh/_brew_cask
+++ b/completions/zsh/_brew_cask
@@ -12,17 +12,21 @@
 zstyle -T ':completion:*:*:*:brew-cask:*' tag-order && \
 	zstyle ':completion:*:*:*:brew-cask:*' tag-order 'commands'
 
+__brew_cask() {
+  [ -d "$(brew --repo caskroom/cask)" ] && brew cask $@
+}
+
 __brew_all_casks() {
   local -a list
   local expl
-  list=( $(brew cask search) )
+  list=( $(__brew_cask search) )
   _wanted list expl 'all casks' compadd -a list
 }
 
 __brew_installed_casks() {
   local -a list
   local expl
-  list=( $(brew cask list|sed 's/(!)//') )
+  list=( $(__brew_cask list|sed 's/(!)//') )
   _wanted list expl 'installed casks' compadd -a list
 }
 


### PR DESCRIPTION
The Bash completion just uses the directory tree rather than invoking `brew cask`, so doesn't exhibit the same behaviour.

Fixes #3677.