### PR TITLE
audit: permit openblas for non-official taps

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -432,6 +432,7 @@ module Homebrew
 
           if @new_formula && dep_f.keg_only_reason &&
              !["openssl", "apr", "apr-util"].include?(dep.name) &&
+             (!["openblas"].include?(dep.name) || @official_tap) &&
              dep_f.keg_only_reason.reason == :provided_by_macos
             new_formula_problem(
               "Dependency '#{dep.name}' may be unnecessary as it is provided " \


### PR DESCRIPTION
macOS provides Accelerate but not OpenBLAS

The version of Accelerate that ships with macOS features an incomplete LAPACK library and its single precision interface is buggy. In scientific formulae, OpenBLAS is the natural fallback. These changes disable the audit error that occurs when a formula depends explicitly on `openblas`.

I made the change for unofficial taps only. Let me know if it should apply to official taps as well.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
