### PR TITLE
formula: improve to_hash output.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -251,11 +251,9 @@ module Homebrew
           problem "#{formula} is versioned but no #{unversioned_name} formula exists"
         end
       elsif ARGV.build_stable? && formula.stable? &&
-            !(versioned_formulae = Dir[formula.path.to_s.gsub(/\.rb$/, "@*.rb")]).empty?
+            !(versioned_formulae = formula.versioned_formulae).empty?
         versioned_aliases = formula.aliases.grep(/.@\d/)
-        _, last_alias_version =
-          File.basename(versioned_formulae.sort.reverse.first)
-              .gsub(/\.rb$/, "").split("@")
+        _, last_alias_version = versioned_formulae.map(&:name).last.split("@")
         major, minor, = formula.version.to_s.split(".")
         alias_name_major = "#{formula.name}@#{major}"
         alias_name_major_minor = "#{alias_name_major}.#{minor}"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1548,44 +1548,34 @@ class Formula
     hsh = {
       "name" => name,
       "full_name" => full_name,
-      "desc" => desc,
-      "homepage" => homepage,
       "oldname" => oldname,
       "aliases" => aliases.sort,
+      "desc" => desc,
+      "homepage" => homepage,
       "versions" => {
         "stable" => stable&.version&.to_s,
-        "bottle" => !bottle_specification.checksums.empty?,
         "devel" => devel&.version&.to_s,
         "head" => head&.version&.to_s,
+        "bottle" => !bottle_specification.checksums.empty?,
       },
       "revision" => revision,
       "version_scheme" => version_scheme,
+      "bottle" => {},
+      "keg_only" => keg_only?,
+      "options" => [],
+      "build_dependencies" => dependencies.select(&:build?).map(&:name).uniq,
+      "dependencies" => dependencies.map(&:name).uniq,
+      "recommended_dependencies" => dependencies.select(&:recommended?).map(&:name).uniq,
+      "optional_dependencies" => dependencies.select(&:optional?).map(&:name).uniq,
+      "requirements" => [],
+      "conflicts_with" => conflicts.map(&:name),
+      "caveats" => caveats,
       "installed" => [],
       "linked_keg" => linked_version&.to_s,
       "pinned" => pinned?,
       "outdated" => outdated?,
-      "keg_only" => keg_only?,
-      "dependencies" => dependencies.map(&:name).uniq,
-      "recommended_dependencies" => dependencies.select(&:recommended?).map(&:name).uniq,
-      "optional_dependencies" => dependencies.select(&:optional?).map(&:name).uniq,
-      "build_dependencies" => dependencies.select(&:build?).map(&:name).uniq,
-      "conflicts_with" => conflicts.map(&:name),
-      "caveats" => caveats,
     }
 
-    hsh["requirements"] = requirements.map do |req|
-      {
-        "name" => req.name,
-        "cask" => req.cask,
-        "download" => req.download,
-      }
-    end
-
-    hsh["options"] = options.map do |opt|
-      { "option" => opt.flag, "description" => opt.description }
-    end
-
-    hsh["bottle"] = {}
     %w[stable devel].each do |spec_sym|
       next unless spec = send(spec_sym)
       next unless spec.bottle_defined?
@@ -1605,6 +1595,18 @@ class Formula
         }
       end
       hsh["bottle"][spec_sym] = bottle_info
+    end
+
+    hsh["options"] = options.map do |opt|
+      { "option" => opt.flag, "description" => opt.description }
+    end
+
+    hsh["requirements"] = requirements.map do |req|
+      {
+        "name" => req.name,
+        "cask" => req.cask,
+        "download" => req.download,
+      }
     end
 
     installed_kegs.each do |keg|

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -370,6 +370,15 @@ class Formula
     name.include?("@")
   end
 
+  # Returns any `@`-versioned formulae for an non-`@`-versioned formula.
+  def versioned_formulae
+    return [] if versioned_formula?
+
+    Pathname.glob(path.to_s.gsub(/\.rb$/, "@*.rb")).map do |path|
+      Formula[path.basename(".rb").to_s]
+    end.sort
+  end
+
   # A named Resource for the currently active {SoftwareSpec}.
   # Additional downloads can be defined as {#resource}s.
   # {Resource#stage} will create a temporary directory and yield to a block.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1559,6 +1559,7 @@ class Formula
       "full_name" => full_name,
       "oldname" => oldname,
       "aliases" => aliases.sort,
+      "versioned_formulae" => versioned_formulae.map(&:name),
       "desc" => desc,
       "homepage" => homepage,
       "versions" => {

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1564,7 +1564,7 @@ class Formula
       "keg_only" => keg_only?,
       "options" => [],
       "build_dependencies" => dependencies.select(&:build?).map(&:name).uniq,
-      "dependencies" => dependencies.map(&:name).uniq,
+      "dependencies" => dependencies.reject(&:optional?).reject(&:recommended?).reject(&:build?).map(&:name).uniq,
       "recommended_dependencies" => dependencies.select(&:recommended?).map(&:name).uniq,
       "optional_dependencies" => dependencies.select(&:optional?).map(&:name).uniq,
       "requirements" => [],

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -107,6 +107,56 @@ describe Formula do
     end
   end
 
+  describe "#versioned_formula?" do
+    let(:f) do
+      formula "foo" do
+        url "foo-1.0"
+      end
+    end
+
+    let(:f2) do
+      formula "foo@2.0" do
+        url "foo-2.0"
+      end
+    end
+
+    it "returns true for @-versioned formulae" do
+      expect(f2.versioned_formula?).to be true
+    end
+
+    it "returns false for non-@-versioned formulae" do
+      expect(f.versioned_formula?).to be false
+    end
+  end
+
+  describe "#versioned_formulae" do
+    let(:f) do
+      formula "foo" do
+        url "foo-1.0"
+      end
+    end
+
+    let(:f2) do
+      formula "foo@2.0" do
+        url "foo-2.0"
+      end
+    end
+
+    it "returns true by default" do
+      FileUtils.touch f.path
+      FileUtils.touch f2.path
+      allow(Formulary).to receive(:load_formula_from_path).with(f2.name, f2.path).and_return(f2)
+      allow(Formulary).to receive(:factory).with(f2.name).and_return(f2)
+      expect(f.versioned_formulae).to eq [f2]
+    end
+
+    it "returns empty array for non-@-versioned formulae" do
+      FileUtils.touch f.path
+      FileUtils.touch f2.path
+      expect(f2.versioned_formulae).to be_empty
+    end
+  end
+
   example "installed alias with core" do
     f = formula do
       url "foo-1.0"
@@ -708,7 +758,7 @@ describe Formula do
       expect(f3.runtime_dependencies.map(&:name)).to eq(["foo/bar/f1", "baz/qux/f2"])
     end
 
-    it "includes non-declared direct dependencies", :focus do
+    it "includes non-declared direct dependencies" do
       formula = Class.new(Testball).new
       dependency = formula("dependency") { url "f-1.0" }
 


### PR DESCRIPTION
- reorder `to_hash` output to more closely match the ordering in a formula file.
- make `dependencies` not duplicate build, recommended and optional dependencies
- add `versioned_formulae` method to `Formula` and include it in `to_hash` output

This makes `to_hash` (and our JSON output) more useful and easily readable for people used to formula files.