### PR TITLE
hardware: add dodeca-core for 2018 MBPs

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -137,6 +137,7 @@ module Hardware
     when 4 then "quad"
     when 6 then "hexa"
     when 8 then "octa"
+    when 12 then "dodeca"
     else
       Hardware::CPU.cores
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

For some reason I can't run `tests` or `style` locally currently because this happens:
```
Error: installing into parent path exe/bundle of /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/bundler-1.16.2 is not allowed

Error: installing into parent path ext/jaro_winkler/adj_matrix.c of /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.3.0/gems/jaro_winkler-1.5.1 is not allowed
```

But this is a simple enough change to probably be fine. Just adds `dodeca-core` for the new 6-core MacBook Pro line launched today. Obviously this is untested because I don't have a spare £2600+ sitting around, but again, a simple enough change to not really need a ton of checking.

<img width="1081" alt="screen shot 2018-07-12 at 21 23 44" src="https://user-images.githubusercontent.com/6998367/42657362-e1c4c320-8619-11e8-9c69-74f3f550971a.png">
