### PR TITLE
Fix broken support GPG containers with embedded signatures

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/dsl/gpg.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl/gpg.rb
@@ -14,7 +14,7 @@ module Hbc
 
       def initialize(signature, parameters = {})
         @parameters = parameters
-        @signature = URI(signature)
+        @signature = URI(signature) unless signature == :embedded
         parameters.each do |hkey, hvalue|
           raise "invalid 'gpg' parameter: '#{hkey.inspect}'" unless VALID_PARAMETERS.include?(hkey)
           writer_method = "#{hkey}=".to_sym

--- a/Library/Homebrew/cask/lib/hbc/verify/gpg.rb
+++ b/Library/Homebrew/cask/lib/hbc/verify/gpg.rb
@@ -49,7 +49,7 @@ module Hbc
       end
 
       def verify
-        return unless available?
+        return unless available? && cask.gpg.signature != :embedded
         import_key
         sig = fetch_sig
 


### PR DESCRIPTION
HBC has support for GPG containers, but due to recent changes the `gpg` signature parameter is now required to be an URL to an *.asc file. GPG containers, by design, contain both data and signature in one file, and therefore don't need a separate *.asc file.

The `gpg` stanza should support some sort of nil / empty / embedded value that can be used instead of an URL to an *.asc file.

Note that this feature was previously supported, but then broke due code changes (with corresponding tests having been removed in prior commits and thus this regression hasn't been noticed).

e.g.
```
url "https://server.com/package.gpg"
gpg :embedded, key_url: 'https://keys.org/package.pub'
```

-----

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I have tested the change manually with this cask file:
https://github.com/filebot/plugins/blob/master/brew/filebot.rb