### PR TITLE
cache_store: handle corrupt DBM database.

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -19,6 +19,8 @@ end
 class SystemCommand
   extend Predicable
 
+  attr_reader :pid
+
   def self.run(executable, **options)
     new(executable, **options).run!
   end
@@ -122,6 +124,7 @@ class SystemCommand
 
     raw_stdin, raw_stdout, raw_stderr, raw_wait_thr =
       Open3.popen3(env, [executable, executable], *args, **options)
+    @pid = raw_wait_thr.pid
 
     write_input_to(raw_stdin)
     raw_stdin.close_write
@@ -191,6 +194,7 @@ class SystemCommand
     end
 
     def success?
+      return false if @exit_status.nil?
       @exit_status.zero?
     end
 

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -118,15 +118,15 @@ describe CacheStoreDatabase do
   end
 
   describe "#created?" do
-    let(:cache_path) { "path/to/homebrew/cache/sample.db" }
+    let(:cache_path) { Pathname("path/to/homebrew/cache/sample.db") }
 
     before(:each) do
       allow(subject).to receive(:cache_path).and_return(cache_path)
     end
 
-    context "`File.exist?(cache_path)` returns `true`" do
+    context "`cache_path.exist?` returns `true`" do
       before(:each) do
-        allow(File).to receive(:exist?).with(cache_path).and_return(true)
+        allow(cache_path).to receive(:exist?).and_return(true)
       end
 
       it "returns `true`" do
@@ -134,9 +134,9 @@ describe CacheStoreDatabase do
       end
     end
 
-    context "`File.exist?(cache_path)` returns `false`" do
+    context "`cache_path.exist?` returns `false`" do
       before(:each) do
-        allow(File).to receive(:exist?).with(cache_path).and_return(false)
+        allow(cache_path).to receive(:exist?).and_return(false)
       end
 
       it "returns `false`" do

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -47,7 +47,7 @@ setup-ruby-path() {
         then
           odie "Failed to install vendor Ruby."
         fi
-        rm -rf "$vendor_dir/bundle/ruby" "$HOMEBREW_CACHE/linkage.db"
+        rm -rf "$vendor_dir/bundle/ruby"
         HOMEBREW_RUBY_PATH="$vendor_ruby_path"
       fi
     fi


### PR DESCRIPTION
When the DBM database cannot be read by the current version of Ruby's DBM library (due to corruption or another incompatibility) it segfaults or freezes which takes down the entire Homebrew Ruby process.

This isn't desirable so instead perform a shell out with the Homebrew Ruby to see if it can read the DBM database before we try to use the information. If this hangs or crashes: silently delete the database and recreate it.

Fixes #4923.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----