### PR TITLE
compat/extend/string: fix odisabled return.

### DIFF
--- a/Library/Homebrew/compat/extend/string.rb
+++ b/Library/Homebrew/compat/extend/string.rb
@@ -1,6 +1,7 @@
 class String
   def undent
     odisabled "<<-EOS.undent", "<<~EOS"
+    self
   end
   alias unindent undent
 


### PR DESCRIPTION
`odisabled` will still return for a formula in `.brew`. This means `EOS.undent` returns `nil` and the formula
cannot be parsed. Instead return the actual string in this case to avoid e.g. patches blowing up with `nil`
strings.


Fixes #4049.