### PR TITLE
Fix regex for eventual support of Xcode 10+

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -131,7 +131,7 @@ module OS
           xcodebuild_output = Utils.popen_read(xcodebuild_path, "-version")
           next unless $CHILD_STATUS.success?
 
-          xcode_version = xcodebuild_output[/Xcode (\d(\.\d)*)/, 1]
+          xcode_version = xcodebuild_output[/Xcode (\d+(\.\d)*)/, 1]
           return xcode_version if xcode_version
 
           # Xcode 2.x's xcodebuild has a different version string


### PR DESCRIPTION
Otherwise Xcode 10 would get detected as Xcode 1

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *N/A, there doesn't appear to be any tests related to Xcode module*
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
