### PR TITLE
Grammar: "formula are" -> "formulae are"

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -822,7 +822,7 @@ module Homebrew
         return if linked.empty?
 
         inject_file_list linked.map(&:full_name), <<~EOS
-          Some keg-only formula are linked into the Cellar.
+          Some keg-only formulae are linked into the Cellar.
           Linking a keg-only formula, such as gettext, into the cellar with
           `brew link <formula>` will cause other formulae to detect them during
           the `./configure` step. This may cause problems when compiling those
@@ -872,7 +872,7 @@ module Homebrew
         return if missing.empty?
 
         <<~EOS
-          Some installed formula are missing dependencies.
+          Some installed formulae are missing dependencies.
           You should `brew install` the missing dependencies:
             brew install #{missing.sort_by(&:full_name) * " "}
 


### PR DESCRIPTION
Fix plural form of formula -> formulae in `brew doctor` output.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). -> Not sure how a test for a grammar change in a string would be useful.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
