### PR TITLE
Fix comparison with Version::NULL on RHS

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -144,6 +144,10 @@ describe Version do
     expect(described_class.create("2.1.0-p194")).to be > nil
   end
 
+  it "can be compared against Version::NULL" do
+    expect(described_class.create("2.1.0-p194")).to be > Version::NULL
+  end
+
   it "can be compared against strings" do
     expect(described_class.create("2.1.0-p194")).to be == "2.1.0-p194"
     expect(described_class.create("1")).to be == 1

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -387,6 +387,7 @@ class Version
     other = Version.new(other.to_s) if other.is_a? Integer
     return 1 if other.nil?
 
+    return 1 if other.respond_to?(:null?) && other.null?
     return unless other.is_a?(Version)
     return 0 if version == other.version
     return 1 if head? && !other.head?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This was accounted for in `Version::NULL.<=>`, but not in `Version#<=>`, so these could only be compared if `Version::NULL` was the left hand side.