### PR TITLE
setup_remote_tap: use system taps.

### DIFF
--- a/Library/Homebrew/test/cmd/cask_spec.rb
+++ b/Library/Homebrew/test/cmd/cask_spec.rb
@@ -1,7 +1,7 @@
 describe "brew cask", :integration_test, :needs_macos, :needs_network do
   describe "list" do
     it "returns a list of installed Casks" do
-      setup_remote_tap("homebrew/cask")
+      setup_remote_tap "homebrew/cask"
 
       expect { brew "cask", "list" }.to be_a_success
     end


### PR DESCRIPTION
This saves recloning the taps we use multiple times when already done by the user.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----