### PR TITLE
Adjusting SVN commands to consider the @ symbol

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -585,7 +585,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
       args << url
       args << target
     elsif svncommand == "update"
-      args << svn_escape(target.to_s)
+      args << svn_escape(target)
     end
     if revision
       ohai "Checking out #{@ref}"

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -571,8 +571,8 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     # the commands are affected as follows:
     #   svn checkout url1 foo@a   # properly checks out url1 to foo@a
     #   svn switch url2 foo@a     # properly switchs foo@a to url2
-    #   svn update foo@a@         # properly updates foo@a 
-    #   svn info foo@a@           # properly obtains info on foo@a 
+    #   svn update foo@a@         # properly updates foo@a
+    #   svn info foo@a@           # properly obtains info on foo@a
     #   svn export foo@a@ newdir  # properly export foo@a contents to newdir
     result = svn_url.to_s.dup
     result << "@" if result.include? "@"
@@ -583,7 +583,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     escape(cached_location)
   end
 
-  def repo_url    
+  def repo_url
     Utils.popen_read("svn", "info", svn_cached_location).strip[/^URL: (.+)$/, 1]
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -554,19 +554,19 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
   end
 
   def source_modified_time
-    info = system_command("svn", args:["info", "--xml"], chdir: cached_location.to_s).stdout
+    info = system_command("svn", args: ["info", "--xml"], chdir: cached_location.to_s).stdout
     xml = REXML::Document.new(info)
     Time.parse REXML::XPath.first(xml, "//date/text()").to_s
   end
 
   def last_commit
-    system_command("svn", args:["info", "--show-item", "revision"], chdir: cached_location.to_s).stdout.strip
+    system_command("svn", args: ["info", "--show-item", "revision"], chdir: cached_location.to_s).stdout.strip
   end
 
   private
 
   def repo_url
-    system_command("svn", args:["info"], chdir: cached_location.to_s).stdout.strip[/^URL: (.+)$/, 1]
+    system_command("svn", args: ["info"], chdir: cached_location.to_s).stdout.strip[/^URL: (.+)$/, 1]
   end
 
   def externals

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -580,16 +580,16 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     # Use "svn update" when the repository already exists locally.
     # This saves on bandwidth and will have a similar effect to verifying the
     # cache as it will make any changes to get the right revision.
-    args = target.directory? ? ["update"] : ["checkout", url, target]
+    args = []
     if revision
       ohai "Checking out #{@ref}"
       args << "-r" << revision
     end
     args << "--ignore-externals" if ignore_externals
-    if args[0] == "update"
-      system_command("svn", args: args, chdir: target.to_s)
+    if target.directory?
+      system_command("svn", args: ["update", *args], chdir: target.to_s)
     else
-      system_command("svn", args: args)
+      system_command("svn", args: ["checkout", url, target, *args])
     end
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -131,7 +131,7 @@ class VCSDownloadStrategy < AbstractDownloadStrategy
   end
 
   def cached_location
-    @clone    
+    @clone
   end
 
   delegate head?: :version

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -580,17 +580,17 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     # Use "svn update" when the repository already exists locally.
     # This saves on bandwidth and will have a similar effect to verifying the
     # cache as it will make any changes to get the right revision.
-    args = if target.directory?
-      ["cd", target.to_s, ";", "svn", "update"]
-    else
-      ["svn", "checkout", url, target]
-    end
+    args = target.directory? ? ["update"] : ["checkout", url, target]
     if revision
       ohai "Checking out #{@ref}"
       args << "-r" << revision
     end
     args << "--ignore-externals" if ignore_externals
-    safe_system(*args)
+    if args[0] == "update"
+      system_command("svn", args: args, chdir: target.to_s)
+    else
+      system_command("svn", args: args)
+    end
   end
 
   def cache_tag

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -579,13 +579,10 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     # Use "svn update" when the repository already exists locally.
     # This saves on bandwidth and will have a similar effect to verifying the
     # cache as it will make any changes to get the right revision.
-    svncommand = target.directory? ? "update" : "checkout"
-    args = ["svn", svncommand]
-    if svncommand == "checkout"
-      args << url
-      args << target
-    elsif svncommand == "update"
-      args << svn_escape(target)
+    args = if target.directory?
+      ["svn", "update", svn_escape(target)]
+    else
+      ["svn", "checkout", url, target]
     end
     if revision
       ohai "Checking out #{@ref}"

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -1,20 +1,5 @@
 require_relative "directory"
 
-def svn_escape(svn_path)
-  # subversion uses '@' to point to a specific revision
-  # so when the path contains a @, it requires an additional @ at the end
-  # but this is not consistent through all commands
-  # the commands are affected as follows:
-  #   svn checkout url1 foo@a   # properly checks out url1 to foo@a
-  #   svn switch url2 foo@a     # properly switchs foo@a to url2
-  #   svn update foo@a@         # properly updates foo@a
-  #   svn info foo@a@           # properly obtains info on foo@a
-  #   svn export foo@a@ newdir  # properly export foo@a contents to newdir
-  result = svn_path.to_s.dup
-  result << "@" if result.include? "@"
-  result
-end
-
 module UnpackStrategy
   class Subversion < Directory
     def self.can_extract?(path:, magic_number:)
@@ -24,7 +9,9 @@ module UnpackStrategy
     private
 
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      system_command! "svn", args: ["export", "--force", svn_escape(path), unpack_dir]
+      system_command! "svn", 
+                      args: ["export", "--force", ".", unpack_dir],
+                      chdir: path.to_s
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -9,7 +9,7 @@ module UnpackStrategy
     private
 
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      system_command! "svn", 
+      system_command! "svn",
                       args: ["export", "--force", ".", unpack_dir],
                       chdir: path.to_s
     end

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -24,8 +24,7 @@ module UnpackStrategy
     private
 
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      path_export = svn_escape(path.to_s)
-      system_command! "svn", args: ["export", "--force", path_export, unpack_dir]
+      system_command! "svn", args: ["export", "--force", svn_escape(path), unpack_dir]
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -9,7 +9,9 @@ module UnpackStrategy
     private
 
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      system_command! "svn", args: ["export", "--force", path, unpack_dir]
+      path_export = path.to_s
+      path_export << "@" if path_export.include? "@"
+      system_command! "svn", args: ["export", "--force", path_export, unpack_dir]
     end
   end
 end

--- a/Library/Homebrew/unpack_strategy/subversion.rb
+++ b/Library/Homebrew/unpack_strategy/subversion.rb
@@ -1,5 +1,20 @@
 require_relative "directory"
 
+def svn_escape(svn_path)
+  # subversion uses '@' to point to a specific revision
+  # so when the path contains a @, it requires an additional @ at the end
+  # but this is not consistent through all commands
+  # the commands are affected as follows:
+  #   svn checkout url1 foo@a   # properly checks out url1 to foo@a
+  #   svn switch url2 foo@a     # properly switchs foo@a to url2
+  #   svn update foo@a@         # properly updates foo@a
+  #   svn info foo@a@           # properly obtains info on foo@a
+  #   svn export foo@a@ newdir  # properly export foo@a contents to newdir
+  result = svn_path.to_s.dup
+  result << "@" if result.include? "@"
+  result
+end
+
 module UnpackStrategy
   class Subversion < Directory
     def self.can_extract?(path:, magic_number:)
@@ -9,8 +24,7 @@ module UnpackStrategy
     private
 
     def extract_to_dir(unpack_dir, basename:, verbose:)
-      path_export = path.to_s
-      path_export << "@" if path_export.include? "@"
+      path_export = svn_escape(path.to_s)
       system_command! "svn", args: ["export", "--force", path_export, unpack_dir]
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

### Details

This is another approach to solve problem presented by the #4358 PR.

Subversion uses '@' to point to a specific revision, so when creating formulas with an @ symbol, the local svn path inherits that character and Subversion gets confused.

Basically, an [additional @ at the end solves it](https://stackoverflow.com/a/757510/796963). So no need to change the paths, it's justing changing the commands.

However, this is not consistent through all commands. The commands are affected as follows:

```
svn checkout url1 foo@a   # properly checks out url1 to foo@a
svn switch url2 foo@a     # properly switchs foo@a to url2
svn update foo@a@         # properly updates foo@a 
svn info foo@a@           # properly obtains info on foo@a 
svn export foo@a@ newdir  # properly export foo@a contents to newdir
```

As previously discussed in the #4358 PR, this approach:
 - affects only SVN resources;
 - doesn't change current path used for svn repositories
 - it's expected to NOT interfere with cleanup or mirror

```brew style``` is OK with my changes, but there were warnings unrelated to this PR.

### Disclaimer

I kindly request **special attention** reviewing this PR, as my ruby experience is equal to 28 lines of code (this PR). :)
