### PR TITLE
lines_cop: Add deprected options audit for depends_on

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula_cop.rb
+++ b/Library/Homebrew/rubocops/extend/formula_cop.rb
@@ -58,7 +58,7 @@ module RuboCop
       # Returns all string nodes among the descendants of given node
       def find_strings(node)
         return [] if node.nil?
-        return node if node.str_type?
+        return [node] if node.str_type?
         node.each_descendant(:str)
       end
 

--- a/Library/Homebrew/test/rubocops/lines_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_cop_spec.rb
@@ -693,13 +693,27 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       RUBY
     end
 
-    it "dependencies with invalid options" do
+    it "dependencies with invalid options which lead to force rebuild" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
           url 'http://example.com/foo-1.0.tgz'
           depends_on "foo" => "with-bar"
-                     ^^^^^^^^^^^^^^^^^^^ Dependency foo should not use option with-bar
+                               ^^^^^^^^ Dependency foo should not use option with-bar
+        end
+      RUBY
+    end
+
+    it "dependencies with invalid options in array value which lead to force rebuild" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url 'http://example.com/foo-1.0.tgz'
+          depends_on "httpd" => [:build, :test]
+          depends_on "foo" => [:optional, "with-bar"]
+                                           ^^^^^^^^ Dependency foo should not use option with-bar
+          depends_on "icu4c" => [:optional, "c++11"]
+                                             ^^^^^ Dependency icu4c should not use option c++11
         end
       RUBY
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
cc @ilovezfs 