### PR TITLE
Implement HOMEBREW_FORCE_BREWED_GIT

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -102,6 +102,7 @@ then
   if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "100900" ]]
   then
     HOMEBREW_SYSTEM_GIT_TOO_OLD="1"
+    HOMEBREW_FORCE_BREWED_GIT="1"
   fi
 
   if [[ -z "$HOMEBREW_CACHE" ]]
@@ -133,6 +134,15 @@ then
   HOMEBREW_CURL="$HOMEBREW_PREFIX/opt/curl/bin/curl"
 else
   HOMEBREW_CURL="curl"
+fi
+
+if [[ -n "$HOMEBREW_FORCE_BREWED_GIT" &&
+      -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]] &&
+         "$HOMEBREW_PREFIX/opt/git/bin/git" --version >/dev/null
+then
+  HOMEBREW_GIT="$HOMEBREW_PREFIX/opt/git/bin/git"
+else
+  HOMEBREW_GIT="git"
 fi
 
 HOMEBREW_USER_AGENT="$HOMEBREW_PRODUCT/$HOMEBREW_USER_AGENT_VERSION ($HOMEBREW_SYSTEM; $HOMEBREW_PROCESSOR $HOMEBREW_OS_USER_AGENT_VERSION)"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -384,7 +384,8 @@ EOS
   fi
 
   if ! git --version &>/dev/null ||
-       [[ -n "$HOMEBREW_SYSTEM_GIT_TOO_OLD" &&
+     [[ ( -n "$HOMEBREW_SYSTEM_GIT_TOO_OLD" ||
+          -n "$HOMEBREW_FORCE_BREWED_GIT" ) &&
         ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
     # we cannot install brewed git if homebrew/core is unavailable.

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -384,9 +384,8 @@ EOS
   fi
 
   if ! git --version &>/dev/null ||
-     [[ ( -n "$HOMEBREW_SYSTEM_GIT_TOO_OLD" ||
-          -n "$HOMEBREW_FORCE_BREWED_GIT" ) &&
-        ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
+     [[ -n "$HOMEBREW_FORCE_BREWED_GIT" &&
+      ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
     # we cannot install brewed git if homebrew/core is unavailable.
     [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -184,6 +184,10 @@ Note that environment variables must have a value set to be detected. For exampl
 
     Set this to force Homebrew to use a particular git binary.
 
+  * `HOMEBREW_FORCE_BREWED_GIT`:
+    If set, Homebrew will use a Homebrew-installed `git` rather than the
+    system version.
+
   * `HOMEBREW_GITHUB_API_TOKEN`:
     A personal access token for the GitHub API, which you can create at
     <https://github.com/settings/tokens>. If set, GitHub will allow you a

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1167,6 +1167,10 @@ Note that environment variables must have a value set to be detected. For exampl
 
     Set this to force Homebrew to use a particular git binary.
 
+  * `HOMEBREW_FORCE_BREWED_GIT`:
+    If set, Homebrew will use a Homebrew-installed `git` rather than the
+    system version.
+
   * `HOMEBREW_GITHUB_API_TOKEN`:
     A personal access token for the GitHub API, which you can create at
     <https://github.com/settings/tokens>. If set, GitHub will allow you a

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1187,6 +1187,10 @@ When using Git, Homebrew will use \fBGIT\fR if set, a Homebrew\-built Git if ins
 Set this to force Homebrew to use a particular git binary\.
 .
 .TP
+\fBHOMEBREW_FORCE_BREWED_GIT\fR
+If set, Homebrew will use a Homebrew\-installed \fBgit\fR rather than the system version\.
+.
+.TP
 \fBHOMEBREW_GITHUB_API_TOKEN\fR
 A personal access token for the GitHub API, which you can create at \fIhttps://github\.com/settings/tokens\fR\. If set, GitHub will allow you a greater number of API requests\. See \fIhttps://developer\.github\.com/v3/#rate\-limiting\fR for more information\. Homebrew uses the GitHub API for features such as \fBbrew search\fR\.
 .


### PR DESCRIPTION
Because of [this messing with the user's path](https://github.com/Homebrew/brew/blob/efc02899c851c62c9ce0d15dea9a231575d7d774/bin/brew#L68), brew uses `/usr/bin/git` over brewed git, even when the former is problematically old.
There may also be other reasons a user prefers to use brewed git.

There was already a `HOMEBREW_FORCE_BREWED_CURL` option and a `HOMEBREW_SYSTEM_CURL_TOO_OLD` check to set it. This mostly copies those to implement `HOMEBREW_FORCE_BREWED_GIT` & `HOMEBREW_SYSTEM_GIT_TOO_OLD`.

See also: https://github.com/Linuxbrew/brew/issues/736

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
