### PR TITLE
Fix Nil error when mirror download fails

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -312,7 +312,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       retry
     end
   ensure
-    download_lock.unlock
+    download_lock&.unlock
   end
 
   def clear_cache


### PR DESCRIPTION
This issue causes a method in a Nil object to be read when a mirror download fails. In my case, this occurs due to my office's proxy blocking certain mirrors. This patch fixes the Nil access, exposing a more helpful error message.

## Before patch
```
$ brew install maven
Error: An exception occurred within a child process:
  NoMethodError: undefined method `unlock' for nil:NilClass
```

## After patch
```
$ brew install maven
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "maven"
Download failed: Couldn't determine mirror, try again later.
```

## Steps to reproduce
1.  Use brew 1.8.0
2.  Ensure maven is not installed:
    ```
    brew remove maven
    ```
3.  Ensure the download is not cached:
    ```
    rm $HOME/Library/Caches/Homebrew/downloads/*--apache-maven-*-bin.tar.gz
    ```
4.  Make the mirrors unreachable by pointing them at a nonfunctional proxy:
    ```
    export http{,s}_proxy=http://localhost:8080
    export no_proxy=*.github.com,*.brew.sh
    ```
5.  Attempt package installation
    ```
    brew install maven
    ```
