### PR TITLE
Add make shim to Linux super env

### DIFF
--- a/Library/Homebrew/shims/linux/super/make
+++ b/Library/Homebrew/shims/linux/super/make
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [[ -n "$HOMEBREW_MAKE" && "$HOMEBREW_MAKE" != "make" ]]
+then
+  export MAKE="$HOMEBREW_MAKE"
+else
+  MAKE="make"
+fi
+export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
+exec "$MAKE" "$@"

--- a/Library/Homebrew/shims/linux/super/make
+++ b/Library/Homebrew/shims/linux/super/make
@@ -7,4 +7,20 @@ else
   MAKE="make"
 fi
 export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
+
+pathremove () {
+        local IFS=':'
+        local NEWPATH
+        local DIR
+        local PATHVARIABLE=${2:-PATH}
+        for DIR in ${!PATHVARIABLE} ; do
+                if [ "$DIR" != "$1" ] ; then
+                  NEWPATH=${NEWPATH:+$NEWPATH:}$DIR
+                fi
+        done
+        export $PATHVARIABLE="$NEWPATH"
+}
+
+pathremove "$HOMEBREW_LIBRARY/Homebrew/shims/linux/super"
+
 exec "$MAKE" "$@"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Add a `shim` for `make` that has been missing from the super env on Linux. 

CC @sjackman and @iMichka 
