### PR TITLE
Allow dmg files with no extension to be converted

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -137,7 +137,8 @@ module UnpackStrategy
           cdr_path = mount_dir/path.basename.sub_ext(".cdr")
 
           system_command! "hdiutil",
-                          args: ["convert", "-quiet", "-format", "UDTO", "-srcimagekey", "diskimage-class=CRawDiskImage", "-o", cdr_path, path],
+                          args: ["convert", "-quiet", "-format", "UDTO", "-srcimagekey", "diskimage-class=CRawDiskImage",
+                                 "-o", cdr_path, path],
                           verbose: verbose
 
           with_eula = system_command! "hdiutil",

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -137,7 +137,7 @@ module UnpackStrategy
           cdr_path = mount_dir/path.basename.sub_ext(".cdr")
 
           system_command! "hdiutil",
-                          args: ["convert", "-quiet", "-format", "UDTO", "-o", cdr_path, path],
+                          args: ["convert", "-quiet", "-format", "UDTO", "-srcimagekey", "diskimage-class=CRawDiskImage", "-o", cdr_path, path],
                           verbose: verbose
 
           with_eula = system_command! "hdiutil",

--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -137,7 +137,8 @@ module UnpackStrategy
           cdr_path = mount_dir/path.basename.sub_ext(".cdr")
 
           system_command! "hdiutil",
-                          args: ["convert", "-quiet", "-format", "UDTO", "-srcimagekey", "diskimage-class=CRawDiskImage",
+                          args: ["convert", "-quiet", "-format", "UDTO",
+                                 "-srcimagekey", "diskimage-class=CRawDiskImage",
                                  "-o", cdr_path, path],
                           verbose: verbose
 


### PR DESCRIPTION
Fixes the underlying problem discussed in https://github.com/Homebrew/homebrew-cask/issues/50622.

Currently, dmg archives with no extension will not be parsed correctly by `hdiutil`.  The added flag (`-srcimagekey diskimage-class=CRawDiskImage`) is a hint to `hdiutil` that the input file can be read like a dmg archive.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
