### PR TITLE
Add Homebrew’s `bin` to PATH for Cask installers.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/artifact/installer.rb
+++ b/Library/Homebrew/cask/lib/hbc/artifact/installer.rb
@@ -23,7 +23,7 @@ module Hbc
         def install_phase(command: nil, **_)
           ohai "Running #{self.class.dsl_key} script '#{path.relative_path_from(cask.staged_path)}'"
           FileUtils.chmod "+x", path unless path.executable?
-          command.run(path, **args)
+          command.run(path, **args, path: PATH.new(HOMEBREW_PREFIX/"bin", HOMEBREW_PREFIX/"sbin", ENV["PATH"]))
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Make sure Formula dependencies for Casks are in the PATH when installing the Cask.

Fixes https://github.com/Homebrew/brew/issues/3630.