### PR TITLE
Update docs for artifact and bottle variables

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -105,7 +105,10 @@ can take several different forms:
 Note that environment variables must have a value set to be detected. For example, `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just `export HOMEBREW_NO_INSECURE_REDIRECT`.
 
   * `HOMEBREW_ARTIFACT_DOMAIN`:
-    If set, instructs Homebrew to use the given URL as a download mirror for bottles and binaries.
+    If set, instructs Homebrew to prefix all download URLs, including those
+    for bottles, with this variable. For example, a formula with a URL of
+    `https://example.com/foo.tar.gz` but `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080`
+    would instead download from `http://localhost:8080/example.com/foo.tar.gz`.
 
   * `HOMEBREW_AUTO_UPDATE_SECS`:
     If set, Homebrew will only check for autoupdates once per this seconds interval.
@@ -121,7 +124,10 @@ Note that environment variables must have a value set to be detected. For exampl
     (unsigned) URL.
 
   * `HOMEBREW_BOTTLE_DOMAIN`:
-    If set, instructs Homebrew to use the given URL as a download mirror for bottles.
+    By default, Homebrew uses `https://homebrew.bintray.com/` as its download
+    mirror for bottles. If set, instructs Homebrew to instead use the given
+    URL. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will
+    cause all bottles to download from the prefix `http://localhost:8080/`.
 
   * `HOMEBREW_BROWSER`:
     If set, uses this setting as the browser when opening project homepages,

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1108,7 +1108,10 @@ can take several different forms:
 Note that environment variables must have a value set to be detected. For example, `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just `export HOMEBREW_NO_INSECURE_REDIRECT`.
 
   * `HOMEBREW_ARTIFACT_DOMAIN`:
-    If set, instructs Homebrew to use the given URL as a download mirror for bottles and binaries.
+    If set, instructs Homebrew to prefix all download URLs, including those
+    for bottles, with this variable. For example, a formula with a URL of
+    `https://example.com/foo.tar.gz` but `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080`
+    would instead download from `http://localhost:8080/example.com/foo.tar.gz`.
 
   * `HOMEBREW_AUTO_UPDATE_SECS`:
     If set, Homebrew will only check for autoupdates once per this seconds interval.
@@ -1124,7 +1127,10 @@ Note that environment variables must have a value set to be detected. For exampl
     (unsigned) URL.
 
   * `HOMEBREW_BOTTLE_DOMAIN`:
-    If set, instructs Homebrew to use the given URL as a download mirror for bottles.
+    By default, Homebrew uses `https://homebrew.bintray.com/` as its download
+    mirror for bottles. If set, instructs Homebrew to instead use the given
+    URL. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will
+    cause all bottles to download from the prefix `http://localhost:8080/`.
 
   * `HOMEBREW_BROWSER`:
     If set, uses this setting as the browser when opening project homepages,

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1051,7 +1051,7 @@ Note that environment variables must have a value set to be detected\. For examp
 .
 .TP
 \fBHOMEBREW_ARTIFACT_DOMAIN\fR
-If set, instructs Homebrew to use the given URL as a download mirror for bottles and binaries\.
+If set, instructs Homebrew to prefix all download URLs, including those for bottles, with this variable\. For example, a formula with a URL of \fBhttps://example\.com/foo\.tar\.gz\fR but \fBHOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080\fR would instead download from \fBhttp://localhost:8080/example\.com/foo\.tar\.gz\fR\.
 .
 .TP
 \fBHOMEBREW_AUTO_UPDATE_SECS\fR
@@ -1066,7 +1066,7 @@ When using the \fBS3\fR download strategy, Homebrew will look in these variables
 .
 .TP
 \fBHOMEBREW_BOTTLE_DOMAIN\fR
-If set, instructs Homebrew to use the given URL as a download mirror for bottles\.
+By default, Homebrew uses \fBhttps://homebrew\.bintray\.com/\fR as its download mirror for bottles\. If set, instructs Homebrew to instead use the given URL\. For example, \fBHOMEBREW_BOTTLE_DOMAIN=http://localhost:8080\fR will cause all bottles to download from the prefix \fBhttp://localhost:8080/\fR\.
 .
 .TP
 \fBHOMEBREW_BROWSER\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently the manpages are very confusing about `HOMEBREW_ARTIFACT_DOMAIN` and `HOMEBREW_BOTTLE_DOMAIN`. They are described as such:

```
HOMEBREW_ARTIFACT_DOMAIN
       If set, instructs Homebrew to use the given URL as a download mirror
       for bottles and binaries.

HOMEBREW_BOTTLE_DOMAIN
       If set, instructs Homebrew to use the given URL as a download mirror
       for bottles.
```

One might be lulled into believing these variables do essentially the same thing, but this is not the case. `HOMEBREW_ARTIFACT_DOMAIN` will prepend the its value to all downloads, while `HOMEBREW_BOTTLE_DOMAIN` has the effect of setting `root_url` with its value for all bottle downloads, with no effect on source downloads.

I'm agnostic with respect to the exact wording but it definitely should be changed from what it is now.