### PR TITLE
brew, diagnostic: tweak CI variable checks.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -788,7 +788,7 @@ module Homebrew
           EOS
         end
 
-        return if ENV["CI"] || ENV["JENKINS_HOME"]
+        return if ENV["CI"]
 
         branch = coretap_path.git_branch
         return if branch.nil? || branch =~ /master/
@@ -838,7 +838,7 @@ module Homebrew
       def check_for_large_cache
         return unless HOMEBREW_CACHE.exist?
         # CI can be expected to have a large cache.
-        return if ENV["CI"] || ENV["JENKINS_HOME"]
+        return if ENV["CI"]
         cache_size = HOMEBREW_CACHE.disk_usage
         return unless cache_size > 2_147_483_648
         <<~EOS

--- a/bin/brew
+++ b/bin/brew
@@ -66,9 +66,9 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS TRAVIS_SUDO SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
-             "${!HOMEBREW_@}" "${!TRAVIS_@}" "${!JENKINS_@}"
+             "${!HOMEBREW_@}"
   do
     # Skip if variable value is empty.
     [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
I've adjusted test-bot in https://github.com/Homebrew/homebrew-test-bot/commit/603918939a58a8d6351177fe35f0193b79549dfa to set CI=1 for Jenkins to make future JENKINS_HOME checks unnecessary.


The only `TRAVIS_*` variable we care about is `TRAVIS_SUDO` so whitelist that specifically rather than passing through loads of others.