### PR TITLE
brew.sh: Don't allow system tmp dirs as prefixes

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -114,8 +114,8 @@ else
   : "${HOMEBREW_OS_VERSION:=$(uname -r)}"
   HOMEBREW_OS_USER_AGENT_VERSION="$HOMEBREW_OS_VERSION"
 
-  cache_home="${XDG_CACHE_HOME:-${HOME}/.cache}"
-  HOMEBREW_CACHE="${HOMEBREW_CACHE:-${cache_home}/Homebrew}"
+  CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
+  HOMEBREW_CACHE="${HOMEBREW_CACHE:-${CACHE_HOME}/Homebrew}"
 
   HOMEBREW_TEMP="${HOMEBREW_TEMP:-/tmp}"
 fi
@@ -295,10 +295,10 @@ check-prefix-is-not-tmpdir() {
   if [[ "${HOMEBREW_PREFIX}" = "${HOMEBREW_TEMP}"* ]]
   then
     odie <<EOS
-Your HOMEBREW_PREFIX is in the system temporary directory, which Homebrew
+Your HOMEBREW_PREFIX is in the Homebrew temporary directory, which Homebrew
 uses to store downloads and builds. You can resolve this by installing Homebrew to
 either the standard prefix (/usr/local) or to a non-standard prefix that is not
-in the system temporary directory.
+in the Homebrew temporary directory.
 EOS
   fi
 }

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -108,6 +108,8 @@ then
   then
     HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"
   fi
+
+  HOMEBREW_TEMP="${HOMEBREW_TEMP:-/private/tmp}"
 else
   HOMEBREW_PROCESSOR="$(uname -m)"
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
@@ -124,6 +126,8 @@ else
       HOMEBREW_CACHE="$HOME/.cache/Homebrew"
     fi
   fi
+
+  HOMEBREW_TEMP="${HOMEBREW_TEMP:-/tmp}"
 fi
 
 if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -301,7 +301,7 @@ check-prefix-is-not-tmpdir() {
 Your HOMEBREW_PREFIX is in the system temporary directory, which Homebrew
 uses to store downloads and builds. You can resolve this by installing Homebrew to
 either the standard prefix (/usr/local/) or to a non-standard prefix that is not
-the system temporary directory.
+in the system temporary directory.
 EOS
   fi
 }

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -104,10 +104,7 @@ then
     HOMEBREW_SYSTEM_GIT_TOO_OLD="1"
   fi
 
-  if [[ -z "$HOMEBREW_CACHE" ]]
-  then
-    HOMEBREW_CACHE="$HOME/Library/Caches/Homebrew"
-  fi
+  HOMEBREW_CACHE="${HOMEBREW_CACHE:-${HOME}/Library/Caches/Homebrew}"
 
   HOMEBREW_TEMP="${HOMEBREW_TEMP:-/private/tmp}"
 else
@@ -117,15 +114,8 @@ else
   : "${HOMEBREW_OS_VERSION:=$(uname -r)}"
   HOMEBREW_OS_USER_AGENT_VERSION="$HOMEBREW_OS_VERSION"
 
-  if [[ -z "$HOMEBREW_CACHE" ]]
-  then
-    if [[ -n "$XDG_CACHE_HOME" ]]
-    then
-      HOMEBREW_CACHE="$XDG_CACHE_HOME/Homebrew"
-    else
-      HOMEBREW_CACHE="$HOME/.cache/Homebrew"
-    fi
-  fi
+  cache_home="${XDG_CACHE_HOME:-${HOME}/.cache}"
+  HOMEBREW_CACHE="${HOMEBREW_CACHE:-${cache_home}/Homebrew}"
 
   HOMEBREW_TEMP="${HOMEBREW_TEMP:-/tmp}"
 fi

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -294,6 +294,20 @@ EOS
 }
 check-run-command-as-root
 
+check-prefix-is-not-tmpdir() {
+  if [[ "${HOMEBREW_PREFIX}" = /tmp/* ||
+        "${HOMEBREW_PREFIX}" = /private/tmp/* ]]
+  then
+    odie <<EOS
+Your HOMEBREW_PREFIX is in one of the system temporary directories, which Homebrew
+uses to store downloads and builds. You can resolve this by installing Homebrew to
+either the standard prefix (/usr/local/) or to a non-standard prefix that is not
+a system temporary directory.
+EOS
+  fi
+}
+check-prefix-is-not-tmpdir
+
 if [[ "$HOMEBREW_PREFIX" = "/usr/local" &&
       "$HOMEBREW_PREFIX" != "$HOMEBREW_REPOSITORY" &&
       "$HOMEBREW_CELLAR" = "$HOMEBREW_REPOSITORY/Cellar" ]]

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -300,7 +300,7 @@ check-prefix-is-not-tmpdir() {
     odie <<EOS
 Your HOMEBREW_PREFIX is in the system temporary directory, which Homebrew
 uses to store downloads and builds. You can resolve this by installing Homebrew to
-either the standard prefix (/usr/local/) or to a non-standard prefix that is not
+either the standard prefix (/usr/local) or to a non-standard prefix that is not
 in the system temporary directory.
 EOS
   fi

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -144,6 +144,7 @@ export HOMEBREW_BREW_FILE
 export HOMEBREW_PREFIX
 export HOMEBREW_REPOSITORY
 export HOMEBREW_LIBRARY
+export HOMEBREW_TEMP
 
 # Declared in brew.sh
 export HOMEBREW_VERSION
@@ -295,7 +296,7 @@ EOS
 check-run-command-as-root
 
 check-prefix-is-not-tmpdir() {
-  if [[ $(realpath "${HOMEBREW_PREFIX}") = /private/tmp/* ]]
+  if [[ "${HOMEBREW_PREFIX}" = "${HOMEBREW_TEMP}"* ]]
   then
     odie <<EOS
 Your HOMEBREW_PREFIX is in the system temporary directory, which Homebrew

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -290,6 +290,8 @@ EOS
 check-run-command-as-root
 
 check-prefix-is-not-tmpdir() {
+  [[ -z "${HOMEBREW_MACOS}" ]] && return
+
   if [[ "${HOMEBREW_PREFIX}" = "${HOMEBREW_TEMP}"* ]]
   then
     odie <<EOS

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -298,7 +298,7 @@ check-prefix-is-not-tmpdir() {
   if [[ $(realpath "${HOMEBREW_PREFIX}") = /private/tmp/* ]]
   then
     odie <<EOS
-Your HOMEBREW_PREFIX is in the system temporary directorie, which Homebrew
+Your HOMEBREW_PREFIX is in the system temporary directory, which Homebrew
 uses to store downloads and builds. You can resolve this by installing Homebrew to
 either the standard prefix (/usr/local/) or to a non-standard prefix that is not
 the system temporary directory.

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -295,14 +295,13 @@ EOS
 check-run-command-as-root
 
 check-prefix-is-not-tmpdir() {
-  if [[ "${HOMEBREW_PREFIX}" = /tmp/* ||
-        "${HOMEBREW_PREFIX}" = /private/tmp/* ]]
+  if [[ $(realpath "${HOMEBREW_PREFIX}") = /private/tmp/* ]]
   then
     odie <<EOS
-Your HOMEBREW_PREFIX is in one of the system temporary directories, which Homebrew
+Your HOMEBREW_PREFIX is in the system temporary directorie, which Homebrew
 uses to store downloads and builds. You can resolve this by installing Homebrew to
 either the standard prefix (/usr/local/) or to a non-standard prefix that is not
-a system temporary directory.
+the system temporary directory.
 EOS
   fi
 }

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -39,7 +39,7 @@ HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE/"Formula"
 HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/").expand_path
 
 # Must use /tmp instead of $TMPDIR because long paths break Unix domain sockets
-HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp"))
+HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp")).realpath
 
 unless defined? HOMEBREW_LIBRARY_PATH
   # Root of the Homebrew code base

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -39,7 +39,7 @@ HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE/"Formula"
 HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/").expand_path
 
 # Must use /tmp instead of $TMPDIR because long paths break Unix domain sockets
-HOMEBREW_TEMP = Pathname.new(ENV.fetch("HOMEBREW_TEMP", "/tmp")).realpath
+HOMEBREW_TEMP = Pathname.new(ENV["HOMEBREW_TEMP"]).realpath
 
 unless defined? HOMEBREW_LIBRARY_PATH
   # Root of the Homebrew code base

--- a/bin/brew
+++ b/bin/brew
@@ -21,7 +21,6 @@ symlink_target_directory() {
 BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
-HOMEBREW_TEMP="${HOMEBREW_TEMP:-/private/tmp}"
 
 # Default to / prefix if unset or the bin/brew file.
 if [[ -z "$HOMEBREW_PREFIX" || "$HOMEBREW_PREFIX" = "$HOMEBREW_BREW_FILE" ]]

--- a/bin/brew
+++ b/bin/brew
@@ -73,7 +73,7 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TEMP TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do

--- a/bin/brew
+++ b/bin/brew
@@ -21,6 +21,7 @@ symlink_target_directory() {
 BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
+HOMEBREW_TEMP="${HOMEBREW_TEMP:-/private/tmp}"
 
 # Default to / prefix if unset or the bin/brew file.
 if [[ -z "$HOMEBREW_PREFIX" || "$HOMEBREW_PREFIX" = "$HOMEBREW_BREW_FILE" ]]
@@ -72,7 +73,7 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TEMP TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----


This explicitly forbids the use of the system's temporary directory as an installation prefix, as we perform checks against the temporary directory when doing binary relocation.

See: https://github.com/Homebrew/homebrew-core/issues/28877#issuecomment-401511742