### PR TITLE
Skip `mtime` for non-existent symlink.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -43,6 +43,8 @@ module CleanupRefinement
       return false unless days
       return true if days.zero?
 
+      return true if symlink? && !exist?
+
       # TODO: Replace with ActiveSupport's `.days.ago`.
       mtime < ((@time ||= Time.now) - days * 60 * 60 * 24)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

`mtime` would fail when called on a symlink which points to a non-existent file.