### PR TITLE
Cask: fixes for quarantining

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -7,7 +7,7 @@ module Cask
   class Download
     attr_reader :cask
 
-    def initialize(cask, force: false, quarantine: true)
+    def initialize(cask, force: false, quarantine: nil)
       @cask = cask
       @force = force
       @quarantine = quarantine
@@ -46,11 +46,10 @@ module Cask
     end
 
     def quarantine
-      return unless @quarantine
+      return if @quarantine.nil?
       return unless Quarantine.available?
-      return if Quarantine.detect(@downloaded_path)
 
-      Quarantine.cask(cask: @cask, download_path: @downloaded_path)
+      Quarantine.cask!(cask: @cask, download_path: @downloaded_path, action: @quarantine)
     end
   end
 end

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -49,7 +49,11 @@ module Cask
       return if @quarantine.nil?
       return unless Quarantine.available?
 
-      Quarantine.cask!(cask: @cask, download_path: @downloaded_path, action: @quarantine)
+      if @quarantine
+        Quarantine.cask!(cask: @cask, download_path: @downloaded_path)
+      else
+        Quarantine.release!(download_path: @downloaded_path)
+      end
     end
   end
 end

--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -184,4 +184,18 @@ module Cask
       s
     end
   end
+
+  class CaskQuarantineReleaseError < CaskQuarantineError
+    def to_s
+      s = "Failed to release #{path} from quarantine."
+
+      unless reason.empty?
+        s << " Here's the reason:\n"
+        s << Formatter.error(reason)
+        s << "\n" unless reason.end_with?("\n")
+      end
+
+      s
+    end
+  end
 end

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -121,7 +121,7 @@ module Cask
 
       resolved_paths = Pathname.glob(to/"**/*", File::FNM_DOTMATCH)
 
-      FileUtils.chmod "u+w", resolved_paths
+      system_command!("/bin/chmod", args: ["-R", "u+w", to])
 
       quarantiner = system_command("/usr/bin/xargs",
                                    args: [

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -55,7 +55,7 @@ module Cask
                      print_stderr: false).stdout.rstrip
     end
 
-    def disable_translocation!(xattr)
+    def toggle_no_translocation_bit(xattr)
       fields = xattr.split(";")
 
       # Fields: status, epoch, download agent, event ID
@@ -117,7 +117,7 @@ module Cask
 
       odebug "Propagating quarantine from #{from} to #{to}"
 
-      quarantine_status = disable_translocation!(status(from))
+      quarantine_status = toggle_no_translocation_bit(status(from))
 
       resolved_paths = Pathname.glob(to/"**/*", File::FNM_DOTMATCH)
 

--- a/Library/Homebrew/test/cask/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/fetch_spec.rb
@@ -37,7 +37,7 @@ describe Cask::Cmd::Fetch, :cask do
 
     old_ctime = File.stat(cached_location).ctime
 
-    described_class.run("local-transmission")
+    described_class.run("local-transmission", "--no-quarantine")
     new_ctime = File.stat(cached_location).ctime
 
     expect(old_ctime.to_i).to eq(new_ctime.to_i)
@@ -49,7 +49,7 @@ describe Cask::Cmd::Fetch, :cask do
     old_ctime = File.stat(cached_location).ctime
     sleep(1)
 
-    described_class.run("local-transmission", "--force")
+    described_class.run("local-transmission", "--force", "--no-quarantine")
     new_ctime = File.stat(cached_location).ctime
 
     expect(new_ctime.to_i).to be > old_ctime.to_i


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
Apple's Gatekeeper is currently making automated app installation a
nightmare for users. Let's disable this and release all existing
downloads from quarantine. If people still want to use it, let them
know the depth of the rabbit hole.

As part of this, let's also toss in some fixes:
- for non-DMG app installs, where dotfiles or dotfolders are not set as write-able,
- for quarantine users, let's toggle the translocation bit ourselves.

Fixes Homebrew/homebrew-cask#51663, fixes Homebrew/homebrew-cask#51646,
fixes Homebrew/homebrew-cask#51554, fixes Homebrew/homebrew-cask#51691.