### PR TITLE
class_cop: flag simple tests

### DIFF
--- a/Library/Homebrew/rubocops/class_cop.rb
+++ b/Library/Homebrew/rubocops/class_cop.rb
@@ -82,6 +82,14 @@ module RuboCop
             return
           end
 
+          if test.body.single_line? &&
+             test.body.source.to_s.include?("version") ||
+             test.body.source.to_s.include?("help")
+            problem "Simple tests should be a last resort. " \
+                    "Please try to write a test that exercises a " \
+                    "deeper level of functionality"
+          end
+
           return unless test.body.single_line? &&
                         test.body.source.to_s == "true"
           problem "`test do` should contain a real test"

--- a/Library/Homebrew/test/rubocops/class_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/class_cop_spec.rb
@@ -139,4 +139,17 @@ describe RuboCop::Cop::FormulaAuditStrict::Test do
       end
     RUBY
   end
+
+  it "reports an offense when test is overly simple" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url 'https://example.com/foo-1.0.tgz'
+
+        test do
+        ^^^^^^^ Simple tests should be a last resort. Please try to write a test that exercises a deeper level of functionality
+          assert_match version.to_s, shell_output("\#{bin}/blah")
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We have too many of these in core, they aren't an effective test, things _alarmingly often_ break in some way or another despite this being the formula's test, and I am tired of seeing my own quick reply asking for a better test on new formulae around core.

Note: If people see the `single_line?` element here & try to work around that by splitting lines I will see, and I will thwack that as well 👀 😈.