### PR TITLE
linkage: fix --test exit code.

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -21,7 +21,7 @@ module Homebrew
       result = LinkageChecker.new(keg)
       if ARGV.include?("--test")
         result.display_test_output
-        Homebrew.failed = true if result.broken_dylibs?
+        Homebrew.failed = true if result.broken_library_linkage?
       elsif ARGV.include?("--reverse")
         result.display_reverse_output
       else

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -66,10 +66,10 @@ module FormulaCellarChecks
     keg = Keg.new(formula.prefix)
     checker = LinkageChecker.new(keg, formula)
 
-    return unless checker.broken_dylibs?
+    return unless checker.broken_library_linkage?
     output = <<~EOS
       #{formula} has broken dynamic library links:
-        #{checker.broken_dylibs.to_a * "\n  "}
+        #{checker.display_test_output}
     EOS
     tab = Tab.for_keg(keg)
     if tab.poured_from_bottle


### PR DESCRIPTION
Ensure that a non-zero exit code is set both for missing random dylibs and random missing dependencies.

Additionally, while we are here, drastically trim down the public interface for this class to the bare minimum and allow getting the output from `display_test_output` as a variable.

Fixes issue mentioned by @ilovezfs in https://github.com/Homebrew/brew/pull/3940#issuecomment-383794520