### PR TITLE
dev-cmd/bottle: recognize version_scheme in merge

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -540,7 +540,7 @@ module Homebrew
                       (\n^\ {3}[\S\ ]+$)*                                        # options can be in multiple lines
                     )?|
                     (homepage|desc|sha1|sha256|version|mirror)\ ['"][\S\ ]+['"]| # specs with a string
-                    revision\ \d+                                                # revision with a number
+                    (revision|version_scheme)\ \d+                               # revision with a number
                   )\n+                                                           # multiple empty lines
                  )+
                /mx


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

`brew bottle --write --merge *.json` puts things in the wrong order when adding a bottle block to a file that has a `version_scheme`. For example, the `gazebo8` formula has a `version_scheme`, and I recently removed the bottle block after an upgraded dependency broke the bottle, and after re-building the bottle, it [inserted the bottle block between the `revision` and `version_scheme` tags](https://github.com/osrf/homebrew-simulation/commit/a94c35c#diff-f7575c78a52b1f716ca49494f4b11ec4), which causes an audit failure.

This small change is enough to fix it.