### PR TITLE
test/Gemfile: add ronn.

### DIFF
--- a/Library/Homebrew/test/Gemfile
+++ b/Library/Homebrew/test/Gemfile
@@ -9,6 +9,10 @@ gem "rspec-retry", require: false
 gem "rspec-wait", require: false
 gem "rubocop", HOMEBREW_RUBOCOP_VERSION
 
+group :development do
+  gem "ronn", require: false
+end
+
 group :coverage do
   gem "codecov", require: false
   gem "simplecov", require: false


### PR DESCRIPTION
This now gets installed into the same place with or without a Bundler installation but this saves an extra install for `brew test-bot` or people running `brew man` after `brew tests`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----