### PR TITLE
cleanup: fix removing lock files on NFS

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -122,7 +122,7 @@ module Homebrew
       lockfiles  = candidates.select(&:file?)
       lockfiles.each do |file|
         next unless file.readable?
-        file.open.flock(File::LOCK_EX | File::LOCK_NB) && file.unlink
+        file.open(File::RDWR).flock(File::LOCK_EX | File::LOCK_NB) && file.unlink
       end
     end
 


### PR DESCRIPTION


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If the underneath file system is a Network File System,
`brew cleanup` will fail to remove the lock files with following error
message:

Error: Bad file descriptor @ rb_file_flock - /path/to/the/lock_file

This commit fixes such issue and adds the corresponding test case.