### PR TITLE
linkage: fix output of optional dependencies.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1518,7 +1518,7 @@ class Formula
 
   # Returns a list of Dependency objects that are required at runtime.
   # @private
-  def runtime_dependencies(read_from_tab: true)
+  def runtime_dependencies(read_from_tab: true, undeclared: true)
     if read_from_tab &&
        (keg = opt_or_installed_prefix_keg) &&
        (tab_deps = keg.runtime_dependencies)
@@ -1529,6 +1529,7 @@ class Formula
       end.compact
     end
 
+    return declared_runtime_dependencies unless undeclared
     declared_runtime_dependencies | undeclared_runtime_dependencies
   end
 

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -149,7 +149,8 @@ class LinkageChecker
     declared_deps_names = declared_deps_full_names.map do |dep|
       dep.split("/").last
     end
-    recursive_deps = formula.declared_runtime_dependencies.map do |dep|
+    recursive_deps = formula.runtime_dependencies(undeclared: false)
+                            .map do |dep|
       begin
         dep.to_formula.name
       rescue FormulaUnavailableError


### PR DESCRIPTION
Check the runtime dependencies from the tab when outputting the `brew linkage` declared vs. undeclared dependencies.

Fixes #4407.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----