### PR TITLE
bump-formula-pr: fix tag/revision argument.

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -138,7 +138,7 @@ module Homebrew
       [checksum.hash_type, checksum.hexdigest]
     end
 
-    new_hash = @args[hash_type]
+    new_hash = @args[hash_type] if hash_type
     new_tag = @args.tag
     new_revision = @args.revision
     new_mirror = @args.mirror


### PR DESCRIPTION
Can't do `@args[hash_type]` if `hash_type` is `nil`.

Addresses issue mentioned in #4130.