### PR TITLE
add ? to svn_remote_exists

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -955,7 +955,7 @@ class ResourceAuditor
       elsif strategy <= SubversionDownloadStrategy
         next unless DevelopmentTools.subversion_handles_most_https_certificates?
         next unless Utils.svn_available?
-        unless Utils.svn_remote_exists url
+        unless Utils.svn_remote_exists? url
           problem "The URL #{url} is not a valid svn URL"
         end
       end

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -15,10 +15,10 @@ describe Utils do
     end
   end
 
-  describe "#self.svn_remote_exists" do
+  describe "#self.svn_remote_exists?" do
     it "returns true when svn is not available" do
       allow(Utils).to receive(:svn_available?).and_return(false)
-      expect(described_class.svn_remote_exists("blah")).to be_truthy
+      expect(described_class.svn_remote_exists?("blah")).to be_truthy
     end
 
     context "when svn is available" do
@@ -27,7 +27,7 @@ describe Utils do
       end
 
       it "returns false when remote does not exist" do
-        expect(described_class.svn_remote_exists(HOMEBREW_CACHE/"install")).to be_falsey
+        expect(described_class.svn_remote_exists?(HOMEBREW_CACHE/"install")).to be_falsey
       end
 
       it "returns true when remote exists", :needs_network, :needs_svn do
@@ -36,7 +36,7 @@ describe Utils do
 
         HOMEBREW_CACHE.cd { system svn, "checkout", remote }
 
-        expect(described_class.svn_remote_exists(HOMEBREW_CACHE/"install")).to be_truthy
+        expect(described_class.svn_remote_exists?(HOMEBREW_CACHE/"install")).to be_truthy
       end
     end
   end

--- a/Library/Homebrew/utils/svn.rb
+++ b/Library/Homebrew/utils/svn.rb
@@ -8,7 +8,7 @@ module Utils
     @svn = quiet_system HOMEBREW_SHIMS_PATH/"scm/svn", "--version"
   end
 
-  def self.svn_remote_exists(url)
+  def self.svn_remote_exists?(url)
     return true unless svn_available?
     quiet_system "svn", "ls", url, "--depth", "empty"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Same as #3925:
`svn_remote_exists` returns boolean, so appending `?` to its name makes a lot of sense.

Possible additional change: remove parentheses here:   https://github.com/Homebrew/brew/blob/96fd1a8c2a7a5680c1ce611415018a2c642ba3e4/Library/Homebrew/utils/svn.rb#L11