### PR TITLE
zsh completion: Remove redundant exclusion lists for single options

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -439,17 +439,17 @@ _brew_leaves() {
 # brew ln, link [--overwrite] [--dry-run] [--force] formulae
 _brew_link() {
   _arguments \
-    '(--overwrite)--overwrite[delete files which already exist in the prefix]' \
+    '--overwrite[delete files which already exist in the prefix]' \
     '(--dry-run -n)'{--dry-run,-n}'[list files that would be linked or deleted]' \
-    '(--force)--force[allow keg-only formulae to be linked]' \
+    '--force[allow keg-only formulae to be linked]' \
     '*:formula:__brew_installed_formulae'
 }
 
 # brew linkage [--test] [--reverse] formulae
 _brew_linkage() {
   _arguments \
-    '(--test)--test[only display missing libraries]' \
-    '(--reverse)--reverse[print the dylib followed by the binaries which link to it]' \
+    '--test[only display missing libraries]' \
+    '--reverse[print the dylib followed by the binaries which link to it]' \
     '*:formula:__brew_installed_formulae'
 }
 
@@ -459,11 +459,11 @@ _brew_linkage() {
 _brew_list() {
   local state
   _arguments \
-    '(--full-name)--full-name[print formulae with fully-qualified names]' \
-    '(--unbrewed)--unbrewed[files in brew --prefix not controlled by brew]' \
-    '(--pinned)--pinned[list all versions of pinned formulae]' \
-    '(--versions)--versions[list all installed versions of a formula]' \
-    '(--multiple)--multiple[only show formulae with multiple versions installed]' \
+    '--full-name[print formulae with fully-qualified names]' \
+    '--unbrewed[files in brew --prefix not controlled by brew]' \
+    '--pinned[list all versions of pinned formulae]' \
+    '--versions[list all installed versions of a formula]' \
+    '--multiple[only show formulae with multiple versions installed]' \
     '*:: :__brew_installed_formulae'
 }
 
@@ -480,7 +480,7 @@ _brew_man() {
 # brew migrate [--force] formulae:
 _brew_migrate() {
   _arguments \
-    '(--force)--force[treat installed formulae and passed formulae ike if they are from same taps and migrate them anyway]' \
+    '--force[treat installed formulae and passed formulae ike if they are from same taps and migrate them anyway]' \
     '*: :__brew_formulae'
 }
 
@@ -488,7 +488,7 @@ _brew_migrate() {
 # TODO missing argument docs
 _brew_mirror() {
   _arguments \
-    '(--test)--test' \
+    '--test' \
     '*: :__brew_formulae'
 }
 
@@ -500,7 +500,7 @@ _brew_missing() {
 # brew options [--compact] (--all|--installed|formulae):
 _brew_options() {
   _arguments \
-    '(--compact)--compact' \
+    '--compact' \
     '(--all --installed :)'{--all,--installed}'[show options for all / installed formula]' \
     '(--all --installed): :__brew_formulae'
 }
@@ -511,7 +511,7 @@ _brew_outdated() {
     '(--quiet --verbose --json)--quiet[list only the names of outdated brews]' \
     '(--quiet --verbose --json)--verbose[display detailed version information]' \
     '(--quiet --verbose --json)--json=-[output in JSON format]:version:(v1)' \
-    '(--fetch-HEAD)--fetch-HEAD[detect if the HEAD installation of the formula is outdated]'
+    '--fetch-HEAD[detect if the HEAD installation of the formula is outdated]'
 }
 
 # brew pin formulae:
@@ -535,14 +535,14 @@ _brew_prune() {
 #   [--branch-okay] [--no-pbcopy] [--no-publish] patch-source [patch-source]
 _brew_pull() {
   _arguments \
-    '(--bottle)--bottle[handle bottles]' \
-    '(--bump)--bump[automatically reword commit message]' \
-    '(--clean)--clean[do not rewrite commits found in the pulled PR]' \
-    '(--ignore-whitespace)--ignore-whitespace[ignore whitespace discrepancies when applying diffs]' \
-    '(--resolve)--resolve[allow user to resolve patches that fail to apply]' \
-    '(--branch-okay)--branch-okay[do not warn on pulling branches other than master]' \
-    '(--no-pbcopy)--no-pbcopy[do not copy anything to the system]' \
-    '(--no-publish)--no-publish[do no publish bottles to Bintray]' \
+    '--bottle[handle bottles]' \
+    '--bump[automatically reword commit message]' \
+    '--clean[do not rewrite commits found in the pulled PR]' \
+    '--ignore-whitespace[ignore whitespace discrepancies when applying diffs]' \
+    '--resolve[allow user to resolve patches that fail to apply]' \
+    '--branch-okay[do not warn on pulling branches other than master]' \
+    '--no-pbcopy[do not copy anything to the system]' \
+    '--no-publish[do no publish bottles to Bintray]' \
     '*:patch source: '
 }
 
@@ -562,7 +562,7 @@ _brew_reinstall() {
 # brew search (--debian|--fedora|--fink|--macports|--opensuse|--ubuntu) text:
 _brew_search() {
   _arguments \
-    '(--desc)--desc[include description for each package]:text: ' \
+    '(--debian --fedora --fink --macports --opensuse --ubuntu)--desc[include description for each package]:text: ' \
     '(--desc --debian --fedora --fink --macports --opensuse --ubuntu)'{--debian,--fedora,--fink,--macports,--opensuse,--ubuntu}'[search for text in given package manager''s list]'
 }
 
@@ -570,14 +570,14 @@ _brew_search() {
 # TODO missing argument docs
 _brew_sh() {
   _arguments \
-    '(--env)--env=-:environment:(std)'
+    '--env=-:environment:(std)'
 }
 
 # brew style [--fix] [--display-cop-names] [formulae|files]:
 _brew_style() {
   _arguments \
-    '(--fix)--fix[fix style violations automatically]' \
-    '(--display-cop-names)--display-cop-names[include RuboCop name for each violation in output]' \
+    '--fix[fix style violations automatically]' \
+    '--display-cop-names[include RuboCop name for each violation in output]' \
     '*::formula:__brew_formulae_or_ruby_files'
 }
 
@@ -601,12 +601,12 @@ _brew_tap() {
   _arguments \
     - empty-args \
     - repo-args \
-      '(--full)--full[perform a full clone]' \
+      '--full[perform a full clone]' \
       '::url:_urls' \
     - repair-args \
-      '(--repair)--repair' \
+      '--repair' \
     - list-pinned \
-      '(--list-pinned)--list-pinned[list all pinned taps]'
+      '--list-pinned[list all pinned taps]'
 }
 
 # brew tap-info:
@@ -615,7 +615,7 @@ _brew_tap() {
 _brew_tap_info() {
   _arguments \
     '(--installed *)--installed[display information on all installed taps]' \
-    '(--json)--json=-[print a JSON representation of taps]:version:(v1)' \
+    '--json=-[print a JSON representation of taps]:version:(v1)' \
     '(--installed)*:taps:__brew_installed_taps'
 }
 
@@ -641,8 +641,8 @@ _brew_tap_unpin() {
 _brew_test() {
   _arguments \
     '(--devel --HEAD)'{--devel,--HEAD}'[use the development / head version of the formula]' \
-    '(--debug)--debug[launch an interactive debugger if test fails]' \
-    '(--keep-tmp)--keep-tmp[don''t delete temporary files]' \
+    '--debug[launch an interactive debugger if test fails]' \
+    '--keep-tmp[don''t delete temporary files]' \
     '*:formula:__brew_formulae'
 }
 
@@ -678,20 +678,20 @@ _brew_test_bot() {
 #   [--only=test_script:test_method] [--seed seed] [--trace] [--online]:
 _brew_tests() {
   _arguments \
-  '(-v)-v' \
-  '(--coverage)--coverage' \
-  '(--generic)--generic' \
-  '(--no-compat)--no-compat' \
-  '(--only)--only=-:test_method: ' \
-  '(--seed)--seed:seed: ' \
-  '(--trace)--trace' \
-  '(--online)--online'
+  '-v' \
+  '--coverage' \
+  '--generic' \
+  '--no-compat' \
+  '--only=-:test_method: ' \
+  '--seed:seed: ' \
+  '--trace' \
+  '--online'
 }
 
 # brew uninstall, rm, remove [--force] formulae:
 _brew_uninstall() {
   _arguments \
-    '(--force)--force[delete all installed versions of formula]' \
+    '--force[delete all installed versions of formula]' \
     '*:formula:__brew_installed_formulae'
 }
 
@@ -707,7 +707,7 @@ _brew_unpack() {
   _arguments \
     '(--git --patch)--git[initialize a Git repository in the unpacked source]' \
     '(--git --patch)--patch[apply patches for formula]' \
-    '(--destdir)--destdir=-[create subdirectories under path]:path:_directories' \
+    '--destdir=-[create subdirectories under path]:path:_directories' \
     '*:formula:__brew_formulae'
 }
 
@@ -720,8 +720,8 @@ _brew_unpin() {
 # brew update [--merge] [--force]:
 _brew_update() {
   _arguments \
-    '(--merge)--merge[use git merge instead of git rebase]' \
-    '(--force)--force[do a slower full update check]'
+    '--merge[use git merge instead of git rebase]' \
+    '--force[do a slower full update check]'
 }
 
 # brew update_report:
@@ -734,15 +734,15 @@ _brew_update_test() {
   _arguments \
     '(--commit=sha1)--commit=-[use sha1 as the start commit]:sha1: ' \
     '(--before=date)--before=-[use the commit at date as the start commit]:date:_dates' \
-    '(--keep-tmp)--keep-tmp[retain the temporary directory]'
+    '--keep-tmp[retain the temporary directory]'
 }
 
 # brew upgrade [install-options] [--cleanup] [--fetch-HEAD] [formulae]
 # install-options is copied from brew install
 _brew_upgrade() {
   _arguments \
-  '(--cleanup)--cleanup[remove previously installed formula version(s)]' \
-  '(--fetch-HEAD)--fetch-HEAD[detect if the HEAD installation of the formula is outdated]' \
+  '--cleanup[remove previously installed formula version(s)]' \
+  '--fetch-HEAD[detect if the HEAD installation of the formula is outdated]' \
   - normal-install \
     '--debug[if brewing fails, open an interactive debugging session]' \
     -'-env=-[use standard or super environment]:environment:(std super)' \
@@ -764,11 +764,11 @@ _brew_upgrade() {
 #   [--skip-recommended] [--devel|--HEAD] formulae:
 _brew_uses() {
   _arguments \
-    '(--installed)--installed[only list installed formulae]' \
-    '(--recursive)--recursive[resolve more than one level of dependencies]' \
-    '(--include-build)--include-build[include the :build type dependencies]' \
-    '(--include-optional)--include-optional[include the :optional dependencies]' \
-    '(--skip-recommended)--skip-recommended[skip :recommended type dependencies]' \
+    '--installed[only list installed formulae]' \
+    '--recursive[resolve more than one level of dependencies]' \
+    '--include-build[include the :build type dependencies]' \
+    '--include-optional[include the :optional dependencies]' \
+    '--skip-recommended[skip :recommended type dependencies]' \
     '(--devel --HEAD)'{--devel,--HEAD}'[find cases where formula is used by development / HEAD build]' \
     '*:formula:__brew_formulae'
 }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No; shell completion is not tested.*
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

These exclusion lists where the optspec contains a single argument and the list contains just that argument are redundant. By default, `zsh`'s completion will not offer to complete the same option more than once; you have to explicitly prefix the optspec with `*` if you want to indicate that it can be provided multiple times.

This PR removes the redundant exclusion lists, to make the code more readable. There is no actual behavior change in this PR; it's just a refactoring. _Except_ that it also fixes the exclusion list for `brew search --desc`; `--desc` cannot be used with any of the `--debian`, `--fink`, etc. arguments.

I have tested this change manually at the command line by trying the various subcommands.

See [Zsh Completion System](http://zsh.sourceforge.net/Doc/Release/Completion-System.html) for documentation; search on the page for "exclusion" and "repeat".