### PR TITLE
check_non_libraries: *.so.* is a valid library

### DIFF
--- a/Library/Homebrew/extend/os/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/formula_cellar_checks.rb
@@ -1,1 +1,5 @@
-require "extend/os/mac/formula_cellar_checks" if OS.mac?
+if OS.mac?
+  require "extend/os/mac/formula_cellar_checks"
+elsif OS.linux?
+  require "extend/os/linux/formula_cellar_checks"
+end

--- a/Library/Homebrew/extend/os/linux/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/linux/formula_cellar_checks.rb
@@ -1,0 +1,5 @@
+module FormulaCellarChecks
+  def valid_library_extension?(filename)
+    generic_valid_library_extension?(filename) || filename.basename.to_s.include?(".so.")
+  end
+end

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -56,14 +56,19 @@ module FormulaCellarChecks
     EOS
   end
 
+  VALID_LIBRARY_EXTENSIONS = %w[.a .dylib .framework .jnilib .la .o .so .jar .prl .pm .sh].freeze
+
+  def valid_library_extension?(filename)
+    VALID_LIBRARY_EXTENSIONS.include? filename.extname
+  end
+  alias generic_valid_library_extension? valid_library_extension?
+
   def check_non_libraries
     return unless formula.lib.directory?
 
-    valid_extensions = %w[.a .dylib .framework .jnilib .la .o .so
-                          .jar .prl .pm .sh]
     non_libraries = formula.lib.children.reject do |g|
       next true if g.directory?
-      valid_extensions.include? g.extname
+      valid_library_extension? g
     end
     return if non_libraries.empty?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`*.so.*` is a valid library file name on Linux. This change could be made specific to Linux, but it's simpler to apply it to both platforms. The list of valid library extensions already includes `*.so` on both platforms.

https://github.com/Homebrew/brew/blob/0d81ad059dd233e2780601e0ee525dc45426657f/Library/Homebrew/formula_cellar_checks.rb#L62-L63