### PR TITLE
utils/git: use exact format for last_revision_*

### DIFF
--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -8,9 +8,10 @@ module Git
 
     out, = Open3.capture3(
       HOMEBREW_SHIMS_PATH/"scm/git", "-C", repo,
-      "log", "--oneline", "--max-count=1", *args, "--", file
+      "log", "--format=%h", "--abbrev=7", "--max-count=1",
+      *args, "--", file
     )
-    out.split(" ").first
+    out.chomp
   end
 
   def last_revision_of_file(repo, file, before_commit: nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] <s>Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).</s> -- covered by existing tests
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----


Format for oneline can be overridden in user's gitconfig. If that's the
case, last_revision_commit_of_file won't work properly, and because of
that last_revision_of_file won't work at all.

<details>
<summary>Here's what I was getting when running brew tests</summary>

```
Failures:

  1) Git#last_revision_commit_of_file gives revision commit based on before_commit when it is not nil
     Failure/Error:
       expect(
         described_class.last_revision_commit_of_file(HOMEBREW_CACHE,
                                                     file,
                                                     before_commit: hash2),
       ).to eq(hash2)

       expected: "ae7a2b6"
            got: "\e[33mae7a2b6cdef0\e[m"

       (compared using ==)
     # ./test/utils/git_spec.rb:34:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:106:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:115:in `block in run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:104:in `loop'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:104:in `run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:33:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

  2) Git#last_revision_commit_of_file gives last revision commit when before_commit is nil
     Failure/Error:
       expect(
         described_class.last_revision_commit_of_file(HOMEBREW_CACHE, file),
       ).to eq(hash1)

       expected: "6bec2de"
            got: "\e[33m6bec2dee633f\e[m"

       (compared using ==)
     # ./test/utils/git_spec.rb:28:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:106:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:115:in `block in run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:104:in `loop'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:104:in `run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:33:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

  3) Git#last_revision_of_file returns last revision of file
     Failure/Error:
       expect(
         described_class.last_revision_of_file(HOMEBREW_CACHE,
                                               HOMEBREW_CACHE/file),
       ).to eq("blah")

       expected: "blah"
            got: ""

       (compared using ==)
     # ./test/utils/git_spec.rb:44:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:106:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:115:in `block in run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:104:in `loop'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:104:in `run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.5.6/lib/rspec/retry.rb:33:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

Finished in 1.35 seconds (files took 1.69 seconds to load)
17 examples, 3 failures, 1 pending

Failed examples:

rspec ./test/utils/git_spec.rb:33 # Git#last_revision_commit_of_file gives revision commit based on before_commit when it is not nil
rspec ./test/utils/git_spec.rb:27 # Git#last_revision_commit_of_file gives last revision commit when before_commit is nil
rspec ./test/utils/git_spec.rb:43 # Git#last_revision_of_file returns last revision of file
```

</details>

I have abbrev length set to 12, and oneline formatting is more colorful.

So, instead of relying on overrideable format, it should rather specify
"--format=%h" to get only hash, and speciy --abbrev=7 to force abbrev
length to be 7

After this commit all tests are passing.
