### PR TITLE
mirror: use curl_executable instead of curl function

### DIFF
--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -26,7 +26,7 @@ module Homebrew
       bintray_repo_url = "https://api.bintray.com/packages/homebrew/mirror"
       package_url = "#{bintray_repo_url}/#{bintray_package}"
 
-      unless curl "--silent", "--fail", "--output", "/dev/null", package_url
+      unless system curl_executable, "--silent", "--fail", "--output", "/dev/null", package_url
         package_blob = <<~EOS
           {"name": "#{bintray_package}",
            "public_download_numbers": true,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

More testing shows that the `curl` function results in

```
$ brew mirror lzip
curl: (22) The requested URL returned error: 404 Not Found
Error: Failure while executing: /usr/local/opt/curl/bin/curl -q --show-error --user-agent Homebrew/1.6.9-25-g535f1fb\ (Macintosh;\ Intel\ Mac\ OS\ X\ 10.8.5)\ curl/7.60.0 --fail --progress-bar --silent --fail --output /dev/null https://api.bintray.com/packages/homebrew/mirror/lzip
```

in the case where the formula has never been mirrored to Bintray before.