### PR TITLE
config: hide optional system packages.

### DIFF
--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -57,11 +57,9 @@ class SystemConfig
       dump_generic_verbose_config(f)
       f.puts "macOS: #{MacOS.full_version}-#{kernel}"
       f.puts "CLT: #{clt || "N/A"}"
-      if MacOS::CLT.separate_header_package?
-        f.puts "CLT headers: #{clt_headers || "N/A"}"
-      end
       f.puts "Xcode: #{xcode || "N/A"}"
-      f.puts "XQuartz: #{xquartz || "N/A"}"
+      f.puts "CLT headers: #{clt_headers}" if MacOS::CLT.separate_header_package? && clt_headers
+      f.puts "XQuartz: #{xquartz}" if !MacOS::XQuartz.provided_by_apple? && xquartz
     end
   end
 end

--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -196,7 +196,7 @@ class SystemConfig
       end
       f.puts "Git: #{describe_git}"
       f.puts "Curl: #{describe_curl}"
-      f.puts "Java: #{describe_java}"
+      f.puts "Java: #{describe_java}" if describe_java != "N/A"
     end
     alias dump_generic_verbose_config dump_verbose_config
   end


### PR DESCRIPTION
Java, XQuartz and the CLT separate header package aren't required for everyone's Homebrew usage or a default macOS development install.

As a result, only show then in `brew config` when they are actually installed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----