### PR TITLE
enhance write_jar_script to launch specific java version

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -438,12 +438,10 @@ class Pathname
   # Writes an exec script that invokes a java jar
   def write_jar_script(target_jar, script_name, java_opts = "", java_version: nil)
     mkpath
-    java_home = if java_version
-      "JAVA_HOME=\"$(#{Language::Java.java_home_cmd(java_version)})\" "
-    end
+    launcher = java_version.nil? ? "java" : "/usr/libexec/java_home -v #{java_version} --exec java"
     join(script_name).write <<~EOS
       #!/bin/bash
-      #{java_home}exec java #{java_opts} -jar #{target_jar} "$@"
+      exec #{launcher} #{java_opts} -jar #{target_jar} "$@"
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
On macOS, the default `java` launcher available from `$PATH` is: 

	/System/Library/Frameworks/JavaVM.framework/Versions/A/Commands/java

which is a specical launcher that allows one to launch certain version
of `java` simplify by specifying the `JAVA_HOME` environment variable.
For example:

	JAVA_HOME="$(/usr/libexec/java_home -v 9)" java -version

It would report java version 9, as expected

However, when `PATH` is modified and pointing to another java, like one
from the standard JDK/JRE, that version of `java` would always be used
regardless the value of `$JAVA_HOME`:

	export PATH="$(/usr/libexec/java_home -v 1.8)/bin:$PATH"
	JAVA_HOME="$(/usr/libexec/java_home -v 9)" java -version

This time the result is java version 1.8, instead of java 9.

To avoid this issue, we can directly use `/usr/libexec/java_home`, which
can be used to launch the specified java version correctly:

	/usr/libexec/java_home -v 9 --exec java -version

and this works regardless whether `$PATH` is messed up or not.

Note: this is the next step for https://github.com/Homebrew/brew/pull/3782, which partly solved the original problem.
