### PR TITLE
language/python: support pypy

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -9,13 +9,21 @@ module Language
       Version.create(version.to_s)
     end
 
-    def self.homebrew_site_packages(version = "3.7")
-      HOMEBREW_PREFIX/"lib/python#{version}/site-packages"
+    def self.homebrew_site_packages(python = "python3.7")
+      HOMEBREW_PREFIX/site_packages(python)
+    end
+
+    def self.site_packages(python = "python3.7")
+      if python == "pypy"
+        "site-packages"
+      else
+        "lib/python#{major_minor_version python}/site-packages"
+      end
     end
 
     def self.each_python(build, &block)
       original_pythonpath = ENV["PYTHONPATH"]
-      { "python@3" => "python3", "python@2" => "python2.7" }.each do |python_formula, python|
+      { "python@3" => "python3", "python@2" => "python2.7", "pypy" => "pypy" }.each do |python_formula, python|
         python_formula = Formulary.factory(python_formula)
         next if build.without? python_formula.to_s
 
@@ -23,7 +31,7 @@ module Language
         ENV["PYTHONPATH"] = if python_formula.installed?
           nil
         else
-          homebrew_site_packages(version)
+          homebrew_site_packages(python)
         end
         block&.call python, version
       end
@@ -31,11 +39,10 @@ module Language
     end
 
     def self.reads_brewed_pth_files?(python)
-      version = major_minor_version python
-      return unless homebrew_site_packages(version).directory?
-      return unless homebrew_site_packages(version).writable_real?
+      return unless homebrew_site_packages(python).directory?
+      return unless homebrew_site_packages(python).writable_real?
 
-      probe_file = homebrew_site_packages(version)/"homebrew-pth-probe.pth"
+      probe_file = homebrew_site_packages(python)/"homebrew-pth-probe.pth"
       begin
         probe_file.atomic_write("import site; site.homebrew_was_here = True")
         with_homebrew_path { quiet_system python, "-c", "import site; assert(site.homebrew_was_here)" }
@@ -69,6 +76,7 @@ module Language
         --no-user-cfg
         install
         --prefix=#{prefix}
+        --install-scripts=#{prefix}/bin
         --single-version-externally-managed
         --record=installed.txt
       ]
@@ -101,17 +109,16 @@ module Language
 
         # Find any Python bindings provided by recursive dependencies
         formula_deps = formula.recursive_dependencies
-        xy = Language::Python.major_minor_version python
         pth_contents = formula_deps.map do |d|
           next if d.build?
 
-          dep_site_packages = Formula[d.name].opt_lib/"python#{xy}/site-packages"
+          dep_site_packages = Formula[d.name].opt_prefix/Language::Python.site_packages(python)
           next unless dep_site_packages.exist?
 
           "import site; site.addsitedir('#{dep_site_packages}')\n"
         end.compact
         unless pth_contents.empty?
-          (venv_root/"lib/python#{xy}/site-packages/homebrew_deps.pth").write pth_contents.join
+          (venv_root/Language::Python.site_packages(python)/"homebrew_deps.pth").write pth_contents.join
         end
 
         venv
@@ -140,7 +147,7 @@ module Language
       def virtualenv_install_with_resources(options = {})
         python = options[:using]
         if python.nil?
-          wanted = %w[python python@2 python2 python3 python@3].select { |py| needs_python?(py) }
+          wanted = %w[python python@2 python2 python3 python@3 pypy].select { |py| needs_python?(py) }
           raise FormulaAmbiguousPythonError, self if wanted.size > 1
 
           python = wanted.first || "python2.7"
@@ -177,9 +184,8 @@ module Language
           @formula.resource("homebrew-virtualenv").stage do |stage|
             old_pythonpath = ENV.delete "PYTHONPATH"
             begin
-              xy = Language::Python.major_minor_version(@python)
               staging = Pathname.new(stage.staging.tmpdir)
-              ENV.prepend_create_path "PYTHONPATH", staging/"target/lib/python#{xy}/site-packages"
+              ENV.prepend_create_path "PYTHONPATH", staging/"target"/Language::Python.site_packages(@python)
               @formula.system @python, *Language::Python.setup_install_args(staging/"target")
               @formula.system @python, "-s", staging/"target/bin/virtualenv", "-p", @python, @venv_root
             ensure

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -1,6 +1,35 @@
 require "language/python"
 require "resource"
 
+describe Language::Python, :needs_python do
+  describe "#major_minor_version" do
+    it "returns a Version for Python 2" do
+      expect(subject).to receive(:major_minor_version).and_return(Version)
+      subject.major_minor_version("python")
+    end
+  end
+
+  describe "#site_packages" do
+    it "gives a different location between PyPy and Python 2" do
+      expect(subject.site_packages("python")).not_to eql(subject.site_packages("pypy"))
+    end
+  end
+
+  describe "#homebrew_site_packages" do
+    it "returns the Homebrew site packages location" do
+      expect(subject).to receive(:site_packages).and_return(Pathname)
+      subject.site_packages("python")
+    end
+  end
+
+  describe "#user_site_packages" do
+    it "can determine user site packages location" do
+      expect(subject).to receive(:user_site_packages).and_return(Pathname)
+      subject.user_site_packages("python")
+    end
+  end
+end
+
 describe Language::Python::Virtualenv::Virtualenv do
   subject { described_class.new(formula, dir, "python") }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Now that PyPy is maturing (it builds numpy and scipy now!) I think it would be good for Homebrew to support this, if not in core, but at least permit taps to use PyPy as opposed to Python. The Python dev team do not have speed as a huge priority, if I recall they prioritize readability and ease of understanding of the CPython source code.

This is an opt-in change. Formulae using the recommended `virtualenv_install_with_resources` method of installing a python formula and its dependencies merely need to change `depends_on "python@"` to `depends_on "pypy"`.

There is an API change here, but I've checked `homebrew/core` and the first ten pages of GitHub search and there are no formulae passing an argument to `Language::Python.homebrew_site_packages`. A backwards compatible change could be made but I think it's cleaner this way.

Formulae doing something more advanced need a bit more work, e.g., this diff for `numpy` successfully compiles a PyPy-enabled NumPy installation. I couldn't get a side-by-side install for Python 3, Python 3, and PyPy to work though. There's some compiler confusion going on. But PyPy by itself is a-ok.

```diff
diff --git a/Formula/numpy.rb b/Formula/numpy.rb
index 2b08e8a790..4d4948de23 100644
--- a/Formula/numpy.rb
+++ b/Formula/numpy.rb
@@ -23,8 +23,7 @@ class Numpy < Formula
   option "without-python@2", "Build without python2 support"
 
   depends_on "gcc" => :build # for gfortran
-  depends_on "python@2" => :recommended
-  depends_on "python" => :recommended
+  depends_on "pypy" => :recommended
 
   resource "nose" do
     url "https://files.pythonhosted.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz"
@@ -33,17 +32,18 @@ class Numpy < Formula
 
   def install
     Language::Python.each_python(build) do |python, version|
-      dest_path = lib/"python#{version}/site-packages"
+      site_packages = Language::Python.site_packages(python)
+      dest_path = prefix/site_packages
       dest_path.mkpath
 
-      nose_path = libexec/"nose/lib/python#{version}/site-packages"
+      nose_path = libexec/"nose"/site_packages
       resource("nose").stage do
         system python, *Language::Python.setup_install_args(libexec/"nose")
         (dest_path/"homebrew-numpy-nose.pth").write "#{nose_path}\n"
       end
 
       if build.head?
-        ENV.prepend_create_path "PYTHONPATH", buildpath/"tools/lib/python#{version}/site-packages"
+        ENV.prepend_create_path "PYTHONPATH", buildpath/"tools"/site_packages
         resource("Cython").stage do
           system python, *Language::Python.setup_install_args(buildpath/"tools")
         end
@@ -51,7 +51,7 @@ class Numpy < Formula
 
       system python, "setup.py",
         "build", "--fcompiler=gnu95", "--parallel=#{ENV.make_jobs}",
-        "install", "--prefix=#{prefix}",
+        "install", "--prefix=#{prefix}", "--install-scripts=#{bin}",
         "--single-version-externally-managed", "--record=installed.txt"
     end
   end
```


* Currently, only pypy for python2 is supported. pypy3 has some issues that I'm investigating. But once that's figured out it should be simple enough to just add `pypy3` to the changed code.

* Setting the `--install-scripts` path is necessary for PyPy but not for regular Python. Not sure why this is. I dug up this commit https://github.com/Homebrew/homebrew-core/commit/7d376d5fdf5 but there's not a whole lot of context why scripts were installed to `share` instead of `bin`.
    * From what I can tell, regular scripts installed via pip are put in `bin` and I *think* their shebang is modified to point to the `opt_prefix`.
    * This means they survive version upgrades anyway as long as python still is installed. I don't recall if the `opt_prefix` thing was introduced before or after 2012. So if that makes sense I'd like to make a follow up pull request in core to get that removed from the pypy formula.