### PR TITLE
Fix `MethodDeprecatedError` output.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -110,9 +110,9 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
   if ARGV.homebrew_developer? || disable ||
      Homebrew.raise_deprecation_exceptions?
     if replacement || tap_message
-      developer_message = message + "Or, even better, submit a PR to fix it!"
+      message += "Or, even better, submit a PR to fix it!"
     end
-    raise MethodDeprecatedError, developer_message
+    raise MethodDeprecatedError, message
   elsif !Homebrew.auditing?
     opoo "#{message}\n"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently, when running e.g. `brew cask install {cask} --caskroom=/tmp`, it only displays

```
Error: MethodDeprecatedError
```

without the message that would actually show that the error is. This fixes it so it shows 

```
Error: Calling `brew cask` with the `--caskroom` flag is disabled!
There is no replacement.
```

Fixes https://github.com/caskroom/homebrew-cask/issues/44748.