### PR TITLE
doctor: Check for /usr/include following Xcode 10

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -104,6 +104,21 @@ module Homebrew
         EOS
       end
 
+      def check_for_missing_legacy_headers
+        return unless DevelopmentTools.installed?
+
+        return if Dir.exist? "/usr/include/"
+
+        <<~EOS
+          Starting in Xcode 10, headers are no longer installed in /usr/include/.
+          Please install the macOS_SDK_headers_for_macOS package located at:
+
+          /Library/Developer/CommandLineTools/Packages/
+
+          Without these headers, some formulae may fail to compile.
+        EOS
+      end
+
       def check_build_from_source
         return unless ENV["HOMEBREW_BUILD_FROM_SOURCE"]
 


### PR DESCRIPTION
In Xcode 10, headers are no longer installed to /usr/include, which
poses a problem when software tries to be built on platforms with it
installed. This means that a fresh copy of Mojave, Homebrew, rbenv, and
ruby-build cannot build and install rubies.

Whether or not this impacts homebrew directly, it does affect software
installed with it -- which can be annoying to debug.

This thread on the Apple Developer Forums is the source for this:

-> https://forums.developer.apple.com/thread/104296

Tests & style pass but I wasn't sure to add a test (since this is basically just checking a ruby standard library method).

This also might not be at all worthy of adding a doctor for. I just hit this snag following the workflow I did above (Mojave, brew, rbenv, ruby-build, and then no rubies could be built because of no `/usr/include/`).