### PR TITLE
Cask: check that the tools for quarantining are available

### DIFF
--- a/Library/Homebrew/cask/cmd/doctor.rb
+++ b/Library/Homebrew/cask/cmd/doctor.rb
@@ -22,6 +22,7 @@ module Hbc
 
       def run
         check_software_versions
+        check_quarantine_support
         check_install_location
         check_staging_location
         check_taps
@@ -114,6 +115,23 @@ module Hbc
         locale_variables = ENV.keys.grep(/^(?:LC_\S+|LANG|LANGUAGE)\Z/).sort
 
         (locale_variables + environment_variables).sort.each(&method(:render_env_var))
+      end
+
+      def check_quarantine_support
+        ohai "Gatekeeper support"
+
+        status = Quarantine.check_quarantine_support
+
+        case status
+        when :quarantine_available
+          puts "Enabled"
+        when :no_swift
+          add_error "Swift is not available on this system."
+        when :no_quarantine
+          add_error "This feature requires the macOS 10.10 SDK or higher."
+        else
+          onoe "Unknown support status"
+        end
       end
 
       def user_tilde(path)

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -186,7 +186,7 @@ module Hbc
       return unless quarantine?
       return unless Quarantine.available?
 
-      Quarantine.propagate(from: @downloaded_path, to: @cask.staged_path, command: @command)
+      Quarantine.propagate(from: @downloaded_path, to: @cask.staged_path)
     end
 
     def install_artifacts

--- a/Library/Homebrew/cask/utils/quarantine.swift
+++ b/Library/Homebrew/cask/utils/quarantine.swift
@@ -7,36 +7,41 @@ struct swifterr: TextOutputStream {
   mutating func write(_ string: String) { fputs(string, stderr) }
 }
 
-if (CommandLine.arguments.count < 4) {
-  exit(2)
-}
-
-let dataLocationUrl: NSURL = NSURL.init(fileURLWithPath: CommandLine.arguments[1])
-
-var errorBag: NSError?
-
-let quarantineProperties: [String: Any] = [
-  kLSQuarantineAgentNameKey as String: "Homebrew Cask",
-  kLSQuarantineTypeKey as String: kLSQuarantineTypeWebDownload,
-  kLSQuarantineDataURLKey as String: CommandLine.arguments[2],
-  kLSQuarantineOriginURLKey as String: CommandLine.arguments[3]
-]
-
-if (dataLocationUrl.checkResourceIsReachableAndReturnError(&errorBag)) {
-  do {
-    try dataLocationUrl.setResourceValue(
-      quarantineProperties as NSDictionary,
-      forKey: URLResourceKey.quarantinePropertiesKey
-      )
+if #available(macOS 10.10, *) {
+  if (CommandLine.arguments.count < 4) {
+    exit(2)
   }
-  catch {
-    print(error.localizedDescription, to: &swifterr.stream)
-    exit(1)
+
+  let dataLocationUrl: NSURL = NSURL.init(fileURLWithPath: CommandLine.arguments[1])
+
+  var errorBag: NSError?
+
+  let quarantineProperties: [String: Any] = [
+    kLSQuarantineAgentNameKey as String: "Homebrew Cask",
+    kLSQuarantineTypeKey as String: kLSQuarantineTypeWebDownload,
+    kLSQuarantineDataURLKey as String: CommandLine.arguments[2],
+    kLSQuarantineOriginURLKey as String: CommandLine.arguments[3]
+  ]
+
+  if (dataLocationUrl.checkResourceIsReachableAndReturnError(&errorBag)) {
+    do {
+      try dataLocationUrl.setResourceValue(
+        quarantineProperties as NSDictionary,
+        forKey: URLResourceKey.quarantinePropertiesKey
+        )
+    }
+    catch {
+      print(error.localizedDescription, to: &swifterr.stream)
+      exit(1)
+    }
   }
+  else {
+    print(errorBag!.localizedDescription, to: &swifterr.stream)
+    exit(3)
+  }
+
+  exit(0)
 }
 else {
-  print(errorBag!.localizedDescription, to: &swifterr.stream)
-  exit(3)
+  exit(5)
 }
-
-exit(0)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The Gatekeeper API I've written relies on an up-to-date CLT (or Xcode) install, and `xattr`'s `-r` flag for native recursion. There are cases where Swift is too old or is set to a deployment target earlier than MacOS 10.10, and thus cannot use the `URLResourceKey.quarantinePropertiesKey` constant. And in the current Mojave beta, `xattr` does not have Apple's `-r` extension for doing native filesystem traversal.

This pull request inserts an additional check in the Swift script, the `Quarantine.available?` function and `brew cask doctor`, and changes `propagate` to use `xargs` for recursion.

Fixes Homebrew/homebrew-cask#51554, and fixes Homebrew/homebrew-cask#51538.