### PR TITLE
scm shim: handle edge case

### DIFF
--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -85,10 +85,16 @@ fi
 
 case "$(lowercase "$SCM_FILE")" in
   git)
-    [[ -n "$HOMEBREW_GIT" ]] && safe_exec "$(type -P "$HOMEBREW_GIT")" "$@"
+    if [[ -n "$HOMEBREW_GIT" && "$HOMEBREW_GIT" != git ]]
+    then
+      safe_exec "$(type -P "$HOMEBREW_GIT")" "$@"
+    fi
     ;;
   svn)
-    [[ -n "$HOMEBREW_SVN" ]] && safe_exec "$(type -P "$HOMEBREW_SVN")" "$@"
+    if [[ -n "$HOMEBREW_SVN" && "$HOMEBREW_SVN" != svn ]]
+    then
+      safe_exec "$(type -P "$HOMEBREW_SVN")" "$@"
+    fi
     ;;
 esac
 


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since #4748 `HOMEBREW_GIT` is set by the `brew.sh`, whose value is default to be `git`.
As a result, it completely bypasses the logic of the shims/scm/git.

This fixes the issue by checking whether `HOMEBREW_GIT` and
`HOMEBREW_SVN` are set to be `git` and `svn` respectively.

Fixes #4825.
