### PR TITLE
config: handle HOMEBREW_TEMP being unset.

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -40,7 +40,9 @@ HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/")
 
 # Must use /tmp instead of $TMPDIR because long paths break Unix domain sockets
 HOMEBREW_TEMP = begin
-  tmp = Pathname.new(ENV["HOMEBREW_TEMP"])
+  # /tmp fallback is here for people auto-updating from a version where
+  # HOMEBREW_TEMP isn't set.
+  tmp = Pathname.new(ENV["HOMEBREW_TEMP"] || "/tmp")
   tmp.mkpath unless tmp.exist?
   tmp.realpath
 end


### PR DESCRIPTION
This can happen when updating from a previous version of Homebrew.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----