### PR TITLE
xcode_requirement: inform users of macOS upgrade.

### DIFF
--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -22,7 +22,12 @@ class XcodeRequirement < Requirement
       A full installation of Xcode.app#{version} is required to compile this software.
       Installing just the Command Line Tools is not sufficient.
     EOS
-    if MacOS.version >= :lion
+    if Version.new(MacOS::Xcode.latest_version) < Version.new(@version)
+      message + <<~EOS
+        Xcode#{version} cannot be installed on macOS #{MacOS.version}.
+        You must upgrade your version of macOS.
+      EOS
+    elsif MacOS.version >= :lion
       message + <<~EOS
         Xcode can be installed from the App Store.
       EOS


### PR DESCRIPTION
If you need a newer Xcode than the latest version provided by your version of macOS then you need to upgrade your OS to install the software.