### PR TITLE
Run `rubocop` in temporary directory to skip reading parent config.

### DIFF
--- a/Library/Homebrew/cask/cmd/style.rb
+++ b/Library/Homebrew/cask/cmd/style.rb
@@ -11,7 +11,9 @@ module Cask
         install_rubocop
         cache_env = { "XDG_CACHE_HOME" => "#{HOMEBREW_CACHE}/style" }
         hide_warnings = debug? ? [] : [ENV["HOMEBREW_RUBY_PATH"], "-W0", "-S"]
-        system(cache_env, *hide_warnings, "rubocop", *rubocop_args, "--", *cask_paths)
+        Dir.mktmpdir do |tmpdir|
+          system(cache_env, *hide_warnings, "rubocop", *rubocop_args, "--", *cask_paths, chdir: tmpdir)
+        end
         raise CaskError, "style check failed" unless $CHILD_STATUS.success?
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

`brew cask style` shouldn't need `rubocop-rspec`, which is `require`d when running `rubocop` somewhere inside `HOMEBREW_LIBRARY`.