### PR TITLE
cache_store: check DBM values size.

### DIFF
--- a/Library/Homebrew/cache_store.rb
+++ b/Library/Homebrew/cache_store.rb
@@ -77,7 +77,7 @@ class CacheStoreDatabase
           args: [
             "-rdbm",
             "-e",
-            "DBM.open('#{dbm_file_path}', #{DATABASE_MODE}, DBM::READER).size",
+            "DBM.open('#{dbm_file_path}', #{DATABASE_MODE}, DBM::READER).values.size",
           ],
           print_stderr: false,
           must_succeed: true,


### PR DESCRIPTION
This seems to reproduce more crashes (and therefore avoid them).

Fixes https://github.com/Homebrew/brew/issues/4951

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----