### PR TITLE
Increase spec timeout to 30 seconds

### DIFF
--- a/Library/Homebrew/test/cask/system_command_spec.rb
+++ b/Library/Homebrew/test/cask/system_command_spec.rb
@@ -183,7 +183,7 @@ describe Hbc::SystemCommand, :cask do
     }
 
     it "returns without deadlocking" do
-      wait(15).for {
+      wait(30).for {
         described_class.run(command, options)
       }.to be_a_success
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] **(Not applicable)** Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I’ve noticed the deadlock test in `cask/system_command_spec.rb` appears to fail spuriously, e. g. in #4529.

Details:

https://travis-ci.org/Homebrew/brew/jobs/406827725#L297-L318

With the spec taking 2 seconds on average on my 2017 MBP, I feel it’s entirely plausible for the aging test-bot hardware to get knocked by the 15-second timeout.

Given that the spec will pass early anyway if it passes, I feel it’s reasonable to bump the timeout to 30 seconds.
