### PR TITLE
bin/brew: introduce `HOMEBREW_PRESERVED_ENVS` for an ENV whitelist

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -244,6 +244,10 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will not use the GitHub API for e.g searches or
     fetching relevant issues on a failed install.
 
+  * `HOMEBREW_PRESERVED_ENVS`:
+    A colon separated list of environment variables denoting not to be
+    filtered by Homebrew.
+
   * `HOMEBREW_PRY`:
     If set, Homebrew will use `pry` for the `brew irb` command.
 

--- a/bin/brew
+++ b/bin/brew
@@ -69,11 +69,13 @@ if [[ -z "$HOMEBREW_NO_ENV_FILTERING" && "$1" != "test-bot" ]]
 then
   PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
+  IFS=":" read -r -a PRESERVED_ENVS <<<"$HOMEBREW_PRESERVED_ENVS"
+
   FILTERED_ENV=()
   # Filter all but the specific variables.
   for VAR in HOME SHELL PATH TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
-             "${!HOMEBREW_@}" "${!TRAVIS_@}"
+             "${!HOMEBREW_@}" "${!TRAVIS_@}" "${PRESERVED_ENVS[@]}"
   do
     # Skip if variable value is empty.
     [[ -z "${!VAR}" ]] && continue

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1276,6 +1276,10 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will not use the GitHub API for e.g searches or
     fetching relevant issues on a failed install.
 
+  * `HOMEBREW_PRESERVED_ENVS`:
+    A colon separated list of environment variables denoting not to be
+    filtered by Homebrew.
+
   * `HOMEBREW_PRY`:
     If set, Homebrew will use `pry` for the `brew irb` command.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1211,6 +1211,10 @@ While ensuring your downloads are fully secure, this is likely to cause from\-so
 If set, Homebrew will not use the GitHub API for e\.g searches or fetching relevant issues on a failed install\.
 .
 .TP
+\fBHOMEBREW_PRESERVED_ENVS\fR
+A colon separated list of environment variables denoting not to be filtered by Homebrew\.
+.
+.TP
 \fBHOMEBREW_PRY\fR
 If set, Homebrew will use \fBpry\fR for the \fBbrew irb\fR command\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This provides an alternative approach to make it possible to keep some environment variables unfiltered. Setting the undocumented `HOMEBREW_NO_ENV_FILTERING` may cause more unintended side effects than expected, e.g. when `GEM_PATH` and/or `GEM_HOME` are set.

For example, if someone does not want Homebrew's Python to write `.pyc` files during `brew install --build-from-source` or `brew postinstall`, then `HOMEBREW_PRESERVED_ENVS =PYTHONDONTWRITEBYTECODE` and `PYTHONDONTWRITEBYTECODE=1` could be set. Comparing to setting the undocumented `HOMEBREW_NO_ENV_FILTERING`, this could be a safer approach.