### PR TITLE
diagnostic: implement cache size check

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -835,6 +835,17 @@ module Homebrew
         EOS
       end
 
+      def check_for_large_cache
+        return unless HOMEBREW_CACHE.exist?
+        return if ENV["CI"] # CI can be expected to have a large cache.
+        cache_size = HOMEBREW_CACHE.disk_usage
+        return unless cache_size > 2_147_483_648
+        <<~EOS
+          Your HOMEBREW_CACHE is using #{disk_usage_readable(cache_size)} of disk space.
+          You may wish to consider running `brew cleanup`.
+        EOS
+      end
+
       def check_for_other_frameworks
         # Other frameworks that are known to cause problems when present
         frameworks_to_check = %w[


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Haven't worked up a test yet because I suspect there's going to be some discussion on this & how to implement it, if at all.

It has been a repetitive theme that people don't know about `brew cleanup` and have no idea how much space `HOMEBREW_CACHE` is occupying, which can be a significant chunk, especially on Macs with smaller storage capacities. Seriously, do any search on Twitter for `brew cleanup` as a starting data point.

This attempts to shine some light on the situation for users, whilst carving out an exemption for CI where massive caches are expected & in some way desirable. I stuck it in `diagnostic` but it could have a place in `brew config` or even `brew --cache` somewhere. Opinions on everything welcome.