### PR TITLE
formula_installer: permit multi-lua dependency trees

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -187,7 +187,7 @@ class FormulaInstaller
     recursive_runtime_formulae.each do |f|
       name = f.name
       unversioned_name, = name.split("@")
-      next if unversioned_name == "python"
+      next if ["python", "lua"].include?(unversioned_name)
       version_hash[unversioned_name] ||= Set.new
       version_hash[unversioned_name] << name
       next if version_hash[unversioned_name].length < 2


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We've sufficiently installed `lua` and `lua@5.1` in a way that makes it very very difficult for them to bump into each other without significant nudging. If `python` is safe enough `lua` should be as well.