### PR TITLE
language/python: expect @ in python@2 Cellar paths

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -184,7 +184,7 @@ module Language
           @venv_root.find do |f|
             next unless f.symlink?
             next unless (rp = f.realpath.to_s).start_with? HOMEBREW_CELLAR
-            python = rp.include?("python2") ? "python2" : "python"
+            python = rp.include?("python@2") ? "python@2" : "python"
             new_target = rp.sub %r{#{HOMEBREW_CELLAR}/#{python}/[^/]+}, Formula[python].opt_prefix
             f.unlink
             f.make_symlink new_target
@@ -192,7 +192,7 @@ module Language
 
           Pathname.glob(@venv_root/"lib/python*/orig-prefix.txt").each do |prefix_file|
             prefix_path = prefix_file.read
-            python = prefix_path.include?("python2") ? "python2" : "python"
+            python = prefix_path.include?("python@2") ? "python@2" : "python"
             prefix_path.sub! %r{^#{HOMEBREW_CELLAR}/#{python}/[^/]+}, Formula[python].opt_prefix
             prefix_file.atomic_write prefix_path
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The realpath of the python@2 Cellar contains "python@2" not "python2" so
check for "python@2" when doing Cellar->opt robustifications.