### PR TITLE
migrator: overwrite by default.

### DIFF
--- a/Library/Homebrew/migrator.rb
+++ b/Library/Homebrew/migrator.rb
@@ -288,7 +288,8 @@ class Migrator
     new_keg.remove_linked_keg_record if new_keg.linked?
 
     begin
-      new_keg.link
+      mode = OpenStruct.new(overwrite: true)
+      new_keg.link(mode)
     rescue Keg::ConflictError => e
       onoe "Error while executing `brew link` step on #{newname}"
       puts e


### PR DESCRIPTION
This avoids getting into an invalid state which will and does break for users.