### PR TITLE
language/python: version 3.6 in site_packages

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -9,7 +9,7 @@ module Language
       Version.create(version.to_s)
     end
 
-    def self.homebrew_site_packages(version = "2.7")
+    def self.homebrew_site_packages(version = "3.6")
       HOMEBREW_PREFIX/"lib/python#{version}/site-packages"
     end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `python` formula now refers to python3, but there is a diagnostic complaint that recommends setting up a site-packages file that refers to python 2.7. So I've updated the `homebrew_site_packages` method. I have tested the changes locally.

There's potentially a similar change to be made at the following line, but I wasn't sure about it:

https://github.com/Homebrew/brew/blob/master/Library/Homebrew/language/python.rb#L140

~~~
++ brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Your default Python does not recognize the Homebrew site-packages
directory as a special site-packages directory, which means that .pth
files will not be followed. This means you will not be able to import
some modules after installing them with Homebrew, like wxpython. To fix
this for the current user, you can run:
  mkdir -p /Users/jenkins/Library/Python/2.7/lib/python/site-packages
  echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> /Users/jenkins/Library/Python/2.7/lib/python/site-packages/homebrew.pth
~~~