### PR TITLE
install: add --include-test option.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -1,4 +1,4 @@
-#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] <formula> [<options> ...]:
+#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] <formula> [<options> ...]:
 #:    Install <formula>.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
@@ -35,6 +35,9 @@
 #:    If `--force-bottle` is passed, install from a bottle if it exists for the
 #:    current or newest version of macOS, even if it would not normally be used
 #:    for installation.
+#:
+#:    If `--include-test` is passed, install testing dependencies. These are only
+#:    needed by formulae maintainers to run `brew test`.
 #:
 #:    If `--devel` is passed, and <formula> defines it, install the development version.
 #:

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -15,6 +15,7 @@ module HomebrewArgvExtension
       --no-sandbox
       --build-bottle
       --force-bottle
+      --include-test
       --verbose
       --force
       -i

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -34,7 +34,7 @@ class FormulaInstaller
   attr_accessor :options, :build_bottle, :invalid_option_names
   attr_accessor :installed_as_dependency, :installed_on_request, :link_keg
   mode_attr_accessor :show_summary_heading, :show_header
-  mode_attr_accessor :build_from_source, :force_bottle
+  mode_attr_accessor :build_from_source, :force_bottle, :include_test
   mode_attr_accessor :ignore_deps, :only_deps, :interactive, :git
   mode_attr_accessor :verbose, :debug, :quieter
 
@@ -47,6 +47,7 @@ class FormulaInstaller
     @build_from_source = ARGV.build_from_source? || ARGV.build_all_from_source?
     @build_bottle = false
     @force_bottle = ARGV.force_bottle?
+    @include_test = ARGV.include?("--include-test")
     @interactive = false
     @git = false
     @verbose = ARGV.verbose?
@@ -442,6 +443,8 @@ class FormulaInstaller
           Requirement.prune
         elsif req.satisfied?
           Requirement.prune
+        elsif include_test? && req.test?
+          next
         elsif !runtime_requirements.include?(req) && install_bottle_for_dependent
           Requirement.prune
         else
@@ -468,6 +471,8 @@ class FormulaInstaller
 
       if (dep.optional? || dep.recommended?) && build.without?(dep)
         Dependency.prune
+      elsif include_test? && dep.test? && !dep.installed?
+        Dependency.keep_but_prune_recursive_deps
       elsif dep.build? && install_bottle_for?(dependent, build)
         Dependency.prune
       elsif dep.build? && dependent.installed?

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -216,7 +216,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     See the docs for examples of using the JSON output:
     <https://docs.brew.sh/Querying-Brew>
 
-  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] `formula` [`options` ...]:
+  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] `formula` [`options` ...]:
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified
@@ -253,6 +253,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--force-bottle` is passed, install from a bottle if it exists for the
     current or newest version of macOS, even if it would not normally be used
     for installation.
+
+    If `--include-test` is passed, install testing dependencies. These are only
+    needed by formulae maintainers to run `brew test`.
 
     If `--devel` is passed, and `formula` defines it, install the development version.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -229,7 +229,7 @@ Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to
 See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
 .TP
-\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] [\fB\-\-force\fR] [\fB\-\-verbose\fR] \fIformula\fR [\fIoptions\fR \.\.\.]
+\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-include\-test\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] [\fB\-\-force\fR] [\fB\-\-verbose\fR] \fIformula\fR [\fIoptions\fR \.\.\.]
 Install \fIformula\fR\.
 .
 .IP
@@ -261,6 +261,9 @@ If \fBHOMEBREW_BUILD_FROM_SOURCE\fR is set, regardless of whether \fB\-\-build\-
 .
 .IP
 If \fB\-\-force\-bottle\fR is passed, install from a bottle if it exists for the current or newest version of macOS, even if it would not normally be used for installation\.
+.
+.IP
+If \fB\-\-include\-test\fR is passed, install testing dependencies\. These are only needed by formulae maintainers to run \fBbrew test\fR\.
 .
 .IP
 If \fB\-\-devel\fR is passed, and \fIformula\fR defines it, install the development version\.


### PR DESCRIPTION
Allow at `install` (or `install --only-dependencies`) time to specify that test dependencies should be installed. This will allow simplifying code in `brew test-bot`.

This could also be made an environment variable if desired by maintainers.