### PR TITLE
Change Mojave bottle behaviour

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -262,14 +262,6 @@ then
 
   # Don't allow non-developers to customise Ruby warnings.
   unset HOMEBREW_RUBY_WARNINGS
-
-  # Default non-developers to bottles on prerelease versions of macOS
-  # in default prefix.
-  if [[ "$HOMEBREW_PREFIX" = "/usr/local" &&
-        "$HOMEBREW_MACOS_VERSION_NUMERIC" -ge "101400" ]]
-  then
-    export HOMEBREW_FORCE_BOTTLE="1"
-  fi
 fi
 
 if [[ -z "$HOMEBREW_RUBY_WARNINGS" ]]

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -262,8 +262,7 @@ module HomebrewArgvExtension
   end
 
   def force_bottle?
-    return false if ENV["HOMEBREW_NO_FORCE_BOTTLE"]
-    include?("--force-bottle") || !ENV["HOMEBREW_FORCE_BOTTLE"].nil?
+    include?("--force-bottle")
   end
 
   def fetch_head?

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -54,8 +54,20 @@ module Utils
             MacOS::Version.from_symbol(later_tag) <= tag_version
           elsif ARGV.force_bottle?
             true
+          # Allow prerelease versions to act as if all bottles are `_or_later`
+          # so that they don't need to wait for us to bottle everything for the
+          # new release.
+          elsif install_older_prerelease_bottles?
+            true
           end
         end
+      end
+
+      def install_older_prerelease_bottles?
+        return false unless OS::Mac.prerelease?
+        return true if ENV["HOMEBREW_INSTALL_OLDER_PRERELEASE_BOTTLES"]
+        return false if ENV["HOMEBREW_NO_INSTALL_OLDER_PRERELEASE_BOTTLES"]
+        !ARGV.homebrew_developer?
       end
     end
   end

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -170,12 +170,6 @@ Note that environment variables must have a value set to be detected. For exampl
     directories. TextMate can handle this correctly in project mode, but many
     editors will do strange things in this case.
 
-  * `HOMEBREW_FORCE_BOTTLE`:
-    If set, Homebrew will install from a bottle if it exists for the
-    current or newest version of macOS, even if it would not normally be used
-    for installation. Please do not file issues if you encounter errors when
-    using this environment variable.
-
   * `HOMEBREW_FORCE_BREWED_CURL`:
     If set, Homebrew will use a Homebrew-installed `curl` rather than the
     system version.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1170,12 +1170,6 @@ Note that environment variables must have a value set to be detected. For exampl
     directories. TextMate can handle this correctly in project mode, but many
     editors will do strange things in this case.
 
-  * `HOMEBREW_FORCE_BOTTLE`:
-    If set, Homebrew will install from a bottle if it exists for the
-    current or newest version of macOS, even if it would not normally be used
-    for installation. Please do not file issues if you encounter errors when
-    using this environment variable.
-
   * `HOMEBREW_FORCE_BREWED_CURL`:
     If set, Homebrew will use a Homebrew-installed `curl` rather than the
     system version.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1112,10 +1112,6 @@ If set, Homebrew will use this editor when editing a single formula, or several 
 \fINote:\fR \fBbrew edit\fR will open all of Homebrew as discontinuous files and directories\. TextMate can handle this correctly in project mode, but many editors will do strange things in this case\.
 .
 .TP
-\fBHOMEBREW_FORCE_BOTTLE\fR
-If set, Homebrew will install from a bottle if it exists for the current or newest version of macOS, even if it would not normally be used for installation\. Please do not file issues if you encounter errors when using this environment variable\.
-.
-.TP
 \fBHOMEBREW_FORCE_BREWED_CURL\fR
 If set, Homebrew will use a Homebrew\-installed \fBcurl\fR rather than the system version\.
 .


### PR DESCRIPTION
Rather than relying on a `HOMEBREW_FORCE_BOTTLE` variable (which ends up doing silly things like forcing bottle usage even when options are provided) instead handle this at the `or_later` bottle detection level so on prerelease versions of macOS any bottle looks like an `or_later` bottle (unless various environment variables are set).

Fixes issues noted in https://github.com/Homebrew/brew/pull/4520#issuecomment-407229605

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----