### PR TITLE
GH-3838 Add Support for S3DownloadStrategy to Bottles

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -111,7 +111,8 @@ module Formulary
         # The name of the formula is found between the last slash and the last hyphen.
         formula_name = File.basename(bottle_name)[/(.+)-/, 1]
         resource = Resource.new(formula_name) { url bottle_name }
-        downloader = CurlBottleDownloadStrategy.new resource.name, resource
+        resource.specs[:bottle] = true
+        downloader = CurlDownloadStrategy.new resource.name, resource
         @bottle_filename = downloader.cached_location
         cached = @bottle_filename.exist?
         downloader.fetch

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -283,13 +283,14 @@ class Bottle
     @name = formula.name
     @resource = Resource.new
     @resource.owner = formula
+    @resource.specs[:bottle] = true
     @spec = spec
 
     checksum, tag = spec.checksum_for(Utils::Bottles.tag)
 
     filename = Filename.create(formula, tag, spec.rebuild)
-    @resource.url(build_url(spec.root_url, filename))
-    @resource.download_strategy = CurlBottleDownloadStrategy
+    @resource.url(build_url(spec.root_url, filename),
+                  select_download_strategy(spec.root_url_specs))
     @resource.version = formula.pkg_version
     @resource.checksum = checksum
     @prefix = spec.prefix
@@ -315,6 +316,11 @@ class Bottle
   def build_url(root_url, filename)
     "#{root_url}/#{filename}"
   end
+
+  def select_download_strategy(specs)
+    specs[:using] = CurlDownloadStrategy unless specs.include?(:using)
+    specs
+  end
 end
 
 class BottleSpecification
@@ -324,20 +330,22 @@ class BottleSpecification
 
   attr_rw :prefix, :cellar, :rebuild
   attr_accessor :tap
-  attr_reader :checksum, :collector
+  attr_reader :checksum, :collector, :root_url_specs
 
   def initialize
     @rebuild = 0
     @prefix = DEFAULT_PREFIX
     @cellar = DEFAULT_CELLAR
     @collector = Utils::Bottles::Collector.new
+    @root_url_specs = {}
   end
 
-  def root_url(var = nil)
+  def root_url(var = nil, specs = {})
     if var.nil?
       @root_url ||= "#{DEFAULT_DOMAIN}/#{Utils::Bottles::Bintray.repository(tap)}"
     else
       @root_url = var
+      @root_url_specs.merge!(specs)
     end
   end
 

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -2,9 +2,10 @@ require "download_strategy"
 
 describe AbstractDownloadStrategy do
   subject { described_class.new(name, resource) }
+  let(:specs) { {} }
   let(:name) { "foo" }
   let(:url) { "http://example.com/foo.tar.gz" }
-  let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: nil) }
+  let(:resource) { double(Resource, url: url, mirrors: [], specs: specs, version: nil) }
   let(:args) { %w[foo bar baz] }
 
   describe "#expand_safe_system_args" do
@@ -32,6 +33,50 @@ describe AbstractDownloadStrategy do
       FileUtils.touch "bar", mtime: Time.now - 100
       FileUtils.ln_s "not-exist", "baz"
       expect(subject.source_modified_time).to eq(File.mtime("foo"))
+    end
+  end
+
+  context "when specs[:bottle] => true" do
+    let(:specs) { { bottle: true } }
+
+    it "extends Pourable" do
+      expect(subject).to be_a_kind_of(AbstractDownloadStrategy::Pourable)
+    end
+  end
+
+  context "when specs[:bottle] => false" do
+    let(:specs) { { bottle: false } }
+
+    it "is not Pourable" do
+      expect(subject).to_not be_a_kind_of(AbstractDownloadStrategy::Pourable)
+    end
+  end
+
+  context "when specs[:bottle] is unspecified" do
+    it "is not Pourable" do
+      expect(subject).to_not be_a_kind_of(AbstractDownloadStrategy::Pourable)
+    end
+  end
+end
+
+describe AbstractDownloadStrategy::Pourable do
+  let(:specs) { {} }
+  let(:name) { "foo" }
+  let(:url) { "http://example.com/foo.tar.gz" }
+  let(:resource) { double(Resource, url: url, mirrors: [], specs: specs, version: nil) }
+  let(:download_strategy) { AbstractDownloadStrategy.new(name, resource) }
+  subject(:pourable_strategy) { download_strategy.extend(AbstractDownloadStrategy::Pourable) }
+
+  describe "#stage" do
+    before(:each) do
+      cached_location = double("cached_location")
+      allow(cached_location).to receive(:basename).and_return("foo.tar.gz")
+      allow(pourable_strategy).to receive(:cached_location).and_return(cached_location)
+    end
+
+    it "ohai's a 'Pouring' message using the object's cached_location.basename" do
+      expect(pourable_strategy).to receive(:ohai).with("Pouring foo.tar.gz")
+      pourable_strategy.stage
     end
   end
 end
@@ -200,26 +245,6 @@ describe GitDownloadStrategy do
   end
 end
 
-describe S3DownloadStrategy do
-  subject { described_class.new(name, resource) }
-  let(:name) { "foo" }
-  let(:url) { "http://bucket.s3.amazonaws.com/foo.tar.gz" }
-  let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: nil) }
-
-  describe "#_fetch" do
-    subject { described_class.new(name, resource)._fetch }
-
-    context "when given Bad S3 URL" do
-      let(:url) { "http://example.com/foo.tar.gz" }
-      it "should raise Bad S3 URL error" do
-        expect {
-          subject._fetch
-        }.to raise_error(RuntimeError)
-      end
-    end
-  end
-end
-
 describe CurlDownloadStrategy do
   subject { described_class.new(name, resource) }
   let(:name) { "foo" }
@@ -240,6 +265,198 @@ describe CurlDownloadStrategy do
     context "when URL file is in middle" do
       let(:url) { "http://example.com/foo.tar.gz/from/this/mirror" }
       it { is_expected.to eq(HOMEBREW_CACHE/"foo-.tar.gz") }
+    end
+  end
+end
+
+describe S3DownloadStrategy do
+  let(:s3_object_summary) { double("s3_object_summary") }
+  let(:name) { "foo" }
+  let(:url) { "https://bar.s3.amazonaws.com/baz/foo-1.0.0.tar.gz" }
+  let(:parsed_bucket_name) { "bar" }
+  let(:parsed_key) { "baz/foo-1.0.0.tar.gz" }
+  let(:invalid_url) { "http://invalid.s3.example.com/foo/foo-1.0.0.tar.gz" }
+  let(:presigned_url) do
+    %w[
+      https://bar.s3.amazonaws.com/baz/foo-1.0.0.tar.gz
+      ?X-Amz-Algorithm=AWS4-HMAC-SHA256
+      &X-Amz-Credential=AKIAIOSFODNN7EXAMPLE/19990101/us-east-1/s3/aws4_request
+      &X-Amz-Date=19990101T000000Z&X-Amz-Expires=900
+      &X-Amz-SignedHeaders=host
+      &X-Amz-Signature=0000000000000000000000000000000000000000000000000000000000000000
+    ].join
+  end
+  let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: "1.0.0") }
+
+  subject(:download_strategy) { described_class.new(name, resource) }
+
+  before(:each) do
+    # ensure we don't use real credentials
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with("HOMEBREW_AWS_ACCESS_KEY_ID").and_return("EXAMPLE_AWS_ACCESS_KEY_ID")
+    allow(ENV).to receive(:[]).with("HOMEBREW_AWS_SECRET_ACCESS_KEY").and_return("EXAMPLE_AWS_SECRET_ACCESS_KEY")
+
+    # ensure we don't actually call curl
+    allow(download_strategy).to receive(:curl_download)
+
+    # stub out the object summary by default
+    allow(download_strategy).to receive(:s3_object_summary).and_return(s3_object_summary)
+    allow(download_strategy).to receive(:create_s3_object_summary).and_return(s3_object_summary)
+
+    allow(s3_object_summary).to receive(:presigned_url).and_return(presigned_url)
+    allow(s3_object_summary).to receive(:key).and_return(parsed_key)
+    allow(s3_object_summary).to receive(:bucket_name).and_return(parsed_bucket_name)
+
+    # stub out the gem requirement
+    allow(download_strategy).to receive(:require).with("aws-sdk-s3").and_return(true)
+  end
+
+  describe "#parse_s3_bucket" do
+    it "returns the S3 URL's bucket" do
+      expect(download_strategy.parse_s3_bucket).to eq(parsed_bucket_name)
+    end
+
+    context "when URL does not match expected S3 format" do
+      let(:url) { invalid_url }
+      it "raises an ErrorDuringExecution" do
+        expect {
+          download_strategy.parse_s3_bucket
+        }.to raise_error(ErrorDuringExecution)
+      end
+    end
+  end
+
+  describe "#parse_s3_key" do
+    it "returns the S3 URL's key" do
+      expect(download_strategy.parse_s3_key).to eq(parsed_key)
+    end
+
+    context "when URL does not match expected S3 format" do
+      let(:url) { invalid_url }
+      it "raises an ErrorDuringExecution" do
+        expect {
+          download_strategy.parse_s3_key
+        }.to raise_error(ErrorDuringExecution)
+      end
+    end
+  end
+
+  describe "s3_bucket" do
+    it "calls parse_s3_bucket" do
+      expect(download_strategy).to receive(:parse_s3_bucket)
+      download_strategy.s3_bucket
+    end
+
+    it "returns a parsed s3 bucket name" do
+      expect(download_strategy.s3_bucket).to eq(parsed_bucket_name)
+    end
+  end
+
+  describe "s3_key" do
+    it "calls parse_s3_key" do
+      expect(download_strategy).to receive(:parse_s3_key)
+      download_strategy.s3_key
+    end
+
+    it "returns a parsed s3 key" do
+      expect(download_strategy.s3_key).to eq(parsed_key)
+    end
+  end
+
+  describe "#create_s3_object_summary" do
+    it "creates an object summary using s3_bucket" do
+      test_object_summary = download_strategy.create_s3_object_summary
+      expect(test_object_summary.bucket_name).to eq(parsed_bucket_name)
+    end
+
+    it "creates an object summary using s3_key" do
+      test_object_summary = download_strategy.create_s3_object_summary
+      expect(test_object_summary.key).to eq(parsed_key)
+    end
+  end
+
+  describe "#s3_object_summary" do
+    context "when the object summary doesn't exist" do
+      it "calls create_s3_object_summary" do
+        # unmock the object summary so it will create itself
+        allow(download_strategy).to receive(:s3_object_summary).and_call_original
+        expect(download_strategy).to receive(:create_s3_object_summary)
+        download_strategy.s3_object_summary
+      end
+    end
+
+    it "returns an s3 object summary" do
+      expect(download_strategy.s3_object_summary).to eq(s3_object_summary)
+    end
+  end
+
+  describe "#require_aws_s3_sdk" do
+    context "when aws-sdk-s3 gem is found" do
+      it "requires the aws-sdk-s3 gem" do
+        expect(download_strategy).to receive(:require).with("aws-sdk-s3").and_return(true)
+        download_strategy.require_aws_s3_sdk
+      end
+    end
+
+    context "when aws-sdk-s3 gem is missing" do
+      it "raises a LoadError" do
+        allow(download_strategy).to receive(:require).with("aws-sdk-s3").and_raise(LoadError)
+        expect {
+          download_strategy.require_aws_s3_sdk
+        }.to raise_error(LoadError)
+      end
+    end
+  end
+
+  describe "#request_s3_url" do
+    it "calls require_aws_s3_sdk" do
+      expect(download_strategy).to receive(:require_aws_s3_sdk)
+      download_strategy.request_s3_url
+    end
+
+    it "preserves the environment's AWS_ACCESS_KEY_ID" do
+      ENV["AWS_ACCESS_KEY_ID"] = "ORIGINAL_AWS_ACCESS_KEY_ID"
+      download_strategy.request_s3_url
+      expect(ENV["AWS_ACCESS_KEY_ID"]).to eq("ORIGINAL_AWS_ACCESS_KEY_ID")
+    end
+
+    it "preserves the environment's AWS_SECRET_ACCESS_KEY" do
+      ENV["AWS_SECRET_ACCESS_KEY"] = "ORIGINAL_AWS_SECRET_ACCESS_KEY"
+      download_strategy.request_s3_url
+      expect(ENV["AWS_SECRET_ACCESS_KEY"]).to eq("ORIGINAL_AWS_SECRET_ACCESS_KEY")
+    end
+
+    it "requests a presigned GET url" do
+      expect(s3_object_summary).to receive(:presigned_url).with(:get)
+      download_strategy.request_s3_url
+    end
+
+    context "when AWS credentials are missing" do
+      it "uses the url as-is" do
+        stub_const("Aws::Errors::MissingCredentialsError", Class.new(Exception))
+        allow(s3_object_summary).to receive(:presigned_url).and_raise(Aws::Errors::MissingCredentialsError)
+        expect(download_strategy.request_s3_url).to eq(url)
+      end
+    end
+  end
+
+  describe "#s3_url" do
+    it "calls request_s3_url" do
+      expect(download_strategy).to receive(:request_s3_url)
+      download_strategy.s3_url
+    end
+
+    it "returns a presigned s3 url" do
+      expect(download_strategy.s3_url).to eq(presigned_url)
+    end
+  end
+
+  describe "#_fetch" do
+    it "calls curl_download with s3_url and to: temporary_path" do
+      allow(download_strategy).to receive(:s3_url).and_return("s3_url")
+      allow(download_strategy).to receive(:temporary_path).and_return("temporary_path")
+      expect(download_strategy).to receive(:curl_download).with("s3_url", to: "temporary_path")
+      download_strategy._fetch
     end
   end
 end


### PR DESCRIPTION
Add Support for S3BottleDownloadStrategy to Bottles

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?

```
→ brew style
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.6-compliant syntax, but you are running 2.3.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Inspecting 665 files
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

665 files inspected, no offenses detected
```

- [x] Have you successfully run `brew tests` with your changes locally?

```
2246 examples, 0 failures, 10 pendings

Took 104 seconds (1:44)
```

-----

#### Preface

No tests written yet. I am happy to write them if we determine this approach is acceptable.
I am taking your contribution notes at heart, and wish to deliver an improvement that fits within the guidelines of the quality bar Homebrew has set. Thus, I expect to iterate on this, as needed, until hopefully we can determine what all changes are needed.

#### Overview

This is an attempt at implementing #3838 by allowing for a `:using =>` statement to be optionally added to the `root_url` of a bottle configuration.

I can specify a new download strategy called `S3BottleDownloadStrategy` which extends the behavior of the `CurlBottleDownloadStrategy` by allowing it to use S3 URLs, but still retaining the bottle "Pouring" text.

#### Example

```
class MyApp < Formula
  desc "MyOrg's MyApp"
  homepage "https://github.com/myorg/myapp"
  url "https://myorg-private-source-dist.s3.amazonaws.com/myapp/1.0/my-app-1.0.0.tar.gz", :using => S3DownloadStrategy
  version "1.0.0"
  sha256 "big-long-sha"
  
  bottle do
    root_url "https://myorg-private-bin-repo.s3.amazonaws.com/myapp/1.0", :using => S3BottleDownloadStrategy
    cellar :any_skip_relocation
    sha256 "big-long-sha" => :high_sierra
  end
  
  def install
    system "./configure", "--disable-silent-rules",
                          "--prefix=#{prefix}"
    system "make", "install"
  end
  
  test do    
    true
  end
end
```

#### Code Changes

##### Library/Homebrew/download_strategy.rb

`CurlBottleDownloadStrategy` is the default bottle download strategy. To support S3, I needed a new class which inherits from this one, and adds the S3 Behavior.

- Added `S3BottleDownloadStrategy` which inherits from `CurlBottleDownloadStrategy`
- Moved the `_fetch` override from `S3DownloadStrategy` to a new mixin inside `CurlDownloadStrategy` called `S3DownloadExtension`
- added `include S3DownloadExtension` into `S3DownloadStrategy` and `S3BottleDownloadStrategy`

##### Library/Homebrew/software_spec.rb

`BottleSpecification` has a `root_url` attribute, I needed to be able to pass a `:using =>` setting into it, so I used a pattern similar to `resource.url` to support optionally passing in a hash of 'specs'.

I then store those specs in a new read-only attribute called `:root_url_specs`

```
-  def root_url(var = nil)
+  def root_url(var = nil, specs = {})
     if var.nil?
       @root_url ||= "#{DEFAULT_DOMAIN}/#{Utils::Bottles::Bintray.repository(tap)}"
     else
       @root_url = var
+      @root_url_specs.merge!(specs)
     end
   end
```

`Bottle.initialize` normally defaults to `CurlBottleDownloadStrategy` and ignores whatever `resource.url` had set it to. I needed to be able to remove the default override and instead use a default suggestion to `resource.url` which would allow the new `S3BottleDownloadStrategy` to be optionally specified.

```
-    @resource.url(build_url(spec.root_url, filename))
-    @resource.download_strategy = CurlBottleDownloadStrategy
```
```
+    @resource.url(build_url(spec.root_url, filename),
+                  select_download_strategy(spec.root_url_specs))
```

I added a helper method `select_download_strategy` which takes the `root_url_specs` hash from the `BottleSpecification`

It's here that I default to `CurlBottleDownloadStrategy`, except now I'm doing it by specifying it as a `:using` flag, and this allows the existing `Formula.url` behavior to set `@resource.download_strategy` appropriately.

```
+  def select_download_strategy(specs)
+    specs[:using] = CurlBottleDownloadStrategy unless specs.include?(:using)
+    specs
+  end
```

