### PR TITLE
Remove cmd/tap requirement because it's no longer used

### DIFF
--- a/Library/Homebrew/cmd/prune.rb
+++ b/Library/Homebrew/cmd/prune.rb
@@ -6,7 +6,6 @@
 #:    actually remove anything.
 
 require "keg"
-require "cmd/tap"
 
 module Homebrew
   module_function


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031)~.
- [ ] ~Have you successfully run `brew style` with your changes locally?~
- [ ] ~Have you successfully run `brew tests` with your changes locally?~

-----

Removing requirement as part of #4059.

The need for requirement was removed here 56cb3325a6404602266539c4203fa32a9dd6ae13