### PR TITLE
cli_parser: improve help text formatting

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -28,13 +28,13 @@ module Homebrew
         @constraints = []
         @conflicts = []
         @processed_options = []
-        @desc_line_length = 48
+        @desc_line_length = 43
         instance_eval(&block)
         post_initialize
       end
 
       def post_initialize
-        @parser.on_tail("-h", "--help", "Show this message") do
+        @parser.on_tail("-h", "--help", "Show this message.") do
           puts generate_help_text
           exit 0
         end
@@ -127,9 +127,10 @@ module Homebrew
 
       def generate_help_text
         @parser.to_s.sub(/^/, "#{Tty.bold}Usage: brew#{Tty.reset} ")
-               .gsub(/`(.*?)`/, "#{Tty.bold}\\1#{Tty.reset}")
+               .gsub(/`(.*?)`/m, "#{Tty.bold}\\1#{Tty.reset}")
                .gsub(%r{<([^\s]+?://[^\s]+?)>}) { |url| Formatter.url(url) }
-               .gsub(/<(.*?)>/, "#{Tty.underline}\\1#{Tty.reset}")
+               .gsub(/<(.*?)>/m, "#{Tty.underline}\\1#{Tty.reset}")
+               .gsub(/\*(.*?)\*/m, "#{Tty.underline}\\1#{Tty.reset}")
       end
 
       private

--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -93,6 +93,7 @@ module Homebrew
               .gsub(/`(.*?)`/, "#{Tty.bold}\\1#{Tty.reset}")
               .gsub(%r{<([^\s]+?://[^\s]+?)>}) { |url| Formatter.url(url) }
               .gsub(/<(.*?)>/, "#{Tty.underline}\\1#{Tty.reset}")
+              .gsub(/\*(.*?)\*/, "#{Tty.underline}\\1#{Tty.reset}")
               .gsub("@hide_from_man_page", "")
         end.join.strip
       end

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -89,6 +89,7 @@ describe Homebrew::CLI::Parser do
 
     it "raises exception on depends_on constraint violation" do
       expect { parser.parse(["--flag2=flag2"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
+      expect { parser.parse(["--flag4=flag4"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
     end
 
     it "raises exception for conflict violation" do
@@ -139,6 +140,7 @@ describe Homebrew::CLI::Parser do
 
     it "raises exception on depends_on constraint violation" do
       expect { parser.parse(["--switch-c"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
+      expect { parser.parse(["--switch-d"]) }.to raise_error(Homebrew::CLI::OptionConstraintError)
     end
 
     it "raises exception for conflict violation" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
- reduce desc_line_length so `brew help` output fits in 80 columns
- support special formatting across line breaks
- support emphasis using asterisks (for both comment-based and Parser-based help text)
- add tests for `depends_on` that seemed to be missing