### PR TITLE
spec_helper: don't truncate output expectations.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -38,6 +38,7 @@ module Homebrew
       ENV.delete("VERBOSE")
       ENV.delete("HOMEBREW_CASK_OPTS")
       ENV.delete("HOMEBREW_TEMP")
+      ENV.delete("HOMEBREW_LINKAGE_CACHE")
       ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
       ENV["HOMEBREW_DEVELOPER"] = "1"
       ENV["HOMEBREW_NO_COMPAT"] = "1" if args.no_compat?

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -40,13 +40,13 @@ class LinkageChecker
   end
 
   def display_test_output(puts_output: true)
-    display_items "Missing libraries", @broken_dylibs, puts_output: puts_output
-    display_items "Broken dependencies", @broken_deps, puts_output: puts_output
+    display_items "Missing libraries", broken_dylibs, puts_output: puts_output
+    display_items "Broken dependencies", broken_deps, puts_output: puts_output
     puts "No broken library linkage" unless broken_library_linkage?
   end
 
   def broken_library_linkage?
-    !@broken_dylibs.empty? || !@broken_deps.empty?
+    !broken_dylibs.empty? || !broken_deps.empty?
   end
 
   def undeclared_deps

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -43,8 +43,8 @@ RSpec.configure do |config|
 
   config.filter_run_when_matching :focus
 
-  # TODO when https://github.com/rspec/rspec-expectations/pull/1056 makes
-  # it into a stable release:
+  # TODO: when https://github.com/rspec/rspec-expectations/pull/1056
+  #       makes it into a stable release:
   # config.expect_with :rspec do |c|
   #   c.max_formatted_output_length = 200
   # end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -43,9 +43,14 @@ RSpec.configure do |config|
 
   config.filter_run_when_matching :focus
 
-  config.expect_with :rspec do |c|
-    c.max_formatted_output_length = nil
-  end
+  # TODO when https://github.com/rspec/rspec-expectations/pull/1056 makes
+  # it into a stable release:
+  # config.expect_with :rspec do |c|
+  #   c.max_formatted_output_length = 200
+  # end
+
+  # Never truncate output objects.
+  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = nil
 
   config.include(FileUtils)
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -43,6 +43,10 @@ RSpec.configure do |config|
 
   config.filter_run_when_matching :focus
 
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
+
   config.include(FileUtils)
 
   config.include(RuboCop::RSpec::ExpectOffense)


### PR DESCRIPTION
It's really useful to be able to see the full output particularly when
a backtrace is in it.