### PR TITLE
Do not show git username prompt during 'brew update'

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -512,7 +512,7 @@ EOS
         git fetch --tags --force "${QUIET_ARGS[@]}" origin \
           "refs/heads/$UPSTREAM_BRANCH_DIR:refs/remotes/origin/$UPSTREAM_BRANCH_DIR" 2>/dev/null
       else
-        if ! git fetch --tags --force "${QUIET_ARGS[@]}" origin \
+        if ! GIT_ASKPASS=true git fetch --tags --force "${QUIET_ARGS[@]}" origin \
           "refs/heads/$UPSTREAM_BRANCH_DIR:refs/remotes/origin/$UPSTREAM_BRANCH_DIR"
         then
           echo "Fetching $DIR failed!" >>"$update_failed_file"


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Hi there,

1.
Whenever I do `brew update` on my laptop, I got the error saying:
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

2.
I found that this is the exactly same issue with the one in the following link:
https://github.com/Homebrew/homebrew-core/issues/10067#issuecomment-280637028
https://github.com/Homebrew/homebrew-core/issues/10067#issuecomment-349995050

In my case, the reason was that the certain repo referred by my homebrew was deleted. (So`git fetch` failed)
https://github.com/Flinesoft/BartyCrouch
https://github.com/flinesoft/homebrew-bartycrouch (now deleted)
```
Bartycrouch now is part of Homebrew Core! No tap needed any more.
If you had installed a previous version (<= 3.8.0) via the tap, you should run the following once:
$ brew untap flinesoft/bartycrouch
```

3.
git client tries to get credential from the user by showing prompt if it couldn't get access to the remote repository like this:

```
Username for 'https://github.com':
```
And I think we don't have to show this prompt because:

First, the error message saying that `terminal prompts disabled`. (git terminal prompt is disabled by design maybe? just guessing)
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Second, if this prompt is shown, there are 2 possible cases:
a) There is no such repo (404)
=> no need to ask credential and we can just fail.

b) Private repo
=> Can a private repo be used in homebrew? I have no idea. **Help needed**

Also, if it just fails instead of showing prompt => more clear error message like `remote: Repository not found`.

4.
So, I set `GIT_ASKPASS` to `true`, which is the shell command that does nothing and always succeeds.

For the `GIT_ASKPASS`:
https://git-scm.com/docs/gitcredentials
```
If the GIT_ASKPASS environment variable is set, the program specified by the variable is invoked. A suitable prompt is provided to the program on the command line, and the user’s input is read from its standard output.
```

With this environment variable set, git client doesn't ask credential and there is no prompt.
I'm worrying about that this solution seems quite tricky and pretty misleading (`ASKPASS = true` but never ask? 😂 )

---
I think this is not the feature or bug reporting so I didn't make the issue and just sent the PR. If I was wrong, please let me know! Thank you.