### PR TITLE
Cask: constrain quarantine support status

### DIFF
--- a/Library/Homebrew/cask/cmd/doctor.rb
+++ b/Library/Homebrew/cask/cmd/doctor.rb
@@ -120,9 +120,7 @@ module Cask
       def check_quarantine_support
         ohai "Gatekeeper support"
 
-        status = Quarantine.check_quarantine_support
-
-        case status
+        case Quarantine.check_quarantine_support
         when :quarantine_available
           puts "Enabled"
         when :no_swift


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

It's come to my attention (waiting for a properly filed issue) that some people are tinkering with their SDKs, leading to Swift being available but rejecting them for outdated.

With this pull request, quarantine support is available **only if the script exits with `2`**.
It is definitely **not** available if Swift doesn't exist or if it exits with `5` (incompatible SDK, probably 10.9 or lower). All other cases are from now on treated as unsupported.

I don't know if we should print a message for these cases in `brew cask doctor`; please review and tell me!

PS: No tests are included for this pull request, as this is just a port of `brew cask doctor` support status handling to the quarantine API itself.

Fixes Homebrew/homebrew-cask#51873, fixes Homebrew/homebrew-cask#51958.