### PR TITLE
go: support & use aggressive caching

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -36,7 +36,7 @@ module CleanupRefinement
     end
 
     def nested_cache?
-      directory? && %w[glide_home java_cache npm_cache gclient_cache].include?(basename.to_s)
+      directory? && %w[go_cache glide_home java_cache npm_cache gclient_cache].include?(basename.to_s)
     end
 
     def prune?(days)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1678,6 +1678,7 @@ class Formula
       PATH: PATH.new(ENV["PATH"], HOMEBREW_PREFIX/"bin"),
       HOMEBREW_PATH: nil,
       _JAVA_OPTIONS: "#{ENV["_JAVA_OPTIONS"]} -Duser.home=#{HOMEBREW_CACHE}/java_cache",
+      GOCACHE: "#{HOMEBREW_CACHE}/go_cache",
     }
 
     ENV.clear_sensitive_environment!
@@ -2029,6 +2030,7 @@ class Formula
         stage_env[:HOME] = env_home
         stage_env[:_JAVA_OPTIONS] =
           "#{ENV["_JAVA_OPTIONS"]} -Duser.home=#{HOMEBREW_CACHE}/java_cache"
+        stage_env[:GOCACHE] = "#{HOMEBREW_CACHE}/go_cache"
         stage_env[:CURL_HOME] = ENV["CURL_HOME"] || ENV["HOME"]
       end
 

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -225,6 +225,15 @@ describe Homebrew::Cleanup do
       expect(incomplete).not_to exist
     end
 
+    it "cleans up 'go_cache'" do
+      go_cache = (HOMEBREW_CACHE/"go_cache")
+      go_cache.mkpath
+
+      subject.cleanup_cache
+
+      expect(go_cache).not_to exist
+    end
+
     it "cleans up 'glide_home'" do
       glide_home = (HOMEBREW_CACHE/"glide_home")
       glide_home.mkpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I hadn't planned to move on this so quickly but impressively core today had its first Go Module using PR, so this has become more useful than it would've been. Useful reading on the Modules system can be found via https://golang.org/doc/go1.11#modules.

`GOCACHE` has been a thing for a while but it hasn't really been especially beneficial to us, so I've ignored it, but with the Go Modules system it can be incredibly useful in reducing build times & thus CI burden. A lot of this is explained rather nicely [here](https://groups.google.com/forum/#!msg/golang-dev/RjSj4bGSmsw/KMHhU8fmAwAJ).

The upsides here for us are obvious:
1) We do a *lot* of go-based builds, and the more things move over to the module system the more comprehensive that cache will become and we'll need to remotely fetch less dependencies, which massively speeds up build times even on high-speed connections.
2) Module dependencies aren't limited per formula. If `hugo` fetches a dependency that is the same version as, for example, `wiki` also needs `wiki` won't bother to fetch that version remotely but instead will simply pluck it out of the cache.

If we look at `hugo`, because it's the only formula so far with Module support:

First build: `built in 1 minute 41 seconds`
Second build: `built in 14 seconds`.

It's worth noting perhaps that we can use just the module cache rather than the build cache + module cache combination, but doing so leads to a significant reduction in regained build time. A build under that system pops an average build time with `hugo` _(after the first build)_ of ~70 seconds, which is only a 30 second saving on the first build. However, if we wanted to speed up builds whilst also not eating big chunks of disk space that is an option.

The downside of a build cache + module cache system is disk usage. `go` does not exactly eat up disk space sparingly, and the cache size from `hugo` alone is 258.8MB. That could be an issue on CIs where disk space is already a squeeze at times, but it's not much different to how we let the `java_cache` behave now. The major difference between `java_cache` and `go_cache` here I guess is that things that use `go` are much more regular visitors in the CI system.

All Module-supporting formulae need to do to use the shared cache is instead of deleting the `GOPATH` env we set everywhere replace it with this:
```
ENV["GOPATH"] = "#{HOMEBREW_CACHE}/go_cache"
```