### PR TITLE
Mac.sdk_path_if_needed tests: stub SDK check

### DIFF
--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -39,6 +39,7 @@ describe OS::Mac do
     it "does not call sdk_path on CLT-only systems with no CLT SDK" do
       allow(OS::Mac::Xcode).to receive(:installed?) { false }
       allow(OS::Mac::CLT).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:provides_sdk?) { false }
       expect(OS::Mac).not_to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed
     end
@@ -46,6 +47,7 @@ describe OS::Mac do
     it "does not call sdk_path on CLT-only systems with a CLT SDK if the system provides headers" do
       allow(OS::Mac::Xcode).to receive(:installed?) { false }
       allow(OS::Mac::CLT).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:provides_sdk?) { true }
       allow(OS::Mac::CLT).to receive(:separate_header_package?) { false }
       expect(OS::Mac).not_to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed
@@ -54,6 +56,7 @@ describe OS::Mac do
     it "calls sdk_path on CLT-only systems with a CLT SDK if the system does not provide headers" do
       allow(OS::Mac::Xcode).to receive(:installed?) { false }
       allow(OS::Mac::CLT).to receive(:installed?) { true }
+      allow(OS::Mac::CLT).to receive(:provides_sdk?) { true }
       allow(OS::Mac::CLT).to receive(:separate_header_package?) { true }
       expect(OS::Mac).to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed

--- a/Library/Homebrew/test/os/mac_spec.rb
+++ b/Library/Homebrew/test/os/mac_spec.rb
@@ -22,42 +22,42 @@ describe OS::Mac do
 
   describe "::sdk_path_if_needed" do
     it "calls sdk_path on Xcode-only systems" do
-      allow(OS::Mac::Xcode).to receive(:installed?) { true }
-      allow(OS::Mac::CLT).to receive(:installed?) { false }
+      allow(OS::Mac::Xcode).to receive(:installed?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:installed?).and_return(false)
       expect(OS::Mac).to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed
     end
 
     it "does not call sdk_path on Xcode-and-CLT systems with system headers" do
-      allow(OS::Mac::Xcode).to receive(:installed?) { true }
-      allow(OS::Mac::CLT).to receive(:installed?) { true }
-      allow(OS::Mac::CLT).to receive(:separate_header_package?) { false }
+      allow(OS::Mac::Xcode).to receive(:installed?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:installed?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:separate_header_package?).and_return(false)
       expect(OS::Mac).not_to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed
     end
 
     it "does not call sdk_path on CLT-only systems with no CLT SDK" do
-      allow(OS::Mac::Xcode).to receive(:installed?) { false }
-      allow(OS::Mac::CLT).to receive(:installed?) { true }
-      allow(OS::Mac::CLT).to receive(:provides_sdk?) { false }
+      allow(OS::Mac::Xcode).to receive(:installed?).and_return(false)
+      allow(OS::Mac::CLT).to receive(:installed?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:provides_sdk?).and_return(false)
       expect(OS::Mac).not_to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed
     end
 
     it "does not call sdk_path on CLT-only systems with a CLT SDK if the system provides headers" do
-      allow(OS::Mac::Xcode).to receive(:installed?) { false }
-      allow(OS::Mac::CLT).to receive(:installed?) { true }
-      allow(OS::Mac::CLT).to receive(:provides_sdk?) { true }
-      allow(OS::Mac::CLT).to receive(:separate_header_package?) { false }
+      allow(OS::Mac::Xcode).to receive(:installed?).and_return(false)
+      allow(OS::Mac::CLT).to receive(:installed?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:provides_sdk?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:separate_header_package?).and_return(false)
       expect(OS::Mac).not_to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed
     end
 
     it "calls sdk_path on CLT-only systems with a CLT SDK if the system does not provide headers" do
-      allow(OS::Mac::Xcode).to receive(:installed?) { false }
-      allow(OS::Mac::CLT).to receive(:installed?) { true }
-      allow(OS::Mac::CLT).to receive(:provides_sdk?) { true }
-      allow(OS::Mac::CLT).to receive(:separate_header_package?) { true }
+      allow(OS::Mac::Xcode).to receive(:installed?).and_return(false)
+      allow(OS::Mac::CLT).to receive(:installed?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:provides_sdk?).and_return(true)
+      allow(OS::Mac::CLT).to receive(:separate_header_package?).and_return(true)
       expect(OS::Mac).to receive(:sdk_path)
       OS::Mac.sdk_path_if_needed
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

@reitermarkus noticed that the "calls sdk_path on CLT-only systems with a CLT SDK if the system does not provide headers" test was failing on a system which was missing the CLT; I believe this is because I didn't stub `OS::Mac::CLT.provides_sdk?`. This PR adds that stub to all appropriate tests, including the one that was broken.