### PR TITLE
formula_cellar_checks: .dylib and .framework are macOS-specific

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -94,4 +94,9 @@ module FormulaCellarChecks
     problem_if_output(check_python_framework_links(formula.lib))
     check_linkage
   end
+
+  def valid_library_extension?(filename)
+    macos_lib_extensions = %w[.dylib .framework]
+    generic_valid_library_extension?(filename) || macos_lib_extensions.include?(filename.extname)
+  end
 end

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -56,7 +56,7 @@ module FormulaCellarChecks
     EOS
   end
 
-  VALID_LIBRARY_EXTENSIONS = %w[.a .dylib .framework .jnilib .la .o .so .jar .prl .pm .sh].freeze
+  VALID_LIBRARY_EXTENSIONS = %w[.a .jnilib .la .o .so .jar .prl .pm .sh].freeze
 
   def valid_library_extension?(filename)
     VALID_LIBRARY_EXTENSIONS.include? filename.extname


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
A follow-up to Homebrew/brew#4685: `.dylib` and `.framework` are macOS-specific, so moving them to `extend/os/mac/...`.

@sjackman