### PR TITLE
Fix brew pull with git commit.gpgsign enabled

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -103,14 +103,16 @@ module Homebrew
     end
 
     # Depending on user configuration, git may try to invoke gpg.
-    begin
-      gnupg = Formula["gnupg"]
-    rescue FormulaUnavailableError # rubocop:disable Lint/HandleExceptions
-    else
-      if gnupg.installed?
-        path = PATH.new(ENV.fetch("PATH"))
-        path.prepend(gnupg.installed_prefix/"bin")
-        ENV["PATH"] = path
+    if Utils.popen_read("git config --get --bool commit.gpgsign").chomp == "true"
+      begin
+        gnupg = Formula["gnupg"]
+      rescue FormulaUnavailableError # rubocop:disable Lint/HandleExceptions
+      else
+        if gnupg.installed?
+          path = PATH.new(ENV.fetch("PATH"))
+          path.prepend(gnupg.installed_prefix/"bin")
+          ENV["PATH"] = path
+        end
       end
     end
 

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -102,6 +102,18 @@ module Homebrew
       ENV["GIT_COMMITTER_EMAIL"] = ENV["HOMEBREW_GIT_EMAIL"]
     end
 
+    # Depending on user configuration, git may try to invoke gpg.
+    begin
+      gnupg = Formula["gnupg"]
+    rescue FormulaUnavailableError # rubocop:disable Lint/HandleExceptions
+    else
+      if gnupg.installed?
+        path = PATH.new(ENV.fetch("PATH"))
+        path.prepend(gnupg.installed_prefix/"bin")
+        ENV["PATH"] = path
+      end
+    end
+
     do_bump = @args.bump? && !@args.clean?
 
     # Formulae with affected bottles that were published


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Because of environment filtering, git tries to sign the commit but can't find gpg, which means that the patch won't be applied.