### PR TITLE
Revert "Use JSON to marshal errors from children"

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -93,14 +93,12 @@ module Homebrew
             exec(*args)
           end
         end
-      rescue ChildProcessError => e
+      rescue ::Test::Unit::AssertionFailedError => e
         ofail "#{f.full_name}: failed"
-        case e.inner["json_class"]
-        when "Test::Unit::AssertionFailedError"
-          puts e.inner["m"]
-        else
-          puts e.inner["json_class"], e.backtrace
-        end
+        puts e.message
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        ofail "#{f.full_name}: failed"
+        puts e, e.backtrace
       ensure
         ENV.replace(env)
       end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -352,16 +352,14 @@ class FormulaAmbiguousPythonError < RuntimeError
 end
 
 class BuildError < RuntimeError
-  attr_reader :formula, :cmd, :args, :env
+  attr_reader :formula, :env
   attr_accessor :options
 
   def initialize(formula, cmd, args, env)
     @formula = formula
-    @cmd = cmd
-    @args = args
     @env = env
-    pretty_args = args.map { |arg| arg.to_s.gsub " ", "\\ " }.join(" ")
-    super "Failed executing: #{cmd} #{pretty_args}"
+    args = args.map { |arg| arg.to_s.gsub " ", "\\ " }.join(" ")
+    super "Failed executing: #{cmd} #{args}"
   end
 
   def issues
@@ -596,22 +594,5 @@ class BottleFormulaUnavailableError < RuntimeError
         #{bottle_path}
         #{formula_path}
     EOS
-  end
-end
-
-# Raised when a child process sends us an exception over its error pipe.
-class ChildProcessError < RuntimeError
-  attr_reader :inner
-
-  def initialize(inner)
-    @inner = inner
-
-    super <<~EOS
-      An exception occured within a build process:
-        #{inner["json_class"]}: #{inner["m"]}
-    EOS
-
-    # Clobber our real (but irrelevant) backtrace with that of the inner exception.
-    set_backtrace inner["b"]
   end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -763,25 +763,14 @@ class FormulaInstaller
       raise "Empty installation"
     end
   rescue Exception => e # rubocop:disable Lint/RescueException
-    # If we've rescued a ChildProcessError and that ChildProcessError
-    # contains a BuildError, then we reconstruct the inner build error
-    # to make analytics happy.
-    if e.is_a?(ChildProcessError) && e.inner["json_class"] == "BuildError"
-      build_error = BuildError.new(formula, e["cmd"], e["args"], e["env"])
-      build_error.set_backtrace e.backtrace
-      build_error.options = display_options(formula)
-
-      e = build_error
-    end
-
+    e.options = display_options(formula) if e.is_a?(BuildError)
     ignore_interrupts do
       # any exceptions must leave us with nothing installed
       formula.update_head_version
       formula.prefix.rmtree if formula.prefix.directory?
       formula.rack.rmdir_if_possible
     end
-
-    raise e
+    raise
   end
 
   def link(keg)

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -4,7 +4,6 @@ require "global"
 require "debrew"
 require "fcntl"
 require "socket"
-require "json/add/core"
 
 begin
   error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
@@ -16,7 +15,7 @@ begin
   formula.extend(Debrew::Formula) if ARGV.debug?
   formula.run_post_install
 rescue Exception => e # rubocop:disable Lint/RescueException
-  error_pipe.write e.to_json
+  Marshal.dump(e, error_pipe)
   error_pipe.close
   exit! 1
 end

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -7,7 +7,6 @@ require "debrew"
 require "formula_assertions"
 require "fcntl"
 require "socket"
-require "json/add/core"
 
 TEST_TIMEOUT_SECONDS = 5 * 60
 
@@ -29,7 +28,7 @@ begin
     raise "test returned false" if formula.run_test == false
   end
 rescue Exception => e # rubocop:disable Lint/RescueException
-  error_pipe.write e.to_json
+  Marshal.dump(e, error_pipe)
   error_pipe.close
   exit! 1
 end


### PR DESCRIPTION
Reverts Homebrew/brew#4717

Need to revert this because https://github.com/Homebrew/brew/pull/4721 isn't ready to go yet. Will accept these changes again when they have more tests written to reproduce the issue @DomT4 described.