### PR TITLE
dev-cmd/bottle: require arg for --root-url

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -106,7 +106,7 @@ module Homebrew
         depends_on: "--write",
         description: "When passed with `--write`, a new commit will not generated after writing changes "\
                      "to the formula file."
-      flag   "--root-url",
+      flag   "--root-url=",
         description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       switch :verbose
       switch :debug

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -12,6 +12,11 @@ describe "brew bottle", :integration_test do
         .and not_to_output.to_stdout
         .and be_a_failure
 
+      expect { brew "bottle", "--root-url" }
+        .to output(/missing argument: --root-url/).to_stderr
+        .and not_to_output.to_stdout
+        .and be_a_failure
+
       setup_test_formula "testball"
 
       # `brew bottle` should not fail with dead symlink


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The `--root-url` argument to `brew bottle` requires specifying an argument with `=` not spaces (ie. `brew bottle --root-url=http://example.com`). In addition to [this discourse question](https://discourse.brew.sh/t/how-do-i-build-a-bottle-for-a-tap/3279/3), I myself have made the same mistake of omitting the `=`. This adds an `=` to the cli parser setup to indicate that an argument is required, and adds a corresponding test.