### PR TITLE
X11Requirement: Recent X11 client is sufficient

### DIFF
--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -27,20 +27,16 @@ class X11Requirement < Requirement
 
   satisfy build_env: false do
     if which_xorg = which("Xorg")
-      version = Utils.popen_read which_xorg, "-version", err: :out
-      next false unless $CHILD_STATUS.success?
-      version = version[/X Server (\d+\.\d+\.\d+)/, 1]
-      next false unless version
-      Version.new(version) >= min_version
-    elsif which_xdpyinfo = which("xdpyinfo")
-      version = Utils.popen_read which_xdpyinfo, "-version"
-      next false unless $CHILD_STATUS.success?
-      version = version[/^xdpyinfo (\d+\.\d+\.\d+)/, 1]
-      next false unless version
-      Version.new(version) >= min_xdpyinfo_version
-    else
-      false
+      version = Utils.popen_read(which_xorg, "-version", err: :out)[/X Server (\d+\.\d+\.\d+)/, 1]
+      next true if $CHILD_STATUS.success? && version && Version.new(version) >= min_version
     end
+
+    if which_xdpyinfo = which("xdpyinfo")
+      version = Utils.popen_read(which_xdpyinfo, "-version")[/^xdpyinfo (\d+\.\d+\.\d+)/, 1]
+      next true if $CHILD_STATUS.success? && version && Version.new(version) >= min_xdpyinfo_version
+    end
+
+    false
   end
 
   def message


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Building and running X11 programs requires sufficiently recent X11 client tools. The X11Requirement is satisfied if the X11 client tools (represented here by the version of xdpyinfo) are sufficiently recent, regarldess of the X server version (which can also change at run time by changing the DISPLAY environment variable).

On Linuxbrew, installing `linuxbrew/xorg/xorg` installs a recent version of the X11 client tools, but does not install an X server.