### PR TITLE
formula_installer: Allow build invocations without exec

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -1,8 +1,6 @@
 # This script is loaded by formula_installer as a separate process.
 # Thrown exceptions are propagated back to the parent process over a pipe
 
-old_trap = trap("INT") { exit! 130 }
-
 require "global"
 require "build_options"
 require "cxxstdlib"
@@ -22,7 +20,7 @@ class Build
     trap("INT") { exit! 130 }
 
     yield
-  rescue Exception => e
+  rescue Exception => e # rubocop:disable Lint/RescueException
     Marshal.dump(e, error_pipe) if error_pipe
     error_pipe&.close
     exit! 1

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -1,4 +1,4 @@
-# This script is loaded by formula_installer as a separate instance.
+# This script is loaded by formula_installer as a separate process.
 # Thrown exceptions are propagated back to the parent process over a pipe
 
 old_trap = trap("INT") { exit! 130 }
@@ -14,6 +14,19 @@ require "socket"
 
 class Build
   attr_reader :formula, :deps, :reqs
+
+  def self.guard_with_error_pipe
+    error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
+    error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+
+    trap("INT") { exit! 130 }
+
+    yield
+  rescue Exception => e
+    Marshal.dump(e, error_pipe) if error_pipe
+    error_pipe&.close
+    exit! 1
+  end
 
   def initialize(formula, options)
     @formula = formula
@@ -179,18 +192,13 @@ class Build
   end
 end
 
-begin
-  error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
-  error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
-
-  trap("INT", old_trap)
-
-  formula = ARGV.formulae.first
-  options = Options.create(ARGV.flags_only)
-  build   = Build.new(formula, options)
-  build.install
-rescue Exception => e # rubocop:disable Lint/RescueException
-  Marshal.dump(e, error_pipe)
-  error_pipe.close
-  exit! 1
+# If build.rb is not being called through exec(2), then
+# we expected the caller to perform this state construction.
+if ENV["HOMEBREW_NO_BUILD_EXEC"].nil?
+  Build.guard_with_error_pipe do
+    formula = ARGV.formulae.first
+    options = Options.create(ARGV.flags_only)
+    build   = Build.new(formula, options)
+    build.install
+  end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -752,6 +752,13 @@ class FormulaInstaller
         sandbox.allow_write_xcode
         sandbox.allow_write_cellar(formula)
         sandbox.exec(*args)
+      elsif ARGV.no_sandbox? && ENV["HOMEBREW_NO_BUILD_EXEC"]
+        require "#{HOMEBREW_LIBRARY_PATH}/build"
+
+        Build.guard_with_error_pipe do
+          build = Build.new(formula, Options.create(build_argv))
+          build.install
+        end
       else
         exec(*args)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When `HOMEBREW_NO_BUILD_EXEC` is set in the environment, these changes cause `FormulaInstaller` to skip the call to `exec(2)` and create a `Build` object directly. This all happens within `Utils.safe_fork`, so the only difference between this and the default fallthrough (in terms of process isolation) should be the elimination of an `exec(2)` call.

Additionally adds `Build.guard_with_error_pipe` to abstract some of the error pipe setup and checking that *build.rb* previously did at the toplevel scope.

I left the original `exec(2)` fallthrough in place since it shouldn't cause any problems, but there also shouldn't be any problems with making this new behavior the fallthrough and removing `HOMEBREW_NO_BUILD_EXEC` entirely. Let me know what you think.