### PR TITLE
Revert "Bump concurrent-ruby from 1.0.5 to 1.1.0 in /Library/Homebrew…

### DIFF
--- a/Library/Homebrew/vendor/Gemfile.lock
+++ b/Library/Homebrew/vendor/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
       tzinfo (~> 1.1)
     ast (2.4.0)
     backports (3.11.4)
-    concurrent-ruby (1.1.0)
+    concurrent-ruby (1.0.5)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)


### PR DESCRIPTION
1.1.0 was yanked from Rubygems: https://rubygems.org/gems/concurrent-ruby/versions

Fixes #5231

This reverts commit ab372d0e64c22b984449ec3df2c4de3d470731a3.
