### PR TITLE
formula_installer: don't automatically upgrade from another tap.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -568,6 +568,14 @@ class FormulaInstaller
       installed_keg.rename(tmp_keg)
     end
 
+    tab_tap = tab.source["tap"]
+    if df.tap.to_s != tab_tap
+      odie <<~EOS
+        #{df} is already installed from #{tab_tap}!
+        Please `brew uninstall #{df}` first."
+      EOS
+    end
+
     fi = FormulaInstaller.new(df)
     fi.options                |= tab.used_options
     fi.options                |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)


### PR DESCRIPTION
Rather than automatically upgrading a formula from one tap to a formula from another when specified as a dependency require a manual intervention to be clear that's the user's intention.

Fixes #5224

CC @blogabe

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----