### PR TITLE
bump-formula-pr: add comment if formula uses resource blocks

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -392,6 +392,13 @@ module Homebrew
         pr_message = <<~EOS
           Created with `brew bump-formula-pr`.
         EOS
+        if requested_spec == :stable && formula.stable.resources.any?
+          pr_message += "\n" + <<~EOS
+            ---
+
+            __Formula uses resource blocks, they may need to be updated.__
+          EOS
+        end
         user_message = args.message
         if user_message
           pr_message += "\n" + <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Because it's easy to overlook in `bump` PRs.

With resource blocks:
- https://github.com/Homebrew/homebrew-core/pull/33580
- https://github.com/Homebrew/homebrew-core/pull/33583

Without resource blocks:
- https://github.com/Homebrew/homebrew-core/pull/33581
- https://github.com/Homebrew/homebrew-core/pull/33582

I haven't bothered with checking the `devel` spec for resources as we've removed them from `core` formulae.