### PR TITLE
linkage: test all kegs if none are specified

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -1,5 +1,5 @@
-#:  * `linkage` [`--test`] [`--reverse`] <formula>:
-#:    Checks the library links of an installed formula.
+#:  * `linkage` [`--test`] [`--reverse`] [<formulae>]:
+#:    Checks the library links of installed formulae.
 #:
 #:    Only works on installed formulae. An error is raised if it is run on
 #:    uninstalled formulae.
@@ -9,6 +9,8 @@
 #:
 #:    If `--reverse` is passed, print the dylib followed by the binaries
 #:    which link to it for each library the keg references.
+#:
+#:    If <formulae> are given, check linkage for only the specified brews.
 
 require "cache_store"
 require "linkage_checker"
@@ -26,8 +28,13 @@ module Homebrew
     end
 
     CacheStoreDatabase.use(:linkage) do |db|
-      ARGV.kegs.each do |keg|
-        ohai "Checking #{keg.name} linkage" if ARGV.kegs.size > 1
+      kegs = if ARGV.kegs.empty?
+        Formula.installed.collect(&:opt_or_installed_prefix_keg).reject(&:nil?)
+      else
+        ARGV.kegs
+      end
+      kegs.each do |keg|
+        ohai "Checking #{keg.name} linkage" if kegs.size > 1
 
         result = LinkageChecker.new(keg, cache_db: db)
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -799,8 +799,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--pry` is passed or HOMEBREW_PRY is set, pry will be
     used instead of irb.
 
-  * `linkage` [`--test`] [`--reverse`] `formula`:
-    Checks the library links of an installed formula.
+  * `linkage` [`--test`] [`--reverse`] [`formulae`]:
+    Checks the library links of installed formulae.
 
     Only works on installed formulae. An error is raised if it is run on
     uninstalled formulae.
@@ -810,6 +810,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--reverse` is passed, print the dylib followed by the binaries
     which link to it for each library the keg references.
+
+    If `formulae` are given, check linkage for only the specified brews.
 
   * `man` [`--fail-if-changed`]:
     Generate Homebrew's manpages.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -738,8 +738,8 @@ Enter the interactive Homebrew Ruby shell\.
 If \fB\-\-examples\fR is passed, several examples will be shown\. If \fB\-\-pry\fR is passed or HOMEBREW_PRY is set, pry will be used instead of irb\.
 .
 .TP
-\fBlinkage\fR [\fB\-\-test\fR] [\fB\-\-reverse\fR] \fIformula\fR
-Checks the library links of an installed formula\.
+\fBlinkage\fR [\fB\-\-test\fR] [\fB\-\-reverse\fR] [\fIformulae\fR]
+Checks the library links of installed formulae\.
 .
 .IP
 Only works on installed formulae\. An error is raised if it is run on uninstalled formulae\.
@@ -749,6 +749,9 @@ If \fB\-\-test\fR is passed, only display missing libraries and exit with a non\
 .
 .IP
 If \fB\-\-reverse\fR is passed, print the dylib followed by the binaries which link to it for each library the keg references\.
+.
+.IP
+If \fIformulae\fR are given, check linkage for only the specified brews\.
 .
 .TP
 \fBman\fR [\fB\-\-fail\-if\-changed\fR]


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

After upgrading python and seeing my macvim broken, I was wondering if anything else had broken linkage. This change allows you to check the linkage of all installed kegs by calling `brew linkage`, similar to how `brew upgrade` will attempt to upgrade everything. I'd like the output to be a little less verbose, but I didn't want to deal with refactoring the `linkage_check` display code at this point.