### PR TITLE
Allow Homebrew/brew(.git)? to ignore the case.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -616,7 +616,7 @@ module Homebrew
             properly. You can solve this by adding the Homebrew remote:
               git -C "#{HOMEBREW_REPOSITORY}" remote add origin #{Formatter.url("https://github.com/Homebrew/brew.git")}
           EOS
-        elsif origin !~ %r{Homebrew/brew(\.git|/)?$}
+        elsif origin !~ %r{Homebrew/brew(\.git|/)?$}i
           <<~EOS
             Suspicious Homebrew/brew git origin remote found.
 


### PR DESCRIPTION
When people opt to install in their home directory this can be all lowercase (as Github doesn't enforce case on their URL's for anything but file names), and this will popup as a warning, even though the repository is perfectly valid.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----