### PR TITLE
docs/Analytics: note retention period.

### DIFF
--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -8,6 +8,9 @@ Homebrew is provided free of charge and run entirely by volunteers in their spar
 - If a formula is widely used and is failing often it will enable us to prioritise fixing that formula over others.
 - Collecting the OS version allows us to decide what versions of macOS to prioritise and support and identify build failures that occur only on single versions.
 
+## How Long?
+Homebrew's anonymous user and event data have a 14 month retention period. This is the [lowest possible value for Google Analytics](https://support.google.com/analytics/answer/7667196).
+
 ## What?
 Homebrew's analytics record some shared information for every event:
 


### PR DESCRIPTION
Due to [GDPR](https://www.eugdpr.org) Google Analytics have added [data retention controls](https://support.google.com/analytics/answer/7667196).

Let's set these as low as possible (14 months) so that we don't keep any anonymous user data any longer than we need it. Google says "note that these settings will not affect reports based on aggregated data" which is what `brew formula-analytics` uses and we don't query more than 365 days ago using that tool anyway when making decisions.

CC @Homebrew/maintainers for thoughts.