### PR TITLE
Fix Bottle::Filename.new for taps

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -252,7 +252,7 @@ class Bottle
     end
 
     def initialize(name, version, tag, rebuild)
-      @name = name
+      @name = File.basename name
       @version = version
       @tag = tag.to_s.gsub(/_or_later$/, "")
       @rebuild = rebuild

--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -4,7 +4,7 @@ require "software_spec"
 describe Bottle::Filename do
   subject { described_class.new(name, version, tag, rebuild) }
 
-  let(:name) { "foo" }
+  let(:name) { "user/repo/foo" }
   let(:version) { "1.0" }
   let(:tag) { :tag }
   let(:rebuild) { 0 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The file name of a bottle should not include the tap.

This fix is particularly for this caller, though there may be others.
https://github.com/Homebrew/homebrew-test-bot/blob/3e0ffa13d47c23546cd98734ecc557ccda661bb3/cmd/brew-test-bot.rb#L1424

```ruby
filename = Bottle::Filename.new(formula_name, version, tag, rebuild)
```

`formula_name` is the full formula name, including tap.