### PR TITLE
cask/audit: remove cask specific sourceforge URL audits

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -282,10 +282,6 @@ module Cask
                       [
                         %r{\Ahttps://sourceforge\.net/projects/[^/]+/files/latest/download\Z},
                         %r{\Ahttps://downloads\.sourceforge\.net/(?!(project|sourceforge)\/)},
-                        # special cases: cannot find canonical format URL
-                        %r{\Ahttps?://brushviewer\.sourceforge\.net/brushviewql\.zip\Z},
-                        %r{\Ahttps?://doublecommand\.sourceforge\.net/files/},
-                        %r{\Ahttps?://excalibur\.sourceforge\.net/get\.php\?id=},
                       ])
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
These casks were deleted in https://github.com/Homebrew/homebrew-cask/pull/53041