### PR TITLE
Explicitly chmod exec script files (take 2)

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -351,10 +351,12 @@ class Pathname
     mkpath
     targets.each do |target|
       target = Pathname.new(target) # allow pathnames or strings
-      join(target.basename).write <<~SH
+      script = join(target.basename)
+      script.write <<~SH
         #!/bin/bash
         exec "#{target}" "$@"
       SH
+      script.chmod "a+x"
     end
   end
 
@@ -367,6 +369,7 @@ class Pathname
       #!/bin/bash
       #{env_export}exec "#{target}" "$@"
     SH
+    chmod "a+x"
   end
 
   # Writes a wrapper env script and moves all files to the dst
@@ -386,10 +389,12 @@ class Pathname
     java_home = if java_version
       "JAVA_HOME=\"$(#{Language::Java.java_home_cmd(java_version)})\" "
     end
-    join(script_name).write <<~SH
+    script = join(script_name)
+    script.write <<~SH
       #!/bin/bash
       #{java_home}exec java #{java_opts} -jar #{target_jar} "$@"
     SH
+    script.chmod "a+x"
   end
 
   def install_metafiles(from = Pathname.pwd)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change? *This supersedes #4470*
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This is a second take on #4470, with a bug fix for the broken `write_jar_script`.

With this version, `openapi-generator` and other formulae using `write_jar_script` do not have their `uninstall` broken.

```
$ brew install -s openapi-generator                                                           chmods-for-exec-scripts-take-2
==> Downloading https://search.maven.org/remotecontent?filepath=org/openapitools/openapi-generator-cli/3.1.1/openapi-generato
######################################################################## 100.0%
🍺  /usr/local/Cellar/openapi-generator/3.1.1: 4 files, 15.3MB, built in 3 seconds
[/usr/local/Homebrew]
$ brew uninstall openapi-generator                                                            chmods-for-exec-scripts-take-2
Uninstalling /usr/local/Cellar/openapi-generator/3.1.1... (4 files, 15.3MB)
[/usr/local/Homebrew]
$                                                                                             chmods-for-exec-scripts-take-2
```
