### PR TITLE
travis.yml: HOME Ruby path caching not needed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: c
 cache:
   directories:
-    - $HOME/.gem/ruby
     - $HOME/Library/Caches/Homebrew/style
     - $HOME/Library/Caches/Homebrew/tests
     - $HOME/Library/Homebrew/vendor/bundle


### PR DESCRIPTION
This is stored in vendor/bundle now instead.