### PR TITLE
Add message to `set_ownership`

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/staged.rb
+++ b/Library/Homebrew/cask/lib/hbc/staged.rb
@@ -33,6 +33,7 @@ module Hbc
     def set_ownership(paths, user: current_user, group: "staff")
       full_paths = remove_nonexistent(paths)
       return if full_paths.empty?
+      ohai "Changing ownership of paths required by #{@cask}; your password may be necessary"
       @command.run!("/usr/sbin/chown", args: ["-R", "--", "#{user}:#{group}"] + full_paths,
                                        sudo: true)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes #4024 

This displays the message when `set_ownership` is run either as part of install or uninstall so that a command that requires `sudo` doesn't run silently, even if the password has already been supplied.

```
$ brew cask uninstall wireshark
==> Uninstalling Cask wireshark
==> Running set_ownership for wireshark; your password may be necessary
Password:
```
```
$ brew cask install sencha

snip

==> Installing Cask sencha
==> Running installer script 'SenchaCmd-6.5.3.6-osx.app/Contents/MacOS/JavaAppli
==> 2018-04-07 20:43:11.160 JavaApplicationStub[4555:20437] NEW LAUNCHER
==> The installation directory has been set to /opt/Sencha/Cmd/6.5.3.6.
==> 
==> Extracting files ...
==> Finishing installation ...
==> Running set_ownership for sencha; your password may be necessary
🍺  sencha was successfully installed!
```