### PR TITLE
docs/Formula-Cookbook: preach what we practise

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -396,12 +396,7 @@ system "make", "target", "VAR2=value1", "VAR2=value2", "VAR3=values can have spa
 ```
 
 ```ruby
-args = %W[
-  CC=#{ENV.cc}
-  PREFIX=#{prefix}
-]
-
-system "make", *args
+system "make", "CC=#{ENV.cc}", "PREFIX=#{prefix}"
 ```
 
 Note that values *can* contain unescaped spaces if you use the multiple-argument form of `system`.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In both core and formula PRs, we tend to request from contributors more often that they inline method arguments rather than using `*args`:

```
system "make", "CC=#{ENV.cc}", "PREFIX=#{prefix}"
```

I feel we should codify that style in the docs so we preach what we practise.
Thanks @r4sas for the [heads up](https://github.com/Homebrew/homebrew-core/pull/31772#discussion_r214862652)!
