### PR TITLE
Fix Travis deprecation error.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,9 @@ before_install:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
       HOMEBREW_REPOSITORY="$(brew --repo)";
       sudo chown -R "$USER" "$HOMEBREW_REPOSITORY/Library/Taps";
-      mkdir -p "$PWD/Library/Taps/homebrew"
-      mv "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core" "$PWD/Library/homebrew/homebrew-core";
-      git -C "$PWD/Library/homebrew/homebrew-core" fetch --tags --force origin
-      git -C "$PWD/Library/homebrew/homebrew-core" checkout --force -B master origin/master
+      mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library";
+      git -C Library/homebrew/homebrew-core fetch --force origin
+      git -C Library/homebrew/homebrew-core checkout --force -B master origin/master
       sudo rm -rf "$HOMEBREW_REPOSITORY";
       sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY";
       git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot Library/Taps/homebrew/homebrew-test-bot;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
       HOMEBREW_REPOSITORY="$(brew --repo)";
       sudo chown -R "$USER" "$HOMEBREW_REPOSITORY/Library/Taps";
       mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library";
-      git -C Library/homebrew/homebrew-core fetch --force origin
-      git -C Library/homebrew/homebrew-core checkout --force -B master origin/master
+      git -C Library/Taps/homebrew/homebrew-core fetch --force origin
+      git -C Library/Taps/homebrew/homebrew-core checkout --force -B master origin/master
       sudo rm -rf "$HOMEBREW_REPOSITORY";
       sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY";
       git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot Library/Taps/homebrew/homebrew-test-bot;

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
       HOMEBREW_REPOSITORY="$(brew --repo)";
       sudo chown -R "$USER" "$HOMEBREW_REPOSITORY/Library/Taps";
       mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library";
-      git -C Library/Taps/homebrew/homebrew-core fetch --force origin
-      git -C Library/Taps/homebrew/homebrew-core checkout --force -B master origin/master
+      git -C Library/Taps/homebrew/homebrew-core fetch --force origin;
+      git -C Library/Taps/homebrew/homebrew-core checkout --force -B master origin/master;
       sudo rm -rf "$HOMEBREW_REPOSITORY";
       sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY";
       git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot Library/Taps/homebrew/homebrew-test-bot;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ before_install:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
       HOMEBREW_REPOSITORY="$(brew --repo)";
       sudo chown -R "$USER" "$HOMEBREW_REPOSITORY/Library/Taps";
-      mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library";
+      mkdir -p "$PWD/Library/Taps/homebrew"
+      mv "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core" "$PWD/Library/homebrew/homebrew-core";
+      git -C "$PWD/Library/homebrew/homebrew-core" fetch --tags --force origin
+      git -C "$PWD/Library/homebrew/homebrew-core" checkout --force -B master origin/master
       sudo rm -rf "$HOMEBREW_REPOSITORY";
       sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY";
       git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot Library/Taps/homebrew/homebrew-test-bot;


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Taps on Travis are outdated and thus builds are failing because of deprecations in Formulae.