### PR TITLE
cache_store: use JSON.

### DIFF
--- a/Library/Homebrew/linkage_cache_store.rb
+++ b/Library/Homebrew/linkage_cache_store.rb
@@ -35,7 +35,7 @@ class LinkageCacheStore < CacheStore
       EOS
     end
 
-    database.set @keg_path, ruby_hash_to_json_string(hash_values)
+    database.set @keg_path, hash_values
   end
 
   # @param  [Symbol] the type to fetch from the `LinkageCacheStore`
@@ -68,6 +68,6 @@ class LinkageCacheStore < CacheStore
     keg_cache = database.get(@keg_path)
     return {} unless keg_cache
 
-    json_string_to_ruby_hash(keg_cache)[type.to_s]
+    keg_cache[type.to_s]
   end
 end

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -97,10 +97,6 @@ describe CacheStoreDatabase do
 
   describe "#close_if_open!" do
     context "database open" do
-      before do
-        subject.instance_variable_set(:@db, instance_double(DBM, close: nil))
-      end
-
       it "does not raise an error when `close` is called on the database" do
         expect { subject.close_if_open! }.not_to raise_error(NoMethodError)
       end
@@ -118,7 +114,7 @@ describe CacheStoreDatabase do
   end
 
   describe "#created?" do
-    let(:cache_path) { Pathname("path/to/homebrew/cache/sample.db") }
+    let(:cache_path) { Pathname("path/to/homebrew/cache/sample.json") }
 
     before do
       allow(subject).to receive(:cache_path).and_return(cache_path)


### PR DESCRIPTION
After all our recent troubles with DBM I figured I'd benchmark the performance of DBM vs. JSON. At read time (what we care more about) the performance is pretty much identical and JSON is only 1.5x slower at write time. This seems worth it for the reliability increases to avoid messing with unreliable native code.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----