### PR TITLE
LinkageChecker: Report linkage of unwanted system libraries [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linkage_checker.rb
@@ -1,0 +1,1 @@
+require "extend/os/linux/linkage_checker" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/linkage_checker.rb
+++ b/Library/Homebrew/extend/os/linux/linkage_checker.rb
@@ -1,0 +1,32 @@
+class LinkageChecker
+  # Libraries provided by glibc and gcc.
+  SYSTEM_LIBRARY_WHITELIST = %w[
+    ld-linux-x86-64.so.2
+    libanl.so.1
+    libc.so.6
+    libcrypt.so.1
+    libdl.so.2
+    libm.so.6
+    libmvec.so.1
+    libnsl.so.1
+    libpthread.so.0
+    libresolv.so.2
+    librt.so.1
+    libutil.so.1
+
+    libgcc_s.so.1
+    libgomp.so.1
+    libstdc++.so.6
+  ].freeze
+
+  def check_dylibs(rebuild_cache:)
+    generic_check_dylibs(rebuild_cache: rebuild_cache)
+
+    # glibc and gcc are implicit dependencies.
+    # No other linkage to system libraries is expected or desired.
+    @unwanted_system_dylibs = @system_dylibs.reject do |s|
+      SYSTEM_LIBRARY_WHITELIST.include? File.basename(s)
+    end
+    @undeclared_deps -= ["gcc", "glibc"]
+  end
+end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -19,6 +19,7 @@ class LinkageChecker
     @indirect_deps    = []
     @undeclared_deps  = []
     @unnecessary_deps = []
+    @unwanted_system_dylibs = []
     @version_conflict_deps = []
 
     check_dylibs(rebuild_cache: rebuild_cache)
@@ -33,6 +34,7 @@ class LinkageChecker
     display_items "Broken dependencies", @broken_deps
     display_items "Undeclared dependencies with linkage", @undeclared_deps
     display_items "Dependencies with no linkage", @unnecessary_deps
+    display_items "Unwanted system libraries", @unwanted_system_dylibs
   end
 
   def display_reverse_output
@@ -51,6 +53,7 @@ class LinkageChecker
   def display_test_output(puts_output: true)
     display_items "Missing libraries", @broken_dylibs, puts_output: puts_output
     display_items "Broken dependencies", @broken_deps, puts_output: puts_output
+    display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
     display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
     puts "No broken library linkage" unless broken_library_linkage?
   end
@@ -58,6 +61,7 @@ class LinkageChecker
   def broken_library_linkage?
     !@broken_dylibs.empty? ||
       !@broken_deps.empty? ||
+      !@unwanted_system_dylibs.empty? ||
       !@version_conflict_deps.empty?
   end
 
@@ -139,6 +143,7 @@ class LinkageChecker
 
     store&.update!(keg_files_dylibs: keg_files_dylibs)
   end
+  alias generic_check_dylibs check_dylibs
 
   def check_formula_deps
     filter_out = proc do |dep|
@@ -244,3 +249,5 @@ class LinkageChecker
     opoo "Formula unavailable: #{keg.name}"
   end
 end
+
+require "extend/os/linkage_checker"


### PR DESCRIPTION
gcc and glibc are implicit dependencies on Linux.
No other linkage to system libraries is expected or desired.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----