### PR TITLE
CoreTap.default_remote: Use Linuxbrew/core [Linux]

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -24,7 +24,12 @@ git() {
 
 git_init_if_necessary() {
   BREW_OFFICIAL_REMOTE="https://github.com/Homebrew/brew"
-  CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/homebrew-core"
+  if [[ -n "$HOMEBREW_MACOS" ]] || [[ -n "$HOMEBREW_FORCE_HOMEBREW_ORG" ]]
+  then
+    CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/homebrew-core"
+  else
+    CORE_OFFICIAL_REMOTE="https://github.com/Linuxbrew/homebrew-core"
+  fi
 
   safe_cd "$HOMEBREW_REPOSITORY"
   if [[ ! -d ".git" ]]

--- a/Library/Homebrew/extend/os/linux/tap.rb
+++ b/Library/Homebrew/extend/os/linux/tap.rb
@@ -1,0 +1,9 @@
+class CoreTap < Tap
+  def default_remote
+    if ENV["HOMEBREW_FORCE_HOMEBREW_ORG"]
+      "https://github.com/Homebrew/homebrew-core".freeze
+    else
+      "https://github.com/Linuxbrew/homebrew-core".freeze
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/tap.rb
+++ b/Library/Homebrew/extend/os/tap.rb
@@ -1,0 +1,1 @@
+require "extend/os/linux/tap" if OS.linux?

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -735,3 +735,5 @@ class TapConfig
     end
   end
 end
+
+require "extend/os/tap"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?