### PR TITLE
Allow user to set HOMEBREW_CELLAR

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -5,12 +5,16 @@ then
 fi
 
 # Where we store built products; a Cellar in HOMEBREW_PREFIX (often /usr/local
-# for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY.
-if [[ -d "$HOMEBREW_REPOSITORY/Cellar" ]]
+# for bottles) unless there's already a Cellar in HOMEBREW_REPOSITORY or the
+# user has specified HOMEBREW_CELLAR explicitly.
+if [[ -z "$HOMEBREW_CELLAR" ]]
 then
-  HOMEBREW_CELLAR="$HOMEBREW_REPOSITORY/Cellar"
-else
-  HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar"
+    if [[ -d "$HOMEBREW_REPOSITORY/Cellar" ]]
+    then
+	HOMEBREW_CELLAR="$HOMEBREW_REPOSITORY/Cellar"
+    else
+	HOMEBREW_CELLAR="$HOMEBREW_PREFIX/Cellar"
+    fi
 fi
 
 case "$*" in


### PR DESCRIPTION
Use environment variable in preference to looking in usual locations.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This implements #3849, allowing user to specify value of HOMEBREW_CELLAR via environment variable.