### PR TITLE
Fix reporting outdated deps as missing

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -35,10 +35,10 @@ class Dependency
     formula
   end
 
-  delegate installed?: :to_formula
+  delegate any_version_installed?: :to_formula
 
   def satisfied?(inherited_options)
-    installed? && missing_options(inherited_options).empty?
+    any_version_installed? && missing_options(inherited_options).empty?
   end
 
   def missing_options(inherited_options)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This patch fixes brew incorrectly reporting outdated dependencies as missing.

```
$ brew info nvim
neovim: stable 0.2.2 (bottled), HEAD
Ambitious Vim-fork focused on extensibility and agility
https://neovim.io/
/usr/local/Cellar/neovim/0.2.2_1 (1,374 files, 17.6MB) *
  Poured from bottle on 2018-02-10 at 01:15:35
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/neovim.rb
==> Dependencies
Build: cmake ✘, lua@5.1 ✔, pkg-config ✔
Required: gettext ✔, jemalloc ✘, libtermkey ✔, libuv ✘, libvterm ✔, luajit ✔, msgpack ✘, unibilium ✔
==> Options
--HEAD
	Install HEAD version
``` 

cmake, jemalloc, libuv and msgpack are installed, but outdated.

```
$ brew outdated 
cmake (3.11.1) < 3.11.2
fontconfig (2.12.6) < 2.13.0
imagemagick (7.0.7-29) < 7.0.7-35
ipython (6.3.1) < 6.4.0
jemalloc (5.0.1) < 5.1.0
libidn2 (2.0.4) < 2.0.5
libuv (1.20.2) < 1.20.3
msgpack (2.1.5) < 3.0.1
pandoc (2.2) < 2.2.1
unrar (5.6.3) < 5.6.4
wget (1.19.4_1) < 1.19.5
```