### PR TITLE
cmd/upgrade: Change `build.build_bottle?` to `build.bottle?`

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -118,7 +118,7 @@ module Homebrew
 
     fi = FormulaInstaller.new(f)
     fi.options = options
-    fi.build_bottle = ARGV.build_bottle? || (!f.bottled? && f.build.build_bottle?)
+    fi.build_bottle = ARGV.build_bottle? || (!f.bottled? && f.build.bottle?)
     fi.installed_on_request = !ARGV.named.empty?
     fi.link_keg           ||= keg_was_linked if keg_had_linked_opt
     if tab


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031)
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I received the following error when attempting to use the `upgrade`
command on a tap:

    $ brew tap teddywing/passextract https://github.com/teddywing/Passextract.git
    $ brew upgrade --verbose teddywing/passextract/passextract
    Updating Homebrew...

    ==> Upgrading 1 outdated package, with result:
    teddywing/passextract/passextract 0.4.0
    Error: Calling build.build_bottle? is disabled!
    Use build.bottle? instead.
    /usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:121:in `upgrade_formula'
    Or, even better, submit a PR to fix it!

Change the method call to use the (presumably) newer version.