### PR TITLE
Maintainer-Guidelines: add communication section.

### DIFF
--- a/docs/Maintainer-Guidelines.md
+++ b/docs/Maintainer-Guidelines.md
@@ -104,3 +104,14 @@ Whitespace corrections (to Ruby standard etc.) are allowed (in fact this
 is a good opportunity to do it) provided the line itself has some kind
 of modification that is not whitespace in it. But be careful about
 making changes to inline patches—make sure they still apply.
+
+## Communication
+Maintainers have a variety of ways to communicate with each other:
+
+- Homebrew's public repositories on GitHub
+- Homebrew's group communications between more than two maintainers on private channels (e.g. GitHub/Slack/Discourse)
+- Homebrew's direct 1:1 messages between two maintainers on private channels (e.g. iMessage/Slack/Discourse/IRC/carrier pigeon)
+
+All communication should ideally occur in public on GitHub. Where this is not possible or appropriate (e.g. a security disclosure, interpersonal issue between two maintainers, urgent breakage that needs to be resolved) this can move to maintainers' private group communication and, if necessary, 1:1 communication. Technical decisions should not happen in 1:1 communications but if they do (or did in the past) they must end up back as something linkable on GitHub. For example, if a technical decision was made a year ago on Slack and another maintainer/contributor/user asks about it on GitHub, that's a good chance to explain it to them and have something that can be linked to in the future.
+
+This makes it easier for other maintainers, contributors and users to follow along with what we're doing (and, more importantly, why we're doing it) and means that decisions have a linkable URL.

--- a/docs/New-Maintainer-Checklist.md
+++ b/docs/New-Maintainer-Checklist.md
@@ -55,7 +55,7 @@ If they accept, follow a few steps to get them set up:
 - Add them to the [Jenkins' GitHub Authorization Settings admin user names](https://jenkins.brew.sh/configureSecurity/) so they can adjust settings and restart jobs
 - Add them to the [Jenkins' GitHub Pull Request Builder admin list](https://jenkins.brew.sh/configure) to enable `@BrewTestBot test this please` for them
 - Invite them to the [`homebrew-maintainers` private maintainers mailing list](https://lists.sfconservancy.org/mailman/admin/homebrew-maintainers/members/add)
-- Invite them to the [`machomebrew` private maintainers Slack](https://machomebrew.slack.com/admin/invites)
+- Invite them to the [`machomebrew` private maintainers Slack](https://machomebrew.slack.com/admin/invites) (and ensure they've read the [communication guidelines](Maintainer-Guidelines.md#communication))
 - Invite them to the [`homebrew` private maintainers 1Password](https://homebrew.1password.com/signin)
 - Invite them to [Google Analytics](https://analytics.google.com/analytics/web/?authuser=1#management/Settings/a76679469w115400090p120682403/%3Fm.page%3DAccountUsers/)
 


### PR DESCRIPTION
I'm proposing a change to the maintainer communication guidelines to steer us back into more public communication with one another. I've been guilty since we set up our Slack of letting technical conversations drift into there and posting comments like "as discussed in Slack". This strips the context for many of Homebrew's decisions from other maintainers, contributors and users and makes it harder to get involved with the project. Obviously I cannot (nor would I want to) force any other maintainers to adopt these guidelines but I think it's worth noting them for improved future communication.

I will follow up on this with trying to make more issues documenting high-level problems we're aiming to solve in Homebrew and PRs to document the roadmap for Homebrew.

CC @Homebrew/maintainers for review and thoughts.
