### PR TITLE
bump-formula-pr: don't unset --mirror= value

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -149,7 +149,7 @@ module Homebrew
     elsif !new_url
       odie "#{formula}: no --url= argument specified!"
     else
-      new_mirror = case new_url
+      new_mirror ||= case new_url
       when requested_spec != :devel && %r{.*ftp.gnu.org/gnu.*}
         new_url.sub "ftp.gnu.org/gnu", "ftpmirror.gnu.org"
       when %r{.*mirrors.ocf.berkeley.edu/debian.*}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise `bump-formula-pr` only sets known mirrors such as
ftpmirror.gnu.org but not the explicitly passed in `--mirror=`