### PR TITLE
dev-cmd/bottle: save local_filename to json

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -392,6 +392,7 @@ module Homebrew
           "tags" => {
             tag => {
               "filename" => filename.bintray,
+              "local_filename" => filename.to_s,
               "sha256" => sha256,
             },
           },


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
As discussed in https://github.com/Homebrew/homebrew-test-bot/issues/172#issuecomment-414932561 and https://github.com/Homebrew/brew/pull/4612, the local bottle filenames differ from the filename on bintray. So this adds the local filename as an extra field called `local_filename` to the json file generated by `brew bottle --json`.