### PR TITLE
test/ENV: Fix prepend_path for Linuxbrew

### DIFF
--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -116,11 +116,11 @@ shared_examples EnvActivation do
 
   describe "#prepend_path" do
     it "prepends to a path" do
-      subject.prepend_path "FOO", "/usr/libexec"
-      expect(subject["FOO"]).to eq("/usr/libexec")
+      subject.prepend_path "FOO", "/usr/local"
+      expect(subject["FOO"]).to eq("/usr/local")
 
       subject.prepend_path "FOO", "/usr"
-      expect(subject["FOO"]).to eq("/usr#{File::PATH_SEPARATOR}/usr/libexec")
+      expect(subject["FOO"]).to eq("/usr#{File::PATH_SEPARATOR}/usr/local")
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This test fails on Ubuntu, because /usr/libexec does not exist.