### PR TITLE
Add support for filtering custom variables

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -64,7 +64,7 @@ if [[ -z "$HOMEBREW_NO_ENV_FILTERING" && "$1" != "test-bot" ]]
 then
   PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
-  FILTERED_ENV=()
+  FILTERED_ENV="${HOMEBREW_BUILD_ENV}"
   # Filter all but the specific variables.
   for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The filtering of environment variables is great. But sometimes you want to pass a custom variable to the build, such as `PKG_CONFIG_PATH` or `XDG_DATA_DIRS`. It would be great if this can be done without fully opting out of filtering.

Here is one simple proposal. This would allow a user to do e.g.:

```sh
export HOMEBREW_BUILD_ENV="PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig"
brew install whatever --build-from-source
```

Which is much nicer than using `HOMEBREW_NO_ENV_FILTERING=1`. Thank you for your time!