### PR TITLE
runtime_dependencies: include recommended deps.

### DIFF
--- a/Library/Homebrew/build_options.rb
+++ b/Library/Homebrew/build_options.rb
@@ -83,6 +83,11 @@ class BuildOptions
     include?("c++11") && option_defined?("c++11")
   end
 
+  # True if the build has any arguments or options specified.
+  def any_args_or_options?
+    !@args.empty? || !@options.empty?
+  end
+
   # @private
   def used_options
     @options & @args

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1525,7 +1525,12 @@ class Formula
   def declared_runtime_dependencies
     recursive_dependencies do |_, dependency|
       Dependency.prune if dependency.build?
-      Dependency.prune if !dependency.required? && build.without?(dependency)
+      next if dependency.required?
+      if build.any_args_or_options?
+        Dependency.prune if build.without?(dependency)
+      elsif !dependency.recommended?
+        Dependency.prune
+      end
     end
   end
 


### PR DESCRIPTION
These previously weren't being generated correctly for dependencies of formulae that weren't installed.

Fixes #4124.