### PR TITLE
brew tests: silence filter announcements

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -45,6 +45,8 @@ RSpec.configure do |config|
 
   config.filter_run_when_matching :focus
 
+  config.silence_filter_announcements = true
+
   # TODO: when https://github.com/rspec/rspec-expectations/pull/1056
   #       makes it into a stable release:
   # config.expect_with :rspec do |c|


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No: `brew tests` is not tested.*
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Supersedes #4296.

Gets rid of that `Run options: exclude {...}` spam in the output of `brew tests`.

Before:

```
$ brew tests       
Randomized with seed 26599
8 processes for 226 specs, ~ 28 specs per process
Run options: exclude {:needs_linux=>true}
.......Run options: exclude {:needs_linux=>true}
...Run options: exclude {:needs_linux=>true}
Run options: exclude {:needs_linux=>true}
......Run options: exclude {:needs_linux=>true}
.Run options: exclude {:needs_linux=>true}
Run options: exclude {:needs_linux=>true}
.Run options: exclude {:needs_linux=>true}
..................*...........................................................
```

After:

```
$ brew tests                                               
Randomized with seed 24974
8 processes for 226 specs, ~ 28 specs per process
..........................................................................................................................................................................................................................................
```