### PR TITLE
utils: stop suggesting fixing hard deprecations

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -109,7 +109,11 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
 
   if ARGV.homebrew_developer? || disable ||
      Homebrew.raise_deprecation_exceptions?
-    developer_message = message + "Or, even better, submit a PR to fix it!"
+    if replacement_message != "There is no replacement."
+      developer_message = message + "Or, even better, submit a PR to fix it!"
+    else
+      developer_message = message
+    end
     raise MethodDeprecatedError, developer_message
   elsif !Homebrew.auditing?
     opoo "#{message}\n"

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -109,10 +109,12 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
 
   if ARGV.homebrew_developer? || disable ||
      Homebrew.raise_deprecation_exceptions?
-    if replacement_message != "There is no replacement."
-      developer_message = message + "Or, even better, submit a PR to fix it!"
-    else
+    if caller_message.match?(HOMEBREW_LIBRARY_PATH/"cmd") ||
+       caller_message.match?(HOMEBREW_LIBRARY_PATH/"dev-cmd") &&
+       replacement_message == "There is no replacement."
       developer_message = message
+    else
+      developer_message = message + "Or, even better, submit a PR to fix it!"
     end
     raise MethodDeprecatedError, developer_message
   elsif !Homebrew.auditing?

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -109,11 +109,7 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
 
   if ARGV.homebrew_developer? || disable ||
      Homebrew.raise_deprecation_exceptions?
-    if caller_message.match?(HOMEBREW_LIBRARY_PATH/"cmd") ||
-       caller_message.match?(HOMEBREW_LIBRARY_PATH/"dev-cmd") &&
-       replacement_message == "There is no replacement."
-      developer_message = message
-    else
+    if replacement || tap
       developer_message = message + "Or, even better, submit a PR to fix it!"
     end
     raise MethodDeprecatedError, developer_message


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

```
Error: Calling 'brew linkapps' is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Homebrew/cmd/linkapps.rb:18:in `linkapps'
Or, even better, submit a PR to fix it!
```

I'm just a mere mortal, but I have yet to find a way to fix permanent death, so it seems reasonable to not expect folks to try and find a way.

I accept `linkapps` isn't an ideal example here & in some cases it _is appropriate_ to tell developers to submit fixes. This could/should _(open for debate)_ be scoped to formulae or even just exempt things in `cmd` and `dev-cmd`, but although I know the intention behind it I can imagine it would be confusing to someone newer to be told to fix something that's, well, never ever coming back.