### PR TITLE
language/python: handle python@* in each_python

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -15,10 +15,11 @@ module Language
 
     def self.each_python(build, &block)
       original_pythonpath = ENV["PYTHONPATH"]
-      ["python", "python3"].each do |python|
-        next if build.without? python
+      { "python@3" => "python3", "python@2" => "python2.7" }.each do |python_formula, python|
+        python_formula = Formulary.factory(python_formula)
+        next if build.without? python_formula.to_s
         version = major_minor_version python
-        ENV["PYTHONPATH"] = if Formulary.factory(python).installed?
+        ENV["PYTHONPATH"] = if python_formula.installed?
           nil
         else
           homebrew_site_packages(version)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Needed for the python3 -> python, python -> python@2 rename.

This should handle both the old formula names and the new formula names since python@2 is an alias before the rename and python@3 is an alias after the rename.

See https://github.com/Homebrew/homebrew-core/pull/24604.