### PR TITLE
linkage: enable cache by default.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -287,11 +287,6 @@ then
   HOMEBREW_BASH_COMMAND="$HOMEBREW_LIBRARY/Homebrew/dev-cmd/$HOMEBREW_COMMAND.sh"
 fi
 
-if [[ -n "$HOMEBREW_DEVELOPER" || -n "$HOMEBREW_DEV_CMD_RUN" ]]
-then
-  export HOMEBREW_LINKAGE_CACHE="1"
-fi
-
 check-run-command-as-root() {
   [[ "$(id -u)" = 0 ]] || return
 

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -1,4 +1,4 @@
-#:  * `linkage` [`--test`] [`--reverse`] [`--cached`] <formula>:
+#:  * `linkage` [`--test`] [`--reverse`] <formula>:
 #:    Checks the library links of an installed formula.
 #:
 #:    Only works on installed formulae. An error is raised if it is run on
@@ -9,9 +9,6 @@
 #:
 #:    If `--reverse` is passed, print the dylib followed by the binaries
 #:    which link to it for each library the keg references.
-#:
-#:    If `--cached` is passed, print the cached linkage values stored in
-#:    HOMEBREW_CACHE, set from a previous `brew linkage` run
 
 require "cache_store"
 require "linkage_checker"
@@ -24,7 +21,6 @@ module Homebrew
     Homebrew::CLI::Parser.parse do
       switch "--test"
       switch "--reverse"
-      switch "--cached"
       switch :verbose
       switch :debug
     end
@@ -33,8 +29,7 @@ module Homebrew
       ARGV.kegs.each do |keg|
         ohai "Checking #{keg.name} linkage" if ARGV.kegs.size > 1
 
-        use_cache = args.cached? || ENV["HOMEBREW_LINKAGE_CACHE"]
-        result = LinkageChecker.new(keg, use_cache: use_cache, cache_db: db)
+        result = LinkageChecker.new(keg, cache_db: db)
 
         if args.test?
           result.display_test_output

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -5,12 +5,10 @@ require "linkage_cache_store"
 class LinkageChecker
   attr_reader :undeclared_deps
 
-  def initialize(keg, formula = nil, cache_db:,
-                 use_cache: !ENV["HOMEBREW_LINKAGE_CACHE"].nil?,
-                 rebuild_cache: false)
+  def initialize(keg, formula = nil, cache_db:, rebuild_cache: false)
     @keg = keg
     @formula = formula || resolve_formula(keg)
-    @store = LinkageCacheStore.new(keg.to_s, cache_db) if use_cache
+    @store = LinkageCacheStore.new(keg.to_s, cache_db)
 
     @system_dylibs    = Set.new
     @broken_dylibs    = Set.new

--- a/Library/Homebrew/test/dev-cmd/linkage_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/linkage_spec.rb
@@ -4,32 +4,16 @@ describe "brew linkage", :integration_test do
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
   end
 
-  context "no cache" do
-    it "works when no arguments are provided" do
-      expect { brew "linkage" }
-        .to be_a_success
-        .and not_to_output.to_stdout
-        .and not_to_output.to_stderr
-    end
-
-    it "works when one argument is provided" do
-      expect { brew "linkage", "testball" }
-        .to be_a_success
-        .and not_to_output.to_stderr
-    end
+  it "works when no arguments are provided" do
+    expect { brew "linkage" }
+      .to be_a_success
+      .and not_to_output.to_stdout
+      .and not_to_output.to_stderr
   end
 
-  context "cache" do
-    it "works when no arguments are provided" do
-      expect { brew "linkage", "--cached" }
-        .to be_a_success
-        .and not_to_output.to_stderr
-    end
-
-    it "works when one argument is provided" do
-      expect { brew "linkage", "--cached", "testball" }
-        .to be_a_success
-        .and not_to_output.to_stderr
-    end
+  it "works when one argument is provided" do
+    expect { brew "linkage", "testball" }
+      .to be_a_success
+      .and not_to_output.to_stderr
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -779,7 +779,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--pry` is passed or HOMEBREW_PRY is set, pry will be
     used instead of irb.
 
-  * `linkage` [`--test`] [`--reverse`] [`--cached`] `formula`:
+  * `linkage` [`--test`] [`--reverse`] `formula`:
     Checks the library links of an installed formula.
 
     Only works on installed formulae. An error is raised if it is run on
@@ -790,9 +790,6 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--reverse` is passed, print the dylib followed by the binaries
     which link to it for each library the keg references.
-
-    If `--cached` is passed, print the cached linkage values stored in
-    HOMEBREW_CACHE, set from a previous `brew linkage` run
 
   * `man` [`--fail-if-changed`]:
     Generate Homebrew's manpages.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -795,7 +795,7 @@ Enter the interactive Homebrew Ruby shell\.
 If \fB\-\-examples\fR is passed, several examples will be shown\. If \fB\-\-pry\fR is passed or HOMEBREW_PRY is set, pry will be used instead of irb\.
 .
 .TP
-\fBlinkage\fR [\fB\-\-test\fR] [\fB\-\-reverse\fR] [\fB\-\-cached\fR] \fIformula\fR
+\fBlinkage\fR [\fB\-\-test\fR] [\fB\-\-reverse\fR] \fIformula\fR
 Checks the library links of an installed formula\.
 .
 .IP
@@ -806,9 +806,6 @@ If \fB\-\-test\fR is passed, only display missing libraries and exit with a non\
 .
 .IP
 If \fB\-\-reverse\fR is passed, print the dylib followed by the binaries which link to it for each library the keg references\.
-.
-.IP
-If \fB\-\-cached\fR is passed, print the cached linkage values stored in HOMEBREW_CACHE, set from a previous \fBbrew linkage\fR run
 .
 .TP
 \fBman\fR [\fB\-\-fail\-if\-changed\fR]


### PR DESCRIPTION
This has not been causing any issues in CI or for `master` users so let's now enable it by default for everyone.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----