### PR TITLE
Clear up tap naming

### DIFF
--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -9,7 +9,8 @@ A tap is usually a Git repository available online, but you can use anything as
 long as it’s a protocol that Git understands, or even just a directory with
 files in it.
 If hosted on GitHub, we recommend that the repository’s name start with
-`homebrew-`.
+`homebrew-` so the short `brew tap` command can be used. 
+See the [manpage](Manpage.md) for more information on repository naming.
 
 Tap formulae follow the same format as the core’s ones, and can be added at the
 repository’s root, or under `Formula` or `HomebrewFormula` subdirectories. We


### PR DESCRIPTION
Explain the recommendation to use the homebrew- prefix.
As pointed out in: https://discourse.brew.sh/t/couldnt-tap-github-repo-without-homebrew-prefix/3178/2

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
