### PR TITLE
Fix tap unavailable error for migrated Cask taps.

### DIFF
--- a/Library/Homebrew/compat/tap.rb
+++ b/Library/Homebrew/compat/tap.rb
@@ -13,10 +13,12 @@ class Tap
 
       old_name = name
       old_path = path
-      old_remote = remote
+      old_remote = path.git_origin
 
       clear_cache
       super(new_user, new_repo)
+
+      return unless old_path.directory?
 
       new_initial_revision_var = "HOMEBREW_UPDATE_BEFORE#{repo_var}"
       new_current_revision_var = "HOMEBREW_UPDATE_AFTER#{repo_var}"
@@ -30,14 +32,14 @@ class Tap
 
       ohai "Migrating tap #{old_name} to #{new_name}..." if $stdout.tty?
 
+      if old_path.git?
+        puts "Changing remote from #{old_remote} to #{new_remote}..." if $stdout.tty?
+        old_path.git_origin = new_remote
+      end
+
       puts "Moving #{old_path} to #{new_path}..." if $stdout.tty?
       path.dirname.mkpath
       FileUtils.mv old_path, new_path
-
-      return unless old_path.git?
-
-      puts "Changing remote from #{old_remote} to #{new_remote}..." if $stdout.tty?
-      new_path.git_origin = new_remote
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We cannot use `remote` to get the old remote, because this will raise a `TapUnavailableError` if the old directory does not exist. Also, skip the migration if the old path doesn't exist.

Fixes https://github.com/Homebrew/brew/issues/4227.