### PR TITLE
[WIP] unpack_strategy: handle xar-compressed .pkg files

### DIFF
--- a/Library/Homebrew/unpack_strategy/pkg.rb
+++ b/Library/Homebrew/unpack_strategy/pkg.rb
@@ -12,5 +12,17 @@ module UnpackStrategy
       path.extname.match?(/\A.m?pkg\Z/) &&
         (path.directory? || path.magic_number.match?(/\Axar!/n))
     end
+
+    private
+
+    def extract_to_dir(unpack_dir, basename:, verbose:)
+      if path.directory?
+        super
+      else
+        system_command! "xar",
+                        args:    ["-x", "-f", path, "-C", unpack_dir],
+                        verbose: verbose
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Asking for help with this fix for handling .pkg files. As you may know, Mac installer .pkg files can be either packages with a Contents folder within, or a XAR archive. So far, the only package in homebrew/core that downloads a .pkg directly is `apple-gcc42`, and attempting to install gives this error:
```
==> Downloading https://r.research.att.com/tools/gcc-42-5666.3-darwin11.pkg
Already downloaded: /Users/serveradmin/Library/Caches/Homebrew/downloads/04786ca1b8eeacb44348a35f53f12103a3a6a4efc4e18375f2558c6e78ec53eb--gcc-42-5666.3-darwin11.pkg
==> /bin/pax --insecure -rz -f usr.pkg/Payload -s ,./usr,/usr/local/Cellar/apple-gcc42/4.2.1-5666.3,
Last 15 lines from /Users/serveradmin/Library/Logs/Homebrew/apple-gcc42/01.pax:
2018-11-17 15:05:02 -0500

/bin/pax
--insecure
-rz
-f
usr.pkg/Payload
-s
,./usr,/usr/local/Cellar/apple-gcc42/4.2.1-5666.3,

pax: Failed open to read on usr.pkg/Payload <No such file or directory>
```
This is because `unpack_strategy/pkg.rb` is being picked based on the file extension, but it's not first extracting its contents with `xar`. This PR fixes that and allows the formula to install, but now tests are failing: 
```
  1) Cask::Installer install works naked-pkg-based Casks
     Failure/Error: expect(Cask::Caskroom.path.join("container-pkg", naked_pkg.version, "container.pkg")).to be_a_file
       expected `#<Pathname:/tmp/homebrew-tests-20181117-16513-168oqs6/prefix/Caskroom/container-pkg/1.2.3/container.pkg>.file?` to return true, got false
     # ./test/cask/installer_spec.rb:182:in `block (3 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/homebrew_cask.rb:38:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:137:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:123:in `block in run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```
```
  1) Cask::Quarantine by default quarantines the pkg in naked-pkg-based Casks
     Failure/Error:
       expect(
         Cask::Caskroom.path.join("container-pkg", naked_pkg.version, "container.pkg"),
       ).to be_quarantined
     
       expected #<Pathname:/tmp/homebrew-tests-20181117-16517-sbz8pc/prefix/Caskroom/container-pkg/1.2.3/container.pkg> to be quarantined
     # ./test/cask/quarantine_spec.rb:109:in `block (3 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/homebrew_cask.rb:38:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:137:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:123:in `block in run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-retry-0.6.1/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.3.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```
brew config / --env output:
```
$ brew config
HOMEBREW_VERSION: 1.8.2-97-g162b643
ORIGIN: https://github.com/Homebrew/brew
HEAD: 162b643327f7a78272b6a329e31da05dd22f9955
Last commit: 6 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 50c4ae03d933a76b2671bfae6162be16e049ceb5
Core tap last commit: 14 hours ago
HOMEBREW_PREFIX: /usr/local
HOMEBREW_DEVELOPER: 1
HOMEBREW_SYSTEM_CURL_TOO_OLD: 1
CPU: dual-core 64-bit sandybridge
Homebrew Ruby: 2.3.7 => /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.3.7/bin/ruby
Clang: 6.0 build 600
Git: 2.19.1 => /usr/local/opt/git/bin/git
Curl: 7.62.0 => /usr/local/opt/curl/bin/curl
macOS: 10.9.5-x86_64
CLT: 6.2.0.0.1.1424975374
Xcode: N/A

$ brew --env
HOMEBREW_CC: clang
HOMEBREW_CXX: clang++
MAKEFLAGS: -j2
CMAKE_PREFIX_PATH: /usr/local
CMAKE_INCLUDE_PATH: /usr/include/libxml2:/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers
CMAKE_LIBRARY_PATH: /System/Library/Frameworks/OpenGL.framework/Versions/Current/Libraries
PKG_CONFIG_LIBDIR: /usr/lib/pkgconfig:/usr/local/Homebrew/Library/Homebrew/os/mac/pkgconfig/10.9
HOMEBREW_GIT: /usr/local/opt/git/bin/git
ACLOCAL_PATH: /usr/local/share/aclocal
PATH: /usr/local/Homebrew/Library/Homebrew/shims/mac/super:/usr/bin:/bin:/usr/sbin:/sbin
```
Ideas, suggestions? This came out of some fixes for older system support in Homebrew/install#154.