### PR TITLE
utils: check for tap_message in odeprecated.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -109,7 +109,7 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
 
   if ARGV.homebrew_developer? || disable ||
      Homebrew.raise_deprecation_exceptions?
-    if replacement || tap
+    if replacement || tap_message
       developer_message = message + "Or, even better, submit a PR to fix it!"
     end
     raise MethodDeprecatedError, developer_message


### PR DESCRIPTION
`tap` is not a method-wide variable.

Fixes #3907