### PR TITLE
formulary: catch argument errors.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -24,7 +24,7 @@ module Formulary
     const_set(namespace, mod)
     begin
       mod.module_eval(contents, path)
-    rescue ScriptError => e
+    rescue ArgumentError, ScriptError => e
       raise FormulaUnreadableError.new(name, e)
     end
     class_name = class_s(name)


### PR DESCRIPTION
Reraise as a `FormulaUnreadableError` as these are formulae that have mistakes that cannot be trivially repaired.

Fixes #4475.
Fixes #4476.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----