### PR TITLE
dependency_order_cop: make strict.

### DIFF
--- a/Library/Homebrew/rubocops/dependency_order_cop.rb
+++ b/Library/Homebrew/rubocops/dependency_order_cop.rb
@@ -2,7 +2,7 @@ require_relative "./extend/formula_cop"
 
 module RuboCop
   module Cop
-    module NewFormulaAudit
+    module FormulaAuditStrict
       # This cop checks for correct order of `depends_on` in a Formula
       #
       # precedence order:

--- a/Library/Homebrew/test/rubocops/dependency_order_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_cop_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../rubocops/dependency_order_cop"
 
-describe RuboCop::Cop::NewFormulaAudit::DependencyOrder do
+describe RuboCop::Cop::FormulaAuditStrict::DependencyOrder do
   subject(:cop) { described_class.new }
 
   context "depends_on" do


### PR DESCRIPTION
This can be strict now that it's been verified for a while on new formulae.