### PR TITLE
formula_installer: don't pass spec arguments from ARGV to postinstall

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -858,7 +858,7 @@ class FormulaInstaller
       --
       #{HOMEBREW_LIBRARY_PATH}/postinstall.rb
       #{formula.path}
-    ].concat(ARGV.options_only)
+    ].concat(ARGV.options_only) - ["--HEAD", "--devel"]
 
     if formula.head?
       args << "--HEAD"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Postinstall should be executed with the spec of the target formula not
the spec argument from ARGV, otherwise the prefix can be incorrect. In
other words, if the stable version of a dependency gets installed,
postinstall for the dependency should use the prefix of the dependency's
stable version, not the prefix of its devel or head version.

Fixes #2941.