### PR TITLE
Defensive check for Checksum == nil

### DIFF
--- a/Library/Homebrew/checksum.rb
+++ b/Library/Homebrew/checksum.rb
@@ -13,6 +13,6 @@ class Checksum
   delegate [:empty?, :to_s] => :@hexdigest
 
   def ==(other)
-    hash_type == other.hash_type && hexdigest == other.hexdigest
+    hash_type == other&.hash_type && hexdigest == other.hexdigest
   end
 end

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -15,5 +15,6 @@ describe Checksum do
     it { is_expected.to eq(other) }
     it { is_expected.not_to eq(other_reversed) }
     it { is_expected.not_to eq(other_sha1) }
+    it { is_expected.not_to eq(nil) }
   end
 end


### PR DESCRIPTION
Protects against NoMethodError when checking a Checksum instance with a bad 'other'

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
