### PR TITLE
bump-formula-pr: run audit by default

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -1,4 +1,4 @@
-#:  * `bump-formula-pr` [`--devel`] [`--dry-run` [`--write`]] [`--audit`|`--strict`] [`--no-browse] [`--mirror=`<URL>] [`--version=`<version>] [`--message=`<message>] (`--url=`<URL> `--sha256=`<SHA-256>|`--tag=`<tag> `--revision=`<revision>) [<formula>]:
+#:  * `bump-formula-pr` [`--devel`] [`--dry-run` [`--write`]] [`--no-audit`|`--strict`] [`--no-browse] [`--mirror=`<URL>] [`--version=`<version>] [`--message=`<message>] (`--url=`<URL> `--sha256=`<SHA-256>|`--tag=`<tag> `--revision=`<revision>) [<formula>]:
 #:    Create a pull request to update a formula with a new URL or a new tag.
 #:
 #:    If a <URL> is specified, the <SHA-256> checksum of the new download should
@@ -16,7 +16,7 @@
 #:    If `--write` is passed along with `--dry-run`, perform a not-so-dry run by
 #:    making the expected file modifications but not taking any Git actions.
 #:
-#:    If `--audit` is passed, run `brew audit` before opening the PR.
+#:    If `--no-audit` is passed, don't run `brew audit` before opening the PR.
 #:
 #:    If `--strict` is passed, run `brew audit --strict` before opening the PR.
 #:
@@ -74,8 +74,8 @@ module Homebrew
         depends_on: "--dry-run",
         description: "When passed along with `--dry-run`, perform a not-so-dry run by making the expected "\
                      "file modifications but not taking any Git actions."
-      switch "--audit",
-        description: "Run `brew audit` before opening the PR."
+      switch "--no-audit",
+        description: "Don't run `brew audit` before opening the PR."
       switch "--strict",
         description: "Run `brew audit --strict` before opening the PR."
       switch "--no-browse",
@@ -320,17 +320,21 @@ module Homebrew
     end
 
     if args.dry_run?
-      if args.strict?
+      if args.no_audit?
+        ohai "Skipping `brew audit`"
+      elsif args.strict?
         ohai "brew audit --strict #{formula.path.basename}"
-      elsif args.audit?
+      else
         ohai "brew audit #{formula.path.basename}"
       end
     else
       failed_audit = false
-      if args.strict?
+      if args.no_audit?
+        ohai "Skipping `brew audit`"
+      elsif args.strict?
         system HOMEBREW_BREW_FILE, "audit", "--strict", formula.path
         failed_audit = !$CHILD_STATUS.success?
-      elsif args.audit?
+      else
         system HOMEBREW_BREW_FILE, "audit", formula.path
         failed_audit = !$CHILD_STATUS.success?
       end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -759,8 +759,8 @@ formula already uses.
   Print what would be done rather than doing it.
 * `--write`:
   When passed along with `--dry-run`, perform a not-so-dry run by making the expected file modifications but not taking any Git actions.
-* `--audit`:
-  Run `brew audit` before opening the PR.
+* `--no-audit`:
+  Don't run `brew audit` before opening the PR.
 * `--strict`:
   Run `brew audit --strict` before opening the PR.
 * `--no-browse`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -807,8 +807,8 @@ Print what would be done rather than doing it\.
 When passed along with \fB\-\-dry\-run\fR, perform a not\-so\-dry run by making the expected file modifications but not taking any Git actions\.
 .
 .TP
-\fB\-\-audit\fR
-Run \fBbrew audit\fR before opening the PR\.
+\fB\-\-no\-audit\fR
+Don\'t run \fBbrew audit\fR before opening the PR\.
 .
 .TP
 \fB\-\-strict\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Have `bump-formula-pr` run `brew audit` by default with an option to skip the audit.
