### PR TITLE
Update tab runtime_dependencies on pour.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -874,6 +874,7 @@ class FormulaInstaller
     tab.installed_as_dependency = installed_as_dependency
     tab.installed_on_request = installed_on_request
     tab.aliases = formula.aliases
+    tab.runtime_dependencies = Tab.runtime_dependencies_fullname_version(formula)
     tab.write
   end
 

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -32,10 +32,7 @@ class Tab < OpenStruct
       "compiler" => compiler,
       "stdlib" => stdlib,
       "aliases" => formula.aliases,
-      "runtime_dependencies" => formula.runtime_dependencies.map do |dep|
-        f = dep.to_formula
-        { "full_name" => f.full_name, "version" => f.version.to_s }
-      end,
+      "runtime_dependencies" => runtime_dependencies_fullname_version(formula),
       "source" => {
         "path" => formula.specified_path.to_s,
         "tap" => formula.tap ? formula.tap.name : nil,
@@ -50,6 +47,13 @@ class Tab < OpenStruct
     }
 
     new(attributes)
+  end
+
+  def self.runtime_dependencies_fullname_version(formula)
+    formula.runtime_dependencies.map do |dep|
+      f = dep.to_formula
+      { "full_name" => f.full_name, "version" => f.version.to_s }
+    end
   end
 
   # Returns the Tab for an install receipt at `path`.


### PR DESCRIPTION
Otherwise we end up making `revision`s for no real reason.