### PR TITLE
Improve error handling during build

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -188,7 +188,11 @@ begin
   build   = Build.new(formula, options)
   build.install
 rescue Exception => e # rubocop:disable Lint/RescueException
-  Marshal.dump(e, error_pipe)
+  begin
+    Marshal.dump(e, error_pipe)
+  rescue TypeError
+    raise e
+  end
   error_pipe.close
   exit! 1
 end


### PR DESCRIPTION
by rescueing TypeErrors and raising a full stacktrace

The current error message does not really help debug errors in formulae,
at least not for ruby beginners.

The new error message should help pin down the error in the formula.

Old error message:
```
==> Verifying zookeeper-3.4.12.tar.gz checksum
tar xzf /home/linuxbrew/.cache/Homebrew/zookeeper-3.4.12.tar.gz
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:204:in `dump': singleton class can't be dumped (TypeError)
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:204:in `rescue in <main>'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:193:in `<main>'
Error: Forked child process failed: pid 2768 exit 1
==> FAILED
```

New error message:
```
==> Verifying zookeeper-3.4.12.tar.gz checksum
tar xzf /home/imichka/.cache/Homebrew/zookeeper-3.4.12.tar.gz
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/hardware.rb:57:in `universal_archs': uninitialized constant #<Class:Hardware::CPU>::ArchitectureListExtension (NameError)
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/zookeeper.rb:63:in `install'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:153:in `block (2 levels) in install'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1098:in `block in brew'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1923:in `block (2 levels) in stage'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils.rb:556:in `with_env'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1922:in `block in stage'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/resource.rb:119:in `block in unpack'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/fileutils.rb:13:in `block in mktemp'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/fileutils.rb:73:in `block in run'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/fileutils.rb:73:in `chdir'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/fileutils.rb:73:in `run'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/fileutils.rb:12:in `mktemp'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/resource.rb:114:in `unpack'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/resource.rb:92:in `stage'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1900:in `stage'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1093:in `brew'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:124:in `block in install'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils.rb:556:in `with_env'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:121:in `install'
	from /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:202:in `<main>'
Error: Forked child process failed: pid 16398 exit 1
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
