### PR TITLE
cask info: display `auto_updates`

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli/info.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/info.rb
@@ -18,7 +18,7 @@ module Hbc
       end
 
       def self.info(cask)
-        puts "#{cask.token}: #{cask.version}"
+        title_info(cask)
         puts Formatter.url(cask.homepage) if cask.homepage
         installation_info(cask)
         repo_info(cask)
@@ -26,6 +26,12 @@ module Hbc
         language_info(cask)
         artifact_info(cask)
         Installer.print_caveats(cask)
+      end
+
+      def self.title_info(cask)
+        title = "#{cask.token}: #{cask.version}"
+        title += " (auto_updates)" if cask.auto_updates
+        puts title
       end
 
       def self.formatted_url(url)

--- a/Library/Homebrew/cask/lib/hbc/cli/upgrade.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli/upgrade.rb
@@ -26,6 +26,7 @@ module Hbc
           return
         end
 
+        ohai "Casks with `auto_updates` or `version :latest` will not be upgraded" if args.empty?
         oh1 "Upgrading #{Formatter.pluralize(outdated_casks.length, "outdated package")}, with result:"
         puts outdated_casks.map { |f| "#{f.full_name} #{f.version}" } * ", "
 

--- a/Library/Homebrew/test/cask/cli/info_spec.rb
+++ b/Library/Homebrew/test/cask/cli/info_spec.rb
@@ -20,6 +20,21 @@ describe Hbc::CLI::Info, :cask do
     EOS
   end
 
+  it "it prints auto_updates if the Cask has `auto_updates true`" do
+    expect {
+      described_class.run("with-auto-updates")
+    }.to output(<<~EOS).to_stdout
+      with-auto-updates: 1.0 (auto_updates)
+      http://example.com/autoupdates
+      Not installed
+      From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-auto-updates.rb
+      ==> Name
+      AutoUpdates
+      ==> Artifacts
+      AutoUpdates.app (App)
+    EOS
+  end
+
   describe "given multiple Casks" do
     let(:expected_output) {
       <<~EOS

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-auto-updates.rb
@@ -1,0 +1,12 @@
+cask 'with-auto-updates' do
+  version '1.0'
+  sha256 'e5be907a51cd0d5b128532284afe1c913608c584936a5e55d94c75a9f48c4322'
+
+  url "https://example.com/autoupdates_#{version}.zip"
+  name 'AutoUpdates'
+  homepage 'http://example.com/autoupdates'
+
+  auto_updates true
+
+  app 'AutoUpdates.app'
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Currently the cask file has to be inspected to see if it sets `auto_updates true`.

Also add a message to `upgrade` about casks that are `:latest` or `auto_updates`