### PR TITLE
linkage_checker: fix detection of broken dependencies and missing libraries

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -91,7 +91,12 @@ class LinkageChecker
       next true if Formula[name].bin.directory?
       @brewed_dylibs.keys.map { |x| x.split("/").last }.include?(name)
     end
-    unnecessary_deps -= @broken_dylibs.map { |_, v| v.map { |d| dylib_to_dep(d) } }.flatten
+    missing_deps = @broken_dylibs.values.map do |v|
+      v.map do |d|
+        dylib_to_dep(d)
+      end
+    end.flatten.compact
+    unnecessary_deps -= missing_deps
     [indirect_deps, undeclared_deps, unnecessary_deps]
   end
 
@@ -167,7 +172,7 @@ class LinkageChecker
     return if things.empty?
     puts "#{label}:"
     if things.is_a? Hash
-      things.sort_by { |k, _| k.to_s }.each do |list_label, list|
+      things.sort_by { |k, | k.to_s }.each do |list_label, list|
         list.sort.each do |item|
           puts "  #{item} (#{list_label})"
         end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -22,11 +22,8 @@ class LinkageChecker
   end
 
   def dylib_to_dep(dylib)
-    if dylib =~ %r{#{Regexp.escape(HOMEBREW_PREFIX)}/(opt|Cellar)/([\w+-.@]+)/}
-      Regexp.last_match(2)
-    else
-      "Not a Homebrew library"
-    end
+    dylib =~ %r{#{Regexp.escape(HOMEBREW_PREFIX)}/(opt|Cellar)/([\w+-.@]+)/}
+    Regexp.last_match(2)
   end
 
   def check_dylibs
@@ -170,7 +167,7 @@ class LinkageChecker
     return if things.empty?
     puts "#{label}:"
     if things.is_a? Hash
-      things.sort.each do |list_label, list|
+      things.sort_by { |k, _| k.to_s }.each do |list_label, list|
         list.sort.each do |item|
           puts "  #{item} (#{list_label})"
         end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -180,7 +180,7 @@ class LinkageChecker
     return if things.empty?
     puts "#{label}:"
     if things.is_a? Hash
-      things.sort_by { |k, | k.to_s }.each do |list_label, list|
+      things.sort_by(&:to_s).each do |list_label, list|
         list.sort.each do |item|
           puts "  #{item} (#{list_label})"
         end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -88,8 +88,8 @@ class LinkageChecker
     end
     missing = []
     @broken_dylibs.each do |str|
-      next unless str.start_with? "#{HOMEBREW_PREFIX}/opt"
-      missing << str.sub("#{HOMEBREW_PREFIX}/opt/", "").split("/")[0]
+      next unless str.start_with?("#{HOMEBREW_PREFIX}/opt", HOMEBREW_CELLAR)
+      missing << str.sub("#{HOMEBREW_PREFIX}/opt/", "").sub("#{HOMEBREW_CELLAR}/", "").split("/")[0]
     end
     unnecessary_deps -= missing
     [indirect_deps, undeclared_deps, unnecessary_deps]

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -13,7 +13,7 @@ class LinkageChecker
     @brewed_dylibs = Hash.new { |h, k| h[k] = Set.new }
     @system_dylibs = Set.new
     @broken_dylibs = []
-    @broken_deps = Hash.new { |h, k| h[k] = Set.new }
+    @broken_deps = Hash.new { |h, k| h[k] = [] }
     @variable_dylibs = Set.new
     @indirect_deps = []
     @undeclared_deps = []
@@ -48,7 +48,7 @@ class LinkageChecker
           rescue Errno::ENOENT
             next if harmless_broken_link?(dylib)
             if (dep = dylib_to_dep(dylib))
-              @broken_deps[dep] << dylib
+              @broken_deps[dep] |= [dylib]
             else
               @broken_dylibs << dylib
             end
@@ -96,7 +96,7 @@ class LinkageChecker
       next true if Formula[name].bin.directory?
       @brewed_dylibs.keys.map { |x| x.split("/").last }.include?(name)
     end
-    missing_deps = @broken_deps.values.flat_map { |d| dylib_to_dep(d) }.compact
+    missing_deps = @broken_deps.values.flatten.map { |d| dylib_to_dep(d) }
     unnecessary_deps -= missing_deps
     [indirect_deps, undeclared_deps, unnecessary_deps]
   end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -91,11 +91,10 @@ class LinkageChecker
       @brewed_dylibs.keys.map { |x| x.split("/").last }.include?(name)
     end
     missing = Set.new
-    @broken_dylibs.each do |key, value|
-    value.each do |str|
-      next unless str.start_with?("#{HOMEBREW_PREFIX}/opt", HOMEBREW_CELLAR)
-      missing << dylib_to_dep(str)
-    end
+    @broken_dylibs.each_value do |value|
+      value.each do |str|
+        missing << dylib_to_dep(str) if str.start_with?("#{HOMEBREW_PREFIX}/opt", HOMEBREW_CELLAR)
+      end
     end
     unnecessary_deps -= missing.to_a
     [indirect_deps, undeclared_deps, unnecessary_deps]

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -48,9 +48,9 @@ class LinkageChecker
           rescue Errno::ENOENT
             next if harmless_broken_link?(dylib)
             if (dep = dylib_to_dep(dylib))
-              @broken_dylibs << dylib
-            else
               @broken_deps[dep] << dylib
+            else
+              @broken_dylibs << dylib
             end
           else
             tap = Tab.for_keg(owner).tap

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -175,8 +175,8 @@ class LinkageChecker
     return if things.empty?
     puts "#{label}:"
     if things.is_a? Hash
-      things.sort_by(&:to_s).each do |list_label, list|
-        list.sort.each do |item|
+      things.keys.sort.each do |list_label|
+        things[list_label].sort.each do |item|
           puts "  #{item} (#{list_label})"
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

1. In `display_test_output`: when printing dependencies without linkage, use `Dependencies with no linkage` string instead of `Possible unnecessary dependencies` for consistency with `display_normal_output`

2. In `check_dylibs`: keep track of and skip repetitive checking of those dylibs that have been previously checked. This is applicable when different executables/libraries are linked against the same libraries.

3. In `check_undeclared_deps`: when there are missing libraries, corresponding dependencies should be excluded from the list of dependencies with no linkage.

```
brew style linkage_checker.rb
```
fails with 
```
== linkage_checker.rb ==
C: 32: 41: Use hash rockets syntax.
```
but this is not touched in this PR, so I'm leaving it "as is". Note, that `brew style` passes just fine:
```
$ brew style
[snip]
670 files inspected, no offenses detected
```

@ilovezfs 
