### PR TITLE
Use JSON to marshal errors from children

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -11,6 +11,8 @@ require "extend/ENV"
 require "debrew"
 require "fcntl"
 require "socket"
+require "json"
+require "json/add/core"
 
 class Build
   attr_reader :formula, :deps, :reqs
@@ -190,7 +192,17 @@ begin
   build   = Build.new(formula, options)
   build.install
 rescue Exception => e # rubocop:disable Lint/RescueException
-  Marshal.dump(e, error_pipe)
+  error_hash = JSON.parse e.to_json
+
+  # Special case: We need to toss our build state into the error hash
+  # for proper analytics reporting and sensible error messages.
+  if e.is_a?(BuildError)
+    error_hash["cmd"] = e.cmd
+    error_hash["args"] = e.args
+    error_hash["env"] = e.env
+  end
+
+  error_pipe.write error_hash.to_json
   error_pipe.close
   exit! 1
 end

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -93,12 +93,14 @@ module Homebrew
             exec(*args)
           end
         end
-      rescue ::Test::Unit::AssertionFailedError => e
+      rescue ChildProcessError => e
         ofail "#{f.full_name}: failed"
-        puts e.message
-      rescue Exception => e # rubocop:disable Lint/RescueException
-        ofail "#{f.full_name}: failed"
-        puts e, e.backtrace
+        case e.inner["json_class"]
+        when "Test::Unit::AssertionFailedError"
+          puts e.inner["m"]
+        else
+          puts e.inner["json_class"], e.backtrace
+        end
       ensure
         ENV.replace(env)
       end

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -4,6 +4,7 @@ require "global"
 require "debrew"
 require "fcntl"
 require "socket"
+require "json/add/core"
 
 begin
   error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
@@ -15,7 +16,7 @@ begin
   formula.extend(Debrew::Formula) if ARGV.debug?
   formula.run_post_install
 rescue Exception => e # rubocop:disable Lint/RescueException
-  Marshal.dump(e, error_pipe)
+  error_pipe.write e.to_json
   error_pipe.close
   exit! 1
 end

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -7,6 +7,7 @@ require "debrew"
 require "formula_assertions"
 require "fcntl"
 require "socket"
+require "json/add/core"
 
 TEST_TIMEOUT_SECONDS = 5 * 60
 
@@ -28,7 +29,7 @@ begin
     raise "test returned false" if formula.run_test == false
   end
 rescue Exception => e # rubocop:disable Lint/RescueException
-  Marshal.dump(e, error_pipe)
+  error_pipe.write e.to_json
   error_pipe.close
   exit! 1
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This replaces our use of `Marshal` to send exceptions from child processes to their controlling parents with a JSON representation of the exception state. This JSON representation is then wrapped in a new exception class, `ChildProcessError`. For particularly interesting exceptions in child processes (namely `BuildError`s), we reify the `ChildProcessError` back into its original exception (which keeps analytics and other parts of the codebase that use it directly happy).