### PR TITLE
formula_desc_cop desclength: make non-strict

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -3,7 +3,7 @@ require_relative "../extend/string"
 
 module RuboCop
   module Cop
-    module FormulaAuditStrict
+    module FormulaAudit
       # This cop audits `desc` in Formulae
       #
       # - Checks for existence of `desc`
@@ -33,7 +33,9 @@ module RuboCop
                   "Length is calculated as #{@formula_name} + desc. (currently #{desc_length})"
         end
       end
+    end
 
+    module FormulaAuditStrict
       # This cop audits `desc` in Formulae
       #
       # - Checks if `desc` begins with an article

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../rubocops/formula_desc_cop"
 
-describe RuboCop::Cop::FormulaAuditStrict::DescLength do
+describe RuboCop::Cop::FormulaAudit::DescLength do
   subject(:cop) { described_class.new }
 
   context "When auditing formula desc" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

3 formulae fail `DescLength`

15 formulae fail `Desc`