### PR TITLE
language/haskell: use `v1` commands

### DIFF
--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -16,7 +16,7 @@ module Language
         saved_home = ENV["HOME"]
         ENV["HOME"] = home
 
-        system "cabal", "sandbox", "init"
+        system "cabal", "v1-sandbox", "init"
         cabal_sandbox_bin = pwd/".cabal-sandbox/bin"
         mkdir_p cabal_sandbox_bin
 
@@ -25,7 +25,7 @@ module Language
         ENV.prepend_path "PATH", cabal_sandbox_bin
 
         # avoid updating the cabal package database more than once
-        system "cabal", "update" unless (home/".cabal/packages").exist?
+        system "cabal", "v1-update" unless (home/".cabal/packages").exist?
 
         yield
 
@@ -41,7 +41,7 @@ module Language
       end
 
       def cabal_sandbox_add_source(*args)
-        system "cabal", "sandbox", "add-source", *args
+        system "cabal", "v1-sandbox", "add-source", *args
       end
 
       def cabal_install(*args)
@@ -55,11 +55,11 @@ module Language
         # needed value by a formula at this time (February 2016) was 43,478 for
         # git-annex, so 100,000 should be enough to avoid most gratuitous
         # backjumps build failures.
-        system "cabal", "install", "--jobs=#{make_jobs}", "--max-backjumps=100000", *args
+        system "cabal", "v1-install", "--jobs=#{make_jobs}", "--max-backjumps=100000", *args
       end
 
       def cabal_configure(flags)
-        system "cabal", "configure", flags
+        system "cabal", "v1-configure", flags
       end
 
       def cabal_install_tools(*tools)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
With the [`cabal-install 2.4.0.0`](https://github.com/Homebrew/homebrew-core/pull/32135) update, cabal commands print this:

```
==> cabal sandbox init
Warning: The sandbox command is a part of the legacy v1 style of cabal usage.

Please switch to using either the new project style and the new-sandbox
command or the legacy v1-sandbox alias as new-style projects will become the
default in the next version of cabal-install. Please file a bug if you cannot
replicate a working v1- use case with the new-style commands.

For more information, see: https://wiki.haskell.org/Cabal/NewBuild

==> cabal update
Warning: The update command is a part of the legacy v1 style of cabal usage.

Please switch to using either the new project style and the new-update command
or the legacy v1-update alias as new-style projects will become the default in
the next version of cabal-install. Please file a bug if you cannot replicate a
working v1- use case with the new-style commands.

For more information, see: https://wiki.haskell.org/Cabal/NewBuild

==> cabal install --jobs=4 --max-backjumps=100000 hpack
Warning: The install command is a part of the legacy v1 style of cabal usage.

Please switch to using either the new project style and the new-install
command or the legacy v1-install alias as new-style projects will become the
default in the next version of cabal-install. Please file a bug if you cannot
replicate a working v1- use case with the new-style commands.

For more information, see: https://wiki.haskell.org/Cabal/NewBuild
```

Eventually I suppose we'll want to switch to the [Nix "new-style"  builds.](https://cabal.readthedocs.io/en/latest/nix-local-build-overview.html)