### PR TITLE
Fix "unrecognized cop" warning in `brew style`

### DIFF
--- a/Library/Homebrew/.rubocop-rspec.yml
+++ b/Library/Homebrew/.rubocop-rspec.yml
@@ -1,0 +1,6 @@
+inherit_from:
+  - .rubocop.yml
+
+RSpec/ExpectActual:
+  Exclude:
+    - 'test/missing_formula_spec.rb'

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -88,7 +88,3 @@ Style/HashSyntax:
 # so many of these in formulae but none in here
 Style/TrailingBodyOnMethodDefinition:
   Enabled: true
-
-Rspec/ExpectActual:
-  Exclude:
-    - 'test/missing_formula_spec.rb'

--- a/Library/Homebrew/cmd/style.rb
+++ b/Library/Homebrew/cmd/style.rb
@@ -112,7 +112,8 @@ module Homebrew
     end
 
     if files.nil?
-      args << "--config" << HOMEBREW_LIBRARY_PATH/".rubocop.yml"
+      config_file = ARGV.include?("--rspec") ? ".rubocop-rspec.yml" : ".rubocop.yml"
+      args << "--config" << HOMEBREW_LIBRARY_PATH/config_file
       args << HOMEBREW_LIBRARY_PATH
     else
       args << "--config" << HOMEBREW_LIBRARY/".rubocop_audit.yml"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes an "unrecognized cop" warning by splitting out the RSpec-specific cop configuration to its own file that's only used when `brew style --rspec` is called.

Before:

```
$ brew style                                                                                                                                  master
Warning: unrecognized cop Rspec/ExpectActual found in .rubocop.yml
Warning: unrecognized cop Rspec/ExpectActual found in .rubocop.yml
Inspecting 657 files
..............................................................................................................................................................................
```

After:

```
$ brew style                                                                                                               fix-rspec-rubocop-warning
Inspecting 657 files
.......................................................................................................................................................................
```

Should probably be merged before doing any more rspec-rubocop configuration, to avoid even more warnings.