### PR TITLE
Don't suggest install from bottle if not available

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -458,7 +458,7 @@ end
 # if the user passes any flags/environment that would case a bottle-only
 # installation on a system without build tools to fail
 class BuildFlagsError < RuntimeError
-  def initialize(flags)
+  def initialize(flags, bottled: true)
     if flags.length > 1
       flag_text = "flags"
       require_text = "require"
@@ -467,13 +467,18 @@ class BuildFlagsError < RuntimeError
       require_text = "requires"
     end
 
-    super <<~EOS
+    message = <<~EOS.chomp!
       The following #{flag_text}:
         #{flags.join(", ")}
       #{require_text} building tools, but none are installed.
       #{DevelopmentTools.installation_instructions}
+    EOS
+
+    message << <<~EOS.chomp! if bottled
       Alternatively, remove the #{flag_text} to attempt bottle installation.
     EOS
+
+    super message
   end
 end
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -70,8 +70,10 @@ class FormulaInstaller
   # can proceed. Only invoked when the user has no developer tools.
   def self.prevent_build_flags
     build_flags = ARGV.collect_build_flags
+    return if build_flags.empty?
 
-    raise BuildFlagsError, build_flags unless build_flags.empty?
+    all_bottled = ARGV.formulae.all?(&:bottled?)
+    raise BuildFlagsError.new(build_flags, bottled: all_bottled)
   end
 
   def build_bottle?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

It only makes sense to tell a user to try installing from a bottle if there are bottles available for them to install for all the formulae they specified.