### PR TITLE
vendor-install: various portable ruby tweaks.

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -8,26 +8,26 @@ source "$HOMEBREW_LIBRARY/Homebrew/utils/lock.sh"
 
 VENDOR_DIR="$HOMEBREW_LIBRARY/Homebrew/vendor"
 
-# Built from https://github.com/Homebrew/homebrew-portable.
+# Built from https://github.com/Homebrew/homebrew-portable-ruby.
 if [[ -n "$HOMEBREW_MACOS" ]]
 then
   if [[ "$HOMEBREW_PROCESSOR" = "Intel" ]]
   then
-    ruby_URL="https://homebrew.bintray.com/bottles-portable/portable-ruby-2.3.3.leopard_64.bottle.1.tar.gz"
+    ruby_URL="https://homebrew.bintray.com/bottles-portable-ruby/portable-ruby-2.3.3.leopard_64.bottle.1.tar.gz"
+    ruby_URL2="https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.3.3/portable-ruby-2.3.3.leopard_64.bottle.1.tar.gz"
     ruby_SHA="34ce9e4c9c1be28db564d744165aa29291426f8a3d2ef806ba4f0b9175aedb2b"
-  else
-    ruby_URL=""
-    ruby_SHA=""
   fi
 elif [[ -n "$HOMEBREW_LINUX" ]]
 then
   case "$HOMEBREW_PROCESSOR" in
     armv7l)
-      ruby_URL="https://homebrew.bintray.com/bottles-portable/portable-ruby-2.3.3.armv7l_linux.bottle.1.tar.gz"
+      ruby_URL="https://homebrew.bintray.com/bottles-portable-ruby/portable-ruby-2.3.3.armv7l_linux.bottle.1.tar.gz"
+      ruby_URL2="https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.3.3/portable-ruby-2.3.3.armv7l_linux.bottle.1.tar.gz"
       ruby_SHA="d26affe6f6ac299557a9044b311b4066b554874fc828ebc323d2705d3f4a8249"
       ;;
     x86_64)
-      ruby_URL="https://homebrew.bintray.com/bottles-portable/portable-ruby-2.3.3.x86_64_linux.bottle.1.tar.gz"
+      ruby_URL="https://homebrew.bintray.com/bottles-portable-ruby/portable-ruby-2.3.3.x86_64_linux.bottle.1.tar.gz"
+      ruby_URL2="https://github.com/Homebrew/homebrew-portable-ruby/releases/download/2.3.3/portable-ruby-2.3.3.x86_64_linux.bottle.1.tar.gz"
       ruby_SHA="33643b1ca6f860d6df01686636326785763e5e81cf0cef37d8a7ab96a6ca1fa1"
       ;;
   esac
@@ -90,7 +90,20 @@ fetch() {
 
     if [[ ! -f "$temporary_path" ]]
     then
-      odie "Download failed: $VENDOR_URL"
+      [[ -n "$HOMEBREW_QUIET" ]] || echo "==> Downloading $VENDOR_URL2" >&2
+      "$HOMEBREW_CURL" "${curl_args[@]}" "$VENDOR_URL2" -o "$temporary_path"
+    fi
+
+    if [[ ! -f "$temporary_path" ]]
+    then
+      odie <<EOS
+Failed to download $VENDOR_URL and $VENDOR_URL2!
+
+Do not file an issue on GitHub about this: you will need to figure out for
+yourself what issue with your internet connection restricts your access to
+both Bintray (used for Homebrew bottles/binary packages) and GitHub
+(used for Homebrew updates).
+EOS
     fi
 
     trap '' SIGINT
@@ -211,8 +224,10 @@ homebrew-vendor-install() {
   [[ -n "$HOMEBREW_DEBUG" ]] && set -x
 
   url_var="${VENDOR_NAME}_URL"
+  url2_var="${VENDOR_NAME}_URL2"
   sha_var="${VENDOR_NAME}_SHA"
   VENDOR_URL="${!url_var}"
+  VENDOR_URL2="${!url2_var}"
   VENDOR_SHA="${!sha_var}"
 
   if [[ -z "$VENDOR_URL" || -z "$VENDOR_SHA" ]]


### PR DESCRIPTION
- Rename repository to homebrew-portable-ruby
- Add a new Bintray repository using new name
- Add GitHub releases mirror and try to use it
- Tell people not to file issues if they can't connect to Bintray or GitHub: we're not here to provide ISP/proxy support.