### PR TITLE
Allow :test dependencies.

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -17,7 +17,8 @@
 #:
 #:    By default, `deps` shows required and recommended dependencies for
 #:    <formulae>. To include the `:build` type dependencies, pass `--include-build`.
-#:    Similarly, pass `--include-optional` to include `:optional` dependencies.
+#:    Similarly, pass `--include-optional` to include `:optional` dependencies or
+#:    `--include-test` to include `:test` dependencies.
 #:    To skip `:recommended` type dependencies, pass `--skip-recommended`.
 #:    To include requirements in addition to dependencies, pass `--include-requirements`.
 #:
@@ -30,8 +31,8 @@
 #:    If `--installed` is passed, output a tree for every installed formula.
 #:
 #:    The <filters> placeholder is any combination of options `--include-build`,
-#:    `--include-optional`, `--skip-recommended`, and `--include-requirements` as
-#:    documented above.
+#:    `--include-optional`, `--include-test`, `--skip-recommended`, and
+#:    `--include-requirements` as documented above.
 #:
 #:    If `--annotate` is passed, the build, optional, and recommended dependencies
 #:    are marked as such in the output.
@@ -42,7 +43,8 @@
 #:    dependencies of that formula.
 #:
 #:    The <filters> placeholder is any combination of options `--include-build`,
-#:    `--include-optional`, and `--skip-recommended` as documented above.
+#:    `--include-optional`, `--include-test`, and `--skip-recommended` as
+#:    documented above.
 
 # The undocumented `--for-each` option will switch into the mode used by `deps --all`,
 # but only list dependencies for specified formula, one specified formula per line.
@@ -111,6 +113,7 @@ module Homebrew
     end
     if ARGV.include?("--annotate")
       str = "#{str}  [build]" if dep.build?
+      str = "#{str}  [test]" if dep.test?
       str = "#{str}  [optional" if dep.optional?
       str = "#{str}  [recommended]" if dep.recommended?
     end
@@ -124,6 +127,11 @@ module Homebrew
       includes << "build?"
     else
       ignores << "build?"
+    end
+    if ARGV.include?("--include-test")
+      includes << "test?"
+    else
+      ignores << "test?"
     end
     if ARGV.include?("--include-optional")
       includes << "optional?"
@@ -140,6 +148,8 @@ module Homebrew
           Dependency.prune if !includes.include?("optional?") && !dependent.build.with?(dep)
         elsif dep.build?
           Dependency.prune unless includes.include?("build?")
+        elsif dep.test?
+          Dependency.prune unless includes.include?("test?")
         end
       end
       reqs = f.recursive_requirements do |dependent, req|
@@ -149,6 +159,8 @@ module Homebrew
           Requirement.prune if !includes.include?("optional?") && !dependent.build.with?(req)
         elsif req.build?
           Requirement.prune unless includes.include?("build?")
+        elsif req.test?
+          Requirement.prune unless includes.include?("test?")
         end
       end
     else
@@ -191,6 +203,7 @@ module Homebrew
     dependables = reqs + deps
     dependables = dependables.reject(&:optional?) unless ARGV.include?("--include-optional")
     dependables = dependables.reject(&:build?) unless ARGV.include?("--include-build")
+    dependables = dependables.reject(&:test) unless ARGV.include?("--include-test")
     dependables = dependables.reject(&:recommended?) if ARGV.include?("--skip-recommended")
     max = dependables.length - 1
     @dep_stack.push f.name

--- a/Library/Homebrew/dependable.rb
+++ b/Library/Homebrew/dependable.rb
@@ -1,7 +1,7 @@
 require "options"
 
 module Dependable
-  RESERVED_TAGS = [:build, :optional, :recommended, :run, :linked].freeze
+  RESERVED_TAGS = [:build, :optional, :recommended, :run, :test, :linked].freeze
 
   def build?
     tags.include? :build
@@ -19,8 +19,12 @@ module Dependable
     tags.include? :run
   end
 
+  def test?
+    tags.include? :test
+  end
+
   def required?
-    !build? && !optional? && !recommended?
+    !build? && !test? && !optional? && !recommended?
   end
 
   def option_tags

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -45,6 +45,15 @@ module Homebrew
         next
       end
 
+      # Don't test formulae missing test dependencies
+      missing_test_deps = f.recursive_dependencies do |_, dependency|
+        Dependency.prune if !dependency.required? && !dependency.test?
+      end.map(&:to_s)
+      unless missing_test_deps.empty?
+        ofail "#{f.full_name} is missing test dependencies: #{missing_test_deps.join(" ")}"
+        next
+      end
+
       puts "Testing #{f.full_name}"
 
       env = ENV.to_hash

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -96,7 +96,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     By default, `deps` shows required and recommended dependencies for
     `formulae`. To include the `:build` type dependencies, pass `--include-build`.
-    Similarly, pass `--include-optional` to include `:optional` dependencies.
+    Similarly, pass `--include-optional` to include `:optional` dependencies or
+    `--include-test` to include `:test` dependencies.
     To skip `:recommended` type dependencies, pass `--skip-recommended`.
     To include requirements in addition to dependencies, pass `--include-requirements`.
 
@@ -109,8 +110,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--installed` is passed, output a tree for every installed formula.
 
     The `filters` placeholder is any combination of options `--include-build`,
-    `--include-optional`, `--skip-recommended`, and `--include-requirements` as
-    documented above.
+    `--include-optional`, `--include-test`, `--skip-recommended`, and
+    `--include-requirements` as documented above.
 
     If `--annotate` is passed, the build, optional, and recommended dependencies
     are marked as such in the output.
@@ -121,7 +122,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     dependencies of that formula.
 
     The `filters` placeholder is any combination of options `--include-build`,
-    `--include-optional`, and `--skip-recommended` as documented above.
+    `--include-optional`, `--include-test`, and `--skip-recommended` as
+    documented above.
 
   * `desc` `formula`:
     Display `formula`'s name and one-line description.

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "February 2018" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "March 2018" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "February 2018" "Homebrew" "brew"
+.TH "BREW" "1" "March 2018" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -107,7 +107,7 @@ If \fB\-\-full\-name\fR is passed, list dependencies by their full name\.
 If \fB\-\-installed\fR is passed, only list those dependencies that are currently installed\.
 .
 .IP
-By default, \fBdeps\fR shows required and recommended dependencies for \fIformulae\fR\. To include the \fB:build\fR type dependencies, pass \fB\-\-include\-build\fR\. Similarly, pass \fB\-\-include\-optional\fR to include \fB:optional\fR dependencies\. To skip \fB:recommended\fR type dependencies, pass \fB\-\-skip\-recommended\fR\. To include requirements in addition to dependencies, pass \fB\-\-include\-requirements\fR\.
+By default, \fBdeps\fR shows required and recommended dependencies for \fIformulae\fR\. To include the \fB:build\fR type dependencies, pass \fB\-\-include\-build\fR\. Similarly, pass \fB\-\-include\-optional\fR to include \fB:optional\fR dependencies or \fB\-\-include\-test\fR to include \fB:test\fR dependencies\. To skip \fB:recommended\fR type dependencies, pass \fB\-\-skip\-recommended\fR\. To include requirements in addition to dependencies, pass \fB\-\-include\-requirements\fR\.
 .
 .TP
 \fBdeps\fR \fB\-\-tree\fR [\fB\-\-1\fR] [\fIfilters\fR] [\fB\-\-annotate\fR] (\fIformulae\fR|\fB\-\-installed\fR)
@@ -120,7 +120,7 @@ If \fB\-\-1\fR is passed, only one level of children is displayed\.
 If \fB\-\-installed\fR is passed, output a tree for every installed formula\.
 .
 .IP
-The \fIfilters\fR placeholder is any combination of options \fB\-\-include\-build\fR, \fB\-\-include\-optional\fR, \fB\-\-skip\-recommended\fR, and \fB\-\-include\-requirements\fR as documented above\.
+The \fIfilters\fR placeholder is any combination of options \fB\-\-include\-build\fR, \fB\-\-include\-optional\fR, \fB\-\-include\-test\fR, \fB\-\-skip\-recommended\fR, and \fB\-\-include\-requirements\fR as documented above\.
 .
 .IP
 If \fB\-\-annotate\fR is passed, the build, optional, and recommended dependencies are marked as such in the output\.
@@ -130,7 +130,7 @@ If \fB\-\-annotate\fR is passed, the build, optional, and recommended dependenci
 Show dependencies for installed or all available formulae\. Every line of output starts with the formula name, followed by a colon and all direct dependencies of that formula\.
 .
 .IP
-The \fIfilters\fR placeholder is any combination of options \fB\-\-include\-build\fR, \fB\-\-include\-optional\fR, and \fB\-\-skip\-recommended\fR as documented above\.
+The \fIfilters\fR placeholder is any combination of options \fB\-\-include\-build\fR, \fB\-\-include\-optional\fR, \fB\-\-include\-test\fR, and \fB\-\-skip\-recommended\fR as documented above\.
 .
 .TP
 \fBdesc\fR \fIformula\fR


### PR DESCRIPTION
These specify that they are needed by the test block. This can be combined with `:build` to ensure that this formula isn't uninstalled by `brew test-bot` when running `test do` blocks on our CI.