### PR TITLE
components_redundancy: audit `stable do` without a head or devel spec

### DIFF
--- a/Library/Homebrew/rubocops/components_redundancy_cop.rb
+++ b/Library/Homebrew/rubocops/components_redundancy_cop.rb
@@ -8,10 +8,12 @@ module RuboCop
       # - `url|checksum|mirror` should be inside `stable` block
       # - `head` and `head do` should not be simultaneously present
       # - `bottle :unneeded/:disable` and `bottle do` should not be simultaneously present
+      # - `stable do` should not be present without a `head` or `devel` spec
 
       class ComponentsRedundancy < FormulaCop
         HEAD_MSG = "`head` and `head do` should not be simultaneously present".freeze
         BOTTLE_MSG = "`bottle :modifier` and `bottle do` should not be simultaneously present".freeze
+        STABLE_MSG = "`stable do` should not be present without a `head` or `devel` spec".freeze
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           stable_block = find_block(body_node, :stable)
@@ -26,6 +28,11 @@ module RuboCop
 
           problem BOTTLE_MSG if method_called?(body_node, :bottle) &&
                                 find_block(body_node, :bottle)
+
+          return if method_called?(body_node, :head) ||
+                    find_block(body_node, :head) ||
+                    find_block(body_node, :devel)
+          problem STABLE_MSG if stable_block
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/components_redundancy_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_cop_spec.rb
@@ -12,6 +12,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
           stable do
             # stuff
           end
+
+          devel do
+            # stuff
+          end
         end
       RUBY
     end
@@ -37,6 +41,46 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
             # bottles go here
           end
           bottle :unneeded
+        end
+      RUBY
+    end
+
+    it "When `stable do` is present with a `head` method" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          head "http://example.com/foo.git"
+
+          stable do
+            # stuff
+          end
+        end
+      RUBY
+    end
+
+    it "When `stable do` is present with a `head do` block" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          stable do
+            # stuff
+          end
+
+          head do
+            # stuff
+          end
+        end
+      RUBY
+    end
+
+    it "When `stable do` is present with a `devel` block" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          stable do
+            # stuff
+          end
+
+          devel do
+            # stuff
+          end
         end
       RUBY
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Stable blocks should only be used if a head or devel spec is also present.