### PR TITLE
dev-cmd/ruby: fix path to dev-cmd/irb and add test

### DIFF
--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -8,6 +8,6 @@ module Homebrew
   module_function
 
   def ruby
-    exec ENV["HOMEBREW_RUBY_PATH"], "-I#{HOMEBREW_LIBRARY_PATH}", "-rglobal", "-rcmd/irb", *ARGV
+    exec ENV["HOMEBREW_RUBY_PATH"], "-I#{HOMEBREW_LIBRARY_PATH}", "-rglobal", "-rdev-cmd/irb", *ARGV
   end
 end

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -1,0 +1,13 @@
+describe "brew ruby", :integration_test do
+  it "executes ruby code with Homebrew's libraries loaded" do
+    expect { brew "ruby", "-e", "exit 0" }
+      .to be_a_success
+      .and not_to_output.to_stdout
+      .and not_to_output.to_stderr
+
+    expect { brew "ruby", "-e", "exit 1" }
+      .to be_a_failure
+      .and not_to_output.to_stdout
+      .and not_to_output.to_stderr
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
The `brew ruby` command was broken by https://github.com/Homebrew/brew/pull/3851 (`cannot load such file -- cmd/irb (LoadError)`):

~~~
$ brew ruby -e 'exit 0'
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- cmd/irb (LoadError)
	from /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
~~~

The `irb` command was moved to `dev-cmd` but we forgot to update the path embedded in the `ruby` command. This fixes the path and adds a very basic test for the `ruby` command.