### PR TITLE
Use `ditto` instead of `unzip`.

### DIFF
--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -1,0 +1,9 @@
+module UnpackStrategy
+  class Zip
+    def extract_to_dir(unpack_dir, basename:, verbose:)
+      # `ditto` keeps Finder attributes intact and does not skip volume labels
+      # like `unzip` does, which can prevent disk images from being unzipped.
+      system_command! "ditto", args: ["-x", "-k", path, unpack_dir]
+    end
+  end
+end

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -14,3 +14,5 @@ module UnpackStrategy
     end
   end
 end
+
+require "extend/os/mac/unpack_strategy/zip" if OS.mac?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

There had to be a reason we were using `ditto` before, here it is:

https://github.com/Homebrew/homebrew-cask-drivers/pull/453.