### PR TITLE
use 'number_readable' when displaying analytics

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -207,7 +207,7 @@ module Homebrew
         value.each do |range, results|
           oh1 "#{category} (#{range})"
           results.each do |name_with_options, count|
-            puts "#{name_with_options}: #{count}"
+            puts "#{name_with_options}: #{number_readable(count)}"
           end
         end
       end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -216,7 +216,7 @@ module Homebrew
 
     json["analytics"].each do |category, value|
       analytics = value.map do |range, results|
-        "#{results.values.inject("+")} (#{range})"
+        "#{number_readable(results.values.inject("+"))} (#{range})"
       end
       puts "#{category}: #{analytics.join(", ")}"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This pull request adds thousands separators to the numbers of installations in <kbd>brew info</kbd>'s analytics output, and closes issue #4889.