### PR TITLE
Remove config/doctor checks we no longer need

### DIFF
--- a/Library/Homebrew/cmd/doctor.rb
+++ b/Library/Homebrew/cmd/doctor.rb
@@ -28,7 +28,6 @@ module Homebrew
       slow_checks = %w[
         check_for_broken_symlinks
         check_missing_deps
-        check_for_linked_keg_only_brews
       ]
       methods = (checks.all.sort - slow_checks) + slow_checks
     else

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -107,18 +107,6 @@ module Homebrew
         EOS
       end
 
-      # See https://github.com/Homebrew/legacy-homebrew/pull/9986
-      def check_path_for_trailing_slashes
-        bad_paths = PATH.new(ENV["HOMEBREW_PATH"]).select { |p| p.end_with?("/") }
-        return if bad_paths.empty?
-
-        inject_file_list bad_paths, <<~EOS
-          Some directories in your path end in a slash.
-          Directories in your path should not end in a slash. This can break other
-          doctor checks. The following directories should be edited:
-        EOS
-      end
-
       # Anaconda installs multiple system & brew dupes, including OpenSSL, Python,
       # sqlite, libpng, Qt, etc. Regularly breaks compile on Vim, MacVim and others.
       # Is flagged as part of the *-config script checks below, but people seem
@@ -620,18 +608,6 @@ module Homebrew
         message
       end
 
-      def check_ssl_cert_file
-        return unless ENV.key?("SSL_CERT_FILE")
-        <<~EOS
-          Setting SSL_CERT_FILE can break downloading files; if that happens
-          you should unset it before running Homebrew.
-
-          Homebrew uses the system curl which uses system certificates by
-          default. Setting SSL_CERT_FILE makes it use an outdated OpenSSL, which
-          does not support modern OpenSSL certificate stores.
-        EOS
-      end
-
       def check_for_symlinked_cellar
         return unless HOMEBREW_CELLAR.exist?
         return unless HOMEBREW_CELLAR.symlink?
@@ -811,28 +787,6 @@ module Homebrew
         false
       end
 
-      def check_for_linked_keg_only_brews
-        return unless HOMEBREW_CELLAR.exist?
-
-        linked = Formula.installed.sort.select do |f|
-          f.keg_only? && __check_linked_brew(f)
-        end
-        return if linked.empty?
-
-        inject_file_list linked.map(&:full_name), <<~EOS
-          Some keg-only formulae are linked into the Cellar.
-          Linking a keg-only formula, such as gettext, into the cellar with
-          `brew link <formula>` will cause other formulae to detect them during
-          the `./configure` step. This may cause problems when compiling those
-          other formulae.
-
-          Binaries provided by keg-only formulae may override system binaries
-          with other strange results.
-
-          You may wish to `brew unlink` these brews:
-        EOS
-      end
-
       def check_for_other_frameworks
         # Other frameworks that are known to cause problems when present
         frameworks_to_check = %w[
@@ -891,53 +845,6 @@ module Homebrew
           should you later need to do so for some reason.
             cd #{HOMEBREW_LIBRARY} && git stash && git clean -d -f
         EOS
-      end
-
-      def check_for_enthought_python
-        return unless which "enpkg"
-
-        <<~EOS
-          Enthought Python was found in your PATH.
-          This can cause build problems, as this software installs its own
-          copies of iconv and libxml2 into directories that are picked up by
-          other build systems.
-        EOS
-      end
-
-      def check_for_library_python
-        return unless File.exist?("/Library/Frameworks/Python.framework")
-
-        <<~EOS
-          Python is installed at /Library/Frameworks/Python.framework
-
-          Homebrew only supports building against the System-provided Python or a
-          brewed Python. In particular, Pythons installed to /Library can interfere
-          with other software installs.
-        EOS
-      end
-
-      def check_for_old_homebrew_share_python_in_path
-        message = ""
-        ["", "3"].map do |suffix|
-          next unless paths.include?((HOMEBREW_PREFIX/"share/python#{suffix}").to_s)
-          message += <<~EOS
-            #{HOMEBREW_PREFIX}/share/python#{suffix} is not needed in PATH.
-          EOS
-        end
-        unless message.empty?
-          message += <<~EOS
-
-            Formerly homebrew put Python scripts you installed via `pip` or `pip3`
-            (or `easy_install`) into that directory above but now it can be removed
-            from your PATH variable.
-            Python scripts will now install into #{HOMEBREW_PREFIX}/bin.
-            You can delete anything, except 'Extras', from the #{HOMEBREW_PREFIX}/share/python
-            (and #{HOMEBREW_PREFIX}/share/python@2) dir and install affected Python packages
-            anew with `pip install --upgrade`.
-          EOS
-        end
-
-        message unless message.empty?
       end
 
       def check_for_bad_python_symlink

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -13,6 +13,8 @@ module Stdenv
   def setup_build_environment(formula = nil)
     super
 
+    self["HOMEBREW_ENV"] = "std"
+
     PATH.new(ENV["HOMEBREW_PATH"]).each { |p| prepend_path "PATH", p }
 
     # Set the default pkg-config search path, overriding the built-in paths

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -38,6 +38,7 @@ module Superenv
     super
     send(compiler)
 
+    self["HOMEBREW_ENV"] = "super"
     self["MAKEFLAGS"] ||= "-j#{determine_make_jobs}"
     self["PATH"] = determine_path
     self["PKG_CONFIG_PATH"] = determine_pkg_config_path

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -1,26 +1,23 @@
 class SystemConfig
   class << self
     def xcode
-      if instance_variable_defined?(:@xcode)
-        @xcode
-      elsif MacOS::Xcode.installed?
-        @xcode = MacOS::Xcode.version.to_s
-        @xcode += " => #{MacOS::Xcode.prefix}" unless MacOS::Xcode.default_prefix?
-        @xcode
+      @xcode ||= if MacOS::Xcode.installed?
+        xcode = MacOS::Xcode.version.to_s
+        xcode += " => #{MacOS::Xcode.prefix}" unless MacOS::Xcode.default_prefix?
+        xcode
       end
     end
 
     def clt
-      if instance_variable_defined?(:@clt)
-        @clt
-      elsif MacOS::CLT.installed? && MacOS::Xcode.version >= "4.3"
-        @clt = MacOS::CLT.version
+      @clt ||= if MacOS::CLT.installed? && MacOS::Xcode.version >= "4.3"
+        MacOS::CLT.version
       end
     end
 
-    def macports_or_fink
-      @ponk ||= MacOS.macports_or_fink
-      @ponk.join(", ") unless @ponk.empty?
+    def xquartz
+      @xquartz ||= if MacOS::XQuartz.installed?
+        "#{MacOS::XQuartz.version} => #{describe_path(MacOS::XQuartz.prefix)}"
+      end
     end
 
     def describe_java
@@ -36,11 +33,6 @@ class SystemConfig
       javas.uniq.join(", ")
     end
 
-    def describe_xquartz
-      return "N/A" unless MacOS::XQuartz.installed?
-      "#{MacOS::XQuartz.version} => #{describe_path(MacOS::XQuartz.prefix)}"
-    end
-
     def describe_homebrew_ruby
       s = describe_homebrew_ruby_version
 
@@ -54,10 +46,9 @@ class SystemConfig
     def dump_verbose_config(f = $stdout)
       dump_generic_verbose_config(f)
       f.puts "macOS: #{MacOS.full_version}-#{kernel}"
-      f.puts "Xcode: #{xcode ? xcode : "N/A"}"
       f.puts "CLT: #{clt ? clt : "N/A"}"
-      f.puts "X11: #{describe_xquartz}"
-      f.puts "MacPorts/Fink: #{macports_or_fink}" if macports_or_fink
+      f.puts "Xcode: #{xcode ? xcode : "N/A"}"
+      f.puts "XQuartz: #{xquartz ? xquartz : "N/A"}"
     end
   end
 end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -151,12 +151,14 @@ class SystemConfig
       if defaults_hash[:HOMEBREW_CACHE] != HOMEBREW_CACHE.to_s
         f.puts "HOMEBREW_CACHE: #{HOMEBREW_CACHE}"
       end
-      ENV.sort.each do |key, value|
-        next unless key.start_with?("HOMEBREW_")
-        next if boring_keys.include?(key)
-        next if defaults_hash[key.to_sym]
-        value = "set" if key =~ /(cookie|key|token|password)/i
-        f.puts "#{key}: #{value}"
+      unless ENV["HOMEBREW_ENV"]
+        ENV.sort.each do |key, value|
+          next unless key.start_with?("HOMEBREW_")
+          next if boring_keys.include?(key)
+          next if defaults_hash[key.to_sym]
+          value = "set" if key =~ /(cookie|key|token|password)/i
+          f.puts "#{key}: #{value}"
+        end
       end
       f.puts hardware if hardware
       f.puts "Homebrew Ruby: #{describe_homebrew_ruby}"

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -6,22 +6,6 @@ require "development_tools"
 
 class SystemConfig
   class << self
-    def gcc_4_2
-      @gcc_4_2 ||= if DevelopmentTools.installed?
-        DevelopmentTools.gcc_4_2_build_version
-      else
-        Version::NULL
-      end
-    end
-
-    def gcc_4_0
-      @gcc_4_0 ||= if DevelopmentTools.installed?
-        DevelopmentTools.gcc_4_0_build_version
-      else
-        Version::NULL
-      end
-    end
-
     def clang
       @clang ||= if DevelopmentTools.installed?
         DevelopmentTools.clang_version
@@ -69,42 +53,6 @@ class SystemConfig
         path
       else
         "#{path} => #{realpath}"
-      end
-    end
-
-    def describe_perl
-      describe_path(which("perl", ENV["HOMEBREW_PATH"]))
-    end
-
-    def describe_python
-      python = begin
-        python_path = PATH.new(ENV["HOMEBREW_PATH"])
-                          .prepend(Formula["python"].opt_libexec/"bin")
-        which "python", python_path
-      rescue FormulaUnavailableError
-        which "python"
-      end
-
-      return "N/A" if python.nil?
-      python_binary = Utils.popen_read python, "-c", "import sys; sys.stdout.write(sys.executable)"
-      python_binary = Pathname.new(python_binary).realpath
-      if python == python_binary
-        python
-      else
-        "#{python} => #{python_binary}"
-      end
-    end
-
-    def describe_ruby
-      ruby = which "ruby", ENV["HOMEBREW_PATH"]
-      return "N/A" if ruby.nil?
-      ruby_binary = Utils.popen_read ruby, "-rrbconfig", "-e", \
-        'include RbConfig;print"#{CONFIG["bindir"]}/#{CONFIG["ruby_install_name"]}#{CONFIG["EXEEXT"]}"'
-      ruby_binary = Pathname.new(ruby_binary).realpath
-      if ruby == ruby_binary
-        ruby
-      else
-        "#{ruby} => #{ruby_binary}"
       end
     end
 
@@ -212,8 +160,6 @@ class SystemConfig
       end
       f.puts hardware if hardware
       f.puts "Homebrew Ruby: #{describe_homebrew_ruby}"
-      f.puts "GCC-4.0: build #{gcc_4_0}" unless gcc_4_0.null?
-      f.puts "GCC-4.2: build #{gcc_4_2}" unless gcc_4_2.null?
       f.print "Clang: "
       if clang.null?
         f.puts "N/A"
@@ -227,9 +173,6 @@ class SystemConfig
       end
       f.puts "Git: #{describe_git}"
       f.puts "Curl: #{describe_curl}"
-      f.puts "Perl: #{describe_perl}"
-      f.puts "Python: #{describe_python}"
-      f.puts "Ruby: #{describe_ruby}"
       f.puts "Java: #{describe_java}"
     end
     alias dump_generic_verbose_config dump_verbose_config

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     parallel (1.12.1)
     parallel_tests (2.21.2)
       parallel
-    parser (2.5.0.2)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     rainbow (3.0.0)
@@ -36,7 +36,7 @@ GEM
     rspec-support (3.7.1)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
-    rubocop (0.53.0)
+    rubocop (0.54.0)
       parallel (~> 1.10)
       parser (>= 2.5)
       powerpack (~> 0.1)
@@ -62,7 +62,7 @@ DEPENDENCIES
   rspec-its
   rspec-retry
   rspec-wait
-  rubocop (= 0.53.0)
+  rubocop (= 0.54.0)
   simplecov
 
 BUNDLED WITH

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -6,12 +6,6 @@ describe Homebrew::Diagnostic::Checks do
     expect(subject.inject_file_list(%w[/a /b], "foo:\n")).to eq("foo:\n  /a\n  /b\n")
   end
 
-  specify "#check_path_for_trailing_slashes" do
-    ENV["HOMEBREW_PATH"] += File::PATH_SEPARATOR + "/foo/bar/"
-    expect(subject.check_path_for_trailing_slashes)
-      .to match("Some directories in your path end in a slash")
-  end
-
   specify "#check_build_from_source" do
     ENV["HOMEBREW_BUILD_FROM_SOURCE"] = "1"
     expect(subject.check_build_from_source)

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -22,14 +22,14 @@ describe Homebrew::Diagnostic::Checks do
       .to match("The following beta release of XQuartz is installed: 2.7.10_beta2")
   end
 
-  specify "#check_xcode_8_without_clt_on_el_capitan" do
+  specify "#check_if_xcode_needs_clt_installed" do
     allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.11"))
     allow(MacOS::Xcode).to receive(:installed?).and_return(true)
     allow(MacOS::Xcode).to receive(:version).and_return("8.0")
     allow(MacOS::Xcode).to receive(:without_clt?).and_return(true)
 
-    expect(subject.check_xcode_8_without_clt_on_el_capitan)
-      .to match("You have Xcode 8 installed without the CLT")
+    expect(subject.check_if_xcode_needs_clt_installed)
+      .to match("Xcode alone is not sufficient on El Capitan")
   end
 
   specify "#check_homebrew_prefix" do


### PR DESCRIPTION
A bunch of these were needed before superenv, environment filtering or on now long-unsupported versions of macOS.