### PR TITLE
audit: Remove FILEUTILS_METHODS constant

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -189,8 +189,6 @@ class FormulaAuditor
     swig
   ].freeze
 
-  FILEUTILS_METHODS = FileUtils.singleton_methods(false).map { |m| Regexp.escape(m) }.join "|"
-
   def initialize(formula, options = {})
     @formula = formula
     @new_formula = options[:new_formula]


### PR DESCRIPTION
This constant hasn't been used since there was an `audit_line` method, and as such is vestigial.

Traced back to 3e3a4cad500ccc347209a7df40ad5e73dc6f88f2.
