### PR TITLE
upgrade: fix the man page wrongly saying that it will upgrade pins.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -10,8 +10,8 @@
 #:    repository's HEAD will be checked for updates when a new stable or devel
 #:    version has been released.
 #:
-#:    If <formulae> are given, upgrade only the specified brews (but do so even
-#:    if they are pinned; see `pin`, `unpin`).
+#:    If <formulae> are given, upgrade only the specified brews (unless they
+#:    are pinned; see `pin`, `unpin`).
 
 require "cmd/install"
 require "cleanup"

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -561,8 +561,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     repository's HEAD will be checked for updates when a new stable or devel
     version has been released.
 
-    If `formulae` are given, upgrade only the specified brews (but do so even
-    if they are pinned; see `pin`, `unpin`).
+    If `formulae` are given, upgrade only the specified brews (unless they
+    are pinned; see `pin`, `unpin`).
 
   * `uses` [`--installed`] [`--recursive`] [`--include-build`] [`--include-optional`] [`--skip-recommended`] [`--devel`|`--HEAD`] `formulae`:
     Show the formulae that specify `formulae` as a dependency. When given

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -576,7 +576,7 @@ If \fB\-\-cleanup\fR is specified then remove previously installed \fIformula\fR
 If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if the HEAD installation of the formula is outdated\. Otherwise, the repository\'s HEAD will be checked for updates when a new stable or devel version has been released\.
 .
 .IP
-If \fIformulae\fR are given, upgrade only the specified brews (but do so even if they are pinned; see \fBpin\fR, \fBunpin\fR)\.
+If \fIformulae\fR are given, upgrade only the specified brews (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.
 .
 .TP
 \fBuses\fR [\fB\-\-installed\fR] [\fB\-\-recursive\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformulae\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is incorrect as in order to upgrade a pinned package it must first be unpinned.