### PR TITLE
DownloadStrategyDetector recognizes s3 URL scheme

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -473,7 +473,8 @@ end
 # distribution.  (It will work for public buckets as well.)
 class S3DownloadStrategy < CurlDownloadStrategy
   def _fetch
-    if @url !~ %r{^https?://([^.].*)\.s3\.amazonaws\.com/(.+)$}
+    if @url !~ %r{^https?://([^.].*)\.s3\.amazonaws\.com/(.+)$} &&
+       @url !~ %r{^s3://([^.].*?)/(.+)$}
       raise "Bad S3 URL: " + @url
     end
     bucket = Regexp.last_match(1)
@@ -1141,6 +1142,9 @@ class DownloadStrategyDetector
       SubversionDownloadStrategy
     when %r{^https?://(.+?\.)?sourceforge\.net/hgweb/}
       MercurialDownloadStrategy
+    when %r{^s3://}
+      require_aws_sdk
+      S3DownloadStrategy
     else
       CurlDownloadStrategy
     end

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -260,6 +260,14 @@ describe DownloadStrategyDetector do
       it { is_expected.to eq(GitHubGitDownloadStrategy) }
     end
 
+    context "when given an S3 URL" do
+      let(:url) { "s3://bucket/homebrew/brew.tar.gz" }
+      it "returns S3DownloadStrategy" do
+        allow(DownloadStrategyDetector).to receive(:require_aws_sdk).and_return(true)
+        is_expected.to eq(S3DownloadStrategy)
+      end
+    end
+
     context "when given strategy = S3DownloadStrategy" do
       let(:url) { "https://bkt.s3.amazonaws.com/key.tar.gz" }
       let(:strategy) { S3DownloadStrategy }


### PR DESCRIPTION
DownloadStrategyDetector now detects URLs with the `s3://` prefix, e.g.:
```
s3://my-bucket/path/to/key/tarball.tar.gz
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
