### PR TITLE
Move `temporary_path` to `AbstractFileDownloadStrategy`.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -176,9 +176,12 @@ class VCSDownloadStrategy < AbstractDownloadStrategy
 end
 
 class AbstractFileDownloadStrategy < AbstractDownloadStrategy
+  attr_reader :temporary_path
+
   def initialize(url, name, version, **meta)
     super
     @cached_location = HOMEBREW_CACHE/"#{name}-#{version}#{ext}"
+    @temporary_path = Pathname.new("#{cached_location}.incomplete")
   end
 
   def stage
@@ -203,12 +206,11 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
 end
 
 class CurlDownloadStrategy < AbstractFileDownloadStrategy
-  attr_reader :mirrors, :temporary_path
+  attr_reader :mirrors
 
   def initialize(url, name, version, **meta)
     super
     @mirrors = meta.fetch(:mirrors, [])
-    @temporary_path = Pathname.new("#{cached_location}.incomplete")
   end
 
   def fetch
@@ -507,12 +509,8 @@ end
 #     url "scp://example.com/src/abc.1.0.tar.gz"
 #     ...
 class ScpDownloadStrategy < AbstractFileDownloadStrategy
-  attr_reader :temporary_path
-
   def initialize(url, name, version, **meta)
     super
-    @cached_location = HOMEBREW_CACHE/"#{name}-#{version}#{ext}"
-    @temporary_path = Pathname.new("#{cached_location}.incomplete")
     parse_url_pattern
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

----

DRY up `temporary_path` in download strategies.