### PR TITLE
Support GCC 8

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -1,7 +1,7 @@
 # @private
 module CompilerConstants
-  GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7].freeze
-  GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-7])$/
+  GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7 8].freeze
+  GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-8])$/
   COMPILER_SYMBOL_MAP = {
     "gcc-4.0"    => :gcc_4_0,
     "gcc-4.2"    => :gcc_4_2,


### PR DESCRIPTION
Support GCC 8 as its release is nearing: https://gcc.gnu.org/ml/gcc/2018-04/msg00187.html

@MikeMcQuaid 