### PR TITLE
dependency_collector: don't create symbol deps.

### DIFF
--- a/Library/Homebrew/compat/dependency_collector.rb
+++ b/Library/Homebrew/compat/dependency_collector.rb
@@ -59,7 +59,7 @@ class DependencyCollector
         Dependency.new("python3", tags)
       when :emacs, :mysql, :perl, :postgresql, :rbenv, :ruby
         output_deprecation(spec)
-        Dependency.new(spec, tags)
+        Dependency.new(spec.to_s, tags)
       else
         super
       end


### PR DESCRIPTION
Need to convert this to a string first or things explode.

Fixes #3721.