### PR TITLE
diagnostic: remove cache size check

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -835,18 +835,6 @@ module Homebrew
         EOS
       end
 
-      def check_for_large_cache
-        return unless HOMEBREW_CACHE.exist?
-        # CI can be expected to have a large cache.
-        return if ENV["CI"]
-        cache_size = HOMEBREW_CACHE.disk_usage
-        return unless cache_size > 2_147_483_648
-        <<~EOS
-          Your HOMEBREW_CACHE is using #{disk_usage_readable(cache_size)} of disk space.
-          You may wish to consider running `brew cleanup`.
-        EOS
-      end
-
       def check_for_other_frameworks
         # Other frameworks that are known to cause problems when present
         frameworks_to_check = %w[


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There's nothing wrong with a cache over 2GB and brew cleanup is not guaranteed to bring the cache size under that threshold. We should not issue doctor warnings that are unfixable by the prescribed advice, especially when the supposed problem isn't actually a problem.

Fixes #3798.
Reverts #3783.