### PR TITLE
Fix #4293: Use a stricter superenv for CMake builds

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -190,7 +190,6 @@ module Superenv
   def determine_cmake_prefix_path
     PATH.new(
       keg_only_deps.map(&:opt_prefix),
-      HOMEBREW_PREFIX.to_s,
     ).existing
   end
 


### PR DESCRIPTION
 - `HOMEBREW_PREFIX.to_s` was getting added to the CMake environment variable:
   `CMAKE_PREFIX_PATH` which causes CMake to look for stuff in:
   `HOMEBREW_PREFIX.to_s/{bin,lib,share,include,etc,...}`
 - This can cause Homebrew to pick up alternate fortran compilres if you provie
   links to them in e.g., `/usr/local/bin` assuming you installed homebrew in
   the standard location.
 - This may cause problems with libraries, programs, headers etc. getting picked
   up that aren't enumerated as formula dependencies.
 - Fixes #4293

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).

No. My ruby isn't super strong, and I looked at the existing tests in `Library/Homebrew/test` both `ENV_spec.rb` and `build_environment_spec.rb` and it wasn't clear how to write a meaningful test for this small change. The big test will be to see if all formulae with `depends_on "cmake" => :build` and then to determine if they fail because the formula is not specifying dependencies correctly, or if there is some deeper reason as to why the homebrew prefix was included in the `CMAKE_PREFIX_PATH` to begin with.

- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
