### PR TITLE
cask audit: check for `latest` with `auto_updates`

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/audit.rb
+++ b/Library/Homebrew/cask/lib/hbc/audit.rb
@@ -36,6 +36,7 @@ module Hbc
       check_untrusted_pkg
       check_hosting_with_appcast
       check_latest_with_appcast
+      check_latest_with_auto_updates
       check_stanza_requires_uninstall
       self
     rescue StandardError => e
@@ -197,6 +198,13 @@ module Hbc
       return unless cask.appcast
 
       add_warning "Casks with an appcast should not use version :latest"
+    end
+
+    def check_latest_with_auto_updates
+      return unless cask.version.latest?
+      return unless cask.auto_updates
+
+      add_warning "Casks with `version :latest` should not use `auto_updates`"
     end
 
     def check_hosting_with_appcast

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -413,6 +413,34 @@ describe Hbc::Audit, :cask do
       end
     end
 
+    describe "latest with auto_updates checks" do
+      let(:warning_msg) { "Casks with `version :latest` should not use `auto_updates`" }
+
+      context "when the Cask is :latest and does not have auto_updates" do
+        let(:cask_token) { "version-latest" }
+
+        it { is_expected.not_to warn_with(warning_msg) }
+      end
+
+      context "when the Cask is versioned and does not have auto_updates" do
+        let(:cask_token) { "basic-cask" }
+
+        it { is_expected.not_to warn_with(warning_msg) }
+      end
+
+      context "when the Cask is versioned and has auto_updates" do
+        let(:cask_token) { "auto-updates" }
+
+        it { is_expected.not_to warn_with(warning_msg) }
+      end
+
+      context "when the Cask is :latest and has auto_updates" do
+        let(:cask_token) { "latest-with-auto-updates" }
+
+        it { is_expected.to warn_with(warning_msg) }
+      end
+    end
+
     describe "preferred download URL formats" do
       let(:warning_msg) { /URL format incorrect/ }
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
@@ -1,0 +1,11 @@
+cask 'latest-with-auto-updates' do
+  version :latest
+  sha256 :no_check
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  homepage 'http://example.com/latest-with-auto-updates'
+
+  auto_updates true
+
+  app 'Caffeine.app'
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Casks having version `:latest` _and_  `auto_updates true` is kind of confusing and doesn't make a difference to `outdated` or `upgrade`. Some of the casks that currently fail this audit are deliberately unversioned (even if they could have an appcast and be versioned) because of update frequency.