### PR TITLE
Added Shell Translation

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -3,6 +3,9 @@
 #:    recognizes can be passed before the formula list.
 
 require "formula"
+require "utils/shell"
+
+using Utils::Shell
 
 module Homebrew
   module_function
@@ -31,7 +34,7 @@ module Homebrew
     end
 
     if File.exist? "#{repo}/.git/shallow"
-      opoo <<~EOS
+      opoo <<~EOS.for_shell
         #{name} is a shallow clone so only partial output will be shown.
         To get a full clone run:
           git -C "#{git_cd}" fetch --unshallow

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -5,6 +5,8 @@ require "version"
 require "development_tools"
 require "utils/shell"
 
+using Utils::Shell
+
 module Homebrew
   module Diagnostic
     def self.missing_deps(ff, hide = nil)
@@ -306,7 +308,7 @@ module Homebrew
         not_exist_dirs = Keg::MUST_EXIST_DIRECTORIES.reject(&:exist?)
         return if not_exist_dirs.empty?
 
-        <<~EOS
+        <<~EOS.for_shell
           The following directories do not exist:
           #{not_exist_dirs.join("\n")}
 
@@ -322,7 +324,7 @@ module Homebrew
                                            .reject(&:writable_real?)
         return if not_writable_dirs.empty?
 
-        <<~EOS
+        <<~EOS.for_shell
           The following directories are not writable by your user:
           #{not_writable_dirs.join("\n")}
 
@@ -595,7 +597,7 @@ module Homebrew
         branch = coretap_path.git_branch
         return if branch.nil? || branch =~ /master/
 
-        <<~EOS
+        <<~EOS.for_shell
           Homebrew/homebrew-core is not on the master branch
 
           Check out the master branch by running:

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -1,3 +1,5 @@
+require "utils/shell"
+
 module Language
   module Java
     def self.java_home_cmd(version = nil)

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -1,4 +1,7 @@
 require "formulary"
+require "utils/shell"
+
+using Utils::Shell
 
 module Homebrew
   module MissingFormula
@@ -130,7 +133,7 @@ module Homebrew
           unless silent
             ohai "Searching for a previously deleted formula (in the last month)..."
             if (tap.path/".git/shallow").exist?
-              opoo <<~EOS
+              opoo <<~EOS.for_shell
                 #{tap} is shallow clone. To get complete history run:
                   git -C "$(brew --repo #{tap})" fetch --unshallow
 
@@ -154,7 +157,7 @@ module Homebrew
           commit_message.sub!(/ \(#(\d+)\)$/, " (#{tap.issues_url}/\\1)")
           commit_message.gsub!(/(Closes|Fixes) #(\d+)/, "\\1 #{tap.issues_url}/\\2")
 
-          <<~EOS
+          <<~EOS.for_shell
             #{name} was deleted from #{tap.name} in commit #{short_hash}:
               #{commit_message}
 

--- a/Library/Homebrew/update_migrator.rb
+++ b/Library/Homebrew/update_migrator.rb
@@ -1,5 +1,8 @@
 require "cask/cask_loader"
 require "cask/download"
+require "utils/shell"
+
+using Utils::Shell
 
 module UpdateMigrator
   class << self
@@ -264,7 +267,7 @@ module UpdateMigrator
       ohai "Migrating HOMEBREW_REPOSITORY (please wait)..."
 
       unless HOMEBREW_PREFIX.writable_real?
-        ofail <<~EOS
+        ofail <<~EOS.for_shell
           #{HOMEBREW_PREFIX} is not writable.
 
           You should change the ownership and permissions of #{HOMEBREW_PREFIX}
@@ -350,7 +353,7 @@ module UpdateMigrator
       begin
         FileUtils.ln_s(src.relative_path_from(dst.parent), dst)
       rescue Errno::EACCES, Errno::ENOENT
-        ofail <<~EOS
+        ofail <<~EOS.for_shell
           Could not create symlink at #{dst}!
           Please do this manually with:
             sudo ln -sf #{src} #{dst}

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -98,5 +98,25 @@ module Utils
       str.gsub!(/\n/, "'\n'")
       str
     end
+
+    def subshell(str)
+      case preferred
+      when :fish
+        str.
+          # fish capturing sub-shells are (...)
+          gsub("$(", "(").
+          # fish sub-shells don't work in quoted strings (but don't need
+          # quoting since the captured result doesn't split on IFS)
+          gsub(/"\((.*)\)"/, '(\1)')
+      else
+        str
+      end
+    end
+
+    refine String do
+      def for_shell
+        Utils::Shell.subshell(self)
+      end
+    end
   end
 end


### PR DESCRIPTION
String#for_shell provides translation for capturing subshells to allow
    fish-shell compatible diagnostic messages.

Alternative to #5343

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----