### PR TITLE
Determine remote_url using git config

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -325,7 +325,11 @@ module Homebrew
           odie "Unable to fork: #{e.message}!"
         end
 
-        remote_url = response.fetch("clone_url")
+        if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
+          remote_url = response.fetch("ssh_url")
+        else
+          remote_url = response.fetch("clone_url")
+        end
         username = response.fetch("owner").fetch("login")
 
         safe_system "git", "fetch", "--unshallow", "origin" if shallow


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

partial fix for #4697.

This allows the bump-formula-pr script to dynamically determine if your remotes are using SSH, and if so, use that instead of HTTPS.

cc: @MikeMcQuaid 