### PR TITLE
Make runtime dependencies handling more consistent

### DIFF
--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -10,15 +10,12 @@ module Homebrew
 
   def leaves
     installed = Formula.installed.sort
-    deps_of_installed = Set.new
 
-    installed.each do |f|
-      deps = f.runtime_dependencies.map { |d| d.to_formula.full_name }
-      deps_of_installed.merge(deps)
+    deps_of_installed = installed.flat_map do |f|
+      f.runtime_dependencies.map(&:to_formula).map(&:full_name)
     end
 
-    installed.each do |f|
-      puts f.full_name unless deps_of_installed.include? f.full_name
-    end
+    leaves = installed.map(&:full_name) - deps_of_installed
+    leaves.each(&method(:puts))
   end
 end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -11,11 +11,9 @@ module Homebrew
       missing = {}
       ff.each do |f|
         missing_dependencies = f.missing_dependencies(hide: hide)
-
-        unless missing_dependencies.empty?
-          yield f.full_name, missing_dependencies if block_given?
-          missing[f.full_name] = missing_dependencies
-        end
+        next if missing_dependencies.empty?
+        yield f.full_name, missing_dependencies if block_given?
+        missing[f.full_name] = missing_dependencies
       end
       missing
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1497,20 +1497,9 @@ class Formula
   # installed
   def missing_dependencies(hide: nil)
     hide ||= []
-    missing_dependencies = recursive_dependencies do |dependent, dep|
-      if dep.build?
-        Dependency.prune
-      elsif dep.optional? || dep.recommended?
-        tab = Tab.for_formula(dependent)
-        Dependency.prune unless tab.with?(dep)
-      end
-    end
-
-    missing_dependencies.map!(&:to_formula)
-    missing_dependencies.select! do |d|
+    runtime_dependencies.map(&:to_formula).select do |d|
       hide.include?(d.name) || d.installed_prefixes.empty?
     end
-    missing_dependencies
   rescue FormulaUnavailableError
     []
   end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -15,6 +15,7 @@ require "keg"
 require "migrator"
 require "extend/ENV"
 require "language/python"
+require "tab"
 
 # A formula provides instructions and metadata for Homebrew to install a piece
 # of software. Every Homebrew formula is a {Formula}.
@@ -438,7 +439,6 @@ class Formula
   # If at least one version of {Formula} is installed.
   # @private
   def any_version_installed?
-    require "tab"
     installed_prefixes.any? { |keg| (keg/Tab::FILENAME).file? }
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1486,7 +1486,14 @@ class Formula
 
   # Returns a list of Dependency objects that are required at runtime.
   # @private
-  def runtime_dependencies
+  def runtime_dependencies(read_from_tab: true)
+    if read_from_tab &&
+       installed_prefix.directory? &&
+       (keg = Keg.new(installed_prefix)) &&
+       (tab_deps = keg.runtime_dependencies)
+      return tab_deps.map { |d| Dependency.new d["full_name"] }.compact
+    end
+
     recursive_dependencies do |_, dependency|
       Dependency.prune if dependency.build?
       Dependency.prune if !dependency.required? && build.without?(dependency)

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -102,47 +102,30 @@ class Keg
   #
   # For efficiency, we don't bother trying to get complete data.
   def self.find_some_installed_dependents(kegs)
-    # First, check in the tabs of installed Formulae.
-    kegs.each do |keg|
-      # Don't include dependencies of kegs that were in the given array.
-      dependents = keg.installed_dependents - kegs
-      dependents.map! { |d| "#{d.name} #{d.version}" }
-      return [keg], dependents if dependents.any?
-    end
-
-    # Some kegs won't have modern Tabs with the dependencies listed.
-    # In this case, fall back to Formula#missing_dependencies.
-
-    # Find formulae that didn't have dependencies saved in all of their kegs,
-    # so need them to be calculated now.
-    #
-    # This happens after the initial dependency check because it's sloooow.
-    remaining_formulae = Formula.installed.select do |f|
-      installed_kegs = f.installed_kegs
-
-      # Don't include dependencies of kegs that were in the given array.
-      next false if (installed_kegs - kegs).empty?
-
-      installed_kegs.any? { |k| Tab.for_keg(k).runtime_dependencies.nil? }
-    end
-
-    keg_names = kegs.map(&:name)
+    keg_names = kegs.select(&:optlinked?).map(&:name)
+    keg_formulae = []
     kegs_by_source = kegs.group_by do |keg|
       begin
         # First, attempt to resolve the keg to a formula
         # to get up-to-date name and tap information.
         f = keg.to_formula
+        keg_formulae << f
         [f.name, f.tap]
       rescue FormulaUnavailableError
         # If the formula for the keg can't be found,
         # fall back to the information in the tab.
-        [keg.name, Tab.for_keg(keg).tap]
+        [keg.name, keg.tab.tap]
       end
     end
 
-    remaining_formulae.each do |dependent|
-      required = dependent.missing_dependencies(hide: keg_names)
+    all_required_kegs = Set.new
+    all_dependents = []
 
+    # Don't include dependencies of kegs that were in the given array.
+    formulae_to_check = Formula.installed - keg_formulae
+
+    formulae_to_check.each do |dependent|
+      required = dependent.missing_dependencies(hide: keg_names)
       required_kegs = required.map do |f|
         f_kegs = kegs_by_source[[f.name, f.tap]]
         next unless f_kegs
@@ -150,12 +133,16 @@ class Keg
         f_kegs.sort_by(&:version).last
       end.compact
 
-      next unless required_kegs.any?
+      next if required_kegs.empty?
 
-      return required_kegs, [dependent.to_s]
+      all_required_kegs += required_kegs
+      all_dependents << dependent.to_s
     end
 
-    nil
+    return if all_required_kegs.empty?
+    return if all_dependents.empty?
+
+    [all_required_kegs.to_a, all_dependents.sort]
   end
 
   # if path is a file in a keg then this will return the containing Keg object
@@ -388,25 +375,6 @@ class Keg
 
   def to_formula
     Formulary.from_keg(self)
-  end
-
-  def installed_dependents
-    return [] unless optlinked?
-    tap = Tab.for_keg(self).source["tap"]
-    Keg.all.select do |keg|
-      tab = Tab.for_keg(keg)
-      next if tab.runtime_dependencies.nil?
-      tab.runtime_dependencies.any? do |dep|
-        # Resolve formula rather than directly comparing names
-        # in case of conflicts between formulae from different taps.
-        begin
-          dep_formula = Formulary.factory(dep["full_name"])
-          dep_formula == to_formula
-        rescue FormulaUnavailableError
-          next dep["full_name"] == "#{tap}/#{name}"
-        end
-      end
-    end
   end
 
   def oldname_opt_record

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -503,8 +503,16 @@ class Keg
     @oldname_opt_record = nil
   end
 
+  def tab
+    Tab.for_keg(self)
+  end
+
+  def runtime_dependencies
+    tab.runtime_dependencies
+  end
+
   def aliases
-    Tab.for_keg(self).aliases || []
+    tab.aliases || []
   end
 
   def optlink(mode = OpenStruct.new)

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -63,7 +63,8 @@ class LinkageChecker
       formula.build.without?(dep)
     end
     declared_deps = formula.deps.reject { |dep| filter_out.call(dep) }.map(&:name)
-    recursive_deps = keg.to_formula.runtime_dependencies.map { |dep| dep.to_formula.name }
+    runtime_deps = keg.to_formula.runtime_dependencies(read_from_tab: false)
+    recursive_deps = runtime_deps.map { |dep| dep.to_formula.name }
     declared_dep_names = declared_deps.map { |dep| dep.split("/").last }
     indirect_deps = []
     undeclared_deps = []

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -17,6 +17,7 @@ class Tab < OpenStruct
   # Instantiates a Tab for a new installation of a formula.
   def self.create(formula, compiler, stdlib)
     build = formula.build
+    runtime_deps = formula.runtime_dependencies(read_from_tab: false)
     attributes = {
       "homebrew_version" => HOMEBREW_VERSION,
       "used_options" => build.used_options.as_flags,
@@ -32,7 +33,7 @@ class Tab < OpenStruct
       "compiler" => compiler,
       "stdlib" => stdlib,
       "aliases" => formula.aliases,
-      "runtime_dependencies" => formula.runtime_dependencies.map do |dep|
+      "runtime_dependencies" => runtime_deps.map do |dep|
         f = dep.to_formula
         { "full_name" => f.full_name, "version" => f.version.to_s }
       end,

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -185,7 +185,7 @@ class Tab < OpenStruct
       "stdlib" => nil,
       "compiler" => DevelopmentTools.default_compiler,
       "aliases" => [],
-      "runtime_dependencies" => [],
+      "runtime_dependencies" => nil,
       "source" => {
         "path" => nil,
         "tap" => nil,

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -68,7 +68,7 @@ describe Tab do
     expect(tab.tap).to be nil
     expect(tab.time).to be nil
     expect(tab.HEAD).to be nil
-    expect(tab.runtime_dependencies).to be_empty
+    expect(tab.runtime_dependencies).to be nil
     expect(tab.stable_version).to be nil
     expect(tab.devel_version).to be nil
     expect(tab.head_version).to be nil


### PR DESCRIPTION
Previously runtime dependencies were stored in the tab but these values were only used by `brew uninstall`. Confusingly this would result in various commands (e.g. `brew leaves`, `brew missing`, `brew doctor`, `brew uses --installed`) contradicting `brew uninstall` in what the dependencies are for a formula.

This refactoring means that `Formula#runtime_dependencies` will now look at the formula's tab if possible (and if not specifically requested not to). After this, `Formula#runtime_dependencies` has been able to be used in more places so all the above commands can be consistent.

While I was here a few other tweaks have been made:

- `diagnostic` and `leaves` didn't need changes but, while looking there, I was able to clean them up a bit for more readable and simple code
- `Tab` now defaults `runtime_dependencies` to `nil` rather than an empty array. This is useful in differentiating between `runtime_dependencies` being not present in a `Tab` vs. there being no runtime dependencies. The `nil` case already needed handled because of returning `nil` for old, invalid `runtime_dependencies` anyway.