### PR TITLE
Add gtk-mac-integration to gnome_devel_whitelist

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -606,6 +606,7 @@ module Homebrew
         libart 2.3.21
         pygtkglext 1.1.0
         libepoxy 1.5.0
+        gtk-mac-integration 2.1.2
       ].each_slice(2).to_a.map do |formula, version|
         [formula, version.split(".")[0..1].join(".")]
       end


### PR DESCRIPTION
Necessary for getting a green light on https://github.com/Homebrew/homebrew-core/pull/28338