### PR TITLE
brew deps:  Fix typo in `--include-optional` output.

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -130,7 +130,7 @@ module Homebrew
     if ARGV.include?("--annotate")
       str = "#{str}  [build]" if dep.build?
       str = "#{str}  [test]" if dep.test?
-      str = "#{str}  [optional" if dep.optional?
+      str = "#{str}  [optional]" if dep.optional?
       str = "#{str}  [recommended]" if dep.recommended?
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?  (Yes, in my commit message.)  
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).('`brew dips` doesn't appear to have any tests at all at the moment, so I'm going to leave fixing that for future work.)  
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?  (Mostly, but, no, not entirely; in '`test/os/mac_spec.rb`,' '`Locale::parse`' failed to parse '`OS::Mac::language`,' but this is unrelated.)  

-----

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;I've been meaning to submit this for  a while, so it's _about_ time I got around to it (and it's such a _simple_ change, too…)  