### PR TITLE
Xcode: fix version detection with unknown clang

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -147,6 +147,7 @@ module OS
       end
 
       def detect_version_from_clang_version
+        return "dunno" if DevelopmentTools.clang_version.null?
         # This logic provides a fake Xcode version based on the
         # installed CLT version. This is useful as they are packaged
         # simultaneously so workarounds need to apply to both based on their


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes an error which occurs if the clang version can't be detected. `DevelopmentTools.clang_version` returns `Version::NULL` if clang is present but its version can't be parsed, for example if the format of clang's version string has changed. `Version::NULL.to_f` returns `NaN`, which we then try to [multiply and call `#to_i` on](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/os/mac/xcode.rb#L154), which will obviously fail. This bails out early with `"dunno"` in the case that `DevelopmentTools.clang_version` is null, which is the same unknown-version string we use elsewhere in the same method.

Sample error output:

```
==> Reinstalling pcre2
Error: NaN
/usr/local/Homebrew/Library/Homebrew/os/mac/xcode.rb:152:in `to_i'
/usr/local/Homebrew/Library/Homebrew/os/mac/xcode.rb:152:in `detect_version_from_clang_version'
/usr/local/Homebrew/Library/Homebrew/os/mac/xcode.rb:144:in `detect_version'
/usr/local/Homebrew/Library/Homebrew/os/mac/xcode.rb:114:in `version'
/usr/local/Homebrew/Library/Homebrew/os/mac/xcode.rb:58:in `without_clt?'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/extend/ENV/super.rb:26:in `homebrew_extra_paths'
/usr/local/Homebrew/Library/Homebrew/extend/ENV/super.rb:109:in `determine_path'
/usr/local/Homebrew/Library/Homebrew/extend/ENV/super.rb:44:in `setup_build_environment'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/extend/ENV/super.rb:114:in `setup_build_environment'
/usr/local/Homebrew/Library/Homebrew/build.rb:84:in `install'
/usr/local/Homebrew/Library/Homebrew/build.rb:191:in `<main>'
```