### PR TITLE
upgrade: add HOMEBREW_UPGRADE_CLEANUP variable.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -3,7 +3,8 @@
 #:
 #:    Options for the `install` command are also valid here.
 #:
-#:    If `--cleanup` is specified then remove previously installed <formula> version(s).
+#:    If `--cleanup` is specified or `HOMEBREW_UPGRADE_CLEANUP` is set then remove
+#:    previously installed <formula> version(s).
 #:
 #:    If `--fetch-HEAD` is passed, fetch the upstream repository to detect if
 #:    the HEAD installation of the formula is outdated. Otherwise, the
@@ -82,7 +83,7 @@ module Homebrew
       Migrator.migrate_if_needed(f)
       begin
         upgrade_formula(f)
-        next unless ARGV.include?("--cleanup")
+        next if !ARGV.include?("--cleanup") && !ENV["HOMEBREW_UPGRADE_CLEANUP"]
         next unless f.installed?
         Homebrew::Cleanup.cleanup_formula f
       rescue UnsatisfiedRequirements => e

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -242,6 +242,9 @@ can take several different forms:
     This issue typically occurs when using FileVault or custom SSD
     configurations.
 
+  * `HOMEBREW_UPGRADE_CLEANUP`:
+    If set, `brew upgrade` always assumes `--cleanup` has been passed.
+
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -554,7 +554,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     Options for the `install` command are also valid here.
 
-    If `--cleanup` is specified then remove previously installed `formula` version(s).
+    If `--cleanup` is specified or `HOMEBREW_UPGRADE_CLEANUP` is set then remove
+    previously installed `formula` version(s).
 
     If `--fetch-HEAD` is passed, fetch the upstream repository to detect if
     the HEAD installation of the formula is outdated. Otherwise, the
@@ -1091,6 +1092,9 @@ can take several different forms:
 
     This issue typically occurs when using FileVault or custom SSD
     configurations.
+
+  * `HOMEBREW_UPGRADE_CLEANUP`:
+    If set, `brew upgrade` always assumes `--cleanup` has been passed.
 
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -570,7 +570,7 @@ Upgrade outdated, unpinned brews (with existing install options)\.
 Options for the \fBinstall\fR command are also valid here\.
 .
 .IP
-If \fB\-\-cleanup\fR is specified then remove previously installed \fIformula\fR version(s)\.
+If \fB\-\-cleanup\fR is specified or \fBHOMEBREW_UPGRADE_CLEANUP\fR is set then remove previously installed \fIformula\fR version(s)\.
 .
 .IP
 If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if the HEAD installation of the formula is outdated\. Otherwise, the repository\'s HEAD will be checked for updates when a new stable or devel version has been released\.
@@ -1109,6 +1109,10 @@ If set, instructs Homebrew to use \fBHOMEBREW_TEMP\fR as the temporary directory
 .
 .IP
 This issue typically occurs when using FileVault or custom SSD configurations\.
+.
+.TP
+\fBHOMEBREW_UPGRADE_CLEANUP\fR
+If set, \fBbrew upgrade\fR always assumes \fB\-\-cleanup\fR has been passed\.
 .
 .TP
 \fBHOMEBREW_VERBOSE\fR


### PR DESCRIPTION
Allow users to specify they want `brew upgrade --cleanup` to always be run when they run `brew upgrade`.