### PR TITLE
Cask: add class attribute for signaling exit codes

### DIFF
--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -1,3 +1,4 @@
+require "global"
 require "optparse"
 require "shellwords"
 
@@ -67,15 +68,6 @@ module Cask
 
     # override default handling of --version
     option "--version", ->(*) { raise OptionParser::InvalidOption }
-
-    class << self
-      attr_writer :failed
-
-      def failed?
-        @failed ||= false
-        @failed == true
-      end
-    end
 
     def self.command_classes
       @command_classes ||= constants.map(&method(:const_get))
@@ -150,33 +142,29 @@ module Cask
     end
 
     def run
-      begin
-        command_name, *args = detect_command_and_arguments(*@args)
-        command = if help?
-          args.unshift(command_name) unless command_name.nil?
-          "help"
-        else
-          self.class.lookup_command(command_name)
-        end
-
-        MacOS.full_version = ENV["MACOS_VERSION"] unless ENV["MACOS_VERSION"].nil?
-
-        Tap.default_cask_tap.install unless Tap.default_cask_tap.installed?
-        self.class.run_command(command, *args)
-      rescue CaskError, MethodDeprecatedError, ArgumentError, OptionParser::InvalidOption => e
-        msg = e.message
-        msg << e.backtrace.join("\n").prepend("\n") if ARGV.debug?
-        onoe msg
-        Cmd.failed = true
-      rescue StandardError, ScriptError, NoMemoryError => e
-        msg = "#{e.message}\n"
-        msg << Utils.error_message_with_suggestions
-        msg << e.backtrace.join("\n")
-        onoe msg
-        Cmd.failed = true
+      command_name, *args = detect_command_and_arguments(*@args)
+      command = if help?
+        args.unshift(command_name) unless command_name.nil?
+        "help"
+      else
+        self.class.lookup_command(command_name)
       end
 
-      exit Cmd.failed? ? 1 : 0
+      MacOS.full_version = ENV["MACOS_VERSION"] unless ENV["MACOS_VERSION"].nil?
+
+      Tap.default_cask_tap.install unless Tap.default_cask_tap.installed?
+      self.class.run_command(command, *args)
+    rescue CaskError, MethodDeprecatedError, ArgumentError, OptionParser::InvalidOption => e
+      msg = e.message
+      msg << e.backtrace.join("\n").prepend("\n") if ARGV.debug?
+      onoe msg
+      Homebrew.failed = true
+    rescue StandardError, ScriptError, NoMemoryError => e
+      msg = "#{e.message}\n"
+      msg << Utils.error_message_with_suggestions
+      msg << e.backtrace.join("\n")
+      onoe msg
+      Homebrew.failed = true
     end
 
     def self.nice_listing(cask_list)

--- a/Library/Homebrew/cask/cmd/outdated.rb
+++ b/Library/Homebrew/cask/cmd/outdated.rb
@@ -28,7 +28,7 @@ module Cask
           puts cask.token
         end
 
-        Cmd.failed = true
+        Homebrew.failed = true
       end
 
       def self.help

--- a/Library/Homebrew/cask/cmd/outdated.rb
+++ b/Library/Homebrew/cask/cmd/outdated.rb
@@ -27,6 +27,8 @@ module Cask
         else
           puts cask.token
         end
+
+        Cmd.failed = true
       end
 
       def self.help

--- a/Library/Homebrew/test/cask/cmd_spec.rb
+++ b/Library/Homebrew/test/cask/cmd_spec.rb
@@ -64,13 +64,6 @@ describe Cask::Cmd, :cask do
 
       expect(Cask::Config.global.appdir).to eq(Pathname.new("/custom/appdir"))
     end
-
-    it "exits with a status of 1 when something goes wrong" do
-      allow(described_class).to receive(:lookup_command).and_raise(Cask::CaskError)
-      command = described_class.new("noop")
-      expect(command).to receive(:exit).with(1)
-      command.run
-    end
   end
 
   it "provides a help message for all visible commands" do


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This pull request enables Cask commands to set a custom exit code.

Inspired in `Homebrew.failed?`,
https://github.com/Homebrew/brew/blob/8f74ba0197635b6ac7b03ea4eb7297d416fcf91a/Library/Homebrew/global.rb#L62-L72
I used a similar approach to align `brew cask outdated` with `brew outdated`.

Fixes Homebrew/homebrew-cask#43226. 