### PR TITLE
bottles: make `or_later` the default.

### DIFF
--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -26,7 +26,9 @@ module Utils
       alias generic_find_matching_tag find_matching_tag
 
       def find_matching_tag(tag)
-        generic_find_matching_tag(tag) || find_altivec_tag(tag) || find_or_later_tag(tag)
+        generic_find_matching_tag(tag) ||
+          find_altivec_tag(tag) ||
+          find_older_compatible_tag(tag)
       end
 
       # This allows generic Altivec PPC bottles to be supported in some
@@ -40,9 +42,8 @@ module Utils
         altivec_tag if key?(altivec_tag)
       end
 
-      # Allows a bottle tag to specify a specific OS or later,
-      # so the same bottle can target multiple OSs.
-      def find_or_later_tag(tag)
+      # Find a bottle built for a previous version of macOS.
+      def find_older_compatible_tag(tag)
         begin
           tag_version = MacOS::Version.from_symbol(tag)
         rescue ArgumentError
@@ -50,26 +51,14 @@ module Utils
         end
 
         keys.find do |key|
-          if key.to_s.end_with?("_or_later")
-            later_tag = key.to_s[/(\w+)_or_later$/, 1].to_sym
-            MacOS::Version.from_symbol(later_tag) <= tag_version
-          elsif ARGV.force_bottle?
-            true
-          # Allow prerelease versions to act as if all bottles are `_or_later`
-          # so that they don't need to wait for us to bottle everything for the
-          # new release.
-          elsif install_older_prerelease_bottles?
-            true
+          # TODO: move to compat?
+          key_tag_version = if key.to_s.end_with?("_or_later")
+            key.to_s[/(\w+)_or_later$/, 1].to_sym
+          else
+            key
           end
+          MacOS::Version.from_symbol(key_tag_version) <= tag_version
         end
-      end
-
-      def install_older_prerelease_bottles?
-        return false unless OS::Mac.prerelease?
-        return true if ENV["HOMEBREW_INSTALL_OLDER_PRERELEASE_BOTTLES"]
-        return false if ENV["HOMEBREW_NO_INSTALL_OLDER_PRERELEASE_BOTTLES"]
-
-        !ARGV.homebrew_developer?
       end
     end
   end


### PR DESCRIPTION
When Mojave was in beta we made it so that High Sierra bottles would automatically be used on Mojave. Let's make this the default in general: older bottles will be used on newer versions of macOS when a newer bottle is not available.

This should make it easier for taps to bottle single versions of bottles which will work more widely and to give us breathing room whenever a new version of macOS is released.

Currently this only applies to the `wine` formula which will have the `or_later` removed in a Homebrew/homebrew-core PR.

Question: should we use an `odeprecated` for the use of `or_later`?

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?