### PR TITLE
Tweak code coverage logic

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -50,8 +50,8 @@ SimpleCov.start do
 
   require "rbconfig"
   host_os = RbConfig::CONFIG["host_os"]
-  add_filter %r{^/os/mac/} if host_os !~ /darwin/
-  add_filter %r{^/os/linux/} if host_os !~ /linux/
+  add_filter %r{/os/mac} if host_os !~ /darwin/
+  add_filter %r{/os/linux} if host_os !~ /linux/
 
   # Add groups and the proper project name to the output.
   project_name "Homebrew"

--- a/Library/Homebrew/test/.codecov.yml
+++ b/Library/Homebrew/test/.codecov.yml
@@ -1,4 +1,8 @@
 comment: off
-
 fixes:
   - "::Library/Homebrew/"
+coverage:
+  status:
+    project:
+    default:
+        threshold: 0.1


### PR DESCRIPTION
- make OS detection looser to exclude more Linux files on macOS (and vice versa)
- Allow slight (0.5%) coverage drops to account for somewhat random   fluctuations.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----