### PR TITLE
docs: update instructions for OS X < 10.9

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -428,6 +428,15 @@ EOS
 
   safe_cd "$HOMEBREW_REPOSITORY"
 
+  # if an older system had a newer curl installed, change each repo's remote URL from GIT to HTTPS
+  if [[ -n "$HOMEBREW_SYSTEM_CURL_TOO_OLD" &&
+        -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" && 
+        "$(git config remote.origin.url)" =~ ^git:// ]]
+  then
+    git config remote.origin.url "$BREW_OFFICIAL_REMOTE"
+    git config -f "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core/.git/config" remote.origin.url "$CORE_OFFICIAL_REMOTE"
+  fi
+
   # kill all of subprocess on interrupt
   trap '{ /usr/bin/pkill -P $$; wait; exit 130; }' SIGINT
 

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -61,7 +61,7 @@ module Homebrew
           You are using macOS #{MacOS.version}.
           #{who} do not provide support for this #{what}.
           You will encounter build failures and other breakages.
-          Please create pull-requests instead of asking for help on Homebrew's
+          Please create pull requests instead of asking for help on Homebrew's
           GitHub, Discourse, Twitter or IRC. As you are running this #{what},
           you are responsible for resolving any issues you experience.
         EOS

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -19,9 +19,10 @@ it does it too. And you have to confirm everything it will do before it starts.
 
 ## Alternative Installs
 
-### OS X Lion 10.7 and below
+### OS X Mountain Lion (10.8) and below
+Because GitHub now only allows clients that support TLS 1.2 to access repositories over HTTPS, the Homebrew installer will use the GIT protocol when run on systems older than OS X Mavericks (10.9). This requires the availability of a `git` binary, which can be provided by pre-installing the [Command Line Tools or Xcode](https://developer.apple.com/download/more/) on Lion or Mountain Lion, or a [prepackaged installer](https://code.google.com/archive/p/git-osx-installer/downloads) on Leopard or Snow Leopard. Homebrew will also require the Command Line Tools or Xcode in order to automatically compile and install a newer `curl` and `git` with support for TLS 1.2.
 
-Using the instructions on https://brew.sh or below whenever you call `curl` you must pass `--insecure` as an argument. This is because your system `curl` is too old to speak to GitHub using HTTPS. Don't worry, on the first `brew update` Homebrew will install a newer, more secure `curl` for your machine.
+Also note that when installing on OS X Leopard (10.5), you need to bypass its outdated built-in certificates by adding `--insecure` to the [installation command](https://brew.sh/#install)'s list of `curl` flags.
 
 ### Untar anywhere
 Just extract (or `git clone`) Homebrew wherever you want. Just avoid:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [N/A] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
New instructions for anyone who wants to install on older versions of OS X that don't support TLS 1.2 out of the box. Tested on 10.5 - 10.9, although the current version of OpenSSL 1.0.2 fails to install on 10.5 and 10.6.

Paired with Homebrew/install#154.