### PR TITLE
Merge `curl` options used by casks into download strategies.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1,4 +1,3 @@
-require "cgi"
 require "json"
 require "rexml/document"
 require "time"
@@ -268,7 +267,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     args = []
 
     if meta.key?(:cookies)
-      escape_cookie = ->(k, v) { "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }
+      escape_cookie = ->(cookie) { URI.encode_www_form([cookie]) }
       args += ["-b", meta.fetch(:cookies).map(&escape_cookie).join(";")]
     end
 
@@ -343,7 +342,7 @@ end
 class CurlPostDownloadStrategy < CurlDownloadStrategy
   def _fetch
     base_url, data = if meta.key?(:data)
-      escape_data = ->(k, v) { ["-d", "#{CGI.escape(k.to_s)}=#{CGI.escape(v.to_s)}"] }
+      escape_data = ->(d) { ["-d", URI.encode_www_form([d])] }
       [@url, meta[:data].flat_map(&escape_data)]
     else
       @url.split("?", 2)

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -239,7 +239,7 @@ describe CurlDownloadStrategy do
   let(:resource) { double(Resource, url: url, mirrors: [], specs: { user: "download:123456" }) }
 
   it "parses the opts and sets the corresponding args" do
-    expect(subject.send(:_curl_opts)).to eq(["--user", "download:123456"])
+    expect(subject.send(:_curl_args)).to eq(["--user", "download:123456"])
   end
 
   describe "#tarball_path" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add `curl` options from cask download strategy to `CurlDownloadStrategy`.