### PR TITLE
Make pinning more robust

### DIFF
--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -1,7 +1,6 @@
 #:  * `pin` <formulae>:
 #:    Pin the specified <formulae>, preventing them from being upgraded when
-#:    issuing the `brew upgrade <formulae>` command (but can still be upgraded
-#:    as dependencies for other formulae). See also `unpin`.
+#:    issuing the `brew upgrade <formulae>` command. See also `unpin`.
 
 require "formula"
 

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -46,6 +46,16 @@ module Homebrew
         rm_pin rack
       else
         kegs.each do |keg|
+          begin
+            f = Formulary.from_rack(rack)
+            if f.pinned?
+              onoe "#{f.full_name} is pinned. You must unpin it to uninstall."
+              next
+            end
+          rescue
+            nil
+          end
+
           keg.lock do
             puts "Uninstalling #{keg}... (#{keg.abv})"
             keg.unlink

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -50,11 +50,8 @@ module Homebrew
       exit 1 if outdated.empty?
     end
 
-    unless upgrade_pinned?
-      pinned = outdated.select(&:pinned?)
-      outdated -= pinned
-    end
-
+    pinned = outdated.select(&:pinned?)
+    outdated -= pinned
     formulae_to_install = outdated.map(&:latest_formula)
 
     if formulae_to_install.empty?
@@ -64,8 +61,8 @@ module Homebrew
       puts formulae_to_install.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 
-    unless upgrade_pinned? || pinned.empty?
-      oh1 "Not upgrading #{Formatter.pluralize(pinned.length, "pinned package")}:"
+    unless pinned.empty?
+      onoe "Not upgrading #{Formatter.pluralize(pinned.length, "pinned package")}:"
       puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 
@@ -93,10 +90,6 @@ module Homebrew
         onoe "#{f}: #{e}"
       end
     end
-  end
-
-  def upgrade_pinned?
-    !ARGV.named.empty?
   end
 
   def upgrade_formula(f)
@@ -143,13 +136,6 @@ module Homebrew
 
     fi.install
     fi.finish
-
-    # If the formula was pinned, and we were force-upgrading it, unpin and
-    # pin it again to get a symlink pointing to the correct keg.
-    if f.pinned?
-      f.unpin
-      f.pin
-    end
   rescue FormulaInstallationAlreadyAttemptedError
     # We already attempted to upgrade f as part of the dependency tree of
     # another formula. In that case, don't generate an error, just move on.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -371,8 +371,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
   * `pin` `formulae`:
     Pin the specified `formulae`, preventing them from being upgraded when
-    issuing the `brew upgrade `formulae command (but can still be upgraded
-    as dependencies for other formulae). See also `unpin`.
+    issuing the `brew upgrade `formulae command. See also `unpin`.
 
   * `postinstall` `formula`:
     Rerun the post-install steps for `formula`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -384,7 +384,7 @@ If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if t
 .
 .TP
 \fBpin\fR \fIformulae\fR
-Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade <formulae>\fR command (but can still be upgraded as dependencies for other formulae)\. See also \fBunpin\fR\.
+Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade <formulae>\fR command\. See also \fBunpin\fR\.
 .
 .TP
 \fBpostinstall\fR \fIformula\fR


### PR DESCRIPTION
Don’t autoremove pins on uninstall or upgrade and note this in the manpage.