### PR TITLE
system_config: never display default_hash keys.

### DIFF
--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -200,10 +200,13 @@ class SystemConfig
       if defaults_hash[:HOMEBREW_CELLAR] != HOMEBREW_CELLAR.to_s
         f.puts "HOMEBREW_CELLAR: #{HOMEBREW_CELLAR}"
       end
+      if defaults_hash[:HOMEBREW_CACHE] != HOMEBREW_CACHE.to_s
+        f.puts "HOMEBREW_CACHE: #{HOMEBREW_CACHE}"
+      end
       ENV.sort.each do |key, value|
         next unless key.start_with?("HOMEBREW_")
         next if boring_keys.include?(key)
-        next if defaults_hash[key.to_sym] == value
+        next if defaults_hash[key.to_sym]
         value = "set" if key =~ /(cookie|key|token|password)/i
         f.puts "#{key}: #{value}"
       end


### PR DESCRIPTION
Otherwise you can end up with duplicate outputs.

CC @ilovezfs