### PR TITLE
pathname: fix rmdir_if_possible with mount points

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -255,7 +255,7 @@ class Pathname
     else
       false
     end
-  rescue Errno::EACCES, Errno::ENOENT
+  rescue Errno::EACCES, Errno::ENOENT, Errno::EBUSY
     false
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Attempting to rmdir a directory that is a mount point results in EBUSY,
not EACCES or ENOENT, so also rescue EBUSY in rmdir_if_possible.

Prevents
```
Joes-Mac:zfs ilovezfs$ brew unlink gpg-agent
Unlinking /usr/local/Cellar/gpg-agent/2.0.31... Error: Resource busy @ dir_s_rmdir - /usr/local/share
Joes-Mac:zfs ilovezfs$
```