### PR TITLE
[WIP] audit: only complain about alias deps for core formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -385,8 +385,7 @@ module Homebrew
             problem "Dependency '#{dep.name}' was renamed; use new name '#{dep_f.name}'."
           end
 
-          if self.class.aliases.include?(dep.name) &&
-             (dep_f.core_formula? || !dep_f.versioned_formula?)
+          if self.class.aliases.include?(dep.name) && dep_f.core_formula?
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This continues a discussion from https://github.com/Homebrew/homebrew-core/pull/31193#issuecomment-413948302 about an audit complaint when depending on an alias of a formula. I haven't run tests or style locally because so far this is for purposes of discussion. I'll fix CI if it gets to that point.

@MikeMcQuaid I think this is the patch you were suggesting? I think this would be a helpful change for 3rd-party taps, but I'm not sure this would help in the context of the comment https://github.com/Homebrew/homebrew-core/pull/31193#issuecomment-413648725 made by @DomT4, which I understood to be the following:

0. Starting point: `boost.rb` is version 1.67.0
1. Create `boost@1.68.rb` and update compatible downstream formulae to depend on `boost@1.68`. Anything that is incompatible (basically what is modified in the boost@1.67 PR https://github.com/Homebrew/homebrew-core/pull/31193) continues to depend on `boost`
2. Gradually the boost 1.68 issues are fixed and all formulae are changed to depend on `boost@1.68`.
3. The `boost.rb` formula is then deleted and a `boost` alias is created that points to `boost@1.68`?

I'm not sure what the final steps of that process are intended to be.

As I've written step 3, I think the audit would still complain about anything that depends on `boost` even after the changes in this PR, since it is an alias.