### PR TITLE
cmd/leaves: handle missing formulae.

### DIFF
--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -12,7 +12,13 @@ module Homebrew
     installed = Formula.installed.sort
 
     deps_of_installed = installed.flat_map do |f|
-      f.runtime_dependencies.map(&:to_formula).map(&:full_name)
+      f.runtime_dependencies.map do |dep|
+        begin
+          dep.to_formula.full_name
+        rescue FormulaUnavailableError
+          dep.name
+        end
+      end
     end
 
     leaves = installed.map(&:full_name) - deps_of_installed


### PR DESCRIPTION
We can't get dependencies of unavailable formulae so don't try.

Fixes #3995.