### PR TITLE
linkage_cache: cache input data and not results.

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -67,9 +67,7 @@ module FormulaCellarChecks
     keg = Keg.new(formula.prefix)
 
     CacheStoreDatabase.use(:linkage) do |db|
-      checker = LinkageChecker.new(
-        keg, formula, cache_db: db, use_cache: !ENV["HOMEBREW_LINKAGE_CACHE"].nil?
-      )
+      checker = LinkageChecker.new(keg, formula, cache_db: db)
       next unless checker.broken_library_linkage?
 
       output = <<~EOS

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1537,9 +1537,7 @@ class Formula
     return [] unless keg
 
     undeclared_deps = CacheStoreDatabase.use(:linkage) do |db|
-      linkage_checker = LinkageChecker.new(
-        keg, self, cache_db: db, use_cache: !ENV["HOMEBREW_LINKAGE_CACHE"].nil?
-      )
+      linkage_checker = LinkageChecker.new(keg, self, cache_db: db)
       linkage_checker.undeclared_deps.map { |n| Dependency.new(n) }
     end
 

--- a/Library/Homebrew/linkage_cache_store.rb
+++ b/Library/Homebrew/linkage_cache_store.rb
@@ -18,106 +18,55 @@ class LinkageCacheStore < CacheStore
   #
   # @return [Boolean]
   def keg_exists?
-    !database.get(keg_name).nil?
+    !database.get(@keg_name).nil?
   end
 
   # Inserts dylib-related information into the cache if it does not exist or
   # updates data into the linkage cache if it does exist
   #
-  # @param  [Hash] array_values: hash containing KVPs of { :type => Array | Set }
   # @param  [Hash] hash_values:  hash containing KVPs of { :type => Hash }
-  # @param  [Array[Hash]] values
-  # @raise  [TypeError] error if the values are not `Arary`, `Set`, or `Hash`
   # @return [nil]
-  def update!(array_values: {}, hash_values: {}, **values)
-    values.each do |key, value|
-      if value.is_a?(Hash)
-        hash_values[key] = value
-      elsif value.is_a?(Array) || value.is_a?(Set)
-        array_values[key] = value
-      else
-        raise TypeError, <<~EOS
-          Can't store types that are not `Array`, `Set` or `Hash` in the
-          linkage store.
-        EOS
-      end
+  def update!(hash_values)
+    hash_values.each_key do |type|
+      next if HASH_LINKAGE_TYPES.include?(type)
+
+      raise TypeError, <<~EOS
+        Can't update types that are not defined for the linkage store
+      EOS
     end
 
-    database.set keg_name, ruby_hash_to_json_string(
-      array_values: format_array_values(array_values),
-      hash_values: format_hash_values(hash_values),
-    )
+    database.set @keg_name, ruby_hash_to_json_string(hash_values)
   end
 
   # @param  [Symbol] the type to fetch from the `LinkageCacheStore`
-  # @raise  [TypeError] error if the type is not in `HASH_LINKAGE_TYPES` or
-  #   `ARRAY_LINKAGE_TYPES`
-  # @return [Hash | Array]
+  # @raise  [TypeError] error if the type is not in `HASH_LINKAGE_TYPES`
+  # @return [Hash]
   def fetch_type(type)
-    if HASH_LINKAGE_TYPES.include?(type)
-      fetch_hash_values(type)
-    elsif ARRAY_LINKAGE_TYPES.include?(type)
-      fetch_array_values(type)
-    else
+    unless HASH_LINKAGE_TYPES.include?(type)
       raise TypeError, <<~EOS
         Can't fetch types that are not defined for the linkage store
       EOS
     end
+
+    return {} unless keg_exists?
+
+    fetch_hash_values(type)
   end
 
   # @return [nil]
   def flush_cache!
-    database.delete(keg_name)
+    database.delete(@keg_name)
   end
 
   private
 
-  ARRAY_LINKAGE_TYPES = [
-    :system_dylibs, :variable_dylibs, :broken_dylibs, :indirect_deps,
-    :undeclared_deps, :unnecessary_deps
-  ].freeze
-  HASH_LINKAGE_TYPES = [:brewed_dylibs, :reverse_links, :broken_deps].freeze
-
-  # @return [String] the key to lookup items in the `CacheStore`
-  attr_reader :keg_name
-
-  # @param  [Symbol] the type to fetch from the `LinkageCacheStore`
-  # @return [Array]
-  def fetch_array_values(type)
-    keg_cache = database.get(keg_name)
-    return [] unless keg_cache
-    json_string_to_ruby_hash(keg_cache)["array_values"][type.to_s]
-  end
+  HASH_LINKAGE_TYPES = [:keg_files_dylibs].freeze
 
   # @param  [Symbol] type
   # @return [Hash]
   def fetch_hash_values(type)
-    keg_cache = database.get(keg_name)
+    keg_cache = database.get(@keg_name)
     return {} unless keg_cache
-    json_string_to_ruby_hash(keg_cache)["hash_values"][type.to_s]
-  end
-
-  # Formats the linkage data for `array_values` into a kind which can be parsed
-  # by the `json_string_to_ruby_hash` method. Internally converts ruby `Set`s to
-  # `Array`s
-  #
-  # @param  [Hash]
-  # @return [String]
-  def format_array_values(hash)
-    hash.each_with_object({}) { |(k, v), h| h[k] = v.to_a }
-  end
-
-  # Formats the linkage data for `hash_values` into a kind which can be parsed
-  # by the `json_string_to_ruby_hash` method. Converts ruby `Set`s to `Array`s,
-  # and converts ruby `Pathname`s to `String`s
-  #
-  # @param  [Hash]
-  # @return [String]
-  def format_hash_values(hash)
-    hash.each_with_object({}) do |(outer_key, outer_values), outer_hash|
-      outer_hash[outer_key] = outer_values.each_with_object({}) do |(k, v), h|
-        h[k] = v.to_a.map(&:to_s)
-      end
-    end
+    json_string_to_ruby_hash(keg_cache)[type.to_s]
   end
 end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -17,7 +17,7 @@ class Tab < OpenStruct
   # Instantiates a Tab for a new installation of a formula.
   def self.create(formula, compiler, stdlib)
     build = formula.build
-    runtime_deps = formula.runtime_dependencies(read_from_tab: false)
+    runtime_deps = formula.declared_runtime_dependencies
     attributes = {
       "homebrew_version" => HOMEBREW_VERSION,
       "used_options" => build.used_options.as_flags,

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -32,20 +32,13 @@ describe LinkageCacheStore do
     context "a `value` is a `Hash`" do
       it "sets the cache for the `keg_name`" do
         expect(database).to receive(:set).with(keg_name, anything)
-        subject.update!(a_value: { key: ["value"] })
+        subject.update!(keg_files_dylibs: { key: ["value"] })
       end
     end
 
-    context "a `value` is an `Array`" do
-      it "sets the cache for the `keg_name`" do
-        expect(database).to receive(:set).with(keg_name, anything)
-        subject.update!(a_value: ["value"])
-      end
-    end
-
-    context "a `value` is not an `Array` or `Hash`" do
-      it "raises a `TypeError` if a `value` is not an `Array` or `Hash`" do
-        expect { subject.update!(key: 1) }.to raise_error(TypeError)
+    context "a `value` is not a `Hash`" do
+      it "raises a `TypeError` if a `value` is not a `Hash`" do
+        expect { subject.update!(a_value: ["value"]) }.to raise_error(TypeError)
       end
     end
   end
@@ -64,21 +57,11 @@ describe LinkageCacheStore do
       end
 
       it "returns a `Hash` of values" do
-        expect(subject.fetch_type(:brewed_dylibs)).to be_an_instance_of(Hash)
+        expect(subject.fetch_type(:keg_files_dylibs)).to be_an_instance_of(Hash)
       end
     end
 
-    context "`ARRAY_LINKAGE_TYPES.include?(type)`" do
-      before(:each) do
-        expect(database).to receive(:get).with(keg_name).and_return(nil)
-      end
-
-      it "returns an `Array` of values" do
-        expect(subject.fetch_type(:system_dylibs)).to be_an_instance_of(Array)
-      end
-    end
-
-    context "`type` not in `HASH_LINKAGE_TYPES` or `ARRAY_LINKAGE_TYPES`" do
+    context "`type` not in `HASH_LINKAGE_TYPES`" do
       it "raises a `TypeError` if the `type` is not supported" do
         expect { subject.fetch_type(:bad_type) }.to raise_error(TypeError)
       end


### PR DESCRIPTION
- Cache all the non-weak dynamic library links for a keg rather than the
result of running `brew linkage`. This means that we correctly handle
changes to e.g. what non-keg files are present on disk.
- linkage_checker: use default use_cache parameter for callers.

Also, regenerate runtime_dependencies after installation.

This ensures the we’re calculating we’ve run `fix_dynamic_linkage` so that their results are consistent with what we’re actually pouring. Combined with the linkage cache (which will be enabled by default in future) this has very little performance overhead for consistently Correct tab results. As a result, don’t bother looking at opportunistically linked dependencies when creating a tab by default but only do so after installation has completed. Finally, only output the caveats and summary after all these operations have completed.

Fixes #4216
Fixes issue mentioned in https://github.com/Homebrew/brew/pull/4066#issuecomment-385180725 CC @scpeters