### PR TITLE
Fix SystemCommand escaping

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/system_command.rb
+++ b/Library/Homebrew/cask/lib/hbc/system_command.rb
@@ -85,7 +85,7 @@ module Hbc
       executable, *args = expanded_command
 
       raw_stdin, raw_stdout, raw_stderr, raw_wait_thr =
-        Open3.popen3({ "PATH" => path }, executable, *args, **options)
+        Open3.popen3({ "PATH" => path }, [executable, executable], *args, **options)
 
       write_input_to(raw_stdin)
       raw_stdin.close_write


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fix escaping for `system_command` without args. 

https://github.com/Homebrew/brew/commit/102a2a491b12db20d5096418bb559e25c864f20a

https://github.com/Homebrew/brew/commit/76c64f9bbf54c9f3b6915469f170d1f8c02be208