### PR TITLE
Display collected caveats at end of `install` or `upgrade`

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -249,6 +249,7 @@ module Homebrew
         Migrator.migrate_if_needed(f)
         install_formula(f)
       end
+      Homebrew.messages.display_messages
     rescue FormulaUnreadableError, FormulaClassUnavailableError,
            TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
       # Need to rescue before `FormulaUnavailableError` (superclass of this)

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -3,6 +3,7 @@
 
 require "formula_installer"
 require "development_tools"
+require "messages"
 
 module Homebrew
   module_function
@@ -18,6 +19,7 @@ module Homebrew
       Migrator.migrate_if_needed(f)
       reinstall_formula(f)
     end
+    Homebrew.messages.display_messages
   end
 
   def reinstall_formula(f)

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -21,6 +21,7 @@ require "install"
 require "formula_installer"
 require "cleanup"
 require "development_tools"
+require "messages"
 
 module Homebrew
   module_function
@@ -102,6 +103,7 @@ module Homebrew
         onoe "#{f}: #{e}"
       end
     end
+    Homebrew.messages.display_messages
   end
 
   def upgrade_formula(f)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -14,6 +14,7 @@ require "development_tools"
 require "cache_store"
 require "linkage_checker"
 require "install"
+require "messages"
 
 class FormulaInstaller
   include FormulaCellarChecks
@@ -348,6 +349,7 @@ class FormulaInstaller
     build_bottle_postinstall if build_bottle?
 
     opoo "Nothing was installed to #{formula.prefix}" unless formula.installed?
+    Homebrew.messages.formula_installed(formula)
   end
 
   def check_conflicts
@@ -604,6 +606,7 @@ class FormulaInstaller
     return if caveats.empty?
     @show_summary_heading = true
     ohai "Caveats", caveats.to_s
+    Homebrew.messages.record_caveats(formula, caveats)
   end
 
   def finish

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -1,6 +1,7 @@
 require "pathname"
 require "English"
 require "ostruct"
+require "messages"
 
 require "pp"
 require "extend/ARGV"
@@ -47,6 +48,10 @@ module Homebrew
 
     def args
       @args ||= OpenStruct.new
+    end
+
+    def messages
+      @messages ||= Messages.new
     end
 
     def raise_deprecation_exceptions?

--- a/Library/Homebrew/messages.rb
+++ b/Library/Homebrew/messages.rb
@@ -1,0 +1,31 @@
+# A Messages object collects messages that may need to be displayed together
+# at the end of a multi-step `brew` command run
+class Messages
+  attr_reader :caveats, :formula_count
+
+  def initialize
+    @caveats = []
+    @formula_count = 0
+  end
+
+  def record_caveats(f, caveats)
+    @caveats.push(formula: f.name, caveats: caveats)
+  end
+
+  def formula_installed(_f)
+    @formula_count += 1
+  end
+
+  def display_messages
+    display_caveats
+  end
+
+  def display_caveats
+    return if @formula_count <= 1
+    return if @caveats.empty?
+    oh1 "Caveats"
+    @caveats.each do |c|
+      ohai c[:formula], c[:caveats]
+    end
+  end
+end

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -1,0 +1,38 @@
+require "messages"
+require "spec_helper"
+
+describe Messages do
+
+  before do
+    @m = Messages.new
+    f_foo = formula("foo") do
+      url "http://example.com/foo-0.1.tgz"
+    end
+    f_bar = formula("bar") do
+      url "http://example.com/bar-0.1.tgz"
+    end
+    f_baz = formula("baz") do
+      url "http://example.com/baz-0.1.tgz"
+    end
+    @m.formula_installed(f_foo)
+    @m.record_caveats(f_foo, "Zsh completions were installed")
+    @m.formula_installed(f_bar)
+    @m.record_caveats(f_bar, "Keg-only formula")
+    @m.formula_installed(f_baz)
+    @m.record_caveats(f_baz, "A valid GOPATH is required to use the go command")
+  end
+
+  it "has the right installed-formula count" do
+    expect(@m.formula_count).to equal(3)
+  end
+
+  it "has recorded caveats" do
+    expect(@m.caveats).to_not be_empty
+  end
+
+  it "maintained the order of recorded caveats" do
+    caveats_formula_order = @m.caveats.map { |x| x[:formula] }
+    expect(caveats_formula_order).to eq(["foo", "bar", "baz"])
+  end
+
+end

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -2,7 +2,6 @@ require "messages"
 require "spec_helper"
 
 describe Messages do
-
   before do
     @m = Messages.new
     f_foo = formula("foo") do
@@ -34,5 +33,4 @@ describe Messages do
     caveats_formula_order = @m.caveats.map { |x| x[:formula] }
     expect(caveats_formula_order).to eq(["foo", "bar", "baz"])
   end
-
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #4057.

This PR collects all caveats encountered during an `install`, `upgrade`, or `reinstall`, and outputs them together at the end of the build.

It also keeps the per-formula caveats output with each individual formula, so when a user is scanning through a long build output, they notice the caveats for each formula, instead of having to skip down to the end to check if there were caveats for that build.

Uses a generic message-collection design, per @ilovezfs's suggestion at https://github.com/Homebrew/brew/pull/4359#issuecomment-398627182, so this could be combined with a build times output, or other output that combines messages from multiple formulae across a multi-step operation.

Example:

```
$ brew install vf vice
==> Downloading https://github.com/glejeune/vf/archive/0.0.1.tar.gz
Already downloaded: /Users/janke/Library/Caches/Homebrew/vf-0.0.1.tar.gz
==> Caveats
To complete installation, add the following line to your shell's rc file:
  source /usr/local/opt/vf/vf.sh
==> Summary
🍺  /usr/local/Cellar/vf/0.0.1: 6 files, 14.2KB, built in 2 seconds
==> Downloading https://homebrew.bintray.com/bottles/vice-3.1_1.high_sierra.bott
Already downloaded: /Users/janke/Library/Caches/Homebrew/vice-3.1_1.high_sierra.bottle.1.tar.gz
==> Pouring vice-3.1_1.high_sierra.bottle.1.tar.gz
==> Caveats
Apps for these emulators have been installed to /usr/local/opt/vice.
==> Summary
🍺  /usr/local/Cellar/vice/3.1_1: 1,493 files, 143.6MB
==> Caveats
==> vf
To complete installation, add the following line to your shell's rc file:
  source /usr/local/opt/vf/vf.sh
==> vice
Apps for these emulators have been installed to /usr/local/opt/vice.
```