### PR TITLE
formula: tweak to_hash bottle output.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1526,7 +1526,7 @@ class Formula
       "aliases" => aliases,
       "versions" => {
         "stable" => stable&.version&.to_s,
-        "bottle" => !bottle.nil?,
+        "bottle" => !bottle_specification.checksums.empty?,
         "devel" => devel&.version&.to_s,
         "head" => head&.version&.to_s,
       },


### PR DESCRIPTION
Make some changes required to have `brew info --json=v1` whether there is any bottle block rather than a bottle checksum for the given system.

This provides more consistent output.
