### PR TITLE
download_strategy: Miscalculated redirect when `Location:` is protocol-relative

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -336,7 +336,10 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
                      .compact
 
     redirect_url = locations.reduce(url) do |current_url, location|
-      if location.start_with?("/")
+      if location.start_with?("//")
+        uri = URI(current_url)
+        "#{uri.scheme}:#{location}"
+      elsif location.start_with?("/")
         uri = URI(current_url)
         "#{uri.scheme}://#{uri.host}#{location}"
       else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently the Homebrew downloader logic considers `Location:` headers with two leading slashes (`//`) as a subdirectory and therefore appends it to the previous location's directory. Locations starting with double slashes however are meant to be handled as protocol-relative URLs and shall replace the whole existing directory keeping only the protocol part. Current behaviour causes URLs using such `Location:`s to fail to resolve to a valid URL. The fix is to explicitly handle the protocol-relative URL case.

Ref: https://tools.ietf.org/html/rfc7231#section-7.1.2
Ref: https://tools.ietf.org/html/rfc3986#section-4.2

Test Formula:
https://raw.githubusercontent.com/Homebrew/homebrew-cask-fonts/d4d4497c7d08030406a6eeb3e8cdd16c6051d0a0/Casks/font-keep-calm.rb
```ruby
cask 'font-keep-calm' do
  version :latest
  sha256 :no_check

  url 'https://dl.1001fonts.com/keep-calm.zip'
  name 'Keep Calm'
  homepage 'http://www.1001fonts.com/keep-calm-font.html'

  font 'Keep Calm Medium – Personal Use/KeepCalm-Medium.ttf'
end
```

Causing this PR to fail: https://github.com/Homebrew/homebrew-cask-fonts/pull/1734
More info at: https://github.com/Homebrew/homebrew-cask-fonts/pull/1733#issuecomment-427622999
