### PR TITLE
Remove the chdir call that was already moved to the ancestor

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -197,11 +197,6 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
     @temporary_path = Pathname.new("#{cached_location}.incomplete")
   end
 
-  def stage
-    super
-    chdir
-  end
-
   private
 
   def ext


### PR DESCRIPTION


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

528b4b367ed2a4026c321e2f2e503ace4548b9d2 moved the chdir definition to the parent class and call it in the parent's stage. chdir was getting called twice for archives with two nested directories.

Example of problem: 

* Formula resource to download test.zip
* test.zip only contains: `top_dir/middle_dir/leaf_dir/file.h`
* the current directory after staging the resource is `middle_dir` instead of `top_dir`