### PR TITLE
docs: fix Official External Commands section

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -1,4 +1,4 @@
-#:  * `cleanup` [`--prune=`<days>] [`--dry-run`] [`-s`] [<formula/cask> ...]:
+#:  * `cleanup` [`--prune=`<days>] [`--dry-run`] [`-s`] [<formulae>|<casks>]:
 #:    Remove stale lock files and outdated downloads for formulae and casks,
 #:    and remove old versions of installed formulae. If arguments are specified,
 #:    only do this for the specified formulae and casks.

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -1,7 +1,7 @@
 #:  * `info`:
 #:    Display brief statistics for your Homebrew installation.
 #:
-#:  * `info` <formula>  (`--verbose`):
+#:  * `info` <formula> [`--verbose`]:
 #:    Display information about <formula> and analytics data (provided neither
 #:    `HOMEBREW_NO_ANALYTICS` or `HOMEBREW_NO_GITHUB_API` are set)
 #:
@@ -10,7 +10,7 @@
 #:  * `info` `--github` <formula>:
 #:    Open a browser to the GitHub History page for <formula>.
 #:
-#:    To view formula history locally: `brew log -p <formula>`
+#:    To view formula history locally: `brew log -p` <formula>
 #:
 #:  * `info` `--json=`<version> (`--all`|`--installed`|<formulae>):
 #:    Print a JSON representation of <formulae>. Currently the only accepted value

--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -1,6 +1,6 @@
 #:  * `pin` <formulae>:
 #:    Pin the specified <formulae>, preventing them from being upgraded when
-#:    issuing the `brew upgrade <formulae>` command. See also `unpin`.
+#:    issuing the `brew upgrade` <formulae> command. See also `unpin`.
 
 require "formula"
 

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -2,7 +2,7 @@
 #:    Display all locally available formulae (including tapped ones).
 #:    No online search is performed.
 #:
-#:  * `search` `--casks`
+#:  * `search` `--casks`:
 #:    Display all locally available casks (including tapped ones).
 #:    No online search is performed.
 #:

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -6,7 +6,7 @@
 #:
 #:    With <URL> unspecified, taps a formula repository from GitHub using HTTPS.
 #:    Since so many taps are hosted on GitHub, this command is a shortcut for
-#:    `tap <user>/<repo> https://github.com/<user>/homebrew-<repo>`.
+#:    `brew tap` <user>`/`<repo> `https://github.com/`<user>`/homebrew-`<repo>.
 #:
 #:    With <URL> specified, taps a formula repository from anywhere, using
 #:    any transport protocol that `git` handles. The one-argument form of `tap`

--- a/Library/Homebrew/cmd/unlink.rb
+++ b/Library/Homebrew/cmd/unlink.rb
@@ -1,7 +1,7 @@
 #:  * `unlink` [`--dry-run`] <formula>:
 #:    Remove symlinks for <formula> from the Homebrew prefix. This can be useful
 #:    for temporarily disabling a formula:
-#:    `brew unlink <formula> && <commands> && brew link <formula>`
+#:    `brew unlink` <formula> `&&` <commands> `&& brew link` <formula>
 #:
 #:    If `--dry-run` or `-n` is passed, Homebrew will list all files which would
 #:    be unlinked, but will not actually unlink or delete any files.

--- a/Library/Homebrew/cmd/unpin.rb
+++ b/Library/Homebrew/cmd/unpin.rb
@@ -1,5 +1,5 @@
 #:  * `unpin` <formulae>:
-#:    Unpin <formulae>, allowing them to be upgraded by `brew upgrade <formulae>`.
+#:    Unpin <formulae>, allowing them to be upgraded by `brew upgrade` <formulae>.
 #:    See also `pin`.
 
 require "formula"

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -79,17 +79,17 @@ module Homebrew
       switch "-D", "--audit-debug",
         description: "Activates debugging and profiling"
       comma_array "--only",
-        description: "Passing `--only`=<method> will run only the methods named audit_<method>, `method` "\
-                     "should be a comma-separated list."
+        description: "Passing `--only=`<method> will run only the methods named audit_<method>. "\
+                     "<method> should be a comma-separated list."
       comma_array "--except",
-        description: "Passing `--except`=<method> will run only the methods named audit_<method>, "\
-                     "`method` should be a comma-separated list."
+        description: "Passing `--except=`<method> will run only the methods named audit_<method>, "\
+                     "<method> should be a comma-separated list."
       comma_array "--only-cops",
-        description: "Passing `--only-cops`=<cops> will check for violations of only the listed "\
-                     "RuboCop cops. `cops` should be a comma-separated list of cop names."
+        description: "Passing `--only-cops=`<cops> will check for violations of only the listed "\
+                     "RuboCop cops. <cops> should be a comma-separated list of cop names."
       comma_array "--except-cops",
-        description: "Passing `--except-cops`=<cops> will skip checking the listed RuboCop cops "\
-                     "violations. `cops` should be a comma-separated list of cop names."
+        description: "Passing `--except-cops=`<cops> will skip checking the listed RuboCop cops "\
+                     "violations. <cops> should be a comma-separated list of cop names."
       switch :verbose
       switch :debug
     end

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -99,7 +99,7 @@ module Homebrew
   def extract_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `extract` [<options>] <formula> <tap>
+        `extract` [<options>] <formula> <tap>:
 
         Looks through repository history to find the <version> of <formula> and
         creates a copy in <tap>/Formula/<formula>@<version>.rb. If the tap is

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -158,8 +158,7 @@ module Homebrew
       ronn_output = ronn.read
       odie "Got no output from ronn!" unless ronn_output
       if format_flag == "--markdown"
-        ronn_output = ronn_output.gsub(%r{</var>`(?=[.!?,;:]?\s)}, "")
-                                 .gsub(%r{</?var>}, "`")
+        ronn_output = ronn_output.gsub(%r{<var>(.*?)</var>}, "*`\\1`*")
       elsif format_flag == "--roff"
         ronn_output = ronn_output.gsub(%r{<code>(.*?)</code>}, "\\fB\\1\\fR")
                                  .gsub(%r{<var>(.*?)</var>}, "\\fI\\1\\fR")
@@ -233,6 +232,6 @@ module Homebrew
   end
 
   def format_usage_banner(usage_banner)
-    usage_banner.sub(/^/, "###")
+    usage_banner.sub(/^/, "### ")
   end
 end

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -82,6 +82,7 @@ module Homebrew
 
   def path_glob_commands(glob)
     Pathname.glob(glob)
+            .sort_by { |source_file| sort_key_for_path(source_file) }
             .map(&:read).map(&:lines)
             .map { |lines| lines.grep(/^#:/).map { |line| line.slice(2..-1) }.join }
             .reject { |s| s.strip.empty? || s.include?("@hide_from_man_page") }

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -156,10 +156,13 @@ module Homebrew
       ronn.close_write
       ronn_output = ronn.read
       odie "Got no output from ronn!" unless ronn_output
-      ronn_output.gsub!(%r{</var>`(?=[.!?,;:]?\s)}, "").gsub!(%r{</?var>}, "`") if format_flag == "--markdown"
-      unless format_flag == "--markdown"
+      if format_flag == "--markdown"
+        ronn_output = ronn_output.gsub(%r{</var>`(?=[.!?,;:]?\s)}, "")
+                                 .gsub(%r{</?var>}, "`")
+      elsif format_flag == "--roff"
         ronn_output = ronn_output.gsub(%r{<code>(.*?)</code>}, "\\fB\\1\\fR")
                                  .gsub(%r{<var>(.*?)</var>}, "\\fI\\1\\fR")
+                                 .gsub(/(^\[?\\fB.+): /, "\\1\n    ")
       end
       target.atomic_write ronn_output
     end

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -1,5 +1,4 @@
 #:  * `pull` [`--bottle`] [`--bump`] [`--clean`] [`--ignore-whitespace`] [`--resolve`] [`--branch-okay`] [`--no-pbcopy`] [`--no-publish`] [`--warn-on-publish-failure`] [`--bintray-org=`<bintray-org>] [`--test-bot-user=`<test-bot-user>] <patch-source> [<patch-source>]:
-#:
 #:    Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
 #:    Optionally, installs the formulae changed by the patch.
 #:
@@ -75,7 +74,7 @@ module Homebrew
   def pull_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        pull [<options>] <formula>:
+        `pull` [<options>] <formula>:
 
         Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
         Optionally, installs the formulae changed by the patch.

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -60,21 +60,20 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
 ## OFFICIAL EXTERNAL COMMANDS
 
-  <%= homebrew_bundle.join("\n  ").strip %>
+  <%= homebrew_bundle.join.strip %>
 
 
-  Homebrew/homebrew-bundle <https://github.com/Homebrew/homebrew-bundle>
+    **Homebrew/homebrew-bundle**: <https://github.com/Homebrew/homebrew-bundle>
 
   * `cask` [`--version` | `audit` | `cat` | `cleanup` | `create` | `doctor` | `edit` | `fetch` | `home` | `info`]:
     Install macOS applications distributed as binaries.
 
+    **Homebrew/homebrew-cask**: <https://github.com/Homebrew/homebrew-cask>
 
-  Homebrew/homebrew-cask <https://github.com/Homebrew/homebrew-cask>
-
-  <%= homebrew_services.join("\n  ").strip %>
+  <%= homebrew_services.join.strip %>
 
 
-  Homebrew/homebrew-services <https://github.com/Homebrew/homebrew-services>
+    **Homebrew/homebrew-services**: <https://github.com/Homebrew/homebrew-services>
 
 ## CUSTOM EXTERNAL COMMANDS
 
@@ -329,6 +328,8 @@ Homebrew Documentation: <https://docs.brew.sh>
 
 See our issues on GitHub:
 
- * Homebrew/brew <https://github.com/Homebrew/brew/issues>
+  * **Homebrew/brew**:
+    <https://github.com/Homebrew/brew/issues>
 
- * Homebrew/homebrew-core <https://github.com/Homebrew/homebrew-core/issues>
+  * **Homebrew/homebrew-core**:
+    <https://github.com/Homebrew/homebrew-core/issues>

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -294,15 +294,15 @@ Note that environment variables must have a value set to be detected. For exampl
 ## USING HOMEBREW BEHIND A PROXY
 Use the `http_proxy`, `https_proxy`, `all_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
 
-For example for an unauthenticated HTTP or SOCKS5 proxy:
+For example, for an unauthenticated HTTP or SOCKS5 proxy:
 
-    export http_proxy=http://<host>:<port>
+    export http_proxy=http://$HOST:$PORT
 
-    export all_proxy=socks5://<host>:<port>
+    export all_proxy=socks5://$HOST:$PORT
 
 And for an authenticated HTTP proxy:
 
-    export http_proxy=http://<user>:<password>@<host>:<port>
+    export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 
 ## SEE ALSO
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -455,7 +455,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Display all locally available formulae (including tapped ones).
     No online search is performed.
 
-  * `search` `--casks`
+  * `search` `--casks`:
     Display all locally available casks (including tapped ones).
     No online search is performed.
 
@@ -794,7 +794,7 @@ Takes a tap [`user``/``repo`] as argument and generates the formula in the speci
   no `formula` is provided.
 
 
-###`extract` [`options`] `formula` `tap`
+###`extract` [`options`] `formula` `tap`:
 
 Looks through repository history to find the `version` of `formula` and
 creates a copy in `tap`/Formula/`formula`@`version`.rb. If the tap is
@@ -850,7 +850,7 @@ Reuploads the stable URL for a formula to Bintray to use it as a mirror.
     For example:
       brew prof readall
 
-###pull [`options`] `formula`:
+###`pull` [`options`] `formula`:
 
 Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
 Optionally, installs the formulae changed by the patch.
@@ -979,140 +979,79 @@ Override warnings and enable potentially unsafe operations.
 ## OFFICIAL EXTERNAL COMMANDS
 
   * `bundle` `command`:
+    Bundler for non-Ruby dependencies from Homebrew.
 
-      Bundler for non-Ruby dependencies from Homebrew.
+    `brew bundle` [`install`] [`-v`|`--verbose`] [`--no-upgrade`] [`--file=``path`|`--global`]:
+    Install or upgrade all dependencies in a Brewfile.
 
-  
+    `brew bundle dump` [`--force`] [`--describe`] [`--file=``path`|`--global`]:
+    Write all installed casks/formulae/taps into a Brewfile.
 
-      `bundle` [`install`] [`-v`|`--verbose`] [`--no-upgrade`] [`--file=``path`|`--global`]:
+    `brew bundle cleanup` [`--force`] [`--zap`] [`--file=``path`|`--global`]:
+    Uninstall all dependencies not listed in a Brewfile.
 
-      Install or upgrade all dependencies in a Brewfile.
+    `brew bundle check` [`--no-upgrade`] [`--file=``path`|`--global`] [`--verbose`]:
+    Check if all dependencies are installed in a Brewfile. Missing dependencies are listed in verbose mode.
+    `check` will exit on the first category missing a dependency unless in verbose mode.
 
-  
+    `brew bundle exec` `command`:
+    Run an external command in an isolated build environment.
 
-      `brew bundle dump` [`--force`] [`--describe`] [`--file=``path`|`--global`]
+    `brew bundle list` [`--all`|`--brews`|`--casks`|`--taps`|`--mas`] [`--file=``path`|`--global`]:
+    List all dependencies present in a Brewfile, optionally limiting by types.
+    By default, only brew dependencies are output.
 
-      Write all installed casks/formulae/taps into a Brewfile.
+    If `-v` or `--verbose` are passed, print verbose output.
 
-  
+    If `--no-upgrade` is passed, don't run `brew upgrade` on outdated dependencies.
+    Note they may still be upgraded by `brew install` if needed.
 
-      `brew bundle cleanup` [`--force`] [`--zap`] [`--file=``path`|`--global`]
+    If `--force` is passed, uninstall dependencies or overwrite an existing Brewfile.
 
-      Uninstall all dependencies not listed in a Brewfile.
+    If `--zap` is passed, casks will be removed using the `zap` command instead of `uninstall`.
 
-  
+    If `--file=``path` is passed, the Brewfile path is set accordingly.
+    Use `--file=-` to output to console.
 
-      `brew bundle check` [`--no-upgrade`] [`--file`=`path`|`--global`] [`--verbose`]
+    If `--global` is passed, set the Brewfile path to `~/.Brewfile`.
 
-      Check if all dependencies are installed in a Brewfile. Missing dependencies are listed in verbose mode. `check` will exit on the first category missing a dependency unless in verbose mode.
+    If `--describe` is passed, output a description comment above each line.
+    This comment will not be output if the dependency does not have a description.
 
-  
+    If `-h` or `--help` are passed, print this help message and exit.
 
-      `brew bundle exec` `command`
-
-      Run an external command in an isolated build environment.
-
-  
-
-      `brew bundle list` [`--all`|`--brews`|`--casks`|`--taps`|`--mas`] [`--file=``path`|`--global`]
-
-      List all dependencies present in a Brewfile, optionally limiting by types.
-
-      By default, only brew dependencies are output.
-
-  
-
-      If `-v` or `--verbose` are passed, print verbose output.
-
-  
-
-      If `--no-upgrade` is passed, don't run `brew upgrade` outdated dependencies.
-
-      Note they may still be upgraded by `brew install` if needed.
-
-  
-
-      If `--force` is passed, uninstall dependencies or overwrite an existing Brewfile.
-
-  
-
-      If `--zap` is passed, casks will be removed using the `zap` command instead of `uninstall`.
-
-  
-
-      If `--file=`path is passed, the Brewfile path is set accordingly
-
-      Use `--file=-` to output to console.
-
-  
-
-      If `--global` is passed, set Brewfile path to `$HOME/.Brewfile`.
-
-  
-
-      If `--describe` is passed, output a description comment above each line.
-
-      This comment will not be output if the dependency does not have a description.
-
-  
-
-      If `-h` or `--help` are passed, print this help message and exit.
-
-  Homebrew/homebrew-bundle <https://github.com/Homebrew/homebrew-bundle>
+    **Homebrew/homebrew-bundle**: <https://github.com/Homebrew/homebrew-bundle>
 
   * `cask` [`--version` | `audit` | `cat` | `cleanup` | `create` | `doctor` | `edit` | `fetch` | `home` | `info`]:
     Install macOS applications distributed as binaries.
 
-
-  Homebrew/homebrew-cask <https://github.com/Homebrew/homebrew-cask>
+    **Homebrew/homebrew-cask**: <https://github.com/Homebrew/homebrew-cask>
 
   * `services` `command`:
+    Integrates Homebrew formulae with macOS' `launchctl` manager.
 
-      Integrates Homebrew formulae with macOS' `launchctl` manager.
+    [`sudo`] `brew services list`:
+    List all running services for the current user (or root).
 
-  
+    [`sudo`] `brew services run` (`formula`|`--all`):
+    Run the service `formula` without registering to launch at login (or boot).
 
-      [`sudo`] `brew services list`
+    [`sudo`] `brew services start` (`formula`|`--all`):
+    Start the service `formula` immediately and register it to launch at login (or boot).
 
-      List all running services for the current user (or `root`)
+    [`sudo`] `brew services stop` (`formula`|`--all`):
+    Stop the service `formula` immediately and unregister it from launching at login (or boot).
 
-  
+    [`sudo`] `brew services restart` (`formula`|`--all`):
+    Stop (if necessary) and start the service `formula` immediately and register it to launch at login (or boot).
 
-      [`sudo`] `brew services run` `formula|--all`
+    [`sudo`] `brew services cleanup`:
+    Remove all unused services.
 
-      Run the service `formula` without starting at login (or boot).
+    If `sudo` is passed, operate on `/Library/LaunchDaemons` (started at boot).
+    Otherwise, operate on `~/Library/LaunchAgents` (started at login).
 
-  
-
-      [`sudo`] `brew services` `start` `formula|--all`
-
-      Start the service `formula` immediately and register it to launch at login (or `boot`).
-
-  
-
-      [`sudo`] `brew services` `stop` `formula|--all`
-
-      Stop the service `formula` immediately and unregister it from launching at login (or `boot`).
-
-  
-
-      [`sudo`] `brew services` `restart` `formula|--all`
-
-      Stop (if necessary) and start the service immediately and register it to launch at login (or `boot`).
-
-  
-
-      [`sudo`] `brew services` `cleanup`
-
-      Remove all unused services.
-
-  
-
-      If `sudo` is passed, operate on `/Library/LaunchDaemons` (started at boot).
-
-      Otherwise, operate on `~/Library/LaunchAgents (started at login)`.
-
-  Homebrew/homebrew-services <https://github.com/Homebrew/homebrew-services>
+    **Homebrew/homebrew-services**: <https://github.com/Homebrew/homebrew-services>
 
 ## CUSTOM EXTERNAL COMMANDS
 
@@ -1367,9 +1306,11 @@ Former maintainers with significant contributions include Dominyk Tiller, Tim Sm
 
 See our issues on GitHub:
 
- * Homebrew/brew <https://github.com/Homebrew/brew/issues>
+  * **Homebrew/brew**:
+    <https://github.com/Homebrew/brew/issues>
 
- * Homebrew/homebrew-core <https://github.com/Homebrew/homebrew-core/issues>
+  * **Homebrew/homebrew-core**:
+    <https://github.com/Homebrew/homebrew-core/issues>
 
 
 [SYNOPSIS]: #SYNOPSIS "SYNOPSIS"

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -4,7 +4,7 @@ brew(1) -- The missing package manager for macOS
 ## SYNOPSIS
 
 `brew` `--version`<br>
-`brew` `command` [`--verbose`|`-v`] [`options`] [`formula`] ...
+`brew` *`command`* [`--verbose`|`-v`] [*`options`*] [*`formula`*] ...
 
 ## DESCRIPTION
 
@@ -17,11 +17,11 @@ For the full command list, see the [COMMANDS](#commands) section.
 
 With `--verbose` or `-v`, many commands print extra debugging information. Note that these flags should only appear after a command.
 
-  * `install` `formula`:
-    Install `formula`.
+  * `install` *`formula`*:
+    Install *`formula`*.
 
-  * `uninstall` `formula`:
-    Uninstall `formula`.
+  * `uninstall` *`formula`*:
+    Uninstall *`formula`*.
 
   * `update`:
     Fetch the newest version of Homebrew from GitHub using `git`(1).
@@ -29,51 +29,13 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `list`:
     List all installed formulae.
 
-  * `search` (`text`|`/``text``/`):
-    Perform a substring search of formula names for `text`. If `text` is
+  * `search` (*`text`*|`/`*`text`*`/`):
+    Perform a substring search of formula names for *`text`*. If *`text`* is
     surrounded with slashes, then it is interpreted as a regular expression.
-    The search for `text` is extended online to some popular taps.
+    The search for *`text`* is extended online to some popular taps.
     If no search term is given, all locally available formulae are listed.
 
 ## COMMANDS
-
-  * `--cache`:
-    Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
-
-  * `--cache` [`--build-from-source`|`-s`] [`--force-bottle`] `formula`:
-    Display the file or directory used to cache `formula`.
-
-  * `--cellar`:
-    Display Homebrew's Cellar path. *Default:* `$(brew --prefix)/Cellar`, or if
-    that directory doesn't exist, `$(brew --repository)/Cellar`.
-
-  * `--cellar` `formula`:
-    Display the location in the cellar where `formula` would be installed,
-    without any sort of versioned directory as the last path.
-
-  * `--env` [`--shell=`(`shell`|`auto`)|`--plain`]:
-    Show a summary of the Homebrew build environment as a plain list.
-
-    Pass `--shell=``shell` to generate a list of environment variables for the
-    specified shell, or `--shell=auto` to detect the current shell.
-
-    If the command's output is sent through a pipe and no shell is specified,
-    the list is formatted for export to `bash`(1) unless `--plain` is passed.
-
-  * `--prefix`:
-    Display Homebrew's install path. *Default:* `/usr/local` on macOS and `/home/linuxbrew/.linuxbrew` on Linux
-
-  * `--prefix` `formula`:
-    Display the location in the cellar where `formula` is or would be installed.
-
-  * `--repository`:
-    Display where Homebrew's `.git` directory is located.
-
-  * `--repository` `user``/``repo`:
-    Display where tap `user``/``repo`'s directory is located.
-
-  * `--version`:
-    Print the version number of Homebrew to standard output and exit.
 
   * `analytics` [`state`]:
     Display anonymous user behaviour analytics state.
@@ -85,15 +47,15 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `analytics` `regenerate-uuid`:
     Regenerate UUID used in Homebrew's analytics.
 
-  * `cat` `formula`:
-    Display the source to `formula`.
+  * `cat` *`formula`*:
+    Display the source to *`formula`*.
 
-  * `cleanup` [`--prune=``days`] [`--dry-run`] [`-s`] [<formula/cask> ...]:
+  * `cleanup` [`--prune=`*`days`*] [`--dry-run`] [`-s`] [*`formulae`*|*`casks`*]:
     Remove stale lock files and outdated downloads for formulae and casks,
     and remove old versions of installed formulae. If arguments are specified,
     only do this for the specified formulae and casks.
 
-    If `--prune=``days` is specified, remove all cache files older than `days`.
+    If `--prune=`*`days`* is specified, remove all cache files older than *`days`*.
 
     If `--dry-run` or `-n` is passed, show what would be removed, but do not
     actually remove anything.
@@ -102,8 +64,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     versions. Note downloads for any installed formula or cask will still not
     be deleted. If you want to delete those too: `rm -rf "$(brew --cache)"`
 
-  * `command` `cmd`:
-    Display the path to the file which is used when invoking `brew` `cmd`.
+  * `command` *`cmd`*:
+    Display the path to the file which is used when invoking `brew` *`cmd`*.
 
   * `commands` [`--quiet` [`--include-aliases`]]:
     Show a list of built-in and external commands.
@@ -116,16 +78,16 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     a bug report, you will likely be asked for this information if you do not
     provide it.
 
-  * `deps` [`--1`] [`-n`] [`--union`] [`--full-name`] [`--installed`] [`--include-build`] [`--include-optional`] [`--skip-recommended`] [`--include-requirements`] `formulae`:
-    Show dependencies for `formulae`. When given multiple formula arguments,
-    show the intersection of dependencies for `formulae`.
+  * `deps` [`--1`] [`-n`] [`--union`] [`--full-name`] [`--installed`] [`--include-build`] [`--include-optional`] [`--skip-recommended`] [`--include-requirements`] *`formulae`*:
+    Show dependencies for *`formulae`*. When given multiple formula arguments,
+    show the intersection of dependencies for *`formulae`*.
 
     If `--1` is passed, only show dependencies one level down, instead of
     recursing.
 
     If `-n` is passed, show dependencies in topological order.
 
-    If `--union` is passed, show the union of dependencies for `formulae`,
+    If `--union` is passed, show the union of dependencies for *`formulae`*,
     instead of the intersection.
 
     If `--full-name` is passed, list dependencies by their full name.
@@ -134,13 +96,13 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     currently installed.
 
     By default, `deps` shows required and recommended dependencies for
-    `formulae`. To include the `:build` type dependencies, pass `--include-build`.
+    *`formulae`*. To include the `:build` type dependencies, pass `--include-build`.
     Similarly, pass `--include-optional` to include `:optional` dependencies or
     `--include-test` to include (non-recursive) `:test` dependencies.
     To skip `:recommended` type dependencies, pass `--skip-recommended`.
     To include requirements in addition to dependencies, pass `--include-requirements`.
 
-  * `deps` `--tree` [`--1`] [`filters`] [`--annotate`] (`formulae`|`--installed`):
+  * `deps` `--tree` [`--1`] [*`filters`*] [`--annotate`] (*`formulae`*|`--installed`):
     Show dependencies as a tree. When given multiple formula arguments, output
     individual trees for every formula.
 
@@ -148,39 +110,39 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--installed` is passed, output a tree for every installed formula.
 
-    The `filters` placeholder is any combination of options `--include-build`,
+    The *`filters`* placeholder is any combination of options `--include-build`,
     `--include-optional`, `--include-test`, `--skip-recommended`, and
     `--include-requirements` as documented above.
 
     If `--annotate` is passed, the build, optional, and recommended dependencies
     are marked as such in the output.
 
-  * `deps` [`filters`] (`--installed`|`--all`):
+  * `deps` [*`filters`*] (`--installed`|`--all`):
     Show dependencies for installed or all available formulae. Every line of
     output starts with the formula name, followed by a colon and all direct
     dependencies of that formula.
 
-    The `filters` placeholder is any combination of options `--include-build`,
+    The *`filters`* placeholder is any combination of options `--include-build`,
     `--include-optional`, `--include-test`, and `--skip-recommended` as
     documented above.
 
-  * `desc` `formula`:
-    Display `formula`'s name and one-line description.
+  * `desc` *`formula`*:
+    Display *`formula`*'s name and one-line description.
 
-  * `desc` [`--search`|`--name`|`--description`] (`text`|`/``text``/`):
+  * `desc` [`--search`|`--name`|`--description`] (*`text`*|`/`*`text`*`/`):
     Search both name and description (`--search` or `-s`), just the names
     (`--name` or `-n`), or just the descriptions (`--description` or `-d`) for
-    `text`. If `text` is flanked by slashes, it is interpreted as a regular
+    *`text`*. If *`text`* is flanked by slashes, it is interpreted as a regular
     expression. Formula descriptions are cached; the cache is created on the
     first search, making that search slower than subsequent ones.
 
-  * `diy` [`--name=``name`] [`--version=``version`]:
+  * `diy` [`--name=`*`name`*] [`--version=`*`version`*]:
     Automatically determine the installation prefix for non-Homebrew software.
 
     Using the output from this command, you can install your own software into
     the Cellar and then link it into Homebrew's prefix with `brew link`.
 
-    The options `--name=``name` and `--version=``version` each take an argument
+    The options `--name=`*`name`* and `--version=`*`version`* each take an argument
     and allow you to explicitly set the name and version of the package you are
     installing.
 
@@ -191,8 +153,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     everything you use Homebrew for is working fine: please don't worry or file
     an issue; just ignore this.
 
-  * `fetch` [`--force`] [`--retry`] [`-v`] [`--devel`|`--HEAD`] [`--deps`] [`--build-from-source`|`--force-bottle`] `formulae`:
-    Download the source packages for the given `formulae`.
+  * `fetch` [`--force`] [`--retry`] [`-v`] [`--devel`|`--HEAD`] [`--deps`] [`--build-from-source`|`--force-bottle`] *`formulae`*:
+    Download the source packages for the given *`formulae`*.
     For tarballs, also print SHA-256 checksums.
 
     If `--HEAD` or `--devel` is passed, fetch that version instead of the
@@ -206,7 +168,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--retry` is passed, retry if a download fails or re-download if the
     checksum of a previously cached version no longer matches.
 
-    If `--deps` is passed, also download dependencies for any listed `formulae`.
+    If `--deps` is passed, also download dependencies for any listed *`formulae`*.
 
     If `--build-from-source` (or `-s`) is passed, download the source rather than a
     bottle.
@@ -215,10 +177,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     current or newest version of macOS, even if it would not be used during
     installation.
 
-  * `gist-logs` [`--new-issue`|`-n`] `formula`:
-    Upload logs for a failed build of `formula` to a new Gist.
+  * `gist-logs` [`--new-issue`|`-n`] *`formula`*:
+    Upload logs for a failed build of *`formula`* to a new Gist.
 
-    `formula` is usually the name of the formula to install, but it can be specified
+    *`formula`* is usually the name of the formula to install, but it can be specified
     in several different ways. See [SPECIFYING FORMULAE](#specifying-formulae).
 
     If `--with-hostname` is passed, include the hostname in the Gist.
@@ -231,26 +193,26 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `home`:
     Open Homebrew's own homepage in a browser.
 
-  * `home` `formula`:
-    Open `formula`'s homepage in a browser.
+  * `home` *`formula`*:
+    Open *`formula`*'s homepage in a browser.
 
   * `info`:
     Display brief statistics for your Homebrew installation.
 
-  * `info` `formula`  (`--verbose`):
-    Display information about `formula` and analytics data (provided neither
+  * `info` *`formula`* [`--verbose`]:
+    Display information about *`formula`* and analytics data (provided neither
     `HOMEBREW_NO_ANALYTICS` or `HOMEBREW_NO_GITHUB_API` are set)
 
     Pass `--verbose` to see more detailed analytics data.
 
-  * `info` `--github` `formula`:
-    Open a browser to the GitHub History page for `formula`.
+  * `info` `--github` *`formula`*:
+    Open a browser to the GitHub History page for *`formula`*.
 
-    To view formula history locally: `brew log -p `formula
+    To view formula history locally: `brew log -p` *`formula`*
 
-  * `info` `--json=``version` (`--all`|`--installed`|`formulae`):
-    Print a JSON representation of `formulae`. Currently the only accepted value
-    for `version` is `v1`.
+  * `info` `--json=`*`version`* (`--all`|`--installed`|*`formulae`*):
+    Print a JSON representation of *`formulae`*. Currently the only accepted value
+    for *`version`* is `v1`.
 
     Pass `--all` to get information on all formulae, or `--installed` to get
     information on all installed formulae.
@@ -258,10 +220,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     See the docs for examples of using the JSON output:
     <https://docs.brew.sh/Querying-Brew>
 
-  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=``compiler`] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] [`--display-times`] `formula` [`options` ...]:
-    Install `formula`.
+  * `install` [`--debug`] [`--env=`(`std`|`super`)] [`--ignore-dependencies`|`--only-dependencies`] [`--cc=`*`compiler`*] [`--build-from-source`|`--force-bottle`] [`--include-test`] [`--devel`|`--HEAD`] [`--keep-tmp`] [`--build-bottle`] [`--force`] [`--verbose`] [`--display-times`] *`formula`* [*`options`* ...]:
+    Install *`formula`*.
 
-    `formula` is usually the name of the formula to install, but it can be specified
+    *`formula`* is usually the name of the formula to install, but it can be specified
     in several different ways. See [SPECIFYING FORMULAE](#specifying-formulae).
 
     If `--debug` (or `-d`) is passed and brewing fails, open an interactive debugging
@@ -279,8 +241,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--only-dependencies` is passed, install the dependencies with specified
     options but do not install the specified formula.
 
-    If `--cc=``compiler` is passed, attempt to compile using `compiler`.
-    `compiler` should be the name of the compiler's executable, for instance
+    If `--cc=`*`compiler`* is passed, attempt to compile using *`compiler`*.
+    *`compiler`* should be the name of the compiler's executable, for instance
     `gcc-8` for gcc 8, `gcc-4.2` for Apple's GCC 4.2, or `gcc-4.9` for a
     Homebrew-provided GCC 4.9. In order to use LLVM's clang, use
     `llvm_clang`. To specify the Apple-provided clang, use `clang`. This
@@ -288,12 +250,12 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     bundled with macOS. Please do not file issues if you encounter errors
     while using this flag.
 
-    If `--build-from-source` (or `-s`) is passed, compile the specified `formula` from
+    If `--build-from-source` (or `-s`) is passed, compile the specified *`formula`* from
     source even if a bottle is provided. Dependencies will still be installed
     from bottles if they are available.
 
     If `HOMEBREW_BUILD_FROM_SOURCE` is set, regardless of whether `--build-from-source` was
-    passed, then both `formula` and the dependencies installed as part of this process
+    passed, then both *`formula`* and the dependencies installed as part of this process
     are built from source even if bottles are available.
 
     If `--force-bottle` is passed, install from a bottle if it exists for the
@@ -303,9 +265,9 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--include-test` is passed, install testing dependencies. These are only
     needed by formulae maintainers to run `brew test`.
 
-    If `--devel` is passed, and `formula` defines it, install the development version.
+    If `--devel` is passed, and *`formula`* defines it, install the development version.
 
-    If `--HEAD` is passed, and `formula` defines it, install the HEAD version,
+    If `--HEAD` is passed, and *`formula`* defines it, install the HEAD version,
     aka master, trunk, unstable.
 
     If `--keep-tmp` is passed, the temporary files created during installation
@@ -322,11 +284,11 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--display-times` is passed, install times for each formula are printed
     at the end of the run.
 
-    Installation options specific to `formula` may be appended to the command,
-    and can be listed with `brew options` `formula`.
+    Installation options specific to *`formula`* may be appended to the command,
+    and can be listed with `brew options` *`formula`*.
 
-  * `install` `--interactive` [`--git`] `formula`:
-    If `--interactive` (or `-i`) is passed, download and patch `formula`, then
+  * `install` `--interactive` [`--git`] *`formula`*:
+    If `--interactive` (or `-i`) is passed, download and patch *`formula`*, then
     open a shell. This allows the user to run `./configure --help` and
     otherwise determine how to turn the software package into a Homebrew
     formula.
@@ -337,8 +299,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `leaves`:
     Show installed formulae that are not dependencies of another installed formula.
 
-  * `ln`, `link` [`--overwrite`] [`--dry-run`] [`--force`] `formula`:
-    Symlink all of `formula`'s installed files into the Homebrew prefix. This
+  * `ln`, `link` [`--overwrite`] [`--dry-run`] [`--force`] *`formula`*:
+    Symlink all of *`formula`*'s installed files into the Homebrew prefix. This
     is done automatically when you install formulae but can be useful for DIY
     installations.
 
@@ -359,40 +321,40 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `list`, `ls` `--unbrewed`:
     List all files in the Homebrew prefix not installed by Homebrew.
 
-  * `list`, `ls` [`--verbose`] [`--versions` [`--multiple`]] [`--pinned`] [`formulae`]:
-    List the installed files for `formulae`. Combined with `--verbose`, recursively
-    list the contents of all subdirectories in each `formula`'s keg.
+  * `list`, `ls` [`--verbose`] [`--versions` [`--multiple`]] [`--pinned`] [*`formulae`*]:
+    List the installed files for *`formulae`*. Combined with `--verbose`, recursively
+    list the contents of all subdirectories in each *`formula`*'s keg.
 
     If `--versions` is passed, show the version number for installed formulae,
-    or only the specified formulae if `formulae` are given. With `--multiple`,
+    or only the specified formulae if *`formulae`* are given. With `--multiple`,
     only show formulae with multiple versions installed.
 
     If `--pinned` is passed, show the versions of pinned formulae, or only the
-    specified (pinned) formulae if `formulae` are given.
+    specified (pinned) formulae if *`formulae`* are given.
     See also `pin`, `unpin`.
 
-  * `log` [`git-log-options`] `formula` ...:
+  * `log` [*`git-log-options`*] *`formula`* ...:
     Show the git log for the given formulae. Options that `git-log`(1)
     recognizes can be passed before the formula list.
 
-  * `migrate` [`--force`] `formulae`:
-    Migrate renamed packages to new name, where `formulae` are old names of
+  * `migrate` [`--force`] *`formulae`*:
+    Migrate renamed packages to new name, where *`formulae`* are old names of
     packages.
 
-    If `--force` (or `-f`) is passed, then treat installed `formulae` and passed `formulae`
+    If `--force` (or `-f`) is passed, then treat installed *`formulae`* and passed *`formulae`*
     like if they are from same taps and migrate them anyway.
 
-  * `missing` [`--hide=``hidden`] [`formulae`]:
-    Check the given `formulae` for missing dependencies. If no `formulae` are
+  * `missing` [`--hide=`*`hidden`*] [*`formulae`*]:
+    Check the given *`formulae`* for missing dependencies. If no *`formulae`* are
     given, check all installed brews.
 
-    If `--hide=``hidden` is passed, act as if none of `hidden` are installed.
-    `hidden` should be a comma-separated list of formulae.
+    If `--hide=`*`hidden`* is passed, act as if none of *`hidden`* are installed.
+    *`hidden`* should be a comma-separated list of formulae.
 
     `missing` exits with a non-zero status if any formulae are missing dependencies.
 
-  * `options` [`--compact`] (`--all`|`--installed`|`formulae`):
-    Display install options specific to `formulae`.
+  * `options` [`--compact`] (`--all`|`--installed`|*`formulae`*):
+    Display install options specific to *`formulae`*.
 
     If `--compact` is passed, show all options on a single line separated by
     spaces.
@@ -401,7 +363,7 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--installed` is passed, show options for all installed formulae.
 
-  * `outdated` [`--quiet`|`--verbose`|`--json=``version`] [`--fetch-HEAD`]:
+  * `outdated` [`--quiet`|`--verbose`|`--json=`*`version`*] [`--fetch-HEAD`]:
     Show formulae that have an updated version available.
 
     By default, version information is displayed in interactive shells, and
@@ -412,20 +374,20 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--verbose` (or `-v`) is passed, display detailed version information.
 
-    If `--json=``version` is passed, the output will be in JSON format.
-    Currently the only accepted value for `version` is `v1`.
+    If `--json=`*`version`* is passed, the output will be in JSON format.
+    Currently the only accepted value for *`version`* is `v1`.
 
     If `--fetch-HEAD` is passed, fetch the upstream repository to detect if
     the HEAD installation of the formula is outdated. Otherwise, the
     repository's HEAD will be checked for updates when a new stable or devel
     version has been released.
 
-  * `pin` `formulae`:
-    Pin the specified `formulae`, preventing them from being upgraded when
-    issuing the `brew upgrade `formulae command. See also `unpin`.
+  * `pin` *`formulae`*:
+    Pin the specified *`formulae`*, preventing them from being upgraded when
+    issuing the `brew upgrade` *`formulae`* command. See also `unpin`.
 
-  * `postinstall` `formula`:
-    Rerun the post-install steps for `formula`.
+  * `postinstall` *`formula`*:
+    Rerun the post-install steps for *`formula`*.
 
   * `prune` [`--dry-run`]:
     Remove dead symlinks from the Homebrew prefix. This is generally not
@@ -434,8 +396,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--dry-run` or `-n` is passed, show what would be removed, but do not
     actually remove anything.
 
-  * `readall` [`--aliases`] [`--syntax`] [`taps`]:
-    Import all formulae from specified `taps` (defaults to all installed taps).
+  * `readall` [`--aliases`] [`--syntax`] [*`taps`*]:
+    Import all formulae from specified *`taps`* (defaults to all installed taps).
 
     This can be useful for debugging issues across all formulae when making
     significant changes to `formula.rb`, testing the performance of loading
@@ -445,8 +407,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--syntax` is passed, also syntax-check all of Homebrew's Ruby files.
 
-  * `reinstall` [`--display-times`] `formula`:
-    Uninstall and then install `formula` (with existing install options).
+  * `reinstall` [`--display-times`] *`formula`*:
+    Uninstall and then install *`formula`* (with existing install options).
 
     If `--display-times` is passed, install times for each formula are printed
     at the end of the run.
@@ -459,16 +421,16 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Display all locally available casks (including tapped ones).
     No online search is performed.
 
-  * `search` [`--desc`] (`text`|`/``text``/`):
-    Perform a substring search of cask tokens and formula names for `text`. If `text`
+  * `search` [`--desc`] (*`text`*|`/`*`text`*`/`):
+    Perform a substring search of cask tokens and formula names for *`text`*. If *`text`*
     is surrounded with slashes, then it is interpreted as a regular expression.
-    The search for `text` is extended online to official taps.
+    The search for *`text`* is extended online to official taps.
 
-    If `--desc` is passed, search formulae with a description matching `text` and
-    casks with a name matching `text`.
+    If `--desc` is passed, search formulae with a description matching *`text`* and
+    casks with a name matching *`text`*.
 
-  * `search` (`--debian`|`--fedora`|`--fink`|`--macports`|`--opensuse`|`--ubuntu`) `text`:
-    Search for `text` in the given package manager's list.
+  * `search` (`--debian`|`--fedora`|`--fink`|`--macports`|`--opensuse`|`--ubuntu`) *`text`*:
+    Search for *`text`* in the given package manager's list.
 
   * `sh` [`--env=std`]:
     Start a Homebrew build environment shell. Uses our years-battle-hardened
@@ -479,10 +441,20 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
 
     If `--env=std` is passed, use the standard `PATH` instead of superenv's.
 
-  * `style` [`--fix`] [`--display-cop-names`] [`--only-cops=``cops`|`--except-cops=``cops`] [`files`|`taps`|`formulae`]:
+  * `shellenv`:
+    Prints export statements - run them in a shell and this installation of
+    Homebrew will be included into your PATH, MANPATH, and INFOPATH.
+
+    HOMEBREW_PREFIX, HOMEBREW_CELLAR and HOMEBREW_REPOSITORY are also exported
+    to save multiple queries of those variables.
+
+    Consider adding evaluating the output in your dotfiles (e.g. `~/.profile`)
+    with `eval $(brew shellenv)`
+
+  * `style` [`--fix`] [`--display-cop-names`] [`--only-cops=`*`cops`*|`--except-cops=`*`cops`*] [*`files`*|*`taps`*|*`formulae`*]:
     Check formulae or files for conformance to Homebrew style guidelines.
 
-    Lists of `files`, `taps` and `formulae` may not be combined. If none are
+    Lists of *`files`*, *`taps`* and *`formulae`* may not be combined. If none are
     provided, `style` will run style checks on the whole Homebrew library,
     including core code and all formulae.
 
@@ -492,50 +464,26 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--display-cop-names` is passed, include the RuboCop cop name for each
     violation in the output.
 
-    Passing `--only-cops=``cops` will check for violations of only the listed
-    RuboCop `cops`, while `--except-cops=``cops` will skip checking the listed
-    `cops`. For either option `cops` should be a comma-separated list of cop names.
+    Passing `--only-cops=`*`cops`* will check for violations of only the listed
+    RuboCop *`cops`*, while `--except-cops=`*`cops`* will skip checking the listed
+    *`cops`*. For either option *`cops`* should be a comma-separated list of cop names.
 
     Exits with a non-zero status if any style violations are found.
 
-  * `switch` `formula` `version`:
-    Symlink all of the specific `version` of `formula`'s install to Homebrew prefix.
-
-  * `tap-info`:
-    Display a brief summary of all installed taps.
-
-  * `tap-info` (`--installed`|`taps`):
-    Display detailed information about one or more `taps`.
-
-    Pass `--installed` to display information on all installed taps.
-
-  * `tap-info` `--json=``version` (`--installed`|`taps`):
-    Print a JSON representation of `taps`. Currently the only accepted value
-    for `version` is `v1`.
-
-    Pass `--installed` to get information on installed taps.
-
-    See the docs for examples of using the JSON output:
-    <https://docs.brew.sh/Querying-Brew>
-
-  * `tap-pin` `tap`:
-    Pin `tap`, prioritizing its formulae over core when formula names are supplied
-    by the user. See also `tap-unpin`.
-
-  * `tap-unpin` `tap`:
-    Unpin `tap` so its formulae are no longer prioritized. See also `tap-pin`.
+  * `switch` *`formula`* *`version`*:
+    Symlink all of the specific *`version`* of *`formula`*'s install to Homebrew prefix.
 
   * `tap`:
     List all installed taps.
 
-  * `tap` [`--full`] [`--force-auto-update`] `user``/``repo` [`URL`]:
+  * `tap` [`--full`] [`--force-auto-update`] *`user`*`/`*`repo`* [*`URL`*]:
     Tap a formula repository.
 
-    With `URL` unspecified, taps a formula repository from GitHub using HTTPS.
+    With *`URL`* unspecified, taps a formula repository from GitHub using HTTPS.
     Since so many taps are hosted on GitHub, this command is a shortcut for
-    `tap `user`/`repo` https://github.com/`user`/homebrew-`repo.
+    `brew tap` *`user`*`/`*`repo`* `https://github.com/`*`user`*`/homebrew-`*`repo`*.
 
-    With `URL` specified, taps a formula repository from anywhere, using
+    With *`URL`* specified, taps a formula repository from anywhere, using
     any transport protocol that `git` handles. The one-argument form of `tap`
     simplifies but also limits. This two-argument command makes no
     assumptions, so taps can be cloned from places other than GitHub and
@@ -550,8 +498,8 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     even if it is not hosted on GitHub.
 
     `tap` is re-runnable and exits successfully if there's nothing to do.
-    However, retapping with a different `URL` will cause an exception, so first
-    `untap` if you need to modify the `URL`.
+    However, retapping with a different *`URL`* will cause an exception, so first
+    `untap` if you need to modify the *`URL`*.
 
   * `tap` `--repair`:
     Migrate tapped formulae from symlink-based to directory-based structure.
@@ -559,48 +507,87 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
   * `tap` `--list-pinned`:
     List all pinned taps.
 
-  * `uninstall`, `rm`, `remove` [`--force`] [`--ignore-dependencies`] `formula`:
-    Uninstall `formula`.
+  * `tap-info`:
+    Display a brief summary of all installed taps.
 
-    If `--force` (or `-f`) is passed, and there are multiple versions of `formula`
+  * `tap-info` (`--installed`|*`taps`*):
+    Display detailed information about one or more *`taps`*.
+
+    Pass `--installed` to display information on all installed taps.
+
+  * `tap-info` `--json=`*`version`* (`--installed`|*`taps`*):
+    Print a JSON representation of *`taps`*. Currently the only accepted value
+    for *`version`* is `v1`.
+
+    Pass `--installed` to get information on installed taps.
+
+    See the docs for examples of using the JSON output:
+    <https://docs.brew.sh/Querying-Brew>
+
+  * `tap-pin` *`tap`*:
+    Pin *`tap`*, prioritizing its formulae over core when formula names are supplied
+    by the user. See also `tap-unpin`.
+
+  * `tap-unpin` *`tap`*:
+    Unpin *`tap`* so its formulae are no longer prioritized. See also `tap-pin`.
+
+  * `uninstall`, `rm`, `remove` [`--force`] [`--ignore-dependencies`] *`formula`*:
+    Uninstall *`formula`*.
+
+    If `--force` (or `-f`) is passed, and there are multiple versions of *`formula`*
     installed, delete all installed versions.
 
     If `--ignore-dependencies` is passed, uninstalling won't fail, even if
-    formulae depending on `formula` would still be installed.
+    formulae depending on *`formula`* would still be installed.
 
-  * `unlink` [`--dry-run`] `formula`:
-    Remove symlinks for `formula` from the Homebrew prefix. This can be useful
+  * `unlink` [`--dry-run`] *`formula`*:
+    Remove symlinks for *`formula`* from the Homebrew prefix. This can be useful
     for temporarily disabling a formula:
-    `brew unlink `formula` && `commands` && brew link `formula
+    `brew unlink` *`formula`* `&&` *`commands`* `&& brew link` *`formula`*
 
     If `--dry-run` or `-n` is passed, Homebrew will list all files which would
     be unlinked, but will not actually unlink or delete any files.
 
-  * `unpack` [`--git`|`--patch`] [`--destdir=``path`] `formulae`:
-    Unpack the source files for `formulae` into subdirectories of the current
-    working directory. If `--destdir=``path` is given, the subdirectories will
-    be created in the directory named by `path` instead.
+  * `unpack` [`--git`|`--patch`] [`--destdir=`*`path`*] *`formulae`*:
+    Unpack the source files for *`formulae`* into subdirectories of the current
+    working directory. If `--destdir=`*`path`* is given, the subdirectories will
+    be created in the directory named by *`path`* instead.
 
-    If `--patch` is passed, patches for `formulae` will be applied to the
+    If `--patch` is passed, patches for *`formulae`* will be applied to the
     unpacked source.
 
     If `--git` (or `-g`) is passed, a Git repository will be initialized in the unpacked
     source. This is useful for creating patches for the software.
 
-  * `unpin` `formulae`:
-    Unpin `formulae`, allowing them to be upgraded by `brew upgrade `formulae.
+  * `unpin` *`formulae`*:
+    Unpin *`formulae`*, allowing them to be upgraded by `brew upgrade` *`formulae`*.
     See also `pin`.
 
-  * `untap` `tap`:
+  * `untap` *`tap`*:
     Remove a tapped repository.
 
-  * `upgrade` [`install-options`] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`--display-times`] [`formulae`]:
+  * `update` [`--merge`] [`--force`]:
+    Fetch the newest version of Homebrew and all formulae from GitHub using
+    `git`(1) and perform any necessary migrations.
+
+    If `--merge` is specified then `git merge` is used to include updates
+    (rather than `git rebase`).
+
+    If `--force` (or `-f`) is specified then always do a slower, full update check even
+    if unnecessary.
+
+  * `update-reset` [*`repositories`*]:
+    Fetches and resets Homebrew and all tap repositories (or the specified
+    `repositories`) using `git`(1) to their latest `origin/master`. Note this
+    will destroy all your uncommitted or committed changes.
+
+  * `upgrade` [*`install-options`*] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`--display-times`] [*`formulae`*]:
     Upgrade outdated, unpinned brews (with existing install options).
 
     Options for the `install` command are also valid here.
 
     If `--cleanup` is specified or `HOMEBREW_UPGRADE_CLEANUP` is set then remove
-    previously installed version(s) of upgraded `formulae`.
+    previously installed version(s) of upgraded *`formulae`*.
 
     If `--fetch-HEAD` is passed, fetch the upstream repository to detect if
     the HEAD installation of the formula is outdated. Otherwise, the
@@ -613,61 +600,74 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     If `--display-times` is passed, install times for each formula are printed
     at the end of the run.
 
-    If `formulae` are given, upgrade only the specified brews (unless they
+    If *`formulae`* are given, upgrade only the specified brews (unless they
     are pinned; see `pin`, `unpin`).
 
-  * `uses` [`--installed`] [`--recursive`] [`--include-build`] [`--include-test`] [`--include-optional`] [`--skip-recommended`] [`--devel`|`--HEAD`] `formulae`:
-    Show the formulae that specify `formulae` as a dependency. When given
+  * `uses` [`--installed`] [`--recursive`] [`--include-build`] [`--include-test`] [`--include-optional`] [`--skip-recommended`] [`--devel`|`--HEAD`] *`formulae`*:
+    Show the formulae that specify *`formulae`* as a dependency. When given
     multiple formula arguments, show the intersection of formulae that use
-    `formulae`.
+    *`formulae`*.
 
     Use `--recursive` to resolve more than one level of dependencies.
 
     If `--installed` is passed, only list installed formulae.
 
-    By default, `uses` shows all formulae that specify `formulae` as a required
+    By default, `uses` shows all formulae that specify *`formulae`* as a required
     or recommended dependency. To include the `:build` type dependencies, pass
     `--include-build`, to include the `:test` type dependencies, pass
     `--include-test` and to include `:optional` dependencies pass
     `--include-optional`. To skip `:recommended` type dependencies, pass
     `--skip-recommended`.
 
-    By default, `uses` shows usage of `formulae` by stable builds. To find
-    cases where `formulae` is used by development or HEAD build, pass
+    By default, `uses` shows usage of *`formulae`* by stable builds. To find
+    cases where *`formulae`* is used by development or HEAD build, pass
     `--devel` or `--HEAD`.
 
-  * `shellenv`:
-    Prints export statements - run them in a shell and this installation of
-    Homebrew will be included into your PATH, MANPATH, and INFOPATH.
+  * `--cache`:
+    Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 
-    HOMEBREW_PREFIX, HOMEBREW_CELLAR and HOMEBREW_REPOSITORY are also exported
-    to save multiple queries of those variables.
+  * `--cache` [`--build-from-source`|`-s`] [`--force-bottle`] *`formula`*:
+    Display the file or directory used to cache *`formula`*.
 
-    Consider adding evaluating the output in your dotfiles (e.g. `~/.profile`)
-    with `eval $(brew shellenv)`
+  * `--cellar`:
+    Display Homebrew's Cellar path. *Default:* `$(brew --prefix)/Cellar`, or if
+    that directory doesn't exist, `$(brew --repository)/Cellar`.
 
-  * `update-reset` [`repositories`]:
-    Fetches and resets Homebrew and all tap repositories (or the specified
-    `repositories`) using `git`(1) to their latest `origin/master`. Note this
-    will destroy all your uncommitted or committed changes.
+  * `--cellar` *`formula`*:
+    Display the location in the cellar where *`formula`* would be installed,
+    without any sort of versioned directory as the last path.
 
-  * `update` [`--merge`] [`--force`]:
-    Fetch the newest version of Homebrew and all formulae from GitHub using
-    `git`(1) and perform any necessary migrations.
+  * `--env` [`--shell=`(*`shell`*|`auto`)|`--plain`]:
+    Show a summary of the Homebrew build environment as a plain list.
 
-    If `--merge` is specified then `git merge` is used to include updates
-    (rather than `git rebase`).
+    Pass `--shell=`*`shell`* to generate a list of environment variables for the
+    specified shell, or `--shell=auto` to detect the current shell.
 
-    If `--force` (or `-f`) is specified then always do a slower, full update check even
-    if unnecessary.
+    If the command's output is sent through a pipe and no shell is specified,
+    the list is formatted for export to `bash`(1) unless `--plain` is passed.
+
+  * `--prefix`:
+    Display Homebrew's install path. *Default:* `/usr/local` on macOS and `/home/linuxbrew/.linuxbrew` on Linux
+
+  * `--prefix` *`formula`*:
+    Display the location in the cellar where *`formula`* is or would be installed.
+
+  * `--repository`:
+    Display where Homebrew's `.git` directory is located.
+
+  * `--repository` *`user`*`/`*`repo`*:
+    Display where tap *`user`*`/`*`repo`*'s directory is located.
+
+  * `--version`:
+    Print the version number of Homebrew to standard output and exit.
 
 ## DEVELOPER COMMANDS
 
-###`audit` [`options`] `formulae`:
+### `audit` [*`options`*] *`formulae`*:
 
-Check `formulae` for Homebrew coding style violations. This should be
+Check *`formulae`* for Homebrew coding style violations. This should be
 run before submitting a new formula.
-If no `formulae` are provided, all of them are checked.
+If no *`formulae`* are provided, all of them are checked.
 
 *  `--strict`:
 Run additional style checks, including Rubocop style checks.
@@ -684,15 +684,15 @@ Prefix everyline of output with name of the file or formula being audited, to ma
 * `-D`,  `--audit-debug`:
 Activates debugging and profiling
 *  `--only`:
-Passing `--only`=`method` will run only the methods named audit_`method`, `method` should be a comma-separated list.
+Passing `--only=`*`method`* will run only the methods named audit_*`method`*. *`method`* should be a comma-separated list.
 *  `--except`:
-Passing `--except`=`method` will run only the methods named audit_`method`, `method` should be a comma-separated list.
+Passing `--except=`*`method`* will run only the methods named audit_*`method`*, *`method`* should be a comma-separated list.
 *  `--only-cops`:
-Passing `--only-cops`=`cops` will check for violations of only the listed RuboCop cops. `cops` should be a comma-separated list of cop names.
+Passing `--only-cops=`*`cops`* will check for violations of only the listed RuboCop cops. *`cops`* should be a comma-separated list of cop names.
 *  `--except-cops`:
-Passing `--except-cops`=`cops` will skip checking the listed RuboCop cops violations. `cops` should be a comma-separated list of cop names.
+Passing `--except-cops=`*`cops`* will skip checking the listed RuboCop cops violations. *`cops`* should be a comma-separated list of cop names.
 
-###`bottle` [`options`] `formulae`:
+### `bottle` [*`options`*] *`formulae`*:
 
 Generate a bottle (binary package) from a formula installed with
 `--build-bottle`.
@@ -705,7 +705,7 @@ Do not check if the bottle can be marked as relocatable.
 *  `--or-later`:
 Append `_or_later` to the bottle tag.
 *  `--force-core-tap`:
-Build a bottle even if `formula` is not in homebrew/core or any installed taps.
+Build a bottle even if *`formula`* is not in homebrew/core or any installed taps.
 *  `--no-rebuild`:
 If the formula specifies a rebuild version, it will be removed in the generated DSL.
 *  `--keep-old`:
@@ -719,17 +719,17 @@ When passed with `--write`, a new commit will not generated while writing change
 *  `--json`:
 Write bottle information to a JSON file, which can be used as the argument for `--merge`.
 *  `--root-url`:
-Use the specified `URL` as the root of the bottle's URL instead of Homebrew's default.
+Use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
 
-###`bump-formula-pr` [`options`] `formula`:
+### `bump-formula-pr` [*`options`*] *`formula`*:
 
 Creates a pull request to update the formula with a new URL or a new tag.
 
-If a `URL` is specified, the `sha-256` checksum of the new download must
-also be specified. A best effort to determine the `sha-256` and `formula`
+If a *`URL`* is specified, the *`sha-256`* checksum of the new download must
+also be specified. A best effort to determine the *`sha-256`* and *`formula`*
 name will be made if either or both values are not supplied by the user.
 
-If a `tag` is specified, the git commit `revision` corresponding to that
+If a *`tag`* is specified, the git commit *`revision`* corresponding to that
 tag must also be specified.
 
 Note that this command cannot be used to transition a formula from a
@@ -750,23 +750,23 @@ Run `brew audit --strict` before opening the PR.
 *  `--no-browse`:
 Output the pull request URL instead of opening in a browser
 *  `--url`:
-Provide new `URL` for the formula. If a `URL` is specified, the `sha-256` checksum of the new download must also be specified.
+Provide new *`URL`* for the formula. If a *`URL`* is specified, the *`sha-256`* checksum of the new download must also be specified.
 *  `--revision`:
-Specify the new git commit `revision` corresponding to a specified `tag`.
+Specify the new git commit *`revision`* corresponding to a specified *`tag`*.
 *  `--tag`:
-Specify the new git commit `tag` for the formula.
+Specify the new git commit *`tag`* for the formula.
 *  `--sha256`:
-Specify the `sha-256` checksum of new download.
+Specify the *`sha-256`* checksum of new download.
 *  `--mirror`:
-Use the provided `URL` as a mirror URL.
+Use the provided *`URL`* as a mirror URL.
 *  `--version`:
-Use the provided `version` to override the value parsed from the URL or tag. Note that `--version=0` can be used to delete an existing `version` override from a formula if it has become redundant.
+Use the provided *`version`* to override the value parsed from the URL or tag. Note that `--version=0` can be used to delete an existing `version` override from a formula if it has become redundant.
 *  `--message`:
-Append provided `message` to the default PR message.
+Append provided *`message`* to the default PR message.
 
-###`create` `URL` [`options`]:
+### `create` *`URL`* [*`options`*]:
 
-Generate a formula for the downloadable file at `URL` and open it in the editor.
+Generate a formula for the downloadable file at *`URL`* and open it in the editor.
 Homebrew will attempt to automatically derive the formula name
 and version, but if it fails, you'll have to make your own template. The `wget`
 formula serves as a simple example. For the complete API have a look at
@@ -779,7 +779,7 @@ Create a basic template for a CMake-style build.
 *  `--meson`:
 Create a basic template for a Meson-style build.
 *  `--no-fetch`:
-Homebrew will not download `URL` to the cache and will thus not add the SHA256 to the formula for you. It will also not check the GitHub API for GitHub projects (to fill out the description and homepage).
+Homebrew will not download *`URL`* to the cache and will thus not add the SHA256 to the formula for you. It will also not check the GitHub API for GitHub projects (to fill out the description and homepage).
 *  `--HEAD`:
 HEAD
 *  `--set-name`:
@@ -787,28 +787,28 @@ Set the provided name of the package you are creating.
 *  `--set-version`:
 Set the provided version of the package you are creating.
 *  `--tap`:
-Takes a tap [`user``/``repo`] as argument and generates the formula in the specified tap.
+Takes a tap [*`user`*`/`*`repo`*] as argument and generates the formula in the specified tap.
 
-###`edit` `formula`:
-  Open `formula` in the editor. Open all of Homebrew for editing if
-  no `formula` is provided.
+### `edit` *`formula`*:
+  Open *`formula`* in the editor. Open all of Homebrew for editing if
+  no *`formula`* is provided.
 
 
-###`extract` [`options`] `formula` `tap`:
+### `extract` [*`options`*] *`formula`* *`tap`*:
 
-Looks through repository history to find the `version` of `formula` and
-creates a copy in `tap`/Formula/`formula`@`version`.rb. If the tap is
+Looks through repository history to find the *`version`* of *`formula`* and
+creates a copy in *`tap`*/Formula/*`formula`*@*`version`*.rb. If the tap is
 not installed yet, attempts to install/clone the tap before continuing.
 
 *  `--version`:
-Provided `version` of `formula` will be extracted and placed in the destination tap. Otherwise, the most recent version that can be found will be used.
+Provided *`version`* of *`formula`* will be extracted and placed in the destination tap. Otherwise, the most recent version that can be found will be used.
 
-###`formula` `formula`:
+### `formula` *`formula`*:
 
-Display the path where `formula` is located.
+Display the path where *`formula`* is located.
 
 
-###`irb` [`options`]:
+### `irb` [*`options`*]:
 
 Enter the interactive Homebrew Ruby shell.
 
@@ -817,7 +817,7 @@ Show several examples.
 *  `--pry`:
 Pry will be used instead of irb if `--pry` is passed or HOMEBREW_PRY is set.
 
-###`linkage` [`options`] `formula`:
+### `linkage` [*`options`*] *`formula`*:
 
 Checks the library links of an installed formula.
 
@@ -831,7 +831,7 @@ Print the dylib followed by the binaries which link to it for each library the k
 *  `--cached`:
 Print the cached linkage values stored in HOMEBREW_CACHE, set from a previous `brew linkage` run.
 
-###`man` [`options`]:
+### `man` [*`options`*]:
 
 Generate Homebrew's manpages.
 
@@ -840,22 +840,22 @@ Return a failing status code if changes are detected in the manpage outputs. Thi
 *  `--link`:
 It is now done automatically by `brew update`.
 
-###`mirror` `formulae`:
+### `mirror` *`formulae`*:
 
 Reuploads the stable URL for a formula to Bintray to use it as a mirror.
 
 
-  * `prof` [`ruby options`]:
+  * `prof` [*`ruby options`*]:
     Run Homebrew with the Ruby profiler.
     For example:
       brew prof readall
 
-###`pull` [`options`] `formula`:
+### `pull` [*`options`*] *`formula`*:
 
 Gets a patch from a GitHub commit or pull request and applies it to Homebrew.
 Optionally, installs the formulae changed by the patch.
 
-Each `patch-source` may be one of:
+Each *`patch-source`* may be one of:
 
   ~ The ID number of a PR (pull request) in the homebrew/core GitHub
     repository
@@ -891,26 +891,26 @@ Publish at the given Bintray organisation.
 *  `--test-bot-user`:
 Pull the bottle block commit from the specified user on GitHub.
 
-###`release-notes` [`options`] [`previous_tag`] [`end_ref`]:
+### `release-notes` [*`options`*] [*`previous_tag`*] [*`end_ref`*]:
 
 Output the merged pull requests on Homebrew/brew between two Git refs.
-If no `previous_tag` is provided it defaults to the latest tag.
-If no `end_ref` is provided it defaults to `origin/master`.
+If no *`previous_tag`* is provided it defaults to the latest tag.
+If no *`end_ref`* is provided it defaults to `origin/master`.
 
 *  `--markdown`:
 Output as a Markdown list.
 
-  * `ruby` [`ruby options`]:
+  * `ruby` [*`ruby options`*]:
     Run a Ruby instance with Homebrew's libraries loaded.
     For example:
 
-###`tap-new` `user`/`repo`:
+### `tap-new` *`user`*/*`repo`*:
 
 Generate the template files for a new tap.
 
 
-  * `test` [`--devel`|`--HEAD`] [`--debug`] [`--keep-tmp`] `formula`:
-    Most formulae provide a test method. `brew test` `formula` runs this
+  * `test` [`--devel`|`--HEAD`] [`--debug`] [`--keep-tmp`] *`formula`*:
+    Most formulae provide a test method. `brew test` *`formula`* runs this
     test method. There is no standard output or return code, but it should
     generally indicate to the user if something is wrong with the installed
     formula.
@@ -926,10 +926,10 @@ Generate the template files for a new tap.
 
     Example: `brew install jruby && brew test jruby`
 
-###`tests` [`options`]:
+### `tests` [*`options`*]:
 
 Run Homebrew's unit and integration tests. If provided,
-`--only=``test_script` runs only `test_script`_spec.rb, and `--seed`
+`--only=`*`test_script`* runs only *`test_script`*_spec.rb, and `--seed`
 randomizes tests with the provided value instead of a random seed.
 
 *  `--coverage`:
@@ -941,11 +941,11 @@ Do not load the compatibility layer when running tests.
 *  `--online`:
 Include tests that use the GitHub API and tests that use any of the taps for official external commands.
 *  `--only`:
-Run only `test_script`_spec.rb
+Run only *`test_script`*_spec.rb
 *  `--seed`:
 Randomizes tests with the provided value instead of a random seed.
 
-###`update-test` [`options`]:
+### `update-test` [*`options`*]:
 
 Runs a test of `brew update` with a new repository clone.
 
@@ -956,9 +956,9 @@ Set `HOMEBREW_UPDATE_TO_TAG` to test updating between tags.
 *  `--keep-tmp`:
 Retain the temporary directory containing the new repository clone.
 *  `--commit`:
-Use provided `commit` as the start commit.
+Use provided *`commit`* as the start commit.
 *  `--before`:
-Use the commit at provided `date` as the start commit.
+Use the commit at provided *`date`* as the start commit.
 
 ## GLOBAL OPTIONS
 
@@ -978,26 +978,26 @@ Override warnings and enable potentially unsafe operations.
 
 ## OFFICIAL EXTERNAL COMMANDS
 
-  * `bundle` `command`:
+  * `bundle` *`command`*:
     Bundler for non-Ruby dependencies from Homebrew.
 
-    `brew bundle` [`install`] [`-v`|`--verbose`] [`--no-upgrade`] [`--file=``path`|`--global`]:
+    `brew bundle` [`install`] [`-v`|`--verbose`] [`--no-upgrade`] [`--file=`*`path`*|`--global`]:
     Install or upgrade all dependencies in a Brewfile.
 
-    `brew bundle dump` [`--force`] [`--describe`] [`--file=``path`|`--global`]:
+    `brew bundle dump` [`--force`] [`--describe`] [`--file=`*`path`*|`--global`]:
     Write all installed casks/formulae/taps into a Brewfile.
 
-    `brew bundle cleanup` [`--force`] [`--zap`] [`--file=``path`|`--global`]:
+    `brew bundle cleanup` [`--force`] [`--zap`] [`--file=`*`path`*|`--global`]:
     Uninstall all dependencies not listed in a Brewfile.
 
-    `brew bundle check` [`--no-upgrade`] [`--file=``path`|`--global`] [`--verbose`]:
+    `brew bundle check` [`--no-upgrade`] [`--file=`*`path`*|`--global`] [`--verbose`]:
     Check if all dependencies are installed in a Brewfile. Missing dependencies are listed in verbose mode.
     `check` will exit on the first category missing a dependency unless in verbose mode.
 
-    `brew bundle exec` `command`:
+    `brew bundle exec` *`command`*:
     Run an external command in an isolated build environment.
 
-    `brew bundle list` [`--all`|`--brews`|`--casks`|`--taps`|`--mas`] [`--file=``path`|`--global`]:
+    `brew bundle list` [`--all`|`--brews`|`--casks`|`--taps`|`--mas`] [`--file=`*`path`*|`--global`]:
     List all dependencies present in a Brewfile, optionally limiting by types.
     By default, only brew dependencies are output.
 
@@ -1010,7 +1010,7 @@ Override warnings and enable potentially unsafe operations.
 
     If `--zap` is passed, casks will be removed using the `zap` command instead of `uninstall`.
 
-    If `--file=``path` is passed, the Brewfile path is set accordingly.
+    If `--file=`*`path`* is passed, the Brewfile path is set accordingly.
     Use `--file=-` to output to console.
 
     If `--global` is passed, set the Brewfile path to `~/.Brewfile`.
@@ -1027,23 +1027,23 @@ Override warnings and enable potentially unsafe operations.
 
     **Homebrew/homebrew-cask**: <https://github.com/Homebrew/homebrew-cask>
 
-  * `services` `command`:
+  * `services` *`command`*:
     Integrates Homebrew formulae with macOS' `launchctl` manager.
 
     [`sudo`] `brew services list`:
     List all running services for the current user (or root).
 
-    [`sudo`] `brew services run` (`formula`|`--all`):
-    Run the service `formula` without registering to launch at login (or boot).
+    [`sudo`] `brew services run` (*`formula`*|`--all`):
+    Run the service *`formula`* without registering to launch at login (or boot).
 
-    [`sudo`] `brew services start` (`formula`|`--all`):
-    Start the service `formula` immediately and register it to launch at login (or boot).
+    [`sudo`] `brew services start` (*`formula`*|`--all`):
+    Start the service *`formula`* immediately and register it to launch at login (or boot).
 
-    [`sudo`] `brew services stop` (`formula`|`--all`):
-    Stop the service `formula` immediately and unregister it from launching at login (or boot).
+    [`sudo`] `brew services stop` (*`formula`*|`--all`):
+    Stop the service *`formula`* immediately and unregister it from launching at login (or boot).
 
-    [`sudo`] `brew services restart` (`formula`|`--all`):
-    Stop (if necessary) and start the service `formula` immediately and register it to launch at login (or boot).
+    [`sudo`] `brew services restart` (*`formula`*|`--all`):
+    Stop (if necessary) and start the service *`formula`* immediately and register it to launch at login (or boot).
 
     [`sudo`] `brew services cleanup`:
     Remove all unused services.
@@ -1056,8 +1056,8 @@ Override warnings and enable potentially unsafe operations.
 ## CUSTOM EXTERNAL COMMANDS
 
 Homebrew, like `git`(1), supports external commands. These are executable
-scripts that reside somewhere in the `PATH`, named `brew-``cmdname` or
-`brew-``cmdname``.rb`, which can be invoked like `brew` `cmdname`. This allows you
+scripts that reside somewhere in the `PATH`, named `brew-`*`cmdname`* or
+`brew-`*`cmdname`*`.rb`, which can be invoked like `brew` *`cmdname`*. This allows you
 to create your own commands without modifying Homebrew's internals.
 
 Instructions for creating your own commands can be found in the docs:
@@ -1065,7 +1065,7 @@ Instructions for creating your own commands can be found in the docs:
 
 ## SPECIFYING FORMULAE
 
-Many Homebrew commands accept one or more `formula` arguments. These arguments
+Many Homebrew commands accept one or more *`formula`* arguments. These arguments
 can take several different forms:
 
   * The name of a formula:
@@ -1272,15 +1272,15 @@ Note that environment variables must have a value set to be detected. For exampl
 ## USING HOMEBREW BEHIND A PROXY
 Use the `http_proxy`, `https_proxy`, `all_proxy`, `no_proxy` and/or `ftp_proxy` documented above.
 
-For example for an unauthenticated HTTP or SOCKS5 proxy:
+For example, for an unauthenticated HTTP or SOCKS5 proxy:
 
-    export http_proxy=http://`host`:`port`
+    export http_proxy=http://$HOST:$PORT
 
-    export all_proxy=socks5://`host`:`port`
+    export all_proxy=socks5://$HOST:$PORT
 
 And for an authenticated HTTP proxy:
 
-    export http_proxy=http://`user`:`password`@`host`:`port`
+    export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 
 ## SEE ALSO
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -44,52 +44,6 @@ Perform a substring search of formula names for \fItext\fR\. If \fItext\fR is su
 .SH "COMMANDS"
 .
 .TP
-\fB\-\-cache\fR
-Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
-.
-.TP
-\fB\-\-cache\fR [\fB\-\-build\-from\-source\fR|\fB\-s\fR] [\fB\-\-force\-bottle\fR] \fIformula\fR
-Display the file or directory used to cache \fIformula\fR\.
-.
-.TP
-\fB\-\-cellar\fR
-Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.
-.
-.TP
-\fB\-\-cellar\fR \fIformula\fR
-Display the location in the cellar where \fIformula\fR would be installed, without any sort of versioned directory as the last path\.
-.
-.TP
-\fB\-\-env\fR [\fB\-\-shell=\fR(\fIshell\fR|\fBauto\fR)|\fB\-\-plain\fR]
-Show a summary of the Homebrew build environment as a plain list\.
-.
-.IP
-Pass \fB\-\-shell=\fR\fIshell\fR to generate a list of environment variables for the specified shell, or \fB\-\-shell=auto\fR to detect the current shell\.
-.
-.IP
-If the command\'s output is sent through a pipe and no shell is specified, the list is formatted for export to \fBbash\fR(1) unless \fB\-\-plain\fR is passed\.
-.
-.TP
-\fB\-\-prefix\fR
-Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR on macOS and \fB/home/linuxbrew/\.linuxbrew\fR on Linux
-.
-.TP
-\fB\-\-prefix\fR \fIformula\fR
-Display the location in the cellar where \fIformula\fR is or would be installed\.
-.
-.TP
-\fB\-\-repository\fR
-Display where Homebrew\'s \fB\.git\fR directory is located\.
-.
-.TP
-\fB\-\-repository\fR \fIuser\fR\fB/\fR\fIrepo\fR
-Display where tap \fIuser\fR\fB/\fR\fIrepo\fR\'s directory is located\.
-.
-.TP
-\fB\-\-version\fR
-Print the version number of Homebrew to standard output and exit\.
-.
-.TP
 \fBanalytics\fR [\fBstate\fR]
 Display anonymous user behaviour analytics state\. Read more at \fIhttps://docs\.brew\.sh/Analytics\fR\.
 .
@@ -106,7 +60,7 @@ Regenerate UUID used in Homebrew\'s analytics\.
 Display the source to \fIformula\fR\.
 .
 .TP
-\fBcleanup\fR [\fB\-\-prune=\fR\fIdays\fR] [\fB\-\-dry\-run\fR] [\fB\-s\fR] [<formula/cask> \.\.\.]
+\fBcleanup\fR [\fB\-\-prune=\fR\fIdays\fR] [\fB\-\-dry\-run\fR] [\fB\-s\fR] [\fIformulae\fR|\fIcasks\fR]
 Remove stale lock files and outdated downloads for formulae and casks, and remove old versions of installed formulae\. If arguments are specified, only do this for the specified formulae and casks\.
 .
 .IP
@@ -254,7 +208,7 @@ Open \fIformula\fR\'s homepage in a browser\.
 Display brief statistics for your Homebrew installation\.
 .
 .TP
-\fBinfo\fR \fIformula\fR (\fB\-\-verbose\fR)
+\fBinfo\fR \fIformula\fR [\fB\-\-verbose\fR]
 Display information about \fIformula\fR and analytics data (provided neither \fBHOMEBREW_NO_ANALYTICS\fR or \fBHOMEBREW_NO_GITHUB_API\fR are set)
 .
 .IP
@@ -265,7 +219,7 @@ Pass \fB\-\-verbose\fR to see more detailed analytics data\.
 Open a browser to the GitHub History page for \fIformula\fR\.
 .
 .IP
-To view formula history locally: \fBbrew log \-p <formula>\fR
+To view formula history locally: \fBbrew log \-p\fR \fIformula\fR
 .
 .TP
 \fBinfo\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR)
@@ -435,7 +389,7 @@ If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if t
 .
 .TP
 \fBpin\fR \fIformulae\fR
-Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade <formulae>\fR command\. See also \fBunpin\fR\.
+Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR \fIformulae\fR command\. See also \fBunpin\fR\.
 .
 .TP
 \fBpostinstall\fR \fIformula\fR
@@ -495,6 +449,16 @@ Start a Homebrew build environment shell\. Uses our years\-battle\-hardened Home
 If \fB\-\-env=std\fR is passed, use the standard \fBPATH\fR instead of superenv\'s\.
 .
 .TP
+\fBshellenv\fR
+Prints export statements \- run them in a shell and this installation of Homebrew will be included into your PATH, MANPATH, and INFOPATH\.
+.
+.IP
+HOMEBREW_PREFIX, HOMEBREW_CELLAR and HOMEBREW_REPOSITORY are also exported to save multiple queries of those variables\.
+.
+.IP
+Consider adding evaluating the output in your dotfiles (e\.g\. \fB~/\.profile\fR) with \fBeval $(brew shellenv)\fR
+.
+.TP
 \fBstyle\fR [\fB\-\-fix\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-only\-cops=\fR\fIcops\fR|\fB\-\-except\-cops=\fR\fIcops\fR] [\fIfiles\fR|\fItaps\fR|\fIformulae\fR]
 Check formulae or files for conformance to Homebrew style guidelines\.
 .
@@ -516,6 +480,37 @@ Exits with a non\-zero status if any style violations are found\.
 .TP
 \fBswitch\fR \fIformula\fR \fIversion\fR
 Symlink all of the specific \fIversion\fR of \fIformula\fR\'s install to Homebrew prefix\.
+.
+.TP
+\fBtap\fR
+List all installed taps\.
+.
+.TP
+\fBtap\fR [\fB\-\-full\fR] [\fB\-\-force\-auto\-update\fR] \fIuser\fR\fB/\fR\fIrepo\fR [\fIURL\fR]
+Tap a formula repository\.
+.
+.IP
+With \fIURL\fR unspecified, taps a formula repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for \fBbrew tap\fR \fIuser\fR\fB/\fR\fIrepo\fR \fBhttps://github\.com/\fR\fIuser\fR\fB/homebrew\-\fR\fIrepo\fR\.
+.
+.IP
+With \fIURL\fR specified, taps a formula repository from anywhere, using any transport protocol that \fBgit\fR handles\. The one\-argument form of \fBtap\fR simplifies but also limits\. This two\-argument command makes no assumptions, so taps can be cloned from places other than GitHub and using protocols other than HTTPS, e\.g\., SSH, GIT, HTTP, FTP(S), RSYNC\.
+.
+.IP
+By default, the repository is cloned as a shallow copy (\fB\-\-depth=1\fR), but if \fB\-\-full\fR is passed, a full clone will be used\. To convert a shallow copy to a full copy, you can retap passing \fB\-\-full\fR without first untapping\.
+.
+.IP
+By default, only taps hosted on GitHub are auto\-updated (for performance reasons)\. If \fB\-\-force\-auto\-update\fR is passed, this tap will be auto\-updated even if it is not hosted on GitHub\.
+.
+.IP
+\fBtap\fR is re\-runnable and exits successfully if there\'s nothing to do\. However, retapping with a different \fIURL\fR will cause an exception, so first \fBuntap\fR if you need to modify the \fIURL\fR\.
+.
+.TP
+\fBtap\fR \fB\-\-repair\fR
+Migrate tapped formulae from symlink\-based to directory\-based structure\.
+.
+.TP
+\fBtap\fR \fB\-\-list\-pinned\fR
+List all pinned taps\.
 .
 .TP
 \fBtap\-info\fR
@@ -547,37 +542,6 @@ Pin \fItap\fR, prioritizing its formulae over core when formula names are suppli
 Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
 .
 .TP
-\fBtap\fR
-List all installed taps\.
-.
-.TP
-\fBtap\fR [\fB\-\-full\fR] [\fB\-\-force\-auto\-update\fR] \fIuser\fR\fB/\fR\fIrepo\fR [\fIURL\fR]
-Tap a formula repository\.
-.
-.IP
-With \fIURL\fR unspecified, taps a formula repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for \fBtap <user>/<repo> https://github\.com/<user>/homebrew\-<repo>\fR\.
-.
-.IP
-With \fIURL\fR specified, taps a formula repository from anywhere, using any transport protocol that \fBgit\fR handles\. The one\-argument form of \fBtap\fR simplifies but also limits\. This two\-argument command makes no assumptions, so taps can be cloned from places other than GitHub and using protocols other than HTTPS, e\.g\., SSH, GIT, HTTP, FTP(S), RSYNC\.
-.
-.IP
-By default, the repository is cloned as a shallow copy (\fB\-\-depth=1\fR), but if \fB\-\-full\fR is passed, a full clone will be used\. To convert a shallow copy to a full copy, you can retap passing \fB\-\-full\fR without first untapping\.
-.
-.IP
-By default, only taps hosted on GitHub are auto\-updated (for performance reasons)\. If \fB\-\-force\-auto\-update\fR is passed, this tap will be auto\-updated even if it is not hosted on GitHub\.
-.
-.IP
-\fBtap\fR is re\-runnable and exits successfully if there\'s nothing to do\. However, retapping with a different \fIURL\fR will cause an exception, so first \fBuntap\fR if you need to modify the \fIURL\fR\.
-.
-.TP
-\fBtap\fR \fB\-\-repair\fR
-Migrate tapped formulae from symlink\-based to directory\-based structure\.
-.
-.TP
-\fBtap\fR \fB\-\-list\-pinned\fR
-List all pinned taps\.
-.
-.TP
 \fBuninstall\fR, \fBrm\fR, \fBremove\fR [\fB\-\-force\fR] [\fB\-\-ignore\-dependencies\fR] \fIformula\fR
 Uninstall \fIformula\fR\.
 .
@@ -589,7 +553,7 @@ If \fB\-\-ignore\-dependencies\fR is passed, uninstalling won\'t fail, even if f
 .
 .TP
 \fBunlink\fR [\fB\-\-dry\-run\fR] \fIformula\fR
-Remove symlinks for \fIformula\fR from the Homebrew prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink <formula> && <commands> && brew link <formula>\fR
+Remove symlinks for \fIformula\fR from the Homebrew prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink\fR \fIformula\fR \fB&&\fR \fIcommands\fR \fB&& brew link\fR \fIformula\fR
 .
 .IP
 If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which would be unlinked, but will not actually unlink or delete any files\.
@@ -606,11 +570,25 @@ If \fB\-\-git\fR (or \fB\-g\fR) is passed, a Git repository will be initialized 
 .
 .TP
 \fBunpin\fR \fIformulae\fR
-Unpin \fIformulae\fR, allowing them to be upgraded by \fBbrew upgrade <formulae>\fR\. See also \fBpin\fR\.
+Unpin \fIformulae\fR, allowing them to be upgraded by \fBbrew upgrade\fR \fIformulae\fR\. See also \fBpin\fR\.
 .
 .TP
 \fBuntap\fR \fItap\fR
 Remove a tapped repository\.
+.
+.TP
+\fBupdate\fR [\fB\-\-merge\fR] [\fB\-\-force\fR]
+Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1) and perform any necessary migrations\.
+.
+.IP
+If \fB\-\-merge\fR is specified then \fBgit merge\fR is used to include updates (rather than \fBgit rebase\fR)\.
+.
+.IP
+If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full update check even if unnecessary\.
+.
+.TP
+\fBupdate\-reset\fR [\fIrepositories\fR]
+Fetches and resets Homebrew and all tap repositories (or the specified \fBrepositories\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
 .TP
 \fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fB\-\-display\-times\fR] [\fIformulae\fR]
@@ -651,28 +629,50 @@ By default, \fBuses\fR shows all formulae that specify \fIformulae\fR as a requi
 By default, \fBuses\fR shows usage of \fIformulae\fR by stable builds\. To find cases where \fIformulae\fR is used by development or HEAD build, pass \fB\-\-devel\fR or \fB\-\-HEAD\fR\.
 .
 .TP
-\fBshellenv\fR
-Prints export statements \- run them in a shell and this installation of Homebrew will be included into your PATH, MANPATH, and INFOPATH\.
-.
-.IP
-HOMEBREW_PREFIX, HOMEBREW_CELLAR and HOMEBREW_REPOSITORY are also exported to save multiple queries of those variables\.
-.
-.IP
-Consider adding evaluating the output in your dotfiles (e\.g\. \fB~/\.profile\fR) with \fBeval $(brew shellenv)\fR
+\fB\-\-cache\fR
+Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
 .
 .TP
-\fBupdate\-reset\fR [\fIrepositories\fR]
-Fetches and resets Homebrew and all tap repositories (or the specified \fBrepositories\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
+\fB\-\-cache\fR [\fB\-\-build\-from\-source\fR|\fB\-s\fR] [\fB\-\-force\-bottle\fR] \fIformula\fR
+Display the file or directory used to cache \fIformula\fR\.
 .
 .TP
-\fBupdate\fR [\fB\-\-merge\fR] [\fB\-\-force\fR]
-Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1) and perform any necessary migrations\.
+\fB\-\-cellar\fR
+Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.
+.
+.TP
+\fB\-\-cellar\fR \fIformula\fR
+Display the location in the cellar where \fIformula\fR would be installed, without any sort of versioned directory as the last path\.
+.
+.TP
+\fB\-\-env\fR [\fB\-\-shell=\fR(\fIshell\fR|\fBauto\fR)|\fB\-\-plain\fR]
+Show a summary of the Homebrew build environment as a plain list\.
 .
 .IP
-If \fB\-\-merge\fR is specified then \fBgit merge\fR is used to include updates (rather than \fBgit rebase\fR)\.
+Pass \fB\-\-shell=\fR\fIshell\fR to generate a list of environment variables for the specified shell, or \fB\-\-shell=auto\fR to detect the current shell\.
 .
 .IP
-If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full update check even if unnecessary\.
+If the command\'s output is sent through a pipe and no shell is specified, the list is formatted for export to \fBbash\fR(1) unless \fB\-\-plain\fR is passed\.
+.
+.TP
+\fB\-\-prefix\fR
+Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR on macOS and \fB/home/linuxbrew/\.linuxbrew\fR on Linux
+.
+.TP
+\fB\-\-prefix\fR \fIformula\fR
+Display the location in the cellar where \fIformula\fR is or would be installed\.
+.
+.TP
+\fB\-\-repository\fR
+Display where Homebrew\'s \fB\.git\fR directory is located\.
+.
+.TP
+\fB\-\-repository\fR \fIuser\fR\fB/\fR\fIrepo\fR
+Display where tap \fIuser\fR\fB/\fR\fIrepo\fR\'s directory is located\.
+.
+.TP
+\fB\-\-version\fR
+Print the version number of Homebrew to standard output and exit\.
 .
 .SH "DEVELOPER COMMANDS"
 .
@@ -709,19 +709,19 @@ Activates debugging and profiling
 .
 .TP
 \fB\-\-only\fR
-Passing \fB\-\-only\fR=\fImethod\fR will run only the methods named audit_\fImethod\fR, \fBmethod\fR should be a comma\-separated list\.
+Passing \fB\-\-only=\fR\fImethod\fR will run only the methods named audit_\fImethod\fR\. \fImethod\fR should be a comma\-separated list\.
 .
 .TP
 \fB\-\-except\fR
-Passing \fB\-\-except\fR=\fImethod\fR will run only the methods named audit_\fImethod\fR, \fBmethod\fR should be a comma\-separated list\.
+Passing \fB\-\-except=\fR\fImethod\fR will run only the methods named audit_\fImethod\fR, \fImethod\fR should be a comma\-separated list\.
 .
 .TP
 \fB\-\-only\-cops\fR
-Passing \fB\-\-only\-cops\fR=\fIcops\fR will check for violations of only the listed RuboCop cops\. \fBcops\fR should be a comma\-separated list of cop names\.
+Passing \fB\-\-only\-cops=\fR\fIcops\fR will check for violations of only the listed RuboCop cops\. \fIcops\fR should be a comma\-separated list of cop names\.
 .
 .TP
 \fB\-\-except\-cops\fR
-Passing \fB\-\-except\-cops\fR=\fIcops\fR will skip checking the listed RuboCop cops violations\. \fBcops\fR should be a comma\-separated list of cop names\.
+Passing \fB\-\-except\-cops=\fR\fIcops\fR will skip checking the listed RuboCop cops violations\. \fIcops\fR should be a comma\-separated list of cop names\.
 .
 .SS "\fBbottle\fR [\fIoptions\fR] \fIformulae\fR:"
 Generate a bottle (binary package) from a formula installed with \fB\-\-build\-bottle\fR\. If the formula specifies a rebuild version, it will be incremented in the generated DSL\. Passing \fB\-\-keep\-old\fR will attempt to keep it at its original value, while \fB\-\-no\-rebuild\fR will remove it\.
@@ -1396,15 +1396,15 @@ Sets the comma\-separated list of hostnames and domain names that should be excl
 Use the \fBhttp_proxy\fR, \fBhttps_proxy\fR, \fBall_proxy\fR, \fBno_proxy\fR and/or \fBftp_proxy\fR documented above\.
 .
 .P
-For example for an unauthenticated HTTP or SOCKS5 proxy:
+For example, for an unauthenticated HTTP or SOCKS5 proxy:
 .
 .IP "" 4
 .
 .nf
 
-export http_proxy=http://<host>:<port>
+export http_proxy=http://$HOST:$PORT
 
-export all_proxy=socks5://<host>:<port>
+export all_proxy=socks5://$HOST:$PORT
 .
 .fi
 .
@@ -1417,7 +1417,7 @@ And for an authenticated HTTP proxy:
 .
 .nf
 
-export http_proxy=http://<user>:<password>@<host>:<port>
+export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 .
 .fi
 .

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -43,20 +43,25 @@ Perform a substring search of formula names for \fItext\fR\. If \fItext\fR is su
 .
 .SH "COMMANDS"
 .
-.IP "\(bu" 4
-\fB\-\-cache\fR: Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
+.TP
+\fB\-\-cache\fR
+Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
 .
-.IP "\(bu" 4
-\fB\-\-cache\fR [\fB\-\-build\-from\-source\fR|\fB\-s\fR] [\fB\-\-force\-bottle\fR] \fIformula\fR: Display the file or directory used to cache \fIformula\fR\.
+.TP
+\fB\-\-cache\fR [\fB\-\-build\-from\-source\fR|\fB\-s\fR] [\fB\-\-force\-bottle\fR] \fIformula\fR
+Display the file or directory used to cache \fIformula\fR\.
 .
-.IP "\(bu" 4
-\fB\-\-cellar\fR: Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.
+.TP
+\fB\-\-cellar\fR
+Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.
 .
-.IP "\(bu" 4
-\fB\-\-cellar\fR \fIformula\fR: Display the location in the cellar where \fIformula\fR would be installed, without any sort of versioned directory as the last path\.
+.TP
+\fB\-\-cellar\fR \fIformula\fR
+Display the location in the cellar where \fIformula\fR would be installed, without any sort of versioned directory as the last path\.
 .
-.IP "\(bu" 4
-\fB\-\-env\fR [\fB\-\-shell=\fR(\fIshell\fR|\fBauto\fR)|\fB\-\-plain\fR]: Show a summary of the Homebrew build environment as a plain list\.
+.TP
+\fB\-\-env\fR [\fB\-\-shell=\fR(\fIshell\fR|\fBauto\fR)|\fB\-\-plain\fR]
+Show a summary of the Homebrew build environment as a plain list\.
 .
 .IP
 Pass \fB\-\-shell=\fR\fIshell\fR to generate a list of environment variables for the specified shell, or \fB\-\-shell=auto\fR to detect the current shell\.
@@ -64,35 +69,45 @@ Pass \fB\-\-shell=\fR\fIshell\fR to generate a list of environment variables for
 .IP
 If the command\'s output is sent through a pipe and no shell is specified, the list is formatted for export to \fBbash\fR(1) unless \fB\-\-plain\fR is passed\.
 .
-.IP "\(bu" 4
-\fB\-\-prefix\fR: Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR on macOS and \fB/home/linuxbrew/\.linuxbrew\fR on Linux
+.TP
+\fB\-\-prefix\fR
+Display Homebrew\'s install path\. \fIDefault:\fR \fB/usr/local\fR on macOS and \fB/home/linuxbrew/\.linuxbrew\fR on Linux
 .
-.IP "\(bu" 4
-\fB\-\-prefix\fR \fIformula\fR: Display the location in the cellar where \fIformula\fR is or would be installed\.
+.TP
+\fB\-\-prefix\fR \fIformula\fR
+Display the location in the cellar where \fIformula\fR is or would be installed\.
 .
-.IP "\(bu" 4
-\fB\-\-repository\fR: Display where Homebrew\'s \fB\.git\fR directory is located\.
+.TP
+\fB\-\-repository\fR
+Display where Homebrew\'s \fB\.git\fR directory is located\.
 .
-.IP "\(bu" 4
-\fB\-\-repository\fR \fIuser\fR\fB/\fR\fIrepo\fR: Display where tap \fIuser\fR\fB/\fR\fIrepo\fR\'s directory is located\.
+.TP
+\fB\-\-repository\fR \fIuser\fR\fB/\fR\fIrepo\fR
+Display where tap \fIuser\fR\fB/\fR\fIrepo\fR\'s directory is located\.
 .
-.IP "\(bu" 4
-\fB\-\-version\fR: Print the version number of Homebrew to standard output and exit\.
+.TP
+\fB\-\-version\fR
+Print the version number of Homebrew to standard output and exit\.
 .
-.IP "\(bu" 4
-\fBanalytics\fR [\fBstate\fR]: Display anonymous user behaviour analytics state\. Read more at \fIhttps://docs\.brew\.sh/Analytics\fR\.
+.TP
+\fBanalytics\fR [\fBstate\fR]
+Display anonymous user behaviour analytics state\. Read more at \fIhttps://docs\.brew\.sh/Analytics\fR\.
 .
-.IP "\(bu" 4
-\fBanalytics\fR (\fBon\fR|\fBoff\fR): Turn on/off Homebrew\'s analytics\.
+.TP
+\fBanalytics\fR (\fBon\fR|\fBoff\fR)
+Turn on/off Homebrew\'s analytics\.
 .
-.IP "\(bu" 4
-\fBanalytics\fR \fBregenerate\-uuid\fR: Regenerate UUID used in Homebrew\'s analytics\.
+.TP
+\fBanalytics\fR \fBregenerate\-uuid\fR
+Regenerate UUID used in Homebrew\'s analytics\.
 .
-.IP "\(bu" 4
-\fBcat\fR \fIformula\fR: Display the source to \fIformula\fR\.
+.TP
+\fBcat\fR \fIformula\fR
+Display the source to \fIformula\fR\.
 .
-.IP "\(bu" 4
-\fBcleanup\fR [\fB\-\-prune=\fR\fIdays\fR] [\fB\-\-dry\-run\fR] [\fB\-s\fR] [<formula/cask> \.\.\.]: Remove stale lock files and outdated downloads for formulae and casks, and remove old versions of installed formulae\. If arguments are specified, only do this for the specified formulae and casks\.
+.TP
+\fBcleanup\fR [\fB\-\-prune=\fR\fIdays\fR] [\fB\-\-dry\-run\fR] [\fB\-s\fR] [<formula/cask> \.\.\.]
+Remove stale lock files and outdated downloads for formulae and casks, and remove old versions of installed formulae\. If arguments are specified, only do this for the specified formulae and casks\.
 .
 .IP
 If \fB\-\-prune=\fR\fIdays\fR is specified, remove all cache files older than \fIdays\fR\.
@@ -103,20 +118,24 @@ If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, show what would be removed, but do
 .IP
 If \fB\-s\fR is passed, scrub the cache, including downloads for even the latest versions\. Note downloads for any installed formula or cask will still not be deleted\. If you want to delete those too: \fBrm \-rf "$(brew \-\-cache)"\fR
 .
-.IP "\(bu" 4
-\fBcommand\fR \fIcmd\fR: Display the path to the file which is used when invoking \fBbrew\fR \fIcmd\fR\.
+.TP
+\fBcommand\fR \fIcmd\fR
+Display the path to the file which is used when invoking \fBbrew\fR \fIcmd\fR\.
 .
-.IP "\(bu" 4
-\fBcommands\fR [\fB\-\-quiet\fR [\fB\-\-include\-aliases\fR]]: Show a list of built\-in and external commands\.
+.TP
+\fBcommands\fR [\fB\-\-quiet\fR [\fB\-\-include\-aliases\fR]]
+Show a list of built\-in and external commands\.
 .
 .IP
 If \fB\-\-quiet\fR is passed, list only the names of commands without the header\. With \fB\-\-include\-aliases\fR, the aliases of internal commands will be included\.
 .
-.IP "\(bu" 4
-\fBconfig\fR: Show Homebrew and system configuration useful for debugging\. If you file a bug report, you will likely be asked for this information if you do not provide it\.
+.TP
+\fBconfig\fR
+Show Homebrew and system configuration useful for debugging\. If you file a bug report, you will likely be asked for this information if you do not provide it\.
 .
-.IP "\(bu" 4
-\fBdeps\fR [\fB\-\-1\fR] [\fB\-n\fR] [\fB\-\-union\fR] [\fB\-\-full\-name\fR] [\fB\-\-installed\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] [\fB\-\-include\-requirements\fR] \fIformulae\fR: Show dependencies for \fIformulae\fR\. When given multiple formula arguments, show the intersection of dependencies for \fIformulae\fR\.
+.TP
+\fBdeps\fR [\fB\-\-1\fR] [\fB\-n\fR] [\fB\-\-union\fR] [\fB\-\-full\-name\fR] [\fB\-\-installed\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] [\fB\-\-include\-requirements\fR] \fIformulae\fR
+Show dependencies for \fIformulae\fR\. When given multiple formula arguments, show the intersection of dependencies for \fIformulae\fR\.
 .
 .IP
 If \fB\-\-1\fR is passed, only show dependencies one level down, instead of recursing\.
@@ -136,8 +155,9 @@ If \fB\-\-installed\fR is passed, only list those dependencies that are currentl
 .IP
 By default, \fBdeps\fR shows required and recommended dependencies for \fIformulae\fR\. To include the \fB:build\fR type dependencies, pass \fB\-\-include\-build\fR\. Similarly, pass \fB\-\-include\-optional\fR to include \fB:optional\fR dependencies or \fB\-\-include\-test\fR to include (non\-recursive) \fB:test\fR dependencies\. To skip \fB:recommended\fR type dependencies, pass \fB\-\-skip\-recommended\fR\. To include requirements in addition to dependencies, pass \fB\-\-include\-requirements\fR\.
 .
-.IP "\(bu" 4
-\fBdeps\fR \fB\-\-tree\fR [\fB\-\-1\fR] [\fIfilters\fR] [\fB\-\-annotate\fR] (\fIformulae\fR|\fB\-\-installed\fR): Show dependencies as a tree\. When given multiple formula arguments, output individual trees for every formula\.
+.TP
+\fBdeps\fR \fB\-\-tree\fR [\fB\-\-1\fR] [\fIfilters\fR] [\fB\-\-annotate\fR] (\fIformulae\fR|\fB\-\-installed\fR)
+Show dependencies as a tree\. When given multiple formula arguments, output individual trees for every formula\.
 .
 .IP
 If \fB\-\-1\fR is passed, only one level of children is displayed\.
@@ -151,20 +171,24 @@ The \fIfilters\fR placeholder is any combination of options \fB\-\-include\-buil
 .IP
 If \fB\-\-annotate\fR is passed, the build, optional, and recommended dependencies are marked as such in the output\.
 .
-.IP "\(bu" 4
-\fBdeps\fR [\fIfilters\fR] (\fB\-\-installed\fR|\fB\-\-all\fR): Show dependencies for installed or all available formulae\. Every line of output starts with the formula name, followed by a colon and all direct dependencies of that formula\.
+.TP
+\fBdeps\fR [\fIfilters\fR] (\fB\-\-installed\fR|\fB\-\-all\fR)
+Show dependencies for installed or all available formulae\. Every line of output starts with the formula name, followed by a colon and all direct dependencies of that formula\.
 .
 .IP
 The \fIfilters\fR placeholder is any combination of options \fB\-\-include\-build\fR, \fB\-\-include\-optional\fR, \fB\-\-include\-test\fR, and \fB\-\-skip\-recommended\fR as documented above\.
 .
-.IP "\(bu" 4
-\fBdesc\fR \fIformula\fR: Display \fIformula\fR\'s name and one\-line description\.
+.TP
+\fBdesc\fR \fIformula\fR
+Display \fIformula\fR\'s name and one\-line description\.
 .
-.IP "\(bu" 4
-\fBdesc\fR [\fB\-\-search\fR|\fB\-\-name\fR|\fB\-\-description\fR] (\fItext\fR|\fB/\fR\fItext\fR\fB/\fR): Search both name and description (\fB\-\-search\fR or \fB\-s\fR), just the names (\fB\-\-name\fR or \fB\-n\fR), or just the descriptions (\fB\-\-description\fR or \fB\-d\fR) for \fItext\fR\. If \fItext\fR is flanked by slashes, it is interpreted as a regular expression\. Formula descriptions are cached; the cache is created on the first search, making that search slower than subsequent ones\.
+.TP
+\fBdesc\fR [\fB\-\-search\fR|\fB\-\-name\fR|\fB\-\-description\fR] (\fItext\fR|\fB/\fR\fItext\fR\fB/\fR)
+Search both name and description (\fB\-\-search\fR or \fB\-s\fR), just the names (\fB\-\-name\fR or \fB\-n\fR), or just the descriptions (\fB\-\-description\fR or \fB\-d\fR) for \fItext\fR\. If \fItext\fR is flanked by slashes, it is interpreted as a regular expression\. Formula descriptions are cached; the cache is created on the first search, making that search slower than subsequent ones\.
 .
-.IP "\(bu" 4
-\fBdiy\fR [\fB\-\-name=\fR\fIname\fR] [\fB\-\-version=\fR\fIversion\fR]: Automatically determine the installation prefix for non\-Homebrew software\.
+.TP
+\fBdiy\fR [\fB\-\-name=\fR\fIname\fR] [\fB\-\-version=\fR\fIversion\fR]
+Automatically determine the installation prefix for non\-Homebrew software\.
 .
 .IP
 Using the output from this command, you can install your own software into the Cellar and then link it into Homebrew\'s prefix with \fBbrew link\fR\.
@@ -172,11 +196,13 @@ Using the output from this command, you can install your own software into the C
 .IP
 The options \fB\-\-name=\fR\fIname\fR and \fB\-\-version=\fR\fIversion\fR each take an argument and allow you to explicitly set the name and version of the package you are installing\.
 .
-.IP "\(bu" 4
-\fBdoctor\fR: Check your system for potential problems\. Doctor exits with a non\-zero status if any potential problems are found\. Please note that these warnings are just used to help the Homebrew maintainers with debugging if you file an issue\. If everything you use Homebrew for is working fine: please don\'t worry or file an issue; just ignore this\.
+.TP
+\fBdoctor\fR
+Check your system for potential problems\. Doctor exits with a non\-zero status if any potential problems are found\. Please note that these warnings are just used to help the Homebrew maintainers with debugging if you file an issue\. If everything you use Homebrew for is working fine: please don\'t worry or file an issue; just ignore this\.
 .
-.IP "\(bu" 4
-\fBfetch\fR [\fB\-\-force\fR] [\fB\-\-retry\fR] [\fB\-v\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-deps\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] \fIformulae\fR: Download the source packages for the given \fIformulae\fR\. For tarballs, also print SHA\-256 checksums\.
+.TP
+\fBfetch\fR [\fB\-\-force\fR] [\fB\-\-retry\fR] [\fB\-v\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-deps\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] \fIformulae\fR
+Download the source packages for the given \fIformulae\fR\. For tarballs, also print SHA\-256 checksums\.
 .
 .IP
 If \fB\-\-HEAD\fR or \fB\-\-devel\fR is passed, fetch that version instead of the stable version\.
@@ -199,8 +225,9 @@ If \fB\-\-build\-from\-source\fR (or \fB\-s\fR) is passed, download the source r
 .IP
 If \fB\-\-force\-bottle\fR is passed, download a bottle if it exists for the current or newest version of macOS, even if it would not be used during installation\.
 .
-.IP "\(bu" 4
-\fBgist\-logs\fR [\fB\-\-new\-issue\fR|\fB\-n\fR] \fIformula\fR: Upload logs for a failed build of \fIformula\fR to a new Gist\.
+.TP
+\fBgist\-logs\fR [\fB\-\-new\-issue\fR|\fB\-n\fR] \fIformula\fR
+Upload logs for a failed build of \fIformula\fR to a new Gist\.
 .
 .IP
 \fIformula\fR is usually the name of the formula to install, but it can be specified in several different ways\. See \fISPECIFYING FORMULAE\fR\.
@@ -214,29 +241,35 @@ If \fB\-\-new\-issue\fR is passed, automatically create a new issue in the appro
 .IP
 If no logs are found, an error message is presented\.
 .
-.IP "\(bu" 4
-\fBhome\fR: Open Homebrew\'s own homepage in a browser\.
+.TP
+\fBhome\fR
+Open Homebrew\'s own homepage in a browser\.
 .
-.IP "\(bu" 4
-\fBhome\fR \fIformula\fR: Open \fIformula\fR\'s homepage in a browser\.
+.TP
+\fBhome\fR \fIformula\fR
+Open \fIformula\fR\'s homepage in a browser\.
 .
-.IP "\(bu" 4
-\fBinfo\fR: Display brief statistics for your Homebrew installation\.
+.TP
+\fBinfo\fR
+Display brief statistics for your Homebrew installation\.
 .
-.IP "\(bu" 4
-\fBinfo\fR \fIformula\fR (\fB\-\-verbose\fR): Display information about \fIformula\fR and analytics data (provided neither \fBHOMEBREW_NO_ANALYTICS\fR or \fBHOMEBREW_NO_GITHUB_API\fR are set)
+.TP
+\fBinfo\fR \fIformula\fR (\fB\-\-verbose\fR)
+Display information about \fIformula\fR and analytics data (provided neither \fBHOMEBREW_NO_ANALYTICS\fR or \fBHOMEBREW_NO_GITHUB_API\fR are set)
 .
 .IP
 Pass \fB\-\-verbose\fR to see more detailed analytics data\.
 .
-.IP "\(bu" 4
-\fBinfo\fR \fB\-\-github\fR \fIformula\fR: Open a browser to the GitHub History page for \fIformula\fR\.
+.TP
+\fBinfo\fR \fB\-\-github\fR \fIformula\fR
+Open a browser to the GitHub History page for \fIformula\fR\.
 .
 .IP
 To view formula history locally: \fBbrew log \-p <formula>\fR
 .
-.IP "\(bu" 4
-\fBinfo\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR): Print a JSON representation of \fIformulae\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
+.TP
+\fBinfo\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR)
+Print a JSON representation of \fIformulae\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
 .
 .IP
 Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to get information on all installed formulae\.
@@ -244,8 +277,9 @@ Pass \fB\-\-all\fR to get information on all formulae, or \fB\-\-installed\fR to
 .IP
 See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
-.IP "\(bu" 4
-\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-include\-test\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] [\fB\-\-force\fR] [\fB\-\-verbose\fR] [\fB\-\-display\-times\fR] \fIformula\fR [\fIoptions\fR \.\.\.]: Install \fIformula\fR\.
+.TP
+\fBinstall\fR [\fB\-\-debug\fR] [\fB\-\-env=\fR(\fBstd\fR|\fBsuper\fR)] [\fB\-\-ignore\-dependencies\fR|\fB\-\-only\-dependencies\fR] [\fB\-\-cc=\fR\fIcompiler\fR] [\fB\-\-build\-from\-source\fR|\fB\-\-force\-bottle\fR] [\fB\-\-include\-test\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] [\fB\-\-keep\-tmp\fR] [\fB\-\-build\-bottle\fR] [\fB\-\-force\fR] [\fB\-\-verbose\fR] [\fB\-\-display\-times\fR] \fIformula\fR [\fIoptions\fR \.\.\.]
+Install \fIformula\fR\.
 .
 .IP
 \fIformula\fR is usually the name of the formula to install, but it can be specified in several different ways\. See \fISPECIFYING FORMULAE\fR\.
@@ -304,17 +338,20 @@ If \fB\-\-display\-times\fR is passed, install times for each formula are printe
 .IP
 Installation options specific to \fIformula\fR may be appended to the command, and can be listed with \fBbrew options\fR \fIformula\fR\.
 .
-.IP "\(bu" 4
-\fBinstall\fR \fB\-\-interactive\fR [\fB\-\-git\fR] \fIformula\fR: If \fB\-\-interactive\fR (or \fB\-i\fR) is passed, download and patch \fIformula\fR, then open a shell\. This allows the user to run \fB\./configure \-\-help\fR and otherwise determine how to turn the software package into a Homebrew formula\.
+.TP
+\fBinstall\fR \fB\-\-interactive\fR [\fB\-\-git\fR] \fIformula\fR
+If \fB\-\-interactive\fR (or \fB\-i\fR) is passed, download and patch \fIformula\fR, then open a shell\. This allows the user to run \fB\./configure \-\-help\fR and otherwise determine how to turn the software package into a Homebrew formula\.
 .
 .IP
 If \fB\-\-git\fR (or \fB\-g\fR) is passed, Homebrew will create a Git repository, useful for creating patches to the software\.
 .
-.IP "\(bu" 4
-\fBleaves\fR: Show installed formulae that are not dependencies of another installed formula\.
+.TP
+\fBleaves\fR
+Show installed formulae that are not dependencies of another installed formula\.
 .
-.IP "\(bu" 4
-\fBln\fR, \fBlink\fR [\fB\-\-overwrite\fR] [\fB\-\-dry\-run\fR] [\fB\-\-force\fR] \fIformula\fR: Symlink all of \fIformula\fR\'s installed files into the Homebrew prefix\. This is done automatically when you install formulae but can be useful for DIY installations\.
+.TP
+\fBln\fR, \fBlink\fR [\fB\-\-overwrite\fR] [\fB\-\-dry\-run\fR] [\fB\-\-force\fR] \fIformula\fR
+Symlink all of \fIformula\fR\'s installed files into the Homebrew prefix\. This is done automatically when you install formulae but can be useful for DIY installations\.
 .
 .IP
 If \fB\-\-overwrite\fR is passed, Homebrew will delete files which already exist in the prefix while linking\.
@@ -325,14 +362,17 @@ If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which
 .IP
 If \fB\-\-force\fR (or \fB\-f\fR) is passed, Homebrew will allow keg\-only formulae to be linked\.
 .
-.IP "\(bu" 4
-\fBlist\fR, \fBls\fR [\fB\-\-full\-name\fR] [\fB\-1\fR] [\fB\-l\fR] [\fB\-t\fR] [\fB\-r\fR]: List all installed formulae\. If \fB\-\-full\-name\fR is passed, print formulae with fully\-qualified names\. If \fB\-\-full\-name\fR is not passed, other options (i\.e\. \fB\-1\fR, \fB\-l\fR, \fB\-t\fR and \fB\-r\fR) are passed to \fBls\fR which produces the actual output\.
+.TP
+\fBlist\fR, \fBls\fR [\fB\-\-full\-name\fR] [\fB\-1\fR] [\fB\-l\fR] [\fB\-t\fR] [\fB\-r\fR]
+List all installed formulae\. If \fB\-\-full\-name\fR is passed, print formulae with fully\-qualified names\. If \fB\-\-full\-name\fR is not passed, other options (i\.e\. \fB\-1\fR, \fB\-l\fR, \fB\-t\fR and \fB\-r\fR) are passed to \fBls\fR which produces the actual output\.
 .
-.IP "\(bu" 4
-\fBlist\fR, \fBls\fR \fB\-\-unbrewed\fR: List all files in the Homebrew prefix not installed by Homebrew\.
+.TP
+\fBlist\fR, \fBls\fR \fB\-\-unbrewed\fR
+List all files in the Homebrew prefix not installed by Homebrew\.
 .
-.IP "\(bu" 4
-\fBlist\fR, \fBls\fR [\fB\-\-verbose\fR] [\fB\-\-versions\fR [\fB\-\-multiple\fR]] [\fB\-\-pinned\fR] [\fIformulae\fR]: List the installed files for \fIformulae\fR\. Combined with \fB\-\-verbose\fR, recursively list the contents of all subdirectories in each \fIformula\fR\'s keg\.
+.TP
+\fBlist\fR, \fBls\fR [\fB\-\-verbose\fR] [\fB\-\-versions\fR [\fB\-\-multiple\fR]] [\fB\-\-pinned\fR] [\fIformulae\fR]
+List the installed files for \fIformulae\fR\. Combined with \fB\-\-verbose\fR, recursively list the contents of all subdirectories in each \fIformula\fR\'s keg\.
 .
 .IP
 If \fB\-\-versions\fR is passed, show the version number for installed formulae, or only the specified formulae if \fIformulae\fR are given\. With \fB\-\-multiple\fR, only show formulae with multiple versions installed\.
@@ -340,17 +380,20 @@ If \fB\-\-versions\fR is passed, show the version number for installed formulae,
 .IP
 If \fB\-\-pinned\fR is passed, show the versions of pinned formulae, or only the specified (pinned) formulae if \fIformulae\fR are given\. See also \fBpin\fR, \fBunpin\fR\.
 .
-.IP "\(bu" 4
-\fBlog\fR [\fIgit\-log\-options\fR] \fIformula\fR \.\.\.: Show the git log for the given formulae\. Options that \fBgit\-log\fR(1) recognizes can be passed before the formula list\.
+.TP
+\fBlog\fR [\fIgit\-log\-options\fR] \fIformula\fR \.\.\.
+Show the git log for the given formulae\. Options that \fBgit\-log\fR(1) recognizes can be passed before the formula list\.
 .
-.IP "\(bu" 4
-\fBmigrate\fR [\fB\-\-force\fR] \fIformulae\fR: Migrate renamed packages to new name, where \fIformulae\fR are old names of packages\.
+.TP
+\fBmigrate\fR [\fB\-\-force\fR] \fIformulae\fR
+Migrate renamed packages to new name, where \fIformulae\fR are old names of packages\.
 .
 .IP
 If \fB\-\-force\fR (or \fB\-f\fR) is passed, then treat installed \fIformulae\fR and passed \fIformulae\fR like if they are from same taps and migrate them anyway\.
 .
-.IP "\(bu" 4
-\fBmissing\fR [\fB\-\-hide=\fR\fIhidden\fR] [\fIformulae\fR]: Check the given \fIformulae\fR for missing dependencies\. If no \fIformulae\fR are given, check all installed brews\.
+.TP
+\fBmissing\fR [\fB\-\-hide=\fR\fIhidden\fR] [\fIformulae\fR]
+Check the given \fIformulae\fR for missing dependencies\. If no \fIformulae\fR are given, check all installed brews\.
 .
 .IP
 If \fB\-\-hide=\fR\fIhidden\fR is passed, act as if none of \fIhidden\fR are installed\. \fIhidden\fR should be a comma\-separated list of formulae\.
@@ -358,8 +401,9 @@ If \fB\-\-hide=\fR\fIhidden\fR is passed, act as if none of \fIhidden\fR are ins
 .IP
 \fBmissing\fR exits with a non\-zero status if any formulae are missing dependencies\.
 .
-.IP "\(bu" 4
-\fBoptions\fR [\fB\-\-compact\fR] (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR): Display install options specific to \fIformulae\fR\.
+.TP
+\fBoptions\fR [\fB\-\-compact\fR] (\fB\-\-all\fR|\fB\-\-installed\fR|\fIformulae\fR)
+Display install options specific to \fIformulae\fR\.
 .
 .IP
 If \fB\-\-compact\fR is passed, show all options on a single line separated by spaces\.
@@ -370,8 +414,9 @@ If \fB\-\-all\fR is passed, show options for all formulae\.
 .IP
 If \fB\-\-installed\fR is passed, show options for all installed formulae\.
 .
-.IP "\(bu" 4
-\fBoutdated\fR [\fB\-\-quiet\fR|\fB\-\-verbose\fR|\fB\-\-json=\fR\fIversion\fR] [\fB\-\-fetch\-HEAD\fR]: Show formulae that have an updated version available\.
+.TP
+\fBoutdated\fR [\fB\-\-quiet\fR|\fB\-\-verbose\fR|\fB\-\-json=\fR\fIversion\fR] [\fB\-\-fetch\-HEAD\fR]
+Show formulae that have an updated version available\.
 .
 .IP
 By default, version information is displayed in interactive shells, and suppressed otherwise\.
@@ -388,20 +433,24 @@ If \fB\-\-json=\fR\fIversion\fR is passed, the output will be in JSON format\. C
 .IP
 If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if the HEAD installation of the formula is outdated\. Otherwise, the repository\'s HEAD will be checked for updates when a new stable or devel version has been released\.
 .
-.IP "\(bu" 4
-\fBpin\fR \fIformulae\fR: Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade <formulae>\fR command\. See also \fBunpin\fR\.
+.TP
+\fBpin\fR \fIformulae\fR
+Pin the specified \fIformulae\fR, preventing them from being upgraded when issuing the \fBbrew upgrade <formulae>\fR command\. See also \fBunpin\fR\.
 .
-.IP "\(bu" 4
-\fBpostinstall\fR \fIformula\fR: Rerun the post\-install steps for \fIformula\fR\.
+.TP
+\fBpostinstall\fR \fIformula\fR
+Rerun the post\-install steps for \fIformula\fR\.
 .
-.IP "\(bu" 4
-\fBprune\fR [\fB\-\-dry\-run\fR]: Remove dead symlinks from the Homebrew prefix\. This is generally not needed, but can be useful when doing DIY installations\.
+.TP
+\fBprune\fR [\fB\-\-dry\-run\fR]
+Remove dead symlinks from the Homebrew prefix\. This is generally not needed, but can be useful when doing DIY installations\.
 .
 .IP
 If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, show what would be removed, but do not actually remove anything\.
 .
-.IP "\(bu" 4
-\fBreadall\fR [\fB\-\-aliases\fR] [\fB\-\-syntax\fR] [\fItaps\fR]: Import all formulae from specified \fItaps\fR (defaults to all installed taps)\.
+.TP
+\fBreadall\fR [\fB\-\-aliases\fR] [\fB\-\-syntax\fR] [\fItaps\fR]
+Import all formulae from specified \fItaps\fR (defaults to all installed taps)\.
 .
 .IP
 This can be useful for debugging issues across all formulae when making significant changes to \fBformula\.rb\fR, testing the performance of loading all formulae or to determine if any current formulae have Ruby issues\.
@@ -412,35 +461,42 @@ If \fB\-\-aliases\fR is passed, also verify any alias symlinks in each tap\.
 .IP
 If \fB\-\-syntax\fR is passed, also syntax\-check all of Homebrew\'s Ruby files\.
 .
-.IP "\(bu" 4
-\fBreinstall\fR [\fB\-\-display\-times\fR] \fIformula\fR: Uninstall and then install \fIformula\fR (with existing install options)\.
+.TP
+\fBreinstall\fR [\fB\-\-display\-times\fR] \fIformula\fR
+Uninstall and then install \fIformula\fR (with existing install options)\.
 .
 .IP
 If \fB\-\-display\-times\fR is passed, install times for each formula are printed at the end of the run\.
 .
-.IP "\(bu" 4
-\fBsearch\fR, \fB\-S\fR: Display all locally available formulae (including tapped ones)\. No online search is performed\.
+.TP
+\fBsearch\fR, \fB\-S\fR
+Display all locally available formulae (including tapped ones)\. No online search is performed\.
 .
-.IP "\(bu" 4
-\fBsearch\fR \fB\-\-casks\fR Display all locally available casks (including tapped ones)\. No online search is performed\.
+.TP
+\fBsearch\fR \fB\-\-casks\fR
+Display all locally available casks (including tapped ones)\. No online search is performed\.
 .
-.IP "\(bu" 4
-\fBsearch\fR [\fB\-\-desc\fR] (\fItext\fR|\fB/\fR\fItext\fR\fB/\fR): Perform a substring search of cask tokens and formula names for \fItext\fR\. If \fItext\fR is surrounded with slashes, then it is interpreted as a regular expression\. The search for \fItext\fR is extended online to official taps\.
+.TP
+\fBsearch\fR [\fB\-\-desc\fR] (\fItext\fR|\fB/\fR\fItext\fR\fB/\fR)
+Perform a substring search of cask tokens and formula names for \fItext\fR\. If \fItext\fR is surrounded with slashes, then it is interpreted as a regular expression\. The search for \fItext\fR is extended online to official taps\.
 .
 .IP
 If \fB\-\-desc\fR is passed, search formulae with a description matching \fItext\fR and casks with a name matching \fItext\fR\.
 .
-.IP "\(bu" 4
-\fBsearch\fR (\fB\-\-debian\fR|\fB\-\-fedora\fR|\fB\-\-fink\fR|\fB\-\-macports\fR|\fB\-\-opensuse\fR|\fB\-\-ubuntu\fR) \fItext\fR: Search for \fItext\fR in the given package manager\'s list\.
+.TP
+\fBsearch\fR (\fB\-\-debian\fR|\fB\-\-fedora\fR|\fB\-\-fink\fR|\fB\-\-macports\fR|\fB\-\-opensuse\fR|\fB\-\-ubuntu\fR) \fItext\fR
+Search for \fItext\fR in the given package manager\'s list\.
 .
-.IP "\(bu" 4
-\fBsh\fR [\fB\-\-env=std\fR]: Start a Homebrew build environment shell\. Uses our years\-battle\-hardened Homebrew build logic to help your \fB\./configure && make && make install\fR or even your \fBgem install\fR succeed\. Especially handy if you run Homebrew in an Xcode\-only configuration since it adds tools like \fBmake\fR to your \fBPATH\fR which otherwise build systems would not find\.
+.TP
+\fBsh\fR [\fB\-\-env=std\fR]
+Start a Homebrew build environment shell\. Uses our years\-battle\-hardened Homebrew build logic to help your \fB\./configure && make && make install\fR or even your \fBgem install\fR succeed\. Especially handy if you run Homebrew in an Xcode\-only configuration since it adds tools like \fBmake\fR to your \fBPATH\fR which otherwise build systems would not find\.
 .
 .IP
 If \fB\-\-env=std\fR is passed, use the standard \fBPATH\fR instead of superenv\'s\.
 .
-.IP "\(bu" 4
-\fBstyle\fR [\fB\-\-fix\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-only\-cops=\fR\fIcops\fR|\fB\-\-except\-cops=\fR\fIcops\fR] [\fIfiles\fR|\fItaps\fR|\fIformulae\fR]: Check formulae or files for conformance to Homebrew style guidelines\.
+.TP
+\fBstyle\fR [\fB\-\-fix\fR] [\fB\-\-display\-cop\-names\fR] [\fB\-\-only\-cops=\fR\fIcops\fR|\fB\-\-except\-cops=\fR\fIcops\fR] [\fIfiles\fR|\fItaps\fR|\fIformulae\fR]
+Check formulae or files for conformance to Homebrew style guidelines\.
 .
 .IP
 Lists of \fIfiles\fR, \fItaps\fR and \fIformulae\fR may not be combined\. If none are provided, \fBstyle\fR will run style checks on the whole Homebrew library, including core code and all formulae\.
@@ -457,20 +513,24 @@ Passing \fB\-\-only\-cops=\fR\fIcops\fR will check for violations of only the li
 .IP
 Exits with a non\-zero status if any style violations are found\.
 .
-.IP "\(bu" 4
-\fBswitch\fR \fIformula\fR \fIversion\fR: Symlink all of the specific \fIversion\fR of \fIformula\fR\'s install to Homebrew prefix\.
+.TP
+\fBswitch\fR \fIformula\fR \fIversion\fR
+Symlink all of the specific \fIversion\fR of \fIformula\fR\'s install to Homebrew prefix\.
 .
-.IP "\(bu" 4
-\fBtap\-info\fR: Display a brief summary of all installed taps\.
+.TP
+\fBtap\-info\fR
+Display a brief summary of all installed taps\.
 .
-.IP "\(bu" 4
-\fBtap\-info\fR (\fB\-\-installed\fR|\fItaps\fR): Display detailed information about one or more \fItaps\fR\.
+.TP
+\fBtap\-info\fR (\fB\-\-installed\fR|\fItaps\fR)
+Display detailed information about one or more \fItaps\fR\.
 .
 .IP
 Pass \fB\-\-installed\fR to display information on all installed taps\.
 .
-.IP "\(bu" 4
-\fBtap\-info\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-installed\fR|\fItaps\fR): Print a JSON representation of \fItaps\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
+.TP
+\fBtap\-info\fR \fB\-\-json=\fR\fIversion\fR (\fB\-\-installed\fR|\fItaps\fR)
+Print a JSON representation of \fItaps\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\.
 .
 .IP
 Pass \fB\-\-installed\fR to get information on installed taps\.
@@ -478,17 +538,21 @@ Pass \fB\-\-installed\fR to get information on installed taps\.
 .IP
 See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
-.IP "\(bu" 4
-\fBtap\-pin\fR \fItap\fR: Pin \fItap\fR, prioritizing its formulae over core when formula names are supplied by the user\. See also \fBtap\-unpin\fR\.
+.TP
+\fBtap\-pin\fR \fItap\fR
+Pin \fItap\fR, prioritizing its formulae over core when formula names are supplied by the user\. See also \fBtap\-unpin\fR\.
 .
-.IP "\(bu" 4
-\fBtap\-unpin\fR \fItap\fR: Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
+.TP
+\fBtap\-unpin\fR \fItap\fR
+Unpin \fItap\fR so its formulae are no longer prioritized\. See also \fBtap\-pin\fR\.
 .
-.IP "\(bu" 4
-\fBtap\fR: List all installed taps\.
+.TP
+\fBtap\fR
+List all installed taps\.
 .
-.IP "\(bu" 4
-\fBtap\fR [\fB\-\-full\fR] [\fB\-\-force\-auto\-update\fR] \fIuser\fR\fB/\fR\fIrepo\fR [\fIURL\fR]: Tap a formula repository\.
+.TP
+\fBtap\fR [\fB\-\-full\fR] [\fB\-\-force\-auto\-update\fR] \fIuser\fR\fB/\fR\fIrepo\fR [\fIURL\fR]
+Tap a formula repository\.
 .
 .IP
 With \fIURL\fR unspecified, taps a formula repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for \fBtap <user>/<repo> https://github\.com/<user>/homebrew\-<repo>\fR\.
@@ -505,14 +569,17 @@ By default, only taps hosted on GitHub are auto\-updated (for performance reason
 .IP
 \fBtap\fR is re\-runnable and exits successfully if there\'s nothing to do\. However, retapping with a different \fIURL\fR will cause an exception, so first \fBuntap\fR if you need to modify the \fIURL\fR\.
 .
-.IP "\(bu" 4
-\fBtap\fR \fB\-\-repair\fR: Migrate tapped formulae from symlink\-based to directory\-based structure\.
+.TP
+\fBtap\fR \fB\-\-repair\fR
+Migrate tapped formulae from symlink\-based to directory\-based structure\.
 .
-.IP "\(bu" 4
-\fBtap\fR \fB\-\-list\-pinned\fR: List all pinned taps\.
+.TP
+\fBtap\fR \fB\-\-list\-pinned\fR
+List all pinned taps\.
 .
-.IP "\(bu" 4
-\fBuninstall\fR, \fBrm\fR, \fBremove\fR [\fB\-\-force\fR] [\fB\-\-ignore\-dependencies\fR] \fIformula\fR: Uninstall \fIformula\fR\.
+.TP
+\fBuninstall\fR, \fBrm\fR, \fBremove\fR [\fB\-\-force\fR] [\fB\-\-ignore\-dependencies\fR] \fIformula\fR
+Uninstall \fIformula\fR\.
 .
 .IP
 If \fB\-\-force\fR (or \fB\-f\fR) is passed, and there are multiple versions of \fIformula\fR installed, delete all installed versions\.
@@ -520,14 +587,16 @@ If \fB\-\-force\fR (or \fB\-f\fR) is passed, and there are multiple versions of 
 .IP
 If \fB\-\-ignore\-dependencies\fR is passed, uninstalling won\'t fail, even if formulae depending on \fIformula\fR would still be installed\.
 .
-.IP "\(bu" 4
-\fBunlink\fR [\fB\-\-dry\-run\fR] \fIformula\fR: Remove symlinks for \fIformula\fR from the Homebrew prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink <formula> && <commands> && brew link <formula>\fR
+.TP
+\fBunlink\fR [\fB\-\-dry\-run\fR] \fIformula\fR
+Remove symlinks for \fIformula\fR from the Homebrew prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink <formula> && <commands> && brew link <formula>\fR
 .
 .IP
 If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, Homebrew will list all files which would be unlinked, but will not actually unlink or delete any files\.
 .
-.IP "\(bu" 4
-\fBunpack\fR [\fB\-\-git\fR|\fB\-\-patch\fR] [\fB\-\-destdir=\fR\fIpath\fR] \fIformulae\fR: Unpack the source files for \fIformulae\fR into subdirectories of the current working directory\. If \fB\-\-destdir=\fR\fIpath\fR is given, the subdirectories will be created in the directory named by \fIpath\fR instead\.
+.TP
+\fBunpack\fR [\fB\-\-git\fR|\fB\-\-patch\fR] [\fB\-\-destdir=\fR\fIpath\fR] \fIformulae\fR
+Unpack the source files for \fIformulae\fR into subdirectories of the current working directory\. If \fB\-\-destdir=\fR\fIpath\fR is given, the subdirectories will be created in the directory named by \fIpath\fR instead\.
 .
 .IP
 If \fB\-\-patch\fR is passed, patches for \fIformulae\fR will be applied to the unpacked source\.
@@ -535,14 +604,17 @@ If \fB\-\-patch\fR is passed, patches for \fIformulae\fR will be applied to the 
 .IP
 If \fB\-\-git\fR (or \fB\-g\fR) is passed, a Git repository will be initialized in the unpacked source\. This is useful for creating patches for the software\.
 .
-.IP "\(bu" 4
-\fBunpin\fR \fIformulae\fR: Unpin \fIformulae\fR, allowing them to be upgraded by \fBbrew upgrade <formulae>\fR\. See also \fBpin\fR\.
+.TP
+\fBunpin\fR \fIformulae\fR
+Unpin \fIformulae\fR, allowing them to be upgraded by \fBbrew upgrade <formulae>\fR\. See also \fBpin\fR\.
 .
-.IP "\(bu" 4
-\fBuntap\fR \fItap\fR: Remove a tapped repository\.
+.TP
+\fBuntap\fR \fItap\fR
+Remove a tapped repository\.
 .
-.IP "\(bu" 4
-\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fB\-\-display\-times\fR] [\fIformulae\fR]: Upgrade outdated, unpinned brews (with existing install options)\.
+.TP
+\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fB\-\-display\-times\fR] [\fIformulae\fR]
+Upgrade outdated, unpinned brews (with existing install options)\.
 .
 .IP
 Options for the \fBinstall\fR command are also valid here\.
@@ -562,8 +634,9 @@ If \fB\-\-display\-times\fR is passed, install times for each formula are printe
 .IP
 If \fIformulae\fR are given, upgrade only the specified brews (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.
 .
-.IP "\(bu" 4
-\fBuses\fR [\fB\-\-installed\fR] [\fB\-\-recursive\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-test\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformulae\fR: Show the formulae that specify \fIformulae\fR as a dependency\. When given multiple formula arguments, show the intersection of formulae that use \fIformulae\fR\.
+.TP
+\fBuses\fR [\fB\-\-installed\fR] [\fB\-\-recursive\fR] [\fB\-\-include\-build\fR] [\fB\-\-include\-test\fR] [\fB\-\-include\-optional\fR] [\fB\-\-skip\-recommended\fR] [\fB\-\-devel\fR|\fB\-\-HEAD\fR] \fIformulae\fR
+Show the formulae that specify \fIformulae\fR as a dependency\. When given multiple formula arguments, show the intersection of formulae that use \fIformulae\fR\.
 .
 .IP
 Use \fB\-\-recursive\fR to resolve more than one level of dependencies\.
@@ -577,8 +650,9 @@ By default, \fBuses\fR shows all formulae that specify \fIformulae\fR as a requi
 .IP
 By default, \fBuses\fR shows usage of \fIformulae\fR by stable builds\. To find cases where \fIformulae\fR is used by development or HEAD build, pass \fB\-\-devel\fR or \fB\-\-HEAD\fR\.
 .
-.IP "\(bu" 4
-\fBshellenv\fR: Prints export statements \- run them in a shell and this installation of Homebrew will be included into your PATH, MANPATH, and INFOPATH\.
+.TP
+\fBshellenv\fR
+Prints export statements \- run them in a shell and this installation of Homebrew will be included into your PATH, MANPATH, and INFOPATH\.
 .
 .IP
 HOMEBREW_PREFIX, HOMEBREW_CELLAR and HOMEBREW_REPOSITORY are also exported to save multiple queries of those variables\.
@@ -586,19 +660,19 @@ HOMEBREW_PREFIX, HOMEBREW_CELLAR and HOMEBREW_REPOSITORY are also exported to sa
 .IP
 Consider adding evaluating the output in your dotfiles (e\.g\. \fB~/\.profile\fR) with \fBeval $(brew shellenv)\fR
 .
-.IP "\(bu" 4
-\fBupdate\-reset\fR [\fIrepositories\fR]: Fetches and resets Homebrew and all tap repositories (or the specified \fBrepositories\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
+.TP
+\fBupdate\-reset\fR [\fIrepositories\fR]
+Fetches and resets Homebrew and all tap repositories (or the specified \fBrepositories\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
-.IP "\(bu" 4
-\fBupdate\fR [\fB\-\-merge\fR] [\fB\-\-force\fR]: Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1) and perform any necessary migrations\.
+.TP
+\fBupdate\fR [\fB\-\-merge\fR] [\fB\-\-force\fR]
+Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1) and perform any necessary migrations\.
 .
 .IP
 If \fB\-\-merge\fR is specified then \fBgit merge\fR is used to include updates (rather than \fBgit rebase\fR)\.
 .
 .IP
 If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full update check even if unnecessary\.
-.
-.IP "" 0
 .
 .SH "DEVELOPER COMMANDS"
 .
@@ -794,7 +868,7 @@ Takes a tap [\fIuser\fR\fB/\fR\fIrepo\fR] as argument and generates the formula 
 .SS "\fBedit\fR \fIformula\fR:"
 Open \fIformula\fR in the editor\. Open all of Homebrew for editing if no \fIformula\fR is provided\.
 .
-.SS "\fBextract\fR [\fIoptions\fR] \fIformula\fR \fItap\fR"
+.SS "\fBextract\fR [\fIoptions\fR] \fIformula\fR \fItap\fR:"
 Looks through repository history to find the \fIversion\fR of \fIformula\fR and creates a copy in \fItap\fR/Formula/\fIformula\fR@\fIversion\fR\.rb\. If the tap is not installed yet, attempts to install/clone the tap before continuing\.
 .
 .TP
@@ -851,7 +925,7 @@ Reuploads the stable URL for a formula to Bintray to use it as a mirror\.
 \fBprof\fR [\fIruby options\fR]
 Run Homebrew with the Ruby profiler\. For example: brew prof readall
 .
-.SS "pull [\fIoptions\fR] \fIformula\fR:"
+.SS "\fBpull\fR [\fIoptions\fR] \fIformula\fR:"
 Gets a patch from a GitHub commit or pull request and applies it to Homebrew\. Optionally, installs the formulae changed by the patch\.
 .
 .P
@@ -1014,58 +1088,38 @@ Override warnings and enable potentially unsafe operations\.
 .SH "OFFICIAL EXTERNAL COMMANDS"
 .
 .TP
-\fBbundle\fR \fIcommand\fR:
-.
-.IP
+\fBbundle\fR \fIcommand\fR
 Bundler for non\-Ruby dependencies from Homebrew\.
 .
 .IP
-\fBbundle\fR [\fBinstall\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-upgrade\fR] [\fB\-\-file=\fR\fIpath\fR|\fB\-\-global\fR]:
-.
-.IP
-Install or upgrade all dependencies in a Brewfile\.
+\fBbrew bundle\fR [\fBinstall\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-upgrade\fR] [\fB\-\-file=\fR\fIpath\fR|\fB\-\-global\fR]
+    Install or upgrade all dependencies in a Brewfile\.
 .
 .IP
 \fBbrew bundle dump\fR [\fB\-\-force\fR] [\fB\-\-describe\fR] [\fB\-\-file=\fR\fIpath\fR|\fB\-\-global\fR]
-.
-.IP
-Write all installed casks/formulae/taps into a Brewfile\.
+    Write all installed casks/formulae/taps into a Brewfile\.
 .
 .IP
 \fBbrew bundle cleanup\fR [\fB\-\-force\fR] [\fB\-\-zap\fR] [\fB\-\-file=\fR\fIpath\fR|\fB\-\-global\fR]
+    Uninstall all dependencies not listed in a Brewfile\.
 .
 .IP
-Uninstall all dependencies not listed in a Brewfile\.
-.
-.IP
-\fBbrew bundle check\fR [\fB\-\-no\-upgrade\fR] [\fB\-\-file\fR=\fIpath\fR|\fB\-\-global\fR] [\fB\-\-verbose\fR]
-.
-.IP
-Check if all dependencies are installed in a Brewfile\. Missing dependencies are listed in verbose mode\. \fBcheck\fR will exit on the first category missing a dependency unless in verbose mode\.
+\fBbrew bundle check\fR [\fB\-\-no\-upgrade\fR] [\fB\-\-file=\fR\fIpath\fR|\fB\-\-global\fR] [\fB\-\-verbose\fR]
+    Check if all dependencies are installed in a Brewfile\. Missing dependencies are listed in verbose mode\. \fBcheck\fR will exit on the first category missing a dependency unless in verbose mode\.
 .
 .IP
 \fBbrew bundle exec\fR \fIcommand\fR
-.
-.IP
-Run an external command in an isolated build environment\.
+    Run an external command in an isolated build environment\.
 .
 .IP
 \fBbrew bundle list\fR [\fB\-\-all\fR|\fB\-\-brews\fR|\fB\-\-casks\fR|\fB\-\-taps\fR|\fB\-\-mas\fR] [\fB\-\-file=\fR\fIpath\fR|\fB\-\-global\fR]
-.
-.IP
-List all dependencies present in a Brewfile, optionally limiting by types\.
-.
-.IP
-By default, only brew dependencies are output\.
+    List all dependencies present in a Brewfile, optionally limiting by types\. By default, only brew dependencies are output\.
 .
 .IP
 If \fB\-v\fR or \fB\-\-verbose\fR are passed, print verbose output\.
 .
 .IP
-If \fB\-\-no\-upgrade\fR is passed, don\'t run \fBbrew upgrade\fR outdated dependencies\.
-.
-.IP
-Note they may still be upgraded by \fBbrew install\fR if needed\.
+If \fB\-\-no\-upgrade\fR is passed, don\'t run \fBbrew upgrade\fR on outdated dependencies\. Note they may still be upgraded by \fBbrew install\fR if needed\.
 .
 .IP
 If \fB\-\-force\fR is passed, uninstall dependencies or overwrite an existing Brewfile\.
@@ -1074,83 +1128,63 @@ If \fB\-\-force\fR is passed, uninstall dependencies or overwrite an existing Br
 If \fB\-\-zap\fR is passed, casks will be removed using the \fBzap\fR command instead of \fBuninstall\fR\.
 .
 .IP
-If \fB\-\-file=<path>\fR is passed, the Brewfile path is set accordingly
+If \fB\-\-file=\fR\fIpath\fR is passed, the Brewfile path is set accordingly\. Use \fB\-\-file=\-\fR to output to console\.
 .
 .IP
-Use \fB\-\-file=\-\fR to output to console\.
+If \fB\-\-global\fR is passed, set the Brewfile path to \fB~/\.Brewfile\fR\.
 .
 .IP
-If \fB\-\-global\fR is passed, set Brewfile path to \fB$HOME/\.Brewfile\fR\.
-.
-.IP
-If \fB\-\-describe\fR is passed, output a description comment above each line\.
-.
-.IP
-This comment will not be output if the dependency does not have a description\.
+If \fB\-\-describe\fR is passed, output a description comment above each line\. This comment will not be output if the dependency does not have a description\.
 .
 .IP
 If \fB\-h\fR or \fB\-\-help\fR are passed, print this help message and exit\.
 .
-.P
-Homebrew/homebrew\-bundle \fIhttps://github\.com/Homebrew/homebrew\-bundle\fR
+.IP
+\fBHomebrew/homebrew\-bundle\fR
+    \fIhttps://github\.com/Homebrew/homebrew\-bundle\fR
 .
 .TP
 \fBcask\fR [\fB\-\-version\fR | \fBaudit\fR | \fBcat\fR | \fBcleanup\fR | \fBcreate\fR | \fBdoctor\fR | \fBedit\fR | \fBfetch\fR | \fBhome\fR | \fBinfo\fR]
 Install macOS applications distributed as binaries\.
 .
-.P
-Homebrew/homebrew\-cask \fIhttps://github\.com/Homebrew/homebrew\-cask\fR
+.IP
+\fBHomebrew/homebrew\-cask\fR
+    \fIhttps://github\.com/Homebrew/homebrew\-cask\fR
 .
 .TP
-\fBservices\fR \fIcommand\fR:
-.
-.IP
+\fBservices\fR \fIcommand\fR
 Integrates Homebrew formulae with macOS\' \fBlaunchctl\fR manager\.
 .
 .IP
-[\fIsudo\fR] \fBbrew services list\fR
+[\fBsudo\fR] \fBbrew services list\fR
+    List all running services for the current user (or root)\.
 .
 .IP
-List all running services for the current user (or \fIroot\fR)
+[\fBsudo\fR] \fBbrew services run\fR (\fIformula\fR|\fB\-\-all\fR)
+    Run the service \fIformula\fR without registering to launch at login (or boot)\.
 .
 .IP
-[\fIsudo\fR] \fBbrew services run\fR \fIformula|\-\-all\fR
+[\fBsudo\fR] \fBbrew services start\fR (\fIformula\fR|\fB\-\-all\fR)
+    Start the service \fIformula\fR immediately and register it to launch at login (or boot)\.
 .
 .IP
-Run the service \fIformula\fR without starting at login (or boot)\.
+[\fBsudo\fR] \fBbrew services stop\fR (\fIformula\fR|\fB\-\-all\fR)
+    Stop the service \fIformula\fR immediately and unregister it from launching at login (or boot)\.
 .
 .IP
-[\fIsudo\fR] \fBbrew services\fR \fBstart\fR \fIformula|\-\-all\fR
+[\fBsudo\fR] \fBbrew services restart\fR (\fIformula\fR|\fB\-\-all\fR)
+    Stop (if necessary) and start the service \fIformula\fR immediately and register it to launch at login (or boot)\.
 .
 .IP
-Start the service \fIformula\fR immediately and register it to launch at login (or \fIboot\fR)\.
+[\fBsudo\fR] \fBbrew services cleanup\fR
+    Remove all unused services\.
 .
 .IP
-[\fIsudo\fR] \fBbrew services\fR \fBstop\fR \fIformula|\-\-all\fR
+If \fBsudo\fR is passed, operate on \fB/Library/LaunchDaemons\fR (started at boot)\. Otherwise, operate on \fB~/Library/LaunchAgents\fR (started at login)\.
 .
 .IP
-Stop the service \fIformula\fR immediately and unregister it from launching at login (or \fIboot\fR)\.
-.
-.IP
-[\fIsudo\fR] \fBbrew services\fR \fBrestart\fR \fIformula|\-\-all\fR
-.
-.IP
-Stop (if necessary) and start the service immediately and register it to launch at login (or \fIboot\fR)\.
-.
-.IP
-[\fIsudo\fR] \fBbrew services\fR \fBcleanup\fR
-.
-.IP
-Remove all unused services\.
-.
-.IP
-If \fBsudo\fR is passed, operate on \fB/Library/LaunchDaemons\fR (started at boot)\.
-.
-.IP
-Otherwise, operate on \fB~/Library/LaunchAgents (started at login)\fR\.
-.
-.P
-Homebrew/homebrew\-services \fIhttps://github\.com/Homebrew/homebrew\-services\fR
+\fBHomebrew/homebrew\-services\fR
+    \fIhttps://github\.com/Homebrew/homebrew\-services\fR
 .
 .SH "CUSTOM EXTERNAL COMMANDS"
 Homebrew, like \fBgit\fR(1), supports external commands\. These are executable scripts that reside somewhere in the \fBPATH\fR, named \fBbrew\-\fR\fIcmdname\fR or \fBbrew\-\fR\fIcmdname\fR\fB\.rb\fR, which can be invoked like \fBbrew\fR \fIcmdname\fR\. This allows you to create your own commands without modifying Homebrew\'s internals\.
@@ -1416,11 +1450,11 @@ Former maintainers with significant contributions include Dominyk Tiller, Tim Sm
 .SH "BUGS"
 See our issues on GitHub:
 .
-.IP "\(bu" 4
-Homebrew/brew \fIhttps://github\.com/Homebrew/brew/issues\fR
+.TP
+\fBHomebrew/brew\fR
+\fIhttps://github\.com/Homebrew/brew/issues\fR
 .
-.IP "\(bu" 4
-Homebrew/homebrew\-core \fIhttps://github\.com/Homebrew/homebrew\-core/issues\fR
-.
-.IP "" 0
+.TP
+\fBHomebrew/homebrew\-core\fR
+\fIhttps://github\.com/Homebrew/homebrew\-core/issues\fR
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Work around ronn's inability to nest indents within list items by modifying its man page output, avoiding the need for the extra line breaks that was causing lines with pipes to become tables in the HTML output. This PR relies on Homebrew/homebrew-bundle#377 and Homebrew/homebrew-services#174, which adds colons to their help texts' command specs, matching those in core `brew` commands. 