### PR TITLE
Explicitly chmod exec script files

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -351,10 +351,12 @@ class Pathname
     mkpath
     targets.each do |target|
       target = Pathname.new(target) # allow pathnames or strings
-      join(target.basename).write <<~SH
+      script = join(target.basename)
+      script.write <<~SH
         #!/bin/bash
         exec "#{target}" "$@"
       SH
+      script.chmod 0555
     end
   end
 
@@ -367,6 +369,7 @@ class Pathname
       #!/bin/bash
       #{env_export}exec "#{target}" "$@"
     SH
+    chmod 0555
   end
 
   # Writes a wrapper env script and moves all files to the dst
@@ -390,6 +393,7 @@ class Pathname
       #!/bin/bash
       #{java_home}exec java #{java_opts} -jar #{target_jar} "$@"
     SH
+    chmod 0555
   end
 
   def install_metafiles(from = Pathname.pwd)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *(I don't see existing tests for the write_exec_script files, and am not sure where they should go.)*
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Currently, in some cases, when you `write_exec_script`, the resulting wrapper scripts may not be executable. This is happening to me when creating exec scripts in libexec for hadoop.

This PR has `write_exec_script` and related scripts explicitly chmod 0755 the newly created wrapper scripts. I think this unconditional behavior is the right behavior, because we know that the wrapper scripts should always be executable.

The particular use case I'm running in to is this: in `hadoop`, it has some scripts in libexec, that end up in libexec/libexec, and I need to re-expose them by doing `write_exec_script` on them. Doing a manual chmod on them in the formula is cumbersome, because I'd need a list of the files that were written – can't just do a chmod on everything in the root libexec, because that contains additional files and directories besides the ones placed there using `write_exec_script`.