### PR TITLE
Fix SVN downloads of versioned formula by munging directory names

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -665,6 +665,10 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     @url = @url.sub("svn+http://", "")
   end
 
+  def cache_filename
+    Resource.safe_download_name("#{name}--#{cache_tag}")
+  end
+
   def fetch
     clear_cache unless @url.chomp("/") == repo_url || quiet_system("svn", "switch", @url, cached_location)
     super

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -66,8 +66,18 @@ class Resource
     name.tr("/", "-")
   end
 
+  def self.safe_download_name(str)
+    # "@" is a special character for Subversion. Keep it out of the cache dir name.
+    str.gsub("@", "-AT-")
+  end
+
   def download_name
-    name.nil? ? owner.name : "#{owner.name}--#{escaped_name}"
+    raw_name = if name
+      "#{owner.name}--#{escaped_name}"
+    else
+      owner.name
+    end
+    Resource.safe_download_name(raw_name)
   end
 
   def cached_download


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The SubversionDownloadStrategy is broken for versioned formulae, because it includes an "@" in the resulting directory names, and "@" is a special character to Subversion. This PR fixes it by munging the cache and staging directory names to use "\_AT\_" instead of "@", avoiding the special character.

There's currently no test for the SubversionDownloadStrategy, and it doesn't look like download strategies are tested in the context of a `stage` operation. Suggestions welcome as to how to do a decent test on this.

###  Details

To reproduce, create a versioned formula that uses an SVN download as its main download, for example, `netpbm`. Do a `brew install -s` on it, and it'll error during the fetch step.

```
$ brew install -s octave-app/octave-app/netpbm@10.73.19                                                                                                                                                      master
==> Installing netpbm@10.73.19 from octave-app/octave-app
==> Cloning svn://svn.code.sf.net/p/netpbm/code/stable
Updating /Users/janke/Library/Caches/Homebrew/netpbm@10.73.19--svn
==> Checking out 3244
svn: E200009: '/Users/janke/Library/Caches/Homebrew/netpbm@10.73.19--svn': a peg revision is not allowed here
Error: Failed to download resource "netpbm@10.73.19"
Failure while executing: svn up -q /Users/janke/Library/Caches/Homebrew/netpbm@10.73.19--svn -r 3244
```

###  References

* https://github.com/silverstripe/silverstripe-framework/issues/4643
* https://jira.apache.org/jira/browse/SCM-859