### PR TITLE
Symlink ld.so [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/install.rb
+++ b/Library/Homebrew/extend/os/install.rb
@@ -1,0 +1,1 @@
+require "extend/os/linux/install" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -1,0 +1,34 @@
+module Homebrew
+  module Install
+    module_function
+
+    DYNAMIC_LINKERS = [
+      "/lib64/ld-linux-x86-64.so.2",
+      "/lib/ld-linux.so.3",
+      "/lib/ld-linux.so.2",
+      "/lib/ld-linux-aarch64.so.1",
+      "/lib/ld-linux-armhf.so.3",
+      "/system/bin/linker64",
+      "/system/bin/linker",
+    ].freeze
+
+    def symlink_ld_so
+      brew_ld_so = HOMEBREW_PREFIX/"lib/ld.so"
+      return if brew_ld_so.readable?
+
+      ld_so = HOMEBREW_PREFIX/"opt/glibc/lib/ld-linux-x86-64.so.2"
+      unless ld_so.readable?
+        ld_so = DYNAMIC_LINKERS.find { |s| File.executable? s }
+        raise "Unable to locate the system's dynamic linker" unless ld_so
+      end
+
+      FileUtils.mkdir_p HOMEBREW_PREFIX/"lib"
+      FileUtils.ln_sf ld_so, brew_ld_so
+    end
+
+    def perform_preinstall_checks
+      generic_perform_preinstall_checks
+      symlink_ld_so
+    end
+  end
+end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -36,6 +36,8 @@ module Homebrew
       attempt_directory_creation
       fatal_checks(:fatal_install_checks)
     end
+    alias generic_perform_preinstall_checks perform_preinstall_checks
+    module_function :generic_perform_preinstall_checks
 
     def fatal_checks(type)
       @checks ||= Diagnostic::Checks.new
@@ -51,3 +53,5 @@ module Homebrew
     end
   end
 end
+
+require "extend/os/install"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Linuxbrew sets the dynamic linker of executables to `HOMEBREW_PREFIX/lib/ld.so`
This symlink points to either the dynamic linker of the host system,
or to the dynamic linker provided by the brewed glibc.