### PR TITLE
Don’t rescue `NameError` for `#run`.

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/cli.rb
+++ b/Library/Homebrew/cask/lib/hbc/cli.rb
@@ -103,12 +103,14 @@ module Hbc
       if external_ruby_cmd
         require external_ruby_cmd
 
-        begin
-          return const_get(command.to_s.capitalize.to_sym)&.run(*args)
+        klass = begin
+          const_get(command.to_s.capitalize.to_sym)
         rescue NameError
           # External command is a stand-alone Ruby script.
           return
         end
+
+        return klass.run(*args)
       end
 
       if external_command = which("brewcask-#{command}", path)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Only a `NameError` from `const_get` should be rescued, not one occurring in `#run`.
