### PR TITLE
Add more Probots

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,13 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 30
+# Comment to post before locking. Set to `false` to disable
+lockComment: false
+# Issues or pull requests with these labels will not be locked
+# exemptLabels:
+#   - no-locking
+# Limit to only `issues` or `pulls`
+# only: issues
+# Add a label when locking. Set to `false` to disable
+lockLabel: outdated

--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,15 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Delete the command comment. Ignored when the comment also contains other content
+deleteCommand: true
+# Close the source issue after moving
+closeSourceIssue: true
+# Lock the source issue after moving
+lockSourceIssue: true
+# Mention issue and comment authors
+mentionAuthors: true
+# Preserve mentions in the issue content
+keepContentMentions: true
+# Set custom aliases for targets
+aliases:
+  core: Homebrew/homebrew-core

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+# Label requiring a response
+responseRequiredLabel: needs response
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.

--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,0 +1,16 @@
+# Configuration for support-requests - https://github.com/dessant/support-requests
+
+# Label used to mark issues as support requests
+supportLabel: support-request
+# Comment to post on issues marked as support requests. Add a link
+# to a support page, or set to `false` to disable
+supportComment: >
+  We use the issue tracker exclusively for bug reports and feature requests.
+  However, this issue appears to be a support request. Please use our
+  [Discourse](https://discourse.brew.sh) or
+  [IRC channel](irc://irc.freenode.net/#machomebrew) to get help with
+  the project.
+# Whether to close issues marked as support requests
+close: true
+# Whether to lock issues marked as support requests
+lock: true


### PR DESCRIPTION
We're already using the stale bot which seems to work quite well for us.
Let's also add:

- [No Response](https://probot.github.io/apps/no-response/) (replacing [github-snooze-button](https://github.com/tdsmith/github-snooze-button))
- [Move Issues](https://probot.github.io/apps/move/)
- [Support Requests](https://probot.github.io/apps/support/)
- [Lock Threads](https://probot.github.io/apps/lock/)

CC @Homebrew/maintainers for thoughts on both the above and the configuration settings I've chosen.