### PR TITLE
Mojave: use the CLT SDK where necessary

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -20,7 +20,6 @@ module Homebrew
           check_xcode_minimum_version
           check_clt_minimum_version
           check_if_xcode_needs_clt_installed
-          check_if_clt_needs_headers_installed
         ].freeze
       end
 
@@ -135,17 +134,6 @@ module Homebrew
         <<~EOS
           Xcode alone is not sufficient on #{MacOS.version.pretty_name}.
           #{DevelopmentTools.installation_instructions}
-        EOS
-      end
-
-      def check_if_clt_needs_headers_installed
-        return unless MacOS::CLT.separate_header_package?
-        return if MacOS::CLT.headers_installed?
-
-        <<~EOS
-          The Command Line Tools header package must be installed on #{MacOS.version.pretty_name}.
-          The installer is located at:
-            #{MacOS::CLT::HEADER_PKG_PATH.sub(":macos_version", MacOS.version)}
         EOS
       end
 

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -27,8 +27,8 @@ module Stdenv
 
     append_path "ACLOCAL_PATH", "#{MacOS::X11.share}/aclocal"
 
-    if MacOS::XQuartz.provided_by_apple? && MacOS.sdk_path
-      append_path "CMAKE_PREFIX_PATH", "#{MacOS.sdk_path}/usr/X11"
+    if MacOS::XQuartz.provided_by_apple? && MacOS.sdk_path_if_needed
+      append_path "CMAKE_PREFIX_PATH", "#{MacOS.sdk_path_if_needed}/usr/X11"
     end
 
     append "CFLAGS", "-I#{MacOS::X11.include}" unless MacOS::CLT.installed?
@@ -93,7 +93,7 @@ module Stdenv
     delete("CPATH")
     remove "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 
-    return unless (sdk = MacOS.sdk_path(version))
+    return unless (sdk = MacOS.sdk_path_if_needed(version))
     delete("SDKROOT")
     remove_from_cflags "-isysroot #{sdk}"
     remove "CPPFLAGS", "-isysroot #{sdk}"
@@ -115,7 +115,7 @@ module Stdenv
     self["CPATH"] = "#{HOMEBREW_PREFIX}/include"
     prepend "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 
-    return unless (sdk = MacOS.sdk_path(version))
+    return unless (sdk = MacOS.sdk_path_if_needed(version))
     # Extra setup to support Xcode 4.3+ without CLT.
     self["SDKROOT"] = sdk
     # Tell clang/gcc where system include's are:
@@ -132,7 +132,7 @@ module Stdenv
 
   # Some configure scripts won't find libxml2 without help
   def libxml2
-    if !MacOS.sdk_path
+    if !MacOS.sdk_path_if_needed
       append "CPPFLAGS", "-I/usr/include/libxml2"
     else
       # Use the includes form the sdk

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -27,7 +27,7 @@ module Stdenv
 
     append_path "ACLOCAL_PATH", "#{MacOS::X11.share}/aclocal"
 
-    if MacOS::XQuartz.provided_by_apple? && !MacOS::CLT.installed?
+    if MacOS::XQuartz.provided_by_apple? && MacOS.sdk_path
       append_path "CMAKE_PREFIX_PATH", "#{MacOS.sdk_path}/usr/X11"
     end
 
@@ -93,7 +93,7 @@ module Stdenv
     delete("CPATH")
     remove "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 
-    return unless (sdk = MacOS.sdk_path(version)) && !MacOS::CLT.installed?
+    return unless (sdk = MacOS.sdk_path(version))
     delete("SDKROOT")
     remove_from_cflags "-isysroot #{sdk}"
     remove "CPPFLAGS", "-isysroot #{sdk}"
@@ -115,7 +115,7 @@ module Stdenv
     self["CPATH"] = "#{HOMEBREW_PREFIX}/include"
     prepend "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 
-    return unless (sdk = MacOS.sdk_path(version)) && !MacOS::CLT.installed?
+    return unless (sdk = MacOS.sdk_path(version))
     # Extra setup to support Xcode 4.3+ without CLT.
     self["SDKROOT"] = sdk
     # Tell clang/gcc where system include's are:
@@ -132,7 +132,7 @@ module Stdenv
 
   # Some configure scripts won't find libxml2 without help
   def libxml2
-    if MacOS::CLT.installed?
+    if !MacOS.sdk_path
       append "CPPFLAGS", "-I/usr/include/libxml2"
     else
       # Use the includes form the sdk

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -113,7 +113,6 @@ module Superenv
   def setup_build_environment(formula = nil)
     generic_setup_build_environment(formula)
     self["HOMEBREW_SDKROOT"] = effective_sysroot
-    self["SDKROOT"] = MacOS.sdk_path if MacOS.sdk_path
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -58,7 +58,7 @@ module Superenv
   def homebrew_extra_library_paths
     paths = []
     if compiler == :llvm_clang
-      if !MacOS.sdk_path
+      if !MacOS.sdk_path_if_needed
         paths << "/usr/lib"
       else
         paths << "#{MacOS.sdk_path}/usr/lib"
@@ -102,7 +102,7 @@ module Superenv
   end
 
   def effective_sysroot
-    MacOS.sdk_path&.to_s
+    MacOS.sdk_path_if_needed&.to_s
   end
 
   def set_x11_env_if_installed

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -58,7 +58,7 @@ module Superenv
   def homebrew_extra_library_paths
     paths = []
     if compiler == :llvm_clang
-      if MacOS::CLT.installed?
+      if !MacOS.sdk_path
         paths << "/usr/lib"
       else
         paths << "#{MacOS.sdk_path}/usr/lib"
@@ -102,7 +102,7 @@ module Superenv
   end
 
   def effective_sysroot
-    MacOS.sdk_path.to_s if MacOS::Xcode.without_clt?
+    MacOS.sdk_path&.to_s
   end
 
   def set_x11_env_if_installed
@@ -113,7 +113,7 @@ module Superenv
   def setup_build_environment(formula = nil)
     generic_setup_build_environment(formula)
     self["HOMEBREW_SDKROOT"] = effective_sysroot
-    self["SDKROOT"] = MacOS.sdk_path if MacOS::Xcode.without_clt?
+    self["SDKROOT"] = MacOS.sdk_path if MacOS.sdk_path
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -85,7 +85,7 @@ module OS
     #      specifically been requested according to the rules above.
 
     def sdk(v = nil)
-      @locator ||= if Xcode.without_clt?
+      @locator ||= if Xcode.installed?
         XcodeSDKLocator.new
       else
         CLTSDKLocator.new

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -91,17 +91,7 @@ module OS
         CLTSDKLocator.new
       end
 
-      begin
-        sdk = if v.nil?
-          (Xcode.version.to_i >= 7) ? @locator.latest_sdk : @locator.sdk_for(version)
-        else
-          @locator.sdk_for v
-        end
-      rescue BaseSDKLocator::NoSDKError
-        sdk = @locator.latest_sdk
-      end
-      # Only return an SDK older than the OS version if it was specifically requested
-      sdk if v || (!sdk.nil? && sdk.version >= version)
+      @locator.sdk_if_applicable(v)
     end
 
     # Returns the path to an SDK or nil, following the rules set by #sdk.

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -110,6 +110,11 @@ module OS
       s&.path
     end
 
+    def sdk_path_if_needed(v = nil)
+      return if !MacOS::Xcode.installed? && MacOS::CLT.separate_header_package?
+      sdk_path(v)
+    end
+
     # See these issues for some history:
     # https://github.com/Homebrew/legacy-homebrew/issues/13
     # https://github.com/Homebrew/legacy-homebrew/issues/41

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -101,7 +101,19 @@ module OS
     end
 
     def sdk_path_if_needed(v = nil)
-      return if !MacOS::Xcode.installed? && MacOS::CLT.separate_header_package?
+      # Prefer Xcode SDK when both Xcode and the CLT are installed.
+      # Expected results:
+      # 1. On Xcode-only systems, return the Xcode SDK.
+      # 2. On Xcode-and-CLT systems where headers are provided by the system, return nil.
+      # 3. On CLT-only systems with no CLT SDK, return nil.
+      # 4. On CLT-only systems with a CLT SDK, where headers are provided by the system, return nil.
+      # 5. On CLT-only systems with a CLT SDK, where headers are not provided by the system, return the CLT SDK.
+
+      # If there's no CLT SDK, return early
+      return if MacOS::CLT.installed? && !MacOS::CLT.provides_sdk?
+      # If the CLT is installed and provides headers, return early
+      return if MacOS::CLT.installed? && !MacOS::CLT.separate_header_package?
+
       sdk_path(v)
     end
 

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -85,14 +85,19 @@ module OS
     #      specifically been requested according to the rules above.
 
     def sdk(v = nil)
-      @locator ||= SDKLocator.new
+      @locator ||= if Xcode.without_clt?
+        XcodeSDKLocator.new
+      else
+        CLTSDKLocator.new
+      end
+
       begin
         sdk = if v.nil?
           (Xcode.version.to_i >= 7) ? @locator.latest_sdk : @locator.sdk_for(version)
         else
           @locator.sdk_for v
         end
-      rescue SDKLocator::NoSDKError
+      rescue BaseSDKLocator::NoSDKError
         sdk = @locator.latest_sdk
       end
       # Only return an SDK older than the OS version if it was specifically requested

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -11,7 +11,7 @@ module OS
       end
     end
 
-    class SDKLocator
+    class BaseSDKLocator
       class NoSDKError < StandardError; end
 
       def sdk_for(v)
@@ -30,15 +30,12 @@ module OS
 
       private
 
+      def sdk_prefix
+        ""
+      end
+
       def sdk_paths
         @sdk_paths ||= begin
-          # Xcode.prefix is pretty smart, so let's look inside to find the sdk
-          sdk_prefix = "#{Xcode.prefix}/Platforms/MacOSX.platform/Developer/SDKs"
-          # Xcode < 4.3 style
-          sdk_prefix = "/Developer/SDKs" unless File.directory? sdk_prefix
-          # Finally query Xcode itself (this is slow, so check it last)
-          sdk_prefix = File.join(Utils.popen_read(DevelopmentTools.locate("xcrun"), "--show-sdk-platform-path").chomp, "Developer", "SDKs") unless File.directory? sdk_prefix
-
           # Bail out if there is no SDK prefix at all
           if !File.directory? sdk_prefix
             {}
@@ -51,6 +48,44 @@ module OS
             end
 
             paths
+          end
+        end
+      end
+    end
+
+    class XcodeSDKLocator < BaseSDKLocator
+      private
+
+      def sdk_prefix
+        @sdk_prefix ||= begin
+          # Xcode.prefix is pretty smart, so let's look inside to find the sdk
+          sdk_prefix = "#{Xcode.prefix}/Platforms/MacOSX.platform/Developer/SDKs"
+          # Xcode < 4.3 style
+          sdk_prefix = "/Developer/SDKs" unless File.directory? sdk_prefix
+          # Finally query Xcode itself (this is slow, so check it last)
+          sdk_prefix = File.join(Utils.popen_read(DevelopmentTools.locate("xcrun"), "--show-sdk-platform-path").chomp, "Developer", "SDKs") unless File.directory? sdk_prefix
+
+          sdk_prefix
+        end
+      end
+    end
+
+    class CLTSDKLocator < BaseSDKLocator
+      private
+
+      # While CLT SDKs existed prior to Xcode 10, those packages also
+      # installed a traditional Unix-style header layout and we prefer
+      # using that
+      # As of Xcode 10, the Unix-style headers are installed via a
+      # separate package, so we can't rely on their being present.
+      # This will only look up SDKs on Xcode 10 or newer, and still
+      # return nil SDKs for Xcode 9 and older.
+      def sdk_prefix
+        @sdk_prefix ||= begin
+          if !CLT.separate_header_package?
+            ""
+          else
+            "#{CLT::PKG_PATH}/SDKs"
           end
         end
       end

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -82,7 +82,7 @@ module OS
       # return nil SDKs for Xcode 9 and older.
       def sdk_prefix
         @sdk_prefix ||= begin
-          if !CLT.separate_header_package?
+          if !CLT.provides_sdk?
             ""
           else
             "#{CLT::PKG_PATH}/SDKs"

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -96,6 +96,16 @@ module OS
         !prefix.nil?
       end
 
+      def sdk(v = nil)
+        @locator ||= XcodeSDKLocator.new
+
+        @locator.sdk_if_applicable(v)
+      end
+
+      def sdk_path(v = nil)
+        sdk(v)&.path
+      end
+
       def update_instructions
         if MacOS.version >= "10.9" && !OS::Mac.prerelease?
           <<~EOS
@@ -224,6 +234,16 @@ module OS
         else
           headers_version == version
         end
+      end
+
+      def sdk(v = nil)
+        @locator ||= CLTSDKLocator.new
+
+        @locator.sdk_if_applicable(v)
+      end
+
+      def sdk_path(v = nil)
+        sdk(v)&.path
       end
 
       def update_instructions

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -214,6 +214,10 @@ module OS
         version >= "10"
       end
 
+      def provides_sdk?
+        version >= "8"
+      end
+
       def headers_installed?
         if !separate_header_package?
           installed?

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -211,7 +211,7 @@ module OS
       end
 
       def separate_header_package?
-        MacOS.version >= :mojave
+        version >= "10"
       end
 
       def headers_installed?

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -32,19 +32,6 @@ describe Homebrew::Diagnostic::Checks do
       .to match("Xcode alone is not sufficient on El Capitan")
   end
 
-  specify "#check_if_clt_needs_headers_installed" do
-    allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.14"))
-    allow(MacOS::CLT).to receive(:installed?).and_return(true)
-    allow(MacOS::CLT).to receive(:headers_installed?).and_return(false)
-
-    expect(subject.check_if_clt_needs_headers_installed)
-      .to match("The Command Line Tools header package must be installed on Mojave.")
-
-    allow(MacOS).to receive(:version).and_return(OS::Mac::Version.new("10.13"))
-    expect(subject.check_if_clt_needs_headers_installed)
-      .to be_nil
-  end
-
   specify "#check_homebrew_prefix" do
     # the integration tests are run in a special prefix
     expect(subject.check_homebrew_prefix)

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -19,4 +19,44 @@ describe OS::Mac do
       expect { Locale.parse(subject.language) }.not_to raise_error
     end
   end
+
+  describe "::sdk_path_if_needed" do
+    it "calls sdk_path on Xcode-only systems" do
+      allow(OS::Mac::Xcode).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:installed?) { false }
+      expect(OS::Mac).to receive(:sdk_path)
+      OS::Mac.sdk_path_if_needed
+    end
+
+    it "does not call sdk_path on Xcode-and-CLT systems with system headers" do
+      allow(OS::Mac::Xcode).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:separate_header_package?) { false }
+      expect(OS::Mac).not_to receive(:sdk_path)
+      OS::Mac.sdk_path_if_needed
+    end
+
+    it "does not call sdk_path on CLT-only systems with no CLT SDK" do
+      allow(OS::Mac::Xcode).to receive(:installed?) { false }
+      allow(OS::Mac::CLT).to receive(:installed?) { true }
+      expect(OS::Mac).not_to receive(:sdk_path)
+      OS::Mac.sdk_path_if_needed
+    end
+
+    it "does not call sdk_path on CLT-only systems with a CLT SDK if the system provides headers" do
+      allow(OS::Mac::Xcode).to receive(:installed?) { false }
+      allow(OS::Mac::CLT).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:separate_header_package?) { false }
+      expect(OS::Mac).not_to receive(:sdk_path)
+      OS::Mac.sdk_path_if_needed
+    end
+
+    it "calls sdk_path on CLT-only systems with a CLT SDK if the system does not provide headers" do
+      allow(OS::Mac::Xcode).to receive(:installed?) { false }
+      allow(OS::Mac::CLT).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:separate_header_package?) { true }
+      expect(OS::Mac).to receive(:sdk_path)
+      OS::Mac.sdk_path_if_needed
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As of Xcode 10, the CLT no longer installs the traditional Unix header layout by default. The CLT SDK is the only location in which headers are located. There is, however, a separate header package which can be installed which restores the traditional Unix-style headers. I've submitted two PRs to address this situation, with conflicting solutions - we should merge only one of the two.

I haven't added tests for the untested files yet, but I'll do that once we pick which of the two solutions we want to go for.

This PR adapts to the new default CLT layout by adapting our existing Xcode SDK code. The existing `SDKLocator` has been refactored into Xcode and CLT SDK locators. The new CLT SDK locator still returns `nil` on CLT-only systems pre-10.14, but it returns the path to the CLT SDK where it's relevant. I've also updated several places which called `MacOS.sdk_path` which now incorrectly assume it's irrelevant on CLT-only systems, and made them check for the presence of `MacOS.sdk_path` instead of hardcoding a CLT check.

See #4334 for a solution which mandates having the header package installed instead