### PR TITLE
Don’t expand `executable` path in `SystemCommand`.

### DIFF
--- a/Library/Homebrew/test/cask/container/naked_spec.rb
+++ b/Library/Homebrew/test/cask/container/naked_spec.rb
@@ -7,15 +7,15 @@ describe Hbc::Container::Naked, :cask do
 
     path                 = "/tmp/downloads/kevin-spacey-1.2.pkg"
     expected_destination = cask.staged_path.join("kevin spacey.pkg")
-    expected_command     = ["/usr/bin/ditto", "--", path, expected_destination]
-    Hbc::FakeSystemCommand.stubs_command(expected_command)
 
     container = Hbc::Container::Naked.new(cask, path, Hbc::FakeSystemCommand)
+
+    Hbc::FakeSystemCommand.expects_command(
+      ["/usr/bin/ditto", "--", path, expected_destination],
+    )
 
     expect {
       container.extract
     }.not_to raise_error
-
-    expect(Hbc::FakeSystemCommand.system_calls[expected_command]).to eq(1)
   end
 end

--- a/Library/Homebrew/test/support/helper/cask/fake_system_command.rb
+++ b/Library/Homebrew/test/support/helper/cask/fake_system_command.rb
@@ -23,17 +23,14 @@ module Hbc
     end
 
     def self.stubs_command(command, response = "")
+      command = command.map(&:to_s)
       responses[command] = response
     end
 
     def self.expects_command(command, response = "", times = 1)
+      command = command.map(&:to_s)
       stubs_command(command, response)
       expectations[command] = times
-    end
-
-    def self.expect_and_pass_through(command, times = 1)
-      pass_through = ->(cmd, opts) { Hbc::SystemCommand.run(cmd, opts) }
-      expects_command(command, pass_through, times)
     end
 
     def self.verify_expectations!


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

Otherwise plain executable names would be expanded to `$PWD/executable` instead of looking for it in the `PATH`.