### PR TITLE
curl: enable session cookies

### DIFF
--- a/Library/Homebrew/test/cask/download_strategy_spec.rb
+++ b/Library/Homebrew/test/cask/download_strategy_spec.rb
@@ -30,6 +30,7 @@ describe "download strategies", :cask do
         "--remote-time",
         "--continue-at", "-",
         "--output", kind_of(Pathname),
+        "--cookie-jar", "/dev/null",
         cask.url.to_s,
         user_agent: :default
       )

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -47,7 +47,7 @@ end
 
 def curl_download(*args, to: nil, continue_at: "-", **options)
   had_incomplete_download ||= File.exist?(to)
-  curl("--location", "--remote-time", "--continue-at", continue_at.to_s, "--output", to, *args, **options)
+  curl("--location", "--remote-time", "--continue-at", continue_at.to_s, "--output", to, "--cookie-jar", "/dev/null", *args, **options)
 rescue ErrorDuringExecution
   # `curl` error 33: HTTP server doesn't seem to support byte ranges. Cannot resume.
   # HTTP status 416: Requested range not satisfiable


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
       Not sure just fixing parameters in the test is enough or not.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

For some URLs like the dmg URL in https://gitlab.com/yan12125/homebrew-staging/blob/master/Casks/pulse-secure.rb, cookies from `Set-Cookie` of the first request should be passed down to the following requests, or the file can't be correctly downloaded. For example:
```
$ brew -v cask install pulse-secure
==> Satisfying dependencies
==> Downloading https://wiki.univ-nantes.fr/_media/nomade:pulse_clients:ps-pulse-mac-9.0r1.0-b571-installer.dmg
/usr/bin/curl -q --show-error --user-agent Homebrew/1.6.9-33-g0d33aba (Macintosh; Intel Mac OS X 10.13.5) curl/7.54.0 --fail --location --remote-time --continue-at - --output /Users/yen/Library/Caches/Homebrew/Cask/pulse-secure--9.0r1.0-b571.dmg.incomplete https://wiki.univ-nantes.fr/_media/nomade:pulse_clients:ps-pulse-mac-9.0r1.0-b571-installer.dmg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   571    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
  0   571    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:11 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:13 --:--:--     0^C
```
Adding two parameters to `curl` does the trick:
```
$ brew -v cask install pulse-secure
Updating Homebrew...
==> Satisfying dependencies
==> Downloading https://wiki.univ-nantes.fr/_media/nomade:pulse_clients:ps-pulse-mac-9.0r1.0-b571-installer.dmg
/usr/bin/curl -q --show-error --user-agent Homebrew/1.6.9-34-gd47f485 (Macintosh; Intel Mac OS X 10.13.5) curl/7.54.0 --fail --location --remote-time --continue-at - --cookie-jar /dev/null --output /Users/yen/Library/Caches/Homebrew/Cask/pulse-secure--9.0r1.0-b571.dmg.incomplete https://wiki.univ-nantes.fr/_media/nomade:pulse_clients:ps-pulse-mac-9.0r1.0-b571-installer.dmg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   571    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
100 15.6M  100 15.6M    0     0   219k      0  0:01:13  0:01:13 --:--:--  418k
==> Verifying checksum for Cask pulse-secure
```