### PR TITLE
info: tweak analytics behaviour.

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -212,7 +212,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     Display information about *`formula`* and analytics data (provided neither
     `HOMEBREW_NO_ANALYTICS` or `HOMEBREW_NO_GITHUB_API` are set)
 
-    Pass `--analytics` to see more detailed analytics data.
+    Pass `--verbose` to see more verbose analytics data.
+
+    Pass `--analytics` to see only more verbose analytics data instead of
+    formula information.
 
   * `info` `--github` *`formula`*:
     Open a browser to the GitHub History page for *`formula`*.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -222,7 +222,10 @@ The value for \fBcategory\fR must be \fBinstall\fR, \fBinstall\-on\-request\fR, 
 Display information about \fIformula\fR and analytics data (provided neither \fBHOMEBREW_NO_ANALYTICS\fR or \fBHOMEBREW_NO_GITHUB_API\fR are set)
 .
 .IP
-Pass \fB\-\-analytics\fR to see more detailed analytics data\.
+Pass \fB\-\-verbose\fR to see more verbose analytics data\.
+.
+.IP
+Pass \fB\-\-analytics\fR to see only more verbose analytics data instead of formula information\.
 .
 .TP
 \fBinfo\fR \fB\-\-github\fR \fIformula\fR


### PR DESCRIPTION
- Make `--verbose` and `--analytics` behave differently.
- Allow `--analytics` to return results for formulae that don't exist (but are in the top 10,000 installed formulae).

Fixes #5144

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----