### PR TITLE
Fix Language::Java::java_home_cmd for Linux

### DIFF
--- a/Library/Homebrew/extend/os/language/java.rb
+++ b/Library/Homebrew/extend/os/language/java.rb
@@ -1,0 +1,1 @@
+require "extend/os/mac/language/java" if OS.mac?

--- a/Library/Homebrew/extend/os/mac/language/java.rb
+++ b/Library/Homebrew/extend/os/mac/language/java.rb
@@ -1,0 +1,18 @@
+module Language
+  module Java
+    def self.java_home_cmd(version = nil)
+      version_flag = " --version #{version}" if version
+      "/usr/libexec/java_home#{version_flag}"
+    end
+
+    def self.java_home(version = nil)
+      cmd = Language::Java.java_home_cmd(version)
+      Pathname.new Utils.popen_read(cmd).chomp
+    end
+
+    # @private
+    def self.java_home_shell(version = nil)
+      "$(#{java_home_cmd(version)})"
+    end
+  end
+end

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -356,7 +356,7 @@ class Pathname
   def write_jar_script(target_jar, script_name, java_opts = "", java_version: nil)
     mkpath
     java_home = if java_version
-      "JAVA_HOME=\"$(#{Language::Java.java_home_cmd(java_version)})\" "
+      "JAVA_HOME=\"#{Language::Java.java_home_shell(java_version)}\" "
     end
     join(script_name).write <<~SH
       #!/bin/bash

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -1,16 +1,29 @@
 module Language
   module Java
-    def self.java_home_cmd(version = nil)
-      version_flag = " --version #{version}" if version
-      "/usr/libexec/java_home#{version_flag}"
+    def self.java_home_cmd(_ = nil)
+      # macOS provides /usr/libexec/java_home, but Linux does not.
+      raise NotImplementedError
+    end
+
+    def self.java_home(version = nil)
+      req = JavaRequirement.new [*version]
+      raise UnsatisfiedRequirements, req.message unless req.satisfied?
+      req.java_home
+    end
+
+    # @private
+    def self.java_home_shell(version = nil)
+      java_home(version).to_s
     end
 
     def self.java_home_env(version = nil)
-      { JAVA_HOME: "$(#{java_home_cmd(version)})" }
+      { JAVA_HOME: java_home_shell(version) }
     end
 
     def self.overridable_java_home_env(version = nil)
-      { JAVA_HOME: "${JAVA_HOME:-$(#{java_home_cmd(version)})}" }
+      { JAVA_HOME: "${JAVA_HOME:-#{java_home_shell(version)}}" }
     end
   end
 end
+
+require "extend/os/language/java"

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -1,6 +1,8 @@
 require "language/java"
 
 class JavaRequirement < Requirement
+  attr_reader :java_home
+
   fatal true
   download "https://www.oracle.com/technetwork/java/javase/downloads/index.html"
 

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -1,25 +1,37 @@
 require "language/java"
 
 describe Language::Java do
+  describe "::java_home" do
+    it "returns valid JAVA_HOME if version is specified", :needs_java do
+      java_home = described_class.java_home("1.8+")
+      expect(java_home/"bin/java").to be_an_executable
+    end
+
+    it "returns valid JAVA_HOME if version is not specified", :needs_java do
+      java_home = described_class.java_home
+      expect(java_home/"bin/java").to be_an_executable
+    end
+  end
+
   describe "::java_home_env" do
-    it "returns java_home path with version if version specified" do
+    it "returns java_home path with version if version specified", :needs_macos do
       java_home = described_class.java_home_env("blah")
       expect(java_home[:JAVA_HOME]).to include("--version blah")
     end
 
-    it "returns java_home path without version if version is not specified" do
+    it "returns java_home path without version if version is not specified", :needs_java do
       java_home = described_class.java_home_env
       expect(java_home[:JAVA_HOME]).not_to include("--version")
     end
   end
 
   describe "::overridable_java_home_env" do
-    it "returns java_home path with version if version specified" do
+    it "returns java_home path with version if version specified", :needs_macos do
       java_home = described_class.overridable_java_home_env("blah")
       expect(java_home[:JAVA_HOME]).to include("--version blah")
     end
 
-    it "returns java_home path without version if version is not specified" do
+    it "returns java_home path without version if version is not specified", :needs_java do
       java_home = described_class.overridable_java_home_env
       expect(java_home[:JAVA_HOME]).not_to include("--version")
     end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -85,6 +85,16 @@ RSpec.configure do |config|
     skip "Not on macOS." unless OS.mac?
   end
 
+  config.before(:each, :needs_java) do
+    java_installed = if OS.mac?
+      Utils.popen_read("/usr/libexec/java_home", "--failfast")
+      $CHILD_STATUS.success?
+    else
+      which("java")
+    end
+    skip "Java not installed." unless java_installed
+  end
+
   config.before(:each, :needs_python) do
     skip "Python not installed." unless which("python")
   end


### PR DESCRIPTION
`/usr/libexec/java_home` is specific to macOS.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?