### PR TITLE
brew audit: avoid error on head-only formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -584,6 +584,7 @@ module Homebrew
       ]
 
       throttled.each_slice(2).to_a.map do |a, b|
+        next if formula.stable.nil?
         version = formula.stable.version.to_s.split(".").last.to_i
         if @strict && a.include?(formula.name) && version.modulo(b.to_i).nonzero?
           problem "should only be updated every #{b} releases on multiples of #{b}"


### PR DESCRIPTION
- [ X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No. This really seems too trivial to write a test for.*
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Right now, running `brew audit` on a head-only formula will throw an exception. This PR fixes it to complete the audit (reporting an audit violation).

Fixes #4345.

(I'm of the opinion that maybe the head-only complaint should not be raised outside Homebrew core taps, since custom taps have more of a use case for head-only formulae (e.g. during initial program development), and it doesn't seem to make sense to require them to name their taps "-head-only". But that can be a separate PR.)