### PR TITLE
Fix `brew cask doctor` for non-standard installation location

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/doctor.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/doctor.rb
@@ -60,13 +60,13 @@ module Hbc
       def check_staging_location
         ohai "Homebrew-Cask Staging Location"
 
-        path = Pathname.new(user_tilde(Caskroom.path.to_s))
+        path = Caskroom.path
 
         if path.exist? && !path.writable?
-          add_error "The staging path #{path} is not writable by the current user."
+          add_error "The staging path #{user_tilde(path.to_s)} is not writable by the current user."
         end
 
-        puts path
+        puts user_tilde(path.to_s)
       end
 
       def check_cached_downloads


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
  * I ran `brew update` several times.
  * `brew doctor` shows one warning `Warning: Your Homebrew's prefix is not /usr/local.`
    * (BTW I would need to find out how to make the exit status of `brew doctor` not to be non-zero only for the non-standard prefix - for automated check.)
  * This is not a formula-specific issue.
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
  * Please refer to commit message. Please let me know if you want me to move symptom&analysis from commit message to PR description.
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
  * No. I had a look at the tests in `Library/Homebrew/test/cmd/doctor_spec.rb` though I am not sure how I would write a test for this fix. Guidance welcome.
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
  * I get one failure - irrespective of my changes:

```
  1) OS::Mac::language can be parsed by Locale::parse
     Failure/Error: expect { Locale.parse(subject.language) }.not_to raise_error

       expected no Exception, got #<Locale::ParserError: '' cannot be parsed to a Locale> with backtrace:
         # ./locale.rb:15:in `parse'
         # ./test/os/mac_spec.rb:19:in `block (4 levels) in <top (required)>'
         # ./test/os/mac_spec.rb:19:in `block (3 levels) in <top (required)>'
         # ./test/spec_helper.rb:117:in `block (2 levels) in <top (required)>'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:120:in `block in run'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `loop'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `run'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:34:in `block (2 levels) in setup'
         # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
     # ./test/os/mac_spec.rb:19:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:117:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:120:in `block in run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `loop'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:109:in `run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.0/lib/rspec/retry.rb:34:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```

I think the test is making a wrong assumption on system configuration, or my system has broken language config:
```
$ defaults read -g AppleLanguages
2018-06-10 00:37:23.861 defaults[17535:160332]
The domain/default pair of (kCFPreferencesAnyApplication, AppleLanguages) does not exist
```
-----
