### PR TITLE
Don't use Linuxbrew/homebrew-core (yet, at least).

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -23,15 +23,8 @@ git() {
 }
 
 git_init_if_necessary() {
-  if [[ -n "$HOMEBREW_MACOS" ]] || [[ -n "$HOMEBREW_FORCE_HOMEBREW_ORG" ]]
-  then
-    BREW_OFFICIAL_REMOTE="https://github.com/Homebrew/brew"
-    CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/homebrew-core"
-  elif [[ -n "$HOMEBREW_LINUX" ]]
-  then
-    BREW_OFFICIAL_REMOTE="https://github.com/Linuxbrew/brew"
-    CORE_OFFICIAL_REMOTE="https://github.com/Linuxbrew/homebrew-core"
-  fi
+  BREW_OFFICIAL_REMOTE="https://github.com/Homebrew/brew"
+  CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/homebrew-core"
 
   safe_cd "$HOMEBREW_REPOSITORY"
   if [[ ! -d ".git" ]]

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -543,11 +543,7 @@ end
 # A specialized {Tap} class for the core formulae
 class CoreTap < Tap
   def default_remote
-    if OS.mac? || ENV["HOMEBREW_FORCE_HOMEBREW_ORG"]
-      "https://github.com/Homebrew/homebrew-core".freeze
-    else
-      "https://github.com/Linuxbrew/homebrew-core".freeze
-    end
+    "https://github.com/Homebrew/homebrew-core".freeze
   end
 
   # @private


### PR DESCRIPTION
This can't be tapped on vanilla Homebrew/brew because things like e.g. `GlibcRequirement` are missing. We will put this back when the Linuxbrew to Homebrew migration is complete.

CC @sjackman @maxim-belkin FYI