### PR TITLE
Generalize Xcode version regex

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -131,7 +131,7 @@ module OS
           xcodebuild_output = Utils.popen_read(xcodebuild_path, "-version")
           next unless $CHILD_STATUS.success?
 
-          xcode_version = xcodebuild_output[/Xcode (\d(\.\d)*)/, 1]
+          xcode_version = xcodebuild_output[/Xcode (\d+(\.\d+)*)/, 1]
           return xcode_version if xcode_version
 
           # Xcode 2.x's xcodebuild has a different version string


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The current regex only matches a single digit for each component of the version (e.g. 9.2). This modifies it to match multiple digits in each component, so that e.g. 10.42 will be matched.

Presumably, Xcode 10 will be released soon, so this should ensure there are no issues with determining the version when that happens.