### PR TITLE
Use CurlDownloadStrategy for Apache direct-download links.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1225,8 +1225,9 @@ class DownloadStrategyDetector
     when %r{^https?://.+\.git$},
          %r{^git://}
       GitDownloadStrategy
-    when %r{^https?://www\.apache\.org/dyn/closer\.cgi},
-         %r{^https?://www\.apache\.org/dyn/closer\.lua}
+    when %r{^https?://www\.apache\.org/dyn/closer\.(cgi|lua)\?action=download&filename=}
+      CurlDownloadStrategy
+    when %r{^https?://www\.apache\.org/dyn/closer\.(cgi|lua)}
       CurlApacheMirrorDownloadStrategy
     when %r{^https?://(.+?\.)?googlecode\.com/svn},
          %r{^https?://svn\.},


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Sources for most Apache projects are downloaded from URLs like this:

    https://www.apache.org/dyn/closer.cgi?path=package/package-1.0.0.tar.bz2

This URL returns an HTML page where the preferred mirror is shown, and Homebrew parses the mirror URL from there.

But there's a better way to do this; an URL like this:

    https://www.apache.org/dyn/closer.cgi?action=download&filename=package/package-1.0.0.tar.bz2

will redirect to the preferred mirror, so that there's no need to parse the response.

This PR adds support for this format of Apache direct-download URLs.