### PR TITLE
Add --display-times option to `install`, `upgrade`, and `reinstall`

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -1,4 +1,4 @@
-#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] <formula> [<options> ...]:
+#:  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`<compiler>] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] [`--display-times`] <formula> [<options> ...]:
 #:    Install <formula>.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
@@ -58,6 +58,9 @@
 #:    installed keg-only or non-migrated versions
 #:
 #:    If `--verbose` (or `-v`) is passed, print the verification and postinstall steps.
+#:
+#:    If `--display-times` is passed, install times for each formula are printed
+#:    at the end of the run.
 #:
 #:    Installation options specific to <formula> may be appended to the command,
 #:    and can be listed with `brew options` <formula>.

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -1,5 +1,8 @@
-#:  * `reinstall` <formula>:
+#:  * `reinstall` [`--display-times`] <formula>:
 #:    Uninstall and then install <formula> (with existing install options).
+#:
+#:    If `--display-times` is passed, install times for each formula are printed
+#:    at the end of the run.
 
 require "formula_installer"
 require "development_tools"

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -1,4 +1,4 @@
-#:  * `upgrade` [<install-options>] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [<formulae>]:
+#:  * `upgrade` [<install-options>] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`--display-times`] [<formulae>]:
 #:    Upgrade outdated, unpinned brews (with existing install options).
 #:
 #:    Options for the `install` command are also valid here.
@@ -13,6 +13,9 @@
 #:
 #:    If `--ignore-pinned` is passed, set a 0 exit code even if pinned formulae
 #:    are not upgraded.
+#:
+#:    If `--display-times` is passed, install times for each formula are printed
+#:    at the end of the run.
 #:
 #:    If <formulae> are given, upgrade only the specified brews (unless they
 #:    are pinned; see `pin`, `unpin`).

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -18,6 +18,7 @@ module HomebrewArgvExtension
       --include-test
       --verbose
       --force
+      --display-times
       -i
       -v
       -d

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -221,6 +221,7 @@ class FormulaInstaller
   end
 
   def install
+    start_time = Time.now
     if !formula.bottle_unneeded? && !pour_bottle? && DevelopmentTools.installed?
       Homebrew::Install.check_development_tools
     end
@@ -349,7 +350,8 @@ class FormulaInstaller
     build_bottle_postinstall if build_bottle?
 
     opoo "Nothing was installed to #{formula.prefix}" unless formula.installed?
-    Homebrew.messages.formula_installed(formula)
+    end_time = Time.now
+    Homebrew.messages.formula_installed(formula, end_time - start_time)
   end
 
   def check_conflicts

--- a/Library/Homebrew/messages.rb
+++ b/Library/Homebrew/messages.rb
@@ -1,23 +1,26 @@
 # A Messages object collects messages that may need to be displayed together
 # at the end of a multi-step `brew` command run
 class Messages
-  attr_reader :caveats, :formula_count
+  attr_reader :caveats, :formula_count, :install_times
 
   def initialize
     @caveats = []
     @formula_count = 0
+    @install_times = []
   end
 
   def record_caveats(f, caveats)
     @caveats.push(formula: f.name, caveats: caveats)
   end
 
-  def formula_installed(_f)
+  def formula_installed(f, elapsed_time)
     @formula_count += 1
+    @install_times.push(formula: f.name, time: elapsed_time)
   end
 
   def display_messages
     display_caveats
+    display_install_times if ARGV.include?("--display-times")
   end
 
   def display_caveats
@@ -26,6 +29,14 @@ class Messages
     oh1 "Caveats"
     @caveats.each do |c|
       ohai c[:formula], c[:caveats]
+    end
+  end
+
+  def display_install_times
+    return if install_times.empty?
+    oh1 "Installation times"
+    install_times.each do |t|
+      puts format("%-20s %10.3f s", t[:formula], t[:time])
     end
   end
 end

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -13,11 +13,11 @@ describe Messages do
     f_baz = formula("baz") do
       url "http://example.com/baz-0.1.tgz"
     end
-    @m.formula_installed(f_foo)
+    @m.formula_installed(f_foo, 1.1)
     @m.record_caveats(f_foo, "Zsh completions were installed")
-    @m.formula_installed(f_bar)
+    @m.formula_installed(f_bar, 2.2)
     @m.record_caveats(f_bar, "Keg-only formula")
-    @m.formula_installed(f_baz)
+    @m.formula_installed(f_baz, 3.3)
     @m.record_caveats(f_baz, "A valid GOPATH is required to use the go command")
   end
 
@@ -32,5 +32,19 @@ describe Messages do
   it "maintained the order of recorded caveats" do
     caveats_formula_order = @m.caveats.map { |x| x[:formula] }
     expect(caveats_formula_order).to eq(["foo", "bar", "baz"])
+  end
+
+  it "has recorded installation times" do
+    expect(@m.install_times).to_not be_empty
+  end
+
+  it "maintained the order of install times" do
+    formula_order = @m.install_times.map { |x| x[:formula] }
+    expect(formula_order).to eq(["foo", "bar", "baz"])
+  end
+
+  it "recorded the right install times" do
+    times = @m.install_times.map { |x| x[:time] }
+    expect(times).to eq([1.1, 2.2, 3.3])
   end
 end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -221,6 +221,7 @@ _brew_install() {
           --interactive
           --only-dependencies
           --verbose
+          --display-times
           $(brew options --compact "$prv" 2>/dev/null)
           "
       fi
@@ -481,6 +482,7 @@ _brew_unpack() {
   esac
   __brew_complete_formulae
 }
+
 _brew_update() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
@@ -504,6 +506,7 @@ _brew_upgrade() {
         --debug
         --verbose
         --fetch-HEAD
+        --display-times
         "
       return
       ;;

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -419,6 +419,7 @@ _brew_install() {
       '(--build-from-source -s)'{--build-from-source,-s}'[compile the specified formula from source even if a bottle is provided]' \
       '(--devel --HEAD)'{--devel,--HEAD}'[install the development / HEAD version]' \
       '--keep-tmp[don''t delete temporary files created during installation]' \
+      '--display-times[display installation times at end of run]' \
       '*: : __brew_formulae' \
     - interactive-install \
       '--interactive[download and patch formula, then open a shell]' \
@@ -554,6 +555,7 @@ _brew_readall() {
 # brew reinstall formulae:
 _brew_reinstall() {
   _arguments \
+    '--display-times[display installation times at end of run]' \
     '*::formula:__brew_installed_formulae'
 }
 
@@ -752,6 +754,7 @@ _brew_upgrade() {
     '(--build-from-source -s)'{--build-from-source,-s}'[compile the specified formula from source even if a bottle is provided]' \
     '(--devel --HEAD)'{--devel,--HEAD}'[install the development / HEAD version]' \
     '--keep-tmp[don''t delete temporary files created during installation]' \
+    '--display-times[display installation times at end of run]' \
     '*: : __brew_outdated_formulae' \
   - interactive-install \
     '--interactive[download and patch formula, then open a shell]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -216,7 +216,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     See the docs for examples of using the JSON output:
     <https://docs.brew.sh/Querying-Brew>
 
-  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] `formula` [`options` ...]:
+  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] [`--display-times`] `formula` [`options` ...]:
     Install `formula`.
 
     `formula` is usually the name of the formula to install, but it can be specified
@@ -276,6 +276,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     installed keg-only or non-migrated versions
 
     If `--verbose` (or `-v`) is passed, print the verification and postinstall steps.
+
+    If `--display-times` is passed, install times for each formula are printed
+    at the end of the run.
 
     Installation options specific to `formula` may be appended to the command,
     and can be listed with `brew options` `formula`.
@@ -400,8 +403,11 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--syntax` is passed, also syntax-check all of Homebrew's Ruby files.
 
-  * `reinstall` `formula`:
+  * `reinstall` [`--display-times`] `formula`:
     Uninstall and then install `formula` (with existing install options).
+
+    If `--display-times` is passed, install times for each formula are printed
+    at the end of the run.
 
   * `search`, `-S`:
     Display all locally available formulae (including tapped ones).
@@ -563,7 +569,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     their latest `origin/master`. Note this will destroy all your uncommitted
     or committed changes.
 
-  * `upgrade` [`install-options`] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`formulae`]:
+  * `upgrade` [`install-options`] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`--display-times`] [`formulae`]:
     Upgrade outdated, unpinned brews (with existing install options).
 
     Options for the `install` command are also valid here.
@@ -578,6 +584,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--ignore-pinned` is passed, set a 0 exit code even if pinned formulae
     are not upgraded.
+
+    If `--display-times` is passed, install times for each formula are printed
+    at the end of the run.
 
     If `formulae` are given, upgrade only the specified brews (unless they
     are pinned; see `pin`, `unpin`).

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -206,7 +206,7 @@ Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to
 See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
 .IP "\(bu" 4
-\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-include\-test\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] [\fB\-\-force\fR] [\fB\-\-verbose\fR] \fIformula\fR [\fIoptions\fR \.\.\.]: Install \fIformula\fR\.
+\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-include\-test\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] [\fB\-\-force\fR] [\fB\-\-verbose\fR] [\fB\-\-display\-times\fR] \fIformula\fR [\fIoptions\fR \.\.\.]: Install \fIformula\fR\.
 .
 .IP
 \fIformula\fR is usually the name of the formula to install, but it can be specified in several different ways\. See \fISPECIFYING FORMULAE\fR\.
@@ -258,6 +258,9 @@ If \fB\-\-force\fR (or \fB\-f\fR) is passed, install without checking for previo
 .
 .IP
 If \fB\-\-verbose\fR (or \fB\-v\fR) is passed, print the verification and postinstall steps\.
+.
+.IP
+If \fB\-\-display\-times\fR is passed, install times for each formula are printed at the end of the run\.
 .
 .IP
 Installation options specific to \fIformula\fR may be appended to the command, and can be listed with \fBbrew options\fR \fIformula\fR\.
@@ -371,7 +374,10 @@ If \fB\-\-aliases\fR is passed, also verify any alias symlinks in each tap\.
 If \fB\-\-syntax\fR is passed, also syntax\-check all of Homebrew\'s Ruby files\.
 .
 .IP "\(bu" 4
-\fBreinstall\fR \fIformula\fR: Uninstall and then install \fIformula\fR (with existing install options)\.
+\fBreinstall\fR [\fB\-\-display\-times\fR] \fIformula\fR: Uninstall and then install \fIformula\fR (with existing install options)\.
+.
+.IP
+If \fB\-\-display\-times\fR is passed, install times for each formula are printed at the end of the run\.
 .
 .IP "\(bu" 4
 \fBsearch\fR, \fB\-S\fR: Display all locally available formulae (including tapped ones)\. No online search is performed\.
@@ -512,7 +518,7 @@ If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full upd
 \fBupdate\-reset\fR: Fetches and resets Homebrew and all tap repositories using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
 .IP "\(bu" 4
-\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fIformulae\fR]: Upgrade outdated, unpinned brews (with existing install options)\.
+\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fB\-\-display\-times\fR] [\fIformulae\fR]: Upgrade outdated, unpinned brews (with existing install options)\.
 .
 .IP
 Options for the \fBinstall\fR command are also valid here\.
@@ -525,6 +531,9 @@ If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if t
 .
 .IP
 If \fB\-\-ignore\-pinned\fR is passed, set a 0 exit code even if pinned formulae are not upgraded\.
+.
+.IP
+If \fB\-\-display\-times\fR is passed, install times for each formula are printed at the end of the run\.
 .
 .IP
 If \fIformulae\fR are given, upgrade only the specified brews (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Would you consider a `--display-build-times` option for `brew install` and `brew upgrade`? This could be helpful to developers who are wrangling big installation trees.

I'm working on a big build with lots of dependencies (like 40 minutes total), and I'd like to see which of the dependencies are taking a lot of compilation time, so I know where to spend my efforts at making relocatable bottles, removing dependencies, or something else. I don't see a good way to do this with a custom `brew` command, since there aren't public API hooks into the installation process.

Adds output like this:

```
$ brew install --display-build-times -s arpack cowsay libpng                                                   display-build-times
==> Downloading https://github.com/opencollab/arpack-ng/archive/3.6.0.tar.gz
...
==> make test
==> make install
🍺  /usr/local/Cellar/libpng/1.6.34: 26 files, 1.2MB, built in 33 seconds
==> Build times
arpack               28.326 s
cowsay               3.063 s
libpng               33.318 s
```