### PR TITLE
requirements: define cask on base class.

### DIFF
--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -4,28 +4,9 @@ class JavaRequirement < Requirement
     env_oracle_jdk || env_apple
   end
 
-  # A strict Java 8 requirement (1.8) should prompt the user to install
-  # the legacy java8 cask because versions newer than Java 8 are not
-  # completely backwards compatible, and contain breaking changes such as
-  # strong encapsulation of JDK-internal APIs and a modified version scheme
-  # (*.0 not 1.*).
-  def cask
-    if @version.nil? || @version.to_s.end_with?("+") ||
-       @version.to_f >= JAVA_CASK_MAP.keys.max.to_f
-      JAVA_CASK_MAP.fetch(JAVA_CASK_MAP.keys.max)
-    else
-      JAVA_CASK_MAP.fetch("1.8")
-    end
-  end
-
   private
 
   undef possible_javas, oracle_java_os
-
-  JAVA_CASK_MAP = {
-    "1.8" => "caskroom/versions/java8",
-    "10.0" => "java",
-  }.freeze
 
   def possible_javas
     javas = []

--- a/Library/Homebrew/extend/os/mac/requirements/osxfuse_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/osxfuse_requirement.rb
@@ -1,7 +1,6 @@
 require "requirement"
 
 class OsxfuseRequirement < Requirement
-  cask "osxfuse"
   download "https://osxfuse.github.io/"
 
   satisfy(build_env: false) { self.class.binary_osxfuse_installed? }

--- a/Library/Homebrew/extend/os/mac/requirements/x11_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/x11_requirement.rb
@@ -1,7 +1,6 @@
 require "requirement"
 
 class X11Requirement < Requirement
-  cask "xquartz"
   download "https://xquartz.macosforge.org"
 
   satisfy build_env: false do

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -4,6 +4,20 @@ class JavaRequirement < Requirement
   fatal true
   download "https://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
+  # A strict Java 8 requirement (1.8) should prompt the user to install
+  # the legacy java8 cask because versions newer than Java 8 are not
+  # completely backwards compatible, and contain breaking changes such as
+  # strong encapsulation of JDK-internal APIs and a modified version scheme
+  # (*.0 not 1.*).
+  def cask
+    if @version.nil? || @version.to_s.end_with?("+") ||
+       @version.to_f >= JAVA_CASK_MAP.keys.max.to_f
+      JAVA_CASK_MAP.fetch(JAVA_CASK_MAP.keys.max)
+    else
+      JAVA_CASK_MAP.fetch("1.8")
+    end
+  end
+
   satisfy build_env: false do
     setup_java
     next false unless @java
@@ -41,6 +55,11 @@ class JavaRequirement < Requirement
   end
 
   private
+
+  JAVA_CASK_MAP = {
+    "1.8" => "caskroom/versions/java8",
+    "10.0" => "java",
+  }.freeze
 
   def version_without_plus
     if exact_version?

--- a/Library/Homebrew/requirements/osxfuse_requirement.rb
+++ b/Library/Homebrew/requirements/osxfuse_requirement.rb
@@ -1,6 +1,7 @@
 require "requirement"
 
 class OsxfuseRequirement < Requirement
+  cask "osxfuse"
   fatal true
 end
 

--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -5,6 +5,7 @@ class X11Requirement < Requirement
 
   fatal true
 
+  cask "xquartz"
   env { ENV.x11 }
 
   def initialize(name = "x11", tags = [])


### PR DESCRIPTION
The `cask` attribute doesn't make as much sense on Linux but can be ignored there. The advantage of this change is that (like #4086) it allows figuring out the relevant cask for a formulae requirement on a Linux machine.