### PR TITLE
keg: remove TOP_LEVEL_DIRECTORIES.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -68,8 +68,6 @@ class Keg
   KEG_LINK_DIRECTORIES = %w[
     bin etc include lib sbin share var Frameworks
   ].freeze
-  # TODO: remove when brew-test-bot no longer uses this
-  TOP_LEVEL_DIRECTORIES = KEG_LINK_DIRECTORIES
   MUST_EXIST_SUBDIRECTORIES = (
     KEG_LINK_DIRECTORIES - %w[var] + %w[
       opt


### PR DESCRIPTION
No longer needed in `brew test-bot` as of https://github.com/Homebrew/homebrew-test-bot/pull/192

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----