### PR TITLE
Fix for Linux make shim

### DIFF
--- a/Library/Homebrew/shims/linux/super/make
+++ b/Library/Homebrew/shims/linux/super/make
@@ -16,7 +16,7 @@ then
 else
   SAVED_PATH="$PATH"
   pathremove "$HOMEBREW_LIBRARY/Homebrew/shims/linux/super"
-  export MAKE="$(command -v make)"
+  export MAKE="$(which make)"
   export PATH="$SAVED_PATH"
 fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `make` shim for Linux had a bug in that it was removing `Library/Homebrew/shims/linux/super` directory from `PATH` for the duration of execution of `make`. This caused some undesired results. 

Here, I moved the code that removes `$HOMEBREW_LIBRARY/Homebrew/shims/linux/super` directory from PATH to within the `if/else` clause to emphasize the fact that we have to do it only to detect the "real" `make` executable.

Props for identifying the issue go to @xu-cheng!
