### PR TITLE
Use `TapPathLoader` in more cases.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cask_loader.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask_loader.rb
@@ -97,14 +97,14 @@ module Hbc
 
     class FromTapPathLoader < FromPathLoader
       def self.can_load?(ref)
-        File.expand_path(ref).match?(HOMEBREW_TAP_PATH_REGEX) && super
+        super && !Tap.from_path(ref).nil?
       end
 
       attr_reader :tap
 
-      def initialize(tap_path)
-        @tap = Tap.from_path(File.expand_path(tap_path))
-        super tap_path
+      def initialize(path)
+        @tap = Tap.from_path(path)
+        super(path)
       end
 
       private

--- a/Library/Homebrew/cask/lib/hbc/cask_loader.rb
+++ b/Library/Homebrew/cask/lib/hbc/cask_loader.rb
@@ -97,13 +97,13 @@ module Hbc
 
     class FromTapPathLoader < FromPathLoader
       def self.can_load?(ref)
-        ref.to_s.match?(HOMEBREW_TAP_PATH_REGEX) && super
+        File.expand_path(ref).match?(HOMEBREW_TAP_PATH_REGEX) && super
       end
 
       attr_reader :tap
 
       def initialize(tap_path)
-        @tap = Tap.from_path(tap_path)
+        @tap = Tap.from_path(File.expand_path(tap_path))
         super tap_path
       end
 

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -181,8 +181,7 @@ class TapFormulaAmbiguityError < RuntimeError
     @name = name
     @paths = paths
     @formulae = paths.map do |path|
-      match = path.to_s.match(HOMEBREW_TAP_PATH_REGEX)
-      "#{Tap.fetch(match[:user], match[:repo])}/#{path.basename(".rb")}"
+      "#{Tap.from_path(path).name}/#{path.basename(".rb")}"
     end
 
     super <<~EOS

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -179,8 +179,8 @@ class Formula
 
     @tap = if path == Formulary.core_path(name)
       CoreTap.instance
-    elsif match = path.to_s.match(HOMEBREW_TAP_PATH_REGEX)
-      Tap.fetch(match[:user], match[:repo])
+    else
+      Tap.from_path(path)
     end
 
     @full_name = full_name_with_optional_tap(name)

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -39,7 +39,7 @@ class Tap
   end
 
   def self.from_path(path)
-    match = path.to_s.match(HOMEBREW_TAP_PATH_REGEX)
+    match = File.expand_path(path).match(HOMEBREW_TAP_PATH_REGEX)
     raise "Invalid tap path '#{path}'" unless match
     fetch(match[:user], match[:repo])
   rescue


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Expand the path before checking agains the Tap regex, so the Tap is also set for Casks loaded with relative paths.

---

Closes https://github.com/caskroom/homebrew-cask/pull/45350.