### PR TITLE
keg_relocate: let each_unique_file_matching always use the system fgrep

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -96,7 +96,7 @@ class Keg
   alias generic_recursive_fgrep_args recursive_fgrep_args
 
   def each_unique_file_matching(string)
-    Utils.popen_read("fgrep", recursive_fgrep_args, string, to_s) do |io|
+    Utils.popen_read("/usr/bin/fgrep", recursive_fgrep_args, string, to_s) do |io|
       hardlinks = Set.new
 
       until io.eof?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I assume that `coreutils` is installed our El Capitan, Sierra and High Sierra CI nodes, but not on those Mojave nodes. When using GNU's `fgrep` together with the `O` option as overrode in `extend/os/mac/keg_relocate.rb`, errors will silently occur without any outputs.

Consequently, the keg relocatable check is a no-op on our El Capitan, Sierra and High Sierra CI nodes. 🙃

However, once this is fixed, some more problems will be exposed. 

For example, from https://jenkins.brew.sh/job/Homebrew%20Mojave%20Testing/596/version=mojave_testing/console:

```
==> brew bottle --verbose --json travis --keep-old
==> FAILED
==> Bottling travis--1.8.9.mojave.bottle.tar.gz...
/usr/bin/touch -h -t 201808161621.04 /usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/libffi-universal-darwin18/.libs/libffi.dylib
/usr/bin/touch -h -t 201808161621.04 /usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/libffi-universal-darwin18/.libs/libffi.la
/usr/bin/touch -h -t 201808161621.04 /usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/libffi-universal-darwin18/.libs/libffi_convenience.la
/usr/bin/touch -h -t 201808161621.04 /usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/libffi-universal-darwin18/include/ffitarget.h
tar cf /Users/brew/Jenkins/workspace/Homebrew Mojave Testing/version/mojave_testing/travis--1.8.9.mojave.bottle.tar travis/1.8.9
gzip -f travis-bottle.tar
==> Detecting if travis--1.8.9.mojave.bottle.tar.gz is relocatable...
Warning: String '/usr/local/Cellar' still exists in these files:
/usr/local/Cellar/travis/1.8.9/libexec/extensions/universal-darwin-18/2.3.0/ffi-1.9.25/ffi_c.bundle
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/' at offset 0x26662
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/AbstractMemory.o' at offset 0x266b5
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/ArrayType.o' at offset 0x277be
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Buffer.o' at offset 0x278bc
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Call.o' at offset 0x27a98
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/ClosurePool.o' at offset 0x27c3c
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/DataConverter.o' at offset 0x27d46
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/DynamicLibrary.o' at offset 0x27e52
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Function.o' at offset 0x27f8d
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/FunctionInfo.o' at offset 0x28303
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/LastError.o' at offset 0x284c0
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/LongDouble.o' at offset 0x28583
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/MappedType.o' at offset 0x2870a
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/MemoryPointer.o' at offset 0x288b1
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/MethodHandle.o' at offset 0x289f5
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Platform.o' at offset 0x28b69
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Pointer.o' at offset 0x28be4
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Struct.o' at offset 0x28e56
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/StructByReference.o' at offset 0x293a3
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/StructByValue.o' at offset 0x29504
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/StructLayout.o' at offset 0x2960b
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Thread.o' at offset 0x29a7b
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Type.o' at offset 0x29b3a
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Types.o' at offset 0x2a1a2
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/Variadic.o' at offset 0x2a257
 --> match '/usr/local/Cellar/travis/1.8.9/libexec/gems/ffi-1.9.25/ext/ffi_c/ffi.o' at offset 0x2a48a
```

The references from `ffi_c.bundle` to those `.o` object files are essentially debug information, which has nothing to do with file / linkage relocation.