### PR TITLE
class_cop: tighten test audit

### DIFF
--- a/Library/Homebrew/rubocops/class_cop.rb
+++ b/Library/Homebrew/rubocops/class_cop.rb
@@ -25,13 +25,24 @@ module RuboCop
     end
 
     module FormulaAuditStrict
-      # - `test do ..end` should be defined in the formula
+      # - `test do ..end` should be meaningfully defined in the formula
       class Test < FormulaCop
-        MSG = "A `test do` test block should be added".freeze
-
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          return if find_block(body_node, :test)
-          problem MSG
+          test = find_block(body_node, :test)
+
+          unless test
+            problem "A `test do` test block should be added"
+            return
+          end
+
+          if test.body.nil?
+            problem "`test do` should not be empty"
+            return
+          end
+
+          return unless test.body.single_line? &&
+                        test.body.source.to_s == "true"
+          problem "`test do` should contain a real test"
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/class_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/class_cop_spec.rb
@@ -59,4 +59,29 @@ describe RuboCop::Cop::FormulaAuditStrict::Test do
       end
     RUBY
   end
+
+  it "reports an offense when there is an empty test block" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url 'https://example.com/foo-1.0.tgz'
+
+        test do
+        ^^^^^^^ `test do` should not be empty
+        end
+      end
+    RUBY
+  end
+
+  it "reports an offense when test is falsely true" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url 'https://example.com/foo-1.0.tgz'
+
+        test do
+        ^^^^^^^ `test do` should contain a real test
+          true
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is probably fighting a losing battle but people are definitely taking
```
A `test do` test block should be added
```
_a little too literally_ in the process of being able to tick the box on core PRs to say the formula passes the strict audit. This clamps down on two of the more popular loopholes that work without breaking `brew test` itself.

It's possible/likely the Rubocop syntax here isn't perfect; I don't especially enjoy trying to wrap my head around Rubocop, no matter how often I end up doing so for one reason or another. Comments on syntax welcome as desired.