### PR TITLE
Add macOS libs ahead of brewed llvm libs in lib search path

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -187,7 +187,7 @@ module Superenv
       paths << Formula["llvm"].opt_lib.to_s
     end
 
-    paths << homebrew_extra_library_paths
+    paths += homebrew_extra_library_paths
     PATH.new(paths).existing
   end
 

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -176,6 +176,8 @@ module Superenv
     PATH.new(
       keg_only_deps.map(&:opt_lib),
       HOMEBREW_PREFIX/"lib",
+      "#{MacOS.sdk_path}/usr/lib",
+      (compiler == :llvm_clang ? Formula["llvm"].opt_lib.to_s : ""),
       homebrew_extra_library_paths,
     ).existing
   end

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -173,31 +173,22 @@ module Superenv
   end
 
   def determine_library_paths
+    paths = [
+      keg_only_deps.map(&:opt_lib),
+      HOMEBREW_PREFIX/"lib",
+    ]
+
     if compiler == :llvm_clang
       if MacOS::CLT.installed?
-        PATH.new(
-          keg_only_deps.map(&:opt_lib),
-          HOMEBREW_PREFIX/"lib",
-          "/usr/lib",
-          Formula["llvm"].opt_lib.to_s,
-          homebrew_extra_library_paths,
-        ).existing
+        paths << "/usr/lib"
       else
-        PATH.new(
-          keg_only_deps.map(&:opt_lib),
-          HOMEBREW_PREFIX/"lib",
-          "#{MacOS.sdk_path}/usr/lib",
-          Formula["llvm"].opt_lib.to_s,
-          homebrew_extra_library_paths,
-        ).existing
+        paths << "#{MacOS.sdk_path}/usr/lib"
       end
-    else
-      PATH.new(
-        keg_only_deps.map(&:opt_lib),
-        HOMEBREW_PREFIX/"lib",
-        homebrew_extra_library_paths,
-      ).existing
+      paths << Formula["llvm"].opt_lib.to_s
     end
+
+    paths << homebrew_extra_library_paths
+    PATH.new(paths).existing
   end
 
   def determine_dependencies

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -173,13 +173,31 @@ module Superenv
   end
 
   def determine_library_paths
-    PATH.new(
-      keg_only_deps.map(&:opt_lib),
-      HOMEBREW_PREFIX/"lib",
-      "#{MacOS.sdk_path}/usr/lib",
-      (compiler == :llvm_clang ? Formula["llvm"].opt_lib.to_s : ""),
-      homebrew_extra_library_paths,
-    ).existing
+    if compiler == :llvm_clang
+      if MacOS::CLT.installed?
+        PATH.new(
+          keg_only_deps.map(&:opt_lib),
+          HOMEBREW_PREFIX/"lib",
+          "/usr/lib",
+          Formula["llvm"].opt_lib.to_s,
+          homebrew_extra_library_paths,
+        ).existing
+      else
+        PATH.new(
+          keg_only_deps.map(&:opt_lib),
+          HOMEBREW_PREFIX/"lib",
+          "#{MacOS.sdk_path}/usr/lib",
+          Formula["llvm"].opt_lib.to_s,
+          homebrew_extra_library_paths,
+        ).existing
+      end
+    else
+      PATH.new(
+        keg_only_deps.map(&:opt_lib),
+        HOMEBREW_PREFIX/"lib",
+        homebrew_extra_library_paths,
+      ).existing
+    end
   end
 
   def determine_dependencies


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This ensures that libraries that are built with brewed LLVM but not
included in the Command Line Tools/Xcode (e.g. libomp) can be found
during a build, while still using system libraries for the essential
stuff (e.g. libc++)

Sorry it took me so long. Given how short this change is, I'm not sure why I haven't done this ages ago...

This should finally resolve [homebrew-core/pull/10456](https://github.com/Homebrew/homebrew-core/pull/10456) and #2234, and hopefully we can start using clang for OpenMP stuff too. Just got Fortran left...