### PR TITLE
rubocop: exclude .simplecov under vendor

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from:
 
 AllCops:
   Include:
-    - '**/.simplecov'
+    - 'Library/Homebrew/.simplecov'
   Exclude:
     - 'bin/*'
     - '**/Casks/**/*'


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No: this is itself a style/test change, and the details of `brew style` aren't tested.*
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

For me, when I run `brew style`, it's complaining about the `.simplecov` file under the Aruba gem in the vendored portable ruby.

```
$ brew style                                                                  master ✭
Inspecting 664 files
.....................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................C..................

Offenses:

/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/gems/2.3.0/gems/aruba-0.7.4/.simplecov:2:33: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
SimpleCov.start unless ENV.key? 'ARUBA_NO_COVERAGE'
                                ^^^^^^^^^^^^^^^^^^^
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/gems/2.3.0/gems/aruba-0.7.4/.simplecov:6:14: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  add_filter '.simplecov'
             ^^^^^^^^^^^^
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/gems/2.3.0/gems/aruba-0.7.4/.simplecov:9:14: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  add_filter 'Rakefile'
             ^^^^^^^^^^
/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.3/lib/ruby/gems/2.3.0/gems/aruba-0.7.4/.simplecov:10:14: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
  add_filter 'lib/tasks'
             ^^^^^^^^^^^
```

I would think this file would be excluded by the `Exclude: ...     - '**/vendor/**/.simplecov'` setting in `.rubocop.yml`. But it looks like the `Include: **/.simplecov` overrides that.

This PR explicitly excludes `**/vendor/**/.simplecov` to complete the vendor exclusion.

After:
```
$ brew style                                                             exclude-vendor-simplecov ✭
Inspecting 663 files
.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

663 files inspected, no offenses detected
```