### PR TITLE
linkage_checker: fix cache invalidation.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -607,7 +607,7 @@ class FormulaInstaller
     # Updates the cache for a particular formula after doing an install
     CacheStoreDatabase.use(:linkage) do |db|
       break unless db.created?
-      LinkageChecker.new(keg, formula, cache_db: db)
+      LinkageChecker.new(keg, formula, cache_db: db, rebuild_cache: true)
     end
 
     # Update tab with actual runtime dependencies

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -272,6 +272,11 @@ class Keg
   end
 
   def uninstall
+    CacheStoreDatabase.use(:linkage) do |db|
+      break unless db.created?
+      LinkageCacheStore.new(path, db).flush_cache!
+    end
+
     path.rmtree
     path.parent.rmdir_if_possible
     remove_opt_record if optlinked?

--- a/Library/Homebrew/linkage_cache_store.rb
+++ b/Library/Homebrew/linkage_cache_store.rb
@@ -6,19 +6,19 @@ require "cache_store"
 # by the `brew linkage` command
 #
 class LinkageCacheStore < CacheStore
-  # @param  [String] keg_name
+  # @param  [String] keg_path
   # @param  [CacheStoreDatabase] database
   # @return [nil]
-  def initialize(keg_name, database)
-    @keg_name = keg_name
+  def initialize(keg_path, database)
+    @keg_path = keg_path
     super(database)
   end
 
-  # Returns `true` if the database has any value for the current `keg_name`
+  # Returns `true` if the database has any value for the current `keg_path`
   #
   # @return [Boolean]
   def keg_exists?
-    !database.get(@keg_name).nil?
+    !database.get(@keg_path).nil?
   end
 
   # Inserts dylib-related information into the cache if it does not exist or
@@ -35,7 +35,7 @@ class LinkageCacheStore < CacheStore
       EOS
     end
 
-    database.set @keg_name, ruby_hash_to_json_string(hash_values)
+    database.set @keg_path, ruby_hash_to_json_string(hash_values)
   end
 
   # @param  [Symbol] the type to fetch from the `LinkageCacheStore`
@@ -55,7 +55,7 @@ class LinkageCacheStore < CacheStore
 
   # @return [nil]
   def flush_cache!
-    database.delete(@keg_name)
+    database.delete(@keg_path)
   end
 
   private
@@ -65,7 +65,7 @@ class LinkageCacheStore < CacheStore
   # @param  [Symbol] type
   # @return [Hash]
   def fetch_hash_values(type)
-    keg_cache = database.get(@keg_name)
+    keg_cache = database.get(@keg_path)
     return {} unless keg_cache
     json_string_to_ruby_hash(keg_cache)[type.to_s]
   end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -6,10 +6,11 @@ class LinkageChecker
   attr_reader :undeclared_deps
 
   def initialize(keg, formula = nil, cache_db:,
-                 use_cache: !ENV["HOMEBREW_LINKAGE_CACHE"].nil?)
+                 use_cache: !ENV["HOMEBREW_LINKAGE_CACHE"].nil?,
+                 rebuild_cache: false)
     @keg = keg
     @formula = formula || resolve_formula(keg)
-    @store = LinkageCacheStore.new(keg.name, cache_db) if use_cache
+    @store = LinkageCacheStore.new(keg.to_s, cache_db) if use_cache
 
     @system_dylibs    = Set.new
     @broken_dylibs    = Set.new
@@ -21,7 +22,7 @@ class LinkageChecker
     @undeclared_deps  = []
     @unnecessary_deps = []
 
-    check_dylibs
+    check_dylibs(rebuild_cache: rebuild_cache)
   end
 
   def display_normal_output
@@ -67,9 +68,16 @@ class LinkageChecker
     Regexp.last_match(2)
   end
 
-  def check_dylibs
+  def check_dylibs(rebuild_cache:)
+    keg_files_dylibs = nil
+
+    if rebuild_cache
+      store&.flush_cache!
+    else
+      keg_files_dylibs = store&.fetch_type(:keg_files_dylibs)
+    end
+
     keg_files_dylibs_was_empty = false
-    keg_files_dylibs = store&.fetch_type(:keg_files_dylibs)
     keg_files_dylibs ||= {}
     if keg_files_dylibs.empty?
       keg_files_dylibs_was_empty = true


### PR DESCRIPTION
Rather than using the name of the keg for the key use the full path. This provides several advantages:

- there's no need to invalidate the cache on a `brew upgrade` or `brew switch`
- it's easier to figure out what cache entries can be removed and this can be done whenever a keg is removed by `brew uninstall` or `brew cleanup`.

Also, ensure that an `install` (or `reinstall`, `upgrade`) always results in the cache being rebuilt for that keg (in case different options were used).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----