### PR TITLE
Handle a too old system Git on OS X 10.8 and below

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -96,6 +96,14 @@ then
     HOMEBREW_FORCE_BREWED_CURL="1"
   fi
 
+  # The system Git is too old for some GitHub's SSL ciphers on older
+  # macOS versions.
+  # https://github.com/blog/2507-weak-cryptographic-standards-removed
+  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "100900" ]]
+  then
+    HOMEBREW_SYSTEM_GIT_TOO_OLD="1"
+  fi
+
   if [[ -z "$HOMEBREW_CACHE" ]]
   then
     HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -390,7 +390,7 @@ EOS
     brew install curl
   fi
 
-  if ! git --version >/dev/null 2>&1
+  if [[ -n "$HOMEBREW_SYSTEM_GIT_TOO_OLD" ]] || ! git --version >/dev/null 2>&1
   then
     # we cannot install brewed git if homebrew/core is unavailable.
     [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git


### PR DESCRIPTION
Needed for GitHub since:
https://github.com/blog/2507-weak-cryptographic-standards-removed