### PR TITLE
audit (strict): check for build.with? dependencies.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -738,6 +738,10 @@ class FormulaAuditor
       problem "Use \#{pkgshare} instead of \#{share}/#{formula.name}"
     end
 
+    if line =~ /depends_on .+ if build\.with(out)?\?\(?["']\w+["']\)?/
+      problem "`Use :optional` or `:recommended` instead of `#{Regexp.last_match(0)}`"
+    end
+
     return unless line =~ %r{share(\s*[/+]\s*)(['"])#{Regexp.escape(formula.name)}(?:\2|/)}
     problem "Use pkgshare instead of (share#{Regexp.last_match(1)}\"#{formula.name}\")"
   end


### PR DESCRIPTION
These don't behave as expected; depending on when and where in Homebrew (or even an installation process) these are evaluated they return different results. This means that sometimes these will be seen as dependencies and sometimes they will be ignored entirely by the DSL.

Instead `:optional` or `:recommended` dependencies should be used. We don't have a solution yet for grouping dependencies together but this is another case for removing more optional dependencies altogether (as there are no designs or proposed implementations).