### PR TITLE
vendor: ruby-macho 2.0

### DIFF
--- a/Library/Homebrew/vendor/README.md
+++ b/Library/Homebrew/vendor/README.md
@@ -3,7 +3,7 @@ Vendored Dependencies
 
 * [plist](https://github.com/patsplat/plist), version 3.3.0
 
-* [ruby-macho](https://github.com/Homebrew/ruby-macho), version 1.2.0
+* [ruby-macho](https://github.com/Homebrew/ruby-macho), version 2.0.0
 
 * [backports](https://github.com/marcandre/backports), version 3.8.0
 

--- a/Library/Homebrew/vendor/macho/macho.rb
+++ b/Library/Homebrew/vendor/macho/macho.rb
@@ -1,18 +1,18 @@
-require "#{File.dirname(__FILE__)}/macho/structure"
-require "#{File.dirname(__FILE__)}/macho/view"
-require "#{File.dirname(__FILE__)}/macho/headers"
-require "#{File.dirname(__FILE__)}/macho/load_commands"
-require "#{File.dirname(__FILE__)}/macho/sections"
-require "#{File.dirname(__FILE__)}/macho/macho_file"
-require "#{File.dirname(__FILE__)}/macho/fat_file"
-require "#{File.dirname(__FILE__)}/macho/exceptions"
-require "#{File.dirname(__FILE__)}/macho/utils"
-require "#{File.dirname(__FILE__)}/macho/tools"
+require_relative "macho/structure"
+require_relative "macho/view"
+require_relative "macho/headers"
+require_relative "macho/load_commands"
+require_relative "macho/sections"
+require_relative "macho/macho_file"
+require_relative "macho/fat_file"
+require_relative "macho/exceptions"
+require_relative "macho/utils"
+require_relative "macho/tools"
 
 # The primary namespace for ruby-macho.
 module MachO
   # release version
-  VERSION = "1.2.0".freeze
+  VERSION = "2.0.0".freeze
 
   # Opens the given filename as a MachOFile or FatFile, depending on its magic.
   # @param filename [String] the file being opened

--- a/Library/Homebrew/vendor/macho/macho/headers.rb
+++ b/Library/Homebrew/vendor/macho/macho/headers.rb
@@ -475,6 +475,15 @@ module MachO
       def serialize
         [magic, nfat_arch].pack(FORMAT)
       end
+
+      # @return [Hash] a hash representation of this {FatHeader}
+      def to_h
+        {
+          "magic" => magic,
+          "magic_sym" => MH_MAGICS[magic],
+          "nfat_arch" => nfat_arch,
+        }.merge super
+      end
     end
 
     # Fat binary header architecture structure. A Fat binary has one or more of
@@ -508,7 +517,7 @@ module MachO
       # @api private
       def initialize(cputype, cpusubtype, offset, size, align)
         @cputype = cputype
-        @cpusubtype = cpusubtype
+        @cpusubtype = cpusubtype & ~CPU_SUBTYPE_MASK
         @offset = offset
         @size = size
         @align = align
@@ -517,6 +526,19 @@ module MachO
       # @return [String] the serialized fields of the fat arch
       def serialize
         [cputype, cpusubtype, offset, size, align].pack(FORMAT)
+      end
+
+      # @return [Hash] a hash representation of this {FatArch}
+      def to_h
+        {
+          "cputype" => cputype,
+          "cputype_sym" => CPU_TYPES[cputype],
+          "cpusubtype" => cpusubtype,
+          "cpusubtype_sym" => CPU_SUBTYPES[cputype][cpusubtype],
+          "offset" => offset,
+          "size" => size,
+          "align" => align,
+        }.merge super
       end
     end
 
@@ -639,6 +661,24 @@ module MachO
       def alignment
         magic32? ? 4 : 8
       end
+
+      # @return [Hash] a hash representation of this {MachHeader}
+      def to_h
+        {
+          "magic" => magic,
+          "magic_sym" => MH_MAGICS[magic],
+          "cputype" => cputype,
+          "cputype_sym" => CPU_TYPES[cputype],
+          "cpusubtype" => cpusubtype,
+          "cpusubtype_sym" => CPU_SUBTYPES[cputype][cpusubtype],
+          "filetype" => filetype,
+          "filetype_sym" => MH_FILETYPES[filetype],
+          "ncmds" => ncmds,
+          "sizeofcmds" => sizeofcmds,
+          "flags" => flags,
+          "alignment" => alignment,
+        }.merge super
+      end
     end
 
     # 64-bit Mach-O file header structure
@@ -659,6 +699,13 @@ module MachO
                      flags, reserved)
         super(magic, cputype, cpusubtype, filetype, ncmds, sizeofcmds, flags)
         @reserved = reserved
+      end
+
+      # @return [Hash] a hash representation of this {MachHeader64}
+      def to_h
+        {
+          "reserved" => reserved,
+        }.merge super
       end
     end
   end

--- a/Library/Homebrew/vendor/macho/macho/sections.rb
+++ b/Library/Homebrew/vendor/macho/macho/sections.rb
@@ -13,6 +13,10 @@ module MachO
     # system settable attributes mask
     SECTION_ATTRIBUTES_SYS = 0x00ffff00
 
+    # maximum specifiable section alignment, as a power of 2
+    # @note see `MAXSECTALIGN` macro in `cctools/misc/lipo.c`
+    MAX_SECT_ALIGN = 15
+
     # association of section flag symbols to values
     # @api private
     SECTION_FLAGS = {
@@ -104,7 +108,7 @@ module MachO
       attr_reader :reserved2
 
       # @see MachOStructure::FORMAT
-      FORMAT = "a16a16L=9".freeze
+      FORMAT = "Z16Z16L=9".freeze
 
       # @see MachOStructure::SIZEOF
       SIZEOF = 68
@@ -125,16 +129,14 @@ module MachO
         @reserved2 = reserved2
       end
 
-      # @return [String] the section's name, with any trailing NULL characters
-      #  removed
+      # @return [String] the section's name
       def section_name
-        sectname.delete("\x00")
+        sectname
       end
 
-      # @return [String] the parent segment's name, with any trailing NULL
-      #  characters removed
+      # @return [String] the parent segment's name
       def segment_name
-        segname.delete("\x00")
+        segname
       end
 
       # @return [Boolean] whether the section is empty (i.e, {size} is 0)
@@ -151,6 +153,23 @@ module MachO
         return false if flag.nil?
         flags & flag == flag
       end
+
+      # @return [Hash] a hash representation of this {Section}
+      def to_h
+        {
+          "sectname" => sectname,
+          "segname" => segname,
+          "addr" => addr,
+          "size" => size,
+          "offset" => offset,
+          "align" => align,
+          "reloff" => reloff,
+          "nreloc" => nreloc,
+          "flags" => flags,
+          "reserved1" => reserved1,
+          "reserved2" => reserved2,
+        }.merge super
+      end
     end
 
     # Represents a section of a segment for 64-bit architectures.
@@ -159,7 +178,7 @@ module MachO
       attr_reader :reserved3
 
       # @see MachOStructure::FORMAT
-      FORMAT = "a16a16Q=2L=8".freeze
+      FORMAT = "Z16Z16Q=2L=8".freeze
 
       # @see MachOStructure::SIZEOF
       SIZEOF = 80
@@ -170,6 +189,13 @@ module MachO
         super(sectname, segname, addr, size, offset, align, reloff,
           nreloc, flags, reserved1, reserved2)
         @reserved3 = reserved3
+      end
+
+      # @return [Hash] a hash representation of this {Section64}
+      def to_h
+        {
+          "reserved3" => reserved3,
+        }.merge super
       end
     end
   end

--- a/Library/Homebrew/vendor/macho/macho/structure.rb
+++ b/Library/Homebrew/vendor/macho/macho/structure.rb
@@ -26,5 +26,15 @@ module MachO
 
       new(*bin.unpack(format))
     end
+
+    # @return [Hash] a hash representation of this {MachOStructure}.
+    def to_h
+      {
+        "structure" => {
+          "format" => self.class::FORMAT,
+          "bytesize" => self.class.bytesize,
+        },
+      }
+    end
   end
 end

--- a/Library/Homebrew/vendor/macho/macho/utils.rb
+++ b/Library/Homebrew/vendor/macho/macho/utils.rb
@@ -22,6 +22,16 @@ module MachO
       round(size, alignment) - size
     end
 
+    # Returns a string of null bytes of the requested (non-negative) size
+    # @param size [Integer] the size of the nullpad
+    # @return [String] the null string (or empty string, for `size = 0`)
+    # @raise [ArgumentError] if a non-positive nullpad is requested
+    def self.nullpad(size)
+      raise ArgumentError, "size < 0: #{size}" if size.negative?
+
+      "\x00" * size
+    end
+
     # Converts an abstract (native-endian) String#unpack format to big or
     #  little.
     # @param format [String] the format string being converted
@@ -46,11 +56,11 @@ module MachO
       strings.each do |key, string|
         offsets[key] = next_offset
         payload << string
-        payload << "\x00"
+        payload << Utils.nullpad(1)
         next_offset += string.bytesize + 1
       end
 
-      payload << "\x00" * padding_for(fixed_offset + payload.bytesize, alignment)
+      payload << Utils.nullpad(padding_for(fixed_offset + payload.bytesize, alignment))
       [payload, offsets]
     end
 

--- a/Library/Homebrew/vendor/macho/macho/view.rb
+++ b/Library/Homebrew/vendor/macho/macho/view.rb
@@ -19,5 +19,13 @@ module MachO
       @endianness = endianness
       @offset = offset
     end
+
+    # @return [Hash] a hash representation of this {MachOView}.
+    def to_h
+      {
+        "endianness" => endianness,
+        "offset" => offset,
+      }
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a major version change, but nothing in it should break the calls that Homebrew is currently using.

Important changes:
* `FatFile.new_from_machos` (which `Tools.merge_machos` uses) now works correctly (earlier versions didn't align Mach-O slices onto page boundaries correctly).
* The entire library now has `to_h` support, which should make inspection/debugging a little easier.

cc @sashkab