### PR TITLE
cli_parser: Common switch options to be accessible across brew

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -18,11 +18,13 @@ module Homebrew
 
       def switch(*names, description: nil, env: nil)
         description = option_to_description(*names) if description.nil?
-        names, env = common_switch(*names) if names.first.is_a?(Symbol)
+        global_switch = names.first.is_a?(Symbol)
+        names, env = common_switch(*names) if global_switch
         @parser.on(*names, description) do
-          enable_switch(*names)
+          enable_switch(*names, global_switch)
         end
-        enable_switch(*names) if !env.nil? && !ENV["HOMEBREW_#{env.to_s.upcase}"].nil?
+        enable_switch(*names, global_switch) if !env.nil? &&
+                                                !ENV["HOMEBREW_#{env.to_s.upcase}"].nil?
       end
 
       def comma_array(name, description: nil)
@@ -53,23 +55,29 @@ module Homebrew
       end
 
       def parse(cmdline_args = ARGV)
-        @parser.parse!(cmdline_args)
+        @parser.parse(cmdline_args)
         @parsed_args
       end
 
       private
 
-      def enable_switch(*names)
+      def enable_switch(*names, global_switch)
         names.each do |name|
+          if global_switch
+            Homebrew.args["#{option_to_name(name)}?"] = true
+            next
+          end
           @parsed_args["#{option_to_name(name)}?"] = true
         end
       end
 
+      # These are common/global switches accessible throughout Homebrew
       def common_switch(name)
         case name
         when :quiet   then [["-q", "--quiet"], :quiet]
         when :verbose then [["-v", "--verbose"], :verbose]
         when :debug   then [["-d", "--debug"], :debug]
+        when :force   then [["-f", "--force"], :force]
         else name
         end
       end

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -79,6 +79,7 @@ module Homebrew
       switch "--no-commit"
       switch "--json"
       switch :verbose
+      switch :debug
       flag   "--root-url"
     end
 
@@ -113,7 +114,7 @@ module Homebrew
       linked_libraries = Keg.file_linked_libraries(file, string)
       result ||= !linked_libraries.empty?
 
-      if @args.verbose?
+      if Homebrew.args.verbose?
         print_filename.call(string, file) unless linked_libraries.empty?
         linked_libraries.each do |lib|
           puts " #{Tty.bold}-->#{Tty.reset} links to #{lib}"
@@ -136,7 +137,7 @@ module Homebrew
         end
       end
 
-      next unless @args.verbose? && !text_matches.empty?
+      next unless Homebrew.args.verbose? && !text_matches.empty?
       print_filename.call(string, file)
       text_matches.first(MAXIMUM_STRING_MATCHES).each do |match, offset|
         puts " #{Tty.bold}-->#{Tty.reset} match '#{match}' at offset #{Tty.bold}0x#{offset}#{Tty.reset}"
@@ -157,7 +158,7 @@ module Homebrew
       absolute_symlinks_start_with_string << pn if link.to_s.start_with?(string)
     end
 
-    if @args.verbose?
+    if Homebrew.args.verbose?
       unless absolute_symlinks_start_with_string.empty?
         opoo "Absolute symlink starting with #{string}:"
         absolute_symlinks_start_with_string.each do |pn|
@@ -298,7 +299,7 @@ module Homebrew
           end
           skip_relocation = relocatable && !keg.require_relocation?
         end
-        puts if !relocatable && @args.verbose?
+        puts if !relocatable && Homebrew.args.verbose?
       rescue Interrupt
         ignore_interrupts { bottle_path.unlink if bottle_path.exist? }
         raise

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -11,8 +11,10 @@ module Homebrew
   module_function
 
   def edit
-    args = Homebrew::CLI::Parser.parse do
-      switch "--force"
+    Homebrew::CLI::Parser.parse do
+      switch :force
+      switch :verbose
+      switch :debug
     end
 
     unless (HOMEBREW_REPOSITORY/".git").directory?
@@ -41,7 +43,7 @@ module Homebrew
       paths = ARGV.named.map do |name|
         path = Formulary.path(name)
 
-        raise FormulaUnavailableError, name unless path.file? || args.force?
+        raise FormulaUnavailableError, name unless path.file? || Homebrew.args.force?
 
         path
       end

--- a/Library/Homebrew/dev-cmd/formula.rb
+++ b/Library/Homebrew/dev-cmd/formula.rb
@@ -2,11 +2,17 @@
 #:    Display the path where <formula> is located.
 
 require "formula"
+require "cli_parser"
 
 module Homebrew
   module_function
 
   def formula
+    Homebrew::CLI::Parser.parse do
+      switch :debug
+      switch :verbose
+    end
+
     raise FormulaUnspecifiedError if ARGV.named.empty?
     ARGV.resolved_formulae.each { |f| puts f.path }
   end

--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -6,6 +6,11 @@ module Homebrew
   module_function
 
   def mirror
+    Homebrew::CLI::Parser.parse do
+      switch :debug
+      switch :verbose
+    end
+
     odie "This command requires at least formula argument!" if ARGV.named.empty?
 
     bintray_user = ENV["HOMEBREW_BINTRAY_USER"]

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -84,6 +84,8 @@ module Homebrew
       switch "--no-pbcopy"
       switch "--no-publish"
       switch "--warn-on-publish-failure"
+      switch :verbose
+      switch :debug
       flag   "--bintray-org",   required: true
       flag   "--test-bot-user", required: true
     end

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -1,6 +1,9 @@
 #:  * `tap-new` <user>`/`<repo>:
 #:    Generate the template files for a new tap.
 
+require "tap"
+require "cli_parser"
+
 module Homebrew
   module_function
 
@@ -12,6 +15,11 @@ module Homebrew
   end
 
   def tap_new
+    Homebrew::CLI::Parser.parse do
+      switch :debug
+      switch :verbose
+    end
+
     raise "A tap argument is required" if ARGV.named.empty?
 
     tap = Tap.fetch(ARGV.named.first)

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -25,9 +25,10 @@ module Homebrew
     args = Homebrew::CLI::Parser.parse do
       switch "--no-compat"
       switch "--generic"
-      switch "-v", "--verbose"
       switch "--coverage"
       switch "--online"
+      switch :debug
+      switch :verbose
       flag   "--only", required: true
       flag   "--seed", required: true
     end

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -23,6 +23,8 @@ module Homebrew
     args = Homebrew::CLI::Parser.parse do
       switch "--to-tag"
       switch "--keep-tmp"
+      switch :verbose
+      switch :debug
       flag   "--commit", required: true
       flag   "--before", required: true
     end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -1,5 +1,6 @@
 require "pathname"
 require "English"
+require "ostruct"
 
 require "pp"
 require "extend/ARGV"
@@ -30,14 +31,16 @@ module Homebrew
   extend FileUtils
 
   class << self
-    attr_writer :failed
+    attr_writer :failed, :raise_deprecation_exceptions, :auditing, :args
 
     def failed?
       @failed ||= false
       @failed == true
     end
 
-    attr_writer :raise_deprecation_exceptions, :auditing
+    def args
+      @args ||= OpenStruct.new
+    end
 
     def raise_deprecation_exceptions?
       @raise_deprecation_exceptions == true

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -16,24 +16,25 @@ describe Homebrew::CLI::Parser do
     }
 
     it "parses short option" do
-      args = parser.parse(["-v"])
-      expect(args).to be_verbose
+      parser.parse(["-v"])
+      expect(Homebrew.args).to be_verbose
     end
 
     it "parses a single valid option" do
-      args = parser.parse(["--verbose"])
-      expect(args).to be_verbose
+      parser.parse(["--verbose"])
+      expect(Homebrew.args).to be_verbose
     end
 
     it "parses a valid option along with few unnamed args" do
       args = %w[--verbose unnamed args]
       parser.parse(args)
-      expect(args).to eq %w[unnamed args]
+      expect(Homebrew.args).to be_verbose
+      expect(args).to eq %w[--verbose unnamed args]
     end
 
     it "parses a single option and checks other options to be nil" do
       args = parser.parse(["--verbose"])
-      expect(args).to be_verbose
+      expect(Homebrew.args).to be_verbose
       expect(args.more_verbose?).to be nil
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#1860 

~As indicated above this a WIP PR, open to feedback.~

Context: Arguments like `--verbose` , `--debug`, `--quiet`, `--force` are to be accessible across commands, they cannot be stored as `Hombrew::CLI::Parser`'s instance variables.
Example: Command `A` might use a method defined elsewhere, and this method could check for `--debug` 

~To achieve this, I'm storing common `switch`es listed above in a class variable of `Homebrew::CLI::Parser` , and I've declared `verbose` and `debug` in every `dev-cmd` that uses `Homebrew::CLI::Parser`~

 