### PR TITLE
oldest_cpu: Bottling architecture of ARM is armv6

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -9,6 +9,8 @@ module Hardware
       OPTIMIZATION_FLAGS = {
         core2: "-march=core2",
         core: "-march=prescott",
+        armv6: "-march=armv6",
+        armv8: "-march=armv8-a",
         dunno: "-march=native",
       }.freeze
 
@@ -146,6 +148,12 @@ module Hardware
         :core2
       else
         :core
+      end
+    elsif Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        :armv8
+      else
+        :armv6
       end
     else
       Hardware::CPU.family


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

This PR is required for `brew portable-bottle ruby` on 32-bit ARM.

-----

armv6 is the oldest supported 32-bit ARM architecture
armv8-a is the oldest 64-bit ARM architecture.

See https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html
and https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html