### PR TITLE
audit: check versioned formulae for `keg_only :versioned_formula`

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -525,6 +525,25 @@ module Homebrew
       problem "keg_only reason should not end with a period."
     end
 
+    def audit_versioned_keg_only
+      return unless formula.versioned_formula?
+      return unless @core_tap
+
+      return if formula.keg_only? && formula.keg_only_reason.reason == :versioned_formula
+
+      keg_only_whitelist = %w[
+        autoconf@2.13
+        bash-completion@2
+        gnupg@1.4
+        lua@5.1
+        python@2
+      ].freeze
+
+      return if keg_only_whitelist.include?(formula.name) || formula.name.start_with?("gcc@")
+
+      problem "Versioned formulae should use `keg_only :versioned_formula`"
+    end
+
     def audit_homepage
       homepage = formula.homepage
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -600,5 +600,49 @@ module Homebrew
         expect(fa.problems).to eq([])
       end
     end
+
+    describe "#audit_versioned_keg_only" do
+      specify "it warns when a versioned formula is not `keg_only`" do
+        fa = formula_auditor "foo@1.1", <<~RUBY, core_tap: true
+          class FooAT11 < Formula
+            url "https://example.com/foo-1.1.tgz"
+          end
+        RUBY
+
+        fa.audit_versioned_keg_only
+
+        expect(fa.problems.first)
+          .to match("Versioned formulae should use `keg_only :versioned_formula`")
+      end
+
+      specify "it warns when a versioned formula has an incorrect `keg_only` reason" do
+        fa = formula_auditor "foo@1.1", <<~RUBY, core_tap: true
+          class FooAT11 < Formula
+            url "https://example.com/foo-1.1.tgz"
+
+            keg_only :provided_by_macos
+          end
+        RUBY
+
+        fa.audit_versioned_keg_only
+
+        expect(fa.problems.first)
+          .to match("Versioned formulae should use `keg_only :versioned_formula`")
+      end
+
+      specify "it does not warn when a versioned formula has `keg_only :versioned_formula`" do
+        fa = formula_auditor "foo@1.1", <<~RUBY, core_tap: true
+          class FooAT11 < Formula
+            url "https://example.com/foo-1.1.tgz"
+
+            keg_only :versioned_formula
+          end
+        RUBY
+
+        fa.audit_versioned_keg_only
+
+        expect(fa.problems).to eq([])
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This is intended to enforce the (almost) default expectation that versioned `@` formulae should be `keg_only :versioned_formula`.


Whitelisted:
- `autoconf@2.13`: suffixed
- `bash-completion@2`: conflicts with `bash-completion`, also whitelisted in conflicts cop
- `gcc@*` formulae: suffixed
- `gnupg@1.4`: suffixed
- `lua@5.1`: doesn't conflict with `lua`
- `python@2`: doesn't conflict with `python`

Stuff that should probably be fixed in `core`:
- `antlr@2`: ~~renamed or~~ `keg_only` https://github.com/Homebrew/homebrew-core/pull/33082
- ~~`autoconf@2.13`: `keg_only`, (`gjs` depends on it)~~ whitelisted
- `gtksourceview@4`: renamed, the other `gtksourceview` formulae aren't `@` https://github.com/Homebrew/homebrew-core/pull/33081