### PR TITLE
formula: handle unavailable versioned formulae.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -385,8 +385,12 @@ class Formula
     return [] if versioned_formula?
 
     Pathname.glob(path.to_s.gsub(/\.rb$/, "@*.rb")).map do |path|
-      Formula[path.basename(".rb").to_s]
-    end.sort
+      begin
+        Formula[path.basename(".rb").to_s]
+      rescue FormulaUnavailableError
+        nil
+      end
+    end.compact.sort
   end
 
   # A named Resource for the currently active {SoftwareSpec}.


### PR DESCRIPTION
If people decide to copy these into their Homebrew/homebrew-core `Formula` directory then it breaks generating the hash for any non-versioned formulae.

See https://github.com/Homebrew/homebrew-bundle/issues/351

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----