### PR TITLE
Capture stderr in Homebrew::Assertions methods

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -6,7 +6,7 @@ module Homebrew
     # Returns the output of running cmd, and asserts the exit status
     def shell_output(cmd, result = 0)
       ohai cmd
-      output = `#{cmd}`
+      output = `#{cmd} 2>&1`
       assert_equal result, $CHILD_STATUS.exitstatus
       output
     end
@@ -15,7 +15,7 @@ module Homebrew
     # optionally asserts the exit status
     def pipe_output(cmd, input = nil, result = nil)
       ohai cmd
-      output = IO.popen(cmd, "w+") do |pipe|
+      output = IO.popen(cmd, "w+", err: [:child, :out]) do |pipe|
         pipe.write(input) unless input.nil?
         pipe.close_write
         pipe.read


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR attempts to address #5149 to capture stderr as well as stdout in the methods provided by `Homebrew::Assertions`. It does so without changing the method signatures of any methods and _should_ not break any existing formulae.

A follow-up to this PR would clean up any formula in Homebrew/homebrew-core that utilize `Open3.popen` or `IO.popen` directly to access stderr.