### PR TITLE
rubocop: don't always display cop names.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
   Exclude:
     - '**/Casks/**/*'
     - '**/vendor/**/*'
+  DisplayCopNames: false
 
 require: ./Homebrew/rubocops.rb
 

--- a/Library/Homebrew/test/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cmd/style_spec.rb
@@ -28,7 +28,7 @@ describe "brew style" do
       rubocop_result = Homebrew.check_style_json([formula])
 
       expect(rubocop_result.file_offenses(formula.realpath.to_s).map(&:message))
-        .to include("Layout/EmptyLinesAroundClassBody: Extra empty line detected at class body beginning.")
+        .to include("Extra empty line detected at class body beginning.")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As of RuboCop >= 0.52.0, DisplayCopNames upstream default switched to
true. Restore the previous default for Homebrew since the cop names
aren't especially useful for end users.

See https://github.com/bbatsov/rubocop/pull/5037.