### PR TITLE
ruby.sh: remove linkage cache on upgrade.

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -47,7 +47,7 @@ setup-ruby-path() {
         then
           odie "Failed to install vendor Ruby."
         fi
-        rm -rf "$vendor_dir/bundle/ruby"
+        rm -rf "$vendor_dir/bundle/ruby" "$HOMEBREW_CACHE/linkage.db"
         HOMEBREW_RUBY_PATH="$vendor_ruby_path"
       fi
     fi


### PR DESCRIPTION
This may not be compatible between portable ruby versions and between portable and system ruby versions.

Fixes #4485.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----