### PR TITLE
Cleanup Travis and CI configuration.

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -74,7 +74,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI provider
         # Homebrew/brew is currently using.
-        return if ENV["TRAVIS"]
+        return if ENV["HOMEBREW_TRAVIS_CI"]
 
         message = <<~EOS
           Your Xcode (#{MacOS::Xcode.version}) is outdated.
@@ -101,7 +101,7 @@ module Homebrew
         # `brew test-bot` runs `brew doctor` in the CI for the Homebrew/brew
         # repository. This only needs to support whatever CI provider
         # Homebrew/brew is currently using.
-        return if ENV["TRAVIS"]
+        return if ENV["HOMEBREW_TRAVIS_CI"]
 
         <<~EOS
           A newer Command Line Tools release is available.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -729,7 +729,7 @@ class FormulaInstaller
     Utils.safe_fork do
       # Invalidate the current sudo timestamp in case a build script calls sudo.
       # Travis CI's Linux sudoless workers have a weird sudo that fails here.
-      system "/usr/bin/sudo", "-k" unless ENV["TRAVIS_SUDO"] == "false"
+      system "/usr/bin/sudo", "-k" if ENV["HOMEBREW_TRAVIS_SUDO"] != "false"
 
       if Sandbox.formula?(formula)
         sandbox = Sandbox.new

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -1,10 +1,14 @@
 if ENV["HOMEBREW_TESTS_COVERAGE"]
   require "simplecov"
 
-  if ENV["CODECOV_TOKEN"] || ENV["TRAVIS"]
+  formatters = [SimpleCov::Formatter::HTMLFormatter]
+  if ENV["HOMEBREW_CODECOV_TOKEN"] || ENV["HOMEBREW_TRAVIS_CI"]
     require "codecov"
-    SimpleCov.formatter = SimpleCov::Formatter::Codecov
+    formatters << SimpleCov::Formatter::Codecov
+    ENV["CODECOV_TOKEN"] = ENV["HOMEBREW_CODECOV_TOKEN"]
   end
+
+  SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
 end
 
 require "rspec/its"

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -32,7 +32,7 @@ def curl_args(*extra_args, show_output: false, user_agent: :default)
     args << "--fail"
     args << "--progress-bar" unless ARGV.verbose?
     args << "--verbose" if ENV["HOMEBREW_CURL_VERBOSE"]
-    args << "--silent" if !$stdout.tty? || ENV["TRAVIS"]
+    args << "--silent" if !$stdout.tty? || ENV["HOMEBREW_TRAVIS_CI"]
   end
 
   args + extra_args

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,18 +4,28 @@ jobs:
     vmImage: xcode9-macos10.13
   steps:
     - bash: |
-        rm -rf /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask*
-        brew update-reset
-        brew test-bot
-      displayName: brew test-bot
+        HOMEBREW_REPOSITORY="$(brew --repo)";
+        mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library";
+        sudo rm -rf "$HOMEBREW_REPOSITORY";
+        sudo ln -s "$PWD" "$HOMEBREW_REPOSITORY";
+        brew update-reset Library/Taps/homebrew/homebrew-core
+        brew test-bot --coverage
+      displayName: Run brew test-bot
       env:
         HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)
+
+    - task: PublishTestResults@2
+      displayName: Publish test-bot test results
+      inputs:
+        testRunner: JUnit
+        testResultsFiles: brew-test-bot.xml
+
 - job: Linux
   pool:
     vmImage: ubuntu-16.04
   steps:
     - bash: |
         "$PWD/bin/brew" test-bot
-      displayName: brew test-bot
+      displayName: Run brew test-bot
       env:
         HOMEBREW_GITHUB_API_TOKEN: $(github.publicApiToken)


### PR DESCRIPTION
Use the environment variables set by `brew test-bot`. Eventually we'll disable Travis CI running CodeCov so move `TRAVIS` references to `HOMEBREW_TRAVIS_CI` so it doesn't need whitelisted.

Also, fix `azure-pipelines.yml` so it's testing the correct version of Homebrew/brew (the one checked out in the `pwd`).

Extracted from #4922.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----