### PR TITLE
fix cask seven_zip containers

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/container/seven_zip.rb
+++ b/Library/Homebrew/cask/lib/hbc/container/seven_zip.rb
@@ -1,8 +1,8 @@
-require "hbc/container/generic_unar"
+require "hbc/container/base"
 
 module Hbc
   class Container
-    class SevenZip
+    class SevenZip < Base
       def self.can_extract?(path:, magic_number:)
         magic_number.match?(/\A7z\xBC\xAF\x27\x1C/n)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
https://github.com/Homebrew/homebrew-cask/pull/49756#issuecomment-405755294
```
==> Checking container class Hbc::Container::SevenZip
==> Purging files for version 0.35.0 of Cask sabaki
Error: wrong number of arguments (given 4, expected 0)
```