### PR TITLE
brew cask upgrade missing from zsh completion

### DIFF
--- a/completions/zsh/_brew_cask
+++ b/completions/zsh/_brew_cask
@@ -49,6 +49,7 @@ __brew_cask_commands() {
     'search:searches all known Casks'
     'style:checks Cask style using RuboCop'
     'uninstall:uninstalls the given Cask'
+    'upgrade:upgrades all outdated casks'
     'zap:zaps all files associated with the given Cask'
   )
   _describe -t commands "brew cask command" commands


### PR DESCRIPTION
Fix #4282 

Adds missing brew cask upgrade in zsh completion (bash completion is already up to date)

----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] N/A Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] N/A Have you successfully run `brew style` with your changes locally?
- [ ] N/A Have you successfully run `brew tests` with your changes locally?

-----
