### PR TITLE
DependencyCollector: Add java_dep_if_needed [Linux]

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -79,6 +79,10 @@ class DependencyCollector
     Dependency.new("bzip2", tags) unless which("bzip2")
   end
 
+  def java_dep_if_needed(tags)
+    JavaRequirement.new(tags)
+  end
+
   def ld64_dep_if_needed(*); end
 
   def self.tar_needs_xz_dependency?
@@ -118,7 +122,7 @@ class DependencyCollector
     case spec
     when :arch          then ArchRequirement.new(tags)
     when :codesign      then CodesignRequirement.new(tags)
-    when :java          then JavaRequirement.new(tags)
+    when :java          then java_dep_if_needed(tags)
     when :linux         then LinuxRequirement.new(tags)
     when :macos         then MacOSRequirement.new(tags)
     when :maximum_macos then MaximumMacOSRequirement.new(tags)

--- a/Library/Homebrew/extend/os/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/dependency_collector.rb
@@ -1,1 +1,5 @@
-require "extend/os/mac/dependency_collector" if OS.mac?
+if OS.mac?
+  require "extend/os/mac/dependency_collector"
+elsif OS.linux?
+  require "extend/os/linux/dependency_collector"
+end

--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -1,0 +1,13 @@
+class DependencyCollector
+  def java_dep_if_needed(tags)
+    req = JavaRequirement.new(tags)
+    begin
+      dep = Dependency.new("openjdk", tags)
+      return dep if dep.installed?
+      return req if req.satisfied?
+      dep
+    rescue FormulaUnavailableError
+      req
+    end
+  end
+end

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -86,7 +86,7 @@ class JavaRequirement < Requirement
     javas = []
     javas << Pathname.new(ENV["JAVA_HOME"])/"bin/java" if ENV["JAVA_HOME"]
     jdk = begin
-      Formula["jdk"]
+      Formula["openjdk"]
     rescue FormulaUnavailableError
       nil
     end


### PR DESCRIPTION
Use the `openjdk` formula if it's installed.
Use the host's Java if it's sufficient.
Otherwise install the `openjdk` formula.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?