### PR TITLE
Add `stderr` output to exception.

### DIFF
--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -76,14 +76,14 @@ module Homebrew
         system(cache_env, "rubocop", "_#{HOMEBREW_RUBOCOP_VERSION}_", *args)
         !$CHILD_STATUS.success?
       when :json
-        json, _, status = Open3.capture3(cache_env, "rubocop", "_#{HOMEBREW_RUBOCOP_VERSION}_", "--format", "json", *args)
+        json, err, status = Open3.capture3(cache_env, "rubocop", "_#{HOMEBREW_RUBOCOP_VERSION}_", "--format", "json", *args)
         # exit status of 1 just means violations were found; other numbers mean
         # execution errors.
         # exitstatus can also be nil if RuboCop process crashes, e.g. due to
         # native extension problems.
         # JSON needs to be at least 2 characters.
         if !(0..1).cover?(status.exitstatus) || json.to_s.length < 2
-          raise "Error running `rubocop --format json #{args.join " "}`"
+          raise "Error running `rubocop --format json #{args.join " "}`\n#{err}"
         end
         RubocopResults.new(JSON.parse(json))
       else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add error output to RuboCop exception. Otherwise https://github.com/Homebrew/homebrew-core/pull/28873 is undebuggable.