### PR TITLE
keg: delete bad tap opt non-symlink directories.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -238,7 +238,9 @@ class Keg
 
     if tap
       bad_tap_opt = opt/tap.user
-      FileUtils.rm_rf bad_tap_opt if bad_tap_opt.directory?
+      if !bad_tap_opt.symlink? && bad_tap_opt.directory?
+        FileUtils.rm_rf bad_tap_opt
+      end
     end
 
     aliases.each do |a|


### PR DESCRIPTION
But don't delete them if they are a symlink to a directory i.e. a normal opt link.

Handles the issue mentioned in
https://github.com/Homebrew/brew/commit/1651647a3dc9dbc03ed3c5da06090228db4cd1a0#r28360427

CC @soonho-tri