### PR TITLE
audit: Fix dependency order with multiple tags

### DIFF
--- a/Library/Homebrew/rubocops/dependency_order_cop.rb
+++ b/Library/Homebrew/rubocops/dependency_order_cop.rb
@@ -44,14 +44,19 @@ module RuboCop
         end
 
         # Separate dependencies according to precedence order:
-        # build-time > run-time > normal > recommended > optional
+        # build-time > test > normal > recommended > optional
         def sort_dependencies_by_type(dependency_nodes)
+          unsorted_deps = dependency_nodes.to_a
           ordered = []
-          ordered.concat(dependency_nodes.select { |dep| buildtime_dependency? dep }.to_a)
-          ordered.concat(dependency_nodes.select { |dep| test_dependency? dep }.to_a)
-          ordered.concat(dependency_nodes.reject { |dep| negate_normal_dependency? dep }.to_a)
-          ordered.concat(dependency_nodes.select { |dep| recommended_dependency? dep }.to_a)
-          ordered.concat(dependency_nodes.select { |dep| optional_dependency? dep }.to_a)
+          ordered.concat(unsorted_deps.select { |dep| buildtime_dependency? dep })
+          unsorted_deps -= ordered
+          ordered.concat(unsorted_deps.select { |dep| test_dependency? dep })
+          unsorted_deps -= ordered
+          ordered.concat(unsorted_deps.reject { |dep| negate_normal_dependency? dep })
+          unsorted_deps -= ordered
+          ordered.concat(unsorted_deps.select { |dep| recommended_dependency? dep })
+          unsorted_deps -= ordered
+          ordered.concat(unsorted_deps.select { |dep| optional_dependency? dep })
         end
 
         # `depends_on :apple if build.with? "foo"` should always be defined

--- a/Library/Homebrew/test/rubocops/dependency_order_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_cop_spec.rb
@@ -46,6 +46,18 @@ describe RuboCop::Cop::NewFormulaAudit::DependencyOrder do
         end
       RUBY
     end
+
+    it "correct depends_on order for multiple tags" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "http://example.com"
+          url "http://example.com/foo-1.0.tgz"
+          depends_on "bar" => [:build, :test]
+          depends_on "foo" => :build
+          depends_on "apple"
+        end
+      RUBY
+    end
   end
 
   context "autocorrect" do


### PR DESCRIPTION


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Dependencies that have multiple tags (`[:build, :test]`) get sorted into multiple locations resulting in the cop always reporting an offense regardless of order.