### PR TITLE
info: show spec options for optionless formulae

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -164,7 +164,7 @@ module Homebrew
       end
     end
 
-    unless f.options.empty?
+    if !f.options.empty? || f.head || f.devel
       ohai "Options"
       Homebrew.dump_options_for_formula f
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Previsiouly, info would not display --HEAD or --devel for formulae that
had no options other than those spec options.