### PR TITLE
missing: exit nonzero if missing deps are found

### DIFF
--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -4,6 +4,8 @@
 #:
 #:    If `--hide=`<hidden> is passed, act as if none of <hidden> are installed.
 #:    <hidden> should be a comma-separated list of formulae.
+#:
+#:    `missing` exits with a non-zero status if any formulae are missing dependencies.
 
 require "formula"
 require "tab"
@@ -25,6 +27,7 @@ module Homebrew
       missing = f.missing_dependencies(hide: ARGV.values("hide"))
       next if missing.empty?
 
+      Homebrew.failed = true
       print "#{f}: " if ff.size > 1
       puts missing.join(" ")
     end

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -14,7 +14,7 @@ describe "brew missing", :integration_test do
     expect { brew "missing" }
       .to output("foo\n").to_stdout
       .and not_to_output.to_stderr
-      .and be_a_success
+      .and be_a_failure
   end
 
   it "prints nothing if all dependencies are installed" do
@@ -35,7 +35,7 @@ describe "brew missing", :integration_test do
       expect { brew "missing", "--hide=foo" }
         .to output("bar: foo\n").to_stdout
         .and not_to_output.to_stderr
-        .and be_a_success
+        .and be_a_failure
     end
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -340,6 +340,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--hide=``hidden` is passed, act as if none of `hidden` are installed.
     `hidden` should be a comma-separated list of formulae.
 
+    `missing` exits with a non-zero status if any formulae are missing dependencies.
+
   * `options` [`--compact`] (`--all`|`--installed`|`formulae`):
     Display install options specific to `formulae`.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -346,6 +346,9 @@ Check the given \fIformulae\fR for missing dependencies\. If no \fIformulae\fR a
 .IP
 If \fB\-\-hide=\fR\fIhidden\fR is passed, act as if none of \fIhidden\fR are installed\. \fIhidden\fR should be a comma\-separated list of formulae\.
 .
+.IP
+\fBmissing\fR exits with a non\-zero status if any formulae are missing dependencies\.
+.
 .TP
 \fBoptions\fR [\fB\-\-compact\fR] (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR)
 Display install options specific to \fIformulae\fR\.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Currently `brew missing` always returns a successful error code. This changes it to return a failing error code when it detects formulae with missing dependencies.
