### PR TITLE
Upgraded use of AWS Ruby SDK for S3

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -473,16 +473,6 @@ end
 # distribution.  (It will work for public buckets as well.)
 class S3DownloadStrategy < CurlDownloadStrategy
   def _fetch
-    # Put the aws gem requirement here (vs top of file) so it's only
-    # a dependency of S3 users, not all Homebrew users
-    require "rubygems"
-    begin
-      require "aws-sdk-v1"
-    rescue LoadError
-      onoe "Install the aws-sdk gem into the gem repo used by brew."
-      raise
-    end
-
     if @url !~ %r{^https?://([^.].*)\.s3\.amazonaws\.com/(.+)$}
       raise "Bad S3 URL: " + @url
     end
@@ -492,12 +482,12 @@ class S3DownloadStrategy < CurlDownloadStrategy
     ENV["AWS_ACCESS_KEY_ID"] = ENV["HOMEBREW_AWS_ACCESS_KEY_ID"]
     ENV["AWS_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_AWS_SECRET_ACCESS_KEY"]
 
-    obj = AWS::S3.new.buckets[bucket].objects[key]
     begin
-      s3url = obj.url_for(:get)
-    rescue AWS::Errors::MissingCredentialsError
+      signer = Aws::S3::Presigner.new
+      s3url = signer.presigned_url :get_object, bucket: bucket, key: key
+    rescue Aws::Sigv4::Errors::MissingCredentialsError
       ohai "AWS credentials missing, trying public URL instead."
-      s3url = obj.public_url
+      s3url = @url
     end
 
     curl_download s3url, to: temporary_path
@@ -1116,6 +1106,9 @@ class DownloadStrategyDetector
   def self.detect(url, strategy = nil)
     if strategy.nil?
       detect_from_url(url)
+    elsif strategy == S3DownloadStrategy
+      require_aws_sdk
+      strategy
     elsif strategy.is_a?(Class) && strategy < AbstractDownloadStrategy
       strategy
     elsif strategy.is_a?(Symbol)
@@ -1168,5 +1161,10 @@ class DownloadStrategyDetector
     else
       raise "Unknown download strategy #{symbol} was requested."
     end
+  end
+
+  def self.require_aws_sdk
+    Homebrew.install_gem! "aws-sdk-s3", "~> 1.8"
+    require "aws-sdk-s3"
   end
 end


### PR DESCRIPTION
When `S3DownloadStrategy` is detected in `DownloadStrategyDetector`, an attempt is made to install & require the `aws-sdk-s3` gem.

The AWS S3 SDK is used to sign the URL and handed off to `curl_download`.

This PR is meant as a companion to https://github.com/Homebrew/brew/pull/3841.

ATTN @MikeMcQuaid, I couldn't figure out how to do this in `formula_installer.rb` because I don't think the `formula` object has access to the `@url` of the formula at that time. However, I think putting it in the `DownloadStrategyDetector` effectively front-runs the sandbox.

I'm a newbie when it comes to writing rspec tests so I've done a pretty barebones job at this. If I get some guidance I can expand the tests.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----