### PR TITLE
x11_requirement: move download to base class.

### DIFF
--- a/Library/Homebrew/extend/os/mac/requirements/x11_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/x11_requirement.rb
@@ -1,8 +1,6 @@
 require "requirement"
 
 class X11Requirement < Requirement
-  download "https://xquartz.macosforge.org"
-
   satisfy build_env: false do
     next false unless MacOS::XQuartz.installed?
     min_version <= MacOS::XQuartz.version

--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -6,6 +6,8 @@ class X11Requirement < Requirement
   fatal true
 
   cask "xquartz"
+  download "https://xquartz.macosforge.org"
+
   env { ENV.x11 }
 
   def initialize(name = "x11", tags = [])


### PR DESCRIPTION
No reason to have it in macOS class and keeps consistent output with `brew info` on Linux.