### PR TITLE
audit: Relax versioning audits for non-official taps

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -310,7 +310,7 @@ module Homebrew
 
       problem "File should end with a newline" unless text.trailing_newline?
 
-      if @versioned_formula
+      if formula.core_formula? && @versioned_formula
         unversioned_formula = begin
           # build this ourselves as we want e.g. homebrew/core to be present
           full_name = if formula.tap


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031). *No; we don't test `audit`.*
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I think a couple of our audits are being applied globally, when they are only really relevant to core/"official" taps.

* Requiring versioned formulae to have non-versioned equivalents in the same tap
* Forbidding head/devel

I think both of these are still legit use cases in non-official taps. For versioned formulae, it's legit for a custom tap to make a versioned formula off a regular one from the official core tap. And I think we still allow/support `head` and `devel` usage in non-core taps.

This PR relaxes the audits on non-official taps so that these requirements are only applied to the core tap.

This will make it easier to use audit in non-core taps like Brewsci and `dpo/openblas`, which would want to use it for the style/best-practices guidelines, but have legit use cases for both the scenarios above, and shouldn't be getting false-positives for them.