### PR TITLE
Fix `CurlApacheMirrorDownloadStrategy` URL resolution.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -405,12 +405,15 @@ class CurlApacheMirrorDownloadStrategy < CurlDownloadStrategy
 
   private
 
-  def resolved_url_and_basename
-    return @resolved_url_and_basename if defined?(@resolved_url_and_basename)
-    @resolved_url_and_basename = [
-      "#{apache_mirrors["preferred"]}#{apache_mirrors["path_info"]}",
-      File.basename(apache_mirrors["path_info"]),
-    ]
+  def resolve_url_and_basename(url)
+    if url == self.url
+      [
+        "#{apache_mirrors["preferred"]}#{apache_mirrors["path_info"]}",
+        File.basename(apache_mirrors["path_info"]),
+      ]
+    else
+      super
+    end
   end
 
   def apache_mirrors


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Use `resolve_url_and_basename ` instead of `resolved_url_and_basename`.

Fixes https://github.com/Homebrew/brew/pull/4662#issuecomment-417893048.