### PR TITLE
audit: use `versioned_formula` instead of `formula.versioned_formula?`

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -252,7 +252,8 @@ module Homebrew
 
     def initialize(formula, options = {})
       @formula = formula
-      @new_formula = options[:new_formula] && !formula.versioned_formula?
+      @versioned_formula = formula.versioned_formula?
+      @new_formula = options[:new_formula] && !@versioned_formula
       @strict = options[:strict]
       @online = options[:online]
       @display_cop_names = options[:display_cop_names]
@@ -273,7 +274,7 @@ module Homebrew
 
       @style_offenses.each do |offense|
         if offense.cop_name.start_with?("NewFormulaAudit")
-          next if formula.versioned_formula?
+          next if @versioned_formula
 
           new_formula_problem offense.to_s(display_cop_name: @display_cop_names)
           next
@@ -307,7 +308,7 @@ module Homebrew
 
       problem "File should end with a newline" unless text.trailing_newline?
 
-      if formula.versioned_formula?
+      if @versioned_formula
         unversioned_formula = begin
           # build this ourselves as we want e.g. homebrew/core to be present
           full_name = if formula.tap
@@ -526,7 +527,7 @@ module Homebrew
     end
 
     def audit_versioned_keg_only
-      return unless formula.versioned_formula?
+      return unless @versioned_formula
       return unless @core_tap
 
       return if formula.keg_only? && formula.keg_only_reason.reason == :versioned_formula
@@ -665,7 +666,7 @@ module Homebrew
         unstable_spec_message = "Formulae should not have a `HEAD` or `devel` spec"
         if @new_formula
           new_formula_problem unstable_spec_message
-        elsif formula.versioned_formula?
+        elsif @versioned_formula
           versioned_unstable_spec = %w[
             bash-completion@2
             imagemagick@6


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I think this is a bit easier to parse and more consistent with `@new_formula`, `@core_tap`, etc.