### PR TITLE
cli_parser: Add depends_on, required_for and conflicts for switch options

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -19,7 +19,7 @@ module Homebrew
         instance_eval(&block)
       end
 
-      def switch(*names, description: nil, env: nil)
+      def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil)
         description = option_to_description(*names) if description.nil?
         global_switch = names.first.is_a?(Symbol)
         names, env = common_switch(*names) if global_switch
@@ -28,6 +28,10 @@ module Homebrew
         end
         enable_switch(*names, global_switch) if !env.nil? &&
                                                 !ENV["HOMEBREW_#{env.to_s.upcase}"].nil?
+
+        names.each do |name|
+          set_constraints(name, required_for: required_for, depends_on: depends_on)
+        end
       end
 
       def comma_array(name, description: nil)

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -71,53 +71,89 @@ describe Homebrew::CLI::Parser do
     end
   end
 
-  describe "test constraints" do
+  describe "test constraints for flag options" do
     subject(:parser) {
       described_class.new do
-        flag      "--flag1"
-        flag      "--flag3"
-        flag      "--flag2", required_for: "--flag1"
-        flag      "--flag4", depends_on: "--flag3"
+        flag      "--flag1="
+        flag      "--flag3="
+        flag      "--flag2=", required_for: "--flag1="
+        flag      "--flag4=", depends_on: "--flag3="
 
-        conflicts "--flag1", "--flag3"
+        conflicts "--flag1=", "--flag3="
       end
     }
 
-    it "raises exception on depends mandatory constraint violation" do
-      expect { parser.parse(["--flag1"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
+    it "raises exception on required_for constraint violation" do
+      expect { parser.parse(["--flag1=flag1"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
     end
 
-    it "raises exception on depends constraint violation" do
-      expect { parser.parse(["--flag2"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
+    it "raises exception on depends_on constraint violation" do
+      expect { parser.parse(["--flag2=flag2"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
     end
 
     it "raises exception for conflict violation" do
-      expect { parser.parse(["--flag1", "--flag3"]) }.to raise_error(Homebrew::CLI::OptionConflictError)
+      expect { parser.parse(["--flag1=flag1", "--flag3=flag3"]) }.to raise_error(Homebrew::CLI::OptionConflictError)
     end
 
     it "raises no exception" do
-      args = parser.parse(["--flag1", "--flag2"])
-      expect(args.flag1).to be true
-      expect(args.flag2).to be true
+      args = parser.parse(["--flag1=flag1", "--flag2=flag2"])
+      expect(args.flag1).to eq "flag1"
+      expect(args.flag2).to eq "flag2"
     end
 
     it "raises no exception for optional dependency" do
-      args = parser.parse(["--flag3"])
-      expect(args.flag3).to be true
+      args = parser.parse(["--flag3=flag3"])
+      expect(args.flag3).to eq "flag3"
     end
   end
 
   describe "test invalid constraints" do
     subject(:parser) {
       described_class.new do
-        flag      "--flag1"
-        flag      "--flag2", depends_on: "--flag1"
-        conflicts "--flag1", "--flag2"
+        flag      "--flag1="
+        flag      "--flag2=", depends_on: "--flag1="
+        conflicts "--flag1=", "--flag2="
       end
     }
 
     it "raises exception due to invalid constraints" do
       expect { parser.parse([]) }.to raise_error(Homebrew::CLI::InvalidConstraintError)
+    end
+  end
+
+  describe "test constraints for switch options" do
+    subject(:parser) {
+      described_class.new do
+        switch      "-a", "--switch-a"
+        switch      "-b", "--switch-b"
+        switch      "--switch-c", required_for: "--switch-a"
+        switch      "--switch-d", depends_on: "--switch-b"
+
+        conflicts "--switch-a", "--switch-b"
+      end
+    }
+
+    it "raises exception on required_for constraint violation" do
+      expect { parser.parse(["--switch-a"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
+    end
+
+    it "raises exception on depends_on constraint violation" do
+      expect { parser.parse(["--switch-c"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
+    end
+
+    it "raises exception for conflict violation" do
+      expect { parser.parse(["-ab"]) }.to raise_error(Homebrew::CLI::OptionConflictError)
+    end
+
+    it "raises no exception" do
+      args = parser.parse(["--switch-a", "--switch-c"])
+      expect(args.switch_a?).to be true
+      expect(args.switch_c?).to be true
+    end
+
+    it "raises no exception for optional dependency" do
+      args = parser.parse(["--switch-b"])
+      expect(args.switch_b?).to be true
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Declaration of `depends_on` , `required_for` and `conflicts` constraints were added for flags  in https://github.com/Homebrew/brew/pull/3987

This PR extends the same functionality for switch options. 