### PR TITLE
linkage: Fix `brew linkage --reverse`

### DIFF
--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -37,7 +37,8 @@ class LinkageChecker
 
   def display_reverse_output
     return if @reverse_links.empty?
-    @reverse_links.sort.each do |dylib, files|
+    sorted = @reverse_links.sort
+    sorted.each do |dylib, files|
       puts dylib
       files.each do |f|
         unprefixed = f.to_s.strip_prefix "#{keg}/"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
A refactor in #4255 introduced a bug which broke `brew linkage --reverse`