### PR TITLE
add new gclient_cache folder to cleanup

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -9,7 +9,7 @@ module CleanupRefinement
     end
 
     def nested_cache?
-      directory? && ["glide_home", "java_cache", "npm_cache"].include?(basename.to_s)
+      directory? && %w[glide_home java_cache npm_cache gclient_cache].include?(basename.to_s)
     end
 
     def prune?(days)

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -197,6 +197,15 @@ describe Homebrew::Cleanup do
       expect(npm_cache).not_to exist
     end
 
+    it "cleans up 'gclient_cache'" do
+      gclient_cache = (HOMEBREW_CACHE/"gclient_cache")
+      gclient_cache.mkpath
+
+      subject.cleanup_cache
+
+      expect(gclient_cache).not_to exist
+    end
+
     it "cleans up all files and directories" do
       git = (HOMEBREW_CACHE/"gist--git")
       gist = (HOMEBREW_CACHE/"gist")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In preparation for the v8 formula update in https://github.com/Homebrew/homebrew-core/pull/30961 this PR adds the newly created `HOMEBREW_CACHE/gclient_cache` folder to the `brew cleanup` `nested_cache` array. Also added a test similar to the other `nested_cache` tests.

This PR should go together with https://github.com/Homebrew/homebrew-core/pull/30961 if we finally decide to go with [option 1](https://github.com/Homebrew/homebrew-core/pull/25786#issuecomment-411109177) over there.