### PR TITLE
style: add optional rubocop-rspec support.

### DIFF
--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -11,6 +11,8 @@
 #:    If `--display-cop-names` is passed, include the RuboCop cop name for each
 #:    violation in the output.
 #:
+#:    If `--rspec` is passed, install and use the RuboCop RSpec gem.
+#:
 #:    Passing `--only-cops=`<cops> will check for violations of only the listed
 #:    RuboCop <cops>, while `--except-cops=`<cops> will skip checking the listed
 #:    <cops>. For either option <cops> should be a comma-separated list of cop names.
@@ -81,6 +83,11 @@ module Homebrew
       args << "--auto-correct"
     else
       args << "--parallel"
+    end
+
+    if ARGV.include?("--rspec")
+      Homebrew.install_gem! "rubocop-rspec"
+      args += %w[--require rubocop-rspec]
     end
 
     if options[:except_cops]

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -436,6 +436,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--display-cop-names` is passed, include the RuboCop cop name for each
     violation in the output.
 
+    If `--rspec` is passed, install and use the RuboCop RSpec gem.
+
     Passing `--only-cops=``cops` will check for violations of only the listed
     RuboCop `cops`, while `--except-cops=``cops` will skip checking the listed
     `cops`. For either option `cops` should be a comma-separated list of cop names.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -446,6 +446,9 @@ If \fB\-\-fix\fR is passed, automatically fix style violations using RuboCop\'s 
 If \fB\-\-display\-cop\-names\fR is passed, include the RuboCop cop name for each violation in the output\.
 .
 .IP
+If \fB\-\-rspec\fR is passed, install and use the RuboCop RSpec gem\.
+.
+.IP
 Passing \fB\-\-only\-cops=\fR\fIcops\fR will check for violations of only the listed RuboCop \fIcops\fR, while \fB\-\-except\-cops=\fR\fIcops\fR will skip checking the listed \fIcops\fR\. For either option \fIcops\fR should be a comma\-separated list of cop names\.
 .
 .IP


### PR DESCRIPTION
It's really noisy and too pedantic for us to use now but I got it working locally and used `--fix` to generate #3981 so let's add it as an option for now.