### PR TITLE
list.rb: use CLI::Parser and improve handling of flags

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -31,7 +31,7 @@ module Homebrew
       switch "--pinned"
       switch "--versions"
       switch "--full-name"
-      switch "--multiple", required_for: "--versions"
+      switch "--multiple", depends_on: "--versions"
       switch :verbose
     end
 

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -20,13 +20,28 @@
 
 require "metafiles"
 require "formula"
+require "cli_parser"
 
 module Homebrew
   module_function
 
   def list
+    @args = CLI::Parser.parse do
+      switch "--unbrewed"
+      switch "--pinned"
+      switch "--versions"
+      switch "--full-name"
+      switch "--multiple"
+      switch :verbose
+    end
+
+    if @args.multiple? && !@args.versions?
+      opoo "--multiple requires --versions"
+      @args.send("versions?=", true)
+    end
+
     # Use of exec means we don't explicitly exit
-    list_unbrewed if ARGV.flag? "--unbrewed"
+    list_unbrewed if @args.unbrewed?
 
     # Unbrewed uses the PREFIX, which will exist
     # Things below use the CELLAR, which doesn't until the first formula is installed.
@@ -35,10 +50,10 @@ module Homebrew
       return
     end
 
-    if ARGV.include?("--pinned") || ARGV.include?("--versions")
+    if @args.pinned? || @args.versions?
       filtered_list
     elsif ARGV.named.empty?
-      if ARGV.include? "--full-name"
+      if @args.full_name?
         full_names = Formula.installed.map(&:full_name).sort(&tap_and_name_comparison)
         return if full_names.empty?
         puts Formatter.columns(full_names)
@@ -46,7 +61,7 @@ module Homebrew
         ENV["CLICOLOR"] = nil
         exec "ls", *ARGV.options_only << HOMEBREW_CELLAR
       end
-    elsif ARGV.verbose? || !$stdout.tty?
+    elsif Homebrew.args.verbose? || !$stdout.tty?
       exec "find", *ARGV.kegs.map(&:to_s) + %w[-not -type d -print]
     else
       ARGV.kegs.each { |keg| PrettyListing.new keg }
@@ -87,13 +102,13 @@ module Homebrew
     dirs.delete "etc"
     dirs.delete "var"
 
-    args = dirs.sort + %w[-type f (]
-    args.concat UNBREWED_EXCLUDE_FILES.flat_map { |f| %W[! -name #{f}] }
-    args.concat UNBREWED_EXCLUDE_PATHS.flat_map { |d| %W[! -path #{d}] }
-    args.concat %w[)]
+    arguments = dirs.sort + %w[-type f (]
+    arguments.concat UNBREWED_EXCLUDE_FILES.flat_map { |f| %W[! -name #{f}] }
+    arguments.concat UNBREWED_EXCLUDE_PATHS.flat_map { |d| %W[! -path #{d}] }
+    arguments.concat %w[)]
 
     cd HOMEBREW_PREFIX
-    exec "find", *args
+    exec "find", *arguments
   end
 
   def filtered_list
@@ -106,7 +121,7 @@ module Homebrew
         rack.exist?
       end
     end
-    if ARGV.include? "--pinned"
+    if @args.pinned?
       pinned_versions = {}
       names.sort.each do |d|
         keg_pin = (HOMEBREW_PINNED_KEGS/d.basename.to_s)
@@ -115,12 +130,12 @@ module Homebrew
         end
       end
       pinned_versions.each do |d, version|
-        puts d.basename.to_s.concat(ARGV.include?("--versions") ? " #{version}" : "")
+        puts d.basename.to_s.concat(@args.versions? ? " #{version}" : "")
       end
     else # --versions without --pinned
       names.sort.each do |d|
         versions = d.subdirs.map { |pn| pn.basename.to_s }
-        next if ARGV.include?("--multiple") && versions.length < 2
+        next if @args.multiple? && versions.length < 2
         puts "#{d.basename} #{versions * " "}"
       end
     end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -31,13 +31,8 @@ module Homebrew
       switch "--pinned"
       switch "--versions"
       switch "--full-name"
-      switch "--multiple"
+      switch "--multiple", required_for: "--versions"
       switch :verbose
-    end
-
-    if @args.multiple? && !@args.versions?
-      opoo "--multiple requires --versions"
-      @args.send("versions?=", true)
     end
 
     # Use of exec means we don't explicitly exit


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew list`:
* When --multiple is specified without --versions it results in the
execution of the `ls` command with `--multiple` flag, which results in a
failure. Here we assume that `--versions` flag was forgotten when  a lone`--multiple` option is provided.

* Use OpenStruct to handle arguments for `list`

**Note**: alternative solution to setting mode.versions? to true (line 39) would be to `odie` instead of `opoo` on line 38.