### PR TITLE
upgrade: make pinned error have correct exit code.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -1,4 +1,4 @@
-#:  * `upgrade` [<install-options>] [`--cleanup`] [`--fetch-HEAD`] [<formulae>]:
+#:  * `upgrade` [<install-options>] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [<formulae>]:
 #:    Upgrade outdated, unpinned brews (with existing install options).
 #:
 #:    Options for the `install` command are also valid here.
@@ -10,6 +10,9 @@
 #:    the HEAD installation of the formula is outdated. Otherwise, the
 #:    repository's HEAD will be checked for updates when a new stable or devel
 #:    version has been released.
+#:
+#:    If `--ignore-pinned` is passed, set a 0 exit code even if pinned formulae
+#:    are not upgraded.
 #:
 #:    If <formulae> are given, upgrade only the specified brews (unless they
 #:    are pinned; see `pin`, `unpin`).
@@ -55,16 +58,16 @@ module Homebrew
     outdated -= pinned
     formulae_to_install = outdated.map(&:latest_formula)
 
+    if !pinned.empty? && !ARGV.include?("--ignore-pinned")
+      ofail "Not upgrading #{Formatter.pluralize(pinned.length, "pinned package")}:"
+      puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
+    end
+
     if formulae_to_install.empty?
       oh1 "No packages to upgrade"
     else
       oh1 "Upgrading #{Formatter.pluralize(formulae_to_install.length, "outdated package")}, with result:"
       puts formulae_to_install.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
-    end
-
-    unless pinned.empty?
-      onoe "Not upgrading #{Formatter.pluralize(pinned.length, "pinned package")}:"
-      puts pinned.map { |f| "#{f.full_specified_name} #{f.pkg_version}" } * ", "
     end
 
     # Sort keg_only before non-keg_only formulae to avoid any needless conflicts

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -4,7 +4,7 @@ describe "brew pin", :integration_test do
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 
     expect { brew "pin", "testball" }.to be_a_success
-    expect { brew "upgrade" }.to be_a_success
+    expect { brew "upgrade" }.to be_a_failure
 
     expect(HOMEBREW_CELLAR/"testball/0.1").not_to be_a_directory
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -552,7 +552,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     their latest `origin/master`. Note this will destroy all your uncommitted
     or committed changes.
 
-  * `upgrade` [`install-options`] [`--cleanup`] [`--fetch-HEAD`] [`formulae`]:
+  * `upgrade` [`install-options`] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`formulae`]:
     Upgrade outdated, unpinned brews (with existing install options).
 
     Options for the `install` command are also valid here.
@@ -564,6 +564,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     the HEAD installation of the formula is outdated. Otherwise, the
     repository's HEAD will be checked for updates when a new stable or devel
     version has been released.
+
+    If `--ignore-pinned` is passed, set a 0 exit code even if pinned formulae
+    are not upgraded.
 
     If `formulae` are given, upgrade only the specified brews (unless they
     are pinned; see `pin`, `unpin`).

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -566,7 +566,7 @@ If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full upd
 Fetches and resets Homebrew and all tap repositories using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
 .TP
-\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fIformulae\fR]
+\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fIformulae\fR]
 Upgrade outdated, unpinned brews (with existing install options)\.
 .
 .IP
@@ -577,6 +577,9 @@ If \fB\-\-cleanup\fR is specified or \fBHOMEBREW_UPGRADE_CLEANUP\fR is set then 
 .
 .IP
 If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if the HEAD installation of the formula is outdated\. Otherwise, the repository\'s HEAD will be checked for updates when a new stable or devel version has been released\.
+.
+.IP
+If \fB\-\-ignore\-pinned\fR is passed, set a 0 exit code even if pinned formulae are not upgraded\.
 .
 .IP
 If \fIformulae\fR are given, upgrade only the specified brews (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.


### PR DESCRIPTION
Also, display before saying "no packages to upgrade".

Fixes #3936.