### PR TITLE
Remove Xcode.installed? guards.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1294,7 +1294,7 @@ class Formula
 
     # Avoid false positives for clock_gettime support on 10.11.
     # CMake cache entries for other weak symbols may be added here as needed.
-    if MacOS.version == "10.11" && MacOS::Xcode.installed? && MacOS::Xcode.version >= "8.0"
+    if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
       args << "-DHAVE_CLOCK_GETTIME:INTERNAL=0"
     end
 

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -22,9 +22,9 @@ class KegOnlyReason
     when :provided_pre_high_sierra
       MacOS.version < :high_sierra
     when :provided_until_xcode43
-      MacOS::Xcode.installed? && MacOS::Xcode.version < "4.3"
+      MacOS::Xcode.version < "4.3"
     when :provided_until_xcode5
-      MacOS::Xcode.installed? && MacOS::Xcode.version < "5.0"
+      MacOS::Xcode.version < "5.0"
     else
       true
     end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -280,9 +280,7 @@ module OS
       def detect_version
         # CLT isn't a distinct entity pre-4.3, and pkgutil doesn't exist
         # at all on Tiger, so just count it as installed if Xcode is installed
-        if MacOS::Xcode.installed? && MacOS::Xcode.version < "3.0"
-          return MacOS::Xcode.version
-        end
+        return MacOS::Xcode.version if MacOS::Xcode.version < "3.0"
 
         version = nil
         [MAVERICKS_PKG_ID, MAVERICKS_NEW_PKG_ID, STANDALONE_PKG_ID, FROM_XCODE_PKG_ID].each do |id|


### PR DESCRIPTION
It's safe since 600d58f4ca3d85894c66a38802965fd94d4ea469 when MacOS::Xcode.version started returning `Version::NULL` where appropriate.

@ilovezfs jogged my memory in https://github.com/Homebrew/homebrew-core/pull/26700#issuecomment-381896896.