### PR TITLE
audit: ensure `bottle` is defined

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -488,10 +488,29 @@ module Homebrew
       end
     end
 
-    def audit_bottle_spec
+    def audit_bottle_disabled
       return unless formula.bottle_disabled?
-      return if formula.bottle_disable_reason.valid?
-      problem "Unrecognized bottle modifier"
+      return if formula.bottle_unneeded?
+
+      if !formula.bottle_disable_reason.valid?
+        problem "Unrecognized bottle modifier"
+      else
+        bottle_disabled_whitelist = %w[
+          cryptopp
+          leafnode
+        ]
+        return if bottle_disabled_whitelist.include?(formula.name)
+        problem "Formulae should not use `bottle :disabled`" if @official_tap
+      end
+    end
+
+    def audit_bottle_spec
+      return unless @official_tap
+      return if @new_formula
+      return unless @online
+      return if formula.bottle_defined? || formula.bottle_disabled?
+      return if formula.name == "testbottest"
+      problem "`bottle` is not defined"
     end
 
     def audit_github_repository


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We can't really prevent new formulae from being merged without `bottle :unneeded` but this will catch it the next time it goes through CI.

Also disallow `bottle :disabled` in core and whitelist the formulae that currently use it.