### PR TITLE
pull --bottle: Fix bug in any_bottle_tag

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -581,7 +581,7 @@ module Homebrew
     end
 
     def any_bottle_tag
-      tag = Utils::Bottles.tag
+      tag = Utils::Bottles.tag.to_s
       # Prefer native bottles as a convenience for download caching
       bottle_tags.include?(tag) ? tag : bottle_tags.first
     end
@@ -640,7 +640,7 @@ module Homebrew
           opoo "Cannot publish bottle: Failed reading info for formula #{f.full_name}"
           next
         end
-        bottle_info = jinfo.bottle_info(jinfo.bottle_tags.first)
+        bottle_info = jinfo.bottle_info_any
         unless bottle_info
           opoo "No bottle defined in formula #{f.full_name}"
           next


### PR DESCRIPTION
`Utils::Bottles.tag` is a symbol, whereas `bottle_tags` is an array of strings.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----