### PR TITLE
cc shim: handle the case when HOMEBREW_CC = cc

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -79,8 +79,8 @@ class Cmd
         "clang++"
       when /llvm-gcc/
         "llvm-g++-4.2"
-      when /gcc(-\d(\.\d)?)?$/
-        "g++" + $1.to_s
+      when /(g)?cc(-\d(\.\d)?)?$/
+        "g++" + $2.to_s
       end
     else
       # Note that this is a universal fallback, so that we'll always invoke


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Handle the case when `HOMEBREW_CC` is set to `cc`. This happens on Linux. I don't know if it is preferred to alter existing patterns or create new ones, so I chose the former approach.