### PR TITLE
Allow taps to require custom lib files

### DIFF
--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -39,12 +39,14 @@ module Homebrew
       tap_count = 0
       formula_count = 0
       command_count = 0
+      library_count = 0
       pinned_count = 0
       private_count = 0
       Tap.each do |tap|
         tap_count += 1
         formula_count += tap.formula_files.size
         command_count += tap.command_files.size
+        library_count += 1 if tap.lib_dir?
         pinned_count += 1 if tap.pinned?
         private_count += 1 if tap.private?
       end
@@ -53,6 +55,7 @@ module Homebrew
       info += ", #{private_count} private"
       info += ", #{formula_count} #{"formula".pluralize(formula_count)}"
       info += ", #{command_count} #{"command".pluralize(command_count)}"
+      info += ", #{library_count} #{"library".pluralize(library_count)}"
       info += ", #{Tap::TAP_DIRECTORY.abv}" if Tap::TAP_DIRECTORY.directory?
       puts info
     else

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -18,6 +18,7 @@ I18n.backend.store_translations :en, support: { array: { last_word_connector: " 
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular "formula", "formulae"
+  inflect.irregular "library", "libraries"
   inflect.irregular "is", "are"
   inflect.irregular "it", "they"
 end
@@ -156,6 +157,8 @@ require "utils"
 require "official_taps"
 require "tap"
 require "tap_constants"
+
+Tap.lib_directories.each { |lib_dir| LoadPath << lib_dir }
 
 if !ARGV.include?("--no-compat") && !ENV["HOMEBREW_NO_COMPAT"]
   require "compat"

--- a/Library/Homebrew/load_path.rb
+++ b/Library/Homebrew/load_path.rb
@@ -2,8 +2,13 @@ require "pathname"
 
 HOMEBREW_LIBRARY_PATH = Pathname(__dir__).realpath
 
-unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
-  $LOAD_PATH.push(HOMEBREW_LIBRARY_PATH.to_s)
+module LoadPath
+  def self.<<(pathname)
+    return if $LOAD_PATH.include?(pathname.to_s)
+    $LOAD_PATH << pathname.to_s
+  end
 end
+
+LoadPath << HOMEBREW_LIBRARY_PATH
 
 require "vendor/bundle-standalone/bundler/setup"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -93,6 +93,7 @@ class Tap
     @repo_var = nil
     @formula_dir = nil
     @cask_dir = nil
+    @lib_dir = nil
     @command_dir = nil
     @formula_files = nil
     @alias_dir = nil
@@ -368,6 +369,15 @@ class Tap
     @cask_dir ||= path/"Casks"
   end
 
+  # path to the directory of all library files for this {Tap}.
+  def lib_dir
+    @lib_dir ||= path/"lib"
+  end
+
+  def lib_dir?
+    lib_dir.directory?
+  end
+
   def contents
     contents = []
 
@@ -381,6 +391,10 @@ class Tap
 
     if (formula_count = formula_files.count).positive?
       contents << "#{formula_count} #{"formula".pluralize(formula_count)}"
+    end
+
+    if lib_dir?
+      contents << "custom code library"
     end
 
     contents
@@ -599,6 +613,11 @@ class Tap
   # An array of all tap cmd directory {Pathname}s
   def self.cmd_directories
     Pathname.glob TAP_DIRECTORY/"*/*/cmd"
+  end
+
+  # an array of all tap lib directory {Pathname}s
+  def self.lib_directories
+    Pathname.glob TAP_DIRECTORY/"*/*/lib"
   end
 
   # @private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **Deferring tests until there’s some consensus on the feature.**
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

## Overview

This PR is a simple implementation of what has been proposed in https://github.com/Homebrew/brew/issues/5074#issuecomment-429268642:

> to maintain download strategy specs alongside with a tap's formulae and to then be able to `require` them in the formulae.

## Details

The idea is to allow a tap to contain libraries, which then can be `require`d from formulae (or Casks). The main rationale is to free the core code base from `DownloadStrategies` that are not used in `homebrew-core` but there are numerous other benefits as well.

## Example

I’ve been using this code on private taps for a few months. Here’s a real-life example for a tap that contains a custom library named `lgog_downloader`, which I use in Casks to install games I’ve purchased from [GOG](https://www.gog.com/):

```
.
├── Casks
│   ├── gog-chuchel.rb
│   ├── gog-orwell.rb
│   └── gog-state-of-mind.rb
└── lib
    └── utils
        ├── gog
        │   ├── game.rb
        │   └── package.rb
        ├── gog.rb
        ├── lgog_downloader
        │   ├── constants.rb
        │   ├── game_details_cache.rb
        │   ├── game_details_map.rb
        │   └── lgog_downloader_error.rb
        └── lgog_downloader.rb
```

A snippet from the [gog-chuchel](https://www.gog.com/game/chuchel) cask (not using a `DownloadStrategy` but you get the idea):

```
cask 'gog-chuchel' do
  version '1.0.0'
  sha256 '6fe648eb33db79ce6997dcaca3c867a0fb08b0243fc2eea39b349911c542bca4'

  require 'utils/lgog_downloader'

  url do
    installer = Utils::LGOGDownloader
      .game('chuchel')
      .installer('en2installer0')
    Utils::LGOGDownloader.url(installer)
  end
  name 'CHUCHEL'
  homepage 'https://www.gog.com/game/chuchel'

  depends_on formula: 'lgogdownloader'
  container type: :naked

  app 'CHUCHEL.app'

  preflight do
    # […]
  end
end
```

A `require`d library can provide one or more `DownloadStrategies`, or just about any objects or classes you’d want. The above example shows a Cask but the same `require` works similarly in formulas.

## Security considerations

Security-wise, I can’t think of a threat model where this PR would introduce any vulnerabilities. I’d still invite @Homebrew/maintainers for a thorough review. Thanks!
