### PR TITLE
keg: `delete_pyc_files!` should also remove `__pycache__`

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -519,7 +519,7 @@ class Keg
 
   def delete_pyc_files!
     find do |path|
-      if %w[.pyc .pyo].include?(pn.extname) || pn.basename.to_s == "__pycache__"
+      if %w[.pyc .pyo].include?(path.extname) || path.basename.to_s == "__pycache__"
         path.delete
       end
     end

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -518,8 +518,11 @@ class Keg
   end
 
   def delete_pyc_files!
-    find { |pn| pn.delete if %w[.pyc .pyo].include?(pn.extname) }
-    find { |pn| pn.delete if pn.basename.to_s == "__pycache__" }
+    find do |path|
+      if %w[.pyc .pyo].include?(pn.extname) || pn.basename.to_s == "__pycache__"
+        path.delete
+      end
+    end
   end
 
   private

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -519,6 +519,7 @@ class Keg
 
   def delete_pyc_files!
     find { |pn| pn.delete if %w[.pyc .pyo].include?(pn.extname) }
+    find { |pn| pn.delete if pn.basename.to_s == "__pycache__" }
   end
 
   private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

As Python 3 becomes the default Python in the core tap, bottles built against Python 3 become a thing. Both `.pyc`and `.pyo` have already been removed from bottles, we should also remove `__pycache__`. Otherwise people who have `PYTHONDONTWRITEBYTECODE` set will find this really annoying.