### PR TITLE
Keg#replace_text_in_files: fix incorrect replace order

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -68,7 +68,7 @@ class Keg
         relocation.old_cellar => relocation.new_cellar,
         relocation.old_repository => relocation.new_repository,
       }
-      changed = s.gsub!(Regexp.union(replacements.keys), replacements)
+      changed = s.gsub!(Regexp.union(replacements.keys.sort_by(&:length).reverse), replacements)
       next unless changed
       changed_files += [first, *rest].map { |file| file.relative_path_from(path) }
 


### PR DESCRIPTION
The order of the regexes in `Keg#replace_text_in_files` matters.
Otherwise, `/usr/local/Cellar` will be replaced to
`@@HOMEBREW_PREFIX@@/Cellar` instead of `@@HOMEBREW_CELLAR@@`.

Fixes Homebrew/homebrew-core#26043

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----