### PR TITLE
Handle missing formulae in runtime_dependencies

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -155,8 +155,8 @@ class FormulaInstaller
 
     recursive_deps = formula.recursive_dependencies
     recursive_formulae = recursive_deps.map(&:to_formula)
-    recursive_runtime_deps = formula.runtime_dependencies
-    recursive_runtime_formulae = recursive_runtime_deps.map(&:to_formula)
+    recursive_runtime_formulae =
+      formula.runtime_formula_dependencies(undeclared: false)
 
     recursive_dependencies = []
     recursive_formulae.each do |dep|
@@ -174,7 +174,9 @@ class FormulaInstaller
       EOS
     end
 
-    if recursive_formulae.flat_map(&:recursive_dependencies).map(&:to_s).include?(formula.name)
+    if recursive_formulae.flat_map(&:recursive_dependencies)
+                         .map(&:to_s)
+                         .include?(formula.name)
       raise CannotInstallFormulaError, <<~EOS
         #{formula.full_name} contains a recursive dependency on itself!
       EOS
@@ -431,7 +433,7 @@ class FormulaInstaller
   end
 
   def runtime_requirements(formula)
-    runtime_deps = formula.runtime_dependencies.map(&:to_formula)
+    runtime_deps = formula.runtime_formula_dependencies(undeclared: false)
     recursive_requirements = formula.recursive_requirements do |dependent, _|
       Requirement.prune unless runtime_deps.include?(dependent)
     end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -149,14 +149,8 @@ class LinkageChecker
     declared_deps_names = declared_deps_full_names.map do |dep|
       dep.split("/").last
     end
-    recursive_deps = formula.runtime_dependencies(undeclared: false)
-                            .map do |dep|
-      begin
-        dep.to_formula.name
-      rescue FormulaUnavailableError
-        nil
-      end
-    end.compact
+    recursive_deps = formula.runtime_formula_dependencies(undeclared: false)
+                            .map(&:name)
 
     indirect_deps = []
     undeclared_deps = []

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -17,7 +17,7 @@ class Tab < OpenStruct
   # Instantiates a Tab for a new installation of a formula.
   def self.create(formula, compiler, stdlib)
     build = formula.build
-    runtime_deps = formula.declared_runtime_dependencies
+    runtime_deps = formula.runtime_dependencies(undeclared: false)
     attributes = {
       "homebrew_version" => HOMEBREW_VERSION,
       "used_options" => build.used_options.as_flags,


### PR DESCRIPTION
Hopefully put this to bed for once and for all. Add a new method `runtime_formula_dependencies` which returns the `runtime_dependencies` which have only the `Formula` objects that exist. I've checked all the `runtime_dependencies` callers and updated them accordingly.

Also, fix a few cases where runtime dependencies were being read from the tab when this wasn't desirable.

Fixes #4482.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----