### PR TITLE
Stop referring to constants.rb in Library/Homebrew/vendor/Gemfile

### DIFF
--- a/Library/Homebrew/vendor/Gemfile
+++ b/Library/Homebrew/vendor/Gemfile
@@ -6,7 +6,4 @@ gem "backports"
 gem "plist"
 gem "ruby-macho"
 gem "rubocop-rspec"
-
-# not actually vendored but used to ensure the version matches here.
-require_relative "../constants"
-gem "rubocop", HOMEBREW_RUBOCOP_VERSION
+gem "rubocop"

--- a/Library/Homebrew/vendor/Gemfile.lock
+++ b/Library/Homebrew/vendor/Gemfile.lock
@@ -44,7 +44,7 @@ DEPENDENCIES
   backports
   concurrent-ruby
   plist
-  rubocop (= 0.60.0)
+  rubocop
   rubocop-rspec
   ruby-macho
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/5285.