### PR TITLE
Shorten tap line length

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - '**/vendor/**/*'
   DisplayCopNames: false
 
-require: 
+require:
   - ./Homebrew/rubocops.rb
   - rubocop-rspec
 
@@ -102,7 +102,7 @@ Metrics/ParameterLists:
 
 # GitHub diff UI wraps beyond 118 characters (so that's the goal)
 Metrics/LineLength:
-  Max: 189
+  Max: 170
   # ignore manpage comments and long single-line strings
   IgnoredPatterns: ['#: ', ' url "', ' mirror "', ' plist_options :']
 


### PR DESCRIPTION
After https://github.com/Homebrew/homebrew-core/pull/32973 is merged this will be the longest line length in Homebrew/homebrew-core.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----