### PR TITLE
caveats: remove python caveats.

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -25,7 +25,6 @@ class Caveats
     caveats << function_completion_caveats(:zsh)
     caveats << function_completion_caveats(:fish)
     caveats << plist_caveats
-    caveats << python_caveats
     caveats << elisp_caveats
     caveats.compact.join("\n")
   end
@@ -106,53 +105,6 @@ class Caveats
       fish_caveats << "\n  #{root_dir}/share/fish/vendor_functions.d" if functions_installed
       fish_caveats
     end
-  end
-
-  def python_caveats
-    return unless keg
-    return unless keg.python_site_packages_installed?
-
-    s = nil
-    homebrew_site_packages = Language::Python.homebrew_site_packages
-    user_site_packages = Language::Python.user_site_packages "python"
-    pth_file = user_site_packages/"homebrew.pth"
-    instructions = <<~EOS.gsub(/^/, "  ")
-      mkdir -p #{user_site_packages}
-      echo 'import site; site.addsitedir("#{homebrew_site_packages}")' >> #{pth_file}
-    EOS
-
-    if f.keg_only?
-      keg_site_packages = f.opt_prefix/"lib/python2.7/site-packages"
-      unless Language::Python.in_sys_path?("python", keg_site_packages)
-        s = <<~EOS
-          If you need Python to find bindings for this keg-only formula, run:
-            echo #{keg_site_packages} >> #{homebrew_site_packages/f.name}.pth
-        EOS
-        s += instructions unless Language::Python.reads_brewed_pth_files?("python")
-      end
-      return s
-    end
-
-    return if Language::Python.reads_brewed_pth_files?("python")
-
-    if !Language::Python.in_sys_path?("python", homebrew_site_packages)
-      s = <<~EOS
-        Python modules have been installed and Homebrew's site-packages is not
-        in your Python sys.path, so you will not be able to import the modules
-        this formula installed. If you plan to develop with these modules,
-        please run:
-      EOS
-      s += instructions
-    elsif keg.python_pth_files_installed?
-      s = <<~EOS
-        This formula installed .pth files to Homebrew's site-packages and your
-        Python isn't configured to process them, so you will not be able to
-        import the modules this formula installed. If you plan to develop
-        with these modules, please run:
-      EOS
-      s += instructions
-    end
-    s
   end
 
   def elisp_caveats

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -201,45 +201,5 @@ describe Caveats do
         expect(caveats).to include(HOMEBREW_PREFIX/"share/fish/vendor_completions.d")
       end
     end
-
-    context "python caveats" do
-      before do
-        (f.prefix.resolved_path/"lib/python2.7/site-packages").mkpath
-      end
-
-      context "when f is not keg_only" do
-        let(:f) {
-          formula do
-            url "foo-1.0"
-          end
-        }
-        let(:caveats) { described_class.new(f).caveats }
-        let(:user_site_packages) { Language::Python.user_site_packages("python") }
-
-        it "give commands to run when Homebrew's site-packages is not in Python sys.path" do
-          expect(caveats).to include("Homebrew's site-packages is not\nin your Python sys.path")
-          expect(caveats).to include(user_site_packages)
-          expect(caveats).to include("import site")
-        end
-
-        it "gives commands to run when python pth files are installed" do
-          allow(Homebrew).to receive(:_system).and_return(true)
-          allow(Dir).to receive(:[]).with(any_args).and_return(["blah.pth"])
-          expect(caveats).to include(".pth files to Homebrew's site-packages and your\nPython isn't configured")
-          expect(caveats).to include(user_site_packages)
-          expect(caveats).to include("import site")
-        end
-      end
-
-      it "gives commands to run when formula is keg_only" do
-        f = formula do
-          url "foo-1.0"
-          keg_only "some reason"
-        end
-        caveats = described_class.new(f).caveats
-        homebrew_site_packages = Language::Python.homebrew_site_packages
-        expect(caveats).to include("echo #{f.opt_prefix}/lib/python2.7/site-packages >> #{homebrew_site_packages/f.name}.pth")
-      end
-    end
   end
 end


### PR DESCRIPTION
These instructions are currently incorrect and need to be ported to `python` 3.x and `python@2` formulae. Until then it's better to not have them than have them be incorrect.

Closes #3890.