### PR TITLE
compat/requirements: add odeprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - travis_retry git clone --depth=1 https://github.com/Homebrew/homebrew-test-bot Library/Taps/homebrew/homebrew-test-bot
 
 script:
-  - brew test-bot
+  - travis_wait 60 brew test-bot
 
 notifications:
   slack: machomebrew:1XNF7p1JRCdBUuKaeSwsWEc1

--- a/Library/Homebrew/compat/requirements/x11_requirement.rb
+++ b/Library/Homebrew/compat/requirements/x11_requirement.rb
@@ -4,8 +4,7 @@ class X11Requirement < Requirement
   module Compat
     def initialize(tags = [])
       if tags.first.to_s.match?(/(\d\.)+\d/)
-        # TODO: deprecate when Homebrew/homebrew-core is fixed.
-        # odeprecated('depends_on :x11 => "X.Y.Z"')
+        odeprecated('depends_on :x11 => "X.Y.Z"')
         tags.shift
       end
 

--- a/Library/Homebrew/compat/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/compat/requirements/xcode_requirement.rb
@@ -8,8 +8,7 @@ class XcodeRequirement < Requirement
       else
         tags.find do |tag|
           next unless tag.to_s.match?(/(\d\.)+\d/)
-          # TODO: deprecate when Homebrew/homebrew-core is fixed.
-          # odeprecated('depends_on :xcode => [..., "X.Y.Z"]')
+          odeprecated('depends_on :xcode => [..., "X.Y.Z"]')
           tags.delete(tag)
         end
       end


### PR DESCRIPTION
These can be enabled now Homebrew/homebrew-core has been fixed (in https://github.com/Homebrew/homebrew-core/pull/32968).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----