### PR TITLE
fix: crash when curl is not installed

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -6,8 +6,8 @@ def curl_executable
     ENV["HOMEBREW_CURL"],
     which("curl"),
     "/usr/bin/curl",
-  ].map { |c| Pathname(c) }.find(&:executable?)
-  raise "curl is not executable" unless @curl
+  ].compact.map { |c| Pathname(c) }.find(&:executable?)
+  raise "no executable curl was found" unless @curl
   @curl
 end
 


### PR DESCRIPTION
Migrated from https://github.com/Linuxbrew/brew/issues/640