### PR TITLE
link: when refusing to link display keg only caveats instead.

### DIFF
--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -37,7 +37,9 @@ module Homebrew
     if shell.nil?
       dump_build_env ENV
     else
-      env_keys.each { |key| puts Utils::Shell.export_value(shell, key, ENV[key]) }
+      env_keys.each do |key|
+        puts Utils::Shell.export_value(key, ENV[key], shell)
+      end
     end
   end
 end

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -13,6 +13,7 @@
 #:    If `--force` (or `-f`) is passed, Homebrew will allow keg-only formulae to be linked.
 
 require "ostruct"
+require "caveats"
 
 module Homebrew
   module_function
@@ -52,14 +53,16 @@ module Homebrew
 
       if keg_only
         if HOMEBREW_PREFIX.to_s == "/usr/local"
-          if keg.to_formula.keg_only_reason.reason == :provided_by_macos &&
+          f = keg.to_formula
+          caveats = Caveats.new(f)
+
+          if f.keg_only_reason.reason == :provided_by_macos &&
              (MacOS.version >= :mojave ||
               MacOS::Xcode.version >= "10.0" ||
               MacOS::CLT.version >= "10.0")
             opoo <<~EOS
               Refusing to link macOS-provided software: #{keg.name}
-              Instead, pass the full include/library paths to your compiler e.g.:
-                -I#{HOMEBREW_PREFIX}/opt/#{keg.name}/include -L#{HOMEBREW_PREFIX}/opt/#{keg.name}/lib
+              #{caveats.keg_only_text(skip_reason: true).strip}
             EOS
             next
           end
@@ -69,8 +72,7 @@ module Homebrew
               Refusing to link: #{keg.name}
               Linking keg-only #{keg.name} means you may end up linking against the insecure,
               deprecated system OpenSSL while using the headers from Homebrew's #{keg.name}.
-              Instead, pass the full include/library paths to your compiler e.g.:
-                -I#{HOMEBREW_PREFIX}/opt/#{keg.name}/include -L#{HOMEBREW_PREFIX}/opt/#{keg.name}/lib
+              #{caveats.keg_only_text(skip_reason: true).strip}
             EOS
             next
           end

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -21,7 +21,7 @@ module Utils
     end
 
     # quote values. quoting keys is overkill
-    def export_value(shell, key, value)
+    def export_value(key, value, shell = preferred)
       case shell
       when :bash, :ksh, :sh, :zsh
         "export #{key}=\"#{sh_quote(value)}\""


### PR DESCRIPTION
These are a bit easier to follow and have been recently improved.

Inspired by conversation in #4441  CC @DomT4 @billinghamj

Also:

- caveats: tweak keg_only_text
  - make it a public method
  - allow skipping the reason
  - output how to set the various variables in your current shell
- shell: tweak export_value parameters.
  - Let’s have a default value for shell (considering this isn’t a public API)
to make it easier to use.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----