### PR TITLE
std: use HOMEBREW_ARCH env var on Linux

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -7,7 +7,8 @@ module Stdenv
 
   # @private
   SAFE_CFLAGS_FLAGS = "-w -pipe".freeze
-  DEFAULT_FLAGS = "-march=core2 -msse4".freeze
+  HOMEBREW_ARCH = (ENV["HOMEBREW_ARCH"] || "native").freeze
+  DEFAULT_FLAGS = (OS.mac? ? "-march=core2 -msse4" : "-march=#{HOMEBREW_ARCH}").freeze
 
   # @private
   def setup_build_environment(formula = nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Unlike macOS, Linux distributions can be installed/deployed on a variety of hardware. The `HOMEBREW_ARCH` environment variable allows the end user to set a custom `-march=...` option for the compiler. If the variable is not set, it defaults to `native`.

This only applies on Linux; on macOS, behavior remains unchanged.

---

This PR is part of the process of [bringing official Linux support into `Homebrew/brew`](https://github.com/Homebrew/brew/issues/4758), and is a tracked action item at https://github.com/Linuxbrew/brew/issues/612. The corresponding commit on the Linuxbrew side is https://github.com/Linuxbrew/brew/commit/68c0ef3f6d37233ad497fce0afedfb7a03b58f71.