### PR TITLE
unpack_strategy: fix extension for compress

### DIFF
--- a/Library/Homebrew/unpack_strategy/compress.rb
+++ b/Library/Homebrew/unpack_strategy/compress.rb
@@ -5,7 +5,7 @@ module UnpackStrategy
     using Magic
 
     def self.extensions
-      [".compress"]
+      [".Z"]
     end
 
     def self.can_extract?(path)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/5161.

`man compress` says:

> Each file is renamed to the same name plus the extension `.Z`

Therefore the previously-specified extension as `.compress` is incorrect.