### PR TITLE
cleanup: remove vendor/bundle/ruby.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -320,10 +320,12 @@ module Homebrew
       return unless Dir.glob(portable_ruby_glob).empty?
       return unless portable_ruby_path.exist?
 
+      bundler_path = vendor_path/"bundle/ruby"
       if dry_run?
+        puts "Would remove: #{bundler_path} (#{bundler_path.abv})"
         puts "Would remove: #{portable_ruby_path} (#{portable_ruby_path.abv})"
       else
-        FileUtils.rm_rf portable_ruby_path
+        FileUtils.rm_rf [bundler_path, portable_ruby_path]
       end
     end
 


### PR DESCRIPTION
Otherwise gem paths will contain references to a now-deleted Ruby.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----