### PR TITLE
append ? to git_remote_exists

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -949,7 +949,7 @@ class ResourceAuditor
           problem http_content_problem
         end
       elsif strategy <= GitDownloadStrategy
-        unless Utils.git_remote_exists url
+        unless Utils.git_remote_exists? url
           problem "The URL #{url} is not a valid git URL"
         end
       elsif strategy <= SubversionDownloadStrategy

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -121,10 +121,10 @@ describe Utils do
     end
   end
 
-  describe "::git_remote_exists" do
+  describe "::git_remote_exists?" do
     it "returns true when git is not available" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class.git_remote_exists("blah")).to be_truthy
+      expect(described_class.git_remote_exists?("blah")).to be_truthy
     end
 
     context "when git is available" do
@@ -139,11 +139,11 @@ describe Utils do
           system git, "remote", "add", "origin", url
         end
 
-        expect(described_class.git_remote_exists(url)).to be_truthy
+        expect(described_class.git_remote_exists?(url)).to be_truthy
       end
 
       it "returns false when git remote does not exist" do
-        expect(described_class.git_remote_exists("blah")).to be_falsey
+        expect(described_class.git_remote_exists?("blah")).to be_falsey
       end
     end
   end

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -67,7 +67,7 @@ module Utils
     @git_version = nil
   end
 
-  def self.git_remote_exists(url)
+  def self.git_remote_exists?(url)
     return true unless git_available?
     quiet_system "git", "ls-remote", url
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`git_remote_exists` returns boolean, so appending `?` to its name makes a lot of sense.

Possible additional change: remove parentheses here:   https://github.com/Homebrew/brew/blob/96fd1a8c2a7a5680c1ce611415018a2c642ba3e4/Library/Homebrew/utils/git.rb#L70