### PR TITLE
Re-enable tests by removing a stray rspec `:focus`

### DIFF
--- a/Library/Homebrew/test/cask/system_command_spec.rb
+++ b/Library/Homebrew/test/cask/system_command_spec.rb
@@ -80,7 +80,7 @@ describe Hbc::SystemCommand, :cask do
         options.merge!(print_stdout: true)
       end
 
-      it "echoes both STDOUT and STDERR", :focus do
+      it "echoes both STDOUT and STDERR" do
         expect { described_class.run(command, options) }
           .to output("1\n3\n5\n").to_stdout
           .and output("2\n4\n6\n").to_stderr


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] **(Does not apply)** Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Following in the tradition of #3006, this PR removes a stray `:focus`. I only caught this because I ran a known-bad test by pure coincidence.

Generally, I feel that those little pests are pretty hard to catch. I’m thinking of enabling a [focus Cop](https://github.com/rubocop-hq/rubocop-rspec/blob/61f1dfed47f1565d964c6fa6446a60b57d4eee99/lib/rubocop/cop/rspec/focus.rb) so it’ll happen less often in the future. I also suggest to change test-bot so it runs `brew style --rspec`.

@Homebrew/maintainers Opinions?
