### PR TITLE
audit: flag redundant shell_output() exit codes

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -803,6 +803,10 @@ module Homebrew
 
       problem "Use separate make calls" if line.include?("make && make")
 
+      if line =~ /shell_output\(['"].+['"], 0\)/
+        problem "Passing 0 to shell_output() is redundant"
+      end
+
       if line =~ /JAVA_HOME/i && !formula.requirements.map(&:class).include?(JavaRequirement)
         problem "Use `depends_on :java` to set JAVA_HOME"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Based on how much this annoys me I'm amazed I hadn't yet stomped on it with the `audit`. The time has come.