### PR TITLE
Allow access to lock directory inside tests.

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -87,6 +87,7 @@ module Homebrew
             sandbox.allow_write_log(f)
             sandbox.allow_write_xcode
             sandbox.allow_write_path(HOMEBREW_PREFIX/"var/cache")
+            sandbox.allow_write_path(HOMEBREW_PREFIX/"var/homebrew/locks")
             sandbox.allow_write_path(HOMEBREW_PREFIX/"var/log")
             sandbox.allow_write_path(HOMEBREW_PREFIX/"var/run")
             sandbox.exec(*args)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This allows lock files for resources to be created inside `test` blocks.

Fixes https://github.com/Homebrew/brew/issues/5122.