### PR TITLE
cask fetch and upgrade: print caveats

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/fetch.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/fetch.rb
@@ -10,6 +10,7 @@ module Hbc
 
       def run
         casks.each do |cask|
+          Installer.print_caveats(cask)
           ohai "Downloading external files for Cask #{cask}"
           downloaded_path = Download.new(cask, force: force?).perform
           Verify.all(cask, downloaded_path)

--- a/Library/Homebrew/cask/lib/hbc/cli/upgrade.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/upgrade.rb
@@ -53,6 +53,8 @@ module Hbc
             # Start new Cask's installation steps
             new_cask_installer.check_conflicts
 
+            new_cask_installer.print_caveats
+
             new_cask_installer.fetch
 
             # Move the old Cask's artifacts back to staging


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
-----
cc @reitermarkus @vitorgalvao 

`fetch` does not display caveats which may include a license caveat which has been accepted by fetching the cask.

`upgrade` does not display caveats which would mean a user would not see the caveat if it was added to the cask after it had been installed.