### PR TITLE
man: Restore args after generating man pages from respective cmd parsers

### DIFF
--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -189,6 +189,7 @@ module Homebrew
   def generate_cmd_manpages(glob)
     cmd_paths = Pathname.glob(glob).sort
     man_page_lines = []
+    man_args = Homebrew.args
     cmd_paths.each do |cmd_path|
       begin
         cmd_parser = Homebrew.send(cmd_arg_parser(cmd_path))
@@ -197,6 +198,7 @@ module Homebrew
         man_page_lines << path_glob_commands(cmd_path.to_s).first
       end
     end
+    Homebrew.args = man_args
     man_page_lines
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fix: `brew man --fail-if-changed`

Reason why it wasn't working: Initializing `Homebrew::CLI::Parser` in `man.rb` to generate man-pages  for individual commands is resetting `Homebrew.args` , this happens only when `brew man` is run, nowhere else we initialize `Homebrew::CLI::Parser` of other commands except its own.

This is change fixes by restoring `Homebrew.args` after it gets reset. 
