### PR TITLE
audit: exact match throttled formula names

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -586,7 +586,7 @@ module Homebrew
       throttled.each_slice(2).to_a.map do |a, b|
         next if formula.stable.nil?
         version = formula.stable.version.to_s.split(".").last.to_i
-        if @strict && a.include?(formula.name) && version.modulo(b.to_i).nonzero?
+        if @strict && a == formula.name && version.modulo(b.to_i).nonzero?
           problem "should only be updated every #{b} releases on multiples of #{b}"
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

```
r:
  * should only be updated every 10 releases on multiples of 10
```

But r is not one of the throttled formulae.

So we need to check for equality.