### PR TITLE
relocation_formulae: Poured bottles depend on gcc [Linux]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ branches:
   only:
     - master
 
+env:
+  - HOMEBREW_FORCE_HOMEBREW_ON_LINUX=1
+
 before_install:
   - HOMEBREW_REPOSITORY="$(brew --repo)"
   - sudo chown -R "$USER" "$HOMEBREW_REPOSITORY"

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -83,4 +83,17 @@ class Keg
   def self.relocation_formulae
     ["patchelf"]
   end
+
+  def self.bottle_dependencies
+    @bottle_dependencies ||= begin
+      formulae = relocation_formulae
+      gcc = Formula["gcc"]
+      if !ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] &&
+         DevelopmentTools.non_apple_gcc_version("gcc") < gcc.version.to_i
+        formulae += gcc.recursive_dependencies.map(&:name)
+        formulae << gcc.name
+      end
+      formulae
+    end
+  end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -489,14 +489,20 @@ class FormulaInstaller
       end
     end
 
-    if pour_bottle && !Keg.relocation_formulae.include?(formula.name)
-      bottle_deps = Keg.relocation_formulae
-                       .map { |formula| Dependency.new(formula) }
-                       .reject do |dep|
+    if pour_bottle && !Keg.bottle_dependencies.empty?
+      bottle_deps = if !Keg.bottle_dependencies.include?(formula.name)
+        Keg.bottle_dependencies
+      elsif !Keg.relocation_formulae.include?(formula.name)
+        Keg.relocation_formulae
+      else
+        []
+      end
+      bottle_deps = bottle_deps.map { |formula| Dependency.new(formula) }
+                               .reject do |dep|
         inherited_options[dep.name] |= inherited_options_for(dep)
         dep.satisfied? inherited_options[dep.name]
       end
-      expanded_deps = Dependency.merge_repeats(bottle_deps + expanded_deps) unless bottle_deps.empty?
+      expanded_deps = Dependency.merge_repeats(bottle_deps + expanded_deps)
     end
 
     expanded_deps.map { |dep| [dep, inherited_options[dep.name]] }

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -187,6 +187,10 @@ class Keg
   def self.relocation_formulae
     []
   end
+
+  def self.bottle_dependencies
+    relocation_formulae
+  end
 end
 
 require "extend/os/keg_relocate"

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -18,6 +18,7 @@ describe FormulaInstaller do
     expect(formula).to pour_bottle
 
     stub_formula_loader formula
+    stub_formula_loader formula("gcc") { url "gcc-1.0" }
     stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
     allow(Formula["patchelf"]).to receive(:installed?).and_return(true)
     described_class.new(formula).install

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -138,6 +138,7 @@ describe Formulary do
     context "with installed Formula" do
       before do
         allow(described_class).to receive(:loader_for).and_call_original
+        stub_formula_loader formula("gcc") { url "gcc-1.0" }
         stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
         allow(Formula["patchelf"]).to receive(:installed?).and_return(true)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When pouring a bottle, install the brewed GCC if the major version of the host's GCC is older than the brewed GCC. GCC provides the libraries `libgcc_s.so.1` and `libstdc++.so.6`, needed by bottles.