### PR TITLE
Make remaining `curl` respect `HOMEBREW_CURLRC`

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -406,6 +406,13 @@ EOS
     QUIET_ARGS=()
   fi
 
+  if [[ -z "$HOMEBREW_CURLRC" ]]
+  then
+    CURL_DISABLE_CURLRC_ARGS=(-q)
+  else
+    CURL_DISABLE_CURLRC_ARGS=()
+  fi
+
   # only allow one instance of brew update
   lock update
 
@@ -481,7 +488,9 @@ EOS
           GITHUB_API_ENDPOINT="commits/$UPSTREAM_BRANCH_DIR"
         fi
 
-        UPSTREAM_SHA_HTTP_CODE="$("$HOMEBREW_CURL" --silent --max-time 3 \
+        UPSTREAM_SHA_HTTP_CODE="$("$HOMEBREW_CURL" \
+           "${CURL_DISABLE_CURLRC_ARGS[@]}" \
+           --silent --max-time 3 \
            --location --output /dev/null --write-out "%{http_code}" \
            --dump-header "$DIR/.git/GITHUB_HEADERS" \
            --user-agent "$HOMEBREW_USER_AGENT_CURL" \


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Make the `curl` invocation in `cmd/update` and `utils/analytics` both respect the `HOMEBREW_CURLRC` environment variable, as `utils/curl` already does so, otherwise the annoying warning `Failed to set filetime on outfile: Operation not permitted` will pop up every time `brew update` running.