### PR TITLE
build: call satisified? before modifying env.

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -81,10 +81,12 @@ class Build
       ENV.x11 = reqs.any? { |rq| rq.is_a?(X11Requirement) }
       ENV.setup_build_environment(formula)
       post_superenv_hacks
+      reqs.each(&:satisfied?)
       reqs.each(&:modify_build_environment)
       deps.each(&:modify_build_environment)
     else
       ENV.setup_build_environment(formula)
+      reqs.each(&:satisfied?)
       reqs.each(&:modify_build_environment)
       deps.each(&:modify_build_environment)
 

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -81,12 +81,10 @@ class Build
       ENV.x11 = reqs.any? { |rq| rq.is_a?(X11Requirement) }
       ENV.setup_build_environment(formula)
       post_superenv_hacks
-      reqs.each(&:satisfied?)
       reqs.each(&:modify_build_environment)
       deps.each(&:modify_build_environment)
     else
       ENV.setup_build_environment(formula)
-      reqs.each(&:satisfied?)
       reqs.each(&:modify_build_environment)
       deps.each(&:modify_build_environment)
 

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -48,7 +48,7 @@ class Requirement
     s
   end
 
-  # Overriding #satisfied? is deprecated.
+  # Overriding #satisfied? is unsupported.
   # Pass a block or boolean to the satisfy DSL method instead.
   def satisfied?
     satisfy = self.class.satisfy
@@ -58,7 +58,7 @@ class Requirement
     true
   end
 
-  # Overriding #fatal? is deprecated.
+  # Overriding #fatal? is unsupported.
   # Pass a boolean to the fatal DSL method instead.
   def fatal?
     self.class.fatal || false
@@ -73,7 +73,7 @@ class Requirement
     parent
   end
 
-  # Overriding #modify_build_environment is deprecated.
+  # Overriding #modify_build_environment is unsupported.
   # Pass a block to the env DSL method instead.
   def modify_build_environment
     satisfied?

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -139,8 +139,8 @@ class Requirement
     attr_reader :env_proc, :build
     attr_rw :fatal, :cask, :download
 
-    def default_formula(val = nil)
-      # odeprecated "Requirement.default_formula"
+    def default_formula(_val = nil)
+      odeprecated "Requirement.default_formula"
     end
 
     def satisfy(options = nil, &block)

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -51,9 +51,10 @@ class Requirement
   # Overriding #satisfied? is deprecated.
   # Pass a block or boolean to the satisfy DSL method instead.
   def satisfied?
-    result = self.class.satisfy.yielder { |p| instance_eval(&p) }
-    @satisfied_result = result
-    return false unless result
+    satisfy = self.class.satisfy
+    return true unless satisfy
+    @satisfied_result = satisfy.yielder { |p| instance_eval(&p) }
+    return false unless @satisfied_result
     true
   end
 
@@ -74,9 +75,8 @@ class Requirement
 
   # Overriding #modify_build_environment is deprecated.
   # Pass a block to the env DSL method instead.
-  # Note: #satisfied? should be called before invoking this method
-  # as the env modifications may depend on its side effects.
   def modify_build_environment
+    satisfied?
     instance_eval(&env_proc) if env_proc
 
     # XXX If the satisfy block returns a Pathname, then make sure that it


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Requirement#modify_build_environment may depend on the side effects of
Requirement#satisfied?, so make sure the latter is called at least once
for each requirement during formula installation. Prior to b70b5429d09,
Requirement#satisfied? would usually be called during Build#expand_reqs,
but that is longer the case.