### PR TITLE
Make sure `.metadata` shows up in Cask backtrace.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cask_loader.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask_loader.rb
@@ -16,11 +16,11 @@ module Hbc
       end
 
       def initialize(content)
-        @content = content
+        @content = content.force_encoding("UTF-8")
       end
 
       def load
-        instance_eval(content.force_encoding("UTF-8"), __FILE__, __LINE__)
+        instance_eval(content, __FILE__, __LINE__)
       end
 
       private
@@ -52,7 +52,7 @@ module Hbc
 
         @content = IO.read(path)
 
-        super
+        instance_eval(content, path)
       end
 
       private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The fix in https://github.com/Homebrew/brew/pull/3765 was not enough, because `.metadata` doesn't show up in Cask backtraces.

Fixes https://github.com/caskroom/homebrew-cask/pull/43426.