### PR TITLE
cask style: fix `--fix`

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/style.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/style.rb
@@ -36,16 +36,19 @@ module Hbc
       end
 
       def rubocop_args
-        fix? ? autocorrect_args : default_args
+        fix? ? autocorrect_args : normal_args
       end
 
       def default_args
         [
           "--require", "rubocop-cask",
           "--force-default-config",
-          "--format", "simple",
-          "--parallel"
+          "--format", "simple"
         ]
+      end
+
+      def normal_args
+        default_args + ["--parallel"]
       end
 
       def autocorrect_args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
cc @reitermarkus 
```
$ brew cask style -vd --fix metasploit
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.5-compliant syntax, but you are running 2.3.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
-P/--parallel can not be combined with --auto-correct.
```