### PR TITLE
env: move HOME away from buildpath/testpath

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2040,6 +2040,10 @@ class Formula
         stage_env[:CURL_HOME] = ENV["CURL_HOME"] || ENV["HOME"]
       end
 
+      if @env_home == HOMEBREW_TEMP.realpath/"brew_home"
+        raise "Refusing to create HOME at #{@env_home}; aborting"
+      end
+
       setup_home @env_home
 
       ENV.clear_sensitive_environment!

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -32,9 +32,6 @@ module Language
 
     def self.std_npm_install_args(libexec)
       setup_npm_environment
-      # tell npm to not install .brew_home by adding it to the .npmignore file
-      # (or creating a new one if no .npmignore file already exists)
-      open(".npmignore", "a") { |f| f.write("\n.brew_home\n") }
 
       pack = pack_for_installation
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -164,7 +164,7 @@ def interactive_shell(f = nil)
     ENV["HOMEBREW_DEBUG_INSTALL"] = f.full_name
   end
 
-  if ENV["SHELL"].include?("zsh") && ENV["HOME"].start_with?(HOMEBREW_TEMP.resolved_path.to_s)
+  if ENV["SHELL"].include?("zsh") && ENV["HOME"].include?("brew_home")
     FileUtils.mkdir_p ENV["HOME"]
     FileUtils.touch "#{ENV["HOME"]}/.zshrc"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Think I've been talking about this with @ilovezfs for _years_, so here's an actual PR. Likely obvious but even if you really really love it as-is it'll need matching `homebrew/core` PRs before this can be rolled in.

Keeping `HOME` inside the buildpath/testpath has led to a series of required silliness in core such as:
* https://github.com/Homebrew/homebrew-core/blob/2e34a6cdb183c0a43f79b777c0a46eca3111ce5e/Formula/docker-credential-helper.rb#L21
* https://github.com/Homebrew/homebrew-core/blob/5b3e828f26db0b73a534d401c71f0f0fd54db2c3/Formula/git-annex.rb#L72-L73
* https://github.com/Homebrew/homebrew-core/blob/4f66111d393034cbed4c50d5fed47e51422d179e/Formula/openshift-cli.rb#L23-L24

For the sake of a fun little piece of history, ref: https://github.com/Homebrew/brew/commit/ac523bac06.