### PR TITLE
download_strategy: use tar xf.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -194,15 +194,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
       if type == :xz && DependencyCollector.tar_needs_xz_dependency?
         pipe_to_tar "#{HOMEBREW_PREFIX}/opt/xz/bin/xz", unpack_dir
       else
-        flags = if type == :gzip
-          ["-z"]
-        elsif type == :bzip2
-          ["-j"]
-        elsif type == :xz
-          ["-J"]
-        end
-
-        safe_system "tar", "-x", *flags, "-f", path, "-C", unpack_dir
+        safe_system "tar", "xf", path, "-C", unpack_dir
       end
       chdir
     when :lzip
@@ -239,7 +231,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     path = cached_location
 
     Utils.popen_read(tool, "-dc", path) do |rd|
-      Utils.popen_write("tar", "-x", "-f", "-", "-C", unpack_dir) do |wr|
+      Utils.popen_write("tar", "xf", "-", "-C", unpack_dir) do |wr|
         buf = ""
         wr.write(buf) while rd.read(16384, buf)
       end


### PR DESCRIPTION
The flags and separate `-` aren't required on 10.5 which is the oldest version of macOS we support (and it looks nicer this way).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----