### PR TITLE
Cleanup HOMEBREW_TEMP handling

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -105,8 +105,7 @@ then
   fi
 
   HOMEBREW_CACHE="${HOMEBREW_CACHE:-${HOME}/Library/Caches/Homebrew}"
-
-  HOMEBREW_TEMP="${HOMEBREW_TEMP:-/private/tmp}"
+  HOMEBREW_SYSTEM_TEMP="/private/tmp"
 else
   HOMEBREW_PROCESSOR="$(uname -m)"
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
@@ -116,9 +115,10 @@ else
 
   CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_CACHE="${HOMEBREW_CACHE:-${CACHE_HOME}/Homebrew}"
-
-  HOMEBREW_TEMP="${HOMEBREW_TEMP:-/tmp}"
+  HOMEBREW_SYSTEM_TEMP="/tmp"
 fi
+
+HOMEBREW_TEMP="${HOMEBREW_TEMP:-${HOMEBREW_SYSTEM_TEMP}}"
 
 if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
       -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]] &&
@@ -147,6 +147,7 @@ export HOMEBREW_BREW_FILE
 export HOMEBREW_PREFIX
 export HOMEBREW_REPOSITORY
 export HOMEBREW_LIBRARY
+export HOMEBREW_SYSTEM_TEMP
 export HOMEBREW_TEMP
 
 # Declared in brew.sh

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -39,7 +39,11 @@ HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE/"Formula"
 HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/").expand_path
 
 # Must use /tmp instead of $TMPDIR because long paths break Unix domain sockets
-HOMEBREW_TEMP = Pathname.new(ENV["HOMEBREW_TEMP"]).realpath
+HOMEBREW_TEMP = begin
+  tmp = Pathname.new(ENV["HOMEBREW_TEMP"])
+  tmp.mkpath unless tmp.exist?
+  tmp.realpath
+end
 
 unless defined? HOMEBREW_LIBRARY_PATH
   # Root of the Homebrew code base

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -116,6 +116,7 @@ class SystemConfig
         HOMEBREW_CELLAR: "/usr/local/Cellar",
         HOMEBREW_CACHE: "#{ENV["HOME"]}/Library/Caches/Homebrew",
         HOMEBREW_RUBY_WARNINGS: "-W0",
+        HOMEBREW_TEMP: ENV["HOMEBREW_SYSTEM_TEMP"],
       }.freeze
       boring_keys = %w[
         HOMEBREW_BROWSER
@@ -134,6 +135,7 @@ class SystemConfig
         HOMEBREW_MACOS_VERSION
         HOMEBREW_RUBY_PATH
         HOMEBREW_SYSTEM
+        HOMEBREW_SYSTEM_TEMP
         HOMEBREW_OS_VERSION
         HOMEBREW_PATH
         HOMEBREW_PROCESSOR
@@ -154,6 +156,9 @@ class SystemConfig
       end
       if defaults_hash[:HOMEBREW_RUBY_WARNINGS] != ENV["HOMEBREW_RUBY_WARNINGS"].to_s
         f.puts "HOMEBREW_RUBY_WARNINGS: #{ENV["HOMEBREW_RUBY_WARNINGS"]}"
+      end
+      if defaults_hash[:HOMEBREW_TEMP] != HOMEBREW_TEMP.to_s
+        f.puts "HOMEBREW_TEMP: #{HOMEBREW_TEMP}"
       end
       unless ENV["HOMEBREW_ENV"]
         ENV.sort.each do |key, value|


### PR DESCRIPTION
- Ensure that `HOMEBREW_TEMP` is only displayed in `brew config` when it's non-default.
- Attempt to create a missing `HOMEBREW_TEMP` directory rather than failing to `realpath`. Note this will still fail on permissions errors which is to be expected.
- Fix `brew update-test` by creating in the current directory