### PR TITLE
irb: add pry support.

### DIFF
--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -1,11 +1,9 @@
-#:  * `irb` [`--examples`]:
+#:  * `irb` [`--examples`] [`--pry`]:
 #:    Enter the interactive Homebrew Ruby shell.
 #:
 #:    If `--examples` is passed, several examples will be shown.
-
-require "formula"
-require "keg"
-require "irb"
+#:    If `--pry` is passed or HOMEBREW_PRY is set, pry will be
+#:    used instead of irb.
 
 class Symbol
   def f(*args)
@@ -23,17 +21,33 @@ module Homebrew
   module_function
 
   def irb
-    $LOAD_PATH.unshift("#{HOMEBREW_LIBRARY_PATH}/cask/lib")
-    require "hbc"
-
     if ARGV.include? "--examples"
       puts "'v8'.f # => instance of the v8 formula"
       puts ":hub.f.installed?"
       puts ":lua.f.methods - 1.methods"
       puts ":mpd.f.recursive_dependencies.reject(&:installed?)"
+      return
+    end
+
+    if ARGV.pry?
+      Homebrew.install_gem_setup_path! "pry"
+      require "pry"
+      Pry.config.prompt_name = "brew"
     else
-      ohai "Interactive Homebrew Shell"
-      puts "Example commands available with: brew irb --examples"
+      require "irb"
+    end
+
+    require "formula"
+    require "keg"
+
+    $LOAD_PATH.unshift("#{HOMEBREW_LIBRARY_PATH}/cask/lib")
+    require "hbc"
+
+    ohai "Interactive Homebrew Shell"
+    puts "Example commands available with: brew irb --examples"
+    if ARGV.pry?
+      Pry.start
+    else
       IRB.start
     end
   end

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -267,6 +267,10 @@ module HomebrewArgvExtension
     include? "--fetch-HEAD"
   end
 
+  def pry?
+    include?("--pry") || !ENV["HOMEBREW_PRY"].nil?
+  end
+
   # eg. `foo -ns -i --bar` has three switches, n, s and i
   def switch?(char)
     return false if char.length > 1

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -183,6 +183,10 @@ can take several different forms:
 
     *Note:* Homebrew doesn't require permissions for any of the scopes.
 
+  * `HOMEBREW_INSTALL_BADGE`:
+    Text printed before the installation summary of each successful build.
+    Defaults to the beer emoji.
+
   * `HOMEBREW_LOGS`:
     If set, Homebrew will use the given directory to store log files.
 
@@ -220,9 +224,8 @@ can take several different forms:
     If set, Homebrew will not use the GitHub API for e.g searches or
     fetching relevant issues on a failed install.
 
-  * `HOMEBREW_INSTALL_BADGE`:
-    Text printed before the installation summary of each successful build.
-    Defaults to the beer emoji.
+  * `HOMEBREW_PRY`:
+    If set, Homebrew will use `pry` for the `brew irb` command.
 
   * `HOMEBREW_SVN`:
     When exporting from Subversion, Homebrew will use `HOMEBREW_SVN` if set,

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -280,11 +280,6 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--git` (or `-g`) is passed, Homebrew will create a Git repository, useful for
     creating patches to the software.
 
-  * `irb` [`--examples`]:
-    Enter the interactive Homebrew Ruby shell.
-
-    If `--examples` is passed, several examples will be shown.
-
   * `leaves`:
     Show installed formulae that are not dependencies of another installed formula.
 
@@ -761,6 +756,13 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `formula` `formula`:
     Display the path where `formula` is located.
 
+  * `irb` [`--examples`] [`--pry`]:
+    Enter the interactive Homebrew Ruby shell.
+
+    If `--examples` is passed, several examples will be shown.
+    If `--pry` is passed or HOMEBREW_PRY is set, pry will be
+    used instead of irb.
+
   * `linkage` [`--test`] [`--reverse`] `formula`:
     Checks the library links of an installed formula.
 
@@ -1029,6 +1031,10 @@ can take several different forms:
 
     *Note:* Homebrew doesn't require permissions for any of the scopes.
 
+  * `HOMEBREW_INSTALL_BADGE`:
+    Text printed before the installation summary of each successful build.
+    Defaults to the beer emoji.
+
   * `HOMEBREW_LOGS`:
     If set, Homebrew will use the given directory to store log files.
 
@@ -1066,9 +1072,8 @@ can take several different forms:
     If set, Homebrew will not use the GitHub API for e.g searches or
     fetching relevant issues on a failed install.
 
-  * `HOMEBREW_INSTALL_BADGE`:
-    Text printed before the installation summary of each successful build.
-    Defaults to the beer emoji.
+  * `HOMEBREW_PRY`:
+    If set, Homebrew will use `pry` for the `brew irb` command.
 
   * `HOMEBREW_SVN`:
     When exporting from Subversion, Homebrew will use `HOMEBREW_SVN` if set,

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -291,13 +291,6 @@ If \fB\-\-interactive\fR (or \fB\-i\fR) is passed, download and patch \fIformula
 If \fB\-\-git\fR (or \fB\-g\fR) is passed, Homebrew will create a Git repository, useful for creating patches to the software\.
 .
 .TP
-\fBirb\fR [\fB\-\-examples\fR]
-Enter the interactive Homebrew Ruby shell\.
-.
-.IP
-If \fB\-\-examples\fR is passed, several examples will be shown\.
-.
-.TP
 \fBleaves\fR
 Show installed formulae that are not dependencies of another installed formula\.
 .
@@ -781,6 +774,13 @@ Open \fIformula\fR in the editor\.
 Display the path where \fIformula\fR is located\.
 .
 .TP
+\fBirb\fR [\fB\-\-examples\fR] [\fB\-\-pry\fR]
+Enter the interactive Homebrew Ruby shell\.
+.
+.IP
+If \fB\-\-examples\fR is passed, several examples will be shown\. If \fB\-\-pry\fR is passed or HOMEBREW_PRY is set, pry will be used instead of irb\.
+.
+.TP
 \fBlinkage\fR [\fB\-\-test\fR] [\fB\-\-reverse\fR] \fIformula\fR
 Checks the library links of an installed formula\.
 .
@@ -1048,6 +1048,10 @@ A personal access token for the GitHub API, which you can create at \fIhttps://g
 \fINote:\fR Homebrew doesn\'t require permissions for any of the scopes\.
 .
 .TP
+\fBHOMEBREW_INSTALL_BADGE\fR
+Text printed before the installation summary of each successful build\. Defaults to the beer emoji\.
+.
+.TP
 \fBHOMEBREW_LOGS\fR
 If set, Homebrew will use the given directory to store log files\.
 .
@@ -1089,8 +1093,8 @@ While ensuring your downloads are fully secure, this is likely to cause from\-so
 If set, Homebrew will not use the GitHub API for e\.g searches or fetching relevant issues on a failed install\.
 .
 .TP
-\fBHOMEBREW_INSTALL_BADGE\fR
-Text printed before the installation summary of each successful build\. Defaults to the beer emoji\.
+\fBHOMEBREW_PRY\fR
+If set, Homebrew will use \fBpry\fR for the \fBbrew irb\fR command\.
 .
 .TP
 \fBHOMEBREW_SVN\fR


### PR DESCRIPTION
Make `brew irb` optionally support `pry`. While doing so, also make it a `dev-cmd`.

CC @mistydemeo who expressed an interest in this.