### PR TITLE
upgrade: changed pinned message from Error to Warning

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -62,7 +62,7 @@ module Homebrew
     end
 
     unless pinned.empty?
-      onoe "Not upgrading #{Formatter.pluralize(pinned.length, "pinned package")}:"
+      opoo "Not upgrading #{Formatter.pluralize(pinned.length, "pinned package")}:"
       puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 


### PR DESCRIPTION
This commit https://github.com/Homebrew/brew/commit/3a2e6b82fd008974c47b87a98c6c7bbf1dcdcea7#diff-aa6192b25b5254b9e0d4b95005b69a44R65 changed the message type from `oh1` to `onoe`. I think that having pinned packages that don't upgrade it's not an error (`onoe`), instead I would give the user just a warning (`opoo`).