### PR TITLE
audit: check for `bottle do` blocks in new formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -254,6 +254,7 @@ module Homebrew
     def initialize(formula, options = {})
       @formula = formula
       @versioned_formula = formula.versioned_formula?
+      @new_formula_inclusive = options[:new_formula]
       @new_formula = options[:new_formula] && !@versioned_formula
       @strict = options[:strict]
       @online = options[:online]
@@ -561,6 +562,18 @@ module Homebrew
                                   strict: @strict)
         problem http_content_problem
       end
+    end
+
+    def audit_bottle_spec
+      # special case: new versioned formulae should be audited
+      return unless @new_formula_inclusive
+      return unless @core_tap
+
+      return if formula.bottle_disabled?
+
+      return unless formula.bottle_defined?
+
+      new_formula_problem "New formulae should not have a `bottle do` block"
     end
 
     def audit_bottle_disabled


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
New formulae should never have a bottle block. This is a reasonably common problem, especially with versioned formulae.

Hopefully this works better than the last bottle audit I added. 😆 
https://github.com/Homebrew/brew/pull/4742