### PR TITLE
audit: comment and fail new formula PRs

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -194,10 +194,8 @@ module Homebrew
       errors_summary += ", #{corrected_problem_plural} corrected"
     end
 
-    if problem_count.positive? ||
-       (new_formula_problem_count.positive? && !created_pr_comment)
-      ofail errors_summary
-    end
+    return if problem_count.zero? && new_formula_problem_count.zero?
+    ofail errors_summary
   end
 
   def format_problem_lines(problems)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`comment && fail CI` for new formula PR problems rather than `comment || fail CI`

This makes it easier to see at a glance if a formula has passed the new formula audit and the regular audit, currently you would need to inspect the formula file and review the PR comments to see if the bot said anything.

I don't think merging new formula PRs that have failed CI is an issue as we have the comment from the bot anyway for posterity.