### PR TITLE
Cask: check if xattr works before quarantining

### DIFF
--- a/Library/Homebrew/cask/cmd/doctor.rb
+++ b/Library/Homebrew/cask/cmd/doctor.rb
@@ -124,6 +124,8 @@ module Cask
         case Quarantine.check_quarantine_support
         when :quarantine_available
           puts "Enabled"
+        when :xattr_broken
+          add_error "There's not a working version of xattr."
         when :no_swift
           add_error "Swift is not available on this system."
         when :no_quarantine


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

`xattr` doesn't work in systems which have set their system Python version to < 2.7. I've added a check to `check_quarantine_support` to account for this.

Fixes Homebrew/homebrew-cask#52128.