### PR TITLE
add ALL_PROXY for brew

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -247,6 +247,10 @@ can take several different forms:
     Sets the HTTPS proxy to be used by `curl`, `git` and `svn` when downloading
     through Homebrew.
 
+  * `all_proxy`:
+    Sets the SOCKS5 proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
   * `ftp_proxy`:
     Sets the FTP proxy to be used by `curl`, `git` and `svn` when downloading
     through Homebrew.
@@ -256,11 +260,13 @@ can take several different forms:
     by `curl`, `git` and `svn` when downloading through Homebrew.
 
 ## USING HOMEBREW BEHIND A PROXY
-Use the `http_proxy`, `https_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
+Use the `http_proxy`, `https_proxy`, `all_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
 
-For example for an unauthenticated HTTP proxy:
+For example for an unauthenticated HTTP or SOCKS5 proxy:
 
     export http_proxy=http://<host>:<port>
+
+    export all_proxy=socks5://<host>:<port>
 
 And for an authenticated HTTP proxy:
 

--- a/bin/brew
+++ b/bin/brew
@@ -67,7 +67,7 @@ then
   FILTERED_ENV=()
   # Filter all but the specific variables.
   for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
-             http_proxy https_proxy ftp_proxy no_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
+             http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}" "${!JENKINS_@}"
   do
     # Skip if variable value is empty.

--- a/bin/brew
+++ b/bin/brew
@@ -67,7 +67,7 @@ then
   FILTERED_ENV=()
   # Filter all but the specific variables.
   for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
-             http_proxy https_proxy ftp_proxy no_proxy HTTPS_PROXY FTP_PROXY \
+             http_proxy https_proxy ftp_proxy no_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}" "${!JENKINS_@}"
   do
     # Skip if variable value is empty.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1062,6 +1062,10 @@ can take several different forms:
     Sets the HTTPS proxy to be used by `curl`, `git` and `svn` when downloading
     through Homebrew.
 
+  * `all_proxy`:
+    Sets the SOCKS5 proxy to be used by `curl`, `git` and `svn` when downloading
+    through Homebrew.
+
   * `ftp_proxy`:
     Sets the FTP proxy to be used by `curl`, `git` and `svn` when downloading
     through Homebrew.
@@ -1071,11 +1075,13 @@ can take several different forms:
     by `curl`, `git` and `svn` when downloading through Homebrew.
 
 ## USING HOMEBREW BEHIND A PROXY
-Use the `http_proxy`, `https_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
+Use the `http_proxy`, `https_proxy`, `all_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
 
-For example for an unauthenticated HTTP proxy:
+For example for an unauthenticated HTTP or SOCKS5 proxy:
 
     export http_proxy=http://`host`:`port`
+
+    export all_proxy=socks5://`host`:`port`
 
 And for an authenticated HTTP proxy:
 

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "January 2018" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "February 2018" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "January 2018" "Homebrew" "brew"
+.TH "BREW" "1" "February 2018" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -1088,6 +1088,10 @@ Sets the HTTP proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downl
 Sets the HTTPS proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
 .
 .TP
+\fBall_proxy\fR
+Sets the SOCKS5 proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
+.
+.TP
 \fBftp_proxy\fR
 Sets the FTP proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
 .
@@ -1096,16 +1100,18 @@ Sets the FTP proxy to be used by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downlo
 Sets the comma\-separated list of hostnames and domain names that should be excluded from proxying by \fBcurl\fR, \fBgit\fR and \fBsvn\fR when downloading through Homebrew\.
 .
 .SH "USING HOMEBREW BEHIND A PROXY"
-Use the \fBhttp_proxy\fR, \fBhttps_proxy\fR, \fBno_proxy\fR and/or \fBftp_proxy\fR documented above\.
+Use the \fBhttp_proxy\fR, \fBhttps_proxy\fR, \fBall_proxy\fR, \fBno_proxy\fR and/or \fBftp_proxy\fR documented above\.
 .
 .P
-For example for an unauthenticated HTTP proxy:
+For example for an unauthenticated HTTP or SOCKS5 proxy:
 .
 .IP "" 4
 .
 .nf
 
 export http_proxy=http://<host>:<port>
+
+export all_proxy=socks5://<host>:<port>
 .
 .fi
 .


### PR DESCRIPTION
Signed-off-by: xiehuc <xiehuc@gmail.com>


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

i don't know why there just lack ALL_PROXY . 

there a so many tutorial say ALL_PROXY to set socks5 proxy

https://github.com/Homebrew/legacy-homebrew/issues/11114
https://stackoverflow.com/questions/37231204/osx-proxy-issue-with-homebrew-install
https://apple.stackexchange.com/questions/228865/how-to-install-an-homebrew-package-behind-a-proxy

Fixes #3752 