### PR TITLE
cask bash completion: have upgrade only complete outdated packages

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -613,6 +613,13 @@ __brew_cask_complete_caskroom ()
     COMPREPLY=($(compgen -W "$files" -- "$cur"))
 }
 
+__brew_cask_complete_outdated ()
+{
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local outdated=$(brew cask outdated --quiet)
+    COMPREPLY=($(compgen -W "$outdated" -- "$cur"))
+}
+
 _brew_cask_cleanup ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -709,7 +716,7 @@ _brew_cask_upgrade ()
         return
         ;;
     esac
-    __brew_cask_complete_installed    
+    __brew_cask_complete_outdated    
 }
 
 _brew_cask ()


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *Nope: We don't test shell completions.*
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR modifies the `brew cask upgrade <foo>` bash completions to only complete outdated formulae, instead of any installed formula.

Fixes comment https://github.com/Homebrew/brew/issues/3673#issuecomment-357438348.