### PR TITLE
utils/github: remove full stop from the "skipping" comment

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -308,7 +308,7 @@ module GitHub
     url = "#{API_URL}/repos/#{user}/#{repo}/issues/#{pr}/comments"
     data = { "body" => body }
     if issue_comment_exists?(user, repo, pr, body)
-      ohai "Skipping: identical comment exists on #{PR_ENV}."
+      ohai "Skipping: identical comment exists on #{PR_ENV}"
       return true
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Removing the full stop makes the link clickable.

https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/27901/version=high_sierra/testReport/junit/brew-test-bot/high_sierra/audit_minikube___online___new_formula/
```
==> Skipping: identical comment exists on https://github.com/Homebrew/homebrew-core/pull/28227.
```