### PR TITLE
Fix bad formula/tab runtime_dependencies handling

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -10,6 +10,8 @@ class Dependency
   DEFAULT_ENV_PROC = proc {}
 
   def initialize(name, tags = [], env_proc = DEFAULT_ENV_PROC, option_names = [name])
+    raise ArgumentError, "Dependency must have a name!" unless name
+
     @name = name
     @tags = tags
     @env_proc = env_proc

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1523,8 +1523,9 @@ class Formula
        (keg = opt_or_installed_prefix_keg) &&
        (tab_deps = keg.runtime_dependencies)
       return tab_deps.map do |d|
-        next unless d["full_name"]
-        Dependency.new d["full_name"]
+        full_name = d["full_name"]
+        next unless full_name
+        Dependency.new full_name
       end.compact
     end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1522,7 +1522,10 @@ class Formula
     if read_from_tab &&
        (keg = opt_or_installed_prefix_keg) &&
        (tab_deps = keg.runtime_dependencies)
-      return tab_deps.map { |d| Dependency.new d["full_name"] }.compact
+      return tab_deps.map do |d|
+        next unless d["full_name"]
+        Dependency.new d["full_name"]
+      end.compact
     end
 
     declared_runtime_dependencies | undeclared_runtime_dependencies

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -613,7 +613,7 @@ class FormulaInstaller
     # Update tab with actual runtime dependencies
     tab = Tab.for_keg(keg)
     Tab.clear_cache
-    tab.runtime_dependencies =
+    tab.runtime_dependency_objects =
       formula.runtime_dependencies(read_from_tab: false)
     tab.write
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -277,6 +277,7 @@ module Formulary
   # * a formula URL
   # * a local bottle reference
   def self.factory(ref, spec = :stable, alias_path: nil, from: nil)
+    raise ArgumentError, "Formulae must have a ref!" unless ref
     loader_for(ref, from: from).get_formula(spec, alias_path: alias_path)
   end
 

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -33,10 +33,7 @@ class Tab < OpenStruct
       "compiler" => compiler,
       "stdlib" => stdlib,
       "aliases" => formula.aliases,
-      "runtime_dependencies" => runtime_deps.map do |dep|
-        f = dep.to_formula
-        { "full_name" => f.full_name, "version" => f.version.to_s }
-      end,
+      "runtime_dependencies" => Tab.runtime_deps_hash(runtime_deps),
       "source" => {
         "path" => formula.specified_path.to_s,
         "tap" => formula.tap&.name,
@@ -203,6 +200,13 @@ class Tab < OpenStruct
     new(attributes)
   end
 
+  def self.runtime_deps_hash(deps)
+    deps.map do |dep|
+      f = dep.to_formula
+      { "full_name" => f.full_name, "version" => f.version.to_s }
+    end
+  end
+
   def with?(val)
     option_names = val.respond_to?(:option_names) ? val.option_names : [val]
 
@@ -260,6 +264,10 @@ class Tab < OpenStruct
     # Homebrew versions prior to 1.1.6 generated incorrect runtime dependency
     # lists.
     super unless parsed_homebrew_version < "1.1.6"
+  end
+
+  def runtime_dependency_objects=(deps)
+    source["runtime_dependencies"] = Tab.runtime_deps_hash(deps)
   end
 
   def cxxstdlib


### PR DESCRIPTION
- Formula: handle bad tap runtime dependencies. Also add some better exceptions for the cases that `nil`s end up getting passed around incorrectly.
- tab: set runtime_dependencies consistently.

In https://github.com/Homebrew/brew/pull/4255 the addition of `tab.runtime_dependencies = formula.runtime_dependencies(read_from_tab: false)` in `formula_installer.rb` meant that all new formulae installations had incorrect `runtime_dependencies` data set in their tabs. This PR both handles that bad data and ensures that a `brew reinstall` will clean it up.

Fixes #4261
Fixes #4262