### PR TITLE
add option to force use of brewed ssh in update command

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -395,8 +395,18 @@ EOS
       odie "Git must be installed and in your PATH!"
     fi
   fi
+  if [[ -n "$HOMEBREW_FORCE_BREWED_SSH" ]]
+    then
+    if [[ ! -x "$HOMEBREW_PREFIX/bin/ssh" ]]
+      then
+        brew install openssh
+    fi
+    HOMEBREW_SSH_EXECUTABLE="$HOMEBREW_PREFIX/bin/ssh"
+  else
+    HOMEBREW_SSH_EXECUTABLE="ssh"
+  fi
   export GIT_TERMINAL_PROMPT="0"
-  export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
+  export GIT_SSH_COMMAND="$HOMEBREW_SSH_EXECUTABLE -oBatchMode=yes"
 
   if [[ -z "$HOMEBREW_VERBOSE" ]]
   then

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -174,6 +174,10 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will use a Homebrew-installed `curl` rather than the
     system version.
 
+  * `HOMEBREW_FORCE_BREWED_SSH`:
+    If set, Homebrew will use a Homebrew-installed `ssh` (using the `openssh` formula if no
+    `$HOMEBREW_PREFIX/bin/ssh` is found) rather than the system version.
+
   * `HOMEBREW_FORCE_VENDOR_RUBY`:
     If set, Homebrew will always use its vendored, relocatable Ruby version
     even if the system version of Ruby is new enough.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
`openssh` added the declaration `Include` in version 7.3p1 (see [here](https://superuser.com/a/1142813)).

The system version of openssh might not support this (it does not on my system), so when I changed my config to use `Include`, I also had to change some other things like `GIT_SSH_COMMAND` to use the correct ssh version.

After that, Homebrew failed to update as I described in this issue: [brew update fails when using Include in ssh config](https://github.com/Homebrew/brew/issues/4132)

I analyzed the brew update commands code and identified the problem.
On line 397 GIT_SSH_COMMAND is set to "ssh -oBatchMode=yes". Since Homebrew replaces PATH when filtering the environment, ssh in this case is the system provided executable in /usr/bin.
As far as I could find, there is currently no way to make Homebrew use the brewed ssh (although it actually does so in pretty much every other case if I correctly set my GIT_SSH_COMMAND environment variable.

This pull-request adds an environment variable HOMEBREW_FORCE_BREWED_SSH, analogous to HOMEBREW_FORCE_BREWED_CURL, that allows to force Homebrew to use the brewed ssh executable instead of the system provided one.

I don't know how I could write a test that adequately tests if this works, but if someone can give me some pointers as to how I would approach that, I would be happy to add them as well.