### PR TITLE
Only use `ditto` to extract skipped volumes.

### DIFF
--- a/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
+++ b/Library/Homebrew/extend/os/mac/unpack_strategy/zip.rb
@@ -1,9 +1,28 @@
 module UnpackStrategy
   class Zip
-    def extract_to_dir(unpack_dir, basename:, verbose:)
-      # `ditto` keeps Finder attributes intact and does not skip volume labels
-      # like `unzip` does, which can prevent disk images from being unzipped.
-      system_command! "ditto", args: ["-x", "-k", path, unpack_dir]
-    end
+    prepend Module.new {
+      def extract_to_dir(unpack_dir, basename:, verbose:)
+        volumes = super.stderr.chomp
+                       .split("\n")
+                       .map { |l| l[/\A   skipping: (.+)  volume label\Z/, 1] }
+                       .compact
+
+        return if volumes.empty?
+
+        Dir.mktmpdir do |tmp_unpack_dir|
+          tmp_unpack_dir = Pathname(tmp_unpack_dir)
+
+          # `ditto` keeps Finder attributes intact and does not skip volume labels
+          # like `unzip` does, which can prevent disk images from being unzipped.
+          system_command! "ditto",
+                          args: ["-x", "-k", path, tmp_unpack_dir],
+                          verbose: verbose
+
+          volumes.each do |volume|
+            FileUtils.mv tmp_unpack_dir/volume, unpack_dir/volume, verbose: verbose
+          end
+        end
+      end
+    }
   end
 end

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -18,7 +18,8 @@ module UnpackStrategy
       quiet_flags = verbose ? [] : ["-qq"]
       system_command! "unzip",
                       args: [*quiet_flags, path, "-d", unpack_dir],
-                      verbose: verbose
+                      verbose: verbose,
+                      print_stderr: false
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Prevents a weird issue where `ditto` does not preserve permissions. Limit the usage of `ditto` to only where a volume label was skipped.