### PR TITLE
audit: Disable "Don't use OS.mac?" for Linuxbrew

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -180,7 +180,7 @@ module RuboCop
           end
 
           [:mac?, :linux?].each do |method_name|
-            next unless formula_tap == "homebrew-core"
+            next if formula_tap != "homebrew-core" || file_path&.match(/linuxbrew/)
 
             find_instance_method_call(body_node, "OS", method_name) do |check|
               problem "Don't use #{check.source}; Homebrew/core only supports macOS"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Linuxbrew/homebrew-core uses `OS.mac?`. Disable this audit check for Linuxbrew.