### PR TITLE
HBC: Make language stanza order not matter

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/dsl.rb
+++ b/Library/Homebrew/cask/lib/hbc/dsl.rb
@@ -134,9 +134,7 @@ module Hbc
       end
 
       MacOS.languages.map(&Locale.method(:parse)).each do |locale|
-        key = @language_blocks.keys.detect do |strings|
-          strings.any? { |string| locale.include?(string) }
-        end
+        key = locale.detect(@language_blocks.keys)
 
         next if key.nil?
 

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -68,6 +68,11 @@ class Locale
   end
   alias == eql?
 
+  def detect(locale_groups)
+    locale_groups.detect { |locales| locales.any? { |locale| eql?(locale) } } ||
+      locale_groups.detect { |locales| locales.any? { |locale| include?(locale) } }
+  end
+
   def to_s
     [@language, @region, @script].compact.join("-")
   end

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -72,4 +72,14 @@ describe Locale do
       expect(subject.eql?("zh_CN_Hans")).to be false
     end
   end
+
+  describe "#detect" do
+    let(:locale_groups) { [["zh"], ["zh-TW"]] }
+
+    it "finds best matching language code, independent of order" do
+      expect(described_class.new("zh", "TW", nil).detect(locale_groups)).to eql(["zh-TW"])
+      expect(described_class.new("zh", "TW", nil).detect(locale_groups.reverse)).to eql(["zh-TW"])
+      expect(described_class.new("zh", "CN", "Hans").detect(locale_groups)).to eql(["zh"])
+    end
+  end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -1,6 +1,6 @@
 cask 'with-languages' do
   version '1.2.3'
-  
+
   language "zh" do
     sha256 "abc123"
     "zh-CN"
@@ -13,6 +13,6 @@ cask 'with-languages' do
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   homepage 'http://example.com/local-caffeine'
- 
+
   app 'Caffeine.app'
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/homebrew-cask/issues/42755 by checking first for exact matches and only then moving to general matches.

I previously kept it as blocks, but that made it uglier/harder to read/edit/find mistakes.