### PR TITLE
Use the `all` matcher to check the existence of each path.

### DIFF
--- a/Library/Homebrew/test/.rubocop_todo.yml
+++ b/Library/Homebrew/test/.rubocop_todo.yml
@@ -79,11 +79,6 @@ RSpec/InstanceVariable:
     - 'version_spec.rb'
 
 # Offense count: 1
-RSpec/IteratedExpectation:
-  Exclude:
-    - 'cask/artifact/uninstall_zap_shared_examples.rb'
-
-# Offense count: 1
 # Cop supports --auto-correct.
 RSpec/LeadingSubject:
   Exclude:

--- a/Library/Homebrew/test/cask/artifact/uninstall_zap_shared_examples.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_zap_shared_examples.rb
@@ -183,9 +183,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
       end
 
       it "is supported" do
-        paths.each do |path|
-          expect(path).to exist
-        end
+        expect(paths).to all(exist)
 
         subject
 


### PR DESCRIPTION
This change allows us to remove the `RSpec/IteratedExpectation` rule from `.rubocop_todo.yml` as we no longer iterate over each path to check existence.

Note: We this PR didn't change the subsequent test checking for the negative expectations as this isn't part of the rule (see: https://github.com/rubocop-hq/rubocop-rspec/issues/278).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
