### PR TITLE
Add HOMEBREW_FORCE_HOMEBREW_ON_LINUX

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -86,7 +86,6 @@ then
   HOMEBREW_OS_VERSION="macOS $HOMEBREW_MACOS_VERSION"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X $HOMEBREW_MACOS_VERSION"
-  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://homebrew.bintray.com"
 
   # The system Curl is too old for some modern HTTPS certificates on
   # older macOS versions.
@@ -114,11 +113,17 @@ else
   [[ -n "$HOMEBREW_LINUX" ]] && HOMEBREW_OS_VERSION="$(lsb_release -sd 2>/dev/null)"
   : "${HOMEBREW_OS_VERSION:=$(uname -r)}"
   HOMEBREW_OS_USER_AGENT_VERSION="$HOMEBREW_OS_VERSION"
-  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://linuxbrew.bintray.com"
 
   CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_CACHE="${HOMEBREW_CACHE:-${CACHE_HOME}/Homebrew}"
   HOMEBREW_SYSTEM_TEMP="/tmp"
+fi
+
+if [[ -n "$HOMEBREW_MACOS" || -n "$HOMEBREW_FORCE_HOMEBREW_ON_LINUX" ]]
+then
+  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://homebrew.bintray.com"
+else
+  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://linuxbrew.bintray.com"
 fi
 
 HOMEBREW_TEMP="${HOMEBREW_TEMP:-${HOMEBREW_SYSTEM_TEMP}}"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -24,7 +24,7 @@ git() {
 
 git_init_if_necessary() {
   BREW_OFFICIAL_REMOTE="https://github.com/Homebrew/brew"
-  if [[ -n "$HOMEBREW_MACOS" ]] || [[ -n "$HOMEBREW_FORCE_HOMEBREW_ORG" ]]
+  if [[ -n "$HOMEBREW_MACOS" ]] || [[ -n "$HOMEBREW_FORCE_HOMEBREW_ON_LINUX" ]]
   then
     CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/homebrew-core"
   else

--- a/Library/Homebrew/extend/os/linux/tap.rb
+++ b/Library/Homebrew/extend/os/linux/tap.rb
@@ -1,6 +1,6 @@
 class CoreTap < Tap
   def default_remote
-    if ENV["HOMEBREW_FORCE_HOMEBREW_ORG"]
+    if ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
       "https://github.com/Homebrew/homebrew-core".freeze
     else
       "https://github.com/Linuxbrew/homebrew-core".freeze

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -54,7 +54,7 @@ HOMEBREW_USER_AGENT_FAKE_SAFARI =
 # `HOMEBREW_BOTTLE_DEFAULT_DOMAIN` isn't set.
 HOMEBREW_BOTTLE_DEFAULT_DOMAIN = if ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"]
   ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"]
-elsif OS.mac?
+elsif OS.mac? || ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
   "https://homebrew.bintray.com".freeze
 else
   "https://linuxbrew.bintray.com".freeze

--- a/Library/Homebrew/os/linux/global.rb
+++ b/Library/Homebrew/os/linux/global.rb
@@ -1,3 +1,7 @@
 module Homebrew
-  DEFAULT_PREFIX = "/home/linuxbrew/.linuxbrew".freeze
+  DEFAULT_PREFIX = if ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
+    "/usr/local".freeze
+  else
+    "/home/linuxbrew/.linuxbrew".freeze
+  end
 end


### PR DESCRIPTION
This serves a similar purpose to the HOMEBREW_FORCE_HOMEBREW_ORG variable but applies to more settings.

CI should be rerun on this once https://github.com/Homebrew/homebrew-test-bot/pull/209 is merged.

CC @sjackman FYI

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----