### PR TITLE
Fixed issue #3885 the versions for homebrew-core and brew are out of …

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -313,6 +313,19 @@ EOS
   trap - SIGINT
 }
 
+sync_repositories() {
+  local HOMEBREW_CORE_PATH
+  HOMEBREW_CORE_PATH=Library/Taps/homebrew/homebrew-core
+  if [ -d ${HOMEBREW_REPOSITORY}/${HOMEBREW_CORE_PATH} ]; then
+    pushd ${HOMEBREW_REPOSITORY} &> /dev/null
+      COMMIT_ID=`git rev-list -n 1 stable`
+      TIMESTAMP=`git show -s --format=%ci ${COMMIT_ID}`
+      cd ${HOMEBREW_CORE_PATH}
+      git checkout "master@{${TIMESTAMP}}"
+    popd &> /dev/null
+  fi
+}
+
 homebrew-update() {
   local option
   local DIR
@@ -561,6 +574,8 @@ EOS
       [[ -n "$HOMEBREW_VERBOSE" ]] && echo
     fi
   done
+
+  sync_repositories
 
   safe_cd "$HOMEBREW_REPOSITORY"
 


### PR DESCRIPTION
…sync

  This commit will sync the repositories between brew and homebrew-core.
  This should enable more stable use of brew when there are major changes
  pending in the next upcoming release which are not available for the latest
  tagged release in brew repository.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We spoked about this issue over #3885 and here is the related pull request. I know that you said that you wont want to have a pull request for this, as it is not an issue, it is a feature. The reasoning for this pull request is the paper trail and in the case that you find this to be something which could be added with tests and possible changes, I am more than happy to contribute my spare time for this issue. If you feel that this is non-sense feel free to close the pull request.
