### PR TITLE
quarantine: do not automatically follow symlinks

### DIFF
--- a/Library/Homebrew/cask/lib/hbc/quarantine.rb
+++ b/Library/Homebrew/cask/lib/hbc/quarantine.rb
@@ -69,7 +69,7 @@ module Hbc
       quarantine_status = status(from, command: command)
 
       quarantiner = command.run("/usr/bin/xattr",
-                                args: ["-w", "-r", QUARANTINE_ATTRIBUTE, quarantine_status, to],
+                                args: ["-w", "-rs", QUARANTINE_ATTRIBUTE, quarantine_status, to],
                                 print_stderr: false)
 
       return if quarantiner.success?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This pull request fixes quarantining when Casks have broken framework symlinks.

```
amalia@Sakura:/usr/local/Homebrew$ brew cask install disk-inventory-x --debug
Updating Homebrew...
==> Hbc::Installer#install
==> Printing caveats
==> Hbc::Installer#fetch
==> Satisfying dependencies
==> Downloading
==> Downloading http://www.derlien.com/diskinventoryx/downloads/dev/DIX1.0Universal.dmg
Already downloaded: /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
==> Quarantine is available.
==> Verifying Gatekeeper status of /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
/usr/bin/xattr -p com.apple.quarantine /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
==> /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg is quarantined
==> Downloaded to -> /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
==> Verifying download
==> Determining which verifications to run for Cask disk-inventory-x
==> Checking for verification class Hbc::Verify::Checksum
==> 1 verifications defined
Hbc::Verify::Checksum
==> Running verification of class Hbc::Verify::Checksum
==> Verifying checksum for Cask disk-inventory-x
==> SHA256 checksums match
==> Installing Cask disk-inventory-x
==> Hbc::Installer#stage
hdiutil imageinfo /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
==> Extracting primary container
==> Using container class UnpackStrategy::Dmg for /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
hdiutil attach -plist -nobrowse -readonly -noidme -mountrandom /var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/d20180831-33514-8qzq7x /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
find . -print0
mkbom -s -i /var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/20180831-33514-1tap6qw.list -- /var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/20180831-33514-ty4094.bom
ditto --bom /var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/20180831-33514-ty4094.bom -- /private/var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/d20180831-33514-8qzq7x/dmg.qxdPbx /var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/d20180831-33514-1d0c7b5
diskutil eject /private/var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/d20180831-33514-8qzq7x/dmg.qxdPbx
cp -pR /var/folders/l1/b3htrbqd3w3f32x9lk1yll6h0000gn/T/d20180831-33514-1d0c7b5/Disk\ Inventory\ X.app/. /usr/local/Caskroom/disk-inventory-x/1.0/Disk\ Inventory\ X.app
==> Quarantine is available.
==> Verifying Gatekeeper status of /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
/usr/bin/xattr -p com.apple.quarantine /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
==> /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg is quarantined
==> Propagating quarantine from /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg to /usr/local/Caskroom/disk-inventory-x/1.0
/usr/bin/xattr -p com.apple.quarantine /Users/amalia/Library/Caches/Homebrew/Cask/disk-inventory-x--1.0.dmg
/usr/bin/xattr -w -r com.apple.quarantine 0081\;5b894cb8\;Homebrew-Cask\;1DD82AAD-93B4-4DEC-85BE-71C442E8342C /usr/local/Caskroom/disk-inventory-x/1.0
==> Purging files for version 1.0 of Cask disk-inventory-x
Error: Failed to quarantine one or more files within /usr/local/Caskroom/disk-inventory-x/1.0. Here's the reason:
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/CocoaTechBase.framework/Headers
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/CocoaTechFoundation.framework/Headers
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/CocoaTechFoundation.framework/PrivateHeaders
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/CocoaTechID3.framework/Headers
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/CocoaTechStrings.framework/Headers
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/OmniAppKit.framework/Headers
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/OmniBase.framework/Headers
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/OmniFoundation.framework/Headers
xattr: No such file: /usr/local/Caskroom/disk-inventory-x/1.0/Disk Inventory X.app/Contents/Frameworks/TreeMapView.framework/Headers

/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/quarantine.rb:77:in `propagate'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/installer.rb:191:in `extract_primary_container'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/installer.rb:75:in `stage'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/installer.rb:97:in `install'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/install.rb:21:in `block in run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/install.rb:14:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/install.rb:14:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/abstract_command.rb:34:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:90:in `run_command'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:156:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:121:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:7:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:87:in `<main>'
Error: Kernel.exit
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:161:in `exit'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:161:in `rescue in run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:144:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:121:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:7:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:87:in `<main>'
```

