### PR TITLE
bottle: Add option --or-later

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -664,7 +664,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     `audit` exits with a non-zero status if any errors are found. This is useful,
     for instance, for implementing pre-commit hooks.
 
-  * `bottle` [`--verbose`] [`--no-rebuild`|`--keep-old`] [`--skip-relocation`] [`--root-url=``URL`] [`--force-core-tap`] `formulae`:
+  * `bottle` [`--verbose`] [`--no-rebuild`|`--keep-old`] [`--skip-relocation`] [`--or-later`] [`--root-url=``URL`] [`--force-core-tap`] `formulae`:
     Generate a bottle (binary package) from a formula installed with
     `--build-bottle`.
 
@@ -680,6 +680,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--root-url` is passed, use the specified `URL` as the root of the
     bottle's URL instead of Homebrew's default.
+
+    If `--or-later` is passed, append _or_later to the bottle tag.
 
     If `--force-core-tap` is passed, build a bottle even if `formula` is not
     in homebrew/core or any installed taps.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -682,7 +682,7 @@ Passing \fB\-\-only\-cops=\fR\fIcops\fR will check for violations of only the li
 \fBaudit\fR exits with a non\-zero status if any errors are found\. This is useful, for instance, for implementing pre\-commit hooks\.
 .
 .TP
-\fBbottle\fR [\fB\-\-verbose\fR] [\fB\-\-no\-rebuild\fR|\fB\-\-keep\-old\fR] [\fB\-\-skip\-relocation\fR] [\fB\-\-root\-url=\fR\fIURL\fR] [\fB\-\-force\-core\-tap\fR] \fIformulae\fR
+\fBbottle\fR [\fB\-\-verbose\fR] [\fB\-\-no\-rebuild\fR|\fB\-\-keep\-old\fR] [\fB\-\-skip\-relocation\fR] [\fB\-\-or\-later\fR] [\fB\-\-root\-url=\fR\fIURL\fR] [\fB\-\-force\-core\-tap\fR] \fIformulae\fR
 Generate a bottle (binary package) from a formula installed with \fB\-\-build\-bottle\fR\.
 .
 .IP
@@ -696,6 +696,9 @@ If \fB\-\-skip\-relocation\fR is passed, do not check if the bottle can be marke
 .
 .IP
 If \fB\-\-root\-url\fR is passed, use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
+.
+.IP
+If \fB\-\-or\-later\fR is passed, append _or_later to the bottle tag\.
 .
 .IP
 If \fB\-\-force\-core\-tap\fR is passed, build a bottle even if \fIformula\fR is not in homebrew/core or any installed taps\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If `--or-later` is passed, append `_or_later` to the bottle tag.

In the tap Brewsci/bio, we build a single bottle for macOS using CircleCI on Sierra, and mark the bottle as `:sierra_or_later`. So far it's been working well. If a particular bottle were found not to work on High Sierra (or later), we could remove the `_or_later` tag.