### PR TITLE
formula: reject dot dirs as racks

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1371,7 +1371,7 @@ class Formula
   def self.racks
     @racks ||= if HOMEBREW_CELLAR.directory?
       HOMEBREW_CELLAR.subdirs.reject do |rack|
-        rack.symlink? || rack.subdirs.empty?
+        rack.symlink? || rack.basename.to_s.start_with?(".") || rack.subdirs.empty?
       end
     else
       []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Dot directories are not racks because formulae names do not start with
"." so avoid attempting to descend into dot directories, which may not
always be possible (e.g. .Trashes).