### PR TITLE
text_cop: require cargo to use `install` instead of `build`

### DIFF
--- a/Library/Homebrew/rubocops/text_cop.rb
+++ b/Library/Homebrew/rubocops/text_cop.rb
@@ -53,6 +53,10 @@ module RuboCop
             next if parameters_passed?(d, /vendor-only/)
             problem "use \"dep\", \"ensure\", \"-vendor-only\""
           end
+
+          find_method_with_args(body_node, :system, "cargo", "build") do
+            problem "use \"cargo\", \"install\", \"--root\", prefix"
+          end
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/text_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_cop_spec.rb
@@ -191,5 +191,19 @@ describe RuboCop::Cop::FormulaAudit::Text do
         end
       RUBY
     end
+
+    it "When cargo build is executed" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "http://example.com/foo-1.0.tgz"
+          homepage "http://example.com"
+
+          def install
+            system "cargo", "build"
+            ^^^^^^^^^^^^^^^^^^^^^^^ use \"cargo\", \"install\", \"--root\", prefix
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Opened this for discussion, I'm still checking if all of the `build` formulae work as expected with `install` or if we would need to whitelist any.

Currently we prefer `cargo install --root prefix` (which doesn't need a `bin.install`) over `cargo build`. We have 27 formulae that run `cargo`, 18 have `build` and 9 have `install`.
