### PR TITLE
Set gist-logs to create private gist (vs. public)

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -1,4 +1,4 @@
-#:  * `gist-logs` [`--new-issue`|`-n`] <formula>:
+#:  * `gist-logs` [`--new-issue`|`-n`] [`--private`|`-p`] <formula>:
 #:    Upload logs for a failed build of <formula> to a new Gist.
 #:
 #:    <formula> is usually the name of the formula to install, but it can be specified
@@ -8,6 +8,9 @@
 #:
 #:    If `--new-issue` is passed, automatically create a new issue in the appropriate
 #:    GitHub repository as well as creating the Gist.
+#:
+#:    If `--private` is passed, the Gist will be marked private and will not
+#:    appear in listings but will be accessible with the link.
 #:
 #:    If no logs are found, an error message is presented.
 
@@ -110,9 +113,13 @@ module Homebrew
     logs
   end
 
+  def create_private?
+    ARGV.include?("--private") || ARGV.switch?("p")
+  end
+
   def create_gist(files, description)
     url = "https://api.github.com/gists"
-    data = { "public" => true, "files" => files, "description" => description }
+    data = { "public" => !create_private?, "files" => files, "description" => description }
     scopes = GitHub::CREATE_GIST_SCOPES
     GitHub.open_api(url, data: data, scopes: scopes)["html_url"]
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Gists don't need to be listed on a user's page because they provide the direct link in their issues.

['Create Gist' GitHub API docs](https://developer.github.com/v3/gists/#create-a-gist).