### PR TITLE
cli_parser: Add support for short flag options

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -76,20 +76,24 @@ module Homebrew
         end
       end
 
-      def flag(name, description: nil, required_for: nil, depends_on: nil)
-        if name.end_with? "="
+      def flag(*names, description: nil, required_for: nil, depends_on: nil)
+        if names.any? { |name| name.end_with? "=" }
           required = OptionParser::REQUIRED_ARGUMENT
-          name.chomp! "="
         else
           required = OptionParser::OPTIONAL_ARGUMENT
         end
-        description = option_to_description(name) if description.nil?
-        process_option(name, description)
-        @parser.on(name, *wrap_option_desc(description), required) do |option_value|
-          Homebrew.args[option_to_name(name)] = option_value
+        names.map! { |name| name.chomp "=" }
+        description = option_to_description(*names) if description.nil?
+        process_option(*names, description)
+        @parser.on(*names, *wrap_option_desc(description), required) do |option_value|
+          names.each do |name|
+            Homebrew.args[option_to_name(name)] = option_value
+          end
         end
 
-        set_constraints(name, required_for: required_for, depends_on: depends_on)
+        names.each do |name|
+          set_constraints(name, required_for: required_for, depends_on: depends_on)
+        end
       end
 
       def conflicts(*options)

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -76,6 +76,20 @@ describe Homebrew::CLI::Parser do
     end
   end
 
+  describe "test short flag options" do
+    subject(:parser) {
+      described_class.new do
+        flag "-f", "--filename=", description: "Name of the file"
+      end
+    }
+
+    it "parses a short flag option with its argument" do
+      parser.parse(["--filename=random.txt"])
+      expect(Homebrew.args.filename).to eq "random.txt"
+      expect(Homebrew.args.f).to eq "random.txt"
+    end
+  end
+
   describe "test constraints for flag options" do
     subject(:parser) {
       described_class.new do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`brew desc` has short flags (flags are options which take values) 
Example: `-s <arg>` or `--search=<arg>` 

Until now only `--search=<arg>` type of flags were supported.
This PR adds support for short flag options in `Homebrew::CLI::Parser`