### PR TITLE
test: rubocop-rspec style auto-corrects.

### DIFF
--- a/Library/Homebrew/test/ARGV_spec.rb
+++ b/Library/Homebrew/test/ARGV_spec.rb
@@ -2,6 +2,7 @@ require "extend/ARGV"
 
 describe HomebrewArgvExtension do
   subject { argv.extend(described_class) }
+
   let(:argv) { ["mxcl"] }
 
   describe "#formulae" do
@@ -26,7 +27,7 @@ describe HomebrewArgvExtension do
 
   describe "#kegs" do
     context "when there are matching Kegs" do
-      before(:each) do
+      before do
         keg = HOMEBREW_CELLAR + "mxcl/10.0"
         keg.mkpath
       end

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -2,6 +2,7 @@ require "extend/ENV"
 
 shared_examples EnvActivation do
   subject { env.extend(described_class) }
+
   let(:env) { {}.extend(EnvActivation) }
 
   it "supports switching compilers" do

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -17,6 +17,7 @@ describe "Bash" do
 
   context "brew" do
     subject { HOMEBREW_LIBRARY_PATH.parent.parent/"bin/brew" }
+
     it { is_expected.to have_valid_bash_syntax }
   end
 
@@ -33,6 +34,7 @@ describe "Bash" do
 
   context "Bash completion" do
     subject { HOMEBREW_LIBRARY_PATH.parent.parent/"completions/bash/brew" }
+
     it { is_expected.to have_valid_bash_syntax }
   end
 

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -43,7 +43,7 @@ describe BuildEnvironment do
     subject { double.extend(described_class) }
 
     context "single argument" do
-      before(:each) do
+      before do
         subject.instance_eval do
           env :userpaths
         end
@@ -53,7 +53,7 @@ describe BuildEnvironment do
     end
 
     context "multiple arguments" do
-      before(:each) do
+      before do
         subject.instance_eval do
           env :userpaths, :std
         end

--- a/Library/Homebrew/test/build_options_spec.rb
+++ b/Library/Homebrew/test/build_options_spec.rb
@@ -6,6 +6,7 @@ describe BuildOptions do
   alias_matcher :be_built_without, :be_without
 
   subject { described_class.new(args, opts) }
+
   let(:bad_build) { described_class.new(bad_args, opts) }
   let(:args) { Options.create(%w[--with-foo --with-bar --without-qux]) }
   let(:opts) { Options.create(%w[--with-foo --with-bar --without-baz --without-qux]) }

--- a/Library/Homebrew/test/cask/accessibility_spec.rb
+++ b/Library/Homebrew/test/cask/accessibility_spec.rb
@@ -5,7 +5,7 @@ describe "Accessibility Access", :cask do
   let(:fake_system_command) { class_double(Hbc::SystemCommand) }
   let(:installer) { Hbc::Installer.new(cask, command: fake_system_command) }
 
-  before(:each) do
+  before do
     allow(MacOS).to receive(:version).and_return(MacOS::Version.new(macos_version))
     allow(installer).to receive(:bundle_identifier).and_return("com.example.BasicCask")
   end

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -10,7 +10,7 @@ describe Hbc::Artifact::App, :cask do
   let(:install_phase) { app.install_phase(command: command, force: force) }
   let(:uninstall_phase) { app.uninstall_phase(command: command, force: force) }
 
-  before(:each) do
+  before do
     InstallHelper.install_without_artifacts(cask)
   end
 
@@ -58,7 +58,7 @@ describe Hbc::Artifact::App, :cask do
     end
 
     describe "when the target already exists" do
-      before(:each) do
+      before do
         target_path.mkpath
       end
 
@@ -76,7 +76,7 @@ describe Hbc::Artifact::App, :cask do
       describe "given the force option" do
         let(:force) { true }
 
-        before(:each) do
+        before do
           allow(Hbc::Utils).to receive(:current_user).and_return("fake_user")
         end
 
@@ -104,7 +104,7 @@ describe Hbc::Artifact::App, :cask do
         end
 
         describe "target is user-owned but contains read-only files" do
-          before(:each) do
+          before do
             FileUtils.touch "#{target_path}/foo"
             FileUtils.chmod 0555, target_path
           end
@@ -137,7 +137,7 @@ describe Hbc::Artifact::App, :cask do
             expect(contents_path).to exist
           end
 
-          after(:each) do
+          after do
             FileUtils.chmod 0755, target_path
           end
         end
@@ -147,7 +147,7 @@ describe Hbc::Artifact::App, :cask do
     describe "when the target is a broken symlink" do
       let(:deleted_path) { cask.staged_path.join("Deleted.app") }
 
-      before(:each) do
+      before do
         deleted_path.mkdir
         File.symlink(deleted_path, target_path)
         deleted_path.rmdir

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -7,7 +7,7 @@ describe Hbc::Artifact::Binary, :cask do
   let(:artifacts) { cask.artifacts.select { |a| a.is_a?(described_class) } }
   let(:expected_path) { Hbc::Config.global.binarydir.join("binary") }
 
-  after(:each) do
+  after do
     FileUtils.rm expected_path if expected_path.exist?
   end
 

--- a/Library/Homebrew/test/cask/artifact/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/pkg_spec.rb
@@ -2,7 +2,7 @@ describe Hbc::Artifact::Pkg, :cask do
   let(:cask) { Hbc::CaskLoader.load(cask_path("with-installable")) }
   let(:fake_system_command) { class_double(Hbc::SystemCommand) }
 
-  before(:each) do
+  before do
     InstallHelper.install_without_artifacts(cask)
   end
 

--- a/Library/Homebrew/test/cask/artifact/suite_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/suite_spec.rb
@@ -12,7 +12,7 @@ describe Hbc::Artifact::Suite, :cask do
   let(:target_path) { Hbc::Config.global.appdir.join("Caffeine") }
   let(:source_path) { cask.staged_path.join("Caffeine") }
 
-  before(:each) do
+  before do
     InstallHelper.install_without_artifacts(cask)
   end
 

--- a/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/two_apps_correct_spec.rb
@@ -16,7 +16,7 @@ describe Hbc::Artifact::App, :cask do
     let(:source_path_pro) { cask.staged_path.join("Caffeine Pro.app") }
     let(:target_path_pro) { Hbc::Config.global.appdir.join("Caffeine Pro.app") }
 
-    before(:each) do
+    before do
       InstallHelper.install_without_artifacts(cask)
     end
 

--- a/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_no_zap_spec.rb
@@ -5,7 +5,7 @@ describe Hbc::Artifact::Zap, :cask do
     cask.artifacts.find { |a| a.is_a?(described_class) }
   }
 
-  before(:each) do
+  before do
     InstallHelper.install_without_artifacts(cask)
   end
 

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -79,13 +79,15 @@ describe Hbc::Audit, :cask do
   end
 
   describe "#run!" do
-    let(:cask) { Hbc::CaskLoader.load(cask_token) }
     subject { audit.run! }
+
+    let(:cask) { Hbc::CaskLoader.load(cask_token) }
 
     describe "required stanzas" do
       %w[version sha256 url name homepage].each do |stanza|
         context "when missing #{stanza}" do
           let(:cask_token) { "missing-#{stanza}" }
+
           it { is_expected.to fail_with(/#{stanza} stanza is required/) }
         end
       end
@@ -96,16 +98,19 @@ describe Hbc::Audit, :cask do
 
       context "when the cask has no preflight stanza" do
         let(:cask_token) { "with-zap-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has only one preflight stanza" do
         let(:cask_token) { "with-preflight" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has multiple preflight stanzas" do
         let(:cask_token) { "with-preflight-multi" }
+
         it { is_expected.to warn_with(error_msg) }
       end
     end
@@ -115,16 +120,19 @@ describe Hbc::Audit, :cask do
 
       context "when the cask has no postflight stanza" do
         let(:cask_token) { "with-zap-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has only one postflight stanza" do
         let(:cask_token) { "with-postflight" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has multiple postflight stanzas" do
         let(:cask_token) { "with-postflight-multi" }
+
         it { is_expected.to warn_with(error_msg) }
       end
     end
@@ -134,16 +142,19 @@ describe Hbc::Audit, :cask do
 
       context "when the cask has no uninstall stanza" do
         let(:cask_token) { "with-zap-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has only one uninstall stanza" do
         let(:cask_token) { "with-uninstall-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has multiple uninstall stanzas" do
         let(:cask_token) { "with-uninstall-multi" }
+
         it { is_expected.to warn_with(error_msg) }
       end
     end
@@ -153,16 +164,19 @@ describe Hbc::Audit, :cask do
 
       context "when the cask has no uninstall_preflight stanza" do
         let(:cask_token) { "with-zap-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has only one uninstall_preflight stanza" do
         let(:cask_token) { "with-uninstall-preflight" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has multiple uninstall_preflight stanzas" do
         let(:cask_token) { "with-uninstall-preflight-multi" }
+
         it { is_expected.to warn_with(error_msg) }
       end
     end
@@ -172,16 +186,19 @@ describe Hbc::Audit, :cask do
 
       context "when the cask has no uninstall_postflight stanza" do
         let(:cask_token) { "with-zap-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has only one uninstall_postflight stanza" do
         let(:cask_token) { "with-uninstall-postflight" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has multiple uninstall_postflight stanzas" do
         let(:cask_token) { "with-uninstall-postflight-multi" }
+
         it { is_expected.to warn_with(error_msg) }
       end
     end
@@ -191,16 +208,19 @@ describe Hbc::Audit, :cask do
 
       context "when the cask has no zap stanza" do
         let(:cask_token) { "with-uninstall-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has only one zap stanza" do
         let(:cask_token) { "with-zap-rmdir" }
-        it { should_not warn_with(error_msg) }
+
+        it { is_expected.not_to warn_with(error_msg) }
       end
 
       context "when the cask has multiple zap stanzas" do
         let(:cask_token) { "with-zap-multi" }
+
         it { is_expected.to warn_with(error_msg) }
       end
     end
@@ -210,28 +230,33 @@ describe Hbc::Audit, :cask do
 
       context "when version is 'latest'" do
         let(:cask_token) { "version-latest-string" }
+
         it { is_expected.to fail_with(error_msg) }
       end
 
       context "when version is :latest" do
         let(:cask_token) { "version-latest-with-checksum" }
-        it { should_not fail_with(error_msg) }
+
+        it { is_expected.not_to fail_with(error_msg) }
       end
     end
 
     describe "sha256 checks" do
       context "when version is :latest and sha256 is not :no_check" do
         let(:cask_token) { "version-latest-with-checksum" }
+
         it { is_expected.to fail_with("you should use sha256 :no_check when version is :latest") }
       end
 
       context "when sha256 is not a legal SHA-256 digest" do
         let(:cask_token) { "invalid-sha256" }
+
         it { is_expected.to fail_with("sha256 string must be of 64 hexadecimal characters") }
       end
 
       context "when sha256 is sha256 for empty string" do
         let(:cask_token) { "sha256-for-empty-string" }
+
         it { is_expected.to fail_with(/cannot use the sha256 for an empty string/) }
       end
     end
@@ -239,22 +264,26 @@ describe Hbc::Audit, :cask do
     describe "appcast checks" do
       context "when appcast has no sha256" do
         let(:cask_token) { "appcast-missing-checkpoint" }
+
         it { is_expected.to fail_with(/checkpoint sha256 is required for appcast/) }
       end
 
       context "when appcast checkpoint is not a string of 64 hexadecimal characters" do
         let(:cask_token) { "appcast-invalid-checkpoint" }
+
         it { is_expected.to fail_with(/string must be of 64 hexadecimal characters/) }
       end
 
       context "when appcast checkpoint is sha256 for empty string" do
         let(:cask_token) { "appcast-checkpoint-sha256-for-empty-string" }
+
         it { is_expected.to fail_with(/cannot use the sha256 for an empty string/) }
       end
 
       context "when appcast checkpoint is valid sha256" do
         let(:cask_token) { "appcast-valid-checkpoint" }
-        it { should_not fail_with(/appcast :checkpoint/) }
+
+        it { is_expected.not_to fail_with(/appcast :checkpoint/) }
       end
 
       context "when verifying appcast HTTP code" do
@@ -279,11 +308,13 @@ describe Hbc::Audit, :cask do
 
           context "when HTTP code is 200" do
             let(:stdout) { "200" }
-            it { should_not warn_with(wrong_code_msg) }
+
+            it { is_expected.not_to warn_with(wrong_code_msg) }
           end
 
           context "when HTTP code is not 200" do
             let(:stdout) { "404" }
+
             it { is_expected.to warn_with(wrong_code_msg) }
           end
         end
@@ -326,14 +357,16 @@ describe Hbc::Audit, :cask do
 
           context "when appcast checkpoint is out of date" do
             let(:actual_checkpoint) { "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" }
+
             it { is_expected.to warn_with(mismatch_msg) }
-            it { should_not warn_with(curl_error_msg) }
+            it { is_expected.not_to warn_with(curl_error_msg) }
           end
 
           context "when appcast checkpoint is up to date" do
             let(:actual_checkpoint) { expected_checkpoint }
-            it { should_not warn_with(mismatch_msg) }
-            it { should_not warn_with(curl_error_msg) }
+
+            it { is_expected.not_to warn_with(mismatch_msg) }
+            it { is_expected.not_to warn_with(curl_error_msg) }
           end
         end
 
@@ -354,39 +387,46 @@ describe Hbc::Audit, :cask do
 
       context "with incorrect SourceForge URL format" do
         let(:cask_token) { "sourceforge-incorrect-url-format" }
+
         it { is_expected.to warn_with(warning_msg) }
       end
 
       context "with correct SourceForge URL format" do
         let(:cask_token) { "sourceforge-correct-url-format" }
-        it { should_not warn_with(warning_msg) }
+
+        it { is_expected.not_to warn_with(warning_msg) }
       end
 
       context "with correct SourceForge URL format for version :latest" do
         let(:cask_token) { "sourceforge-version-latest-correct-url-format" }
-        it { should_not warn_with(warning_msg) }
+
+        it { is_expected.not_to warn_with(warning_msg) }
       end
 
       context "with incorrect OSDN URL format" do
         let(:cask_token) { "osdn-incorrect-url-format" }
+
         it { is_expected.to warn_with(warning_msg) }
       end
 
       context "with correct OSDN URL format" do
         let(:cask_token) { "osdn-correct-url-format" }
-        it { should_not warn_with(warning_msg) }
+
+        it { is_expected.not_to warn_with(warning_msg) }
       end
     end
 
     describe "generic artifact checks" do
       context "with relative target" do
         let(:cask_token) { "generic-artifact-relative-target" }
+
         it { is_expected.to fail_with(/target must be absolute path for Generic Artifact/) }
       end
 
       context "with absolute target" do
         let(:cask_token) { "generic-artifact-absolute-target" }
-        it { should_not fail_with(/target required for Generic Artifact/) }
+
+        it { is_expected.not_to fail_with(/target required for Generic Artifact/) }
       end
     end
 
@@ -418,12 +458,14 @@ describe Hbc::Audit, :cask do
 
       context "when cask token conflicts with a core formula" do
         let(:formula_names) { %w[with-binary other-formula] }
+
         it { is_expected.to warn_with(/possible duplicate/) }
       end
 
       context "when cask token does not conflict with a core formula" do
         let(:formula_names) { %w[other-formula] }
-        it { should_not warn_with(/possible duplicate/) }
+
+        it { is_expected.not_to warn_with(/possible duplicate/) }
       end
     end
 
@@ -440,7 +482,7 @@ describe Hbc::Audit, :cask do
           expect(verify).to receive(:all)
         end
 
-        it { should_not fail_with(/#{error_msg}/) }
+        it { is_expected.not_to fail_with(/#{error_msg}/) }
       end
 
       context "when download fails" do
@@ -463,6 +505,7 @@ describe Hbc::Audit, :cask do
 
     context "when an exception is raised" do
       let(:cask) { instance_double(Hbc::Cask) }
+
       before do
         expect(cask).to receive(:version).and_raise(StandardError.new)
       end

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -101,8 +101,9 @@ describe Hbc::Cask, :cask do
     end
 
     describe "versioned casks" do
-      let(:cask) { described_class.new("basic-cask") }
       subject { cask.outdated_versions }
+
+      let(:cask) { described_class.new("basic-cask") }
 
       shared_examples "versioned casks" do |tap_version, expectations|
         expectations.each do |installed_versions, expected_output|
@@ -139,6 +140,7 @@ describe Hbc::Cask, :cask do
         expectations.each do |installed_version, expected_output|
           context "when versions #{installed_version} are installed and the tap version is #{tap_version}, #{greedy ? "" : "not"} greedy" do
             subject { cask.outdated_versions greedy }
+
             it {
               allow(cask).to receive(:versions).and_return(installed_version)
               allow(cask).to receive(:version).and_return(Hbc::DSL::Version.new(tap_version))

--- a/Library/Homebrew/test/cask/cli/cleanup_spec.rb
+++ b/Library/Homebrew/test/cask/cli/cleanup_spec.rb
@@ -1,12 +1,12 @@
 require_relative "shared_examples/invalid_option"
 
 describe Hbc::CLI::Cleanup, :cask do
+  subject { described_class.new(*cask_tokens, cache_location: cache_location) }
+
   let(:cache_location) { Pathname.new(Dir.mktmpdir).realpath }
   let(:outdated_only) { false }
 
-  subject { described_class.new(*cask_tokens, cache_location: cache_location) }
-
-  before(:each) do
+  before do
     allow_any_instance_of(described_class).to receive(:outdated_only?).and_return(outdated_only)
   end
 

--- a/Library/Homebrew/test/cask/cli/create_spec.rb
+++ b/Library/Homebrew/test/cask/cli/create_spec.rb
@@ -2,7 +2,7 @@ require_relative "shared_examples/requires_cask_token"
 require_relative "shared_examples/invalid_option"
 
 describe Hbc::CLI::Create, :cask do
-  around(:each) do |example|
+  around do |example|
     begin
       example.run
     ensure
@@ -12,7 +12,7 @@ describe Hbc::CLI::Create, :cask do
     end
   end
 
-  before(:each) do
+  before do
     allow_any_instance_of(described_class).to receive(:exec_editor)
   end
 

--- a/Library/Homebrew/test/cask/cli/edit_spec.rb
+++ b/Library/Homebrew/test/cask/cli/edit_spec.rb
@@ -2,7 +2,7 @@ require_relative "shared_examples/requires_cask_token"
 require_relative "shared_examples/invalid_option"
 
 describe Hbc::CLI::Edit, :cask do
-  before(:each) do
+  before do
     allow_any_instance_of(described_class).to receive(:exec_editor)
   end
 

--- a/Library/Homebrew/test/cask/cli/info_spec.rb
+++ b/Library/Homebrew/test/cask/cli/info_spec.rb
@@ -49,7 +49,7 @@ describe Hbc::CLI::Info, :cask do
     end
   end
 
-  it "should print caveats if the Cask provided one" do
+  it "prints caveats if the Cask provided one" do
     expect {
       described_class.run("with-caveats")
     }.to output(<<~EOS).to_stdout
@@ -75,7 +75,7 @@ describe Hbc::CLI::Info, :cask do
     EOS
   end
 
-  it 'should not print "Caveats" section divider if the caveats block has no output' do
+  it 'does not print "Caveats" section divider if the caveats block has no output' do
     expect {
       described_class.run("with-conditional-caveats")
     }.to output(<<~EOS).to_stdout

--- a/Library/Homebrew/test/cask/cli/list_spec.rb
+++ b/Library/Homebrew/test/cask/cli/list_spec.rb
@@ -47,7 +47,7 @@ describe Hbc::CLI::List, :cask do
       EOS
     }
 
-    before(:each) do
+    before do
       casks.map(&Hbc::CaskLoader.method(:load)).each(&InstallHelper.method(:install_with_caskfile))
     end
 

--- a/Library/Homebrew/test/cask/cli/search_spec.rb
+++ b/Library/Homebrew/test/cask/cli/search_spec.rb
@@ -1,7 +1,7 @@
 require_relative "shared_examples/invalid_option"
 
 describe Hbc::CLI::Search, :cask do
-  before(:each) do
+  before do
     allow(Tty).to receive(:width).and_return(0)
   end
 

--- a/Library/Homebrew/test/cask/cli/style_spec.rb
+++ b/Library/Homebrew/test/cask/cli/style_spec.rb
@@ -92,6 +92,7 @@ describe Hbc::CLI::Style, :cask do
 
     context "when at least one cask token is a path that exists" do
       let(:tokens) { ["adium", "Casks/dropbox.rb"] }
+
       before do
         allow(File).to receive(:exist?).and_return(false, true)
       end
@@ -103,6 +104,7 @@ describe Hbc::CLI::Style, :cask do
 
     context "when no cask tokens are paths that exist" do
       let(:tokens) { %w[adium dropbox] }
+
       before do
         allow(File).to receive(:exist?).and_return(false)
       end
@@ -123,11 +125,13 @@ describe Hbc::CLI::Style, :cask do
 
     context "when fix? is true" do
       let(:fix) { true }
+
       it { is_expected.to include("--auto-correct") }
     end
 
     context "when fix? is false" do
       let(:fix) { false }
+
       it { is_expected.not_to include("--auto-correct") }
     end
   end
@@ -140,9 +144,10 @@ describe Hbc::CLI::Style, :cask do
 
   describe "#autocorrect_args" do
     subject { cli.autocorrect_args }
+
     let(:default_args) { ["--format", "simple"] }
 
-    it "should add --auto-correct to default args" do
+    it "adds --auto-correct to default args" do
       allow(cli).to receive(:default_args).and_return(default_args)
       expect(subject).to include("--auto-correct", *default_args)
     end

--- a/Library/Homebrew/test/cask/cli/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/cli/uninstall_spec.rb
@@ -105,7 +105,7 @@ describe Hbc::CLI::Uninstall, :cask do
     }
     let(:caskroom_path) { Hbc.caskroom.join(token).tap(&:mkpath) }
 
-    before(:each) do
+    before do
       timestamped_versions.each do |timestamped_version|
         caskroom_path.join(".metadata", *timestamped_version, "Casks").tap(&:mkpath)
                      .join("#{token}.rb").open("w") do |caskfile|

--- a/Library/Homebrew/test/cask/cli/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/cli/upgrade_spec.rb
@@ -13,7 +13,7 @@ describe Hbc::CLI::Upgrade, :cask do
       ]
     }
 
-    before(:example) do
+    before do
       installed.each { |cask| Hbc::CLI::Install.run(cask) }
 
       allow_any_instance_of(described_class).to receive(:verbose?).and_return(true)
@@ -176,7 +176,7 @@ describe Hbc::CLI::Upgrade, :cask do
       ]
     }
 
-    before(:example) do
+    before do
       installed.each { |cask| Hbc::CLI::Install.run(cask) }
 
       allow_any_instance_of(described_class).to receive(:verbose?).and_return(true)
@@ -201,7 +201,7 @@ describe Hbc::CLI::Upgrade, :cask do
       expect(will_fail_if_upgraded).to be_installed
       expect(will_fail_if_upgraded_path).to be_a_file
       expect(will_fail_if_upgraded.versions).to include("1.2.2")
-      expect(will_fail_if_upgraded.staged_path).to_not exist
+      expect(will_fail_if_upgraded.staged_path).not_to exist
     end
 
     it "does not restore the old Cask if the upgrade failed pre-install" do
@@ -219,7 +219,7 @@ describe Hbc::CLI::Upgrade, :cask do
       expect(bad_checksum).to be_installed
       expect(bad_checksum_path).to be_a_directory
       expect(bad_checksum.versions).to include("1.2.2")
-      expect(bad_checksum.staged_path).to_not exist
+      expect(bad_checksum.staged_path).not_to exist
     end
   end
 end

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -10,6 +10,7 @@ describe "Satisfy Dependencies and Requirements", :cask do
   describe "depends_on cask" do
     context "when depends_on cask is cyclic" do
       let(:cask) { Hbc::CaskLoader.load(cask_path("with-depends-on-cask-cyclic")) }
+
       it {
         is_expected.to raise_error(Hbc::CaskCyclicDependencyError,
         "Cask 'with-depends-on-cask-cyclic' includes cyclic dependencies on other Casks: with-depends-on-cask-cyclic-helper")
@@ -31,26 +32,31 @@ describe "Satisfy Dependencies and Requirements", :cask do
   describe "depends_on macos" do
     context "given an array" do
       let(:cask) { Hbc::CaskLoader.load(cask_path("with-depends-on-macos-array")) }
+
       it { is_expected.not_to raise_error }
     end
 
     context "given a comparison" do
       let(:cask) { Hbc::CaskLoader.load(cask_path("with-depends-on-macos-comparison")) }
+
       it { is_expected.not_to raise_error }
     end
 
     context "given a string" do
       let(:cask) { Hbc::CaskLoader.load(cask_path("with-depends-on-macos-string")) }
+
       it { is_expected.not_to raise_error }
     end
 
     context "given a symbol" do
       let(:cask) { Hbc::CaskLoader.load(cask_path("with-depends-on-macos-symbol")) }
+
       it { is_expected.not_to raise_error }
     end
 
     context "when not satisfied" do
       let(:cask) { Hbc::CaskLoader.load(cask_path("with-depends-on-macos-failure")) }
+
       it { is_expected.to raise_error(Hbc::CaskError) }
     end
   end
@@ -58,12 +64,13 @@ describe "Satisfy Dependencies and Requirements", :cask do
   describe "depends_on arch" do
     context "when satisfied" do
       let(:cask) { Hbc::CaskLoader.load(cask_path("with-depends-on-arch")) }
+
       it { is_expected.not_to raise_error }
     end
   end
 
   describe "depends_on x11" do
-    before(:each) do
+    before do
       allow(MacOS::X11).to receive(:installed?).and_return(x11_installed)
     end
 

--- a/Library/Homebrew/test/cask/download_strategy_spec.rb
+++ b/Library/Homebrew/test/cask/download_strategy_spec.rb
@@ -97,6 +97,7 @@ describe "download strategies", :cask do
     context "with a file name trailing the URL path" do
       describe "#tarball_path" do
         subject { downloader.tarball_path }
+
         its(:extname) { is_expected.to eq(".dmg") }
       end
     end
@@ -106,6 +107,7 @@ describe "download strategies", :cask do
 
       describe "#tarball_path" do
         subject { downloader.tarball_path }
+
         its(:to_path) { is_expected.to end_with("some-cask--1.2.3.4") }
       end
     end
@@ -115,6 +117,7 @@ describe "download strategies", :cask do
 
       describe "#tarball_path" do
         subject { downloader.tarball_path }
+
         its(:extname) { is_expected.to eq(".zip") }
       end
     end
@@ -124,6 +127,7 @@ describe "download strategies", :cask do
 
       describe "#tarball_path" do
         subject { downloader.tarball_path }
+
         its(:extname) { is_expected.to eq(".zip") }
       end
     end
@@ -149,6 +153,7 @@ describe "download strategies", :cask do
 
       describe "#tarball_path" do
         subject { downloader.tarball_path }
+
         its(:extname) { is_expected.to eq(".zip") }
         its("to_path.length") { is_expected.to be_between(0, 255) }
       end
@@ -202,6 +207,7 @@ describe "download strategies", :cask do
     let(:url_options) { { using: :svn } }
     let(:fake_system_command) { class_double(Hbc::SystemCommand) }
     let(:downloader) { Hbc::SubversionDownloadStrategy.new(cask, command: fake_system_command) }
+
     before do
       allow(fake_system_command).to receive(:run!)
     end

--- a/Library/Homebrew/test/cask/dsl/stanza_proxy_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/stanza_proxy_spec.rb
@@ -1,9 +1,10 @@
 describe Hbc::DSL::StanzaProxy, :cask do
+  subject { stanza_proxy }
+
   let(:stanza_proxy) {
     described_class.new(Array) { [:foo, :bar, :cake] }
   }
 
-  subject { stanza_proxy }
   it { is_expected.to be_a_proxy }
   it { is_expected.to respond_to(:pop) }
   its(:pop) { is_expected.to eq(:cake) }

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -3,6 +3,7 @@ describe Hbc::DSL::Version, :cask do
     expectations.each do |input_value, expected_output|
       context "when #{input_name} is #{input_value.inspect}" do
         let(input_name.to_sym) { input_value }
+
         it { is_expected.to eq expected_output }
       end
     end
@@ -13,17 +14,20 @@ describe Hbc::DSL::Version, :cask do
 
     context "when other is nil" do
       let(:other) { nil }
+
       it { is_expected.to be false }
     end
 
     context "when other is a String" do
       context "when other == self.raw_version" do
         let(:other) { "1.2.3" }
+
         it { is_expected.to be true }
       end
 
       context "when other != self.raw_version" do
         let(:other) { "1.2.3.4" }
+
         it { is_expected.to be false }
       end
     end
@@ -31,11 +35,13 @@ describe Hbc::DSL::Version, :cask do
     context "when other is a #{described_class}" do
       context "when other.raw_version == self.raw_version" do
         let(:other) { described_class.new("1.2.3") }
+
         it { is_expected.to be true }
       end
 
       context "when other.raw_version != self.raw_version" do
         let(:other) { described_class.new("1.2.3.4") }
+
         it { is_expected.to be false }
       end
     end
@@ -45,16 +51,19 @@ describe Hbc::DSL::Version, :cask do
 
   describe "#==" do
     subject { version == other }
+
     include_examples "version equality"
   end
 
   describe "#eql?" do
     subject { version.eql?(other) }
+
     include_examples "version equality"
   end
 
   shared_examples "version expectations hash" do |method, hash|
     subject { version.send(method) }
+
     include_examples "expectations hash", :raw_version,
                      { :latest  => "latest",
                        "latest" => "latest",

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -44,6 +44,7 @@ describe Hbc::DSL, :cask do
   describe "header line" do
     context "when invalid" do
       let(:token) { "invalid/invalid-header-format" }
+
       it "raises an error" do
         expect { cask }.to raise_error(SyntaxError)
       end
@@ -273,6 +274,7 @@ describe Hbc::DSL, :cask do
 
   describe "version stanza" do
     let(:token) { "invalid/invalid-two-version" }
+
     it "prevents defining multiple versions" do
       expect { cask }.to raise_error(Hbc::CaskInvalidError, /'version' stanza may only appear once/)
     end
@@ -313,6 +315,7 @@ describe Hbc::DSL, :cask do
 
     context "with :key_url" do
       let(:token) { "with-gpg-key-url" }
+
       it "is allowed to be specified" do
         expect(cask.gpg.to_s).to match(/\S/)
       end
@@ -404,6 +407,7 @@ describe Hbc::DSL, :cask do
   describe "depends_on cask" do
     context "specifying one" do
       let(:token) { "with-depends-on-cask" }
+
       it "is allowed" do
         expect(cask.depends_on.cask).not_to be nil
       end

--- a/Library/Homebrew/test/cask/staged_spec.rb
+++ b/Library/Homebrew/test/cask/staged_spec.rb
@@ -5,6 +5,7 @@ describe "Operations on staged Casks", :cask do
   describe "bundle ID" do
     let(:cask) { Hbc::CaskLoader.load(cask_path("local-transmission")) }
     let(:installer) { Hbc::Installer.new(cask) }
+
     it "fetches the bundle ID from a staged cask" do
       installer.install
       expect(installer.bundle_identifier).to eq("org.m0k.transmission")

--- a/Library/Homebrew/test/cask/system_command_result_spec.rb
+++ b/Library/Homebrew/test/cask/system_command_result_spec.rb
@@ -3,6 +3,7 @@ require "hbc/system_command"
 describe Hbc::SystemCommand::Result, :cask do
   describe "::_parse_plist" do
     subject { described_class._parse_plist(command, input) }
+
     let(:command) { Hbc::SystemCommand.new("/usr/bin/true", {}) }
     let(:plist) {
       <<~EOS

--- a/Library/Homebrew/test/cask/verify_spec.rb
+++ b/Library/Homebrew/test/cask/verify_spec.rb
@@ -41,11 +41,11 @@ describe Hbc::Verify, :cask do
   end
 
   describe ".all" do
+    subject { described_class.all(cask, downloaded_path) }
+
     let(:downloaded_path) { double("downloaded_path") }
     let(:applicable_verification) { double("applicable_verification") }
     let(:inapplicable_verification) { double("inapplicable_verification") }
-
-    subject { described_class.all(cask, downloaded_path) }
 
     before do
       allow(applicable_verification_class).to receive(:new)

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -3,6 +3,7 @@ require "caveats"
 
 describe Caveats do
   subject { described_class.new(f) }
+
   let(:f) { formula { url "foo-1.0" } }
 
   specify "#f" do

--- a/Library/Homebrew/test/checksum_spec.rb
+++ b/Library/Homebrew/test/checksum_spec.rb
@@ -3,11 +3,13 @@ require "checksum"
 describe Checksum do
   describe "#empty?" do
     subject { described_class.new(:sha256, "") }
+
     it { is_expected.to be_empty }
   end
 
   describe "#==" do
     subject { described_class.new(:sha256, TEST_SHA256) }
+
     let(:other) { described_class.new(:sha256, TEST_SHA256) }
     let(:other_reversed) { described_class.new(:sha256, TEST_SHA256.reverse) }
     let(:other_sha1) { described_class.new(:sha1, TEST_SHA1) }

--- a/Library/Homebrew/test/cleaner_spec.rb
+++ b/Library/Homebrew/test/cleaner_spec.rb
@@ -5,9 +5,10 @@ describe Cleaner do
   include FileUtils
 
   subject { described_class.new(f) }
+
   let(:f) { formula("cleaner_test") { url "foo-1.0" } }
 
-  before(:each) do
+  before do
     f.prefix.mkpath
   end
 

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -8,7 +8,7 @@ describe Homebrew::Cleanup do
   let(:lock_file) { Pathname.new("#{HOMEBREW_LOCK_DIR}/foo") }
   let(:sec_in_a_day) { 60 * 60 * 24 }
 
-  around(:each) do |example|
+  around do |example|
     begin
       FileUtils.touch ds_store
       FileUtils.touch lock_file
@@ -50,7 +50,7 @@ describe Homebrew::Cleanup do
       let(:f2) { Class.new(Testball) { version "0.2" }.new }
       let(:unremovable_kegs) { [] }
 
-      before(:each) do
+      before do
         described_class.instance_variable_set(:@unremovable_kegs, [])
         [f1, f2].each do |f|
           f.brew do
@@ -230,7 +230,7 @@ describe Homebrew::Cleanup do
       let(:bottle) { (HOMEBREW_CACHE/"testball-0.0.1.bottle.tar.gz") }
       let(:testball) { (HOMEBREW_CACHE/"testball-0.0.1") }
 
-      before(:each) do
+      before do
         FileUtils.touch(bottle)
         FileUtils.touch(testball)
         (HOMEBREW_CELLAR/"testball"/"0.0.1").mkpath
@@ -268,11 +268,11 @@ describe Homebrew::Cleanup do
 
     it "returns true when path_modified_time < days_default" do
       allow_any_instance_of(Pathname).to receive(:mtime).and_return(Time.now - sec_in_a_day * 2)
-      expect(described_class.prune?(foo, days_default: "1")).to be_truthy
+      expect(described_class).to be_prune(foo, days_default: "1")
     end
 
     it "returns false when path_modified_time >= days_default" do
-      expect(described_class.prune?(foo, days_default: "2")).to be_falsey
+      expect(described_class).not_to be_prune(foo, days_default: "2")
     end
   end
 end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -260,6 +260,8 @@ describe Homebrew::Cleanup do
   end
 
   describe "::prune?" do
+    alias_matcher :be_pruned, :be_prune
+
     before do
       foo.mkpath
     end
@@ -268,11 +270,11 @@ describe Homebrew::Cleanup do
 
     it "returns true when path_modified_time < days_default" do
       allow_any_instance_of(Pathname).to receive(:mtime).and_return(Time.now - sec_in_a_day * 2)
-      expect(described_class).to be_prune(foo, days_default: "1")
+      expect(described_class).to be_pruned(foo, days_default: "1")
     end
 
     it "returns false when path_modified_time >= days_default" do
-      expect(described_class).not_to be_prune(foo, days_default: "2")
+      expect(described_class).not_to be_pruned(foo, days_default: "2")
     end
   end
 end

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -50,6 +50,7 @@ describe Homebrew::CLI::Parser do
         comma_array "--files",    description: "Comma separated filenames"
       end
     }
+
     it "parses a long flag option with its argument" do
       args = parser.parse(["--filename=random.txt"])
       expect(args.filename).to eq "random.txt"

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -1,5 +1,5 @@
 describe "brew analytics", :integration_test do
-  before(:each) do
+  before do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end

--- a/Library/Homebrew/test/cmd/commands_spec.rb
+++ b/Library/Homebrew/test/cmd/commands_spec.rb
@@ -23,7 +23,7 @@ RSpec.shared_context "custom internal commands" do
     ]
   end
 
-  around(:each) do |example|
+  around do |example|
     begin
       cmds.each do |f|
         FileUtils.touch f

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -1,5 +1,5 @@
 describe "brew migrate", :integration_test do
-  before(:each) do
+  before do
     setup_test_formula "testball1"
     setup_test_formula "testball2"
   end

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -1,5 +1,5 @@
 describe "brew missing", :integration_test do
-  before(:each) do
+  before do
     setup_test_formula "foo"
     setup_test_formula "bar"
   end

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -1,7 +1,7 @@
 require "extend/ENV"
 
 describe "brew reinstall", :integration_test do
-  before(:each) do
+  before do
     setup_test_formula "testball"
 
     expect { brew "install", "testball", "--with-foo" }.to be_a_success

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,5 +1,5 @@
 describe "brew search", :integration_test do
-  before(:each) do
+  before do
     setup_test_formula "testball"
     setup_remote_tap "caskroom/cask"
   end

--- a/Library/Homebrew/test/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cmd/style_spec.rb
@@ -1,7 +1,7 @@
 require "cmd/style"
 
 describe "brew style" do
-  around(:each) do |example|
+  around do |example|
     begin
       FileUtils.ln_s HOMEBREW_LIBRARY_PATH, HOMEBREW_LIBRARY/"Homebrew"
       FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".rubocop_audit.yml"

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -22,7 +22,7 @@ describe Homebrew do
 
   let(:opts) { { dependency.rack => [Keg.new(dependency.installed_prefix)] } }
 
-  before(:each) do
+  before do
     [dependency, dependent].each do |f|
       f.installed_prefix.mkpath
       Keg.new(f.installed_prefix).optlink

--- a/Library/Homebrew/test/cmd/update-report_spec.rb
+++ b/Library/Homebrew/test/cmd/update-report_spec.rb
@@ -13,6 +13,8 @@ describe Reporter do
     hub.add(subject) if subject.updated?
   end
 
+  subject { reporter_class.new(tap) }
+
   let(:reporter_class) do
     Class.new(described_class) do
       def initialize(tap)
@@ -25,7 +27,7 @@ describe Reporter do
       end
     end
   end
-  subject { reporter_class.new(tap) }
+
   let(:tap) { CoreTap.new }
   let(:hub) { ReporterHub.new }
 
@@ -83,11 +85,11 @@ describe Reporter do
   context "when updating a Tap other than the core Tap" do
     let(:tap) { Tap.new("foo", "bar") }
 
-    before(:each) do
+    before do
       (tap.path/"Formula").mkpath
     end
 
-    after(:each) do
+    after do
       tap.path.parent.rmtree
     end
 

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -3,6 +3,7 @@ require "software_spec"
 
 describe CompilerSelector do
   subject { described_class.new(software_spec, versions, compilers) }
+
   let(:compilers) { [:clang, :gcc, :gnu] }
   let(:software_spec) { SoftwareSpec.new }
   let(:cc) { :clang }
@@ -15,7 +16,7 @@ describe CompilerSelector do
     )
   end
 
-  before(:each) do
+  before do
     allow(versions).to receive(:non_apple_gcc_version) do |name|
       case name
       when "gcc-4.8" then Version.create("4.8.1")

--- a/Library/Homebrew/test/cxxstdlib_spec.rb
+++ b/Library/Homebrew/test/cxxstdlib_spec.rb
@@ -2,14 +2,14 @@ require "formula"
 require "cxxstdlib"
 
 describe CxxStdlib do
-  let(:clang) { CxxStdlib.create(:libstdcxx, :clang) }
-  let(:gcc) { CxxStdlib.create(:libstdcxx, :gcc) }
-  let(:gcc40) { CxxStdlib.create(:libstdcxx, :gcc_4_0) }
-  let(:gcc42) { CxxStdlib.create(:libstdcxx, :gcc_4_2) }
-  let(:gcc48) { CxxStdlib.create(:libstdcxx, "gcc-4.8") }
-  let(:gcc49) { CxxStdlib.create(:libstdcxx, "gcc-4.9") }
-  let(:lcxx) { CxxStdlib.create(:libcxx, :clang) }
-  let(:purec) { CxxStdlib.create(nil, :clang) }
+  let(:clang) { described_class.create(:libstdcxx, :clang) }
+  let(:gcc) { described_class.create(:libstdcxx, :gcc) }
+  let(:gcc40) { described_class.create(:libstdcxx, :gcc_4_0) }
+  let(:gcc42) { described_class.create(:libstdcxx, :gcc_4_2) }
+  let(:gcc48) { described_class.create(:libstdcxx, "gcc-4.8") }
+  let(:gcc49) { described_class.create(:libstdcxx, "gcc-4.9") }
+  let(:lcxx) { described_class.create(:libcxx, :clang) }
+  let(:purec) { described_class.create(nil, :clang) }
 
   describe "#compatible_with?" do
     specify "Apple libstdcxx intercompatibility" do

--- a/Library/Homebrew/test/dependable_spec.rb
+++ b/Library/Homebrew/test/dependable_spec.rb
@@ -4,6 +4,7 @@ describe Dependable do
   alias_matcher :be_a_build_dependency, :be_build
 
   subject { double(tags: tags).extend(described_class) }
+
   let(:tags) { ["foo", "bar", :build] }
 
   specify "#options" do

--- a/Library/Homebrew/test/dependencies_spec.rb
+++ b/Library/Homebrew/test/dependencies_spec.rb
@@ -53,8 +53,8 @@ describe Dependencies do
   end
 
   specify "equality" do
-    a = Dependencies.new
-    b = Dependencies.new
+    a = described_class.new
+    b = described_class.new
 
     dep = Dependency.new("foo")
 

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -11,7 +11,7 @@ describe DependencyCollector do
     subject.requirements.find { |req| req.is_a? klass }
   end
 
-  after(:each) do
+  after do
     described_class.clear_cache
   end
 
@@ -51,7 +51,7 @@ describe DependencyCollector do
 
     specify "x11 with (ignored) minimum version" do
       subject.add x11: "2.5.1"
-      expect(find_requirement(X11Requirement).min_version.to_s).to_not eq("2.5.1")
+      expect(find_requirement(X11Requirement).min_version.to_s).not_to eq("2.5.1")
     end
 
     specify "x11 with tag" do
@@ -62,7 +62,7 @@ describe DependencyCollector do
     specify "x11 with (ignored) minimum version and tag" do
       subject.add x11: ["2.5.1", :optional]
       dep = find_requirement(X11Requirement)
-      expect(dep.min_version.to_s).to_not eq("2.5.1")
+      expect(dep.min_version.to_s).not_to eq("2.5.1")
       expect(dep).to be_optional
     end
 

--- a/Library/Homebrew/test/deps_spec.rb
+++ b/Library/Homebrew/test/deps_spec.rb
@@ -1,5 +1,5 @@
 describe "brew deps", :integration_test do
-  before(:each) do
+  before do
     setup_test_formula "foo"
     setup_test_formula "bar"
     setup_test_formula "baz", <<~EOS

--- a/Library/Homebrew/test/descriptions_spec.rb
+++ b/Library/Homebrew/test/descriptions_spec.rb
@@ -2,6 +2,7 @@ require "descriptions"
 
 describe Descriptions do
   subject { described_class.new(descriptions_hash) }
+
   let(:descriptions_hash) { {} }
 
   it "can print description for a core Formula" do

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -2,6 +2,7 @@ require "download_strategy"
 
 describe AbstractDownloadStrategy do
   subject { described_class.new(name, resource) }
+
   let(:specs) { {} }
   let(:name) { "foo" }
   let(:url) { "http://example.com/foo.tar.gz" }
@@ -46,7 +47,7 @@ describe AbstractDownloadStrategy do
 
   context "without specs[:bottle]" do
     it "is does not extend Pourable" do
-      expect(subject).to_not be_a_kind_of(AbstractDownloadStrategy::Pourable)
+      expect(subject).not_to be_a_kind_of(AbstractDownloadStrategy::Pourable)
     end
   end
 end
@@ -66,10 +67,11 @@ end
 
 describe GitHubPrivateRepositoryDownloadStrategy do
   subject { described_class.new("foo", resource) }
+
   let(:url) { "https://github.com/owner/repo/archive/1.1.5.tar.gz" }
   let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: nil) }
 
-  before(:each) do
+  before do
     ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
     allow(GitHub).to receive(:repository).and_return({})
   end
@@ -89,10 +91,11 @@ end
 
 describe GitHubPrivateRepositoryReleaseDownloadStrategy do
   subject { described_class.new("foo", resource) }
+
   let(:url) { "https://github.com/owner/repo/releases/download/tag/foo_v0.1.0_darwin_amd64.tar.gz" }
   let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: nil) }
 
-  before(:each) do
+  before do
     ENV["HOMEBREW_GITHUB_API_TOKEN"] = "token"
     allow(GitHub).to receive(:repository).and_return({})
   end
@@ -139,6 +142,7 @@ end
 
 describe GitHubGitDownloadStrategy do
   subject { described_class.new(name, resource) }
+
   let(:name) { "brew" }
   let(:url) { "https://github.com/homebrew/brew.git" }
   let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: nil) }
@@ -151,12 +155,13 @@ end
 
 describe GitDownloadStrategy do
   subject { described_class.new(name, resource) }
+
   let(:name) { "baz" }
   let(:url) { "https://github.com/homebrew/foo" }
   let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: nil) }
   let(:cached_location) { subject.cached_location }
 
-  before(:each) do
+  before do
     @commit_id = 1
     FileUtils.mkpath cached_location
   end
@@ -198,9 +203,9 @@ describe GitDownloadStrategy do
     let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: version) }
     let(:remote_repo) { HOMEBREW_PREFIX/"remote_repo" }
 
-    before(:each) { remote_repo.mkpath }
+    before { remote_repo.mkpath }
 
-    after(:each) { FileUtils.rm_rf remote_repo }
+    after { FileUtils.rm_rf remote_repo }
 
     it "fetches the hash of the last commit" do
       remote_repo.cd do
@@ -217,6 +222,7 @@ end
 
 describe S3DownloadStrategy do
   subject { described_class.new(name, resource) }
+
   let(:name) { "foo" }
   let(:url) { "http://bucket.s3.amazonaws.com/foo.tar.gz" }
   let(:resource) { double(Resource, url: url, mirrors: [], specs: {}, version: nil) }
@@ -226,7 +232,8 @@ describe S3DownloadStrategy do
 
     context "when given Bad S3 URL" do
       let(:url) { "http://example.com/foo.tar.gz" }
-      it "should raise Bad S3 URL error" do
+
+      it "raises Bad S3 URL error" do
         expect {
           subject._fetch
         }.to raise_error(RuntimeError)
@@ -237,6 +244,7 @@ end
 
 describe CurlDownloadStrategy do
   subject { described_class.new(name, resource) }
+
   let(:name) { "foo" }
   let(:url) { "http://example.com/foo.tar.gz" }
   let(:resource) { double(Resource, url: url, mirrors: [], specs: { user: "download:123456" }, version: nil) }
@@ -254,6 +262,7 @@ describe CurlDownloadStrategy do
 
     context "when URL file is in middle" do
       let(:url) { "http://example.com/foo.tar.gz/from/this/mirror" }
+
       it { is_expected.to eq(HOMEBREW_CACHE/"foo-.tar.gz") }
     end
   end
@@ -262,23 +271,27 @@ end
 describe DownloadStrategyDetector do
   describe "::detect" do
     subject { described_class.detect(url, strategy) }
+
     let(:url) { Object.new }
     let(:strategy) { nil }
 
     context "when given Git URL" do
       let(:url) { "git://example.com/foo.git" }
+
       it { is_expected.to eq(GitDownloadStrategy) }
     end
 
     context "when given a GitHub Git URL" do
       let(:url) { "https://github.com/homebrew/brew.git" }
+
       it { is_expected.to eq(GitHubGitDownloadStrategy) }
     end
 
     context "when given an S3 URL" do
       let(:url) { "s3://bucket/homebrew/brew.tar.gz" }
+
       it "returns S3DownloadStrategy" do
-        allow(DownloadStrategyDetector).to receive(:require_aws_sdk).and_return(true)
+        allow(described_class).to receive(:require_aws_sdk).and_return(true)
         is_expected.to eq(S3DownloadStrategy)
       end
     end
@@ -286,8 +299,9 @@ describe DownloadStrategyDetector do
     context "when given strategy = S3DownloadStrategy" do
       let(:url) { "https://bkt.s3.amazonaws.com/key.tar.gz" }
       let(:strategy) { S3DownloadStrategy }
+
       it "requires aws-sdk-s3" do
-        allow(DownloadStrategyDetector).to receive(:require_aws_sdk).and_return(true)
+        allow(described_class).to receive(:require_aws_sdk).and_return(true)
         is_expected.to eq(S3DownloadStrategy)
       end
     end

--- a/Library/Homebrew/test/emoji_spec.rb
+++ b/Library/Homebrew/test/emoji_spec.rb
@@ -4,7 +4,7 @@ describe Emoji do
   describe "#install_badge" do
     subject { described_class.install_badge }
 
-    before(:each) do
+    before do
       ENV.delete("HOMEBREW_NO_EMOJI")
       ENV.delete("HOMEBREW_INSTALL_BADGE")
     end

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -2,16 +2,19 @@ require "exceptions"
 
 describe MultipleVersionsInstalledError do
   subject { described_class.new("foo") }
+
   its(:to_s) { is_expected.to eq("foo has multiple installed versions") }
 end
 
 describe NoSuchKegError do
   subject { described_class.new("foo") }
+
   its(:to_s) { is_expected.to eq("No such keg: #{HOMEBREW_CELLAR}/foo") }
 end
 
 describe FormulaValidationError do
   subject { described_class.new("foo", "sha257", "magic") }
+
   its(:to_s) {
     is_expected.to eq(%q(invalid attribute for formula 'foo': sha257 ("magic")))
   }
@@ -41,7 +44,7 @@ describe FormulaUnavailableError do
   end
 
   context "with a dependent" do
-    before(:each) do
+    before do
       subject.dependent = "foobar"
     end
 
@@ -53,12 +56,15 @@ end
 
 describe TapFormulaUnavailableError do
   subject { described_class.new(tap, "foo") }
+
   let(:tap) { double(Tap, user: "u", repo: "r", to_s: "u/r", installed?: false) }
+
   its(:to_s) { is_expected.to match(%r{Please tap it and then try again: brew tap u/r}) }
 end
 
 describe FormulaClassUnavailableError do
   subject { described_class.new("foo", "foo.rb", "Foo", list) }
+
   let(:mod) do
     Module.new do
       class Bar < Requirement; end
@@ -68,6 +74,7 @@ describe FormulaClassUnavailableError do
 
   context "no classes" do
     let(:list) { [] }
+
     its(:to_s) {
       is_expected.to match(/Expected to find class Foo, but found no classes\./)
     }
@@ -75,6 +82,7 @@ describe FormulaClassUnavailableError do
 
   context "class not derived from Formula" do
     let(:list) { [mod.const_get(:Bar)] }
+
     its(:to_s) {
       is_expected.to match(/Expected to find class Foo, but only found: Bar \(not derived from Formula!\)\./)
     }
@@ -82,107 +90,134 @@ describe FormulaClassUnavailableError do
 
   context "class derived from Formula" do
     let(:list) { [mod.const_get(:Baz)] }
+
     its(:to_s) { is_expected.to match(/Expected to find class Foo, but only found: Baz\./) }
   end
 end
 
 describe FormulaUnreadableError do
   subject { described_class.new("foo", formula_error) }
+
   let(:formula_error) { LoadError.new("bar") }
+
   its(:to_s) { is_expected.to eq("foo: bar") }
 end
 
 describe TapUnavailableError do
   subject { described_class.new("foo") }
+
   its(:to_s) { is_expected.to eq("No available tap foo.\n") }
 end
 
 describe TapAlreadyTappedError do
   subject { described_class.new("foo") }
+
   its(:to_s) { is_expected.to eq("Tap foo already tapped.\n") }
 end
 
 describe TapPinStatusError do
   context "pinned" do
     subject { described_class.new("foo", true) }
+
     its(:to_s) { is_expected.to eq("foo is already pinned.") }
   end
 
   context "unpinned" do
     subject { described_class.new("foo", false) }
+
     its(:to_s) { is_expected.to eq("foo is already unpinned.") }
   end
 end
 
 describe BuildError do
   subject { described_class.new(formula, "badprg", %w[arg1 arg2], {}) }
+
   let(:formula) { double(Formula, name: "foo") }
+
   its(:to_s) { is_expected.to eq("Failed executing: badprg arg1 arg2") }
 end
 
 describe OperationInProgressError do
   subject { described_class.new("foo") }
+
   its(:to_s) { is_expected.to match(/Operation already in progress for foo/) }
 end
 
 describe FormulaInstallationAlreadyAttemptedError do
   subject { described_class.new(formula) }
+
   let(:formula) { double(Formula, full_name: "foo/bar") }
+
   its(:to_s) { is_expected.to eq("Formula installation already attempted: foo/bar") }
 end
 
 describe FormulaConflictError do
   subject { described_class.new(formula, [conflict]) }
+
   let(:formula) { double(Formula, full_name: "foo/qux") }
   let(:conflict) { double(name: "bar", reason: "I decided to") }
+
   its(:to_s) { is_expected.to match(/Please `brew unlink bar` before continuing\./) }
 end
 
 describe CompilerSelectionError do
   subject { described_class.new(formula) }
+
   let(:formula) { double(Formula, full_name: "foo") }
+
   its(:to_s) { is_expected.to match(/foo cannot be built with any available compilers\./) }
 end
 
 describe CurlDownloadStrategyError do
   context "file does not exist" do
     subject { described_class.new("file:///tmp/foo") }
+
     its(:to_s) { is_expected.to eq("File does not exist: /tmp/foo") }
   end
 
   context "download failed" do
     subject { described_class.new("http://brew.sh") }
+
     its(:to_s) { is_expected.to eq("Download failed: http://brew.sh") }
   end
 end
 
 describe ErrorDuringExecution do
   subject { described_class.new("badprg", %w[arg1 arg2]) }
+
   its(:to_s) { is_expected.to eq("Failure while executing: badprg arg1 arg2") }
 end
 
 describe ChecksumMismatchError do
   subject { described_class.new("/file.tar.gz", hash1, hash2) }
+
   let(:hash1) { double(hash_type: "sha256", to_s: "deadbeef") }
   let(:hash2) { double(hash_type: "sha256", to_s: "deadcafe") }
+
   its(:to_s) { is_expected.to match(/SHA256 mismatch/) }
 end
 
 describe ResourceMissingError do
   subject { described_class.new(formula, resource) }
+
   let(:formula) { double(Formula, full_name: "bar") }
   let(:resource) { double(inspect: "<resource foo>") }
+
   its(:to_s) { is_expected.to eq("bar does not define resource <resource foo>") }
 end
 
 describe DuplicateResourceError do
   subject { described_class.new(resource) }
+
   let(:resource) { double(inspect: "<resource foo>") }
+
   its(:to_s) { is_expected.to eq("Resource <resource foo> is defined more than once") }
 end
 
 describe BottleFormulaUnavailableError do
   subject { described_class.new("/foo.bottle.tar.gz", "foo/1.0/.brew/foo.rb") }
+
   let(:formula) { double(Formula, full_name: "foo") }
+
   its(:to_s) { is_expected.to match(/This bottle does not contain the formula file/) }
 end

--- a/Library/Homebrew/test/formatter_spec.rb
+++ b/Library/Homebrew/test/formatter_spec.rb
@@ -3,6 +3,8 @@ require "utils/tty"
 
 describe Formatter do
   describe "::columns" do
+    subject { described_class.columns(input) }
+
     let(:input) {
       %w[
         aa
@@ -11,7 +13,6 @@ describe Formatter do
         dd
       ]
     }
-    subject { described_class.columns(input) }
 
     it "doesn't output columns if $stdout is not a TTY." do
       allow_any_instance_of(IO).to receive(:tty?).and_return(false)

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -71,7 +71,7 @@ describe FormulaInstaller do
     expect(formula).not_to be_bottled
 
     expect {
-      FormulaInstaller.new(formula).install
+      described_class.new(formula).install
     }.to raise_error(BuildToolsError)
 
     expect(formula).not_to be_installed

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -126,7 +126,7 @@ describe FormulaInstaller do
     expect(dependency_keg).to be_linked
     expect(dependency).to be_pinned
 
-    fi = FormulaInstaller.new(dependent)
+    fi = described_class.new(dependent)
 
     expect {
       fi.check_install_sanity

--- a/Library/Homebrew/test/formula_pin_spec.rb
+++ b/Library/Homebrew/test/formula_pin_spec.rb
@@ -2,10 +2,11 @@ require "formula_pin"
 
 describe FormulaPin do
   subject { described_class.new(formula) }
+
   let(:name) { "double" }
   let(:formula) { double(Formula, name: name, rack: HOMEBREW_CELLAR/name) }
 
-  before(:each) do
+  before do
     formula.rack.mkpath
 
     allow(formula).to receive(:installed_prefixes) do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -905,7 +905,7 @@ describe Formula do
     let(:tab) { Tab.empty }
     let(:alias_path) { "#{CoreTap.instance.alias_dir}/bar" }
 
-    before(:each) do
+    before do
       allow(described_class).to receive(:installed).and_return([f])
 
       f.build = tab

--- a/Library/Homebrew/test/formula_support_spec.rb
+++ b/Library/Homebrew/test/formula_support_spec.rb
@@ -3,17 +3,17 @@ require "formula_support"
 describe KegOnlyReason do
   describe "#to_s" do
     it "returns the reason provided" do
-      r = KegOnlyReason.new :provided_by_macos, "test"
+      r = described_class.new :provided_by_macos, "test"
       expect(r.to_s).to eq("test")
     end
 
     it "returns a default message when no reason is provided" do
-      r = KegOnlyReason.new :provided_by_macos, ""
+      r = described_class.new :provided_by_macos, ""
       expect(r.to_s).to match(/^macOS already provides/)
     end
 
     it "is deprecated when reason mentions 'osx'", :needs_compat do
-      r = KegOnlyReason.new :provided_by_osx, "test"
+      r = described_class.new :provided_by_osx, "test"
       expect(r).to receive(:odeprecated)
       r.to_s
     end
@@ -22,13 +22,13 @@ end
 
 describe BottleDisableReason do
   specify ":unneeded" do
-    bottle_disable_reason = BottleDisableReason.new :unneeded, nil
+    bottle_disable_reason = described_class.new :unneeded, nil
     expect(bottle_disable_reason).to be_unneeded
     expect(bottle_disable_reason.to_s).to eq("This formula doesn't require compiling.")
   end
 
   specify ":disabled" do
-    bottle_disable_reason = BottleDisableReason.new :disable, "reason"
+    bottle_disable_reason = described_class.new :disable, "reason"
     expect(bottle_disable_reason).not_to be_unneeded
     expect(bottle_disable_reason.to_s).to eq("reason")
   end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -45,7 +45,7 @@ describe Formulary do
   end
 
   describe "::factory" do
-    before(:each) do
+    before do
       formula_path.write formula_content
     end
 
@@ -185,7 +185,7 @@ describe Formulary do
     let(:tap) { Tap.new("homebrew", "foo") }
     let(:tap_path) { tap.path/"#{formula_name}.rb" }
 
-    before(:each) do
+    before do
       core_path.write formula_content
       tap_path.write formula_content
     end

--- a/Library/Homebrew/test/inreplace_spec.rb
+++ b/Library/Homebrew/test/inreplace_spec.rb
@@ -216,7 +216,7 @@ end
 describe Utils::Inreplace do
   let(:file) { Tempfile.new("test") }
 
-  before(:each) do
+  before do
     file.write <<~EOS
       a
       b
@@ -224,7 +224,7 @@ describe Utils::Inreplace do
     EOS
   end
 
-  after(:each) { file.unlink }
+  after { file.unlink }
 
   it "raises error if there is nothing to replace" do
     expect {

--- a/Library/Homebrew/test/java_requirement_spec.rb
+++ b/Library/Homebrew/test/java_requirement_spec.rb
@@ -3,7 +3,7 @@ require "requirements/java_requirement"
 describe JavaRequirement do
   subject { described_class.new([]) }
 
-  before(:each) do
+  before do
     ENV["JAVA_HOME"] = nil
   end
 
@@ -13,6 +13,7 @@ describe JavaRequirement do
 
   describe "#inspect" do
     subject { described_class.new(%w[1.7+]) }
+
     its(:inspect) { is_expected.to eq('#<JavaRequirement: "java" [] version="1.7+">') }
   end
 
@@ -23,11 +24,13 @@ describe JavaRequirement do
 
     context "with version 1.8" do
       subject { described_class.new(%w[1.8]) }
+
       its(:display_s) { is_expected.to eq("java = 1.8") }
     end
 
     context "with version 1.8+" do
       subject { described_class.new(%w[1.8+]) }
+
       its(:display_s) { is_expected.to eq("java >= 1.8") }
     end
   end
@@ -57,7 +60,7 @@ describe JavaRequirement do
         FileUtils.chmod "+x", java
       end
 
-      before(:each) do
+      before do
         allow(subject).to receive(:possible_javas).and_return([java])
       end
 

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -17,7 +17,7 @@ describe Keg do
     keg
   end
 
-  around(:each) do |example|
+  around do |example|
     begin
       @old_stdout = $stdout
       $stdout = StringIO.new
@@ -34,12 +34,12 @@ describe Keg do
   let!(:keg) { setup_test_keg("foo", "1.0") }
   let(:kegs) { [] }
 
-  before(:each) do
+  before do
     (HOMEBREW_PREFIX/"bin").mkpath
     (HOMEBREW_PREFIX/"lib").mkpath
   end
 
-  after(:each) do
+  after do
     kegs.each(&:unlink)
     rmtree HOMEBREW_PREFIX/"lib"
   end
@@ -345,7 +345,7 @@ describe Keg do
       keg
     end
 
-    before(:each) do
+    before do
       keg.link
     end
 

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -26,19 +26,19 @@ describe Language::Node do
     npm_pack_cmd = "npm pack --ignore-scripts"
 
     it "raises error with non zero exitstatus" do
-      allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `false` }
+      allow(Utils).to receive(:popen_read).with(npm_pack_cmd).and_return(`false`)
       expect { subject.std_npm_install_args(npm_install_arg) }.to \
         raise_error("npm failed to pack #{Dir.pwd}")
     end
 
     it "raises error with empty npm pack output" do
-      allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `true` }
+      allow(Utils).to receive(:popen_read).with(npm_pack_cmd).and_return(`true`)
       expect { subject.std_npm_install_args(npm_install_arg) }.to \
         raise_error("npm failed to pack #{Dir.pwd}")
     end
 
     it "does not raise error with a zero exitstatus" do
-      allow(Utils).to receive(:popen_read).with(npm_pack_cmd) { `echo pack.tgz` }
+      allow(Utils).to receive(:popen_read).with(npm_pack_cmd).and_return(`echo pack.tgz`)
       resp = subject.std_npm_install_args(npm_install_arg)
       expect(resp).to include("--prefix=#{npm_install_arg}", "#{Dir.pwd}/pack.tgz")
     end

--- a/Library/Homebrew/test/language_module_requirement_spec.rb
+++ b/Library/Homebrew/test/language_module_requirement_spec.rb
@@ -10,6 +10,7 @@ describe LanguageModuleRequirement, :needs_compat do
 
   context "when module and import name differ" do
     subject { described_class.new(:python, mod_name, import_name) }
+
     let(:mod_name) { "foo" }
     let(:import_name) { "bar" }
 

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -60,11 +60,11 @@ describe Locale do
     end
 
     context "only some parts match" do
-      it { is_expected.to_not eql("zh") }
-      it { is_expected.to_not eql("zh-CN") }
-      it { is_expected.to_not eql("CN") }
-      it { is_expected.to_not eql("CN-Hans") }
-      it { is_expected.to_not eql("Hans") }
+      it { is_expected.not_to eql("zh") }
+      it { is_expected.not_to eql("zh-CN") }
+      it { is_expected.not_to eql("CN") }
+      it { is_expected.not_to eql("CN-Hans") }
+      it { is_expected.not_to eql("Hans") }
     end
 
     it "does not raise if 'other' cannot be parsed" do

--- a/Library/Homebrew/test/migrator_spec.rb
+++ b/Library/Homebrew/test/migrator_spec.rb
@@ -17,7 +17,7 @@ describe Migrator do
   let(:keg) { Keg.new(old_keg_record) }
   let(:old_pin) { HOMEBREW_PINNED_KEGS/"oldname" }
 
-  before(:each) do |example|
+  before do |example|
     allow(new_formula).to receive(:oldname).and_return("oldname")
 
     # do not create directories for error tests
@@ -43,7 +43,7 @@ describe Migrator do
     (HOMEBREW_PREFIX/"bin").mkpath
   end
 
-  after(:each) do
+  after do
     keg.unlink if !old_keg_record.parent.symlink? && old_keg_record.directory?
 
     if new_keg_record.directory?
@@ -210,14 +210,14 @@ describe Migrator do
     tab.tabfile = HOMEBREW_CELLAR/"oldname/0.1/INSTALL_RECEIPT.json"
     tab.source["path"] = "/should/be/the/same"
     tab.write
-    migrator = Migrator.new(new_formula)
+    migrator = described_class.new(new_formula)
     tab.tabfile.delete
     migrator.backup_old_tabs
     expect(Tab.for_keg(old_keg_record).source["path"]).to eq("/should/be/the/same")
   end
 
   describe "#backup_oldname" do
-    after(:each) do
+    after do
       expect(old_keg_record.parent).to be_a_directory
       expect(old_keg_record.parent.subdirs).not_to be_empty
       expect(HOMEBREW_LINKED_KEGS/"oldname").to exist

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -9,7 +9,9 @@ describe Homebrew::MissingFormula do
 
   context "::blacklisted_reason" do
     matcher(:be_blacklisted) do
-      match(&described_class.method(:blacklisted_reason))
+      match do |expected|
+        described_class.blacklisted_reason(expected)
+      end
     end
 
     context "rubygems" do

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -4,12 +4,12 @@ describe Homebrew::MissingFormula do
   context "::reason" do
     subject { described_class.reason("gem") }
 
-    it { is_expected.to_not be_nil }
+    it { is_expected.not_to be_nil }
   end
 
   context "::blacklisted_reason" do
     matcher(:be_blacklisted) do
-      match(&Homebrew::MissingFormula.method(:blacklisted_reason))
+      match(&described_class.method(:blacklisted_reason))
     end
 
     context "rubygems" do
@@ -123,11 +123,13 @@ describe Homebrew::MissingFormula do
 
     context "with a migrated formula" do
       let(:formula) { "migrated-formula" }
-      it { is_expected.to_not be_nil }
+
+      it { is_expected.not_to be_nil }
     end
 
     context "with a missing formula" do
       let(:formula) { "missing-formula" }
+
       it { is_expected.to be_nil }
     end
   end
@@ -154,11 +156,13 @@ describe Homebrew::MissingFormula do
 
     context "with a deleted formula" do
       let(:formula) { "homebrew/foo/deleted-formula" }
-      it { is_expected.to_not be_nil }
+
+      it { is_expected.not_to be_nil }
     end
 
     context "with a formula that never existed" do
       let(:formula) { "homebrew/foo/missing-formula" }
+
       it { is_expected.to be_nil }
     end
   end

--- a/Library/Homebrew/test/mpi_requirement_spec.rb
+++ b/Library/Homebrew/test/mpi_requirement_spec.rb
@@ -3,6 +3,7 @@ require "compat/requirements"
 describe MPIRequirement, :needs_compat do
   describe "::new" do
     subject { described_class.new(wrappers + tags) }
+
     let(:wrappers) { [:cc, :cxx, :f77] }
     let(:tags) { [:optional, "some-other-tag"] }
 

--- a/Library/Homebrew/test/options_spec.rb
+++ b/Library/Homebrew/test/options_spec.rb
@@ -8,8 +8,8 @@ describe Option do
   end
 
   specify "equality" do
-    foo = Option.new("foo")
-    bar = Option.new("bar")
+    foo = described_class.new("foo")
+    bar = described_class.new("bar")
     expect(subject).to eq(foo)
     expect(subject).not_to eq(bar)
     expect(subject).to eql(foo)
@@ -18,7 +18,7 @@ describe Option do
 
   specify "#description" do
     expect(subject.description).to be_empty
-    expect(Option.new("foo", "foo").description).to eq("foo")
+    expect(described_class.new("foo", "foo").description).to eq("foo")
   end
 
   specify "#inspect" do
@@ -46,8 +46,8 @@ describe DeprecatedOption do
   end
 
   specify "equality" do
-    foobar = DeprecatedOption.new("foo", "bar")
-    boofar = DeprecatedOption.new("boo", "far")
+    foobar = described_class.new("foo", "bar")
+    boofar = described_class.new("boo", "far")
     expect(foobar).to eq(subject)
     expect(subject).to eq(foobar)
     expect(boofar).not_to eq(subject)
@@ -81,26 +81,26 @@ describe Options do
 
   describe "#+" do
     it "returns options" do
-      expect(subject + Options.new).to be_an_instance_of(Options)
+      expect(subject + described_class.new).to be_an_instance_of(described_class)
     end
   end
 
   describe "#-" do
     it "returns options" do
-      expect(subject - Options.new).to be_an_instance_of(Options)
+      expect(subject - described_class.new).to be_an_instance_of(described_class)
     end
   end
 
   specify "#&" do
     foo, bar, baz = %w[foo bar baz].map { |o| Option.new(o) }
-    options = Options.new << foo << bar
+    options = described_class.new << foo << bar
     subject << foo << baz
     expect((subject & options).to_a).to eq([foo])
   end
 
   specify "#|" do
     foo, bar, baz = %w[foo bar baz].map { |o| Option.new(o) }
-    options = Options.new << foo << bar
+    options = described_class.new << foo << bar
     subject << foo << baz
     expect((subject | options).sort).to eq([foo, bar, baz].sort)
   end
@@ -137,7 +137,7 @@ describe Options do
     array = %w[--foo --bar]
     option1 = Option.new("foo")
     option2 = Option.new("bar")
-    expect(Options.create(array).sort).to eq([option1, option2].sort)
+    expect(described_class.create(array).sort).to eq([option1, option2].sort)
   end
 
   specify "#inspect" do

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -3,7 +3,7 @@ require "dependency_collector"
 describe DependencyCollector do
   alias_matcher :be_a_build_requirement, :be_build
 
-  after(:each) do
+  after do
     described_class.clear_cache
   end
 

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -3,7 +3,7 @@ require "dependency_collector"
 describe DependencyCollector do
   alias_matcher :need_tar_xz_dependency, :be_tar_needs_xz_dependency
 
-  after(:each) do
+  after do
     described_class.clear_cache
   end
 

--- a/Library/Homebrew/test/os/mac/hardware_spec.rb
+++ b/Library/Homebrew/test/os/mac/hardware_spec.rb
@@ -4,53 +4,53 @@ require "extend/os/mac/hardware/cpu"
 describe Hardware::CPU do
   describe "::can_run?" do
     it "reports that Intel Macs can run Intel executables" do
-      allow(Hardware::CPU).to receive(:type).and_return :intel
-      allow(Hardware::CPU).to receive(:bits).and_return 64
-      expect(Hardware::CPU.can_run?(:i386)).to be true
-      expect(Hardware::CPU.can_run?(:x86_64)).to be true
+      allow(described_class).to receive(:type).and_return :intel
+      allow(described_class).to receive(:bits).and_return 64
+      expect(described_class.can_run?(:i386)).to be true
+      expect(described_class.can_run?(:x86_64)).to be true
     end
 
     it "reports that PowerPC Macs can run PowerPC executables" do
-      allow(Hardware::CPU).to receive(:type).and_return :ppc
-      allow(Hardware::CPU).to receive(:bits).and_return 64
-      expect(Hardware::CPU.can_run?(:ppc)).to be true
-      expect(Hardware::CPU.can_run?(:ppc64)).to be true
+      allow(described_class).to receive(:type).and_return :ppc
+      allow(described_class).to receive(:bits).and_return 64
+      expect(described_class.can_run?(:ppc)).to be true
+      expect(described_class.can_run?(:ppc64)).to be true
     end
 
     it "reports that 32-bit Intel Macs can't run x86_64 executables" do
-      allow(Hardware::CPU).to receive(:type).and_return :intel
-      allow(Hardware::CPU).to receive(:bits).and_return 32
-      expect(Hardware::CPU.can_run?(:x86_64)).to be false
+      allow(described_class).to receive(:type).and_return :intel
+      allow(described_class).to receive(:bits).and_return 32
+      expect(described_class.can_run?(:x86_64)).to be false
     end
 
     it "reports that 32-bit PowerPC Macs can't run ppc64 executables" do
-      allow(Hardware::CPU).to receive(:type).and_return :ppc
-      allow(Hardware::CPU).to receive(:bits).and_return 32
-      expect(Hardware::CPU.can_run?(:ppc64)).to be false
+      allow(described_class).to receive(:type).and_return :ppc
+      allow(described_class).to receive(:bits).and_return 32
+      expect(described_class.can_run?(:ppc64)).to be false
     end
 
     it "reports that Intel Macs can only run 32-bit PowerPC executables on 10.6 and older" do
-      allow(Hardware::CPU).to receive(:type).and_return :intel
+      allow(described_class).to receive(:type).and_return :intel
       allow(OS::Mac).to receive(:version).and_return OS::Mac::Version.new "10.6"
-      expect(Hardware::CPU.can_run?(:ppc)).to be true
+      expect(described_class.can_run?(:ppc)).to be true
 
       allow(OS::Mac).to receive(:version).and_return OS::Mac::Version.new "10.7"
-      expect(Hardware::CPU.can_run?(:ppc)).to be false
+      expect(described_class.can_run?(:ppc)).to be false
     end
 
     it "reports that PowerPC Macs can't run Intel executables" do
-      allow(Hardware::CPU).to receive(:type).and_return :ppc
-      expect(Hardware::CPU.can_run?(:i386)).to be false
-      expect(Hardware::CPU.can_run?(:x86_64)).to be false
+      allow(described_class).to receive(:type).and_return :ppc
+      expect(described_class.can_run?(:i386)).to be false
+      expect(described_class.can_run?(:x86_64)).to be false
     end
 
     it "returns false for unknown CPU types" do
-      allow(Hardware::CPU).to receive(:type).and_return :dunno
-      expect(Hardware::CPU.can_run?(:i386)).to be false
+      allow(described_class).to receive(:type).and_return :dunno
+      expect(described_class.can_run?(:i386)).to be false
     end
 
     it "returns false for unknown arches" do
-      expect(Hardware::CPU.can_run?(:blah)).to be false
+      expect(described_class.can_run?(:blah)).to be false
     end
   end
 end

--- a/Library/Homebrew/test/os/mac/java_requirement_spec.rb
+++ b/Library/Homebrew/test/os/mac/java_requirement_spec.rb
@@ -3,9 +3,10 @@ require "fileutils"
 
 describe JavaRequirement do
   subject { described_class.new(%w[1.8]) }
+
   let(:java_home) { mktmpdir }
 
-  before(:each) do
+  before do
     FileUtils.mkdir java_home/"bin"
     FileUtils.touch java_home/"bin/java"
     allow(subject).to receive(:preferred_java).and_return(java_home/"bin/java")

--- a/Library/Homebrew/test/os/mac/keg_spec.rb
+++ b/Library/Homebrew/test/os/mac/keg_spec.rb
@@ -8,9 +8,9 @@ describe Keg do
   describe "#mach_o_files" do
     let(:keg_path) { HOMEBREW_CELLAR/"a/1.0" }
 
-    before(:each) { (keg_path/"lib").mkpath }
+    before { (keg_path/"lib").mkpath }
 
-    after(:each) { subject.unlink }
+    after { subject.unlink }
 
     it "skips hardlinks" do
       cp dylib_path("i386"), keg_path/"lib/i386.dylib"

--- a/Library/Homebrew/test/os/mac/mach_spec.rb
+++ b/Library/Homebrew/test/os/mac/mach_spec.rb
@@ -152,7 +152,7 @@ end
 describe "text executables" do
   let(:pn) { HOMEBREW_PREFIX/"an_executable" }
 
-  after(:each) { pn.unlink }
+  after { pn.unlink }
 
   specify "simple shebang" do
     pn.write "#!/bin/sh"

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -4,6 +4,7 @@ describe Patch do
   describe "#create" do
     context "simple patch" do
       subject { described_class.create(:p2, nil) }
+
       it { is_expected.to be_kind_of ExternalPatch }
       it { is_expected.to be_external }
       its(:strip) { is_expected.to eq(:p2) }
@@ -11,24 +12,28 @@ describe Patch do
 
     context "string patch" do
       subject { described_class.create(:p0, "foo") }
+
       it { is_expected.to be_kind_of StringPatch }
       its(:strip) { is_expected.to eq(:p0) }
     end
 
     context "string patch without strip" do
       subject { described_class.create("foo", nil) }
+
       it { is_expected.to be_kind_of StringPatch }
       its(:strip) { is_expected.to eq(:p1) }
     end
 
     context "data patch" do
       subject { described_class.create(:p0, :DATA) }
+
       it { is_expected.to be_kind_of DATAPatch }
       its(:strip) { is_expected.to eq(:p0) }
     end
 
     context "data patch without strip" do
       subject { described_class.create(:DATA, nil) }
+
       it { is_expected.to be_kind_of DATAPatch }
       its(:strip) { is_expected.to eq(:p1) }
     end
@@ -86,7 +91,7 @@ describe Patch do
     end
 
     it "can create patches from a :p0 hash" do
-      patches = Patch.normalize_legacy_patches(
+      patches = described_class.normalize_legacy_patches(
         p0: "http://example.com/patch.diff",
       )
 
@@ -95,7 +100,7 @@ describe Patch do
     end
 
     it "can create patches from a :p1 hash" do
-      patches = Patch.normalize_legacy_patches(
+      patches = described_class.normalize_legacy_patches(
         p1: "http://example.com/patch.diff",
       )
 
@@ -104,7 +109,7 @@ describe Patch do
     end
 
     it "can create patches from a mixed hash" do
-      patches = Patch.normalize_legacy_patches(
+      patches = described_class.normalize_legacy_patches(
         p1: "http://example.com/patch1.diff",
         p0: "http://example.com/patch0.diff",
       )
@@ -115,7 +120,7 @@ describe Patch do
     end
 
     it "can create patches from a mixed hash with array" do
-      patches = Patch.normalize_legacy_patches(
+      patches = described_class.normalize_legacy_patches(
         p1: [
           "http://example.com/patch10.diff",
           "http://example.com/patch11.diff",
@@ -132,7 +137,7 @@ describe Patch do
     end
 
     it "returns an empty array if given nil" do
-      expect(Patch.normalize_legacy_patches(nil)).to be_empty
+      expect(described_class.normalize_legacy_patches(nil)).to be_empty
     end
   end
 end
@@ -140,6 +145,7 @@ end
 describe EmbeddedPatch do
   describe "#new" do
     subject { described_class.new(:p1) }
+
     its(:inspect) { is_expected.to eq("#<EmbeddedPatch: :p1>") }
   end
 end
@@ -156,7 +162,7 @@ describe ExternalPatch do
   end
 
   describe "#cached_download" do
-    before(:each) do
+    before do
       allow(subject.resource).to receive(:cached_download).and_return("/tmp/foo.tar.gz")
     end
 

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -11,7 +11,7 @@ describe Pathname do
   let(:dir) { src/"bar" }
 
   describe DiskUsageExtension do
-    before(:each) do
+    before do
       mkdir_p dir/"a-directory"
       touch [dir/".DS_Store", dir/"a-file"]
       File.truncate(dir/"a-file", 1_048_576)
@@ -41,7 +41,7 @@ describe Pathname do
   end
 
   describe "#rmdir_if_possible" do
-    before(:each) { mkdir_p dir }
+    before { mkdir_p dir }
 
     it "returns true and removes a directory if it doesn't contain files" do
       expect(dir.rmdir_if_possible).to be true
@@ -131,8 +131,8 @@ describe Pathname do
 
   describe "#extname" do
     it "supports common multi-level archives" do
-      expect(Pathname.new("foo-0.1.tar.gz").extname).to eq(".tar.gz")
-      expect(Pathname.new("foo-0.1.cpio.gz").extname).to eq(".cpio.gz")
+      expect(described_class.new("foo-0.1.tar.gz").extname).to eq(".tar.gz")
+      expect(described_class.new("foo-0.1.cpio.gz").extname).to eq(".cpio.gz")
     end
   end
 
@@ -144,7 +144,7 @@ describe Pathname do
   end
 
   describe "#install" do
-    before(:each) do
+    before do
       (src/"a.txt").write "This is sample file a."
       (src/"b.txt").write "This is sample file b."
     end
@@ -233,12 +233,12 @@ describe Pathname do
 
     it "can install relative paths as symlinks" do
       dst.install_symlink "foo" => "bar"
-      expect((dst/"bar").readlink).to eq(Pathname.new("foo"))
+      expect((dst/"bar").readlink).to eq(described_class.new("foo"))
     end
   end
 
   describe InstallRenamed do
-    before(:each) do
+    before do
       dst.extend(InstallRenamed)
     end
 

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -160,11 +160,11 @@ describe Requirement do
     let(:const) { :FooRequirement }
     let(:klass) { self.class.const_get(const) }
 
-    before(:each) do
+    before do
       self.class.const_set(const, Class.new(described_class))
     end
 
-    after(:each) do
+    after do
       self.class.send(:remove_const, const)
     end
 

--- a/Library/Homebrew/test/sandbox_spec.rb
+++ b/Library/Homebrew/test/sandbox_spec.rb
@@ -6,7 +6,7 @@ describe Sandbox do
   let(:dir) { mktmpdir }
   let(:file) { dir/"foo" }
 
-  before(:each) do
+  before do
     skip "Sandbox not implemented." unless described_class.available?
   end
 

--- a/Library/Homebrew/test/string_spec.rb
+++ b/Library/Homebrew/test/string_spec.rb
@@ -2,6 +2,7 @@ require "extend/string"
 
 describe StringInreplaceExtension do
   subject { string.extend(described_class) }
+
   let(:string) { "foobar" }
 
   describe "#sub!" do

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -14,13 +14,13 @@ HOMEBREW_CASK_DIRS = {
 }.freeze
 
 RSpec.shared_context "Homebrew-Cask" do
-  before(:each) do
+  before do
     HOMEBREW_CASK_DIRS.each do |method, path|
       allow(Hbc::Config.global).to receive(method).and_return(path)
     end
   end
 
-  around(:each) do |example|
+  around do |example|
     third_party_tap = Tap.fetch("third-party", "tap")
     begin
       HOMEBREW_CASK_DIRS.values.each(&:mkpath)

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -36,7 +36,7 @@ RSpec.shared_context "integration test" do
     end
   end
 
-  around(:each) do |example|
+  around do |example|
     begin
       (HOMEBREW_PREFIX/"bin").mkpath
       FileUtils.touch HOMEBREW_PREFIX/"bin/brew"

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/hbc_staged.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/hbc_staged.rb
@@ -4,7 +4,7 @@ shared_examples Hbc::Staged do
   let(:existing_path) { Pathname.new("/path/to/file/that/exists") }
   let(:non_existent_path) { Pathname.new("/path/to/file/that/does/not/exist") }
 
-  before(:each) do
+  before do
     allow(existing_path).to receive(:exist?).and_return(true)
     allow(existing_path).to receive(:expand_path)
       .and_return(existing_path)

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -42,6 +42,7 @@ describe Tab do
       },
     )
   }
+
   let(:time) { Time.now.to_i }
   let(:unused_options) { Options.create(%w[--with-baz --without-qux]) }
   let(:used_options) { Options.create(%w[--with-foo --without-bar]) }

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -3,6 +3,7 @@ describe Tap do
   alias_matcher :have_custom_remote, :be_custom_remote
 
   subject { described_class.new("Homebrew", "foo") }
+
   let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-foo" }
   let(:formula_file) { path/"Formula/foo.rb" }
   let(:alias_file) { path/"Aliases/bar" }
@@ -12,7 +13,7 @@ describe Tap do
   let(:zsh_completion_file) { path/"completions/zsh/_brew-tap-cmd" }
   let(:fish_completion_file) { path/"completions/fish/brew-tap-cmd.fish" }
 
-  before(:each) do
+  before do
     path.mkpath
   end
 
@@ -62,7 +63,7 @@ describe Tap do
       expect(described_class.fetch("Homebrew", "core")).to be_kind_of(CoreTap)
       expect(described_class.fetch("Homebrew", "homebrew")).to be_kind_of(CoreTap)
       tap = described_class.fetch("Homebrew", "foo")
-      expect(tap).to be_kind_of(Tap)
+      expect(tap).to be_kind_of(described_class)
       expect(tap.name).to eq("homebrew/foo")
 
       expect {
@@ -232,7 +233,7 @@ describe Tap do
       setup_tap_files
       setup_git_repo
 
-      tap = Tap.new("Homebrew", "bar")
+      tap = described_class.new("Homebrew", "bar")
 
       tap.install clone_target: subject.path/".git"
 
@@ -259,7 +260,7 @@ describe Tap do
     begin
       setup_tap_files
       setup_git_repo
-      tap = Tap.new("Homebrew", "baz")
+      tap = described_class.new("Homebrew", "baz")
       tap.install clone_target: subject.path/".git"
       (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
       (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -4,7 +4,7 @@ require "formula_installer"
 describe Utils::Analytics do
   describe "::os_prefix_ci" do
     context "when os_prefix_ci is not set" do
-      before(:each) do
+      before do
         described_class.clear_os_prefix_ci
       end
 

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -1,7 +1,7 @@
 require "utils/git"
 
 describe Git do
-  before(:each) do
+  before do
     git = HOMEBREW_SHIMS_PATH/"scm/git"
 
     HOMEBREW_CACHE.cd do
@@ -57,18 +57,18 @@ describe Git do
 end
 
 describe Utils do
-  before(:each) do
+  before do
     described_class.clear_git_available_cache
   end
 
   describe "::git_available?" do
     it "returns true if git --version command succeeds" do
-      expect(described_class.git_available?).to be_truthy
+      expect(described_class).to be_git_available
     end
 
     it "returns false if git --version command does not succeed" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class.git_available?).to be_falsey
+      expect(described_class).not_to be_git_available
     end
   end
 
@@ -124,7 +124,7 @@ describe Utils do
   describe "::git_remote_exists?" do
     it "returns true when git is not available" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class.git_remote_exists?("blah")).to be_truthy
+      expect(described_class).to be_git_remote_exists("blah")
     end
 
     context "when git is available" do
@@ -139,11 +139,11 @@ describe Utils do
           system git, "remote", "add", "origin", url
         end
 
-        expect(described_class.git_remote_exists?(url)).to be_truthy
+        expect(described_class).to be_git_remote_exists(url)
       end
 
       it "returns false when git remote does not exist" do
-        expect(described_class.git_remote_exists?("blah")).to be_falsey
+        expect(described_class).not_to be_git_remote_exists("blah")
       end
     end
   end

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -2,32 +2,32 @@ require "utils/svn"
 
 describe Utils do
   describe "#self.svn_available?" do
-    before(:each) do
+    before do
       described_class.clear_svn_version_cache
     end
 
     it "returns svn version if svn available" do
       if File.executable? "/usr/bin/svn"
-        expect(described_class.svn_available?).to be_truthy
+        expect(described_class).to be_svn_available
       else
-        expect(described_class.svn_available?).to be_falsey
+        expect(described_class).not_to be_svn_available
       end
     end
   end
 
   describe "#self.svn_remote_exists?" do
     it "returns true when svn is not available" do
-      allow(Utils).to receive(:svn_available?).and_return(false)
-      expect(described_class.svn_remote_exists?("blah")).to be_truthy
+      allow(described_class).to receive(:svn_available?).and_return(false)
+      expect(described_class).to be_svn_remote_exists("blah")
     end
 
     context "when svn is available" do
       before do
-        allow(Utils).to receive(:svn_available?).and_return(true)
+        allow(described_class).to receive(:svn_available?).and_return(true)
       end
 
       it "returns false when remote does not exist" do
-        expect(described_class.svn_remote_exists?(HOMEBREW_CACHE/"install")).to be_falsey
+        expect(described_class).not_to be_svn_remote_exists(HOMEBREW_CACHE/"install")
       end
 
       it "returns true when remote exists", :needs_network, :needs_svn do
@@ -36,7 +36,7 @@ describe Utils do
 
         HOMEBREW_CACHE.cd { system svn, "checkout", remote }
 
-        expect(described_class.svn_remote_exists?(HOMEBREW_CACHE/"install")).to be_truthy
+        expect(described_class).to be_svn_remote_exists(HOMEBREW_CACHE/"install")
       end
     end
   end

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -32,7 +32,7 @@ describe Tty do
   end
 
   context "when $stdout is not a TTY" do
-    before(:each) do
+    before do
       allow($stdout).to receive(:tty?).and_return(false)
     end
 
@@ -49,7 +49,7 @@ describe Tty do
   end
 
   context "when $stdout is a TTY" do
-    before(:each) do
+    before do
       allow($stdout).to receive(:tty?).and_return(true)
     end
 

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -30,10 +30,10 @@ describe "globally-scoped helper methods" do
     subject { pretty_installed("foo") }
 
     context "when $stdout is a TTY" do
-      before(:each) { allow($stdout).to receive(:tty?).and_return(true) }
+      before { allow($stdout).to receive(:tty?).and_return(true) }
 
       context "with HOMEBREW_NO_EMOJI unset" do
-        before(:each) { ENV.delete("HOMEBREW_NO_EMOJI") }
+        before { ENV.delete("HOMEBREW_NO_EMOJI") }
 
         it "returns a string with a colored checkmark" do
           expect(subject)
@@ -42,7 +42,7 @@ describe "globally-scoped helper methods" do
       end
 
       context "with HOMEBREW_NO_EMOJI set" do
-        before(:each) { ENV["HOMEBREW_NO_EMOJI"] = "1" }
+        before { ENV["HOMEBREW_NO_EMOJI"] = "1" }
 
         it "returns a string with colored info" do
           expect(subject)
@@ -52,7 +52,7 @@ describe "globally-scoped helper methods" do
     end
 
     context "when $stdout is not a TTY" do
-      before(:each) { allow($stdout).to receive(:tty?).and_return(false) }
+      before { allow($stdout).to receive(:tty?).and_return(false) }
 
       it "returns plain text" do
         expect(subject).to eq("foo")
@@ -64,10 +64,10 @@ describe "globally-scoped helper methods" do
     subject { pretty_uninstalled("foo") }
 
     context "when $stdout is a TTY" do
-      before(:each) { allow($stdout).to receive(:tty?).and_return(true) }
+      before { allow($stdout).to receive(:tty?).and_return(true) }
 
       context "with HOMEBREW_NO_EMOJI unset" do
-        before(:each) { ENV.delete("HOMEBREW_NO_EMOJI") }
+        before { ENV.delete("HOMEBREW_NO_EMOJI") }
 
         it "returns a string with a colored checkmark" do
           expect(subject)
@@ -76,7 +76,7 @@ describe "globally-scoped helper methods" do
       end
 
       context "with HOMEBREW_NO_EMOJI set" do
-        before(:each) { ENV["HOMEBREW_NO_EMOJI"] = "1" }
+        before { ENV["HOMEBREW_NO_EMOJI"] = "1" }
 
         it "returns a string with colored info" do
           expect(subject)
@@ -86,7 +86,7 @@ describe "globally-scoped helper methods" do
     end
 
     context "when $stdout is not a TTY" do
-      before(:each) { allow($stdout).to receive(:tty?).and_return(false) }
+      before { allow($stdout).to receive(:tty?).and_return(false) }
 
       it "returns plain text" do
         expect(subject).to eq("foo")
@@ -139,7 +139,7 @@ describe "globally-scoped helper methods" do
   describe "#which" do
     let(:cmd) { dir/"foo" }
 
-    before(:each) { FileUtils.touch cmd }
+    before { FileUtils.touch cmd }
 
     it "returns the first executable that is found" do
       cmd.chmod 0744
@@ -166,7 +166,7 @@ describe "globally-scoped helper methods" do
     let(:cmd2) { dir/"bar/foo" }
     let(:cmd3) { dir/"bar/baz/foo" }
 
-    before(:each) do
+    before do
       (dir/"bar/baz").mkpath
 
       FileUtils.touch cmd2

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -241,10 +241,9 @@ describe Version do
 
   describe "::detect" do
     matcher :be_detected_from do |url, specs = {}|
-      detected = described_class.detect(url, specs)
-
       match do |expected|
-        detected == expected
+        @detected = described_class.detect(url, specs)
+        @detected == expected
       end
 
       failure_message do |expected|
@@ -252,7 +251,7 @@ describe Version do
           expected: %s
           detected: %s
         EOS
-        format(message, expected, detected)
+        format(message, expected, @detected)
       end
     end
 

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -2,34 +2,34 @@ require "version"
 
 describe Version::Token do
   specify "#inspect" do
-    expect(Version::Token.new("foo").inspect).to eq('#<Version::Token "foo">')
+    expect(described_class.new("foo").inspect).to eq('#<Version::Token "foo">')
   end
 
   specify "#to_s" do
-    expect(Version::Token.new("foo").to_s).to eq("foo")
+    expect(described_class.new("foo").to_s).to eq("foo")
   end
 end
 
 describe Version::NULL do
   it "is always smaller" do
-    expect(Version::NULL).to be < Version.create("1")
+    expect(described_class).to be < Version.create("1")
   end
 
   it "is never greater" do
-    expect(Version::NULL).not_to be > Version.create("0")
+    expect(described_class).not_to be > Version.create("0")
   end
 
   it "isn't equal to itself" do
-    expect(Version::NULL).not_to eql(Version::NULL)
+    expect(described_class).not_to eql(described_class)
   end
 
   it "creates an empty string" do
-    expect(Version::NULL.to_s).to eq("")
+    expect(described_class.to_s).to eq("")
   end
 
   it "produces NaN as a Float" do
     # Float::NAN is not equal to itself so compare object IDs
-    expect(Version::NULL.to_f.object_id).to eql(Float::NAN.object_id)
+    expect(described_class.to_f.object_id).to eql(Float::NAN.object_id)
   end
 end
 
@@ -45,112 +45,112 @@ end
 
 describe Version do
   specify "comparison" do
-    expect(Version.create("0.1")).to be == Version.create("0.1.0")
-    expect(Version.create("0.1")).to be < Version.create("0.2")
-    expect(Version.create("1.2.3")).to be > Version.create("1.2.2")
-    expect(Version.create("1.2.4")).to be < Version.create("1.2.4.1")
+    expect(described_class.create("0.1")).to be == described_class.create("0.1.0")
+    expect(described_class.create("0.1")).to be < described_class.create("0.2")
+    expect(described_class.create("1.2.3")).to be > described_class.create("1.2.2")
+    expect(described_class.create("1.2.4")).to be < described_class.create("1.2.4.1")
 
-    expect(Version.create("1.2.3")).to be > Version.create("1.2.3alpha4")
-    expect(Version.create("1.2.3")).to be > Version.create("1.2.3beta2")
-    expect(Version.create("1.2.3")).to be > Version.create("1.2.3rc3")
-    expect(Version.create("1.2.3")).to be < Version.create("1.2.3-p34")
+    expect(described_class.create("1.2.3")).to be > described_class.create("1.2.3alpha4")
+    expect(described_class.create("1.2.3")).to be > described_class.create("1.2.3beta2")
+    expect(described_class.create("1.2.3")).to be > described_class.create("1.2.3rc3")
+    expect(described_class.create("1.2.3")).to be < described_class.create("1.2.3-p34")
   end
 
   specify "HEAD" do
-    expect(Version.create("HEAD")).to be > Version.create("1.2.3")
-    expect(Version.create("HEAD-abcdef")).to be > Version.create("1.2.3")
-    expect(Version.create("1.2.3")).to be < Version.create("HEAD")
-    expect(Version.create("1.2.3")).to be < Version.create("HEAD-fedcba")
-    expect(Version.create("HEAD-abcdef")).to be == Version.create("HEAD-fedcba")
-    expect(Version.create("HEAD")).to be == Version.create("HEAD-fedcba")
+    expect(described_class.create("HEAD")).to be > described_class.create("1.2.3")
+    expect(described_class.create("HEAD-abcdef")).to be > described_class.create("1.2.3")
+    expect(described_class.create("1.2.3")).to be < described_class.create("HEAD")
+    expect(described_class.create("1.2.3")).to be < described_class.create("HEAD-fedcba")
+    expect(described_class.create("HEAD-abcdef")).to be == described_class.create("HEAD-fedcba")
+    expect(described_class.create("HEAD")).to be == described_class.create("HEAD-fedcba")
   end
 
   specify "comparing alpha versions" do
-    expect(Version.create("1.2.3alpha")).to be < Version.create("1.2.3")
-    expect(Version.create("1.2.3")).to be < Version.create("1.2.3a")
-    expect(Version.create("1.2.3alpha4")).to be == Version.create("1.2.3a4")
-    expect(Version.create("1.2.3alpha4")).to be == Version.create("1.2.3A4")
-    expect(Version.create("1.2.3alpha4")).to be > Version.create("1.2.3alpha3")
-    expect(Version.create("1.2.3alpha4")).to be < Version.create("1.2.3alpha5")
-    expect(Version.create("1.2.3alpha4")).to be < Version.create("1.2.3alpha10")
+    expect(described_class.create("1.2.3alpha")).to be < described_class.create("1.2.3")
+    expect(described_class.create("1.2.3")).to be < described_class.create("1.2.3a")
+    expect(described_class.create("1.2.3alpha4")).to be == described_class.create("1.2.3a4")
+    expect(described_class.create("1.2.3alpha4")).to be == described_class.create("1.2.3A4")
+    expect(described_class.create("1.2.3alpha4")).to be > described_class.create("1.2.3alpha3")
+    expect(described_class.create("1.2.3alpha4")).to be < described_class.create("1.2.3alpha5")
+    expect(described_class.create("1.2.3alpha4")).to be < described_class.create("1.2.3alpha10")
 
-    expect(Version.create("1.2.3alpha4")).to be < Version.create("1.2.3beta2")
-    expect(Version.create("1.2.3alpha4")).to be < Version.create("1.2.3rc3")
-    expect(Version.create("1.2.3alpha4")).to be < Version.create("1.2.3")
-    expect(Version.create("1.2.3alpha4")).to be < Version.create("1.2.3-p34")
+    expect(described_class.create("1.2.3alpha4")).to be < described_class.create("1.2.3beta2")
+    expect(described_class.create("1.2.3alpha4")).to be < described_class.create("1.2.3rc3")
+    expect(described_class.create("1.2.3alpha4")).to be < described_class.create("1.2.3")
+    expect(described_class.create("1.2.3alpha4")).to be < described_class.create("1.2.3-p34")
   end
 
   specify "comparing beta versions" do
-    expect(Version.create("1.2.3beta2")).to be == Version.create("1.2.3b2")
-    expect(Version.create("1.2.3beta2")).to be == Version.create("1.2.3B2")
-    expect(Version.create("1.2.3beta2")).to be > Version.create("1.2.3beta1")
-    expect(Version.create("1.2.3beta2")).to be < Version.create("1.2.3beta3")
-    expect(Version.create("1.2.3beta2")).to be < Version.create("1.2.3beta10")
+    expect(described_class.create("1.2.3beta2")).to be == described_class.create("1.2.3b2")
+    expect(described_class.create("1.2.3beta2")).to be == described_class.create("1.2.3B2")
+    expect(described_class.create("1.2.3beta2")).to be > described_class.create("1.2.3beta1")
+    expect(described_class.create("1.2.3beta2")).to be < described_class.create("1.2.3beta3")
+    expect(described_class.create("1.2.3beta2")).to be < described_class.create("1.2.3beta10")
 
-    expect(Version.create("1.2.3beta2")).to be > Version.create("1.2.3alpha4")
-    expect(Version.create("1.2.3beta2")).to be < Version.create("1.2.3rc3")
-    expect(Version.create("1.2.3beta2")).to be < Version.create("1.2.3")
-    expect(Version.create("1.2.3beta2")).to be < Version.create("1.2.3-p34")
+    expect(described_class.create("1.2.3beta2")).to be > described_class.create("1.2.3alpha4")
+    expect(described_class.create("1.2.3beta2")).to be < described_class.create("1.2.3rc3")
+    expect(described_class.create("1.2.3beta2")).to be < described_class.create("1.2.3")
+    expect(described_class.create("1.2.3beta2")).to be < described_class.create("1.2.3-p34")
   end
 
   specify "comparing pre versions" do
-    expect(Version.create("1.2.3pre9")).to be == Version.create("1.2.3PRE9")
-    expect(Version.create("1.2.3pre9")).to be > Version.create("1.2.3pre8")
-    expect(Version.create("1.2.3pre8")).to be < Version.create("1.2.3pre9")
-    expect(Version.create("1.2.3pre9")).to be < Version.create("1.2.3pre10")
+    expect(described_class.create("1.2.3pre9")).to be == described_class.create("1.2.3PRE9")
+    expect(described_class.create("1.2.3pre9")).to be > described_class.create("1.2.3pre8")
+    expect(described_class.create("1.2.3pre8")).to be < described_class.create("1.2.3pre9")
+    expect(described_class.create("1.2.3pre9")).to be < described_class.create("1.2.3pre10")
 
-    expect(Version.create("1.2.3pre3")).to be > Version.create("1.2.3alpha2")
-    expect(Version.create("1.2.3pre3")).to be > Version.create("1.2.3alpha4")
-    expect(Version.create("1.2.3pre3")).to be > Version.create("1.2.3beta3")
-    expect(Version.create("1.2.3pre3")).to be > Version.create("1.2.3beta5")
-    expect(Version.create("1.2.3pre3")).to be < Version.create("1.2.3rc2")
-    expect(Version.create("1.2.3pre3")).to be < Version.create("1.2.3")
-    expect(Version.create("1.2.3pre3")).to be < Version.create("1.2.3-p2")
+    expect(described_class.create("1.2.3pre3")).to be > described_class.create("1.2.3alpha2")
+    expect(described_class.create("1.2.3pre3")).to be > described_class.create("1.2.3alpha4")
+    expect(described_class.create("1.2.3pre3")).to be > described_class.create("1.2.3beta3")
+    expect(described_class.create("1.2.3pre3")).to be > described_class.create("1.2.3beta5")
+    expect(described_class.create("1.2.3pre3")).to be < described_class.create("1.2.3rc2")
+    expect(described_class.create("1.2.3pre3")).to be < described_class.create("1.2.3")
+    expect(described_class.create("1.2.3pre3")).to be < described_class.create("1.2.3-p2")
   end
 
   specify "comparing RC versions" do
-    expect(Version.create("1.2.3rc3")).to be == Version.create("1.2.3RC3")
-    expect(Version.create("1.2.3rc3")).to be > Version.create("1.2.3rc2")
-    expect(Version.create("1.2.3rc3")).to be < Version.create("1.2.3rc4")
-    expect(Version.create("1.2.3rc3")).to be < Version.create("1.2.3rc10")
+    expect(described_class.create("1.2.3rc3")).to be == described_class.create("1.2.3RC3")
+    expect(described_class.create("1.2.3rc3")).to be > described_class.create("1.2.3rc2")
+    expect(described_class.create("1.2.3rc3")).to be < described_class.create("1.2.3rc4")
+    expect(described_class.create("1.2.3rc3")).to be < described_class.create("1.2.3rc10")
 
-    expect(Version.create("1.2.3rc3")).to be > Version.create("1.2.3alpha4")
-    expect(Version.create("1.2.3rc3")).to be > Version.create("1.2.3beta2")
-    expect(Version.create("1.2.3rc3")).to be < Version.create("1.2.3")
-    expect(Version.create("1.2.3rc3")).to be < Version.create("1.2.3-p34")
+    expect(described_class.create("1.2.3rc3")).to be > described_class.create("1.2.3alpha4")
+    expect(described_class.create("1.2.3rc3")).to be > described_class.create("1.2.3beta2")
+    expect(described_class.create("1.2.3rc3")).to be < described_class.create("1.2.3")
+    expect(described_class.create("1.2.3rc3")).to be < described_class.create("1.2.3-p34")
   end
 
   specify "comparing patch-level versions" do
-    expect(Version.create("1.2.3-p34")).to be == Version.create("1.2.3-P34")
-    expect(Version.create("1.2.3-p34")).to be > Version.create("1.2.3-p33")
-    expect(Version.create("1.2.3-p34")).to be < Version.create("1.2.3-p35")
-    expect(Version.create("1.2.3-p34")).to be > Version.create("1.2.3-p9")
+    expect(described_class.create("1.2.3-p34")).to be == described_class.create("1.2.3-P34")
+    expect(described_class.create("1.2.3-p34")).to be > described_class.create("1.2.3-p33")
+    expect(described_class.create("1.2.3-p34")).to be < described_class.create("1.2.3-p35")
+    expect(described_class.create("1.2.3-p34")).to be > described_class.create("1.2.3-p9")
 
-    expect(Version.create("1.2.3-p34")).to be > Version.create("1.2.3alpha4")
-    expect(Version.create("1.2.3-p34")).to be > Version.create("1.2.3beta2")
-    expect(Version.create("1.2.3-p34")).to be > Version.create("1.2.3rc3")
-    expect(Version.create("1.2.3-p34")).to be > Version.create("1.2.3")
+    expect(described_class.create("1.2.3-p34")).to be > described_class.create("1.2.3alpha4")
+    expect(described_class.create("1.2.3-p34")).to be > described_class.create("1.2.3beta2")
+    expect(described_class.create("1.2.3-p34")).to be > described_class.create("1.2.3rc3")
+    expect(described_class.create("1.2.3-p34")).to be > described_class.create("1.2.3")
   end
 
   specify "comparing unevenly-padded versions" do
-    expect(Version.create("2.1.0-p194")).to be < Version.create("2.1-p195")
-    expect(Version.create("2.1-p195")).to be > Version.create("2.1.0-p194")
-    expect(Version.create("2.1-p194")).to be < Version.create("2.1.0-p195")
-    expect(Version.create("2.1.0-p195")).to be > Version.create("2.1-p194")
-    expect(Version.create("2-p194")).to be < Version.create("2.1-p195")
+    expect(described_class.create("2.1.0-p194")).to be < described_class.create("2.1-p195")
+    expect(described_class.create("2.1-p195")).to be > described_class.create("2.1.0-p194")
+    expect(described_class.create("2.1-p194")).to be < described_class.create("2.1.0-p195")
+    expect(described_class.create("2.1.0-p195")).to be > described_class.create("2.1-p194")
+    expect(described_class.create("2-p194")).to be < described_class.create("2.1-p195")
   end
 
   it "can be compared against nil" do
-    expect(Version.create("2.1.0-p194")).to be > nil
+    expect(described_class.create("2.1.0-p194")).to be > nil
   end
 
   it "can be compared against strings" do
-    expect(Version.create("2.1.0-p194")).to be == "2.1.0-p194"
-    expect(Version.create("1")).to be == 1
+    expect(described_class.create("2.1.0-p194")).to be == "2.1.0-p194"
+    expect(described_class.create("1")).to be == 1
   end
 
   specify "comparison returns nil for non-version" do
-    v = Version.create("1.0")
+    v = described_class.create("1.0")
     expect(v <=> Object.new).to be nil
     expect { v > Object.new }.to raise_error(ArgumentError)
   end
@@ -158,13 +158,13 @@ describe Version do
   specify "erlang versions" do
     versions = %w[R16B R15B03-1 R15B03 R15B02 R15B01 R14B04 R14B03
                   R14B02 R14B01 R14B R13B04 R13B03 R13B02-1].reverse
-    expect(versions.sort_by { |v| Version.create(v) }).to eq(versions)
+    expect(versions.sort_by { |v| described_class.create(v) }).to eq(versions)
   end
 
   specify "hash equality" do
-    v1 = Version.create("0.1.0")
-    v2 = Version.create("0.1.0")
-    v3 = Version.create("0.1.1")
+    v1 = described_class.create("0.1.0")
+    v2 = described_class.create("0.1.0")
+    v3 = described_class.create("0.1.1")
 
     expect(v1).to eql(v2)
     expect(v1).not_to eql(v3)
@@ -178,50 +178,50 @@ describe Version do
   describe "::create" do
     it "accepts objects responding to #to_str" do
       value = double(to_str: "0.1")
-      expect(Version.create(value).to_s).to eq("0.1")
+      expect(described_class.create(value).to_s).to eq("0.1")
     end
 
     it "raises a TypeError for non-string objects" do
-      expect { Version.create(1.1) }.to raise_error(TypeError)
-      expect { Version.create(1) }.to raise_error(TypeError)
-      expect { Version.create(:symbol) }.to raise_error(TypeError)
+      expect { described_class.create(1.1) }.to raise_error(TypeError)
+      expect { described_class.create(1) }.to raise_error(TypeError)
+      expect { described_class.create(:symbol) }.to raise_error(TypeError)
     end
 
     it "parses a version from a string" do
-      v = Version.create("1.20")
+      v = described_class.create("1.20")
       expect(v).not_to be_head
       expect(v.to_str).to eq("1.20")
     end
 
     specify "HEAD with commit" do
-      v = Version.create("HEAD-abcdef")
+      v = described_class.create("HEAD-abcdef")
       expect(v.commit).to eq("abcdef")
       expect(v.to_str).to eq("HEAD-abcdef")
     end
 
     specify "HEAD without commit" do
-      v = Version.create("HEAD")
+      v = described_class.create("HEAD")
       expect(v.commit).to be nil
       expect(v.to_str).to eq("HEAD")
     end
   end
 
   specify "#detected_from_url?" do
-    expect(Version.create("1.0")).not_to be_detected_from_url
+    expect(described_class.create("1.0")).not_to be_detected_from_url
     expect(Version::FromURL.new("1.0")).to be_detected_from_url
   end
 
   specify "#head?" do
-    v1 = Version.create("HEAD-abcdef")
-    v2 = Version.create("HEAD")
+    v1 = described_class.create("HEAD-abcdef")
+    v2 = described_class.create("HEAD")
 
     expect(v1).to be_head
     expect(v2).to be_head
   end
 
   specify "#update_commit" do
-    v1 = Version.create("HEAD-abcdef")
-    v2 = Version.create("HEAD")
+    v1 = described_class.create("HEAD-abcdef")
+    v2 = described_class.create("HEAD")
 
     v1.update_commit("ffffff")
     expect(v1.commit).to eq("ffffff")
@@ -234,14 +234,14 @@ describe Version do
 
   describe "::parse" do
     it "returns a NULL version when the URL cannot be parsed" do
-      expect(Version.parse("http://example.com/blah.tar")).to be_null
-      expect(Version.parse("foo")).to be_null
+      expect(described_class.parse("http://example.com/blah.tar")).to be_null
+      expect(described_class.parse("foo")).to be_null
     end
   end
 
   describe "::detect" do
     matcher :be_detected_from do |url, specs = {}|
-      detected = Version.detect(url, specs)
+      detected = described_class.detect(url, specs)
 
       match do |expected|
         detected == expected
@@ -257,405 +257,405 @@ describe Version do
     end
 
     specify "version all dots" do
-      expect(Version.create("1.14"))
+      expect(described_class.create("1.14"))
         .to be_detected_from("http://example.com/foo.bar.la.1.14.zip")
     end
 
     specify "version underscore separator" do
-      expect(Version.create("1.1"))
+      expect(described_class.create("1.1"))
         .to be_detected_from("http://example.com/grc_1.1.tar.gz")
     end
 
     specify "boost version style" do
-      expect(Version.create("1.39.0"))
+      expect(described_class.create("1.39.0"))
         .to be_detected_from("http://example.com/boost_1_39_0.tar.bz2")
     end
 
     specify "erlang version style" do
-      expect(Version.create("R13B"))
+      expect(described_class.create("R13B"))
         .to be_detected_from("http://erlang.org/download/otp_src_R13B.tar.gz")
     end
 
     specify "another erlang version style" do
-      expect(Version.create("R15B01"))
+      expect(described_class.create("R15B01"))
         .to be_detected_from("https://github.com/erlang/otp/tarball/OTP_R15B01")
     end
 
     specify "yet another erlang version style" do
-      expect(Version.create("R15B03-1"))
+      expect(described_class.create("R15B03-1"))
         .to be_detected_from("https://github.com/erlang/otp/tarball/OTP_R15B03-1")
     end
 
     specify "p7zip version style" do
-      expect(Version.create("9.04"))
+      expect(described_class.create("9.04"))
         .to be_detected_from("http://kent.dl.sourceforge.net/sourceforge/p7zip/p7zip_9.04_src_all.tar.bz2")
     end
 
     specify "new github style" do
-      expect(Version.create("1.1.4"))
+      expect(described_class.create("1.1.4"))
         .to be_detected_from("https://github.com/sam-github/libnet/tarball/libnet-1.1.4")
     end
 
     specify "codeload style" do
-      expect(Version.create("0.7.1"))
+      expect(described_class.create("0.7.1"))
         .to be_detected_from("https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1")
     end
 
     specify "elasticsearch alpha style" do
-      expect(Version.create("5.0.0-alpha5"))
+      expect(described_class.create("5.0.0-alpha5"))
         .to be_detected_from("https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/5.0.0-alpha5/elasticsearch-5.0.0-alpha5.tar.gz")
     end
 
     specify "gloox beta style" do
-      expect(Version.create("1.0-beta7"))
+      expect(described_class.create("1.0-beta7"))
         .to be_detected_from("http://camaya.net/download/gloox-1.0-beta7.tar.bz2")
     end
 
     specify "sphinx beta style" do
-      expect(Version.create("1.10-beta"))
+      expect(described_class.create("1.10-beta"))
         .to be_detected_from("http://sphinxsearch.com/downloads/sphinx-1.10-beta.tar.gz")
     end
 
     specify "astyle version style" do
-      expect(Version.create("1.23"))
+      expect(described_class.create("1.23"))
         .to be_detected_from("http://kent.dl.sourceforge.net/sourceforge/astyle/astyle_1.23_macosx.tar.gz")
     end
 
     specify "version dos2unix" do
-      expect(Version.create("3.1"))
+      expect(described_class.create("3.1"))
         .to be_detected_from("http://www.sfr-fresh.com/linux/misc/dos2unix-3.1.tar.gz")
     end
 
     specify "version internal dash" do
-      expect(Version.create("1.1-2"))
+      expect(described_class.create("1.1-2"))
         .to be_detected_from("http://example.com/foo-arse-1.1-2.tar.gz")
     end
 
     specify "version single digit" do
-      expect(Version.create("45"))
+      expect(described_class.create("45"))
         .to be_detected_from("http://example.com/foo_bar.45.tar.gz")
     end
 
     specify "noseparator single digit" do
-      expect(Version.create("45"))
+      expect(described_class.create("45"))
         .to be_detected_from("http://example.com/foo_bar45.tar.gz")
     end
 
     specify "version developer that hates us format" do
-      expect(Version.create("1.2.3"))
+      expect(described_class.create("1.2.3"))
         .to be_detected_from("http://example.com/foo-bar-la.1.2.3.tar.gz")
     end
 
     specify "version regular" do
-      expect(Version.create("1.21"))
+      expect(described_class.create("1.21"))
         .to be_detected_from("http://example.com/foo_bar-1.21.tar.gz")
     end
 
     specify "version sourceforge download" do
-      expect(Version.create("1.21"))
+      expect(described_class.create("1.21"))
         .to be_detected_from("http://sourceforge.net/foo_bar-1.21.tar.gz/download")
-      expect(Version.create("1.21"))
+      expect(described_class.create("1.21"))
         .to be_detected_from("http://sf.net/foo_bar-1.21.tar.gz/download")
     end
 
     specify "version github" do
-      expect(Version.create("1.0.5"))
+      expect(described_class.create("1.0.5"))
         .to be_detected_from("http://github.com/lloyd/yajl/tarball/1.0.5")
     end
 
     specify "version github with high patch number" do
-      expect(Version.create("1.2.34"))
+      expect(described_class.create("1.2.34"))
         .to be_detected_from("http://github.com/lloyd/yajl/tarball/v1.2.34")
     end
 
     specify "yet another version" do
-      expect(Version.create("0.15.1b"))
+      expect(described_class.create("0.15.1b"))
         .to be_detected_from("http://example.com/mad-0.15.1b.tar.gz")
     end
 
     specify "lame version style" do
-      expect(Version.create("398-2"))
+      expect(described_class.create("398-2"))
         .to be_detected_from("http://kent.dl.sourceforge.net/sourceforge/lame/lame-398-2.tar.gz")
     end
 
     specify "ruby version style" do
-      expect(Version.create("1.9.1-p243"))
+      expect(described_class.create("1.9.1-p243"))
         .to be_detected_from("ftp://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.1-p243.tar.gz")
     end
 
     specify "omega version style" do
-      expect(Version.create("0.80.2"))
+      expect(described_class.create("0.80.2"))
         .to be_detected_from("http://www.alcyone.com/binaries/omega/omega-0.80.2-src.tar.gz")
     end
 
     specify "rc style" do
-      expect(Version.create("1.2.2rc1"))
+      expect(described_class.create("1.2.2rc1"))
         .to be_detected_from("http://downloads.xiph.org/releases/vorbis/libvorbis-1.2.2rc1.tar.bz2")
     end
 
     specify "dash rc style" do
-      expect(Version.create("1.8.0-rc1"))
+      expect(described_class.create("1.8.0-rc1"))
         .to be_detected_from("http://ftp.mozilla.org/pub/mozilla.org/js/js-1.8.0-rc1.tar.gz")
     end
 
     specify "angband version style" do
-      expect(Version.create("3.0.9b"))
+      expect(described_class.create("3.0.9b"))
         .to be_detected_from("http://rephial.org/downloads/3.0/angband-3.0.9b-src.tar.gz")
     end
 
     specify "stable suffix" do
-      expect(Version.create("1.4.14b"))
+      expect(described_class.create("1.4.14b"))
         .to be_detected_from("http://www.monkey.org/~provos/libevent-1.4.14b-stable.tar.gz")
     end
 
     specify "debian style 1" do
-      expect(Version.create("3.03"))
+      expect(described_class.create("3.03"))
         .to be_detected_from("http://ftp.de.debian.org/debian/pool/main/s/sl/sl_3.03.orig.tar.gz")
     end
 
     specify "debian style 2" do
-      expect(Version.create("1.01b"))
+      expect(described_class.create("1.01b"))
         .to be_detected_from("http://ftp.de.debian.org/debian/pool/main/m/mmv/mmv_1.01b.orig.tar.gz")
     end
 
     specify "bottle style" do
-      expect(Version.create("4.8.0"))
+      expect(described_class.create("4.8.0"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/qt-4.8.0.lion.bottle.tar.gz")
     end
 
     specify "versioned bottle style" do
-      expect(Version.create("4.8.1"))
+      expect(described_class.create("4.8.1"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/qt-4.8.1.lion.bottle.1.tar.gz")
     end
 
     specify "erlang bottle style" do
-      expect(Version.create("R15B"))
+      expect(described_class.create("R15B"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/erlang-R15B.lion.bottle.tar.gz")
     end
 
     specify "another erlang bottle style" do
-      expect(Version.create("R15B01"))
+      expect(described_class.create("R15B01"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/erlang-R15B01.mountain_lion.bottle.tar.gz")
     end
 
     specify "yet another erlang bottle style" do
-      expect(Version.create("R15B03-1"))
+      expect(described_class.create("R15B03-1"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/erlang-R15B03-1.mountainlion.bottle.tar.gz")
     end
 
     specify "imagemagick style" do
-      expect(Version.create("6.7.5-7"))
+      expect(described_class.create("6.7.5-7"))
         .to be_detected_from("http://downloads.sf.net/project/machomebrew/mirror/ImageMagick-6.7.5-7.tar.bz2")
     end
 
     specify "imagemagick bottle style" do
-      expect(Version.create("6.7.5-7"))
+      expect(described_class.create("6.7.5-7"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/imagemagick-6.7.5-7.lion.bottle.tar.gz")
     end
 
     specify "imagemagick versioned bottle style" do
-      expect(Version.create("6.7.5-7"))
+      expect(described_class.create("6.7.5-7"))
         .to be_detected_from("https://homebrew.bintray.com/bottles/imagemagick-6.7.5-7.lion.bottle.1.tar.gz")
     end
 
     specify "date-based version style" do
-      expect(Version.create("2017-04-17"))
+      expect(described_class.create("2017-04-17"))
         .to be_detected_from("https://example.com/dada-v2017-04-17.tar.gz")
     end
 
     specify "devel spec version style" do
-      expect(Version.create("1.3.0-beta.1"))
+      expect(described_class.create("1.3.0-beta.1"))
         .to be_detected_from("https://registry.npmjs.org/@angular/cli/-/cli-1.3.0-beta.1.tgz")
-      expect(Version.create("2.074.0-beta1"))
+      expect(described_class.create("2.074.0-beta1"))
         .to be_detected_from("https://github.com/dlang/dmd/archive/v2.074.0-beta1.tar.gz")
-      expect(Version.create("2.074.0-rc1"))
+      expect(described_class.create("2.074.0-rc1"))
         .to be_detected_from("https://github.com/dlang/dmd/archive/v2.074.0-rc1.tar.gz")
-      expect(Version.create("5.0.0-alpha10"))
+      expect(described_class.create("5.0.0-alpha10"))
         .to be_detected_from("https://github.com/premake/premake-core/releases/download/v5.0.0-alpha10/premake-5.0.0-alpha10-src.zip")
     end
 
     specify "jenkins version style" do
-      expect(Version.create("1.486"))
+      expect(described_class.create("1.486"))
         .to be_detected_from("http://mirrors.jenkins-ci.org/war/1.486/jenkins.war")
-      expect(Version.create("0.10.11"))
+      expect(described_class.create("0.10.11"))
         .to be_detected_from("https://github.com/hechoendrupal/DrupalConsole/releases/download/0.10.11/drupal.phar")
     end
 
     specify "char prefixed, url-only version style" do
-      expect(Version.create("1.9.293"))
+      expect(described_class.create("1.9.293"))
         .to be_detected_from("https://github.com/clojure/clojurescript/releases/download/r1.9.293/cljs.jar")
-      expect(Version.create("0.6.1"))
+      expect(described_class.create("0.6.1"))
         .to be_detected_from("https://github.com/fibjs/fibjs/releases/download/v0.6.1/fullsrc.zip")
-      expect(Version.create("1.9"))
+      expect(described_class.create("1.9"))
         .to be_detected_from("https://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_1.9/E.tgz")
     end
 
     specify "w.x.y.z url-only version style" do
-      expect(Version.create("2.3.2.0"))
+      expect(described_class.create("2.3.2.0"))
         .to be_detected_from("https://github.com/JustArchi/ArchiSteamFarm/releases/download/2.3.2.0/ASF.zip")
-      expect(Version.create("1.7.5.2"))
+      expect(described_class.create("1.7.5.2"))
         .to be_detected_from("https://people.gnome.org/~newren/eg/download/1.7.5.2/eg")
     end
 
     specify "dash version style" do
-      expect(Version.create("3.4"))
+      expect(described_class.create("3.4"))
         .to be_detected_from("http://www.antlr.org/download/antlr-3.4-complete.jar")
-      expect(Version.create("9.2"))
+      expect(described_class.create("9.2"))
         .to be_detected_from("https://cdn.nuxeo.com/nuxeo-9.2/nuxeo-server-9.2-tomcat.zip")
-      expect(Version.create("0.181"))
+      expect(described_class.create("0.181"))
         .to be_detected_from("https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.181/presto-cli-0.181-executable.jar")
-      expect(Version.create("1.2.3"))
+      expect(described_class.create("1.2.3"))
         .to be_detected_from("https://search.maven.org/remotecontent?filepath=org/apache/orc/orc-tools/1.2.3/orc-tools-1.2.3-uber.jar")
     end
 
     specify "apache version style" do
-      expect(Version.create("1.2.0-rc2"))
+      expect(described_class.create("1.2.0-rc2"))
         .to be_detected_from("http://www.apache.org/dyn/closer.cgi?path=/cassandra/1.2.0/apache-cassandra-1.2.0-rc2-bin.tar.gz")
     end
 
     specify "jpeg version style" do
-      expect(Version.create("8d"))
+      expect(described_class.create("8d"))
         .to be_detected_from("http://www.ijg.org/files/jpegsrc.v8d.tar.gz")
     end
 
     specify "ghc version style" do
-      expect(Version.create("7.0.4"))
+      expect(described_class.create("7.0.4"))
         .to be_detected_from("http://www.haskell.org/ghc/dist/7.0.4/ghc-7.0.4-x86_64-apple-darwin.tar.bz2")
-      expect(Version.create("7.0.4"))
+      expect(described_class.create("7.0.4"))
         .to be_detected_from("http://www.haskell.org/ghc/dist/7.0.4/ghc-7.0.4-i386-apple-darwin.tar.bz2")
     end
 
     specify "pypy version style" do
-      expect(Version.create("1.4.1"))
+      expect(described_class.create("1.4.1"))
         .to be_detected_from("http://pypy.org/download/pypy-1.4.1-osx.tar.bz2")
     end
 
     specify "openssl version style" do
-      expect(Version.create("0.9.8s"))
+      expect(described_class.create("0.9.8s"))
         .to be_detected_from("http://www.openssl.org/source/openssl-0.9.8s.tar.gz")
     end
 
     specify "xaw3d version style" do
-      expect(Version.create("1.5E"))
+      expect(described_class.create("1.5E"))
         .to be_detected_from("ftp://ftp.visi.com/users/hawkeyd/X/Xaw3d-1.5E.tar.gz")
     end
 
     specify "assimp version style" do
-      expect(Version.create("2.0.863"))
+      expect(described_class.create("2.0.863"))
         .to be_detected_from("http://downloads.sourceforge.net/project/assimp/assimp-2.0/assimp--2.0.863-sdk.zip")
     end
 
     specify "cmucl version style" do
-      expect(Version.create("20c"))
+      expect(described_class.create("20c"))
         .to be_detected_from("http://common-lisp.net/project/cmucl/downloads/release/20c/cmucl-20c-x86-darwin.tar.bz2")
     end
 
     specify "fann version style" do
-      expect(Version.create("2.1.0beta"))
+      expect(described_class.create("2.1.0beta"))
         .to be_detected_from("http://downloads.sourceforge.net/project/fann/fann/2.1.0beta/fann-2.1.0beta.zip")
     end
 
     specify "grads version style" do
-      expect(Version.create("2.0.1"))
+      expect(described_class.create("2.0.1"))
         .to be_detected_from("ftp://iges.org/grads/2.0/grads-2.0.1-bin-darwin9.8-intel.tar.gz")
     end
 
     specify "haxe version style" do
-      expect(Version.create("2.08"))
+      expect(described_class.create("2.08"))
         .to be_detected_from("http://haxe.org/file/haxe-2.08-osx.tar.gz")
     end
 
     specify "imap version style" do
-      expect(Version.create("2007f"))
+      expect(described_class.create("2007f"))
         .to be_detected_from("ftp://ftp.cac.washington.edu/imap/imap-2007f.tar.gz")
     end
 
     specify "suite3270 version style" do
-      expect(Version.create("3.3.12ga7"))
+      expect(described_class.create("3.3.12ga7"))
         .to be_detected_from("http://downloads.sourceforge.net/project/x3270/x3270/3.3.12ga7/suite3270-3.3.12ga7-src.tgz")
     end
 
     specify "wwwoffle version style" do
-      expect(Version.create("2.9h"))
+      expect(described_class.create("2.9h"))
         .to be_detected_from("http://www.gedanken.demon.co.uk/download-wwwoffle/wwwoffle-2.9h.tgz")
     end
 
     specify "synergy version style" do
-      expect(Version.create("1.3.6p2"))
+      expect(described_class.create("1.3.6p2"))
         .to be_detected_from("http://synergy.googlecode.com/files/synergy-1.3.6p2-MacOSX-Universal.zip")
     end
 
     specify "fontforge version style" do
-      expect(Version.create("20120731"))
+      expect(described_class.create("20120731"))
         .to be_detected_from("http://downloads.sourceforge.net/project/fontforge/fontforge-source/fontforge_full-20120731-b.tar.bz2")
     end
 
     specify "ezlupdate version style" do
-      expect(Version.create("2011.10"))
+      expect(described_class.create("2011.10"))
         .to be_detected_from("https://github.com/downloads/ezsystems/ezpublish-legacy/ezpublish_community_project-2011.10-with_ezc.tar.bz2")
     end
 
     specify "aespipe version style" do
-      expect(Version.create("2.4c"))
+      expect(described_class.create("2.4c"))
         .to be_detected_from("http://loop-aes.sourceforge.net/aespipe/aespipe-v2.4c.tar.bz2")
     end
 
     specify "win version style" do
-      expect(Version.create("0.9.17"))
+      expect(described_class.create("0.9.17"))
         .to be_detected_from("http://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-0.9.17-w32.zip")
-      expect(Version.create("1.29"))
+      expect(described_class.create("1.29"))
         .to be_detected_from("http://ftpmirror.gnu.org/libidn/libidn-1.29-win64.zip")
     end
 
     specify "with arch" do
-      expect(Version.create("4.0.18-1"))
+      expect(described_class.create("4.0.18-1"))
         .to be_detected_from("http://ftpmirror.gnu.org/mtools/mtools-4.0.18-1.i686.rpm")
-      expect(Version.create("5.5.7-5"))
+      expect(described_class.create("5.5.7-5"))
         .to be_detected_from("http://ftpmirror.gnu.org/autogen/autogen-5.5.7-5.i386.rpm")
-      expect(Version.create("2.8"))
+      expect(described_class.create("2.8"))
         .to be_detected_from("http://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x86.zip")
-      expect(Version.create("2.8"))
+      expect(described_class.create("2.8"))
         .to be_detected_from("http://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x64.zip")
-      expect(Version.create("4.0.18"))
+      expect(described_class.create("4.0.18"))
         .to be_detected_from("http://ftpmirror.gnu.org/mtools/mtools_4.0.18_i386.deb")
     end
 
     specify "opam version" do
-      expect(Version.create("2.18.3"))
+      expect(described_class.create("2.18.3"))
         .to be_detected_from("https://opam.ocaml.org/archives/lablgtk.2.18.3+opam.tar.gz")
-      expect(Version.create("1.9"))
+      expect(described_class.create("1.9"))
         .to be_detected_from("https://opam.ocaml.org/archives/sha.1.9+opam.tar.gz")
-      expect(Version.create("0.99.2"))
+      expect(described_class.create("0.99.2"))
         .to be_detected_from("https://opam.ocaml.org/archives/ppx_tools.0.99.2+opam.tar.gz")
-      expect(Version.create("1.0.2"))
+      expect(described_class.create("1.0.2"))
         .to be_detected_from("https://opam.ocaml.org/archives/easy-format.1.0.2+opam.tar.gz")
     end
 
     specify "no extension version" do
-      expect(Version.create("1.8.12"))
+      expect(described_class.create("1.8.12"))
         .to be_detected_from("https://waf.io/waf-1.8.12")
-      expect(Version.create("0.7.1"))
+      expect(described_class.create("0.7.1"))
         .to be_detected_from("https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1")
-      expect(Version.create("0.9.1234"))
+      expect(described_class.create("0.9.1234"))
         .to be_detected_from("https://my.datomic.com/downloads/free/0.9.1234")
-      expect(Version.create("0.9"))
+      expect(described_class.create("0.9"))
         .to be_detected_from("https://my.datomic.com/downloads/free/0.9.1t34")
-      expect(Version.create("1.2.3"))
+      expect(described_class.create("1.2.3"))
         .to be_detected_from("https://my.datomic.com/downloads/free/1.2.3")
     end
 
     specify "dash separated version" do
-      expect(Version.create("6-20151227"))
+      expect(described_class.create("6-20151227"))
         .to be_detected_from("ftp://gcc.gnu.org/pub/gcc/snapshots/6-20151227/gcc-6-20151227.tar.bz2")
     end
 
     specify "semver in middle of URL" do
-      expect(Version.create("7.1.10"))
+      expect(described_class.create("7.1.10"))
         .to be_detected_from("https://php.net/get/php-7.1.10.tar.gz/from/this/mirror")
     end
 
     specify "from URL" do
-      expect(Version.create("1.2.3"))
+      expect(described_class.create("1.2.3"))
         .to be_detected_from("http://github.com/foo/bar.git", tag: "v1.2.3")
     end
   end


### PR DESCRIPTION
There’s too many warnings to start enabling `rubocop-rspec` by default but let’s at least apply the cleanups it does automatically.