### PR TITLE
cli_parser: Rename @bump_args to args

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -289,7 +289,7 @@ module Homebrew
           # GitHub API responds immediately but fork takes a few seconds to be ready.
           sleep 3
         rescue *GitHub.api_errors => e
-          formula.path.atomic_write(backup_file) unless @bump_args.dry_run?
+          formula.path.atomic_write(backup_file) unless args.dry_run?
           odie "Unable to fork: #{e.message}!"
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Missed renaming `@bump_args` to `args` in #9445