### PR TITLE
Define OS::Mac on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,22 +36,13 @@ before_install:
       mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library";
       sudo rm -rf "$HOMEBREW_REPOSITORY";
       sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY";
-    else
-      HOMEBREW_CORE_TAP_DIR="$(brew --repo "homebrew/core")";
-      mkdir -p "$HOMEBREW_CORE_TAP_DIR";
     fi
   - if [ "$MACOS" ]; then
       travis_retry git -C Library/Taps/homebrew/homebrew-core fetch --depth=1 origin;
+    else
+      travis_retry git clone --depth=1 https://github.com/Homebrew/homebrew-core Library/Taps/homebrew/homebrew-core;
     fi
   - travis_retry git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot Library/Taps/homebrew/homebrew-test-bot
-  - if [ "$LINUX" ]; then
-      HOMEBREW_TEST_BOT_TAP_DIR="$(brew --repo "homebrew/test-bot")";
-      ln -s "$HOMEBREW_TEST_BOT_TAP_DIR/.git" "$HOMEBREW_TEST_BOT_TAP_DIR/Formula" "$HOMEBREW_CORE_TAP_DIR";
-    fi
-  # can be removed after 1.5.3 is tagged
-  - if [ "$LINUX" ]; then
-      export HOMEBREW_FORCE_VENDOR_RUBY=1;
-    fi
 
 script:
   - brew test-bot

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -21,6 +21,7 @@ module OS
     end
     PATH_OPEN = "/usr/bin/open".freeze
   elsif OS.linux?
+    require "os/linux"
     ISSUES_URL = "https://github.com/Linuxbrew/brew/wiki/troubleshooting".freeze
     PATH_OPEN = "xdg-open".freeze
   end

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -1,0 +1,28 @@
+module OS
+  # Define OS::Mac on Linux for formula API compatibility.
+  module Mac
+    module_function
+
+    ::MacOS = self # rubocop:disable Naming/ConstantName
+
+    def prefer_64_bit?
+      Hardware::CPU.is_64_bit?
+    end
+
+    def version
+      Version::NULL
+    end
+
+    def full_version
+      Version::NULL
+    end
+
+    module Xcode
+      module_function
+
+      def version
+        Version::NULL
+      end
+    end
+  end
+end


### PR DESCRIPTION
Define `OS::Mac` on Linux for formula API compatibility.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Define `MacOS.version`, `MacOS.full_version`, and `MacOS::Xcode.version` to `Version::NULL` on Linux so that `brew readall` succeeds and `Homebrew/brew` can tap `Homebrew/core` on Linux.