### PR TITLE
Library/.rubocop.yml: disable `RescueEnsureAlignment`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -51,6 +51,11 @@ Layout/Tab:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
+# Auto-correct is broken (https://github.com/rubocop-hq/rubocop/issues/6258)
+# and layout is not configurable (https://github.com/rubocop-hq/rubocop/issues/6254).
+Layout/RescueEnsureAlignment:
+  Enabled: false
+
 # favour parens-less DSL-style arguments
 Lint/AmbiguousBlockAssociation:
   Enabled: false

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -97,11 +97,6 @@ Naming/UncommunicativeMethodParamName:
     - 'to'
     - 'v'
 
-# Auto-correct is broken (https://github.com/rubocop-hq/rubocop/issues/6258)
-# and layout is not configurable (https://github.com/rubocop-hq/rubocop/issues/6254).
-Layout/RescueEnsureAlignment:
-  Enabled: false
-
 # Avoid false positives on modifiers used on symbols of methods
 # See https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
ref: https://github.com/Homebrew/brew/pull/4919#issuecomment-422198183

disable `RescueEnsureAlignment` for taps.