### PR TITLE
Elide prefix "/usr/local" in bottle block

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -44,12 +44,12 @@ BOTTLE_ERB = <<-EOS.freeze
     <% if !root_url.start_with?(HOMEBREW_BOTTLE_DEFAULT_DOMAIN) %>
     root_url "<%= root_url %>"
     <% end %>
-    <% if prefix != BottleSpecification::DEFAULT_PREFIX %>
+    <% if ![Homebrew::DEFAULT_PREFIX, "/usr/local"].include?(prefix) %>
     prefix "<%= prefix %>"
     <% end %>
     <% if cellar.is_a? Symbol %>
     cellar :<%= cellar %>
-    <% elsif cellar != BottleSpecification::DEFAULT_CELLAR %>
+    <% elsif ![Homebrew::DEFAULT_CELLAR, "/usr/local/Cellar"].include?(cellar) %>
     cellar "<%= cellar %>"
     <% end %>
     <% if rebuild.positive? %>

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -49,6 +49,8 @@ module Homebrew
   extend FileUtils
 
   DEFAULT_PREFIX ||= "/usr/local".freeze
+  DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar".freeze
+  DEFAULT_REPOSITORY = "#{DEFAULT_PREFIX}/Homebrew".freeze
 
   class << self
     attr_writer :failed, :raise_deprecation_exceptions, :auditing, :args

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -327,7 +327,6 @@ end
 
 class BottleSpecification
   DEFAULT_PREFIX = Homebrew::DEFAULT_PREFIX
-  DEFAULT_CELLAR = "#{DEFAULT_PREFIX}/Cellar".freeze
 
   attr_rw :prefix, :cellar, :rebuild
   attr_accessor :tap
@@ -335,8 +334,8 @@ class BottleSpecification
 
   def initialize
     @rebuild = 0
-    @prefix = DEFAULT_PREFIX
-    @cellar = DEFAULT_CELLAR
+    @prefix = Homebrew::DEFAULT_PREFIX
+    @cellar = Homebrew::DEFAULT_CELLAR
     @collector = Utils::Bottles::Collector.new
     @root_url_specs = {}
   end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -113,8 +113,8 @@ class SystemConfig
       end
       defaults_hash = {
         HOMEBREW_PREFIX: Homebrew::DEFAULT_PREFIX,
-        HOMEBREW_REPOSITORY: "#{Homebrew::DEFAULT_PREFIX}/Homebrew",
-        HOMEBREW_CELLAR: "#{Homebrew::DEFAULT_PREFIX}/Cellar",
+        HOMEBREW_REPOSITORY: Homebrew::DEFAULT_REPOSITORY,
+        HOMEBREW_CELLAR: Homebrew::DEFAULT_CELLAR,
         HOMEBREW_CACHE: "#{ENV["HOME"]}/Library/Caches/Homebrew",
         HOMEBREW_RUBY_WARNINGS: "-W0",
         HOMEBREW_TEMP: ENV["HOMEBREW_SYSTEM_TEMP"],


### PR DESCRIPTION
brew test-bot --ci-upload is run on a Linux machine.
The macOS bottles have a prefix of `/usr/local`.
The default prefix on Linux is `/home/linuxbrew/.linuxbrew`.
Elide `prefix "/usr/local"` in the bottle block, even it does not match the default prefix. Ditto for cellar.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----