### PR TITLE
keg: don't delete main opt links of other formulae.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -256,7 +256,11 @@ class Keg
 
     aliases.each do |a|
       alias_symlink = opt/a
-      alias_symlink.delete if alias_symlink.symlink? || alias_symlink.exist?
+      if alias_symlink.symlink? && alias_symlink.exist?
+        alias_symlink.delete if alias_symlink.realpath == opt_record.realpath
+      elsif alias_symlink.symlink? || alias_symlink.exist?
+        alias_symlink.delete
+      end
     end
 
     Pathname.glob("#{opt_record}@*").each do |a|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If an old alias, according to the tab, of a formula being upgraded (e.g.
python) has the same name as the main opt link of some other formula
(e.g. python@2), don't remove the main opt link of that other formula.

Specifically,

  brew install python@2
  brew upgrade python

should not accidentally delete /usr/local/opt/python@2 even though
python@2 used to be an alias of python.

Fixes https://github.com/Homebrew/brew/pull/3893.