### PR TITLE
update.sh: use version-sort option of sort

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -218,8 +218,8 @@ merge_or_rebase() {
   if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -n "$HOMEBREW_UPDATE_TO_TAG" ]]
   then
     UPSTREAM_TAG="$(git tag --list |
-                    sort --field-separator=. --key=1,1nr -k 2,2nr -k 3,3nr |
-                    grep --max-count=1 '^[0-9]*\.[0-9]*\.[0-9]*$')"
+                    sort --version-sort --reverse |
+                    grep --max-count=1 -E '^([0-9]*\.){1,}[0-9]*$')"
   else
     UPSTREAM_TAG=""
   fi


### PR DESCRIPTION
Also, use more general regular expression in grep

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I think `--version-sort` is a more robust approach than specifying individual fields for sorting.
Not sure why `grep` is used instead of `head -n 1` but I kept it and generalized its pattern a bit.

Also, not sure why this is not something like:
```
git describe --abbrev=0 --tags origin/master
```