### PR TITLE
cask/audit: update OSDN URL style

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -290,7 +290,7 @@ module Cask
     end
 
     def bad_osdn_url?
-      bad_url_format?(/osd/, [%r{\Ahttps?://([^/]+.)?dl\.osdn\.jp/}])
+      bad_url_format?(/osd/, [%r{\Ahttps://osdn\.net/(dl|downloads)/}])
     end
 
     def check_generic_artifacts

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-correct-url-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/osdn-correct-url-format.rb
@@ -1,6 +1,6 @@
 cask 'osdn-correct-url-format' do
   version '1.2.3'
 
-  url 'https://user.dl.osdn.jp/something/id/Something-1.2.3.dmg'
-  homepage 'https://osdn.jp/projects/something/'
+  url 'https://osdn.net/dl/something/Something-1.2.3.dmg'
+  homepage 'https://osdn.net/projects/something/'
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

OSDN (JP) has made some changes last year and now has a cleaned up URL layout. Reflect that in the cask audit checker.

Ref: https://github.com/Homebrew/homebrew-cask/pull/52975#issuecomment-427613612