### PR TITLE
`Hbc::init` does not exist anymore.

### DIFF
--- a/Library/Homebrew/test/cask/cli_spec.rb
+++ b/Library/Homebrew/test/cask/cli_spec.rb
@@ -37,9 +37,6 @@ describe Hbc::CLI, :cask do
     let(:noop_command) { double("CLI::Noop") }
 
     before do
-      skip "random test failures due to leaking doubles"
-
-      allow(Hbc).to receive(:init)
       allow(described_class).to receive(:lookup_command).with("noop").and_return(noop_command)
       allow(noop_command).to receive(:run)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
