### PR TITLE
docs: fix Jekyll theme usage.

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,3 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
-gem "jekyll-theme-homebrew"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -156,10 +156,6 @@ GEM
     jekyll-theme-hacker (0.1.1)
       jekyll (~> 3.5)
       jekyll-seo-tag (~> 2.0)
-    jekyll-theme-homebrew (1.0.0)
-      jekyll (~> 3)
-      jekyll-feed (~> 0)
-      jekyll-seo-tag (~> 2)
     jekyll-theme-leap-day (0.1.1)
       jekyll (~> 3.5)
       jekyll-seo-tag (~> 2.0)
@@ -249,7 +245,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  jekyll-theme-homebrew
 
 BUNDLED WITH
    1.16.1

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: Homebrew Documentation
 description: Documentation for the missing package manager for macOS.
 
-theme: jekyll-theme-homebrew
+remote_theme: Homebrew/brew-sh
 
 exclude:
   - bin
@@ -11,6 +11,8 @@ exclude:
 
 plugins:
   - jekyll-feed
+  - jekyll-remote-theme
+  - jekyll-seo-tag
   - jekyll-sitemap
 
 permalink: :title
@@ -19,9 +21,9 @@ defaults:
   - scope:
       path: ""
     values:
-      image: /img/homebrew-256x256.png
+      image: /assets/img/homebrew-256x256.png
 
-logo: /img/homebrew-256x256.png
+logo: /assets/img/homebrew-256x256.png
 
 github:
   repository_nwo: Homebrew/brew


### PR DESCRIPTION
Need to use `remote_theme` not `theme` for this to work on GitHub Pages.
Handily, though, this removes the need for making and uploading a gem.