### PR TITLE
Adjust docs and more internal code for Python 3.

### DIFF
--- a/Library/Homebrew/compat/dependency_collector.rb
+++ b/Library/Homebrew/compat/dependency_collector.rb
@@ -52,11 +52,11 @@ class DependencyCollector
         output_deprecation(spec, "open-mpi")
         Dependency.new("open-mpi", tags)
       when :python, :python2
+        output_deprecation(spec, "python@2")
+        Dependency.new("python@2", tags)
+      when :python3
         output_deprecation(spec, "python")
         Dependency.new("python", tags)
-      when :python3
-        output_deprecation(spec, "python3")
-        Dependency.new("python3", tags)
       when :emacs, :mysql, :perl, :postgresql, :rbenv, :ruby
         output_deprecation(spec)
         Dependency.new(spec.to_s, tags)

--- a/Library/Homebrew/compat/requirements.rb
+++ b/Library/Homebrew/compat/requirements.rb
@@ -84,16 +84,16 @@ end
 class PythonRequirement < Requirement
   fatal true
   satisfy do
-    odeprecated("PythonRequirement", "'depends_on \"python\"'")
-    which "python"
+    odeprecated("PythonRequirement", "'depends_on \"python@2\"'")
+    which "python2"
   end
 end
 
 class Python3Requirement < Requirement
   fatal true
   satisfy do
-    odeprecated("Python3Requirement", "'depends_on \"python3\"'")
-    which "python3"
+    odeprecated("Python3Requirement", "'depends_on \"python\"'")
+    which "python"
   end
 end
 

--- a/Library/Homebrew/compat/requirements/language_module_requirement.rb
+++ b/Library/Homebrew/compat/requirements/language_module_requirement.rb
@@ -38,9 +38,9 @@ class LanguageModuleRequirement < Requirement
     when :perl
       ["/usr/bin/env", "perl", "-e", "use #{@import_name}"]
     when :python
-      ["/usr/bin/env", "python", "-c", "import #{@import_name}"]
+      ["/usr/bin/env", "python2", "-c", "import #{@import_name}"]
     when :python3
-      ["/usr/bin/env", "python3", "-c", "import #{@import_name}"]
+      ["/usr/bin/env", "python", "-c", "import #{@import_name}"]
     when :ruby
       ["/usr/bin/env", "ruby", "-rubygems", "-e", "require '#{@import_name}'"]
     end
@@ -51,8 +51,8 @@ class LanguageModuleRequirement < Requirement
     when :lua     then "luarocks-5.2 install"
     when :lua51   then "luarocks-5.1 install"
     when :perl    then "cpan -i"
-    when :python  then "pip install"
-    when :python3 then "pip3 install"
+    when :python  then "pip3 install"
+    when :python3 then "pip install"
     when :ruby    then "gem install"
     end
   end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -934,7 +934,7 @@ module Homebrew
             from your PATH variable.
             Python scripts will now install into #{HOMEBREW_PREFIX}/bin.
             You can delete anything, except 'Extras', from the #{HOMEBREW_PREFIX}/share/python
-            (and #{HOMEBREW_PREFIX}/share/python3) dir and install affected Python packages
+            (and #{HOMEBREW_PREFIX}/share/python@2) dir and install affected Python packages
             anew with `pip install --upgrade`.
           EOS
         end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -343,8 +343,8 @@ class FormulaAmbiguousPythonError < RuntimeError
   def initialize(formula)
     super <<~EOS
       The version of python to use with the virtualenv in the `#{formula.full_name}` formula
-      cannot be guessed automatically. If the simultaneous use of python and python3
-      is intentional, please add `:using => "python"` or `:using => "python3"` to
+      cannot be guessed automatically. If the simultaneous use of python and python@2
+      is intentional, please add `:using => "python"` or `:using => "python@2"` to
       `virtualenv_install_with_resources` to resolve the ambiguity manually.
     EOS
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2201,12 +2201,12 @@ class Formula
     # # `build.with?` or `build.without? "another_formula"`:
     # depends_on "postgresql" if build.without? "sqlite"
     #
-    # <pre># Python 2.7:
-    # depends_on "python"</pre>
-    # <pre># Python 2.7 but use system Python where possible
-    # depends_on "python" if MacOS.version <= :snow_leopard</pre>
-    # <pre># Python 3.x if the `--with-python3` is given to `brew install example`
+    # <pre># Python 3.x if the `--with-python` is given to `brew install example`
     # depends_on "python3" => :optional</pre>
+    # <pre># Python 2.7:
+    # depends_on "python@2"</pre>
+    # <pre># Python 2.7 but use system Python where possible
+    # depends_on "python@2" if MacOS.version <= :snow_leopard</pre>
     def depends_on(dep)
       specs.each { |spec| spec.depends_on(dep) }
     end

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -89,7 +89,7 @@ module Language
       # @param venv_root [Pathname, String] the path to the root of the virtualenv
       #   (often `libexec/"venv"`)
       # @param python [String] which interpreter to use (e.g. "python"
-      #   or "python3")
+      #   or "python2")
       # @param formula [Formula] the active Formula
       # @return [Virtualenv] a {Virtualenv} instance
       def virtualenv_create(venv_root, python = "python", formula = self)
@@ -115,8 +115,8 @@ module Language
 
       # Returns true if a formula option for the specified python is currently
       # active or if the specified python is required by the formula. Valid
-      # inputs are "python", "python3", :python, and :python3. Note that
-      # "with-python", "without-python", "with-python3", and "without-python3"
+      # inputs are "python", "python2", :python, and :python2. Note that
+      # "with-python", "without-python", "with-python@2", and "without-python@2"
       # formula options are handled correctly even if not associated with any
       # corresponding depends_on statement.
       # @api private
@@ -128,16 +128,16 @@ module Language
       # Helper method for the common case of installing a Python application.
       # Creates a virtualenv in `libexec`, installs all `resource`s defined
       # on the formula, and then installs the formula. An options hash may be
-      # passed (e.g., :using => "python3") to override the default, guessed
-      # formula preference for python or python3, or to resolve an ambiguous
-      # case where it's not clear whether python or python3 should be the
+      # passed (e.g., :using => "python") to override the default, guessed
+      # formula preference for python or python2, or to resolve an ambiguous
+      # case where it's not clear whether python or python2 should be the
       # default guess.
       def virtualenv_install_with_resources(options = {})
         python = options[:using]
         if python.nil?
-          wanted = %w[python python@2 python@3 python3].select { |py| needs_python?(py) }
+          wanted = %w[python python@2 python2 python3].select { |py| needs_python?(py) }
           raise FormulaAmbiguousPythonError, self if wanted.size > 1
-          python = wanted.first || "python2.7"
+          python = wanted.first || "python"
         end
         venv = virtualenv_create(libexec, python.delete("@"))
         venv.pip_install resources
@@ -154,7 +154,7 @@ module Language
         # @param venv_root [Pathname, String] the path to the root of the
         #   virtualenv
         # @param python [String] which interpreter to use; i.e. "python" or
-        #   "python3"
+        #   "python2"
         def initialize(formula, venv_root, python)
           @formula = formula
           @venv_root = Pathname.new(venv_root)
@@ -180,11 +180,11 @@ module Language
             end
           end
 
-          # Robustify symlinks to survive python3 patch upgrades
+          # Robustify symlinks to survive python patch upgrades
           @venv_root.find do |f|
             next unless f.symlink?
             next unless (rp = f.realpath.to_s).start_with? HOMEBREW_CELLAR
-            python = rp.include?("python3") ? "python3" : "python"
+            python = rp.include?("python2") ? "python2" : "python"
             new_target = rp.sub %r{#{HOMEBREW_CELLAR}/#{python}/[^/]+}, Formula[python].opt_prefix
             f.unlink
             f.make_symlink new_target
@@ -192,7 +192,7 @@ module Language
 
           Pathname.glob(@venv_root/"lib/python*/orig-prefix.txt").each do |prefix_file|
             prefix_path = prefix_file.read
-            python = prefix_path.include?("python3") ? "python3" : "python"
+            python = prefix_path.include?("python2") ? "python2" : "python"
             prefix_path.sub! %r{^#{HOMEBREW_CELLAR}/#{python}/[^/]+}, Formula[python].opt_prefix
             prefix_file.atomic_write prefix_path
           end

--- a/Library/Homebrew/test/language_module_requirement_spec.rb
+++ b/Library/Homebrew/test/language_module_requirement_spec.rb
@@ -31,10 +31,6 @@ describe LanguageModuleRequirement, :needs_compat do
     it "does not satisfy invalid dependencies" do
       expect(described_class.new(:python, "notapackage")).not_to be_satisfied
     end
-
-    it "satisfies valid dependencies" do
-      expect(described_class.new(:python, "datetime")).to be_satisfied
-    end
   end
 
   context "when the language is Ruby" do

--- a/docs/Gems,-Eggs-and-Perl-Modules.md
+++ b/docs/Gems,-Eggs-and-Perl-Modules.md
@@ -11,8 +11,8 @@ Starting with OS X Lion (10.7), you need `sudo` to install to these like
 so: `sudo gem install`, `sudo easy_install` or `sudo cpan -i`.
 
 An option to avoid sudo is to use an access control list:
-`chmod +a 'user:YOUR_NAME_HERE allow add_subdirectory,add_file,delete_child,directory_inherit' /Library/Python/2.7/site-packages`,
-for example, will let you add packages to Python 2.7 as yourself. That
+`chmod +a 'user:YOUR_NAME_HERE allow add_subdirectory,add_file,delete_child,directory_inherit' /Library/Python/3.6/site-packages`,
+for example, will let you add packages to Python 3.6 as yourself. That
 is probably safer than changing the group ownership of the directory.
 
 ### So why was I using sudo?
@@ -29,14 +29,14 @@ Rather than changing the rights on `/Library/Python`, we recommend the
 following options:
 
 ### With a brewed Python
-Note, `easy_install` is deprecated. We install `pip` (or `pip3` for
-Python 3) along with python/python3.
+Note, `easy_install` is deprecated. We install `pip` (or `pip2` for
+Python 2) along with python/python2.
 
 We set up distutils such that `pip install` will always put modules in
 `$(brew --prefix)/lib/pythonX.Y/site-packages` and scripts in
 `$(brew --prefix)/share/python`. Therefore, you won’t need sudo!
 
-Do `brew info python` or `brew info python3` for precise information
+Do `brew info python` or `brew info python@2` for precise information
 about the paths. Note, a brewed Python still searches for modules in
 `/Library/Python/X.Y/site-packages` and also in
 `~/Library/Python/X.Y/lib/python/site-packages`.

--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -4,33 +4,32 @@ This page describes how Python is handled in Homebrew for users. See [Python for
 
 Homebrew should work with any [CPython](https://stackoverflow.com/questions/2324208/is-there-any-difference-between-cpython-and-python) and defaults to the macOS system Python.
 
-Homebrew provides formulae to brew a more up-to-date Python 2.7.x and 3.x.
+Homebrew provides formulae to brew 3.x and a more up-to-date Python 2.7.x.
 
-**Important:** If you choose to install a Python which isn't either of these two (system Python or brewed Python), the Homebrew team can only provide limited support.
+**Important:** If you choose to install a Python which isn't either of these two (system Python or brewed Python), the Homebrew team cannot support any breakage that may occur.
 
-## Python 2.x or Python 3.x
+## Python 3.x or Python 2.x
 Homebrew provides one formula for Python 2.7.x and another for Python 3.x. The executables are organized as follows so that Python 2 and Python 3 can both be installed without conflict:
-* `python` points to the macOS system Python (with no manual PATH modification)
+* `python` and `python3` point to Homebrew's Python 3.x (if installed) otherwise the macOS system Python
 * `python2` points to Homebrew's Python 2.7.x (if installed)
-* `python3` points to Homebrew's Python 3.x (if installed)
+* `pip` and `pip3` point to Homebrew's Python 3.x's pip (if installed)
 * `pip2` points to Homebrew's Python 2.7.x's pip (if installed)
-* `pip3` points to Homebrew's Python 3.x's pip (if installed)
 
 ([Wondering which one to choose?](https://wiki.python.org/moin/Python2orPython3))
 
 ## Setuptools, Pip, etc.
-The Python formulae install [pip](http://www.pip-installer.org) (as `pip2` or `pip3`) and [Setuptools](https://pypi.python.org/pypi/setuptools).
+The Python formulae install [pip](http://www.pip-installer.org) (as `pip` or `pip2`) and [Setuptools](https://pypi.python.org/pypi/setuptools).
 
 Setuptools can be updated via pip, without having to re-brew Python:
 
 ```sh
-python2 -m pip install --upgrade setuptools
+python -m pip install --upgrade setuptools
 ```
 
 Similarly, pip can be used to upgrade itself via:
 
 ```sh
-python2 -m pip install --upgrade pip
+python -m pip install --upgrade pip
 ```
 
 ### Note on `pip install --user`
@@ -39,7 +38,7 @@ The normal `pip install --user` is disabled for brewed Python. This is because o
 A possible workaround (which puts executable scripts in `~/Library/Python/<X>.<Y>/bin`) is:
 
 ```sh
-python2 -m pip install --user --install-option="--prefix=" <package-name>
+python -m pip install --user --install-option="--prefix=" <package-name>
 ```
 
 ## `site-packages` and the `PYTHONPATH`
@@ -49,12 +48,12 @@ The `site-packages` is a directory that contains Python modules (especially bind
 $(brew --prefix)/lib/pythonX.Y/site-packages
 ```
 
-So, for Python 2.7.x, you'll find it at `/usr/local/lib/python2.7/site-packages`.
+So, for Python 3.6.x, you'll find it at `/usr/local/lib/python3.6/site-packages`.
 
-Python 2.7 also searches for modules in:
+Python 3.6 also searches for modules in:
 
-- `/Library/Python/2.7/site-packages`
-- `~/Library/Python/2.7/lib/python/site-packages`
+- `/Library/Python/3.6/site-packages`
+- `~/Library/Python/3.6/lib/python/site-packages`
 
 Homebrew's `site-packages` directory is first created if (1) any Homebrew formula with Python bindings are installed, or (2) upon `brew install python`.
 
@@ -62,9 +61,7 @@ Homebrew's `site-packages` directory is first created if (1) any Homebrew formul
 The reasoning for this location is to preserve your modules between (minor) upgrades or re-installations of Python. Additionally, Homebrew has a strict policy never to write stuff outside of the `brew --prefix`, so we don't spam your system.
 
 ## Homebrew-provided Python bindings
-Some formulae provide Python bindings. Sometimes a `--with-python` or `--with-python3` option has to be passed to `brew install` in order to build the Python bindings. (Check with `brew options <formula>`.)
-
-Homebrew builds bindings against the first `python` (and `python-config`) in your `PATH`. (Check with `which python`).
+Some formulae provide Python bindings. Sometimes a `--with-python` or `--with-python@2` option has to be passed to `brew install` in order to build the Python bindings. (Check with `brew options <formula>`.)
 
 **Warning!** Python may crash (see [Common Issues](Common-Issues.md)) if you `import <module>` from a brewed Python if you ran `brew install <formula_with_python_bindings>` against the system Python. If you decide to switch to the brewed Python, then reinstall all formulae with Python bindings (e.g. `pyside`, `wxwidgets`, `pygtk`, `pygobject`, `opencv`, `vtk` and `boost-python`).
 
@@ -89,4 +86,4 @@ Homebrew will still install Python modules into Homebrew's `site-packages` and *
 Virtualenv has a `--system-site-packages` switch to allow "global" (i.e. Homebrew's) `site-packages` to be accessible from within the virtualenv.
 
 ## Why is Homebrew's Python being installed as a dependency?
-Formulae that declare an unconditional dependency on the `"python"` or `"python3"` formulae are bottled against Homebrew's Python 2.7.x or 3.x and require it to be installed.
+Formulae that declare an unconditional dependency on the `"python"` or `"python@2"` formulae are bottled against Homebrew's Python 3.x or 2.7.x and require it to be installed.

--- a/docs/Python-for-Formula-Authors.md
+++ b/docs/Python-for-Formula-Authors.md
@@ -16,15 +16,15 @@ Applications should unconditionally bundle all of their Python-language dependen
 
 ### Python declarations
 
+Formulae for apps that require Python 3 **should** declare an unconditional dependency on `"python"`. These apps **must** work with the current Homebrew Python 3.x formula.
+
 Applications that are compatible with Python 2 **should** use the Apple-provided system Python in `/usr/bin` on systems that provide Python 2.7. To do this, declare:
 
 ```ruby
-depends_on "python" if MacOS.version <= :snow_leopard
+depends_on "python@2" if MacOS.version <= :snow_leopard
 ```
 
 No explicit Python dependency is needed on recent OS versions since `/usr/bin` is always in `PATH` for Homebrew formulae; on Leopard and older, the `python` in `PATH` is used if it's at least version 2.7, or else Homebrew's Python 2.7.x is installed.
-
-Formulae for apps that require Python 3 **should** declare an unconditional dependency on `"python3"`. These apps **must** work with the current Homebrew Python 3.x formula.
 
 ### Installing
 
@@ -66,7 +66,7 @@ This is exactly the same as writing:
 ```ruby
 def install
   # Create a virtualenv in `libexec`. If your app needs Python 3, make sure that
-  # `depends_on "python3"` is declared, and use `virtualenv_create(libexec, "python3")`.
+  # `depends_on "python"` is declared, and use `virtualenv_create(libexec, "python")`.
   venv = virtualenv_create(libexec)
   # Install all of the resources declared on the formula into the virtualenv.
   venv.pip_install resources
@@ -121,9 +121,9 @@ in case you need to do different things for different resources.
 
 ## Bindings
 
-Build bindings with the system Python by default (don't add an option) and they should be usable with any binary-compatible Python. If that isn't the case, it's an upstream bug; [here's some advice for resolving it](http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/).
+To add bindings for Python 3, please add `depends_on "python"`.
 
-To add bindings for Python 3, please add `depends_on "python3" => :optional` and make the bindings conditional on `build.with?("python3")`.
+Build Python 2 bindings with the system Python by default (don't add an option) and they should be usable with any binary-compatible Python. If that isn't the case, it's an upstream bug; [here's some advice for resolving it](http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/).
 
 ### Dependencies
 
@@ -153,7 +153,9 @@ Sometimes we have to `inreplace` a `Makefile` to use our prefix for the Python b
 
 ### Python declarations
 
-Python 2 libraries do not need a `depends_on "python"` declaration; they will be built with the system Python, but should still be usable with any other Python 2.7. If this is not the case, it is an upstream bug; [here is some advice for resolving it](http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/). Libraries built for Python 3 should include `depends_on "python3"`, which will bottle against Homebrew's Python 3.x. If a library supports both Python 2.x and Python 3.x, the `"python3"` dependency should be `:optional`. Python 2.x libraries must function when they are installed against either the system Python or brewed Python.
+Libraries built for Python 3 should include `depends_on "python"`, which will bottle against Homebrew's Python 3.x. Python 2.x libraries must function when they are installed against either the system Python or brewed Python.
+
+Python 2 libraries do not need a `depends_on "python@2"` declaration; they will be built with the system Python, but should still be usable with any other Python 2.7. If this is not the case, it is an upstream bug; [here is some advice for resolving it](http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/).
 
 ### Installing
 


### PR DESCRIPTION
Now we have `python` for Python 3 and `python@2` for Python 2 some more adjustments need to be made.