### PR TITLE
Remove some integration tests

### DIFF
--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -30,20 +30,6 @@ describe "brew analytics", :integration_test do
     end
   end
 
-  it "fails when running `brew analytics on off`" do
-    expect { brew "analytics", "on", "off" }
-      .to output(/Invalid usage/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  it "fails when running `brew analytics testball`" do
-    expect { brew "analytics", "testball" }
-      .to output(/Invalid usage/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
   it "can generate a new UUID" do
     expect { brew "analytics", "regenerate-uuid" }.to be_a_success
   end

--- a/Library/Homebrew/test/cmd/command_spec.rb
+++ b/Library/Homebrew/test/cmd/command_spec.rb
@@ -4,10 +4,4 @@ describe "brew command", :integration_test do
       .to output(%r{#{Regexp.escape(HOMEBREW_LIBRARY_PATH)}/cmd/info.rb}).to_stdout
       .and be_a_success
   end
-
-  it "fails when the given command is unknown" do
-    expect { brew "command", "does-not-exist" }
-      .to output(/Unknown command/).to_stderr
-      .and be_a_failure
-  end
 end

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -10,22 +10,6 @@ describe "brew desc", :integration_test do
       .and be_a_success
   end
 
-  it "fails when both --search and --name are specified" do
-    expect { brew "desc", "--search", "--name" }
-      .to output(/Pick one, and only one/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  describe "--search" do
-    it "fails when no search term is given" do
-      expect { brew "desc", "--search" }
-        .to output(/You must provide a search term/).to_stderr
-        .and not_to_output.to_stdout
-        .and be_a_failure
-    end
-  end
-
   describe "--description" do
     it "creates a description cache" do
       expect(desc_cache).not_to exist

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -2,21 +2,6 @@ describe "brew install", :integration_test do
   it "installs Formulae" do
     setup_test_formula "testball1"
 
-    expect { brew "install", "testball1", "--head" }
-      .to output(/Specify `\-\-HEAD`/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
-    expect { brew "install", "testball1", "--HEAD" }
-      .to output(/No head is defined/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
-    expect { brew "install", "testball1", "--devel" }
-      .to output(/No devel block/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
     expect { brew "install", "testball1" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}).to_stdout
       .and not_to_output.to_stderr
@@ -27,27 +12,12 @@ describe "brew install", :integration_test do
       .and not_to_output.to_stdout
       .and be_a_success
 
-    expect { brew "install", "macruby" }
-      .to output(/MacRuby is not packaged/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
     expect { brew "install", "formula" }
       .to output(/No available formula/).to_stderr
       .and output(/Searching for similarly named formulae/).to_stdout
       .and be_a_failure
 
-    expect { brew "install", "testball" }
-      .to output(/This similarly named formula was found/).to_stdout
-      .and output(/No available formula/).to_stderr
-      .and be_a_failure
-
     setup_test_formula "testball2"
-    expect { brew "install", "testball" }
-      .to output(/These similarly named formulae were found/).to_stdout
-      .and output(/No available formula/).to_stderr
-      .and be_a_failure
-
     install_and_rename_coretap_formula "testball1", "testball2"
     expect { brew "install", "testball2" }
       .to output(/testball1 already installed, it's just not migrated/).to_stderr

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -1,11 +1,4 @@
 describe "brew link", :integration_test do
-  it "fails when no argument is given" do
-    expect { brew "link" }
-      .to output(/This command requires a keg argument/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
   it "does not fail if the given Formula is already linked" do
     setup_test_formula "testball1"
 

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -4,27 +4,6 @@ describe "brew migrate", :integration_test do
     setup_test_formula "testball2"
   end
 
-  it "fails when no argument is given" do
-    expect { brew "migrate" }
-      .to output(/Invalid usage/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  it "fails when a given Formula doesn't exist" do
-    expect { brew "migrate", "testball" }
-      .to output(/No available formula with the name "testball"/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  it "fails if a given Formula doesn't replace another one" do
-    expect { brew "migrate", "testball1" }
-      .to output(/testball1 doesn't replace any formula/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
   it "migrates a renamed Formula" do
     install_and_rename_coretap_formula "testball1", "testball2"
 
@@ -32,15 +11,5 @@ describe "brew migrate", :integration_test do
       .to output(/Processing testball1 formula rename to testball2/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
-  end
-
-  it "fails if a given Formula is not installed" do
-    install_and_rename_coretap_formula "testball1", "testball2"
-    (HOMEBREW_CELLAR/"testball1").rmtree
-
-    expect { brew "migrate", "testball1" }
-      .to output(/Error: No such keg/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
   end
 end

--- a/Library/Homebrew/test/cmd/switch_spec.rb
+++ b/Library/Homebrew/test/cmd/switch_spec.rb
@@ -1,15 +1,5 @@
 describe "brew switch", :integration_test do
   it "allows switching between Formula versions" do
-    expect { brew "switch" }
-      .to output(/Usage: brew switch <formula> <version>/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
-    expect { brew "switch", "testball", "0.1" }
-      .to output(/testball not found/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
     setup_test_formula "testball", <<~EOS
       keg_only "just because"
     EOS
@@ -23,10 +13,5 @@ describe "brew switch", :integration_test do
       .to output(/link created/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
-
-    expect { brew "switch", "testball", "0.3" }
-      .to output("testball installed versions: 0.1, 0.2\n").to_stdout
-      .and output(/testball does not have a version "0.3"/).to_stderr
-      .and be_a_failure
   end
 end

--- a/Library/Homebrew/test/deps_spec.rb
+++ b/Library/Homebrew/test/deps_spec.rb
@@ -15,13 +15,6 @@ describe "brew deps", :integration_test do
       .and not_to_output.to_stderr
   end
 
-  it "outputs a dependency for a Formula that has one dependency" do
-    expect { brew "deps", "bar" }
-      .to be_a_success
-      .and output("foo\n").to_stdout
-      .and not_to_output.to_stderr
-  end
-
   it "outputs all of a Formula's dependencies and their dependencies on separate lines" do
     expect { brew "deps", "baz" }
       .to be_a_success

--- a/Library/Homebrew/test/dev-cmd/pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pull_spec.rb
@@ -1,11 +1,4 @@
 describe "brew pull", :integration_test do
-  it "fails when no argument is given" do
-    expect { brew "pull" }
-      .to output(/This command requires at least one argument/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
   it "fetches a patch from a GitHub commit or pull request and applies it", :needs_network, retry: 3 do
     CoreTap.instance.path.cd do
       system "git", "init"
@@ -22,11 +15,6 @@ describe "brew pull", :integration_test do
       .and output(/Current branch is new\-branch/).to_stderr
       .and be_a_failure
 
-    expect { brew "pull", "--bump", "https://github.com/Homebrew/homebrew-core/pull/8" }
-      .to output(/Fetching patch/).to_stdout
-      .and output(/No changed formulae found to bump/).to_stderr
-      .and be_a_failure
-
     expect { brew "pull", "--bump", "https://api.github.com/repos/Homebrew/homebrew-core/pulls/122" }
       .to output(/Fetching patch/).to_stdout
       .and output(/Can only bump one changed formula/).to_stderr
@@ -35,22 +23,6 @@ describe "brew pull", :integration_test do
     expect { brew "pull", "https://github.com/Homebrew/brew/pull/1249" }
       .to output(/Fetching patch/).to_stdout
       .and output(/Patch failed to apply/).to_stderr
-      .and be_a_failure
-  end
-
-  describe "--rebase" do
-    it "fails" do
-      expect { brew "pull", "--rebase" }
-        .to output(/You meant `git pull --rebase`./).to_stderr
-        .and not_to_output.to_stdout
-        .and be_a_failure
-    end
-  end
-
-  it "fails when given 0" do
-    expect { brew "pull", "0" }
-      .to output(/Not a GitHub pull request or commit/).to_stderr
-      .and not_to_output.to_stdout
       .and be_a_failure
   end
 end

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -4,10 +4,5 @@ describe "brew ruby", :integration_test do
       .to be_a_success
       .and not_to_output.to_stdout
       .and not_to_output.to_stderr
-
-    expect { brew "ruby", "-e", "exit 1" }
-      .to be_a_failure
-      .and not_to_output.to_stdout
-      .and not_to_output.to_stderr
   end
 end

--- a/Library/Homebrew/test/dev-cmd/tap_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap_spec.rb
@@ -69,15 +69,5 @@ describe "brew tap", :integration_test do
       .to be_a_success
       .and not_to_output.to_stdout
       .and not_to_output.to_stderr
-
-    expect { brew "tap", "--force-auto-update", "homebrew/bar" }
-      .to be_a_success
-      .and not_to_output.to_stdout
-      .and not_to_output.to_stderr
-
-    expect { brew "untap", "homebrew/bar" }
-      .to output(/Untapped/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
   end
 end

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -1,27 +1,4 @@
 describe "brew test", :integration_test do
-  it "fails when no argument is given" do
-    expect { brew "test" }
-      .to output(/This command requires a formula argument/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  it "fails when a Formula is not installed" do
-    expect { brew "test", testball }
-      .to output(/Testing requires the latest version of testball/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  it "fails when a Formula has no test" do
-    expect { brew "install", testball }.to be_a_success
-
-    expect { brew "test", testball }
-      .to output(/testball defines no test/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
   it "tests a given Formula" do
     setup_test_formula "testball", <<~EOS
       head "https://github.com/example/testball2.git"


### PR DESCRIPTION
We have an awful lot of integration tests and they are (comparatively) really slow. Let's kill those that test edge case conditions and focus on those that test that our functionality works as expected. Edge cases can be better tested with unit tests.