### PR TITLE
tests: set HOME.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -49,6 +49,10 @@ module Homebrew
       ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if args.generic?
       ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
 
+      # Avoid local configuration messing with tests e.g. git being configured
+      # to use GPG to sign by default
+      ENV["HOME"] = "#{HOMEBREW_LIBRARY_PATH}/test"
+
       if args.coverage?
         ENV["HOMEBREW_TESTS_COVERAGE"] = "1"
         FileUtils.rm_f "test/coverage/.resultset.json"


### PR DESCRIPTION
This is the only way to override the user's Git configuration which can
break tests when e.g. `gpg` cannot be found but signing is requested.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----