### PR TITLE
Update minimum Git version.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -96,10 +96,8 @@ then
     HOMEBREW_FORCE_BREWED_CURL="1"
   fi
 
-  # The system Git is too old for some GitHub's SSL ciphers on older
-  # macOS versions.
-  # https://github.com/blog/2507-weak-cryptographic-standards-removed
-  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "100900" ]]
+  # The system Git is too old for some Homebrew functionality we rely on.
+  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101200" ]]
   then
     HOMEBREW_FORCE_BREWED_GIT="1"
   fi

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -559,16 +559,16 @@ module Homebrew
       end
 
       def check_git_version
-        # https://help.github.com/articles/https-cloning-errors
+        # System Git version on macOS Sierra.
+        minimum_version = "2.14.3".freeze
         return unless Utils.git_available?
-        return unless Version.create(Utils.git_version) < Version.create("1.8.5")
+        return if Version.create(Utils.git_version) >= Version.create(minimum_version)
 
         git = Formula["git"]
         git_upgrade_cmd = git.any_version_installed? ? "upgrade" : "install"
         <<~EOS
           An outdated version (#{Utils.git_version}) of Git was detected in your PATH.
-          Git 1.8.5 or newer is required to perform checkouts over HTTPS from GitHub and
-          to support the 'git -C <path>' option.
+          Git #{minimum_version} or newer is required for Homebrew.
           Please upgrade:
             brew #{git_upgrade_cmd} git
         EOS


### PR DESCRIPTION
This forces the use of Homebrew's Git on El Capitan and below. Normally I'd remove the need for this but given we're weeks away from El Capitan being unsupported it doesn't seem worth the effort to remove useful functionality. Instead, let's warn about an old Git and autoinstall Homebrew's Git wherever needed.

Fixes #4818.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----