### PR TITLE
Default compiler is gcc on Linux

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -3,6 +3,7 @@ module CompilerConstants
   GNU_GCC_VERSIONS = %w[4.3 4.4 4.5 4.6 4.7 4.8 4.9 5 6 7 8].freeze
   GNU_GCC_REGEXP = /^gcc-(4\.[3-9]|[5-8])$/
   COMPILER_SYMBOL_MAP = {
+    "gcc"        => :gcc,
     "gcc-4.0"    => :gcc_4_0,
     "gcc-4.2"    => :gcc_4_2,
     "clang"      => :clang,
@@ -101,6 +102,7 @@ class CompilerSelector
     clang: [:clang, :gcc_4_2, :gnu, :gcc_4_0, :llvm_clang],
     gcc_4_2: [:gcc_4_2, :gnu, :clang, :gcc_4_0],
     gcc_4_0: [:gcc_4_0, :gcc_4_2, :gnu, :clang],
+    gcc: [:gnu, :gcc, :llvm_clang, :clang, :gcc_4_2, :gcc_4_0],
   }.freeze
 
   def self.select_for(formula, compilers = self.compilers)
@@ -150,9 +152,9 @@ class CompilerSelector
   end
 
   def compiler_version(name)
-    case name
-    when GNU_GCC_REGEXP
-      versions.non_apple_gcc_version(name)
+    case name.to_s
+    when "gcc", GNU_GCC_REGEXP
+      versions.non_apple_gcc_version(name.to_s)
     else
       versions.send("#{name}_build_version")
     end

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -99,7 +99,7 @@ class DevelopmentTools
         path = HOMEBREW_PREFIX/"opt/gcc/bin"/cc
         path = locate(cc) unless path.exist?
         version = if path &&
-                     build_version = `#{path} --version`[/gcc(?:-\d(?:\.\d)? \(.+\))? (\d\.\d\.\d)/, 1]
+                     build_version = `#{path} --version`[/gcc(?:(?:-\d(?:\.\d)?)? \(.+\))? (\d\.\d\.\d)/, 1]
           Version.new build_version
         else
           Version::NULL

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -319,7 +319,11 @@ module SharedEnvExtension
   def compiler_with_cxx11_support?(cc)
     return if compiler_any_clang?(cc)
 
-    version = cc[/^gcc-(\d+(?:\.\d+)?)$/, 1]
+    version = if cc == :gcc
+      non_apple_gcc_version "gcc"
+    else
+      cc[/^gcc-(\d+(?:\.\d+)?)$/, 1]
+    end
     version && Version.create(version) >= Version.create("4.8")
   end
 

--- a/Library/Homebrew/extend/os/development_tools.rb
+++ b/Library/Homebrew/extend/os/development_tools.rb
@@ -1,1 +1,5 @@
-require "extend/os/mac/development_tools" if OS.mac?
+if OS.mac?
+  require "extend/os/mac/development_tools"
+elsif OS.linux?
+  require "extend/os/linux/development_tools"
+end

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -1,0 +1,7 @@
+class DevelopmentTools
+  class << self
+    def default_compiler
+      :gcc
+    end
+  end
+end

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -4,13 +4,13 @@ require "software_spec"
 describe CompilerSelector do
   subject { described_class.new(software_spec, versions, compilers) }
 
-  let(:compilers) { [:clang, :gcc, :gnu] }
+  let(:compilers) { [:clang, :gcc_4_2, :gnu] }
   let(:software_spec) { SoftwareSpec.new }
   let(:cc) { :clang }
   let(:versions) do
     double(
       gcc_4_0_build_version: Version::NULL,
-      gcc_build_version: Version.create("5666"),
+      gcc_4_2_build_version: Version.create("5666"),
       llvm_build_version: Version::NULL,
       clang_build_version: Version.create("425"),
     )
@@ -29,7 +29,7 @@ describe CompilerSelector do
   describe "#compiler" do
     it "raises an error if no matching compiler can be found" do
       software_spec.fails_with(:clang)
-      software_spec.fails_with(:gcc)
+      software_spec.fails_with(:gcc_4_2)
       software_spec.fails_with(gcc: "4.8")
       software_spec.fails_with(gcc: "4.7")
 
@@ -42,11 +42,11 @@ describe CompilerSelector do
 
     it "returns gcc if it fails with clang" do
       software_spec.fails_with(:clang)
-      expect(subject.compiler).to eq(:gcc)
+      expect(subject.compiler).to eq(:gcc_4_2)
     end
 
     it "returns clang if it fails with gcc" do
-      software_spec.fails_with(:gcc)
+      software_spec.fails_with(:gcc_4_2)
       expect(subject.compiler).to eq(:clang)
     end
 
@@ -57,41 +57,41 @@ describe CompilerSelector do
 
     it "still returns gcc-4.8 if it fails with gcc without a specific version" do
       software_spec.fails_with(:clang)
-      software_spec.fails_with(:gcc)
+      software_spec.fails_with(:gcc_4_2)
       expect(subject.compiler).to eq("gcc-4.8")
     end
 
     it "returns gcc if it fails with clang and llvm" do
       software_spec.fails_with(:clang)
-      expect(subject.compiler).to eq(:gcc)
+      expect(subject.compiler).to eq(:gcc_4_2)
     end
 
     it "returns clang if it fails with gcc and llvm" do
-      software_spec.fails_with(:gcc)
+      software_spec.fails_with(:gcc_4_2)
       expect(subject.compiler).to eq(:clang)
     end
 
     example "returns gcc if it fails with a specific gcc version" do
       software_spec.fails_with(:clang)
       software_spec.fails_with(gcc: "4.8")
-      expect(subject.compiler).to eq(:gcc)
+      expect(subject.compiler).to eq(:gcc_4_2)
     end
 
     example "returns a lower version of gcc if it fails with the highest version" do
       software_spec.fails_with(:clang)
-      software_spec.fails_with(:gcc)
+      software_spec.fails_with(:gcc_4_2)
       software_spec.fails_with(gcc: "4.8")
       expect(subject.compiler).to eq("gcc-4.7")
     end
 
     it "prefers gcc" do
       software_spec.fails_with(:clang)
-      software_spec.fails_with(:gcc)
+      software_spec.fails_with(:gcc_4_2)
       expect(subject.compiler).to eq("gcc-4.8")
     end
 
     it "raises an error when gcc is missing" do
-      allow(versions).to receive(:gcc_build_version).and_return(Version::NULL)
+      allow(versions).to receive(:gcc_4_2_build_version).and_return(Version::NULL)
 
       software_spec.fails_with(:clang)
       software_spec.fails_with(gcc: "4.8")
@@ -101,7 +101,7 @@ describe CompilerSelector do
     end
 
     it "raises an error when llvm and gcc are missing" do
-      allow(versions).to receive(:gcc_build_version).and_return(Version::NULL)
+      allow(versions).to receive(:gcc_4_2_build_version).and_return(Version::NULL)
 
       software_spec.fails_with(:clang)
       software_spec.fails_with(gcc: "4.8")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`DevelopmentTools.default_compiler` is already overridden on macOS to be `clang` (usually).
https://github.com/Homebrew/brew/blob/dae47914ca383e0ed5192436b9e7e11e0bf2640e/Library/Homebrew/extend/os/mac/development_tools.rb#L28