### PR TITLE
Tell curl to not use .curlrc

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -47,8 +47,15 @@ fetch() {
   local sha
   local temporary_path
 
-  curl_args=(
-    -q # do not load .curlrc (must be the first argument)
+  curl_args=()
+
+  # do not load .curlrc unless requested (must be the first argument)
+  if [[ -n "$HOMEBREW_CURLRC" ]]
+  then
+    curl_args[${#curl_args[*]}]="-q"
+  fi
+
+  curl_args+=(
     --fail
     --remote-time
     --location

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -48,6 +48,7 @@ fetch() {
   local temporary_path
 
   curl_args=(
+    -q # do not load .curlrc (must be the first argument)
     --fail
     --remote-time
     --location

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -480,21 +480,6 @@ module Homebrew
         EOS
       end
 
-      def check_user_curlrc
-        curlrc_found = %w[CURL_HOME HOME].any? do |var|
-          ENV[var] && File.exist?("#{ENV[var]}/.curlrc")
-        end
-        return unless curlrc_found
-
-        <<~EOS
-          You have a curlrc file
-          If you have trouble downloading packages with Homebrew, then maybe this
-          is the problem? If the following command doesn't work, then try removing
-          your curlrc:
-            curl #{Formatter.url("https://github.com")}
-        EOS
-      end
-
       def check_for_gettext
         find_relative_paths("lib/libgettextlib.dylib",
                             "lib/libintl.dylib",

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -136,6 +136,10 @@ can take several different forms:
 
     *Default:* `~/Library/Caches/Homebrew`.
 
+  * `HOMEBREW_CURLRC`:
+    If set, Homebrew will not pass `-q` when invoking `curl`(1) (which disables
+    the use of `curlrc`).
+
   * `HOMEBREW_CURL_VERBOSE`:
     If set, Homebrew will pass `--verbose` when invoking `curl`(1).
 

--- a/Library/Homebrew/test/diagnostic_spec.rb
+++ b/Library/Homebrew/test/diagnostic_spec.rb
@@ -131,15 +131,6 @@ describe Homebrew::Diagnostic::Checks do
     end
   end
 
-  specify "#check_user_curlrc" do
-    mktmpdir do |path|
-      FileUtils.touch "#{path}/.curlrc"
-      ENV["CURL_HOME"] = path
-
-      expect(subject.check_user_curlrc).to match("You have a curlrc file")
-    end
-  end
-
   specify "#check_for_config_scripts" do
     mktmpdir do |path|
       file = "#{path}/foo-config"

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -1,0 +1,10 @@
+require "utils/curl"
+
+describe "curl" do
+  describe "curl_args" do
+    it "returns -q as the first argument" do
+      # -q must be the first argument according to "man curl"
+      expect(curl_args("foo")[1]).to eq("-q")
+    end
+  end
+end

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -2,9 +2,14 @@ require "utils/curl"
 
 describe "curl" do
   describe "curl_args" do
-    it "returns -q as the first argument" do
+    it "returns -q as the first argument when HOMEBREW_CURLRC is set" do
+      ENV["HOMEBREW_CURLRC"] = "1"
       # -q must be the first argument according to "man curl"
       expect(curl_args("foo")[1]).to eq("-q")
+    end
+
+    it "doesn't return -q as the first argument when HOMEBREW_CURLRC is not set" do
+      expect(curl_args("foo")[1]).to_not eq("-q")
     end
   end
 end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -14,6 +14,7 @@ end
 def curl_args(*extra_args, show_output: false, user_agent: :default)
   args = [
     curl_executable.to_s,
+    "-q", # do not load .curlrc (must be the first argument)
     "--show-error",
   ]
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -12,11 +12,14 @@ def curl_executable
 end
 
 def curl_args(*extra_args, show_output: false, user_agent: :default)
-  args = [
-    curl_executable.to_s,
-    "-q", # do not load .curlrc (must be the first argument)
-    "--show-error",
-  ]
+  args = [curl_executable.to_s]
+
+  # do not load .curlrc unless requested (must be the first argument)
+  if ENV["HOMEBREW_CURLRC"]
+    args << "-q"
+  end
+
+  args << "--show-error"
 
   args << "--user-agent" << case user_agent
   when :browser, :fake

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1110,6 +1110,10 @@ can take several different forms:
 
     *Default:* `~/Library/Caches/Homebrew`.
 
+  * `HOMEBREW_CURLRC`:
+    If set, Homebrew will not pass `-q` when invoking `curl`(1) (which disables
+    the use of `curlrc`).
+
   * `HOMEBREW_CURL_VERBOSE`:
     If set, Homebrew will pass `--verbose` when invoking `curl`(1).
 

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "March 2018" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "April 2018" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "March 2018" "Homebrew" "brew"
+.TH "BREW" "1" "April 2018" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -1126,6 +1126,10 @@ If set, instructs Homebrew to use the given directory as the download cache\.
 .
 .IP
 \fIDefault:\fR \fB~/Library/Caches/Homebrew\fR\.
+.
+.TP
+\fBHOMEBREW_CURLRC\fR
+If set, Homebrew will not pass \fB\-q\fR when invoking \fBcurl\fR(1) (which disables the use of \fBcurlrc\fR)\.
 .
 .TP
 \fBHOMEBREW_CURL_VERBOSE\fR


### PR DESCRIPTION
Searching the issues and PRs, I wasn't able to find prior discussion of this. Apologies if this is something that has already been decided that it can't be used for some reason.

I have known that Homebrew does not like `~/.curlrc` because `brew doctor` warns about it. But it hasn't been an issue for me until I tried creating a cask (https://github.com/caskroom/homebrew-cask/pull/45612).

In deciding between `-q` and `--disable`, I chose `-q` because it appears that `--disable` was only added in [7.49.0 (May 18 2016)](https://curl.haxx.se/changes.html). I wasn't able to determine when `-q` was initially added.

One reason I can think about against not merging this, is if a user puts special proxy settings in their curlrc. But even in that case I'm not sure, because the user might not expect Homebrew to use that. Is there a way to tell curl to use the macos proxy settings?

Let me know what you think! Thanks!

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
