### PR TITLE
Set HOMEBREW_BOTTLE_DEFAULT_DOMAIN based on operating system

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -86,6 +86,7 @@ then
   HOMEBREW_OS_VERSION="macOS $HOMEBREW_MACOS_VERSION"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X $HOMEBREW_MACOS_VERSION"
+  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://homebrew.bintray.com"
 
   # The system Curl is too old for some modern HTTPS certificates on
   # older macOS versions.
@@ -110,6 +111,7 @@ else
   [[ -n "$HOMEBREW_LINUX" ]] && HOMEBREW_OS_VERSION="$(lsb_release -sd 2>/dev/null)"
   : "${HOMEBREW_OS_VERSION:=$(uname -r)}"
   HOMEBREW_OS_USER_AGENT_VERSION="$HOMEBREW_OS_VERSION"
+  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://linuxbrew.bintray.com"
 
   CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_CACHE="${HOMEBREW_CACHE:-${CACHE_HOME}/Homebrew}"
@@ -274,7 +276,6 @@ then
   export HOMEBREW_RUBY_WARNINGS="-W0"
 fi
 
-export HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://homebrew.bintray.com"
 if [[ -z "$HOMEBREW_BOTTLE_DOMAIN" ]]
 then
   export HOMEBREW_BOTTLE_DOMAIN="$HOMEBREW_BOTTLE_DEFAULT_DOMAIN"

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -8,6 +8,7 @@ require "pp"
 require_relative "load_path"
 
 require "config"
+require "os"
 require "extend/ARGV"
 require "messages"
 require "system_command"
@@ -36,8 +37,14 @@ HOMEBREW_USER_AGENT_FAKE_SAFARI =
 
 # Bintray fallback is here for people auto-updating from a version where
 # HOMEBREW_BOTTLE_DEFAULT_DOMAIN isn't set.
-HOMEBREW_BOTTLE_DEFAULT_DOMAIN = ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"] ||
-                                 "https://homebrew.bintray.com"
+HOMEBREW_BOTTLE_DEFAULT_DOMAIN = if ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"]
+  ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"]
+elsif OS.mac?
+  "https://homebrew.bintray.com".freeze
+else
+  "https://linuxbrew.bintray.com".freeze
+end
+
 HOMEBREW_BOTTLE_DOMAIN = ENV["HOMEBREW_BOTTLE_DOMAIN"] ||
                          HOMEBREW_BOTTLE_DEFAULT_DOMAIN
 
@@ -108,7 +115,6 @@ HOMEBREW_INTERNAL_COMMAND_ALIASES = {
 
 require "set"
 
-require "os"
 require "extend/pathname"
 
 require "extend/module"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This change is an action item over at https://github.com/Linuxbrew/brew/issues/612, related to #4758.

Linuxbrew bottles are at https://linuxbrew.bintray.com by default, so use that as `HOMEBREW_BOTTLE_DEFAULT_DOMAIN` on Linux. Continue to default to https://homebrew.bintray.com on macOS.

I know the changes in `brew.sh` are implemented differently in Linuxbrew, but wasn't sure if we would be needing `$HOMEBREW_SYSTEM`, `$HOMEBREW_MACOS`, et al enough to justify copying the logic verbatim.