### PR TITLE
test/utils/svn: Requires svn to succeed

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -75,6 +75,10 @@ RSpec.configure do |config|
     skip "Requires network connection." unless ENV["HOMEBREW_TEST_ONLINE"]
   end
 
+  config.before(:each, :needs_svn) do
+    skip "Requires subversion." unless which "svn"
+  end
+
   config.around(:each) do |example|
     def find_files
       Find.find(TEST_TMPDIR)

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -30,7 +30,7 @@ describe Utils do
         expect(described_class.svn_remote_exists(HOMEBREW_CACHE/"install")).to be_falsey
       end
 
-      it "returns true when remote exists", :needs_network do
+      it "returns true when remote exists", :needs_network, :needs_svn do
         remote = "http://github.com/Homebrew/install"
         svn = HOMEBREW_SHIMS_PATH/"scm/svn"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This test fails on Linux if `svn` is not installed. I've added `:needs_macos`. Is there a better way to skip this test when `svn` is not available?