### PR TITLE
formula_installer: also run audit_installed for keg_only formulae

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -566,7 +566,7 @@ class FormulaInstaller
   def caveats
     return if only_deps?
 
-    audit_installed if ARGV.homebrew_developer? && !formula.keg_only?
+    audit_installed if ARGV.homebrew_developer?
 
     caveats = Caveats.new(formula)
 
@@ -882,8 +882,10 @@ class FormulaInstaller
   end
 
   def audit_installed
-    problem_if_output(check_env_path(formula.bin))
-    problem_if_output(check_env_path(formula.sbin))
+    unless formula.keg_only?
+      problem_if_output(check_env_path(formula.bin))
+      problem_if_output(check_env_path(formula.sbin))
+    end
     super
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`check_linkage` wasn't warning about broken keg_only bottles because none of the audit_installed checks have been running for keg_only formulae. These checks have always been disabled for keg_only formulae, ever since keg_only formulae were first introduced in https://github.com/Homebrew/brew/commit/ee2b521ca8fa134f32b46a9de29b71328c1a98ed as checks kept getting added to the non-keg_only section of that block. But I cannot see any current reason they shouldn't be run. For keg_only formulae, we should still skip the checks for whether HOMEBREW_PREFIX/bin and HOMEBREW_PREFIX/sbin are in your PATH.