### PR TITLE
bump-formula-pr: gracefully handle unforkable repositories

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -36,6 +36,9 @@
 #:    If `--quiet` is passed, don't output replacement messages or warn about
 #:    duplicate pull requests.
 #:
+#:    If `--no-fork` is passed, create a pull request from a branch in the tap
+#:    repository rather than a fork.
+#:
 #:    Note that this command cannot be used to transition a formula from a
 #:    URL-and-sha256 style specification into a tag-and-revision style
 #:    specification, nor vice versa. It must use whichever style specification
@@ -79,6 +82,8 @@ module Homebrew
         description: "Run `brew audit --strict` before opening the PR."
       switch "--no-browse",
         description: "Output the pull request URL instead of opening in a browser"
+      switch "--no-fork",
+        description: "Create pull request directly from tap repo, not a fork"
       flag "--url=",
         description: "Provide new <URL> for the formula. If a <URL> is specified, the <sha-256> "\
                      "checksum of the new download must also be specified."
@@ -345,7 +350,7 @@ module Homebrew
       shallow = !git_dir.empty? && File.exist?("#{git_dir}/shallow")
 
       if args.dry_run?
-        ohai "fork repository with GitHub API"
+        ohai "fork repository with GitHub API" unless args.no_fork?
         ohai "git fetch --unshallow origin" if shallow
         ohai "git checkout --no-track -b #{branch} origin/master"
         ohai "git commit --no-edit --verbose --message='#{formula.name} " \
@@ -355,21 +360,26 @@ module Homebrew
         ohai "git checkout -"
       else
 
-        begin
-          response = GitHub.create_fork(formula.tap.full_name)
-          # GitHub API responds immediately but fork takes a few seconds to be ready.
-          sleep 3
-        rescue *GitHub.api_errors => e
-          formula.path.atomic_write(backup_file) unless args.dry_run?
-          odie "Unable to fork: #{e.message}!"
-        end
-
-        if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
-          remote_url = response.fetch("ssh_url")
+        if args.no_fork?
+          remote_url = Utils.popen_read("git remote get-url --push origin").chomp
+          username = remote_url.match(%r{\A(?:\w+://.*/|[^/]*:)(.*)/})[1]
         else
-          remote_url = response.fetch("clone_url")
+          begin
+            response = GitHub.create_fork(formula.tap.full_name)
+            # GitHub API responds immediately but fork takes a few seconds to be ready.
+            sleep 3
+          rescue *GitHub.api_errors => e
+            formula.path.atomic_write(backup_file) unless args.dry_run?
+            odie "Unable to fork: #{e.message}!"
+          end
+
+          if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
+            remote_url = response.fetch("ssh_url")
+          else
+            remote_url = response.fetch("clone_url")
+          end
+          username = response.fetch("owner").fetch("login")
         end
-        username = response.fetch("owner").fetch("login")
 
         safe_system "git", "fetch", "--unshallow", "origin" if shallow
         safe_system "git", "checkout", "--no-track", "-b", branch, "origin/master"


### PR DESCRIPTION
Hello! 👋 It's been a while.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

GitHub seems to be [discouraging](https://help.github.com/articles/allowing-people-to-fork-private-repositories-in-your-organization/) forking private repositories:

> By default, new organizations are configured to disallow the forking of private repositories.

bump-formula-pr tries to create its pull requests from a fork, so it can't be used for private taps set up in this way.

I've added a --no-fork option that will create PRs in the tap repo itself, rather than in a fork, to accommodate this use case.