### PR TITLE
Fix `atomic_write` inside non-sticky directory.

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -160,9 +160,16 @@ class Pathname
     open("a", *open_args) { |f| f.puts(content) }
   end
 
-  # NOTE always overwrites
+  # NOTE: This always overwrites.
   def atomic_write(content)
+    # The enclosing `mktmpdir` and the `chmod` are a workaround
+    # for https://github.com/rails/rails/pull/34037.
     Dir.mktmpdir(".d", dirname) do |tmpdir|
+      begin
+        FileUtils.chmod "+t", dirname
+      rescue Errno::EPERM
+        :ignore
+      end
       File.atomic_write(self, tmpdir) do |file|
         file.write(content)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/32584.