### PR TITLE
Make `HOMEBREW_TAP_PATH_REGEX` also match exact path.

### DIFF
--- a/Library/Homebrew/tap_constants.rb
+++ b/Library/Homebrew/tap_constants.rb
@@ -5,6 +5,6 @@ HOMEBREW_TAP_CASK_REGEX = %r{^([\w-]+)/([\w-]+)/([a-z0-9\-]+)$}
 # match taps' directory paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap
 HOMEBREW_TAP_DIR_REGEX = %r{#{Regexp.escape(HOMEBREW_LIBRARY)}/Taps/(?<user>[\w-]+)/(?<repo>[\w-]+)}
 # match taps' formula paths, e.g. HOMEBREW_LIBRARY/Taps/someuser/sometap/someformula
-HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{/(.*)}.source)
+HOMEBREW_TAP_PATH_REGEX = Regexp.new(HOMEBREW_TAP_DIR_REGEX.source + %r{(?:/.*)?$}.source)
 # match official taps' casks, e.g. homebrew/cask/somecask or homebrew/cask-versions/somecask
 HOMEBREW_CASK_TAP_CASK_REGEX = %r{^(?:([Cc]askroom)/(cask|versions)|(homebrew)/(cask|cask-[\w-]+))/([\w+-.]+)$}

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -82,6 +82,20 @@ describe Tap do
     end
   end
 
+  describe "::from_path" do
+    let(:tap) { described_class.fetch("Homebrew", "core") }
+    let(:path) { tap.path }
+    let(:formula_path) { path/"Formula/formula.rb" }
+
+    it "returns the Tap for a Formula path" do
+      expect(described_class.from_path(formula_path)).to eq tap
+    end
+
+    it "returns the Tap when given its exact path" do
+      expect(described_class.from_path(path)).to eq tap
+    end
+  end
+
   specify "::names" do
     expect(described_class.names.sort).to eq(["homebrew/core", "homebrew/foo"])
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

This way `Tap::from_path` also works for the exact path of a tap.