### PR TITLE
audit: use `core_tap` instead of `official_tap`

### DIFF
--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -525,7 +525,7 @@ module Homebrew
 
     describe "#audit_url_is_not_binary" do
       specify "it detects a url containing darwin and x86_64" do
-        fa = formula_auditor "foo", <<~RUBY, official_tap: true
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://example.com/example-darwin.x86_64.tar.gz"
           end
@@ -534,11 +534,11 @@ module Homebrew
         fa.audit_url_is_not_binary
 
         expect(fa.problems.first)
-          .to match("looks like a binary package, not a source archive. Official taps are source-only.")
+          .to match("looks like a binary package, not a source archive. The `core` tap is source-only.")
       end
 
       specify "it detects a url containing darwin and amd64" do
-        fa = formula_auditor "foo", <<~RUBY, official_tap: true
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://example.com/example-darwin.amd64.tar.gz"
           end
@@ -547,11 +547,11 @@ module Homebrew
         fa.audit_url_is_not_binary
 
         expect(fa.problems.first)
-          .to match("looks like a binary package, not a source archive. Official taps are source-only.")
+          .to match("looks like a binary package, not a source archive. The `core` tap is source-only.")
       end
 
       specify "it works on the devel spec" do
-        fa = formula_auditor "foo", <<~RUBY, official_tap: true
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://example.com/valid-1.0.tar.gz"
 
@@ -564,11 +564,11 @@ module Homebrew
         fa.audit_url_is_not_binary
 
         expect(fa.problems.first)
-          .to match("looks like a binary package, not a source archive. Official taps are source-only.")
+          .to match("looks like a binary package, not a source archive. The `core` tap is source-only.")
       end
 
       specify "it works on the head spec" do
-        fa = formula_auditor "foo", <<~RUBY, official_tap: true
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://example.com/valid-1.0.tar.gz"
 
@@ -581,11 +581,11 @@ module Homebrew
         fa.audit_url_is_not_binary
 
         expect(fa.problems.first)
-          .to match("looks like a binary package, not a source archive. Official taps are source-only.")
+          .to match("looks like a binary package, not a source archive. The `core` tap is source-only.")
       end
 
       specify "it ignores resource urls" do
-        fa = formula_auditor "foo", <<~RUBY, official_tap: true
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://example.com/valid-1.0.tar.gz"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
We only have one tap for formulae.