### PR TITLE
superenv: fix libxml2 on xcode 9.3 with clt

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -158,10 +158,15 @@ module Superenv
     []
   end
 
+  def homebrew_libxml2_includes
+    []
+  end
+
   def determine_isystem_paths
     PATH.new(
       HOMEBREW_PREFIX/"include",
       homebrew_extra_isystem_paths,
+      homebrew_libxml2_includes,
     ).existing
   end
 
@@ -208,7 +213,10 @@ module Superenv
   end
 
   def determine_cmake_include_path
-    PATH.new(homebrew_extra_cmake_include_paths).existing
+    PATH.new(
+      homebrew_extra_cmake_include_paths,
+      homebrew_libxml2_includes,
+    ).existing
   end
 
   def homebrew_extra_cmake_library_paths

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -15,6 +15,7 @@ module Superenv
   undef homebrew_extra_paths,
         homebrew_extra_pkg_config_paths, homebrew_extra_aclocal_paths,
         homebrew_extra_isystem_paths, homebrew_extra_library_paths,
+        homebrew_libxml2_includes,
         homebrew_extra_cmake_include_paths,
         homebrew_extra_cmake_library_paths,
         homebrew_extra_cmake_frameworks_paths,
@@ -47,9 +48,17 @@ module Superenv
     paths
   end
 
+  def homebrew_libxml2_includes
+    paths = []
+    return if deps.any? { |d| d.name == "libxml2" }
+    return unless MacOS::Xcode.version < "9.3"
+    return unless MacOS::Xcode.without_clt?
+    paths << "#{effective_sysroot}/usr/include/libxml2"
+    paths
+  end
+
   def homebrew_extra_isystem_paths
     paths = []
-    paths << "#{effective_sysroot}/usr/include/libxml2" unless deps.any? { |d| d.name == "libxml2" }
     paths << "#{effective_sysroot}/usr/include/apache2" if MacOS::Xcode.without_clt?
     paths << MacOS::X11.include.to_s << "#{MacOS::X11.include}/freetype2" if x11?
     paths << "#{effective_sysroot}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers"
@@ -65,7 +74,6 @@ module Superenv
 
   def homebrew_extra_cmake_include_paths
     paths = []
-    paths << "#{effective_sysroot}/usr/include/libxml2" unless deps.any? { |d| d.name == "libxml2" }
     paths << "#{effective_sysroot}/usr/include/apache2" if MacOS::Xcode.without_clt?
     paths << MacOS::X11.include.to_s << "#{MacOS::X11.include}/freetype2" if x11?
     paths << "#{effective_sysroot}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/libxml2/module.modulemap:1:8: error: redefinition of module 'libxml2'
module libxml2 [system] [extern_c] {
       ^
/usr/include/libxml2/module.modulemap:1:8: note: previously defined here
module libxml2 [system] [extern_c] {
       ^
1 error generated.
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/libxml2/module.modulemap:1:8: error: redefinition of module 'libxml2'
module libxml2 [system] [extern_c] {
       ^
/usr/include/libxml2/module.modulemap:1:8: note: previously defined here
module libxml2 [system] [extern_c] {
       ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include/libxml2/module.modulemap:1:8: error: redefinition of module 'libxml2'
module libxml2 [system] [extern_c] {
       ^
/usr/include/libxml2/module.modulemap:1:8: note: previously defined here
module libxml2 [system] [extern_c] {
       ^
```

https://github.com/Homebrew/homebrew-core/pull/26487#issuecomment-381278678
https://github.com/Homebrew/homebrew-core/pull/26958#issuecomment-383744299