### PR TITLE
Remove mentions to official taps

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -25,9 +25,6 @@
 #:  * `tap` `--repair`:
 #:    Migrate tapped formulae from symlink-based to directory-based structure.
 #:
-#:  * `tap` `--list-official`:
-#:    List all official taps.
-#:
 #:  * `tap` `--list-pinned`:
 #:    List all pinned taps.
 
@@ -40,8 +37,7 @@ module Homebrew
     if ARGV.include? "--repair"
       Tap.each(&:link_completions_and_manpages)
     elsif ARGV.include? "--list-official"
-      require "official_taps"
-      puts OFFICIAL_TAPS.map { |t| "homebrew/#{t}" }
+      odeprecated("brew tap --list-official")
     elsif ARGV.include? "--list-pinned"
       puts Tap.select(&:pinned?).map(&:name)
     elsif ARGV.named.empty?

--- a/Library/Homebrew/test/dev-cmd/tap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap_spec.rb
@@ -15,11 +15,6 @@ describe "brew tap", :integration_test do
       .and not_to_output.to_stderr
       .and be_a_success
 
-    expect { brew "tap", "--list-official" }
-      .to output(%r{homebrew/php}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
     expect { brew "tap-info" }
       .to output(/2 taps/).to_stdout
       .and not_to_output.to_stderr

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -430,11 +430,10 @@ _brew_tap() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     --*)
-      __brewcomp "--repair --list-official --list-pinned"
+      __brewcomp "--repair --list-pinned"
       return
       ;;
   esac
-  __brewcomp "$(brew tap --list-official)"
 }
 
 _brew_tap_info() {
@@ -716,7 +715,7 @@ _brew_cask_upgrade ()
         return
         ;;
     esac
-    __brew_cask_complete_outdated    
+    __brew_cask_complete_outdated
 }
 
 _brew_cask ()

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -56,12 +56,6 @@ __brew_installed_taps() {
   _describe -t installed-taps 'installed taps' taps
 }
 
-__brew_official_taps() {
-  local -a taps
-  taps=($(brew tap --list-official))
-  _describe -t official-taps 'official taps' taps
-}
-
 __brew_pinned_taps() {
   local -a taps
   taps=($(brew tap --list-pinned))
@@ -70,8 +64,7 @@ __brew_pinned_taps() {
 
 __brew_any_tap() {
   _alternative \
-    'installed-taps:installed taps:__brew_installed_taps' \
-    'official-taps:official taps:__brew_official_taps'
+    'installed-taps:installed taps:__brew_installed_taps'
 }
 
 __brew_common_commands() {
@@ -605,19 +598,15 @@ _brew_switch() {
 # brew tap:
 # brew tap [--full] user/repo [URL]:
 # brew tap --repair:
-# brew tap --list-official:
 # brew tap --list-pinned:
 _brew_tap() {
   _arguments \
     - empty-args \
     - repo-args \
       '(--full)--full[perform a full clone]' \
-      ':repo:__brew_official_taps' \
       '::url:_urls' \
     - repair-args \
       '(--repair)--repair' \
-    - list-official \
-      '(--list-official)--list-official[list all official taps]' \
     - list-pinned \
       '(--list-pinned)--list-pinned[list all pinned taps]'
 }

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -31,7 +31,6 @@ Before submitting a new formula make sure your package:
 
 *   meets all our [Acceptable Formulae](Acceptable-Formulae.md) requirements
 *   isn't already in Homebrew (check `brew search <formula>`)
-*   isn't in another official [Homebrew tap](https://github.com/Homebrew)
 *   isn't already waiting to be merged (check the [issue tracker](https://github.com/Homebrew/homebrew-core/pulls))
 *   is still supported by upstream (i.e. doesn't require extensive patching)
 *   has a stable, tagged version (i.e. not just a GitHub repository with no versions)

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -25,8 +25,6 @@ Depending on the change you want to make, you need to send the pull request to t
 3. Add your pushable forked repository with `git remote add <YOUR_USERNAME> https://github.com/<YOUR_USERNAME>/homebrew-core.git`
   * `<YOUR_USERNAME>` is your GitHub username, not your local machine username.
 
-For formulae in central taps other than `homebrew/core`, such as `homebrew/php`, substitute that tap's name for `homebrew/core` in each step, and alter the GitHub repository URLs as necessary.
-
 ## Create your pull request from a new branch
 
 To make a new branch and submit it for review, create a GitHub pull request with the following steps:

--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -16,7 +16,7 @@ repository’s root, or under `Formula` or `HomebrewFormula` subdirectories. We
 recommend the latter options because it makes the repository organisation
 easier to grasp, and top-level files are not mixed with formulae.
 
-See [homebrew/php](https://github.com/Homebrew/homebrew-php) for an example of
+See [homebrew/core](https://github.com/Homebrew/homebrew-core) for an example of
 a tap with a `Formula` subdirectory.
 
 ### Installing

--- a/docs/Interesting-Taps-and-Forks.md
+++ b/docs/Interesting-Taps-and-Forks.md
@@ -3,15 +3,9 @@
 A _tap_ is homebrew-speak for a Git repository containing extra formulae.
 Homebrew has the capability to add (and remove) multiple taps to your local installation with the `brew tap` and `brew untap` commands. Type `man brew` in your Terminal. The main repository [https://github.com/Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core), often called `homebrew/core`, is always built-in.
 
-## Main taps
+Your taps are Git repositories located at `$(brew --repository)/Library/Taps`.
 
-*   [homebrew/php](https://github.com/Homebrew/homebrew-php): Repository for PHP-related formulae.
-
-`brew search` looks in these taps as well as in [homebrew/core](https://github.com/Homebrew/homebrew-core) so don't worry about missing stuff.
-
-You can be added as a maintainer for one of the Homebrew organization taps and aid the project! If you are interested please feel free to ask in an issue or pull request after submitting multiple high-quality pull requests. We want your help!
-
-## Other interesting taps
+## Unsupported interesting taps
 
 *   [denji/nginx](https://github.com/denji/homebrew-nginx): A tap for NGINX modules, intended for its `nginx-full` formula which includes more module options.
 
@@ -37,12 +31,8 @@ You can be added as a maintainer for one of the Homebrew organization taps and a
 
 *   [lifepillar/appleii](https://github.com/lifepillar/homebrew-appleii): Formulae for vintage Apple emulation.
 
-## Interesting forks
+## Unsupported interesting forks
 
 *   [mistydemeo/tigerbrew](https://github.com/mistydemeo/tigerbrew): Experimental Tiger PowerPC version.
 
 *   [Linuxbrew/brew](https://github.com/Linuxbrew/brew): Experimental Linux version.
-
-## Technical details
-
-Your taps are Git repositories located at `$(brew --repository)/Library/Taps`.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -474,9 +474,6 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `tap` `--repair`:
     Migrate tapped formulae from symlink-based to directory-based structure.
 
-  * `tap` `--list-official`:
-    List all official taps.
-
   * `tap` `--list-pinned`:
     List all pinned taps.
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -17,7 +17,7 @@ Follow these steps to fix common problems:
 ## Check to see if the issue has been reported
 
 * Search the [issue tracker](https://github.com/Homebrew/homebrew-core/issues) to see if someone else has already reported the same issue.
-* Make sure you search issues on the correct repository. If a formula that has failed to build is part of a tap like [homebrew/php](https://github.com/Homebrew/homebrew-php/issues) or a cask is part of [caskroom/cask](https://github.com/caskroom/homebrew-cask/issues) check those issue trackers instead.
+* Make sure you search issues on the correct repository. If a formula that has failed to build is part of a non-homebrew-core tap or a cask is part of [caskroom/cask](https://github.com/caskroom/homebrew-cask/issues) check those issue trackers instead.
 
 ## Create an issue
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -483,10 +483,6 @@ By default, the repository is cloned as a shallow copy (\fB\-\-depth=1\fR), but 
 Migrate tapped formulae from symlink\-based to directory\-based structure\.
 .
 .TP
-\fBtap\fR \fB\-\-list\-official\fR
-List all official taps\.
-.
-.TP
 \fBtap\fR \fB\-\-list\-pinned\fR
 List all pinned taps\.
 .


### PR DESCRIPTION
There are none remaining. We don’t want PHP to get the deprecated messages until all formulae have been deleted so that will be in a later PR.