### PR TITLE
utils: reduce odeprecated warnings.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -82,6 +82,12 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
   # - Location of caller of deprecated method (if all else fails).
   backtrace = caller
   tap_message = nil
+
+  # Don't throw deprecations at all for cached or .brew formulae.
+  return if backtrace.any? do |line|
+    line.include?(HOMEBREW_CACHE) || line.include?("/.brew/")
+  end
+
   caller_message = backtrace.detect do |line|
     next unless line =~ %r{^#{Regexp.escape(HOMEBREW_LIBRARY)}/Taps/([^/]+/[^/]+)/}
     tap = Tap.fetch Regexp.last_match(1)
@@ -89,9 +95,6 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
     true
   end
   caller_message ||= backtrace.detect do |line|
-    # Don't throw deprecations at all for cached or .brew formulae.
-    next false if line.include?(HOMEBREW_CACHE)
-    next false if line.include?("/.brew/")
     !line.start_with?("#{HOMEBREW_LIBRARY_PATH}/compat/")
   end
   caller_message ||= backtrace[1]


### PR DESCRIPTION
Fix the code so we don't actually output `odeprecated` warnings for `HOMEBREW_CACHE`d or `.brew`d formulae.