### PR TITLE
Detect bottle download strategy

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -318,7 +318,7 @@ class Bottle
   end
 
   def select_download_strategy(specs)
-    specs[:using] ||= CurlDownloadStrategy
+    specs[:using] ||= DownloadStrategyDetector.detect(@spec.root_url)
     specs
   end
 end


### PR DESCRIPTION
Use ::detect method of DownloadStrategyDetector to detect download strategy of a bottle from its root_url.

This allows bottle root_urls to be s3:// style URLs and be handled by the S3DownloadStrategy without specifying ':using =>'

No tests were written as this method is tested elsewhere.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
