### PR TITLE
mirror: invoke correct curl

### DIFF
--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -26,7 +26,7 @@ module Homebrew
       bintray_repo_url = "https://api.bintray.com/packages/homebrew/mirror"
       package_url = "#{bintray_repo_url}/#{bintray_package}"
 
-      unless system "curl", "--silent", "--fail", "--output", "/dev/null", package_url
+      unless curl "--silent", "--fail", "--output", "/dev/null", package_url
         package_blob = <<~EOS
           {"name": "#{bintray_package}",
            "public_download_numbers": true,


### PR DESCRIPTION
Remove remaining use of `system "curl"` in favor of the `curl` function.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Discoved due to
https://jfrog.com/knowledge-base/why-am-i-failing-to-work-with-jfrog-saas-service-with-tls-1-0-1-1/

which caused `brew mirror` to stop working on Mountain Lion in some cases.