### PR TITLE
Hide lockfiles being cleaned up.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -245,9 +245,9 @@ module Homebrew
     end
 
     def cleanup_lockfiles(*lockfiles)
-      return unless HOMEBREW_LOCK_DIR.directory?
+      return if dry_run?
 
-      if lockfiles.empty?
+      if lockfiles.empty? && HOMEBREW_LOCK_DIR.directory?
         lockfiles = HOMEBREW_LOCK_DIR.children.select(&:file?)
       end
 
@@ -256,7 +256,7 @@ module Homebrew
         next unless file.open(File::RDWR).flock(File::LOCK_EX | File::LOCK_NB)
 
         begin
-          cleanup_path(file) { file.unlink }
+          file.unlink
         ensure
           file.open(File::RDWR).flock(File::LOCK_UN) if file.exist?
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Revert to not showing lockfiles in cleanup output.

Closes https://github.com/Homebrew/brew/issues/4689.