### PR TITLE
install: make --only-dependencies fill in missing.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -159,6 +159,8 @@ module Homebrew
               #{f.full_name} #{optlinked_version} is already installed
               To upgrade to #{f.version}, run `brew upgrade #{f.name}`
             EOS
+          elsif ARGV.only_deps?
+            formulae << f
           else
             opoo <<~EOS
               #{f.full_name} #{f.pkg_version} is already installed
@@ -188,8 +190,11 @@ module Homebrew
               #{msg}, it's just not linked.
               You can use `brew link #{f}` to link this version.
             EOS
+          elsif ARGV.only_deps?
+            msg = nil
+            formulae << f
           end
-          opoo msg
+          opoo msg if msg
         elsif !f.any_version_installed? && old_formula = f.old_installed_formulae.first
           msg = "#{old_formula.full_name} #{old_formula.installed_version} already installed"
           if !old_formula.linked? && !old_formula.keg_only?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -224,17 +224,19 @@ class FormulaInstaller
       message = <<~EOS
         #{formula.name} #{formula.linked_version} is already installed
       EOS
-      message += if formula.outdated? && !formula.head?
-        <<~EOS
+      if formula.outdated? && !formula.head?
+        message += <<~EOS
           To upgrade to #{formula.pkg_version}, run `brew upgrade #{formula.name}`
         EOS
+      elsif only_deps?
+        message = nil
       else
         # some other version is already installed *and* linked
-        <<~EOS
+        message += <<~EOS
           To install #{formula.pkg_version}, first run `brew unlink #{formula.name}`
         EOS
       end
-      raise CannotInstallFormulaError, message
+      raise CannotInstallFormulaError, message if message
     end
 
     # Warn if a more recent version of this formula is available in the tap.


### PR DESCRIPTION
This makes the `brew install --only-dependencies` command more useful by filling in missing dependencies for a formula even if it's already installed.