### PR TITLE
add check that ALL_TOP_LEVEL_DIRECTORIES exist

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -345,6 +345,23 @@ module Homebrew
         EOS
       end
 
+      def check_missing_prefix_directories
+        missing_dirs = []
+        Keg::ALL_TOP_LEVEL_DIRECTORIES.each do |dir|
+          path = HOMEBREW_PREFIX/dir
+          missing_dirs << path unless path.exist?
+        end
+
+        return if missing_dirs.empty?
+
+        <<~EOS
+          The following directories are missing:
+          #{missing_dirs.join("\n")}
+          You should create them:
+            sudo mkdir -p #{missing_dirs.join(" ")}
+        EOS
+      end
+
       def check_access_site_packages
         return unless Language::Python.homebrew_site_packages.exist?
         return if Language::Python.homebrew_site_packages.writable_real?

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -346,6 +346,9 @@ module Homebrew
       end
 
       def check_missing_prefix_directories
+        path = HOMEBREW_PREFIX/('.brew-detect' + Time.now.to_i.to_s)
+        Dir.mkdir(path) and Dir.rmdir(path) # and return nil for all-ok
+      rescue SystemCallError # what mkdir/rmdir throws
         missing_dirs = []
         Keg::ALL_TOP_LEVEL_DIRECTORIES.each do |dir|
           path = HOMEBREW_PREFIX/dir

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -357,7 +357,7 @@ module Homebrew
       def check_existing_prefix_directories_are_searchable
         return if HOMEBREW_PREFIX.to_s != "/usr/local"
 
-        existing_dirs = Keg::ALL_TOP_LEVEL_PATHS.select(&:exist?)
+        existing_dirs = (Keg::ALL_TOP_LEVEL_PATHS + Keg::ALL_SHARE_PATHS).select(&:exist?)
         not_searchable_dirs = existing_dirs.reject(&:executable_real?)
         return if not_searchable_dirs.empty?
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1108,6 +1108,12 @@ module Homebrew
       def all
         methods.map(&:to_s).grep(/^check_/)
       end
+
+      def permission_commands_for(dirs)
+        dirs.compact.each_slice(4).map do |slice|
+          "sudo chmod -R u+rwx,g+rwx #{slice.join(" ")}"
+        end
+      end
     end
   end
 end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -320,8 +320,7 @@ module Homebrew
       end
 
       def check_access_prefix_directories
-        existing_dirs = Keg::ALL_TOP_LEVEL_PATHS.select(&:exist?) +
-          Keg::ALL_SHARE_PATHS.select(&:exist?)
+        existing_dirs = Keg::ALL_TOP_AND_SHARE_PATHS.select(&:exist?)
         not_writable_dirs = existing_dirs.reject(&:writable_real?)
         return if not_writable_dirs.empty?
 
@@ -357,7 +356,7 @@ module Homebrew
       def check_existing_prefix_directories_are_searchable
         return if HOMEBREW_PREFIX.to_s != "/usr/local"
 
-        existing_dirs = (Keg::ALL_TOP_LEVEL_PATHS + Keg::ALL_SHARE_PATHS).select(&:exist?)
+        existing_dirs = Keg::ALL_TOP_AND_SHARE_PATHS.select(&:exist?)
         not_searchable_dirs = existing_dirs.reject(&:executable_real?)
         return if not_searchable_dirs.empty?
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -320,7 +320,8 @@ module Homebrew
       end
 
       def check_access_prefix_directories
-        existing_dirs = Keg::ALL_TOP_LEVEL_PATHS.select(&:exist?)
+        existing_dirs = Keg::ALL_TOP_LEVEL_PATHS.select(&:exist?) +
+          Keg::ALL_SHARE_PATHS.select(&:exist?)
         not_writable_dirs = existing_dirs.reject(&:writable_real?)
         return if not_writable_dirs.empty?
 

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -67,7 +67,6 @@ class Keg
   INFOFILE_RX = %r{info/([^.].*?\.info|dir)$}
   TOP_LEVEL_DIRECTORIES = %w[bin etc include lib sbin share var Frameworks].freeze
   ALL_TOP_LEVEL_DIRECTORIES = (TOP_LEVEL_DIRECTORIES + %w[lib/pkgconfig share/locale share/man opt]).freeze
-  ALL_TOP_LEVEL_PATHS = ALL_TOP_LEVEL_DIRECTORIES.map { |dir| HOMEBREW_PREFIX/dir }
   PRUNEABLE_DIRECTORIES = %w[bin etc include lib sbin share opt Frameworks LinkedKegs var/homebrew/linked].map do |dir|
     case dir
     when "LinkedKegs"
@@ -88,6 +87,9 @@ class Keg
     applications gnome gnome/help icons
     mime-info pixmaps sounds postgresql
   ].freeze
+
+  ALL_TOP_LEVEL_PATHS = ALL_TOP_LEVEL_DIRECTORIES.map { |dir| HOMEBREW_PREFIX/dir }
+  ALL_SHARE_PATHS = SHARE_PATHS.map { |dir| HOMEBREW_PREFIX/"share"/dir }
 
   # Given an array of kegs, this method will try to find some other kegs
   # that depend on them.

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -90,6 +90,7 @@ class Keg
 
   ALL_TOP_LEVEL_PATHS = ALL_TOP_LEVEL_DIRECTORIES.map { |dir| HOMEBREW_PREFIX/dir }
   ALL_SHARE_PATHS = SHARE_PATHS.map { |dir| HOMEBREW_PREFIX/"share"/dir }
+  ALL_TOP_AND_SHARE_PATHS = ALL_TOP_LEVEL_PATHS + ALL_SHARE_PATHS
 
   # Given an array of kegs, this method will try to find some other kegs
   # that depend on them.

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -67,6 +67,7 @@ class Keg
   INFOFILE_RX = %r{info/([^.].*?\.info|dir)$}
   TOP_LEVEL_DIRECTORIES = %w[bin etc include lib sbin share var Frameworks].freeze
   ALL_TOP_LEVEL_DIRECTORIES = (TOP_LEVEL_DIRECTORIES + %w[lib/pkgconfig share/locale share/man opt]).freeze
+  ALL_TOP_LEVEL_PATHS = ALL_TOP_LEVEL_DIRECTORIES.map { |dir| HOMEBREW_PREFIX/dir }
   PRUNEABLE_DIRECTORIES = %w[bin etc include lib sbin share opt Frameworks LinkedKegs var/homebrew/linked].map do |dir|
     case dir
     when "LinkedKegs"


### PR DESCRIPTION
First PR-half requested in #3708

To prevent messy errors from `brew upgrade` - add check to make sure that ALL_TOP_LEVEL_DIRECTORIES exist.

As noticed in #3228 this is necessary for at least some users for users of High Sierra. Worst case, you get an empty folder you don't need.

Everybody typically installs python, and in case some of these directories aren't necessary to sudo mkdir we can fix that in a later PR.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew tests` with your changes locally?

-----
