### PR TITLE
[WIP] formula_installer: Don't check devtools if pouring

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -13,6 +13,7 @@ require "emoji"
 require "development_tools"
 require "cache_store"
 require "linkage_checker"
+require "install"
 
 class FormulaInstaller
   include FormulaCellarChecks
@@ -220,7 +221,7 @@ class FormulaInstaller
 
   def install
     if !formula.bottle_unneeded? && !pour_bottle? && DevelopmentTools.installed?
-      Install.check_development_tools
+      Homebrew::Install.check_development_tools
     end
 
     # not in initialize so upgrade can unlink the active keg before calling this

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -219,7 +219,7 @@ class FormulaInstaller
   end
 
   def install
-    if DevelopmentTools.installed? && !pour_bottle?
+    if !formula.bottle_unneeded? && !pour_bottle? && DevelopmentTools.installed?
       Install.check_development_tools
     end
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -219,6 +219,10 @@ class FormulaInstaller
   end
 
   def install
+    if DevelopmentTools.installed? && !pour_bottle?
+      Install.check_development_tools
+    end
+
     # not in initialize so upgrade can unlink the active keg before calling this
     # function but after instantiating this class so that it can avoid having to
     # relink the active keg if possible (because it is slow).

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -47,7 +47,6 @@ module Homebrew
     def perform_preinstall_checks
       check_ppc
       check_writable_install_location
-      check_development_tools if DevelopmentTools.installed?
       check_cellar
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This *should* stop Homebrew from nagging users about their outdated Xcode installation during bottle-only installs. I'll be able to test it locally in a few days (my mac is currently packed away).

Some notes:
* This fixes the current behavior by moving the development tools check out of `perform_preinstall_checks` and into `FormulaInstaller#install`. This should be fine, although it does cause us to run the check *N + 1* times for 1 formula and  *N* dependencies.
* Some users may prefer this behavior, but it may not be beneficial in the long term: users *should* be nagged about the presence of unsupported Xcode installs, as doing so lessens the amount of weird setup triaging we have to do. Warning the user instead of totally failing the install might be a workable middle ground.
