### PR TITLE
rust/cargo: enable caching

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -36,7 +36,7 @@ module CleanupRefinement
     end
 
     def nested_cache?
-      directory? && %w[go_cache glide_home java_cache npm_cache gclient_cache].include?(basename.to_s)
+      directory? && %w[cargo_cache go_cache glide_home java_cache npm_cache gclient_cache].include?(basename.to_s)
     end
 
     def go_cache_directory?

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1680,6 +1680,7 @@ class Formula
       HOMEBREW_PATH: nil,
       _JAVA_OPTIONS: "#{ENV["_JAVA_OPTIONS"]} -Duser.home=#{HOMEBREW_CACHE}/java_cache",
       GOCACHE: "#{HOMEBREW_CACHE}/go_cache",
+      CARGO_HOME: "#{HOMEBREW_CACHE}/cargo_cache",
     }
 
     ENV.clear_sensitive_environment!
@@ -2034,6 +2035,7 @@ class Formula
         stage_env[:_JAVA_OPTIONS] =
           "#{ENV["_JAVA_OPTIONS"]} -Duser.home=#{HOMEBREW_CACHE}/java_cache"
         stage_env[:GOCACHE] = "#{HOMEBREW_CACHE}/go_cache"
+        stage_env[:CARGO_HOME] = "#{HOMEBREW_CACHE}/cargo_cache"
         stage_env[:CURL_HOME] = ENV["CURL_HOME"] || ENV["HOME"]
       end
 

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -225,6 +225,15 @@ describe Homebrew::Cleanup do
       expect(incomplete).not_to exist
     end
 
+    it "cleans up 'cargo_cache'" do
+      cargo_cache = (HOMEBREW_CACHE/"cargo_cache")
+      cargo_cache.mkpath
+
+      subject.cleanup_cache
+
+      expect(cargo_cache).not_to exist
+    end
+
     it "cleans up 'go_cache'" do
       go_cache = (HOMEBREW_CACHE/"go_cache")
       go_cache.mkpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The primary intention of this PR is to avoid having to download the complete `crates.io-index` package registry (currently a 125MB download) for each build. The formulae crate dependencies are also cached and can be reused between formulae. This will work without needing any changes to be made in formulae.

Similar to https://github.com/Homebrew/brew/pull/4774 one downside is increased disk usage. Also, `rust` formulae aren't as common (currently 35), but we do seem to be adding them quickly (16 this year so far.)

One possible problem that I've encountered with setting `CARGO_HOME` occurs if the install target (i.e. `"--root", prefix`) isn't set as it will install by default into `CARGO_HOME`.
```
  Installing /Users/commitay/Library/Caches/Homebrew/cargo_cache/bin/bat
warning: be sure to add `/Users/commitay/Library/Caches/Homebrew/cargo_cache/bin` to your PATH to be able to run the installed binaries
Error: Empty installation
```

Disclaimer: My internet is terrible, so while this is a decent improvement for me locally it might not actually be that useful.

Removing `cargo_cache` for each formula:
```
/usr/local/Cellar/bat/0.6.1: 5 files, 5.2MB, built in 11 minutes 45 seconds

/usr/local/Cellar/bat/0.6.1: 5 files, 5.2MB, built in 5 minutes 34 seconds
```
```
/usr/local/Cellar/exa/0.8.0: 9 files, 1.4MB, built in 7 minutes 17 seconds

/usr/local/Cellar/exa/0.8.0: 9 files, 1.4MB, built in 2 minutes 38 seconds
```
```
/usr/local/Cellar/fd/7.1.0: 9 files, 3.1MB, built in 6 minutes 43 seconds

/usr/local/Cellar/fd/7.1.0: 9 files, 3.1MB, built in 1 minute 56 seconds
```
```
/usr/local/Cellar/ripgrep/0.9.0: 11 files, 4.9MB, built in 6 minutes 54 seconds

/usr/local/Cellar/ripgrep/0.9.0: 11 files, 4.9MB, built in 2 minutes 45 seconds
```
```
/usr/local/Cellar/watchexec/1.9.0: 7 files, 2.3MB, built in 6 minutes 52 seconds

/usr/local/Cellar/watchexec/1.9.0: 7 files, 2.3MB, built in 2 minutes 28 seconds
```

The `cargo_cache` size after building all of the above formulae again was 247MB (including the 125MB package registry.)