### PR TITLE
Generate Cobertura coverage data for Azure Pipelines

### DIFF
--- a/Library/Homebrew/test/Gemfile
+++ b/Library/Homebrew/test/Gemfile
@@ -17,4 +17,5 @@ end
 group :coverage do
   gem "codecov", require: false
   gem "simplecov", require: false
+  gem "simplecov-cobertura", require: false
 end

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-cobertura (1.3.0)
+      simplecov (~> 0.8)
     simplecov-html (0.10.2)
     unicode-display_width (1.4.0)
     url (0.3.2)
@@ -77,6 +79,7 @@ DEPENDENCIES
   rubocop (= 0.59.1)
   rubocop-rspec
   simplecov
+  simplecov-cobertura
 
 BUNDLED WITH
    1.16.4

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -8,6 +8,11 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
     ENV["CODECOV_TOKEN"] = ENV["HOMEBREW_CODECOV_TOKEN"]
   end
 
+  if ENV["HOMEBREW_AZURE_PIPELINES"]
+    require "simplecov-cobertura"
+    formatters << SimpleCov::Formatter::CoberturaFormatter
+  end
+
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
 end
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,14 @@ jobs:
         testRunner: JUnit
         testResultsFiles: brew-test-bot.xml
 
+    - task: PublishCodeCoverageResults@1
+      displayName: Publish brew tests code coverage
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: $(Build.SourcesDirectory)/coverage/coverage.xml
+        reportDirectory: $(Build.SourcesDirectory)/coverage
+        failIfCoverageEmpty: true
+
 - job: Linux
   pool:
     vmImage: ubuntu-16.04
@@ -31,3 +39,10 @@ jobs:
       displayName: Run brew test-bot
       env:
         HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
+
+    - task: PublishTestResults@2
+      displayName: Publish test-bot test results
+      condition: succeededOrFailed()
+      inputs:
+        testRunner: JUnit
+        testResultsFiles: brew-test-bot.xml


### PR DESCRIPTION
Generate Cobertura coverage data for Azure Pipelines

These can be used and displayed directly in the Azure Pipelines GUI.

It may not end up replacing CodeCov but it's easy enough so: why not.

Azure coverage docs: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-code-coverage-results?view=vsts

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?