### PR TITLE
check_undeclared_deps: Fix for taps

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -63,7 +63,7 @@ class LinkageChecker
       formula.build.without?(dep)
     end
     declared_deps = formula.deps.reject { |dep| filter_out.call(dep) }.map(&:name)
-    recursive_deps = keg.to_formula.runtime_dependencies.map { |dep| dep.to_formula.full_name }
+    recursive_deps = keg.to_formula.runtime_dependencies.map { |dep| dep.to_formula.name }
     declared_dep_names = declared_deps.map { |dep| dep.split("/").last }
     indirect_deps = []
     undeclared_deps = []


### PR DESCRIPTION
undeclared_deps reported all dependencies in taps as undeclared.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

After PR https://github.com/Homebrew/brew/pull/3785, `undeclared_deps` reports all dependencies in taps as undeclared. This PR resolves that issue.

Lines 66 and 73 should either both use `name` or both use `full_name`.
https://github.com/Homebrew/brew/blob/02682d3bc9840040e81e13271a38df80a72cde09/Library/Homebrew/linkage_checker.rb#L66-L73

# Observed

```
❯❯❯ brew linkage brewsci/bio/fwdpp
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /Users/sjackman/.homebrew/opt/libsequence/lib/libsequence.20.dylib (brewsci/bio/libsequence)
  /Users/sjackman/.homebrew/opt/gsl/lib/libgsl.23.dylib (gsl)
  /Users/sjackman/.homebrew/opt/gsl/lib/libgslcblas.0.dylib (gsl)
Undeclared dependencies with linkage:
  brewsci/bio/libsequence
```

# Expected

```
❯❯❯ brew linkage brewsci/bio/fwdpp
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /Users/sjackman/.homebrew/opt/libsequence/lib/libsequence.20.dylib (brewsci/bio/libsequence)
  /Users/sjackman/.homebrew/opt/gsl/lib/libgsl.23.dylib (gsl)
  /Users/sjackman/.homebrew/opt/gsl/lib/libgslcblas.0.dylib (gsl)
```