### PR TITLE
cmd/list: add common `ls` options.

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -1,7 +1,7 @@
-#:  * `list`, `ls` [`--full-name`]:
+#:  * `list`, `ls` [`--full-name`] [`-1`] [`-l`] [`-t`] [`-r`]:
 #:    List all installed formulae. If `--full-name` is passed, print formulae
-#:    with fully-qualified names. If `--full-name` is not passed, any other
-#:    options (e.g. `-t`) are passed to `ls` which produces the actual output.
+#:    with fully-qualified names. If `--full-name` is not passed, other
+#:    options (i.e. `-1`, `-l`, `-t` and `-r`) are passed to `ls` which produces the actual output.
 #:
 #:  * `list`, `ls` `--unbrewed`:
 #:    List all files in the Homebrew prefix not installed by Homebrew.
@@ -33,6 +33,11 @@ module Homebrew
       switch "--full-name"
       switch "--multiple", depends_on: "--versions"
       switch :verbose
+      # passed through to ls
+      switch "-1"
+      switch "-l"
+      switch "-t"
+      switch "-r"
     end
 
     # Use of exec means we don't explicitly exit

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -302,10 +302,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--force` (or `-f`) is passed, Homebrew will allow keg-only formulae to be linked.
 
-  * `list`, `ls` [`--full-name`]:
+  * `list`, `ls` [`--full-name`] [`-1`] [`-l`] [`-t`] [`-r`]:
     List all installed formulae. If `--full-name` is passed, print formulae
-    with fully-qualified names. If `--full-name` is not passed, any other
-    options (e.g. `-t`) are passed to `ls` which produces the actual output.
+    with fully-qualified names. If `--full-name` is not passed, other
+    options (i.e. `-1`, `-l`, `-t` and `-r`) are passed to `ls` which produces the actual output.
 
   * `list`, `ls` `--unbrewed`:
     List all files in the Homebrew prefix not installed by Homebrew.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -311,8 +311,8 @@ If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which
 If \fB\-\-force\fR (or \fB\-f\fR) is passed, Homebrew will allow keg\-only formulae to be linked\.
 .
 .TP
-\fBlist\fR, \fBls\fR [\fB\-\-full\-name\fR]
-List all installed formulae\. If \fB\-\-full\-name\fR is passed, print formulae with fully\-qualified names\. If \fB\-\-full\-name\fR is not passed, any other options (e\.g\. \fB\-t\fR) are passed to \fBls\fR which produces the actual output\.
+\fBlist\fR, \fBls\fR [\fB\-\-full\-name\fR] [\fB\-1\fR] [\fB\-l\fR] [\fB\-t\fR] [\fB\-r\fR]
+List all installed formulae\. If \fB\-\-full\-name\fR is passed, print formulae with fully\-qualified names\. If \fB\-\-full\-name\fR is not passed, other options (i\.e\. \fB\-1\fR, \fB\-l\fR, \fB\-t\fR and \fB\-r\fR) are passed to \fBls\fR which produces the actual output\.
 .
 .TP
 \fBlist\fR, \fBls\fR \fB\-\-unbrewed\fR


### PR DESCRIPTION
We need to manually specify these now so let's add a few that we'd either previously documented or we've caught being used in the wild and adjust the documentation accordingly.

Followup from https://github.com/Homebrew/brew/pull/4067
Address issue in https://github.com/Homebrew/homebrew-core/pull/28429.
Closes https://github.com/Homebrew/homebrew-core/pull/28429.