### PR TITLE
formula_support: deprecate more keg_only reasons.

### DIFF
--- a/Library/Homebrew/compat/formula_support.rb
+++ b/Library/Homebrew/compat/formula_support.rb
@@ -2,15 +2,80 @@ require "formula_support"
 
 class KegOnlyReason
   module Compat
+    def valid?
+      case @reason
+      when :provided_by_osx
+        odisabled "keg_only :provided_by_osx", "keg_only :provided_by_macos"
+      when :shadowed_by_osx
+        odisabled "keg_only :shadowed_by_osx", "keg_only :shadowed_by_macos"
+      when :provided_pre_mountain_lion
+        odeprecated "keg_only :provided_pre_mountain_lion"
+        MacOS.version < :mountain_lion
+      when :provided_pre_mavericks
+        odeprecated "keg_only :provided_pre_mavericks"
+        MacOS.version < :mavericks
+      when :provided_pre_el_capitan
+        odeprecated "keg_only :provided_pre_el_capitan"
+        MacOS.version < :el_capitan
+      when :provided_pre_high_sierra
+        odeprecated "keg_only :provided_pre_high_sierra"
+        MacOS.version < :high_sierra
+      when :provided_until_xcode43
+        odeprecated "keg_only :provided_until_xcode43"
+        MacOS::Xcode.version < "4.3"
+      when :provided_until_xcode5
+        odeprecated "keg_only :provided_until_xcode5"
+        MacOS::Xcode.version < "5.0"
+      else
+        super
+      end
+    end
+
     def to_s
       case @reason
       when :provided_by_osx
         odisabled "keg_only :provided_by_osx", "keg_only :provided_by_macos"
       when :shadowed_by_osx
         odisabled "keg_only :shadowed_by_osx", "keg_only :shadowed_by_macos"
-      end
+      when :provided_pre_mountain_lion
+        odeprecated "keg_only :provided_pre_mountain_lion"
 
-      super
+        <<~EOS
+          macOS already provides this software in versions before Mountain Lion
+        EOS
+      when :provided_pre_mavericks
+        odeprecated "keg_only :provided_pre_mavericks"
+
+        <<~EOS
+          macOS already provides this software in versions before Mavericks
+        EOS
+      when :provided_pre_el_capitan
+        odeprecated "keg_only :provided_pre_el_capitan"
+
+        <<~EOS
+          macOS already provides this software in versions before El Capitan
+        EOS
+      when :provided_pre_high_sierra
+        odeprecated "keg_only :provided_pre_high_sierra"
+
+        <<~EOS
+          macOS already provides this software in versions before High Sierra
+        EOS
+      when :provided_until_xcode43
+        odeprecated "keg_only :provided_until_xcode43"
+
+        <<~EOS
+          Xcode provides this software prior to version 4.3
+        EOS
+      when :provided_until_xcode5
+        odeprecated "keg_only :provided_until_xcode5"
+
+        <<~EOS
+          Xcode provides this software prior to version 5
+        EOS
+      else
+        super
+      end.to_s.strip
     end
   end
 

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -12,57 +12,27 @@ class KegOnlyReason
   end
 
   def valid?
-    case @reason
-    when :provided_pre_mountain_lion
-      MacOS.version < :mountain_lion
-    when :provided_pre_mavericks
-      MacOS.version < :mavericks
-    when :provided_pre_el_capitan
-      MacOS.version < :el_capitan
-    when :provided_pre_high_sierra
-      MacOS.version < :high_sierra
-    when :provided_until_xcode43
-      MacOS::Xcode.version < "4.3"
-    when :provided_until_xcode5
-      MacOS::Xcode.version < "5.0"
-    else
-      true
-    end
+    true
   end
 
   def to_s
     return @explanation unless @explanation.empty?
 
     case @reason
-    when :versioned_formula then <<~EOS
-      this is an alternate version of another formula
-    EOS
-    when :provided_by_macos then <<~EOS
-      macOS already provides this software and installing another version in
-      parallel can cause all kinds of trouble
-    EOS
-    when :shadowed_by_macos then <<~EOS
-      macOS provides similar software and installing this software in
-      parallel can cause all kinds of trouble
-    EOS
-    when :provided_pre_mountain_lion then <<~EOS
-      macOS already provides this software in versions before Mountain Lion
-    EOS
-    when :provided_pre_mavericks then <<~EOS
-      macOS already provides this software in versions before Mavericks
-    EOS
-    when :provided_pre_el_capitan then <<~EOS
-      macOS already provides this software in versions before El Capitan
-    EOS
-    when :provided_pre_high_sierra then <<~EOS
-      macOS already provides this software in versions before High Sierra
-    EOS
-    when :provided_until_xcode43 then <<~EOS
-      Xcode provides this software prior to version 4.3
-    EOS
-    when :provided_until_xcode5 then <<~EOS
-      Xcode provides this software prior to version 5
-    EOS
+    when :versioned_formula
+      <<~EOS
+        this is an alternate version of another formula
+      EOS
+    when :provided_by_macos
+      <<~EOS
+        macOS already provides this software and installing another version in
+        parallel can cause all kinds of trouble
+      EOS
+    when :shadowed_by_macos
+      <<~EOS
+        macOS provides similar software and installing this software in
+        parallel can cause all kinds of trouble
+      EOS
     else
       @reason
     end.strip
@@ -87,10 +57,7 @@ class BottleDisableReason
   end
 
   def to_s
-    if unneeded?
-      "This formula doesn't require compiling."
-    else
-      @reason
-    end
+    return "This formula doesn't require compiling." if unneeded?
+    @reason
   end
 end


### PR DESCRIPTION
formula_support: deprecate more keg_only reasons.

It's unnecessary extra complexity to have versions that are keg-only on some versions of macOS and not others.

Initially this was to only do so on old versions of OS X and Xcode but the discussion in https://github.com/Homebrew/brew/pull/4081 meant that it made more sense to remove them all.

Remove from homebrew/core in https://github.com/Homebrew/homebrew-core/pull/26700.