### PR TITLE
brew: Conciser error when run from nonexistent directory

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,6 +1,12 @@
 #!/bin/bash
 set +o posix
 
+# Fail fast with concise message when cwd does not exist
+if ! [[ -d "$PWD" ]]; then
+  echo "Error: The current working directory doesn't exist, cannot proceed." >&2
+  exit 1
+fi
+
 quiet_cd() {
   cd "$@" >/dev/null
 }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No. This seems a little tricky since it'll require wrangling an ongoing subshell while interleaving file system operations, and it's not part of core `brew` operations, so maybe we can let this slide.*
- [ ] Have you successfully run `brew style` with your changes locally? *No. `brew style` doesn't cover the `brew` bash script.*
- [ ] Have you successfully run `brew tests` with your changes locally? *No, but I don't think it's a regression; see notes below.*

-----

This PR makes `brew` emit a more concise error message when it is run from a directory that does not exist.

I know this may sound like a pedantic issue, but I actually run in to this quite a bit in practice, when I have one terminal window open somewhere in my Cellar, and I've uninstalled some stuff from another terminal window.

This PR doesn't change any real behavior, but produces a more concise, readable error message, which I think makes for a better user experience.

Before:

```

$ brew --version
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
chdir: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
chdir: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
chdir: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
pwd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
Error: The current working directory doesn't exist, cannot proceed.
```

Gross.

After:

```
$ brew --version
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
Error: The current working directory doesn't exist, cannot proceed.
```

Nicer.

I can't figure out how to get rid of that last `shell-init` error message; suggestions welcome.

To reproduce:

In terminal A:
```
mkdir foo
cd foo
```
In terminal B:
```
rmdir foo
```
Back in terminal A:
```
brew --version
```

##  Possible Issues

Are there cases where a user might be calling `brew --prefix` or something similar from a context where there is no cwd? I can't think of any, but you never know. This could break those.

##  Test Failures

When I run `brew tests`, I get this failure:

```

Failures:

  1) OS::Mac::language can be parsed by Locale::parse
     Failure/Error: expect { Locale.parse(subject.language) }.not_to raise_error

       expected no Exception, got #<Locale::ParserError: '' cannot be parsed to a Locale> with backtrace:
         # ./locale.rb:15:in `parse'
         # ./test/os/mac_spec.rb:19:in `block (4 levels) in <top (required)>'
         # ./test/os/mac_spec.rb:19:in `block (3 levels) in <top (required)>'
         # ./test/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:120:in `block in run'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `loop'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `run'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:34:in `block (2 levels) in setup'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
     # ./test/os/mac_spec.rb:19:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:112:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:120:in `block in run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `loop'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:34:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

Deprecation Warnings:

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /usr/local/Homebrew/Library/Homebrew/test/cache_store_spec.rb:24:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 1 minute 2.89 seconds (files took 1.67 seconds to load)
585 examples, 1 failure, 3 pending

Failed examples:

rspec ./test/os/mac_spec.rb:18 # OS::Mac::language can be parsed by Locale::parse
```

But I get the same failure when running `brew tests` from `master`, so I don't think this PR caused the regression.

I also get these warnings, I don't know if they're related:

```

$ brew tests
Randomized with seed 352
4 processes for 226 specs, ~ 56 specs per process
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.6-compliant syntax, but you are running 2.3.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.6-compliant syntax, but you are running 2.3.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.6-compliant syntax, but you are running 2.3.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.6-compliant syntax, but you are running 2.3.3.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Run options: exclude {:needs_linux=>true}
.....Run options: exclude {:needs_linux=>true}
.Run options: exclude {:needs_linux=>true}
............Run options: exclude {:needs_linux=>true}
```