### PR TITLE
Fix Tty.width cannot get the real width in certain terminal like emacs shell

### DIFF
--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -7,7 +7,7 @@ module Tty
 
   def width
     width = `/bin/stty size 2>/dev/null`.split[1]
-    width ||= `/usr/bin/tput cols 2>/dev/null`.split[0]
+    width = `/usr/bin/tput cols 2>/dev/null`.split[0] if width.to_i.zero?
     width ||= 80
     width.to_i
   end

--- a/bin/brew
+++ b/bin/brew
@@ -72,7 +72,7 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TERM COLUMNS LINES LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do

--- a/bin/brew
+++ b/bin/brew
@@ -72,7 +72,7 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TERM LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM COLUMNS LINES LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do


### PR DESCRIPTION
In [eshell](https://www.gnu.org/software/emacs/manual/html_mono/eshell.html), ``` `/bin/stty size 2>/dev/null`.split[1]``` always returns `0`, however, `tput cols` can get correct width when `COLUMNS` is in `FILTERED_ENV`.

Note that `nil.to_i.zero?` is also true.

----

See also https://emacs-china.org/t/topic/5943/5