### PR TITLE
Don’t truncate headlines.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -548,8 +548,7 @@ class FormulaInstaller
     if deps.empty? && only_deps?
       puts "All dependencies for #{formula.full_name} are satisfied."
     elsif !deps.empty?
-      oh1 "Installing dependencies for #{formula.full_name}: #{deps.map(&:first).map(&Formatter.method(:identifier)).join(", ")}",
-        truncate: false
+      oh1 "Installing dependencies for #{formula.full_name}: #{deps.map(&:first).map(&Formatter.method(:identifier)).join(", ")}"
       deps.each { |dep, options| install_dependency(dep, options) }
     end
 

--- a/Library/Homebrew/test/utils/tty_spec.rb
+++ b/Library/Homebrew/test/utils/tty_spec.rb
@@ -15,20 +15,6 @@ describe Tty do
     end
   end
 
-  describe "::truncate" do
-    it "truncates the text to the terminal width, minus 4, to account for '==> '" do
-      allow(subject).to receive(:width).and_return(15)
-
-      expect(subject.truncate("foobar something very long")).to eq("foobar some")
-      expect(subject.truncate("truncate")).to eq("truncate")
-    end
-
-    it "doesn't truncate the text if the terminal is unsupported, i.e. the width is 0" do
-      allow(subject).to receive(:width).and_return(0)
-      expect(subject.truncate("foobar something very long")).to eq("foobar something very long")
-    end
-  end
-
   context "when $stdout is not a TTY" do
     before do
       allow($stdout).to receive(:tty?).and_return(false)

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -23,7 +23,6 @@ rescue LoadError => e
 end
 
 def ohai(title, *sput)
-  title = Tty.truncate(title) if $stdout.tty? && !ARGV.verbose?
   puts Formatter.headline(title, color: :blue)
   puts sput
 end
@@ -31,13 +30,10 @@ end
 def odebug(title, *sput)
   return unless ARGV.debug?
   puts Formatter.headline(title, color: :magenta)
-  puts sput unless sput.empty?
+  puts sput
 end
 
-def oh1(title, options = {})
-  if $stdout.tty? && !ARGV.verbose? && options.fetch(:truncate, :auto) == :auto
-    title = Tty.truncate(title)
-  end
+def oh1(title)
   puts Formatter.headline(title, color: :green)
 end
 

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -14,10 +14,6 @@ module Tty
     end
   end
 
-  def truncate(string)
-    (w = width).zero? ? string.to_s : string.to_s[0, w - 4]
-  end
-
   COLOR_CODES = {
     red: 31,
     green: 32,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I never understood why this is a thing. We only do this for headlines, which are supposed to be short to begin with, and if they are not, it is probably because they contain a URL, which should still always be visible in full.