### PR TITLE
bump-formula-pr: only validate tar files.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -184,23 +184,23 @@ module Homebrew
     elsif !new_url
       odie "#{formula}: no --url= argument specified!"
     else
-      rsrc_url = if requested_spec != :devel && new_url =~ /.*ftpmirror.gnu.*/
+      resource_url = if requested_spec != :devel && new_url =~ /.*ftpmirror.gnu.*/
         new_mirror = new_url.sub "ftpmirror.gnu.org", "ftp.gnu.org/gnu"
         new_mirror
       else
         new_url
       end
-      rsrc = Resource.new { @url = rsrc_url }
-      rsrc.download_strategy = CurlDownloadStrategy
-      rsrc.owner = Resource.new(formula.name)
-      rsrc.version = forced_version if forced_version
-      odie "No --version= argument specified!" unless rsrc.version
-      rsrc_path = rsrc.fetch
+      resource = Resource.new { @url = resource_url }
+      resource.download_strategy = CurlDownloadStrategy
+      resource.owner = Resource.new(formula.name)
+      resource.version = forced_version if forced_version
+      odie "No --version= argument specified!" unless resource.version
+      resource_path = resource.fetch
       gnu_tar_gtar_path = HOMEBREW_PREFIX/"opt/gnu-tar/bin/gtar"
       gnu_tar_gtar = gnu_tar_gtar_path if gnu_tar_gtar_path.executable?
       tar = which("gtar") || gnu_tar_gtar || which("tar")
-      if Utils.popen_read(tar, "-tf", rsrc_path) =~ %r{/.*\.}
-        new_hash = rsrc_path.sha256
+      if Utils.popen_read(tar, "-tf", resource_path) =~ %r{/.*\.}
+        new_hash = resource_path.sha256
       elsif new_url.include? ".tar"
         odie "#{formula}: no --url=/--#{hash_type}= arguments specified!"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Stop this crash from happening:
```
==> replace nil with nil
Error: no implicit conversion of nil into String
Please report this bug:
  https://docs.brew.sh/Troubleshooting.html
/usr/local/Homebrew/Library/Homebrew/extend/string.rb:39:in `gsub!'
/usr/local/Homebrew/Library/Homebrew/extend/string.rb:39:in `gsub!'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:54:in `block in inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:50:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:50:in `inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:263:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:100:in `<main>'
```