### PR TITLE
extend/ENV: support CX11 for LLVM Clang.

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -147,7 +147,7 @@ module SharedEnvExtension
 
   # Outputs the current compiler.
   # @return [Symbol]
-  # <pre># Do something only for clang
+  # <pre># Do something only for the system clang
   # if ENV.compiler == :clang
   #   # modify CFLAGS CXXFLAGS OBJCFLAGS OBJCXXFLAGS in one go:
   #   ENV.append_to_cflags "-I ./missing/includes"
@@ -301,6 +301,18 @@ module SharedEnvExtension
   # A no-op until we enable this by default again (which we may never do).
   def permit_weak_imports; end
 
+  # @private
+  def compiler_any_clang?(cc = compiler)
+    %w[clang llvm_clang].include?(cc.to_s)
+  end
+
+  # @private
+  def compiler_with_cxx11_support?(cc)
+    return if compiler_any_clang?(cc)
+    version = cc[/^gcc-(\d+(?:\.\d+)?)$/, 1]
+    version && Version.create(version) >= Version.create("4.8")
+  end
+
   private
 
   def cc=(val)
@@ -329,11 +341,6 @@ module SharedEnvExtension
   def check_for_compiler_universal_support
     return unless homebrew_cc =~ GNU_GCC_REGEXP
     raise "Non-Apple GCC can't build universal binaries"
-  end
-
-  def gcc_with_cxx11_support?(cc)
-    version = cc[/^gcc-(\d+(?:\.\d+)?)$/, 1]
-    version && Version.create(version) >= Version.create("4.8")
   end
 end
 

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -157,7 +157,7 @@ module Stdenv
     append_to_cflags Hardware::CPU.universal_archs.as_arch_flags
     append "LDFLAGS", Hardware::CPU.universal_archs.as_arch_flags
 
-    return if compiler == :clang
+    return if compiler_any_clang?
     return unless Hardware.is_32_bit?
     # Can't mix "-march" for a 32-bit CPU  with "-arch x86_64"
     replace_in_cflags(/-march=\S*/, "-Xarch_#{Hardware::CPU.arch_32_bit} \\0")
@@ -167,7 +167,7 @@ module Stdenv
     if compiler == :clang
       append "CXX", "-std=c++11"
       append "CXX", "-stdlib=libc++"
-    elsif gcc_with_cxx11_support?(compiler)
+    elsif compiler_with_cxx11_support?(compiler)
       append "CXX", "-std=c++11"
     else
       raise "The selected compiler doesn't support C++11: #{compiler}"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -276,7 +276,7 @@ module Superenv
     self["HOMEBREW_ARCHFLAGS"] = Hardware::CPU.universal_archs.as_arch_flags
 
     # GCC doesn't accept "-march" for a 32-bit CPU with "-arch x86_64"
-    return if compiler == :clang
+    return if compiler_any_clang?
     return unless Hardware::CPU.is_32_bit?
     self["HOMEBREW_OPTFLAGS"] = self["HOMEBREW_OPTFLAGS"].sub(
       /-march=\S*/,
@@ -300,7 +300,7 @@ module Superenv
     if homebrew_cc == "clang"
       append "HOMEBREW_CCCFG", "x", ""
       append "HOMEBREW_CCCFG", "g", ""
-    elsif gcc_with_cxx11_support?(homebrew_cc)
+    elsif compiler_with_cxx11_support?(homebrew_cc)
       append "HOMEBREW_CCCFG", "x", ""
     else
       raise "The selected compiler doesn't support C++11: #{homebrew_cc}"

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -156,6 +156,18 @@ shared_examples EnvActivation do
       expect(subject["FOO"]).to eq "bar"
     end
   end
+
+  describe "#compiler_any_clang?" do
+    it "returns true for llvm_clang" do
+      expect(subject.compiler_any_clang?(:llvm_clang)).to be true
+    end
+  end
+
+  describe "#compiler_with_cxx11_support?" do
+    it "returns true for gcc-4.9" do
+      expect(subject.compiler_with_cxx11_support?("gcc-4.9")).to be true
+    end
+  end
 end
 
 describe Stdenv do


### PR DESCRIPTION
Fix some checks for `:clang` which should match for either `:clang` or `:llvm_clang`. Note that's not every check.

Fixes #4419.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----