### PR TITLE
deps: don't display recursive test dependencies.

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -83,6 +83,9 @@ class Dependency
       deps.each do |dep|
         next if dependent.name == dep.name
 
+        # we only care about one level of test dependencies.
+        next if dep.test? && @expand_stack.length > 1
+
         case action(dependent, dep, &block)
         when :prune
           next

--- a/Library/Homebrew/test/dependency_expansion_spec.rb
+++ b/Library/Homebrew/test/dependency_expansion_spec.rb
@@ -102,12 +102,12 @@ describe Dependency do
   end
 
   it "keeps dependency but prunes recursive dependencies with ::keep_but_prune_recursive_deps" do
-    foo = build_dep(:foo, [:build], bar)
-    baz = build_dep(:baz, [:build])
+    foo = build_dep(:foo, [:test], bar)
+    baz = build_dep(:baz, [:test])
     f = double(name: "f", deps: [foo, baz])
 
     deps = described_class.expand(f) do |_dependent, dep|
-      described_class.keep_but_prune_recursive_deps if dep.build?
+      described_class.keep_but_prune_recursive_deps if dep.test?
     end
 
     expect(deps).to eq([foo, baz])

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -97,7 +97,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     By default, `deps` shows required and recommended dependencies for
     `formulae`. To include the `:build` type dependencies, pass `--include-build`.
     Similarly, pass `--include-optional` to include `:optional` dependencies or
-    `--include-test` to include `:test` dependencies.
+    `--include-test` to include (non-recursive) `:test` dependencies.
     To skip `:recommended` type dependencies, pass `--skip-recommended`.
     To include requirements in addition to dependencies, pass `--include-requirements`.
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -565,7 +565,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `formulae` are given, upgrade only the specified brews (unless they
     are pinned; see `pin`, `unpin`).
 
-  * `uses` [`--installed`] [`--recursive`] [`--include-build`] [`--include-optional`] [`--skip-recommended`] [`--devel`|`--HEAD`] `formulae`:
+  * `uses` [`--installed`] [`--recursive`] [`--include-build`] [`--include-test`] [`--include-optional`] [`--skip-recommended`] [`--devel`|`--HEAD`] `formulae`:
     Show the formulae that specify `formulae` as a dependency. When given
     multiple formula arguments, show the intersection of formulae that use
     `formulae`.
@@ -576,10 +576,12 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     By default, `uses` shows all formulae that specify `formulae` as a required
     or recommended dependency. To include the `:build` type dependencies, pass
-    `--include-build`. Similarly, pass `--include-optional` to include `:optional`
-    dependencies. To skip `:recommended` type dependencies, pass `--skip-recommended`.
+    `--include-build`, to include the `:test` type dependencies, pass
+    `--include-test` and to include `:optional` dependencies pass
+    `--include-optional`. To skip `:recommended` type dependencies, pass
+    `--skip-recommended`.
 
-    By default, `uses` shows usages of `formulae` by stable builds. To find
+    By default, `uses` shows usage of `formulae` by stable builds. To find
     cases where `formulae` is used by development or HEAD build, pass
     `--devel` or `--HEAD`.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -107,7 +107,7 @@ If \fB\-\-full\-name\fR is passed, list dependencies by their full name\.
 If \fB\-\-installed\fR is passed, only list those dependencies that are currently installed\.
 .
 .IP
-By default, \fBdeps\fR shows required and recommended dependencies for \fIformulae\fR\. To include the \fB:build\fR type dependencies, pass \fB\-\-include\-build\fR\. Similarly, pass \fB\-\-include\-optional\fR to include \fB:optional\fR dependencies or \fB\-\-include\-test\fR to include \fB:test\fR dependencies\. To skip \fB:recommended\fR type dependencies, pass \fB\-\-skip\-recommended\fR\. To include requirements in addition to dependencies, pass \fB\-\-include\-requirements\fR\.
+By default, \fBdeps\fR shows required and recommended dependencies for \fIformulae\fR\. To include the \fB:build\fR type dependencies, pass \fB\-\-include\-build\fR\. Similarly, pass \fB\-\-include\-optional\fR to include \fB:optional\fR dependencies or \fB\-\-include\-test\fR to include (non\-recursive) \fB:test\fR dependencies\. To skip \fB:recommended\fR type dependencies, pass \fB\-\-skip\-recommended\fR\. To include requirements in addition to dependencies, pass \fB\-\-include\-requirements\fR\.
 .
 .TP
 \fBdeps\fR \fB\-\-tree\fR [\fB\-\-1\fR] [\fIfilters\fR] [\fB\-\-annotate\fR] (\fIformulae\fR|\fB\-\-installed\fR)

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -579,7 +579,7 @@ If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if t
 If \fIformulae\fR are given, upgrade only the specified brews (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.
 .
 .TP
-\fBuses\fR [\fB\-\-installed\fR] [\fB\-\-recursive\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformulae\fR
+\fBuses\fR [\fB\-\-installed\fR] [\fB\-\-recursive\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-test\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformulae\fR
 Show the formulae that specify \fIformulae\fR as a dependency\. When given multiple formula arguments, show the intersection of formulae that use \fIformulae\fR\.
 .
 .IP
@@ -589,10 +589,10 @@ Use \fB\-\-recursive\fR to resolve more than one level of dependencies\.
 If \fB\-\-installed\fR is passed, only list installed formulae\.
 .
 .IP
-By default, \fBuses\fR shows all formulae that specify \fIformulae\fR as a required or recommended dependency\. To include the \fB:build\fR type dependencies, pass \fB\-\-include\-build\fR\. Similarly, pass \fB\-\-include\-optional\fR to include \fB:optional\fR dependencies\. To skip \fB:recommended\fR type dependencies, pass \fB\-\-skip\-recommended\fR\.
+By default, \fBuses\fR shows all formulae that specify \fIformulae\fR as a required or recommended dependency\. To include the \fB:build\fR type dependencies, pass \fB\-\-include\-build\fR, to include the \fB:test\fR type dependencies, pass \fB\-\-include\-test\fR and to include \fB:optional\fR dependencies pass \fB\-\-include\-optional\fR\. To skip \fB:recommended\fR type dependencies, pass \fB\-\-skip\-recommended\fR\.
 .
 .IP
-By default, \fBuses\fR shows usages of \fIformulae\fR by stable builds\. To find cases where \fIformulae\fR is used by development or HEAD build, pass \fB\-\-devel\fR or \fB\-\-HEAD\fR\.
+By default, \fBuses\fR shows usage of \fIformulae\fR by stable builds\. To find cases where \fIformulae\fR is used by development or HEAD build, pass \fB\-\-devel\fR or \fB\-\-HEAD\fR\.
 .
 .TP
 \fB\-\-cache\fR


### PR DESCRIPTION
You only care about the test dependencies for the specific formula you
are testing right now.