### PR TITLE
Add Homebrew::DEFAULT_PREFIX for Linux

### DIFF
--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -1,5 +1,5 @@
 #:  * `--prefix`:
-#:    Display Homebrew's install path. *Default:* `/usr/local`
+#:    Display Homebrew's install path. *Default:* `/usr/local` on macOS and `/home/linuxbrew/.linuxbrew` on Linux
 #:
 #:  * `--prefix` <formula>:
 #:    Display the location in the cellar where <formula> is or would be installed.

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -52,7 +52,7 @@ module Homebrew
       end
 
       if keg_only
-        if HOMEBREW_PREFIX.to_s == "/usr/local"
+        if Homebrew.default_prefix?
           f = keg.to_formula
           caveats = Caveats.new(f)
 

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -285,7 +285,7 @@ module Homebrew
           ohai "Detecting if #{filename} is relocatable..."
         end
 
-        if prefix == "/usr/local"
+        if Homebrew.default_prefix?(prefix)
           prefix_check = File.join(prefix, "opt")
         else
           prefix_check = prefix

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -56,7 +56,7 @@ module Homebrew
       osx_image: xcode9.2
       cache:
         directories:
-          - /usr/local/Homebrew/Library/Homebrew/vendor/bundle
+          - #{Homebrew::DEFAULT_PREFIX}/Homebrew/Library/Homebrew/vendor/bundle
       branches:
         only:
           - master

--- a/Library/Homebrew/extend/os/analytics.rb
+++ b/Library/Homebrew/extend/os/analytics.rb
@@ -1,0 +1,1 @@
+require "extend/os/mac/utils/analytics" if OS.mac?

--- a/Library/Homebrew/extend/os/mac/utils/analytics.rb
+++ b/Library/Homebrew/extend/os/mac/utils/analytics.rb
@@ -1,0 +1,9 @@
+module Utils
+  module Analytics
+    class << self
+      def custom_prefix_label
+        "non-/usr/local".freeze
+      end
+    end
+  end
+end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -42,12 +42,20 @@ HOMEBREW_BOTTLE_DOMAIN = ENV["HOMEBREW_BOTTLE_DOMAIN"] ||
                          HOMEBREW_BOTTLE_DEFAULT_DOMAIN
 
 require "fileutils"
+require "os"
+require "os/global"
 
 module Homebrew
   extend FileUtils
 
+  DEFAULT_PREFIX ||= "/usr/local".freeze
+
   class << self
     attr_writer :failed, :raise_deprecation_exceptions, :auditing, :args
+
+    def Homebrew.default_prefix?(prefix = HOMEBREW_PREFIX)
+      prefix.to_s == DEFAULT_PREFIX
+    end
 
     def failed?
       @failed ||= false
@@ -108,7 +116,6 @@ HOMEBREW_INTERNAL_COMMAND_ALIASES = {
 
 require "set"
 
-require "os"
 require "extend/pathname"
 
 require "extend/module"

--- a/Library/Homebrew/os/global.rb
+++ b/Library/Homebrew/os/global.rb
@@ -1,0 +1,1 @@
+require "os/linux/global" if OS.linux?

--- a/Library/Homebrew/os/linux/global.rb
+++ b/Library/Homebrew/os/linux/global.rb
@@ -1,0 +1,3 @@
+module Homebrew
+  DEFAULT_PREFIX = "/home/linuxbrew/.linuxbrew".freeze
+end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -7,6 +7,7 @@ require "dependency_collector"
 require "utils/bottles"
 require "patch"
 require "compilers"
+require "global"
 require "os/mac/version"
 
 class SoftwareSpec
@@ -325,8 +326,8 @@ class Bottle
 end
 
 class BottleSpecification
-  DEFAULT_PREFIX = "/usr/local".freeze
-  DEFAULT_CELLAR = "/usr/local/Cellar".freeze
+  DEFAULT_PREFIX = Homebrew::DEFAULT_PREFIX
+  DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar".freeze
 
   attr_rw :prefix, :cellar, :rebuild
   attr_accessor :tap

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -112,9 +112,9 @@ class SystemConfig
         f.puts "Core tap: N/A"
       end
       defaults_hash = {
-        HOMEBREW_PREFIX: "/usr/local",
-        HOMEBREW_REPOSITORY: "/usr/local/Homebrew",
-        HOMEBREW_CELLAR: "/usr/local/Cellar",
+        HOMEBREW_PREFIX: Homebrew::DEFAULT_PREFIX,
+        HOMEBREW_REPOSITORY: "#{Homebrew::DEFAULT_PREFIX}/Homebrew",
+        HOMEBREW_CELLAR: "#{Homebrew::DEFAULT_PREFIX}/Cellar",
         HOMEBREW_CACHE: "#{ENV["HOME"]}/Library/Caches/Homebrew",
         HOMEBREW_RUBY_WARNINGS: "-W0",
         HOMEBREW_TEMP: ENV["HOMEBREW_SYSTEM_TEMP"],

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -8,9 +8,9 @@ describe Utils::Analytics do
         described_class.clear_os_prefix_ci
       end
 
-      it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is not /usr/local" do
+      it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix" do
         stub_const("HOMEBREW_PREFIX", "blah")
-        expect(described_class.os_prefix_ci).to include("#{OS_VERSION}, non-/usr/local")
+        expect(described_class.os_prefix_ci).to include("#{OS_VERSION}, #{Utils::Analytics.custom_prefix_label}")
       end
 
       it "includes CI when ENV['CI'] is set" do
@@ -18,9 +18,9 @@ describe Utils::Analytics do
         expect(described_class.os_prefix_ci).to include("CI")
       end
 
-      it "does not include prefix when HOMEBREW_PREFIX is /usr/local" do
-        stub_const("HOMEBREW_PREFIX", "/usr/local")
-        expect(described_class.os_prefix_ci).not_to include("non-/usr/local")
+      it "does not include prefix when HOMEBREW_PREFIX is the default prefix" do
+        stub_const("HOMEBREW_PREFIX", Homebrew::DEFAULT_PREFIX)
+        expect(described_class.os_prefix_ci).not_to include(Utils::Analytics.custom_prefix_label)
       end
     end
   end

--- a/Library/Homebrew/update_migrator.rb
+++ b/Library/Homebrew/update_migrator.rb
@@ -256,8 +256,8 @@ module UpdateMigrator
     end
 
     def migrate_legacy_repository_if_necessary
-      return unless HOMEBREW_PREFIX.to_s == "/usr/local"
-      return unless HOMEBREW_REPOSITORY.to_s == "/usr/local"
+      return unless Homebrew.default_prefix?
+      return unless Homebrew.default_prefix?(HOMEBREW_REPOSITORY)
 
       ohai "Migrating HOMEBREW_REPOSITORY (please wait)..."
 
@@ -273,7 +273,7 @@ module UpdateMigrator
         return
       end
 
-      new_homebrew_repository = Pathname.new "/usr/local/Homebrew"
+      new_homebrew_repository = Pathname.new "#{HOMEBREW_PREFIX}/Homebrew"
       new_homebrew_repository.rmdir_if_possible
       if new_homebrew_repository.exist?
         ofail <<~EOS
@@ -359,11 +359,13 @@ module UpdateMigrator
       link_completions_manpages_and_docs(new_homebrew_repository)
 
       ohai "Migrated HOMEBREW_REPOSITORY to #{new_homebrew_repository}!"
-      puts <<~EOS
-        Homebrew no longer needs to have ownership of /usr/local. If you wish you can
-        return /usr/local to its default ownership with:
-          sudo chown root:wheel #{HOMEBREW_PREFIX}
-      EOS
+      if HOMEBREW_PREFIX == "/usr/local"
+        puts <<~EOS
+          Homebrew no longer needs to have ownership of #{HOMEBREW_PREFIX}. If you wish you can
+          return #{HOMEBREW_PREFIX} to its default ownership with:
+            sudo chown root:wheel #{HOMEBREW_PREFIX}
+        EOS
+      end
     rescue => e
       ofail <<~EOS
         #{Tty.bold}Failed to migrate HOMEBREW_REPOSITORY to #{new_homebrew_repository}!#{Tty.reset}

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -3,6 +3,10 @@ require "erb"
 module Utils
   module Analytics
     class << self
+      def custom_prefix_label
+        "generic-prefix".freeze
+      end
+
       def clear_os_prefix_ci
         return unless instance_variable_defined?(:@os_prefix_ci)
         remove_instance_variable(:@os_prefix_ci)
@@ -11,7 +15,7 @@ module Utils
       def os_prefix_ci
         @os_prefix_ci ||= begin
           os = OS_VERSION
-          prefix = ", non-/usr/local" if HOMEBREW_PREFIX.to_s != "/usr/local"
+          prefix = ", #{custom_prefix_label}" if HOMEBREW_PREFIX.to_s != Homebrew::DEFAULT_PREFIX
           ci = ", CI" if ENV["CI"]
           "#{os}#{prefix}#{ci}"
         end
@@ -79,3 +83,5 @@ module Utils
     end
   end
 end
+
+require "extend/os/analytics"

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -644,7 +644,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     the list is formatted for export to `bash`(1) unless `--plain` is passed.
 
   * `--prefix`:
-    Display Homebrew's install path. *Default:* `/usr/local`
+    Display Homebrew's install path. *Default:* `/usr/local` on macOS and `/home/linuxbrew/.linuxbrew` on Linux
 
   * `--prefix` `formula`:
     Display the location in the cellar where `formula` is or would be installed.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -581,7 +581,7 @@ Pass \fB\-\-shell=\fR\fIshell\fR to generate a list of environment variables for
 If the command\'s output is sent through a pipe and no shell is specified, the list is formatted for export to \fBbash\fR(1) unless \fB\-\-plain\fR is passed\.
 .
 .IP "\(bu" 4
-\fB\-\-prefix\fR: Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR
+\fB\-\-prefix\fR: Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR on macOS and \fB/home/linuxbrew/\.linuxbrew\fR on Linux
 .
 .IP "\(bu" 4
 \fB\-\-prefix\fR \fIformula\fR: Display the location in the cellar where \fIformula\fR is or would be installed\.


### PR DESCRIPTION
The default prefix is /usr/local on macOS
and /home/linuxbrew/.linuxbrew on Linux.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----