### PR TITLE
Only read curlrc if HOMEBREW_CURLRC is set.

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -50,7 +50,7 @@ fetch() {
   curl_args=()
 
   # do not load .curlrc unless requested (must be the first argument)
-  if [[ -n "$HOMEBREW_CURLRC" ]]
+  if [[ -z "$HOMEBREW_CURLRC" ]]
   then
     curl_args[${#curl_args[*]}]="-q"
   fi

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -2,13 +2,13 @@ require "utils/curl"
 
 describe "curl" do
   describe "curl_args" do
-    it "returns -q as the first argument when HOMEBREW_CURLRC is set" do
-      ENV["HOMEBREW_CURLRC"] = "1"
+    it "returns -q as the first argument when HOMEBREW_CURLRC is not set" do
       # -q must be the first argument according to "man curl"
       expect(curl_args("foo")[1]).to eq("-q")
     end
 
-    it "doesn't return -q as the first argument when HOMEBREW_CURLRC is not set" do
+    it "doesn't return -q as the first argument when HOMEBREW_CURLRC is set" do
+      ENV["HOMEBREW_CURLRC"] = "1"
       expect(curl_args("foo")[1]).to_not eq("-q")
     end
   end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -14,9 +14,7 @@ def curl_args(*extra_args, show_output: false, user_agent: :default)
   args = [curl_executable.to_s]
 
   # do not load .curlrc unless requested (must be the first argument)
-  if ENV["HOMEBREW_CURLRC"]
-    args << "-q"
-  end
+  args << "-q" unless ENV["HOMEBREW_CURLRC"]
 
   args << "--show-error"
 


### PR DESCRIPTION
This reverses the previous, incorrect order.

Spotted by @stefansundin in https://github.com/Homebrew/brew/pull/4022#discussion_r180132685.