### PR TITLE
Cask: set write permissions on symlinks

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -136,11 +136,6 @@ module Cask
 
       resolved_paths = Pathname.glob(to/"**/*", File::FNM_DOTMATCH)
 
-      system_command!("/bin/chmod", args: ["-R", "u+w", to])
-
-      # Symlinks cannot be fixed with -R.
-      resolved_symlinks = resolved_paths.select(&:symlink?)
-
       system_command!("/usr/bin/xargs",
                       args: [
                         "-0",
@@ -149,7 +144,7 @@ module Cask
                         "-h",
                         "u+w",
                       ],
-                      input: resolved_symlinks.join("\0"))
+                      input: resolved_paths.join("\0"))
 
       quarantiner = system_command("/usr/bin/xargs",
                                    args: [

--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -138,6 +138,19 @@ module Cask
 
       system_command!("/bin/chmod", args: ["-R", "u+w", to])
 
+      # Symlinks cannot be fixed with -R.
+      resolved_symlinks = resolved_paths.select(&:symlink?)
+
+      system_command!("/usr/bin/xargs",
+                      args: [
+                        "-0",
+                        "--",
+                        "/bin/chmod",
+                        "-h",
+                        "u+w",
+                      ],
+                      input: resolved_symlinks.join("\0"))
+
       quarantiner = system_command("/usr/bin/xargs",
                                    args: [
                                      "-0",


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Related to Homebrew/homebrew-cask-versions#6368, turns out some zip files ship with symbolic links set to read-only for the current user, which is not covered by `chmod -R` (it needs the `-h` flag which is mutually exclusive).

This pull request adds an extra pass that only touches symlinks on the staged path, courtesy of `xargs`.

Ping @Homebrew/brew for review, as it blocks the AdoptOpenJDK Cask.
