### PR TITLE
dev-cmd/bottle: formula rebuild `--onto` another

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -670,7 +670,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     `audit` exits with a non-zero status if any errors are found. This is useful,
     for instance, for implementing pre-commit hooks.
 
-  * `bottle` [`--verbose`] [`--no-rebuild`|`--keep-old`] [`--skip-relocation`] [`--or-later`] [`--root-url=``URL`] [`--force-core-tap`] `formulae`:
+  * `bottle` [`--verbose`] [`--no-rebuild`|`--keep-old`] [`--skip-relocation`] [`--or-later`] [`--root-url=``URL`] [`--force-core-tap` [`--onto=``formulae`]] `formulae`:
     Generate a bottle (binary package) from a formula installed with
     `--build-bottle`.
 
@@ -691,6 +691,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--force-core-tap` is passed, build a bottle even if `formula` is not
     in homebrew/core or any installed taps.
+
+    If `--onto` is passed, consider the formula an extension of a homebrew/core
+    or tap formula, for purposes of considering rebuilds.
 
   * `bottle` `--merge` [`--keep-old`] [`--write` [`--no-commit`]] `formulae`:
     Generate a bottle from a formula and print the new DSL merged into the

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -688,7 +688,7 @@ Passing \fB\-\-only\-cops=\fR\fIcops\fR will check for violations of only the li
 \fBaudit\fR exits with a non\-zero status if any errors are found\. This is useful, for instance, for implementing pre\-commit hooks\.
 .
 .TP
-\fBbottle\fR [\fB\-\-verbose\fR] [\fB\-\-no\-rebuild\fR|\fB\-\-keep\-old\fR] [\fB\-\-skip\-relocation\fR] [\fB\-\-or\-later\fR] [\fB\-\-root\-url=\fR\fIURL\fR] [\fB\-\-force\-core\-tap\fR] \fIformulae\fR
+\fBbottle\fR [\fB\-\-verbose\fR] [\fB\-\-no\-rebuild\fR|\fB\-\-keep\-old\fR] [\fB\-\-skip\-relocation\fR] [\fB\-\-or\-later\fR] [\fB\-\-root\-url=\fR\fIURL\fR] [\fB\-\-force\-core\-tap\fR [\fB\-\-onto=\fR\fIformulae\fR]] \fIformulae\fR
 Generate a bottle (binary package) from a formula installed with \fB\-\-build\-bottle\fR\.
 .
 .IP
@@ -708,6 +708,9 @@ If \fB\-\-or\-later\fR is passed, append _or_later to the bottle tag\.
 .
 .IP
 If \fB\-\-force\-core\-tap\fR is passed, build a bottle even if \fIformula\fR is not in homebrew/core or any installed taps\.
+.
+.IP
+If \fB\-\-onto\fR is passed, consider the formula an extension of a homebrew/core or tap formula, for purposes of considering rebuilds\.
 .
 .TP
 \fBbottle\fR \fB\-\-merge\fR [\fB\-\-keep\-old\fR] [\fB\-\-write\fR [\fB\-\-no\-commit\fR]] \fIformulae\fR


### PR DESCRIPTION
When your workflow is based around bottling on a branch, rather than on
master, you work with formula files from your branch. However, for
purposes of bottle rebuilds, you'd like to consider the file an
extension of a tapped formula.

The current behavior, using `--force-core-tap`, always sets rebuild to
`0`. This can result in bottle hashes falling out of sync with users, as
every build will generate the same filename.

This commit adds an `--onto` flag to `brew bottle` that allows you to
specify a core or tapped formula to consider the file an extension on
for rebuild purposes.

This allows for correct bottle filenames and build metadata, when
rebuilding from formula files.

Change-Id: I3e5864b73ccbd3c0e32aa5f045128a83ec46a1e6

-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?