### PR TITLE
audit: fixes for test checks 

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -772,7 +772,7 @@ module Homebrew
       end
       bin_names.each do |name|
         ["system", "shell_output", "pipe_output"].each do |cmd|
-          if text =~ %r{(def test|test do).*(#{Regexp.escape(HOMEBREW_PREFIX)}/bin/)?#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]}m
+          if text =~ /test do.*#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]/m
             problem %Q(fully scope test #{cmd} calls e.g. #{cmd} "\#{bin}/#{name}")
           end
         end
@@ -802,10 +802,6 @@ module Homebrew
       end
 
       problem "Use separate make calls" if line.include?("make && make")
-
-      if line =~ /shell_output\(['"].+['"], 0\)/
-        problem "Passing 0 to shell_output() is redundant"
-      end
 
       if line =~ /JAVA_HOME/i && !formula.requirements.map(&:class).include?(JavaRequirement)
         problem "Use `depends_on :java` to set JAVA_HOME"

--- a/Library/Homebrew/rubocops/class_cop.rb
+++ b/Library/Homebrew/rubocops/class_cop.rb
@@ -22,6 +22,27 @@ module RuboCop
           end
         end
       end
+
+      class TestCalls < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          test_calls(find_block(body_node, :test)) do |node, params|
+            p1, p2 = params
+            if match = string_content(p1).match(%r{(/usr/local/(s?bin))})
+              offending_node(p1)
+              problem "use \#{#{match[2]}} instead of #{match[1]} in #{node}"
+            end
+
+            if node == :shell_output && node_equals?(p2, 0)
+              offending_node(p2)
+              problem "Passing 0 to shell_output() is redundant"
+            end
+          end
+        end
+
+        def_node_search :test_calls, <<~EOS
+          (send nil? ${:system :shell_output :pipe_output} $...)
+        EOS
+      end
     end
 
     module FormulaAuditStrict

--- a/Library/Homebrew/rubocops/class_cop.rb
+++ b/Library/Homebrew/rubocops/class_cop.rb
@@ -39,6 +39,17 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            case node.type
+            when :str, :dstr
+              corrector.replace(node.source_range, node.source.to_s.sub(%r{(/usr/local/(s?bin))}, '#{\2}'))
+            when :int
+              corrector.remove(range_with_surrounding_comma(range_with_surrounding_space(range: node.source_range, side: :left)))
+            end
+          end
+        end
+
         def_node_search :test_calls, <<~EOS
           (send nil? ${:system :shell_output :pipe_output} $...)
         EOS

--- a/Library/Homebrew/test/rubocops/class_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/class_cop_spec.rb
@@ -48,6 +48,36 @@ describe RuboCop::Cop::FormulaAudit::ClassName do
   end
 end
 
+describe RuboCop::Cop::FormulaAudit::TestCalls do
+  subject(:cop) { described_class.new }
+
+  it "reports an offense when /usr/local/bin is found in test calls" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url 'https://example.com/foo-1.0.tgz'
+
+        test do
+          system "/usr/local/bin/test"
+                 ^^^^^^^^^^^^^^^^^^^^^ use \#{bin} instead of /usr/local/bin in system
+        end
+      end
+    RUBY
+  end
+
+  it "reports an offense when passing 0 as the second parameter to shell_output" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url 'https://example.com/foo-1.0.tgz'
+
+        test do
+          shell_output("\#{bin}/test", 0)
+                                      ^ Passing 0 to shell_output() is redundant
+        end
+      end
+    RUBY
+  end
+end
+
 describe RuboCop::Cop::FormulaAuditStrict::Test do
   subject(:cop) { described_class.new }
 

--- a/Library/Homebrew/test/rubocops/class_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/class_cop_spec.rb
@@ -76,6 +76,31 @@ describe RuboCop::Cop::FormulaAudit::TestCalls do
       end
     RUBY
   end
+
+  it "supports auto-correcting test calls" do
+    source = <<~RUBY
+      class Foo < Formula
+        url 'https://example.com/foo-1.0.tgz'
+
+        test do
+          shell_output("/usr/local/sbin/test", 0)
+        end
+      end
+    RUBY
+
+    corrected_source = <<~RUBY
+      class Foo < Formula
+        url 'https://example.com/foo-1.0.tgz'
+
+        test do
+          shell_output("\#{sbin}/test")
+        end
+      end
+    RUBY
+
+    new_source = autocorrect_source(source)
+    expect(new_source).to eq(corrected_source)
+  end
 end
 
 describe RuboCop::Cop::FormulaAuditStrict::Test do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As far as I can tell, the regular expression from https://github.com/Homebrew/brew/pull/1530 never actually worked:

```
(def test|test do).*(#{Regexp.escape(HOMEBREW_PREFIX)}/bin/)?#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]
```

Because `cmd` is one of `system shell_output pipe_output`, it would match lines like `/usr/local/bin/system "hello"` but never `system "/usr/local/bin/hello"`.

It would be nice to be able to use `HOMEBREW_PREFIX` in cops but sadly that's not available for some reason. Regardless, this is a improvement over the previously broken behavior. It now also checks for `sbin`.

Since I was here, I also moved https://github.com/Homebrew/brew/pull/4663 into a cop.