### PR TITLE
Pass through AWS session token

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -401,6 +401,7 @@ class S3DownloadStrategy < CurlDownloadStrategy
 
     ENV["AWS_ACCESS_KEY_ID"] = ENV["HOMEBREW_AWS_ACCESS_KEY_ID"]
     ENV["AWS_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_AWS_SECRET_ACCESS_KEY"]
+    ENV["AWS_SESSION_TOKEN"] = ENV["HOMEBREW_AWS_SESSION_TOKEN"]
 
     begin
       signer = Aws::S3::Presigner.new

--- a/bin/brew
+++ b/bin/brew
@@ -53,7 +53,7 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 # Whitelist and copy to HOMEBREW_* all variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
 for VAR in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BINTRAY_USER BINTRAY_KEY \
-           BROWSER EDITOR GIT NO_COLOR PATH VISUAL
+           BROWSER EDITOR GIT NO_COLOR PATH VISUAL AWS_SESSION_TOKEN
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example] (https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Originally raised with https://github.com/Homebrew/brew/issues/4706

This explicitly passes the AWS_SESSION_TOKEN variable into the AWS SDK Ruby client for the S3DownloadStrategy. The existing test suite doesn't cover credential passing, so I was having trouble figuring out if it was even possible to test this.  

I did run locally and was able to successfully use AWS session based AWS credentials with brew install.  It is worth noting that I did need to update the brew bash command, when I didn't include AWS_SESSION_TOKEN in the whitelist as @MikeMcQuaid suggested, I was unable to successfully download from S3.