### PR TITLE
Added Utils::Shell.subshell for embedding capturing subshells

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -3,6 +3,7 @@
 #:    recognizes can be passed before the formula list.
 
 require "formula"
+require "utils/shell"
 
 module Homebrew
   module_function
@@ -22,10 +23,10 @@ module Homebrew
     repo = Utils.popen_read("git rev-parse --show-toplevel").chomp
     if tap
       name = tap.to_s
-      git_cd = "$(brew --repo #{tap})"
+      git_cd = Utils::Shell.subshell("brew --repo #{tap}")
     elsif cd_dir == HOMEBREW_REPOSITORY
       name = "Homebrew/brew"
-      git_cd = "$(brew --repo)"
+      git_cd = Utils::Shell.subshell("brew --repo")
     else
       name, git_cd = cd_dir
     end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -312,7 +312,7 @@ module Homebrew
 
           You should create these directories and change their ownership to your account.
             sudo mkdir -p #{not_exist_dirs.join(" ")}
-            sudo chown -R $(whoami) #{not_exist_dirs.join(" ")}
+            sudo chown -R #{Utils::Shell.subshell('whoami')} #{not_exist_dirs.join(" ")}
         EOS
       end
 
@@ -327,7 +327,7 @@ module Homebrew
           #{not_writable_dirs.join("\n")}
 
           You should change the ownership of these directories to your user.
-            sudo chown -R $(whoami) #{not_writable_dirs.join(" ")}
+            sudo chown -R #{Utils::Shell.subshell('whoami')} #{not_writable_dirs.join(" ")}
         EOS
       end
 
@@ -599,7 +599,7 @@ module Homebrew
           Homebrew/homebrew-core is not on the master branch
 
           Check out the master branch by running:
-            git -C "$(brew --repo homebrew/core)" checkout master
+            git -C "#{Utils::Shell.subshell('brew --repo homebrew/core')}" checkout master
         EOS
       end
 

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -1,3 +1,5 @@
+require "utils/shell"
+
 module Language
   module Java
     def self.java_home_cmd(version = nil)
@@ -6,11 +8,11 @@ module Language
     end
 
     def self.java_home_env(version = nil)
-      { JAVA_HOME: "$(#{java_home_cmd(version)})" }
+      { JAVA_HOME: Utils::Shell.subshell(java_home_cmd(version)) }
     end
 
     def self.overridable_java_home_env(version = nil)
-      { JAVA_HOME: "${JAVA_HOME:-$(#{java_home_cmd(version)})}" }
+      { JAVA_HOME: "${JAVA_HOME:-#{Utils::Shell.subshell(java_home_cmd(version))}" }
     end
   end
 end

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -1,4 +1,5 @@
 require "formulary"
+require "utils/shell"
 
 module Homebrew
   module MissingFormula
@@ -132,7 +133,7 @@ module Homebrew
             if (tap.path/".git/shallow").exist?
               opoo <<~EOS
                 #{tap} is shallow clone. To get complete history run:
-                  git -C "$(brew --repo #{tap})" fetch --unshallow
+                  git -C "#{Utils::Shell.subshell('brew --repo ' + tap)}" fetch --unshallow
 
               EOS
             end
@@ -159,7 +160,7 @@ module Homebrew
               #{commit_message}
 
             To show the formula before removal run:
-              git -C "$(brew --repo #{tap})" show #{short_hash}^:#{relative_path}
+              git -C "#{Utils::Shell.subshell('brew --repo ' + tap)}" show #{short_hash}^:#{relative_path}
 
             If you still use this formula consider creating your own tap:
               https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -52,6 +52,19 @@ describe Utils::Shell do
     end
   end
 
+  describe "::subshell" do
+    it "returns (...) for fish" do
+      ENV["SHELL"] = "/usr/bin/fish"
+      expect(subject.subshell('whoami')).to eq("(whoami)")
+    end
+    %w[bash csh ksh sh tcsh zsh].each |shell| do
+      it "returns $(...) for #{shell}" do
+        ENV["SHELL"] = "/bin/#{shell}"
+        expect(subject.subshell('whoami')).to eq("$(whoami)")
+      end
+    end
+  end
+
   specify "::sh_quote" do
     expect(subject.send(:sh_quote, "")).to eq("''")
     expect(subject.send(:sh_quote, "\\")).to eq("\\\\")

--- a/Library/Homebrew/update_migrator.rb
+++ b/Library/Homebrew/update_migrator.rb
@@ -1,5 +1,6 @@
 require "cask/cask_loader"
 require "cask/download"
+require "utils/shell"
 
 module UpdateMigrator
   class << self
@@ -270,7 +271,7 @@ module UpdateMigrator
           You should change the ownership and permissions of #{HOMEBREW_PREFIX}
           temporarily back to your user account so we can complete the Homebrew
           repository migration:
-            sudo chown -R $(whoami) #{HOMEBREW_PREFIX}
+            sudo chown -R #{Utils::Shell.subshell('whoami')} #{HOMEBREW_PREFIX}
         EOS
         return
       end
@@ -354,7 +355,7 @@ module UpdateMigrator
           Could not create symlink at #{dst}!
           Please do this manually with:
             sudo ln -sf #{src} #{dst}
-            sudo chown $(whoami) #{dst}
+            sudo chown #{Utils::Shell.subshell('whoami')} #{dst}
         EOS
       end
 

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -62,6 +62,14 @@ module Utils
       end
     end
 
+    def subshell(cmd):
+      case preferred
+      when :fish
+        "(#{cmd})"
+      else
+        "$(#{cmd})"
+    end
+
     SHELL_PROFILE_MAP = {
       bash: "~/.bash_profile",
       csh:  "~/.cshrc",


### PR DESCRIPTION
This should improve diagnostic messages on the fish-shell which doesn't
use `$()` for capturing the subshell output.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
