### PR TITLE
superenv: set effective_sysroot on 10.14 CLT

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -102,7 +102,15 @@ module Superenv
   end
 
   def effective_sysroot
-    MacOS.sdk_path.to_s if MacOS::Xcode.without_clt?
+    if MacOS::Xcode.without_clt?
+      MacOS.sdk_path.to_s
+    # Possibly a temporary workaround, depending on how the
+    # CLT shakes out this dev cycle.
+    # We need this sysroot set because there are no headers
+    # in /usr.
+    elsif MacOS.version >= :mojave
+      "#{MacOS::CLT::PKG_PATH}/SDKs/MacOSX#{MacOS.version}.sdk"
+    end
   end
 
   def set_x11_env_if_installed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I'm mostly opening this for documentation. It's probably too early in the cycle to start committing workarounds like this.

The current version of the CLT doesn't include headers in the traditional Unixy locations, which breaks some software and which means that we end up not setting some special include paths. I've filed this bug as `rdar://40833474`, but meanwhile this workaround fixes broken builds like imagemagick.

If the traditional Unix locations aren't coming back, we'll have to look at wider-reaching changes, but I'll want to let more time pass before looking at something like that.

See also https://github.com/Homebrew/homebrew-core/issues/28703 and https://github.com/Homebrew/homebrew-core/pull/28733.