### PR TITLE
mach: Always report Mach-O parsing errors

### DIFF
--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -43,10 +43,8 @@ module MachOShim
       []
     rescue
       # ... but complain about other (parse) errors for further investigation.
-      if ARGV.homebrew_developer?
-        onoe "Failed to read Mach-O binary: #{self}"
-        raise
-      end
+      onoe "Failed to read Mach-O binary: #{self}"
+      raise if ARGV.homebrew_developer?
       []
     end
   end


### PR DESCRIPTION
This retains the raise-on-error behavior for developers, but
otherwise only prints an error message.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This augments the reporting behavior for Mach-O parsing errors slightly, to make catching problems like https://github.com/Homebrew/homebrew-core/issues/28675 slightly easier. We still don't fail/raise unless `homebrew_developer?`, but now we display an error message to all users.