### PR TITLE
make dependency_order_cop a regular audit

### DIFF
--- a/Library/Homebrew/rubocops/dependency_order_cop.rb
+++ b/Library/Homebrew/rubocops/dependency_order_cop.rb
@@ -2,7 +2,7 @@ require "rubocops/extend/formula_cop"
 
 module RuboCop
   module Cop
-    module NewFormulaAudit
+    module FormulaAudit
       # This cop checks for correct order of `depends_on` in a Formula
       #
       # precedence order:

--- a/Library/Homebrew/test/rubocops/dependency_order_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_cop_spec.rb
@@ -1,6 +1,6 @@
 require "rubocops/dependency_order_cop"
 
-describe RuboCop::Cop::NewFormulaAudit::DependencyOrder do
+describe RuboCop::Cop::FormulaAudit::DependencyOrder do
   subject(:cop) { described_class.new }
 
   context "depends_on" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
As we're trying to enforce this in PRs, let's make it a regular audit. Currently ≈ 900 formulae need changes to pass this audit, I'll submit the necessary changes to `core` if people are 👍.