### PR TITLE
audit: remove `openssl@1.1` from unstable spec whitelist

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -650,7 +650,6 @@ module Homebrew
           versioned_unstable_spec = %w[
             bash-completion@2
             imagemagick@6
-            openssl@1.1
             python@2
           ]
           problem unstable_spec_message unless versioned_unstable_spec.include?(formula.name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
https://github.com/Homebrew/homebrew-core/pull/31989
Now that TLS1.3 has landed in a stable release we probably don't need to allow for an unstable spec.