### PR TITLE
urls_cop: Search for func calls to match `url` and `mirror` calls

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -99,6 +99,17 @@ module RuboCop
         end
       end
 
+      # Returns array of function call nodes matching func_name in every descendant of node
+      #           Ex. function call:  foo(*args, **kwargs)
+      # Does not match method calls:  foo.bar(*args, **kwargs)
+      # Returns every function calls if no func_name is passed
+      def find_every_func_call_by_name(node, func_name = nil)
+        return if node.nil?
+        node.each_descendant(:send).select do |func_node|
+          func_node.receiver.nil? && (func_name.nil? || func_name == func_node.method_name)
+        end
+      end
+
       # Given a method_name and arguments, yields to a block with
       # matching method passed as a parameter to the block
       def find_method_with_args(node, method_name, *args)

--- a/Library/Homebrew/rubocops/urls_cop.rb
+++ b/Library/Homebrew/rubocops/urls_cop.rb
@@ -6,8 +6,8 @@ module RuboCop
       # This cop audits urls and mirrors in Formulae
       class Urls < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          urls = find_every_method_call_by_name(body_node, :url)
-          mirrors = find_every_method_call_by_name(body_node, :mirror)
+          urls = find_every_func_call_by_name(body_node, :url)
+          mirrors = find_every_func_call_by_name(body_node, :mirror)
 
           # GNU urls; doesn't apply to mirrors
           gnu_pattern = %r{^(?:https?|ftp)://ftpmirror.gnu.org/(.*)}
@@ -195,8 +195,8 @@ module RuboCop
     module FormulaAuditStrict
       class PyPiUrls < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          urls = find_every_method_call_by_name(body_node, :url)
-          mirrors = find_every_method_call_by_name(body_node, :mirror)
+          urls = find_every_func_call_by_name(body_node, :url)
+          mirrors = find_every_func_call_by_name(body_node, :mirror)
           urls += mirrors
 
           # Check pypi urls


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fixes bug found in https://github.com/Homebrew/homebrew-core/pull/26325

`curl.rb` has `system "#{bin}/curl", "-L", stable.url, "-o", filename` and `find_every_method_call_by_name` in `urls_cop.rb` was matching `stable.url` with empty params leading to NPE.

We also need a way to print RuboCop tracebacks when running `brew audit --debug` (Currently it doesn't) which i'll open a PR soon

cc @MikeMcQuaid 