### PR TITLE
cleanup: fix spurious detection of stale cache due to naming conflicts

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -64,6 +64,7 @@ module CleanupRefinement
     private
 
     def stale_formula?(scrub)
+      return false if dirname == "Cask"
       return false unless HOMEBREW_CELLAR.directory?
 
       version = if to_s.match?(Pathname::BOTTLE_EXTNAME_RX)
@@ -110,6 +111,7 @@ module CleanupRefinement
     end
 
     def stale_cask?(scrub)
+      return false unless dirname == "Cask"
       return false unless name = basename.to_s[/\A(.*?)\-\-/, 1]
 
       cask = begin


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If a formula and a cask share a common name, `brew cleanup` may report false positives.

For example, if I have the formula `flow` installed, `brew cleanup --dry-run` will always report that it would remove `$HOMEBREW_CACHE/flow--0.81.0.mojave.bottle.tar.gz`, as there is also a cask named `flow`.