### PR TITLE
JavaRequirement: fix version parsing to handle Java 9 and higher

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -26,7 +26,7 @@ class JavaRequirement < Requirement
   end
 
   def initialize(tags = [])
-    @version = tags.shift if /(\d+\.)+\d/ =~ tags.first
+    @version = tags.shift if /^\d/ =~ tags.first
     super(tags)
   end
 

--- a/Library/Homebrew/test/requirements/java_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/java_requirement_spec.rb
@@ -1,0 +1,30 @@
+require "requirements/java_requirement"
+
+describe JavaRequirement do
+  describe "initialize" do
+    it "parses '1.8' tag correctly" do
+      req = described_class.new(["1.8"])
+      expect(req.display_s).to eq("java = 1.8")
+    end
+
+    it "parses '9' tag correctly" do
+      req = described_class.new(["9"])
+      expect(req.display_s).to eq("java = 9")
+    end
+
+    it "parses '9+' tag correctly" do
+      req = described_class.new(["9+"])
+      expect(req.display_s).to eq("java >= 9")
+    end
+
+    it "parses '11' tag correctly" do
+      req = described_class.new(["11"])
+      expect(req.display_s).to eq("java = 11")
+    end
+
+    it "parses bogus tag correctly" do
+      req = described_class.new(["bogus1.8"])
+      expect(req.display_s).to eq("java")
+    end
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

<strike>WIP: No test written yet. If folks approve of this approach, I'll add a test.</strike> Test written. Ready for review and merge.

Fixes #5279.
Lets https://github.com/Homebrew/homebrew-core/pull/33484 proceed.

This PR fixes an issue with option parsing in `JavaRequirement` that causes the version in `depends_on :java => "x"` to be ignored for Java 9 and higher.