### PR TITLE
audit: add back new formulae condition for patches

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -541,6 +541,7 @@ module Homebrew
         end
 
         next if spec.patches.empty?
+        next unless @new_formula
         new_formula_problem "Formulae should not require patches to build. Patches should be submitted and accepted upstream first."
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Regular `brew audit` is warning about patches for formulae.

https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/24468/version=high_sierra/console
```
07:27:12 ==> brew audit lua --online
07:28:04 ==> FAILED
07:28:04 Error: 1 problem in 1 formula
07:28:04 lua:
07:28:04   * Formulae should not require patches to build. Patches should be submitted and accepted upstream first.
```
https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/24461/version=high_sierra/console
```
06:02:28 ==> brew audit qt --online
06:03:33 ==> FAILED
06:03:33 Error: 2 problems in 1 formula
06:03:33 qt:
06:03:33   * Formulae should not require patches to build. Patches should be submitted and accepted upstream first.
06:03:33   * Formulae should not require patches to build. Patches should be submitted and accepted upstream first.
```
https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/24471/version=high_sierra/testReport/junit/brew-test-bot/high_sierra/audit_creduce___online/
https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/24471/version=high_sierra/testReport/junit/brew-test-bot/high_sierra/audit_mytop___online/