### PR TITLE
official_taps: deprecate homebrew/php.

### DIFF
--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -1,7 +1,3 @@
-OFFICIAL_TAPS = %w[
-  php
-].freeze
-
 OFFICIAL_CASK_TAPS = %w[
   cask
   versions
@@ -25,6 +21,7 @@ DEPRECATED_OFFICIAL_TAPS = %w[
   gui
   head-only
   nginx
+  php
   python
   science
   tex


### PR DESCRIPTION
After all these formulae have been deleted (not until April 7th, most likely) we want to warn people on tapping it.