### PR TITLE
link: fix undefined `dep_f`

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -40,7 +40,7 @@ module Homebrew
         elsif (MacOS.version >= :mojave ||
                MacOS::Xcode.version >= "10.0" ||
                MacOS::CLT.version >= "10.0") &&
-              dep_f.keg_only_reason.reason == :provided_by_macos
+              keg.to_formula.keg_only_reason.reason == :provided_by_macos
           opoo <<~EOS
             Refusing to link macOS-provided software: #{keg.name}
             Instead, pass the full include/library paths to your compiler e.g.:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix bug pointed out here: https://github.com/Homebrew/brew/commit/2f181b3f41487c0c2c4459e3dfb5a9e3d256eccb#commitcomment-29649448

```
Error: undefined local variable or method `dep_f' for Homebrew:Module
/usr/local/Homebrew/Library/Homebrew/cmd/link.rb:43:in `block in link'
/usr/local/Homebrew/Library/Homebrew/cmd/link.rb:28:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/link.rb:28:in `link'
/usr/local/Homebrew/Library/Homebrew/brew.rb:100:in `<main>'
```