### PR TITLE
cli_parser: Make Homebrew.args immutable once CLI args have been processed

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -126,6 +126,7 @@ module Homebrew
         remaining_args = @parser.parse(cmdline_args)
         check_constraint_violations
         Homebrew.args[:remaining] = remaining_args
+        Homebrew.args.freeze
         @parser
       end
 

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -177,4 +177,18 @@ describe Homebrew::CLI::Parser do
       expect(Homebrew.args.switch_b?).to be true
     end
   end
+
+  describe "test immutability of args" do
+    subject(:parser) {
+      described_class.new do
+        switch "-a", "--switch-a"
+        switch "-b", "--switch-b"
+      end
+    }
+
+    it "raises exception upon Homebrew.args mutation" do
+      parser.parse(["--switch-a"])
+      expect { parser.parse(["--switch-b"]) }.to raise_error(RuntimeError, /can't modify frozen OpenStruct/)
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
cc @MikeMcQuaid 