### PR TITLE
brew tests: suppress "Run options: exclude..." output

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -103,7 +103,7 @@ module Homebrew
         --seed #{seed}
         --color
         --require spec_helper
-        --format NoSeedProgressFormatter
+        --format QuietProgressFormatter
         --format ParallelTests::RSpec::RuntimeLogger
         --out #{HOMEBREW_CACHE}/tests/parallel_runtime_rspec.log
       ]

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -19,7 +19,7 @@ $LOAD_PATH.unshift(File.expand_path("#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/test/su
 
 require "global"
 
-require "test/support/no_seed_progress_formatter"
+require "test/support/quiet_progress_formatter"
 require "test/support/helper/fixtures"
 require "test/support/helper/formula"
 require "test/support/helper/mktmpdir"

--- a/Library/Homebrew/test/support/no_seed_progress_formatter.rb
+++ b/Library/Homebrew/test/support/no_seed_progress_formatter.rb
@@ -1,7 +1,0 @@
-require "rspec/core/formatters/progress_formatter"
-
-class NoSeedProgressFormatter < RSpec::Core::Formatters::ProgressFormatter
-  RSpec::Core::Formatters.register self, :seed
-
-  def seed(notification); end
-end

--- a/Library/Homebrew/test/support/quiet_progress_formatter.rb
+++ b/Library/Homebrew/test/support/quiet_progress_formatter.rb
@@ -1,0 +1,14 @@
+require "rspec/core/formatters/progress_formatter"
+
+class QuietProgressFormatter < RSpec::Core::Formatters::ProgressFormatter
+  RSpec::Core::Formatters.register self, :seed
+
+  def seed(notification); end
+
+  def message(notification)
+    if notification.message.start_with? "Run options: exclude"
+      return
+    end
+    puts "MESSAGE: #{notification}"
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No: `brew tests` is not itself tested.*
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Gets rid of that `Run options: exclude {...}` spam in the output of `brew tests`.

Before:

```
$ brew tests       
Randomized with seed 26599
8 processes for 226 specs, ~ 28 specs per process
Run options: exclude {:needs_linux=>true}
.......Run options: exclude {:needs_linux=>true}
...Run options: exclude {:needs_linux=>true}
Run options: exclude {:needs_linux=>true}
......Run options: exclude {:needs_linux=>true}
.Run options: exclude {:needs_linux=>true}
Run options: exclude {:needs_linux=>true}
.Run options: exclude {:needs_linux=>true}
..................*...........................................................
```

After:

```
$ brew tests                                               
Randomized with seed 24974
8 processes for 226 specs, ~ 28 specs per process
..........................................................................................................................................................................................................................................
```