### PR TITLE
Make release-notes command work from any location

### DIFF
--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -1,6 +1,6 @@
 #:  * `release-notes` [`--markdown`] [<previous_tag>] [<end_ref>]:
 #:    Output the merged pull requests on Homebrew/brew between two Git refs.
-#:    If no <previous_tag> is provided it defaults to the newest tag.
+#:    If no <previous_tag> is provided it defaults to the latest tag.
 #:    If no <end_ref> is provided it defaults to `origin/master`.
 #:
 #:    If `--markdown` is passed, output as a Markdown list.
@@ -16,19 +16,21 @@ module Homebrew
     end
 
     previous_tag = ARGV.named.first
-    previous_tag ||= Utils.popen_read("git tag --list --sort=-version:refname")
-                          .lines.first.chomp
+    previous_tag ||= Utils.popen_read(
+      "git", "-C", HOMEBREW_REPOSITORY, "tag", "--list", "--sort=-version:refname"
+    ).lines.first.chomp
     odie "Could not find any previous tags!" unless previous_tag
 
     end_ref = ARGV.named[1] || "origin/master"
 
     [previous_tag, end_ref].each do |ref|
-      next if quiet_system "git", "rev-parse", "--verify", "--quiet", ref
+      next if quiet_system "git", "-C", HOMEBREW_REPOSITORY, "rev-parse", "--verify", "--quiet", ref
       odie "Ref #{ref} does not exist!"
     end
 
-    output = Utils.popen_read("git log --pretty=format:'%s >> - %b%n' '#{previous_tag}'..'#{end_ref}'")
-                  .lines.grep(/Merge pull request/)
+    output = Utils.popen_read(
+      "git", "-C", HOMEBREW_REPOSITORY, "log", "--pretty=format:'%s >> - %b%n'", "#{previous_tag}..#{end_ref}"
+    ).lines.grep(/Merge pull request/)
 
     output.map! do |s|
       s.gsub(%r{.*Merge pull request #(\d+) from ([^/]+)/[^>]*(>>)*},

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -850,7 +850,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
   * `release-notes` [`--markdown`] [`previous_tag`] [`end_ref`]:
     Output the merged pull requests on Homebrew/brew between two Git refs.
-    If no `previous_tag` is provided it defaults to the newest tag.
+    If no `previous_tag` is provided it defaults to the latest tag.
     If no `end_ref` is provided it defaults to `origin/master`.
 
     If `--markdown` is passed, output as a Markdown list.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -868,7 +868,7 @@ If \fB\-\-test\-bot\-user=\fR\fItest\-bot\-user\fR is passed, pull the bottle bl
 .
 .TP
 \fBrelease\-notes\fR [\fB\-\-markdown\fR] [\fIprevious_tag\fR] [\fIend_ref\fR]
-Output the merged pull requests on Homebrew/brew between two Git refs\. If no \fIprevious_tag\fR is provided it defaults to the newest tag\. If no \fIend_ref\fR is provided it defaults to \fBorigin/master\fR\.
+Output the merged pull requests on Homebrew/brew between two Git refs\. If no \fIprevious_tag\fR is provided it defaults to the latest tag\. If no \fIend_ref\fR is provided it defaults to \fBorigin/master\fR\.
 .
 .IP
 If \fB\-\-markdown\fR is passed, output as a Markdown list\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
**Context**: `brew release-notes` currently fails when executed in a directory other than `$HOMEBREW_REPOSITORY`. Hence, this PR.

* specify repository location using git's `-C` option
* change `newest` to `latest` when talking about the latest tagged commit (a.k.a. _tag_)
