### PR TITLE
Mojave: require CLT header package

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -20,6 +20,7 @@ module Homebrew
           check_xcode_minimum_version
           check_clt_minimum_version
           check_if_xcode_needs_clt_installed
+          check_if_clt_needs_headers_installed
         ].freeze
       end
 
@@ -132,6 +133,17 @@ module Homebrew
         <<~EOS
           Xcode alone is not sufficient on #{MacOS.version.pretty_name}.
           #{DevelopmentTools.installation_instructions}
+        EOS
+      end
+
+      def check_if_clt_needs_headers_installed
+        return unless MacOS::CLT.separate_header_package?
+        return if MacOS::CLT.headers_installed?
+
+        <<~EOS
+          The Command Line Tools header package must be installed on #{MacOS.version.pretty_name}.
+          The installer is located at:
+            #{MacOS::CLT::HEADER_PKG_PATH.sub(":macos_version", MacOS.version)}
         EOS
       end
 

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -39,6 +39,12 @@ class SystemConfig
       end
     end
 
+    def clt_headers
+      @clt_headers ||= if MacOS::CLT.headers_installed?
+        MacOS::CLT.headers_version
+      end
+    end
+
     def xquartz
       @xquartz ||= if MacOS::XQuartz.installed?
         "#{MacOS::XQuartz.version} => #{describe_path(MacOS::XQuartz.prefix)}"
@@ -49,6 +55,9 @@ class SystemConfig
       dump_generic_verbose_config(f)
       f.puts "macOS: #{MacOS.full_version}-#{kernel}"
       f.puts "CLT: #{clt ? clt : "N/A"}"
+      if MacOS::CLT.separate_header_package?
+        f.puts "CLT headers: #{clt_headers ? clt_headers : "N/A"}"
+      end
       f.puts "Xcode: #{xcode ? xcode : "N/A"}"
       f.puts "XQuartz: #{xquartz ? xquartz : "N/A"}"
     end

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -32,6 +32,19 @@ describe Homebrew::Diagnostic::Checks do
       .to match("Xcode alone is not sufficient on El Capitan")
   end
 
+  specify "#check_if_clt_needs_headers_installed" do
+    allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.14"))
+    allow(MacOS::CLT).to receive(:installed?).and_return(true)
+    allow(MacOS::CLT).to receive(:headers_installed?).and_return(false)
+
+    expect(subject.check_if_clt_needs_headers_installed)
+      .to match("The Command Line Tools header package must be installed on Mojave.")
+
+    allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.13"))
+    expect(subject.check_if_clt_needs_headers_installed)
+      .to be_nil
+  end
+
   specify "#check_homebrew_prefix" do
     # the integration tests are run in a special prefix
     expect(subject.check_homebrew_prefix)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As of Xcode 10, the CLT no longer installs the traditional Unix header layout by default. The CLT SDK is the only location in which headers are located. There is, however, a separate header package which can be installed which restores the traditional Unix-style headers. I've submitted two PRs to address this situation, with conflicting solutions - we should merge only one of the two.

I haven't added tests for the untested files yet, but I'll do that once we pick which of the two solutions we want to go for.

This PR attempts to retain the status quo by making the CLT header package mandatory. It makes the following changes:

* Allows `MacOS::CLT` to detect whether the header package is relevant, whether it's installed, and whether it matches the installed CLT.
* Prints header package information as a part of `brew --config`.
* Adds a doctor check, and makes the header package mandatory for installing software in a CLT-only configuration.

See #4335 for a PR which uses the CLT SDKs instead.