### PR TITLE
Alphabetize the `brew outdated` formula listing.

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -41,7 +41,9 @@ module Homebrew
     verbose = ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
     fetch_head = ARGV.fetch_head?
 
-    outdated_formulae = formulae.select { |f| f.outdated?(fetch_head: fetch_head) }
+    outdated_formulae = formulae
+                        .select { |f| f.outdated?(fetch_head: fetch_head) }
+                        .sort
 
     outdated_formulae.each do |f|
       if verbose

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -41,9 +41,8 @@ module Homebrew
     verbose = ($stdout.tty? || ARGV.verbose?) && !ARGV.flag?("--quiet")
     fetch_head = ARGV.fetch_head?
 
-    outdated_formulae = formulae
-                        .select { |f| f.outdated?(fetch_head: fetch_head) }
-                        .sort
+    outdated_formulae = formulae.select { |f| f.outdated?(fetch_head: fetch_head) }
+                                .sort
 
     outdated_formulae.each do |f|
       if verbose

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -4,8 +4,11 @@ describe "brew outdated", :integration_test do
       setup_test_formula "testball"
       (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 
+      setup_test_formula "foo"
+      (HOMEBREW_CELLAR/"foo/0.0.1/foo").mkpath
+
       expect { brew "outdated" }
-        .to output("testball\n").to_stdout
+        .to output("foo\ntestball\n").to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     end


### PR DESCRIPTION
Sorts the output of `brew outdated` by `Formula#<=>`.

For me this significantly speeds up scanning the list to look for formula I consider critical to my work.

Includes updated test example.

> Have you written new tests for your changes?

Not strictly speaking. I modified an existing test.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----