### PR TITLE
write_jar_script: add java version option

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -436,11 +436,14 @@ class Pathname
   end
 
   # Writes an exec script that invokes a java jar
-  def write_jar_script(target_jar, script_name, java_opts = "")
+  def write_jar_script(target_jar, script_name, java_opts = "", java_version: nil)
     mkpath
+    java_home = if java_version
+      "JAVA_HOME=\"$(#{Language::Java.java_home_cmd(java_version)})\" "
+    end
     join(script_name).write <<~EOS
       #!/bin/bash
-      exec java #{java_opts} -jar #{target_jar} "$@"
+      #{java_home}exec java #{java_opts} -jar #{target_jar} "$@"
     EOS
   end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change? *This supersedes #3656*
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This expands `write_jar_script` to allow specifying the Java version. This will be needed to fix some of the Java 9 breakage in https://github.com/Homebrew/homebrew-core/issues/19696, for those formulae which use `write_jar_script` instead of `write_env_script`.

Closes #3656. This PR supersedes it; I'm putting in a new version since there's been no activity there in two weeks.

This is indeed another way to do https://github.com/Homebrew/homebrew-core/commit/39e0b03cdc6d8001aeed4881310faed7c7b75916, and I know ILZ won't like it. But consider this my vote that it's nicer to have `write_jar_script` do it. Let me know what you decide, and if it's a nay, I'll stick with the manual script generation like the `metabase` formula does does. (Feel free to just downvote this PR to vote "No"; I won't take it personal.)