### PR TITLE
brew style: assume file args are non-formulae when passed --rspec

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -57,12 +57,24 @@ module Homebrew
         args << "--only" << cops_to_include.join(",")
       end
 
+      has_non_formula = Array(files).any? do |file|
+        File.expand_path(file).start_with? HOMEBREW_LIBRARY_PATH
+      end
+      config_file = if files.nil? || has_non_formula
+        if ARGV.include?("--rspec")
+          HOMEBREW_LIBRARY_PATH/".rubocop-rspec.yml"
+        else
+          HOMEBREW_LIBRARY_PATH/".rubocop.yml"
+        end
+      else
+        HOMEBREW_LIBRARY/".rubocop_audit.yml"
+      end
+
+      args << "--config" << config_file
+
       if files.nil?
-        config_file = ARGV.include?("--rspec") ? ".rubocop-rspec.yml" : ".rubocop.yml"
-        args << "--config" << HOMEBREW_LIBRARY_PATH/config_file
         args << HOMEBREW_LIBRARY_PATH
       else
-        args << "--config" << HOMEBREW_LIBRARY/".rubocop_audit.yml"
         args += files
       end
 

--- a/Library/Homebrew/test/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cmd/style_spec.rb
@@ -31,4 +31,18 @@ describe "brew style" do
         .to include("Extra empty line detected at class body beginning.")
     end
   end
+
+  describe "Homebrew::check_style_and_print" do
+    let(:dir) { mktmpdir }
+
+    it "returns false for conforming file with only audit-level violations" do
+      # This file is known to use non-rocket hashes and other things that trigger audit,
+      # but not regular, cop violations
+      target_file = HOMEBREW_LIBRARY_PATH/"utils.rb"
+
+      rubocop_result = Homebrew::Style.check_style_and_print([target_file])
+
+      expect(rubocop_result).to eq false
+    end
+  end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Modifies `brew style` to always use the non-audit, rubocop-rspec config file when the `--rspec` option is passed, even if files were specified on the command line. This makes it feasible to test individual spec definition files with `brew style --rspec` to help work on #4058. Otherwise, it won't pick up the RSpec configurations, which you may need to modify while working on that task. And if you omit a file and just do `brew style --rspec` on everything, there are so many cop violations that it spams your terminal.