### PR TITLE
Remove `__MACOSX` directory after unzipping.

### DIFF
--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -16,10 +16,14 @@ module UnpackStrategy
 
     def extract_to_dir(unpack_dir, basename:, verbose:)
       quiet_flags = verbose ? [] : ["-qq"]
-      system_command! "unzip",
-                      args: [*quiet_flags, path, "-d", unpack_dir],
-                      verbose: verbose,
-                      print_stderr: false
+      result = system_command! "unzip",
+                               args: [*quiet_flags, path, "-d", unpack_dir],
+                               verbose: verbose,
+                               print_stderr: false
+
+      FileUtils.rm_rf unpack_dir/"__MACOSX"
+
+      result
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`unzip` doesn't automatically remove `__MACOSX` like `ditto` does.

Closes https://github.com/Homebrew/homebrew-cask/pull/51775.