### PR TITLE
Mojave is being released

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -31,21 +31,21 @@ module OS
 
     def latest_sdk_version
       # TODO: bump version when new Xcode macOS SDK is released
-      Version.new "10.13"
+      Version.new "10.14"
     end
 
     def latest_stable_version
       # TODO: bump version when new macOS is released and also update
       # references in docs/Installation.md and
       # https://github.com/Homebrew/install/blob/master/install
-      Version.new "10.13"
+      Version.new "10.14"
     end
 
     def outdated_release?
       # TODO: bump version when new macOS is released and also update
       # references in docs/Installation.md and
       # https://github.com/Homebrew/install/blob/master/install
-      version < "10.11"
+      version < "10.12"
     end
 
     def prerelease?

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -11,7 +11,7 @@ it does it too. And you have to confirm everything it will do before it starts.
 
 ## Requirements
 * An Intel CPU <sup>[1](#1)</sup>
-* OS X 10.11 or higher <sup>[2](#2)</sup>
+* macOS 10.12 or higher <sup>[2](#2)</sup>
 * Command Line Tools (CLT) for Xcode: `xcode-select --install`,
   [developer.apple.com/downloads](https://developer.apple.com/downloads) or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
@@ -51,7 +51,7 @@ you can assume you will have trouble if you don’t conform. Also, you can find
 PowerPC and Tiger branches from other users in the fork network. See
 [Interesting Taps and Forks](Interesting-Taps-and-Forks.md).
 
-<a name="2"><sup>2</sup></a> 10.11 or higher is recommended. 10.5–10.10 are
+<a name="2"><sup>2</sup></a> 10.12 or higher is recommended. 10.5–10.11 are
 supported on a best-effort basis. For 10.4 see
 [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 


### PR DESCRIPTION
macOS 10.14 Mojave will be released on September 24th:
- Add support for Mojave.
- Drop support for El Capitan (unsupported as of August 2018)

Companion PR for install: https://github.com/Homebrew/install/pull/143