### PR TITLE
formula: read runtime dependencies from more tabs.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1502,7 +1502,6 @@ class Formula
   # @private
   def runtime_dependencies(read_from_tab: true)
     if read_from_tab &&
-       installed_prefix.directory? &&
        (keg = opt_or_installed_prefix_keg) &&
        (tab_deps = keg.runtime_dependencies)
       return tab_deps.map { |d| Dependency.new d["full_name"] }.compact


### PR DESCRIPTION
The fixes the issue mentioned in https://github.com/Homebrew/brew/pull/4066#issuecomment-381308153 by @ilovezfs where `brew missing` was not reading from a tab of an outdated formula.

The `installed_prefix.directory?` check is unnecessary as the following `opt_or_installed_prefix_keg` call is already checking that when it is necessary. In this case it's not necessary anyway as `opt_prefix` is preferred and makes more sense on outdated formulae.