### PR TITLE
Swap in description of current behavior instead of 1.9.3 hack comment

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -80,7 +80,7 @@ module Homebrew
     s
   end
 
-  # Hack for ruby < 1.9.3
+  # Causes some terminals to display secure entry indicators
   def noecho_gets
     system "stty -echo"
     result = $stdin.gets

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -80,7 +80,7 @@ module Homebrew
     s
   end
 
-  # Causes some terminals to display secure entry indicators
+  # Causes some terminals to display secure password entry indicators
   def noecho_gets
     system "stty -echo"
     result = $stdin.gets


### PR DESCRIPTION
While working on f10691bcc, I noticed this odd comment and decided to investigate. I wasn't able to reproduce the undesirable behavior because I cannot get 1.8.7 to compile with rvm but I did notice through some testing that iTerm2 displays a lock character when echo mode is disabled.

My intent had been to remove this method because Homebrew has moved past a Ruby version that would necessitate the "hack" but this method's behavior is actually desirable today, so I changed the comment to remove the potential flag and instead left a comment explaining a good second reason for the method.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] ~~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~~
- [X] ~~Have you successfully run `brew style` with your changes locally?~~
- [X] ~~Have you successfully run `brew tests` with your changes locally?~~

-----