### PR TITLE
cli_parser: undefine OpenStruct instance tap.

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -11,6 +11,8 @@ module Homebrew
       def initialize(&block)
         @parser = OptionParser.new
         @parsed_args = OpenStruct.new
+        # undefine tap to allow --tap argument
+        @parsed_args.instance_eval { undef tap }
         instance_eval(&block)
       end
 


### PR DESCRIPTION
Undefine `tap` to allow `--tap` arguments to work as expected.

A simpler solution to #4003.

Closes #4003.