### PR TITLE
analytics: fix display of build error options.

### DIFF
--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -83,7 +83,7 @@ module Utils
         return if exception.formula.tap.private?
 
         action = exception.formula.full_name
-        if (options = exception.options)
+        if (options = exception.options&.to_a&.join(" "))
           action = "#{action} #{options}".strip
         end
         report_event("BuildError", action)


### PR DESCRIPTION
Currently these are all like `wget #<Options:0x0000000101171658>`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----