### PR TITLE
formula_desc_cop: make `desc` non-strict

### DIFF
--- a/Library/Homebrew/rubocops/formula_desc_cop.rb
+++ b/Library/Homebrew/rubocops/formula_desc_cop.rb
@@ -34,9 +34,7 @@ module RuboCop
                   "Length is calculated as #{@formula_name} + desc. (currently #{desc_length})"
         end
       end
-    end
 
-    module FormulaAuditStrict
       # This cop audits `desc` in Formulae.
       #
       # - Checks for leading/trailing whitespace in `desc`

--- a/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_cop_spec.rb
@@ -46,7 +46,7 @@ describe RuboCop::Cop::FormulaAudit::DescLength do
   end
 end
 
-describe RuboCop::Cop::FormulaAuditStrict::Desc do
+describe RuboCop::Cop::FormulaAudit::Desc do
   subject(:cop) { described_class.new }
 
   context "When auditing formula desc" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Some of these need to be fixed in the formula, others added to the whitelist here.
```
cctools-headers:
  * C: 3: col 9: Description should start with a capital letter
crc32c:
  * C: 2: col 9: Description shouldn't start with the formula name
cxxtest:
  * C: 2: col 9: Description should start with a capital letter
dcal:
  * C: 2: col 9: Description should start with a capital letter
gollum:
  * C: 2: col 9: Description should start with a capital letter
libbladerf:
  * C: 2: col 9: Description should start with a capital letter
libopennet:
  * C: 2: col 9: Description should start with a capital letter
minio-mc:
  * C: 2: col 9: Description should start with a capital letter
msgpuck:
  * C: 2: col 9: Description shouldn't start with an indefinite article i.e. "A"
neatvi:
  * C: 2: col 9: Description should start with a capital letter
nudoku:
  * C: 2: col 9: Description should start with a capital letter
proctools:
  * C: 2: col 9: Description should start with a capital letter
socat:
  * C: 2: col 9: Description should start with a capital letter
swfmill:
  * C: 2: col 9: Description should start with a capital letter
```
`style` also needs to be fixed so results aren't in hash order but that's another PR.