### PR TITLE
Avoid network call in `#initialize`.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -188,11 +188,8 @@ class VCSDownloadStrategy < AbstractDownloadStrategy
 end
 
 class AbstractFileDownloadStrategy < AbstractDownloadStrategy
-  attr_reader :temporary_path
-
-  def initialize(url, name, version, **meta)
-    super
-    @temporary_path = Pathname.new("#{cached_location}.incomplete")
+  def temporary_path
+    @temporary_path ||= Pathname.new("#{cached_location}.incomplete")
   end
 
   def symlink_location


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

--- 

Don't set `temporary_path` in `#initialize` as it uses `#cached_location`, which makes a network call.
