### PR TITLE
man: document how to use install --build-bottle

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -52,7 +52,10 @@
 #:    are not deleted.
 #:
 #:    If `--build-bottle` is passed, prepare the formula for eventual bottling
-#:    during installation.
+#:    during installation. A formula installed this way is not guaranteed to be
+#:    usable normally. If you wish to use the formula locally, too, then
+#:    install it with this switch, build a bottle, uninstall the formula,
+#:    then install the bottle (or install the formula without the switch).
 #:
 #:    If `--force` (or `-f`) is passed, install without checking for previously
 #:    installed keg-only or non-migrated versions

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -289,7 +289,10 @@ With `--verbose` or `-v`, many commands print extra debugging information. Note 
     are not deleted.
 
     If `--build-bottle` is passed, prepare the formula for eventual bottling
-    during installation.
+    during installation. A formula installed this way is not guaranteed to be
+    usable normally. If you wish to use the formula locally, too, then
+    install it with this switch, build a bottle, uninstall the formula,
+    then install the bottle (or install the formula without the switch).
 
     If `--force` (or `-f`) is passed, install without checking for previously
     installed keg-only or non-migrated versions

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -294,7 +294,7 @@ If \fB\-\-HEAD\fR is passed, and \fIformula\fR defines it, install the HEAD vers
 If \fB\-\-keep\-tmp\fR is passed, the temporary files created during installation are not deleted\.
 .
 .IP
-If \fB\-\-build\-bottle\fR is passed, prepare the formula for eventual bottling during installation\.
+If \fB\-\-build\-bottle\fR is passed, prepare the formula for eventual bottling during installation\. A formula installed this way is not guaranteed to be usable normally\. If you wish to use the formula locally, too, then install it with this switch, build a bottle, uninstall the formula, then install the bottle (or install the formula without the switch)\.
 .
 .IP
 If \fB\-\-force\fR (or \fB\-f\fR) is passed, install without checking for previously installed keg\-only or non\-migrated versions


### PR DESCRIPTION
See https://discourse.brew.sh/t/how-are-bottle-and-postinstall-related-is-it-safe-to-run-bottle-after-postinstall/3410 for context.

I have doubts if [what @MikeMcQuaid suggested](https://discourse.brew.sh/t/how-are-bottle-and-postinstall-related-is-it-safe-to-run-bottle-after-postinstall/3410/3) is really the only supported way:
```
==> Not running post_install as we're building a bottle
You can run it manually using `brew postinstall <pkg>`
```
clearly suggests that running `postinstall` afterwards should get you a working installation.

I deliberately used strong wording to discourage people from writing broken code, so this is something to consider before committing.

---
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
