### PR TITLE
unzip_dep_if_needed: Needs unzip not zip [Linux] (#632)

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -70,8 +70,8 @@ class DependencyCollector
     Dependency.new("xz", tags) unless which("xz")
   end
 
-  def zip_dep_if_needed(tags)
-    Dependency.new("zip", tags) unless which("zip")
+  def unzip_dep_if_needed(tags)
+    Dependency.new("unzip", tags) unless which("unzip")
   end
 
   def bzip2_dep_if_needed(tags)
@@ -166,7 +166,7 @@ class DependencyCollector
   def parse_url_spec(url, tags)
     case File.extname(url)
     when ".xz"          then xz_dep_if_needed(tags)
-    when ".zip"         then zip_dep_if_needed(tags)
+    when ".zip"         then unzip_dep_if_needed(tags)
     when ".bz2"         then bzip2_dep_if_needed(tags)
     when ".lha", ".lzh" then Dependency.new("lha", tags)
     when ".lz"          then Dependency.new("lzip", tags)

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -10,7 +10,7 @@ describe DependencyCollector do
   describe "#add" do
     resource = Resource.new
 
-    context "when xz, zip, and bzip2 are not available" do
+    context "when xz, unzip, and bzip2 are not available" do
       it "creates a resource dependency from a '.xz' URL" do
         resource.url("http://example.com/foo.xz")
         allow_any_instance_of(Object).to receive(:which).with("xz")
@@ -19,8 +19,8 @@ describe DependencyCollector do
 
       it "creates a resource dependency from a '.zip' URL" do
         resource.url("http://example.com/foo.zip")
-        allow_any_instance_of(Object).to receive(:which).with("zip")
-        expect(subject.add(resource)).to eq(Dependency.new("zip", [:build]))
+        allow_any_instance_of(Object).to receive(:which).with("unzip")
+        expect(subject.add(resource)).to eq(Dependency.new("unzip", [:build]))
       end
 
       it "creates a resource dependency from a '.bz2' URL" do
@@ -39,7 +39,7 @@ describe DependencyCollector do
 
       it "does not create a resource dependency from a '.zip' URL" do
         resource.url("http://example.com/foo.zip")
-        allow_any_instance_of(Object).to receive(:which).with("zip").and_return(Pathname.new("foo"))
+        allow_any_instance_of(Object).to receive(:which).with("unzip").and_return(Pathname.new("foo"))
         expect(subject.add(resource)).to be nil
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The executable `unzip` need to unzip ZIP archives is provided by the formula `unzip` rather than `zip`.