### PR TITLE
update-reset: allow specifying repositories.

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -1,10 +1,11 @@
-#:  * `update-reset`:
-#:    Fetches and resets Homebrew and all tap repositories using `git`(1) to
-#:    their latest `origin/master`. Note this will destroy all your uncommitted
-#:    or committed changes.
+#:  * `update-reset` [<repositories>]:
+#:    Fetches and resets Homebrew and all tap repositories (or the specified
+#:    `repositories`) using `git`(1) to their latest `origin/master`. Note this
+#:    will destroy all your uncommitted or committed changes.
 
 homebrew-update-reset() {
   local DIR
+  local -a REPOS=()
 
   for option in "$@"
   do
@@ -15,10 +16,7 @@ homebrew-update-reset() {
         [[ "$option" = *d* ]] && HOMEBREW_DEBUG=1
         ;;
       *)
-        odie <<EOS
-This command updates brew itself, and does not take formula names.
-Use 'brew upgrade <formula>'.
-EOS
+        REPOS+=("$option")
         ;;
     esac
   done
@@ -28,7 +26,12 @@ EOS
     set -x
   fi
 
-  for DIR in "$HOMEBREW_REPOSITORY" "$HOMEBREW_LIBRARY"/Taps/*/*
+  if [[ -z "$REPOS" ]]
+  then
+    REPOS+=("$HOMEBREW_REPOSITORY" "$HOMEBREW_LIBRARY"/Taps/*/*)
+  fi
+
+  for DIR in ${REPOS[@]}
   do
     [[ -d "$DIR/.git" ]] || continue
     cd "$DIR" || continue

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -578,10 +578,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--force` (or `-f`) is specified then always do a slower, full update check even
     if unnecessary.
 
-  * `update-reset`:
-    Fetches and resets Homebrew and all tap repositories using `git`(1) to
-    their latest `origin/master`. Note this will destroy all your uncommitted
-    or committed changes.
+  * `update-reset` [`repositories`]:
+    Fetches and resets Homebrew and all tap repositories (or the specified
+    `repositories`) using `git`(1) to their latest `origin/master`. Note this
+    will destroy all your uncommitted or committed changes.
 
   * `upgrade` [`install-options`] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`--display-times`] [`formulae`]:
     Upgrade outdated, unpinned brews (with existing install options).

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -527,7 +527,7 @@ If \fB\-\-merge\fR is specified then \fBgit merge\fR is used to include updates 
 If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full update check even if unnecessary\.
 .
 .IP "\(bu" 4
-\fBupdate\-reset\fR: Fetches and resets Homebrew and all tap repositories using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
+\fBupdate\-reset\fR [\fIrepositories\fR]: Fetches and resets Homebrew and all tap repositories (or the specified \fBrepositories\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
 .IP "\(bu" 4
 \fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fB\-\-display\-times\fR] [\fIformulae\fR]: Upgrade outdated, unpinned brews (with existing install options)\.


### PR DESCRIPTION
This makes it easier to use this in e.g. CI to quickly reset various repositories to their upstream versions.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----