### PR TITLE
cmd/info: display analytics data.

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -199,8 +199,11 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `info`:
     Display brief statistics for your Homebrew installation.
 
-  * `info` `formula`:
-    Display information about `formula`.
+  * `info` `formula`  (`--verbose`):
+    Display information about `formula` and analytics data (provided neither
+    `HOMEBREW_NO_ANALYTICS` or `HOMEBREW_NO_GITHUB_API` are set)
+
+    Pass `--verbose` to see more detailed analytics data.
 
   * `info` `--github` `formula`:
     Open a browser to the GitHub History page for `formula`.

--- a/docs/Querying-Brew.md
+++ b/docs/Querying-Brew.md
@@ -71,6 +71,10 @@ To find the names of normal (not keg-only) formulae that are installed, but not 
 brew info --json=v1 --installed | jq "map(select(.keg_only == false and .linked_keg == null) | .name)"
 ```
 
+## formulae.brew.sh
+
+formulae.brew.sh has a [documented JSON API](https://formulae.brew.sh/docs/api/) which provides access to the `brew info --json=v1` output without needing access to Homebrew.
+
 ## Concluding remarks
 
 Using the JSON output, queries can be made against Homebrew with less risk of being broken due to Homebrew code changes, and without needing to understand Homebrew's Ruby internals.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -188,7 +188,10 @@ If no logs are found, an error message is presented\.
 \fBinfo\fR: Display brief statistics for your Homebrew installation\.
 .
 .IP "\(bu" 4
-\fBinfo\fR \fIformula\fR: Display information about \fIformula\fR\.
+\fBinfo\fR \fIformula\fR (\fB\-\-verbose\fR): Display information about \fIformula\fR and analytics data (provided neither \fBHOMEBREW_NO_ANALYTICS\fR or \fBHOMEBREW_NO_GITHUB_API\fR are set)
+.
+.IP
+Pass \fB\-\-verbose\fR to see more detailed analytics data\.
 .
 .IP "\(bu" 4
 \fBinfo\fR \fB\-\-github\fR \fIformula\fR: Open a browser to the GitHub History page for \fIformula\fR\.


### PR DESCRIPTION
cmd/info: display analytics data.
When users don't have `HOMEBREW_NO_ANALYTICS` or
`HOMEBREW_NO_GITHUB_API` set let's display some analytics data in
`brew info`. This should be useful for both maintainers and for users of
Homebrew.

Note this by default combines all installs across options for a single
number; for formulae with lots of options it's a bit overwhelming to
print the installs per-option. However, for `HOMEBREW_DEVELOPER`s print
the full output.

Sample non-developer output:

```console
$ brew info wget
wget: stable 1.19.5 (bottled), HEAD
Internet file retriever
https://www.gnu.org/software/wget/
/usr/local/Cellar/wget/1.19.5 (49 files, 3.7MB) *
  Built from source on 2018-09-03 at 20:46:32
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/wget.rb
==> Dependencies
Build: pkg-config ✔
Required: libidn2 ✔, openssl ✔
Optional: pcre ✔, libmetalink ✘, gpgme ✘
==> Options
--with-debug
	Build with debug support
--with-gpgme
	Build with gpgme support
--with-libmetalink
	Build with libmetalink support
--with-pcre
	Build with pcre support
--HEAD
	Install HEAD version
==> Analytics
install: 84638 (30d), 353800 (90d), 1372775 (365d)
install_on_request: 77926 (30d), 291305 (90d), 1044898 (365d)
build_error: 11 (30d)
```

Sample developer output:
```console
$ brew info wget
wget: stable 1.19.5 (bottled), HEAD
Internet file retriever
https://www.gnu.org/software/wget/
/usr/local/Cellar/wget/1.19.5 (49 files, 3.7MB) *
  Built from source on 2018-09-03 at 20:46:32
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/wget.rb
==> Dependencies
Build: pkg-config ✔
Required: libidn2 ✔, openssl ✔
Optional: pcre ✔, libmetalink ✘, gpgme ✘
==> Options
--with-debug
	Build with debug support
--with-gpgme
	Build with gpgme support
--with-libmetalink
	Build with libmetalink support
--with-pcre
	Build with pcre support
--HEAD
	Install HEAD version
==> Analytics
==> install (30d)
wget: 84516
wget --with-debug: 51
wget --with-libressl: 16
wget --with-pcre: 14
wget --with-pcre --with-libmetalink --with-gpgme: 12
wget --with-debug --with-pcre --with-libmetalink --with-gpgme: 8
wget --HEAD: 3
wget --HEAD --with-debug --with-libmetalink --with-gpgme: 3
wget --with-gpgme: 3
wget --with-libmetalink: 3
wget --with-pcre --with-libmetalink: 3
wget --with-debug --with-pcre: 2
wget --with-libmetalink --with-gpgme: 2
wget --with-pcre --with-gpgme: 2
==> install (90d)
wget: 353131
wget --with-debug: 188
wget --with-pcre: 138
wget --with-pcre --with-libmetalink --with-gpgme: 118
wget --with-libressl: 81
wget --with-debug --with-pcre --with-libmetalink --with-gpgme: 47
wget --with-pcre --with-libmetalink: 31
wget --HEAD: 13
wget --with-pcre --with-gpgme: 12
wget --with-gpgme: 11
wget --with-debug --with-pcre: 10
wget --with-libmetalink: 8
wget --HEAD --with-pcre --with-libmetalink --with-gpgme: 4
wget --with-debug --with-pcre --with-libmetalink: 4
wget --with-libmetalink --with-gpgme: 4
==> install (365d)
wget: 1369530
wget --with-pcre: 810
wget --with-debug: 649
wget --with-pcre --with-libmetalink --with-gpgme: 554
wget --with-libressl: 479
wget --with-debug --with-pcre --with-libmetalink --with-gpgme: 235
wget --with-pcre --with-libmetalink: 184
wget --with-gpgme: 67
wget --with-pcre --with-gpgme: 67
wget --with-debug --with-pcre: 65
wget --HEAD: 54
wget --with-libmetalink: 30
wget --with-libmetalink --with-gpgme: 27
wget --with-debug --with-pcre --with-libmetalink: 24
==> install_on_request (30d)
wget: 77827
wget --with-debug: 48
wget --with-pcre: 12
wget --with-pcre --with-libmetalink --with-gpgme: 11
wget --with-debug --with-pcre --with-libmetalink --with-gpgme: 8
wget --HEAD: 3
wget --HEAD --with-debug --with-libmetalink --with-gpgme: 3
wget --with-gpgme: 3
wget --with-libmetalink: 3
wget --with-debug --with-pcre: 2
wget --with-libmetalink --with-gpgme: 2
wget --with-pcre --with-gpgme: 2
wget --with-pcre --with-libmetalink: 2
==> install_on_request (90d)
wget: 290818
wget --with-debug: 157
wget --with-pcre --with-libmetalink --with-gpgme: 101
wget --with-pcre: 100
wget --with-debug --with-pcre --with-libmetalink --with-gpgme: 42
wget --with-pcre --with-libmetalink: 30
wget --HEAD: 13
wget --with-pcre --with-gpgme: 11
wget --with-gpgme: 10
wget --with-debug --with-pcre: 8
wget --with-libmetalink: 7
wget --HEAD --with-pcre --with-libmetalink --with-gpgme: 4
wget --with-debug --with-pcre --with-libmetalink: 4
==> install_on_request (365d)
wget: 1042845
wget --with-pcre: 504
wget --with-debug: 458
wget --with-pcre --with-libmetalink --with-gpgme: 432
wget --with-debug --with-pcre --with-libmetalink --with-gpgme: 201
wget --with-pcre --with-libmetalink: 158
wget --with-gpgme: 61
wget --HEAD: 54
wget --with-pcre --with-gpgme: 49
wget --with-debug --with-pcre: 47
wget --with-debug --with-pcre --with-libmetalink: 24
wget --with-libressl: 23
wget --with-libmetalink: 22
wget --with-libmetalink --with-gpgme: 20
==> build_error (30d)
wget: 9
wget --HEAD: 1
wget --with-debug: 1
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----