### PR TITLE
Remove redundant check in formula_files and cask_files

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -382,7 +382,7 @@ class Tap
   # an array of all {Formula} files of this {Tap}.
   def formula_files
     @formula_files ||= if formula_dir.directory?
-      formula_dir.children.select { |file| file.extname == ".rb" }
+      formula_dir.children.select(&method(:ruby_file?))
     else
       []
     end
@@ -391,10 +391,16 @@ class Tap
   # an array of all {Cask} files of this {Tap}.
   def cask_files
     @cask_files ||= if cask_dir.directory?
-      cask_dir.children.select { |file| file.extname == ".rb" }
+      cask_dir.children.select(&method(:ruby_file?))
     else
       []
     end
+  end
+
+  # returns true if the file has a Ruby extension
+  # @private
+  def ruby_file?(file)
+    file.extname == ".rb"
   end
 
   # return true if given path would present a {Formula} file in this {Tap}.
@@ -403,7 +409,7 @@ class Tap
   def formula_file?(file)
     file = Pathname.new(file) unless file.is_a? Pathname
     file = file.expand_path(path)
-    file.extname == ".rb" && file.parent == formula_dir
+    ruby_file?(file) && file.parent == formula_dir
   end
 
   # return true if given path would present a {Cask} file in this {Tap}.
@@ -412,7 +418,7 @@ class Tap
   def cask_file?(file)
     file = Pathname.new(file) unless file.is_a? Pathname
     file = file.expand_path(path)
-    file.extname == ".rb" && file.parent == cask_dir
+    ruby_file?(file) && file.parent == cask_dir
   end
 
   # an array of all {Formula} names of this {Tap}.


### PR DESCRIPTION
Formula_files consists of every non-recursive child of `formula_dir`, for which `formula_file?` evaluates to true. `formula_file?` checks if the file is a child of `formula_dir`, which it is by definition. It turns out that by removing the check, the time used for `brew search` decreased from 800 ms to 700 ms, noticably faster during tab completion. The same happens with
cask_files and cask_file?

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
