### PR TITLE
Further tweak formula installer runtime dep handling

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -613,8 +613,8 @@ class FormulaInstaller
     # Update tab with actual runtime dependencies
     tab = Tab.for_keg(keg)
     Tab.clear_cache
-    tab.runtime_dependency_objects =
-      formula.runtime_dependencies(read_from_tab: false)
+    f_runtime_deps = formula.runtime_dependencies(read_from_tab: false)
+    tab.runtime_dependencies = Tab.runtime_deps_hash(f_runtime_deps)
     tab.write
 
     # let's reset Utils.git_available? if we just installed git

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -266,10 +266,6 @@ class Tab < OpenStruct
     super unless parsed_homebrew_version < "1.1.6"
   end
 
-  def runtime_dependency_objects=(deps)
-    source["runtime_dependencies"] = Tab.runtime_deps_hash(deps)
-  end
-
   def cxxstdlib
     # Older tabs won't have these values, so provide sensible defaults
     lib = stdlib.to_sym if stdlib

--- a/Library/Homebrew/test/dependency_spec.rb
+++ b/Library/Homebrew/test/dependency_spec.rb
@@ -23,6 +23,10 @@ describe Dependency do
       dep = described_class.new("foo", [:build, "bar"])
       expect(dep.tags).to eq([:build, "bar"])
     end
+
+    it "rejects nil names" do
+      expect { described_class.new(nil) }.to raise_error(ArgumentError)
+    end
   end
 
   describe "::merge_repeats" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -771,6 +771,20 @@ describe Formula do
 
       expect(formula.runtime_dependencies.map(&:name)).to eq [dependency.name]
     end
+
+    it "handles bad tab runtime_dependencies" do
+      formula = Class.new(Testball).new
+
+      formula.brew { formula.install }
+      tab = Tab.create(formula, DevelopmentTools.default_compiler, :libcxx)
+      tab.runtime_dependencies = ["foo"]
+      tab.write
+
+      keg = Keg.for(formula.installed_prefix)
+      keg.link
+
+      expect(formula.runtime_dependencies.map(&:name)).to be_empty
+    end
   end
 
   specify "requirements" do

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -72,6 +72,12 @@ describe Formulary do
       }.to raise_error(FormulaUnavailableError)
     end
 
+    it "raises an error if ref is nil" do
+      expect {
+        described_class.factory(nil)
+      }.to raise_error(ArgumentError)
+    end
+
     context "when the Formula has the wrong class" do
       let(:formula_name) { "giraffe" }
       let(:formula_content) do

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -138,6 +138,18 @@ describe Tab do
     expect(tab.runtime_dependencies).not_to be nil
   end
 
+  specify "::runtime_deps_hash" do
+    runtime_deps = [Dependency.new("foo")]
+    stub_formula_loader formula("foo") { url "foo-1.0" }
+    runtime_deps_hash = described_class.runtime_deps_hash(runtime_deps)
+    tab = described_class.new
+    tab.homebrew_version = "1.1.6"
+    tab.runtime_dependencies = runtime_deps_hash
+    expect(tab.runtime_dependencies).to eql(
+      [{ "full_name" => "foo", "version" => "1.0" }],
+    )
+  end
+
   specify "#cxxstdlib" do
     expect(subject.cxxstdlib.compiler).to eq(:clang)
     expect(subject.cxxstdlib.type).to eq(:libcxx)


### PR DESCRIPTION
Instead of adding a custom method to `Tab` use `Tab.runtime_deps_hash` within `FormulaInstaller` to ensure the `runtime_dependencies` are in the right format.