### PR TITLE
diagnostic: remove python pth check.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -1016,24 +1016,6 @@ module Homebrew
         EOS
       end
 
-      def check_for_pth_support
-        homebrew_site_packages = Language::Python.homebrew_site_packages
-        return unless homebrew_site_packages.directory?
-        return if Language::Python.reads_brewed_pth_files?("python") != false
-        return unless Language::Python.in_sys_path?("python", homebrew_site_packages)
-
-        user_site_packages = Language::Python.user_site_packages "python"
-        <<~EOS
-          Your default Python does not recognize the Homebrew site-packages
-          directory as a special site-packages directory, which means that .pth
-          files will not be followed. This means you will not be able to import
-          some modules after installing them with Homebrew, like wxpython. To fix
-          this for the current user, you can run:
-            mkdir -p #{user_site_packages}
-            echo 'import site; site.addsitedir("#{homebrew_site_packages}")' >> #{user_site_packages}/homebrew.pth
-        EOS
-      end
-
       def check_for_external_cmd_name_conflict
         cmds = Tap.cmd_directories.flat_map { |p| Dir["#{p}/brew-*"] }.uniq
         cmds = cmds.select { |cmd| File.file?(cmd) && File.executable?(cmd) }


### PR DESCRIPTION
This isn't an issue with Homebrew but an issue for users to configure themselves. It's also nonsensical with current Python configurations e.g. https://discourse.brew.sh/t/brew-doctor-warnings-about-python-3-6-site-packages-and-sitecustomize/1805