### PR TITLE
text_cop: require `dep ensure` to use `-vendor-only`

### DIFF
--- a/Library/Homebrew/rubocops/text_cop.rb
+++ b/Library/Homebrew/rubocops/text_cop.rb
@@ -48,6 +48,11 @@ module RuboCop
           find_method_with_args(body_node, :system, "go", "get") do
             problem "Do not use `go get`. Please ask upstream to implement Go vendoring"
           end
+
+          find_method_with_args(body_node, :system, "dep", "ensure") do |d|
+            next if parameters_passed?(d, /vendor-only/)
+            problem "use \"dep\", \"ensure\", \"-vendor-only\""
+          end
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/text_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_cop_spec.rb
@@ -177,5 +177,19 @@ describe RuboCop::Cop::FormulaAudit::Text do
         end
       RUBY
     end
+
+    it "When dep ensure is used without `-vendor-only`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "http://example.com/foo-1.0.tgz"
+          homepage "http://example.com"
+
+          def install
+            system "dep", "ensure"
+            ^^^^^^^^^^^^^^^^^^^^^^ use \"dep\", \"ensure\", \"-vendor-only\"
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
cc @ilovezfs 