### PR TITLE
tab: correctly handle options request.

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -211,6 +211,10 @@ class Tab < OpenStruct
     end
   end
 
+  def any_args_or_options?
+    !used_options.empty? || !unused_options.empty?
+  end
+
   def with?(val)
     option_names = val.respond_to?(:option_names) ? val.option_names : [val]
 


### PR DESCRIPTION
Because a `Tab` is an `OpenStruct` the existing calls to
`any_args_or_options?` would always return `false`. This means that
`Formula#declared_runtime_dependencies` would never call
`Tab#without?` to check whether a dependency has been brought in by an
option.

Fixes #4407

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----