### PR TITLE
Move post_install from cmd to FormulaInstaller

### DIFF
--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -2,6 +2,7 @@
 #:    Rerun the post-install steps for <formula>.
 
 require "sandbox"
+require "formula_installer"
 
 module Homebrew
   module_function
@@ -9,43 +10,8 @@ module Homebrew
   def postinstall
     ARGV.resolved_formulae.each do |f|
       ohai "Postinstalling #{f}"
-      run_post_install(f)
-    end
-  end
-
-  def run_post_install(formula)
-    args = %W[
-      nice #{RUBY_PATH}
-      -W0
-      -I #{HOMEBREW_LOAD_PATH}
-      --
-      #{HOMEBREW_LIBRARY_PATH}/postinstall.rb
-      #{formula.path}
-    ].concat(ARGV.options_only)
-
-    if formula.head?
-      args << "--HEAD"
-    elsif formula.devel?
-      args << "--devel"
-    end
-
-    Utils.safe_fork do
-      if Sandbox.formula?(formula)
-        sandbox = Sandbox.new
-        formula.logs.mkpath
-        sandbox.record_log(formula.logs/"postinstall.sandbox.log")
-        sandbox.allow_write_temp_and_cache
-        sandbox.allow_write_log(formula)
-        sandbox.allow_write_xcode
-        sandbox.deny_write_homebrew_repository
-        sandbox.allow_write_cellar(formula)
-        Keg::TOP_LEVEL_DIRECTORIES.each do |dir|
-          sandbox.allow_write_path "#{HOMEBREW_PREFIX}/#{dir}"
-        end
-        sandbox.exec(*args)
-      else
-        exec(*args)
-      end
+      fi = FormulaInstaller.new(f)
+      fi.post_install
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031)~.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

One more cmd requirement removal as part of #4059.

I went with the naive fix - just move the code from `cmd/postinstall` to `FormulaInstaller`. Do let me know if this isn't a good solution and how I should improve it.