### PR TITLE
Use Homebrew-controlled domain for Cask dummy URLs

### DIFF
--- a/Library/Homebrew/test/bottle_filename_spec.rb
+++ b/Library/Homebrew/test/bottle_filename_spec.rb
@@ -45,7 +45,7 @@ describe Bottle::Filename do
 
     let(:f) {
       formula do
-        url "https://example.com/foo.tar.gz"
+        url "https://brew.sh/foo.tar.gz"
         version "1.0"
       end
     }

--- a/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/alt_target_spec.rb
@@ -31,7 +31,7 @@ describe Cask::Artifact::App, :cask do
       let(:cask) {
         Cask::Cask.new("subdir") do
           url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-          homepage "https://example.com/local-caffeine"
+          homepage "https://brew.sh/local-caffeine"
           version "1.2.3"
           sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
           app "subdir/Caffeine.app", target: "AnotherName.app"

--- a/Library/Homebrew/test/cask/artifact/app_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/app_spec.rb
@@ -26,7 +26,7 @@ describe Cask::Artifact::App, :cask do
       let(:cask) {
         Cask::Cask.new("subdir") do
           url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-          homepage "https://example.com/local-caffeine"
+          homepage "https://brew.sh/local-caffeine"
           version "1.2.3"
           sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
           app "subdir/Caffeine.app"

--- a/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from_uri_loader_spec.rb
@@ -3,17 +3,17 @@ describe Cask::CaskLoader::FromURILoader do
 
   describe "::can_load?" do
     it "returns true when given an URI" do
-      expect(described_class).to be_able_to_load(URI("https://example.com/"))
+      expect(described_class).to be_able_to_load(URI("https://brew.sh/"))
     end
 
     it "returns true when given a String which can be parsed to a URI" do
-      expect(described_class).to be_able_to_load("https://example.com/")
+      expect(described_class).to be_able_to_load("https://brew.sh/")
     end
 
     it "returns false when given a String with Cask contents containing a URL" do
       expect(described_class).not_to be_able_to_load <<~RUBY
         cask 'token' do
-          url 'https://example.com/'
+          url 'https://brew.sh/'
         end
       RUBY
     end

--- a/Library/Homebrew/test/cask/cmd/cat_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/cat_spec.rb
@@ -12,8 +12,8 @@ describe Cask::Cmd::Cat, :cask do
           version '1.2.3'
           sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
-          url 'https://example.com/TestCask.dmg'
-          homepage 'https://example.com/'
+          url 'https://brew.sh/TestCask.dmg'
+          homepage 'https://brew.sh/'
 
           app 'TestCask.app'
         end

--- a/Library/Homebrew/test/cask/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/home_spec.rb
@@ -8,13 +8,13 @@ describe Cask::Cmd::Home, :cask do
   it_behaves_like "a command that handles invalid options"
 
   it "opens the homepage for the specified Cask" do
-    expect(described_class).to receive(:open_url).with("https://example.com")
+    expect(described_class).to receive(:open_url).with("https://brew.sh")
     described_class.run("local-caffeine")
   end
 
   it "works for multiple Casks" do
-    expect(described_class).to receive(:open_url).with("https://example.com")
-    expect(described_class).to receive(:open_url).with("https://example.com")
+    expect(described_class).to receive(:open_url).with("https://brew.sh")
+    expect(described_class).to receive(:open_url).with("https://brew.sh")
     described_class.run("local-caffeine", "local-transmission")
   end
 

--- a/Library/Homebrew/test/cask/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/info_spec.rb
@@ -10,7 +10,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("local-caffeine")
     }.to output(<<~EOS).to_stdout
       local-caffeine: 1.2.3
-      https://example.com
+      https://brew.sh
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/local-caffeine.rb
       ==> Name
@@ -25,7 +25,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("with-auto-updates")
     }.to output(<<~EOS).to_stdout
       with-auto-updates: 1.0 (auto_updates)
-      https://example.com/autoupdates
+      https://brew.sh/autoupdates
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-auto-updates.rb
       ==> Name
@@ -39,7 +39,7 @@ describe Cask::Cmd::Info, :cask do
     let(:expected_output) {
       <<~EOS
         local-caffeine: 1.2.3
-        https://example.com
+        https://brew.sh
         Not installed
         From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/local-caffeine.rb
         ==> Name
@@ -47,7 +47,7 @@ describe Cask::Cmd::Info, :cask do
         ==> Artifacts
         Caffeine.app (App)
         local-transmission: 2.61
-        https://example.com
+        https://brew.sh
         Not installed
         From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/local-transmission.rb
         ==> Name
@@ -69,7 +69,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("with-caveats")
     }.to output(<<~EOS).to_stdout
       with-caveats: 1.2.3
-      https://example.com
+      https://brew.sh
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-caveats.rb
       ==> Name
@@ -95,7 +95,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("with-conditional-caveats")
     }.to output(<<~EOS).to_stdout
       with-conditional-caveats: 1.2.3
-      https://example.com
+      https://brew.sh
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-conditional-caveats.rb
       ==> Name
@@ -110,7 +110,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("with-languages")
     }.to output(<<~EOS).to_stdout
       with-languages: 1.2.3
-      https://example.com
+      https://brew.sh
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-languages.rb
       ==> Name
@@ -127,7 +127,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("without-languages")
     }.to output(<<~EOS).to_stdout
       without-languages: 1.2.3
-      https://example.com
+      https://brew.sh
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/without-languages.rb
       ==> Name

--- a/Library/Homebrew/test/cask/cmd/internal_stanza_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/internal_stanza_spec.rb
@@ -3,7 +3,7 @@ describe Cask::Cmd::InternalStanza, :cask do
     command = described_class.new("homepage", "local-caffeine")
     expect {
       command.run
-    }.to output("https://example.com\n").to_stdout
+    }.to output("https://brew.sh\n").to_stdout
   end
 
   it "raises an exception when stanza is unknown/unsupported" do

--- a/Library/Homebrew/test/cask/dsl/appcast_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/appcast_spec.rb
@@ -3,13 +3,13 @@ require "cmd/cask"
 describe Cask::DSL::Appcast do
   subject { described_class.new(url, params) }
 
-  let(:url) { "https://example.com" }
+  let(:url) { "https://brew.sh" }
   let(:uri) { URI(url) }
   let(:params) { {} }
 
   describe "#to_s" do
     it "returns the parsed URI string" do
-      expect(subject.to_s).to eq("https://example.com")
+      expect(subject.to_s).to eq("https://brew.sh")
     end
   end
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -4,8 +4,8 @@ describe Cask::DSL, :cask do
 
   context "stanzas" do
     it "lets you set url, homepage, and version" do
-      expect(cask.url.to_s).to eq("https://example.com/TestCask.dmg")
-      expect(cask.homepage).to eq("https://example.com/")
+      expect(cask.url.to_s).to eq("https://brew.sh/TestCask.dmg")
+      expect(cask.homepage).to eq("https://brew.sh/")
       expect(cask.version.to_s).to eq("1.2.3")
     end
   end
@@ -65,8 +65,8 @@ describe Cask::DSL, :cask do
 
       it "does not require a DSL version in the header" do
         expect(cask.token).to eq("no-dsl-version")
-        expect(cask.url.to_s).to eq("https://example.com/TestCask.dmg")
-        expect(cask.homepage).to eq("https://example.com/")
+        expect(cask.url.to_s).to eq("https://brew.sh/TestCask.dmg")
+        expect(cask.homepage).to eq("https://brew.sh/")
         expect(cask.version.to_s).to eq("1.2.3")
       end
     end

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -3,7 +3,7 @@ describe "brew uses", :integration_test do
     setup_test_formula "foo"
     setup_test_formula "bar"
     setup_test_formula "baz", <<~RUBY
-      url "https://example.com/baz-1.0"
+      url "https://brew.sh/baz-1.0"
       depends_on "bar"
     RUBY
 

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -75,43 +75,43 @@ describe DependencyCollector do
 
     it "creates a resource dependency from a CVS URL" do
       resource = Resource.new
-      resource.url(":pserver:anonymous:@example.com:/cvsroot/foo/bar", using: :cvs)
+      resource.url(":pserver:anonymous:@brew.sh:/cvsroot/foo/bar", using: :cvs)
       expect(subject.add(resource)).to eq(Dependency.new("cvs", [:build]))
     end
 
     it "creates a resource dependency from a '.7z' URL" do
       resource = Resource.new
-      resource.url("https://example.com/foo.7z")
+      resource.url("https://brew.sh/foo.7z")
       expect(subject.add(resource)).to eq(Dependency.new("p7zip", [:build]))
     end
 
     it "creates a resource dependency from a '.gz' URL" do
       resource = Resource.new
-      resource.url("https://example.com/foo.tar.gz")
+      resource.url("https://brew.sh/foo.tar.gz")
       expect(subject.add(resource)).to be nil
     end
 
     it "creates a resource dependency from a '.lz' URL" do
       resource = Resource.new
-      resource.url("https://example.com/foo.lz")
+      resource.url("https://brew.sh/foo.lz")
       expect(subject.add(resource)).to eq(Dependency.new("lzip", [:build]))
     end
 
     it "creates a resource dependency from a '.lha' URL" do
       resource = Resource.new
-      resource.url("https://example.com/foo.lha")
+      resource.url("https://brew.sh/foo.lha")
       expect(subject.add(resource)).to eq(Dependency.new("lha", [:build]))
     end
 
     it "creates a resource dependency from a '.lzh' URL" do
       resource = Resource.new
-      resource.url("https://example.com/foo.lzh")
+      resource.url("https://brew.sh/foo.lzh")
       expect(subject.add(resource)).to eq(Dependency.new("lha", [:build]))
     end
 
     it "creates a resource dependency from a '.rar' URL" do
       resource = Resource.new
-      resource.url("https://example.com/foo.rar")
+      resource.url("https://brew.sh/foo.rar")
       expect(subject.add(resource)).to eq(Dependency.new("unrar", [:build]))
     end
 

--- a/Library/Homebrew/test/deps_spec.rb
+++ b/Library/Homebrew/test/deps_spec.rb
@@ -3,7 +3,7 @@ describe "brew deps", :integration_test do
     setup_test_formula "foo"
     setup_test_formula "bar"
     setup_test_formula "baz", <<~RUBY
-      url "https://example.com/baz-1.0"
+      url "https://brew.sh/baz-1.0"
       depends_on "bar"
     RUBY
   end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -31,7 +31,7 @@ module Homebrew
 
     specify "simple valid Formula" do
       ft = formula_text "valid", <<~RUBY
-        url "https://www.example.com/valid-1.0.tar.gz"
+        url "https://www.brew.sh/valid-1.0.tar.gz"
       RUBY
 
       expect(ft).not_to have_data
@@ -80,7 +80,7 @@ module Homebrew
       it "is empty by default" do
         fa = formula_auditor "foo", <<~RUBY
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
 
@@ -94,7 +94,7 @@ module Homebrew
 
         fa = formula_auditor "foo", <<~RUBY
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
 
@@ -109,7 +109,7 @@ module Homebrew
       specify "DATA but no __END__" do
         fa = formula_auditor "foo", <<~RUBY
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
             patch :DATA
           end
         RUBY
@@ -121,7 +121,7 @@ module Homebrew
       specify "__END__ but no DATA" do
         fa = formula_auditor "foo", <<~RUBY
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
           end
           __END__
           a patch goes here
@@ -141,8 +141,8 @@ module Homebrew
       specify "no issue" do
         fa = formula_auditor "foo", <<~RUBY
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
-            homepage "https://example.com"
+            url "https://brew.sh/foo-1.0.tgz"
+            homepage "https://brew.sh"
           end
         RUBY
 
@@ -155,7 +155,7 @@ module Homebrew
       specify "pkgshare" do
         fa = formula_auditor "foo", <<~RUBY, strict: true
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
 
@@ -188,7 +188,7 @@ module Homebrew
         fa = formula_auditor "foolibc++", <<~RUBY, strict: true
           class Foolibcxx < Formula
             desc "foolibc++ is a test"
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
 
@@ -209,7 +209,7 @@ module Homebrew
         fa = formula_auditor "foo", <<~RUBY, strict: true, online: true
           class Foo < Formula
             homepage "https://github.com/example/example"
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
 
@@ -226,8 +226,8 @@ module Homebrew
           let(:fa) do
             formula_auditor "foo", <<~RUBY, new_formula: true
               class Foo < Formula
-                url "https://example.com/foo-1.0.tgz"
-                homepage "https://example.com"
+                url "https://brew.sh/foo-1.0.tgz"
+                homepage "https://brew.sh"
 
                 depends_on "openssl"
               end
@@ -236,8 +236,8 @@ module Homebrew
 
           let(:f_openssl) do
             formula do
-              url "https://example.com/openssl-1.0.tgz"
-              homepage "https://example.com"
+              url "https://brew.sh/openssl-1.0.tgz"
+              homepage "https://brew.sh"
 
               keg_only :provided_by_macos
             end
@@ -258,8 +258,8 @@ module Homebrew
           let(:fa) do
             formula_auditor "foo", <<~RUBY, new_formula: true
               class Foo < Formula
-                url "https://example.com/foo-1.0.tgz"
-                homepage "https://example.com"
+                url "https://brew.sh/foo-1.0.tgz"
+                homepage "https://brew.sh"
 
                 depends_on "bc"
               end
@@ -268,8 +268,8 @@ module Homebrew
 
           let(:f_bc) do
             formula do
-              url "https://example.com/bc-1.0.tgz"
-              homepage "https://example.com"
+              url "https://brew.sh/bc-1.0.tgz"
+              homepage "https://brew.sh"
 
               keg_only :provided_by_macos
             end
@@ -290,7 +290,7 @@ module Homebrew
       specify "keg_only_needs_downcasing" do
         fa = formula_auditor "foo", <<~RUBY, strict: true
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
 
             keg_only "Because why not"
           end
@@ -304,7 +304,7 @@ module Homebrew
       specify "keg_only_redundant_period" do
         fa = formula_auditor "foo", <<~RUBY, strict: true
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
 
             keg_only "because this line ends in a period."
           end
@@ -318,7 +318,7 @@ module Homebrew
       specify "keg_only_handles_block_correctly" do
         fa = formula_auditor "foo", <<~RUBY, strict: true
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
 
             keg_only <<~EOF
               this line starts with a lowercase word.
@@ -337,7 +337,7 @@ module Homebrew
       specify "keg_only_handles_whitelist_correctly" do
         fa = formula_auditor "foo", <<~RUBY, strict: true
           class Foo < Formula
-            url "https://example.com/foo-1.0.tgz"
+            url "https://brew.sh/foo-1.0.tgz"
 
             keg_only "Apple ships foo in the CLT package"
           end
@@ -366,7 +366,7 @@ module Homebrew
       before do
         origin_formula_path.write <<~RUBY
           class Foo#{foo_version} < Formula
-            url "https://example.com/foo-1.0.tar.gz"
+            url "https://brew.sh/foo-1.0.tar.gz"
             revision 2
             version_scheme 1
           end
@@ -527,7 +527,7 @@ module Homebrew
       specify "it detects a url containing darwin and x86_64" do
         fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
-            url "https://example.com/example-darwin.x86_64.tar.gz"
+            url "https://brew.sh/example-darwin.x86_64.tar.gz"
           end
         RUBY
 
@@ -540,7 +540,7 @@ module Homebrew
       specify "it detects a url containing darwin and amd64" do
         fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
-            url "https://example.com/example-darwin.amd64.tar.gz"
+            url "https://brew.sh/example-darwin.amd64.tar.gz"
           end
         RUBY
 
@@ -553,10 +553,10 @@ module Homebrew
       specify "it works on the devel spec" do
         fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
-            url "https://example.com/valid-1.0.tar.gz"
+            url "https://brew.sh/valid-1.0.tar.gz"
 
             devel do
-              url "https://example.com/example-darwin.x86_64.tar.gz"
+              url "https://brew.sh/example-darwin.x86_64.tar.gz"
             end
           end
         RUBY
@@ -570,10 +570,10 @@ module Homebrew
       specify "it works on the head spec" do
         fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
-            url "https://example.com/valid-1.0.tar.gz"
+            url "https://brew.sh/valid-1.0.tar.gz"
 
             head do
-              url "https://example.com/example-darwin.x86_64.tar.gz"
+              url "https://brew.sh/example-darwin.x86_64.tar.gz"
             end
           end
         RUBY
@@ -587,10 +587,10 @@ module Homebrew
       specify "it ignores resource urls" do
         fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
-            url "https://example.com/valid-1.0.tar.gz"
+            url "https://brew.sh/valid-1.0.tar.gz"
 
             resource "binary_res" do
-              url "https://example.com/example-darwin.x86_64.tar.gz"
+              url "https://brew.sh/example-darwin.x86_64.tar.gz"
             end
           end
         RUBY
@@ -605,7 +605,7 @@ module Homebrew
       specify "it warns when a versioned formula is not `keg_only`" do
         fa = formula_auditor "foo@1.1", <<~RUBY, core_tap: true
           class FooAT11 < Formula
-            url "https://example.com/foo-1.1.tgz"
+            url "https://brew.sh/foo-1.1.tgz"
           end
         RUBY
 
@@ -618,7 +618,7 @@ module Homebrew
       specify "it warns when a versioned formula has an incorrect `keg_only` reason" do
         fa = formula_auditor "foo@1.1", <<~RUBY, core_tap: true
           class FooAT11 < Formula
-            url "https://example.com/foo-1.1.tgz"
+            url "https://brew.sh/foo-1.1.tgz"
 
             keg_only :provided_by_macos
           end
@@ -633,7 +633,7 @@ module Homebrew
       specify "it does not warn when a versioned formula has `keg_only :versioned_formula`" do
         fa = formula_auditor "foo@1.1", <<~RUBY, core_tap: true
           class FooAT11 < Formula
-            url "https://example.com/foo-1.1.tgz"
+            url "https://brew.sh/foo-1.1.tgz"
 
             keg_only :versioned_formula
           end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -17,7 +17,7 @@ describe Formula do
   describe "::new" do
     let(:klass) do
       Class.new(described_class) do
-        url "https://example.com/foo-1.0.tar.gz"
+        url "https://brew.sh/foo-1.0.tar.gz"
       end
     end
 
@@ -510,22 +510,22 @@ describe Formula do
 
   specify "spec integration" do
     f = formula do
-      homepage "https://example.com"
+      homepage "https://brew.sh"
 
-      url "https://example.com/test-0.1.tbz"
+      url "https://brew.sh/test-0.1.tbz"
       mirror "https://example.org/test-0.1.tbz"
       sha256 TEST_SHA256
 
-      head "https://example.com/test.git", tag: "foo"
+      head "https://brew.sh/test.git", tag: "foo"
 
       devel do
-        url "https://example.com/test-0.2.tbz"
+        url "https://brew.sh/test-0.2.tbz"
         mirror "https://example.org/test-0.2.tbz"
         sha256 TEST_SHA256
       end
     end
 
-    expect(f.homepage).to eq("https://example.com")
+    expect(f.homepage).to eq("https://brew.sh")
     expect(f.version).to eq(Version.create("0.1"))
     expect(f).to be_stable
     expect(f.stable.version).to eq(Version.create("0.1"))

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 
 describe Messages do
   let(:messages) { described_class.new }
-  let(:test_formula) { formula("foo") { url("https://example.com/foo-0.1.tgz") } }
+  let(:test_formula) { formula("foo") { url("https://brew.sh/foo-0.1.tgz") } }
   let(:elapsed_time) { 1.1 }
 
   describe "#record_caveats" do
@@ -51,7 +51,7 @@ describe Messages do
     end
 
     context "when formula_count is greater than one and caveats are present" do
-      let(:test_formula2) { formula("bar") { url("https://example.com/bar-0.1.tgz") } }
+      let(:test_formula2) { formula("bar") { url("https://brew.sh/bar-0.1.tgz") } }
 
       before do
         messages.record_caveats(test_formula, "Zsh completions were installed")

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -12,19 +12,19 @@ describe DependencyCollector do
 
     context "when xz, unzip, and bzip2 are not available" do
       it "creates a resource dependency from a '.xz' URL" do
-        resource.url("https://example.com/foo.xz")
+        resource.url("https://brew.sh/foo.xz")
         allow_any_instance_of(Object).to receive(:which).with("xz")
         expect(subject.add(resource)).to eq(Dependency.new("xz", [:build]))
       end
 
       it "creates a resource dependency from a '.zip' URL" do
-        resource.url("https://example.com/foo.zip")
+        resource.url("https://brew.sh/foo.zip")
         allow_any_instance_of(Object).to receive(:which).with("unzip")
         expect(subject.add(resource)).to eq(Dependency.new("unzip", [:build]))
       end
 
       it "creates a resource dependency from a '.bz2' URL" do
-        resource.url("https://example.com/foo.tar.bz2")
+        resource.url("https://brew.sh/foo.tar.bz2")
         allow_any_instance_of(Object).to receive(:which).with("bzip2")
         expect(subject.add(resource)).to eq(Dependency.new("bzip2", [:build]))
       end
@@ -32,19 +32,19 @@ describe DependencyCollector do
 
     context "when xz, zip, and bzip2 are available" do
       it "does not create a resource dependency from a '.xz' URL" do
-        resource.url("https://example.com/foo.xz")
+        resource.url("https://brew.sh/foo.xz")
         allow_any_instance_of(Object).to receive(:which).with("xz").and_return(Pathname.new("foo"))
         expect(subject.add(resource)).to be nil
       end
 
       it "does not create a resource dependency from a '.zip' URL" do
-        resource.url("https://example.com/foo.zip")
+        resource.url("https://brew.sh/foo.zip")
         allow_any_instance_of(Object).to receive(:which).with("unzip").and_return(Pathname.new("foo"))
         expect(subject.add(resource)).to be nil
       end
 
       it "does not create a resource dependency from a '.bz2' URL" do
-        resource.url("https://example.com/foo.tar.bz2")
+        resource.url("https://brew.sh/foo.tar.bz2")
         allow_any_instance_of(Object).to receive(:which).with("bzip2").and_return(Pathname.new("foo"))
         expect(subject.add(resource)).to be nil
       end

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -25,38 +25,38 @@ describe DependencyCollector do
   specify "Resource xz pre-Mavericks dependency" do
     allow(MacOS).to receive(:version).and_return(MacOS::Version.new("10.8"))
     resource = Resource.new
-    resource.url("https://example.com/foo.tar.xz")
+    resource.url("https://brew.sh/foo.tar.xz")
     expect(subject.add(resource)).to eq(Dependency.new("xz", [:build]))
   end
 
   specify "Resource xz Mavericks or newer dependency" do
     allow(MacOS).to receive(:version).and_return(MacOS::Version.new("10.9"))
     resource = Resource.new
-    resource.url("https://example.com/foo.tar.xz")
+    resource.url("https://brew.sh/foo.tar.xz")
     expect(subject.add(resource)).to be nil
   end
 
   specify "Resource dependency from a '.zip' URL" do
     resource = Resource.new
-    resource.url("https://example.com/foo.zip")
+    resource.url("https://brew.sh/foo.zip")
     expect(subject.add(resource)).to be nil
   end
 
   specify "Resource dependency from a '.bz2' URL" do
     resource = Resource.new
-    resource.url("https://example.com/foo.tar.bz2")
+    resource.url("https://brew.sh/foo.tar.bz2")
     expect(subject.add(resource)).to be nil
   end
 
   specify "Resource dependency from a '.git' URL" do
     resource = Resource.new
-    resource.url("git://example.com/foo/bar.git")
+    resource.url("git://brew.sh/foo/bar.git")
     expect(subject.add(resource)).to be nil
   end
 
   specify "Resource dependency from a Subversion URL" do
     resource = Resource.new
-    resource.url("svn://example.com/foo/bar")
+    resource.url("svn://brew.sh/foo/bar")
     expect(subject.add(resource)).to be nil
   end
 end

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -75,14 +75,14 @@ describe Patch do
 
   describe "#normalize_legacy_patches" do
     it "can create a patch from a single string" do
-      patches = described_class.normalize_legacy_patches("https://example.com/patch.diff")
+      patches = described_class.normalize_legacy_patches("https://brew.sh/patch.diff")
       expect(patches.length).to eq(1)
       expect(patches.first.strip).to eq(:p1)
     end
 
     it "can create patches from an array" do
       patches = described_class.normalize_legacy_patches(
-        %w[https://example.com/patch1.diff https://example.com/patch2.diff],
+        %w[https://brew.sh/patch1.diff https://brew.sh/patch2.diff],
       )
 
       expect(patches.length).to eq(2)
@@ -92,7 +92,7 @@ describe Patch do
 
     it "can create patches from a :p0 hash" do
       patches = described_class.normalize_legacy_patches(
-        p0: "https://example.com/patch.diff",
+        p0: "https://brew.sh/patch.diff",
       )
 
       expect(patches.length).to eq(1)
@@ -101,7 +101,7 @@ describe Patch do
 
     it "can create patches from a :p1 hash" do
       patches = described_class.normalize_legacy_patches(
-        p1: "https://example.com/patch.diff",
+        p1: "https://brew.sh/patch.diff",
       )
 
       expect(patches.length).to eq(1)
@@ -110,8 +110,8 @@ describe Patch do
 
     it "can create patches from a mixed hash" do
       patches = described_class.normalize_legacy_patches(
-        p1: "https://example.com/patch1.diff",
-        p0: "https://example.com/patch0.diff",
+        p1: "https://brew.sh/patch1.diff",
+        p0: "https://brew.sh/patch0.diff",
       )
 
       expect(patches.length).to eq(2)
@@ -122,12 +122,12 @@ describe Patch do
     it "can create patches from a mixed hash with array" do
       patches = described_class.normalize_legacy_patches(
         p1: [
-          "https://example.com/patch10.diff",
-          "https://example.com/patch11.diff",
+          "https://brew.sh/patch10.diff",
+          "https://brew.sh/patch11.diff",
         ],
         p0: [
-          "https://example.com/patch00.diff",
-          "https://example.com/patch01.diff",
+          "https://brew.sh/patch00.diff",
+          "https://brew.sh/patch01.diff",
         ],
       )
 

--- a/Library/Homebrew/test/resource_spec.rb
+++ b/Library/Homebrew/test/resource_spec.rb
@@ -57,7 +57,7 @@ describe Resource do
     end
 
     it "can detect the version from a URL" do
-      subject.url("https://example.com/foo-1.0.tar.gz")
+      subject.url("https://brew.sh/foo-1.0.tar.gz")
       expect(subject.version).to eq(Version.parse("1.0"))
       expect(subject.version).to be_detected_from_url
     end
@@ -70,7 +70,7 @@ describe Resource do
     end
 
     it "can set the version from a tag" do
-      subject.url("https://example.com/foo-1.0.tar.gz", tag: "v1.0.2")
+      subject.url("https://brew.sh/foo-1.0.tar.gz", tag: "v1.0.2")
       expect(subject.version).to eq(Version.parse("1.0.2"))
       expect(subject.version).to be_detected_from_url
     end

--- a/Library/Homebrew/test/rubocops/cask/homepage_matches_url_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/homepage_matches_url_spec.rb
@@ -10,8 +10,8 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          url 'https://foo.example.com/foo.zip'
-          homepage 'https://foo.example.com'
+          url 'https://foo.brew.sh/foo.zip'
+          homepage 'https://foo.brew.sh'
         end
       CASK
     end
@@ -24,9 +24,9 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          url 'https://foo.example.com/foo.zip',
-              referrer: 'https://example.com/foo/'
-          homepage 'https://foo.example.com'
+          url 'https://foo.brew.sh/foo.zip',
+              referrer: 'https://brew.sh/foo/'
+          homepage 'https://foo.brew.sh'
         end
       CASK
     end
@@ -40,9 +40,9 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       <<-CASK.undent
         cask 'foo' do
           version '1.8.0_72,8.13.0.5'
-          url "https://foo.example.com/foo-\#{version.after_comma}-\#{version.minor}.\#{version.patch}.\#{version.before_comma.sub(\%r{.*_}, '')}.zip",
-              referrer: 'https://example.com/foo/'
-          homepage 'https://foo.example.com'
+          url "https://foo.brew.sh/foo-\#{version.after_comma}-\#{version.minor}.\#{version.patch}.\#{version.before_comma.sub(\%r{.*_}, '')}.zip",
+              referrer: 'https://brew.sh/foo/'
+          homepage 'https://foo.brew.sh'
         end
       CASK
     end
@@ -56,8 +56,8 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       <<-CASK.undent
         cask 'foo' do
           # this is just a comment with information
-          url 'https://example.com/foo.zip'
-          homepage 'https://example.com'
+          url 'https://brew.sh/foo.zip'
+          homepage 'https://brew.sh'
         end
       CASK
     end
@@ -70,21 +70,21 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          # foo.example.com was verified as official when first introduced to the cask
-          url 'https://foo.example.com/foo.zip'
-          homepage 'https://foo.example.com'
+          # foo.brew.sh was verified as official when first introduced to the cask
+          url 'https://foo.brew.sh/foo.zip'
+          homepage 'https://foo.brew.sh'
         end
       CASK
     end
     let(:expected_offenses) do
       [{
-        message:  "The URL's domain `foo.example.com` matches the homepage " \
-                 "`foo.example.com`, the comment above the `url` stanza is " \
+        message:  "The URL's domain `foo.brew.sh` matches the homepage " \
+                 "`foo.brew.sh`, the comment above the `url` stanza is " \
                  "unnecessary",
         severity: :convention,
         line:     2,
         column:   2,
-        source:   "# foo.example.com was verified as official when " \
+        source:   "# foo.brew.sh was verified as official when " \
                 "first introduced to the cask",
       }]
     end
@@ -98,22 +98,22 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       let(:source) do
         <<-CASK.undent
           cask 'foo' do
-            # example.com was verified as official
-            url 'https://example.com/foo.zip'
+            # brew.sh was verified as official
+            url 'https://brew.sh/foo.zip'
             homepage 'https://foo.example.org'
           end
         CASK
       end
       let(:expected_offenses) do
         [{
-          message:  "`# example.com was verified as official` does not " \
+          message:  "`# brew.sh was verified as official` does not " \
                    "match the expected comment format. For details, see " \
                   "https://github.com/Homebrew/homebrew-cask/blob/master/doc/" \
                   "cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment",
           severity: :convention,
           line:     2,
           column:   2,
-          source:   "# example.com was verified as official",
+          source:   "# brew.sh was verified as official",
         }]
       end
 
@@ -125,8 +125,8 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       let(:source) do
         <<-CASK.undent
           cask 'foo' do
-            # example.com was verified as official when first introduced to the cask
-            url 'https://example.com/foo.zip'
+            # brew.sh was verified as official when first introduced to the cask
+            url 'https://brew.sh/foo.zip'
             homepage 'https://foo.example.org'
           end
         CASK
@@ -139,8 +139,8 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       let(:source) do
         <<-CASK.undent
           cask 'foo' do
-            # example.com/vendor/app was verified as official when first introduced to the cask
-            url 'https://downloads.example.com/vendor/app/foo.zip'
+            # brew.sh/vendor/app was verified as official when first introduced to the cask
+            url 'https://downloads.brew.sh/vendor/app/foo.zip'
             homepage 'https://vendor.example.org/app/'
           end
         CASK
@@ -153,19 +153,19 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       let(:source) do
         <<-CASK.undent
           cask 'foo' do
-            # example.com was verified as official when first introduced to the cask
+            # brew.sh was verified as official when first introduced to the cask
             url 'https://example.org/foo.zip'
-            homepage 'https://foo.example.com'
+            homepage 'https://foo.brew.sh'
           end
         CASK
       end
       let(:expected_offenses) do
         [{
-          message:  "`example.com` does not match `example.org/foo.zip`",
+          message:  "`brew.sh` does not match `example.org/foo.zip`",
           severity: :convention,
           line:     2,
           column:   2,
-          source:   "# example.com was verified as official when " \
+          source:   "# brew.sh was verified as official when " \
                   "first introduced to the cask",
         }]
       end
@@ -177,21 +177,21 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
       let(:source) do
         <<-CASK.undent
           cask 'foo' do
-            url 'https://example.com/foo.zip'
+            url 'https://brew.sh/foo.zip'
             homepage 'https://example.org'
           end
         CASK
       end
       let(:expected_offenses) do
         [{
-          message:  "`example.com` does not match `example.org`, a comment " \
+          message:  "`brew.sh` does not match `example.org`, a comment " \
                    "has to be added above the `url` stanza. For details, see " \
                    "https://github.com/Homebrew/homebrew-cask/blob/master/doc/" \
                    "cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment",
           severity: :convention,
           line:     2,
           column:   2,
-          source:   "url 'https://example.com/foo.zip'",
+          source:   "url 'https://brew.sh/foo.zip'",
         }]
       end
 
@@ -203,7 +203,7 @@ describe RuboCop::Cop::Cask::HomepageMatchesUrl do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          url 'https://example.com/foo.zip'
+          url 'https://brew.sh/foo.zip'
         end
       CASK
     end

--- a/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/homepage_url_trailing_slash_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Cask::HomepageUrlTrailingSlash do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          homepage 'https://foo.example.com/'
+          homepage 'https://foo.brew.sh/'
         end
       CASK
     end
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Cask::HomepageUrlTrailingSlash do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          homepage 'https://foo.example.com/path'
+          homepage 'https://foo.brew.sh/path'
         end
       CASK
     end
@@ -34,25 +34,25 @@ describe RuboCop::Cop::Cask::HomepageUrlTrailingSlash do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          homepage 'https://foo.example.com'
+          homepage 'https://foo.brew.sh'
         end
       CASK
     end
     let(:correct_source) do
       <<-CASK.undent
         cask 'foo' do
-          homepage 'https://foo.example.com/'
+          homepage 'https://foo.brew.sh/'
         end
       CASK
     end
     let(:expected_offenses) do
       [{
-        message:  "'https://foo.example.com' must have a slash "\
+        message:  "'https://foo.brew.sh' must have a slash "\
                  "after the domain.",
         severity: :convention,
         line:     2,
         column:   11,
-        source:   "'https://foo.example.com'",
+        source:   "'https://foo.brew.sh'",
       }]
     end
 

--- a/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb
@@ -77,11 +77,11 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
         cask 'foo' do
           version :latest
           sha256 :no_check
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
 
           name 'Foo'
 
-          homepage 'https://foo.example.com'
+          homepage 'https://foo.brew.sh'
 
           app 'Foo.app'
           uninstall :quit => 'com.example.foo',
@@ -95,9 +95,9 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
           version :latest
           sha256 :no_check
 
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
-          homepage 'https://foo.example.com'
+          homepage 'https://foo.brew.sh'
 
           app 'Foo.app'
 
@@ -112,7 +112,7 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
         severity: :convention,
         line:     4,
         column:   0,
-        source:   "  url 'https://foo.example.com/foo.zip'",
+        source:   "  url 'https://foo.brew.sh/foo.zip'",
       }, {
         message:  extra_line_msg,
         severity: :convention,
@@ -145,7 +145,7 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
         cask 'foo' do
           version :latest
           sha256 :no_check
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
           app 'Foo.app'
           %{caveats}
@@ -158,7 +158,7 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
           version :latest
           sha256 :no_check
 
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
 
           app 'Foo.app'
@@ -209,7 +209,7 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
         cask 'foo' do
           version :latest
           sha256 :no_check
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
           app 'Foo.app'
           postflight do
@@ -224,7 +224,7 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
           version :latest
           sha256 :no_check
 
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
 
           app 'Foo.app'
@@ -251,7 +251,7 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
           postflight do
             puts 'We have liftoff!'
           end
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
           app 'Foo.app'
         end
@@ -270,7 +270,7 @@ describe RuboCop::Cop::Cask::StanzaGrouping do
             puts 'We have liftoff!'
           end
 
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
 
           app 'Foo.app'

--- a/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/cask/stanza_order_spec.rb
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
     let(:source) do
       <<-CASK.undent
         cask 'foo' do
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           uninstall :quit => 'com.example.foo',
                     :kext => 'com.example.foo.kext'
           version :latest
@@ -87,7 +87,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
         cask 'foo' do
           version :latest
           sha256 :no_check
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           app 'Foo.app'
           uninstall :quit => 'com.example.foo',
                     :kext => 'com.example.foo.kext'
@@ -100,7 +100,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
         severity: :convention,
         line:     2,
         column:   2,
-        source:   "url 'https://foo.example.com/foo.zip'",
+        source:   "url 'https://foo.brew.sh/foo.zip'",
       }, {
         message:  "`uninstall` stanza out of order",
         severity: :convention,
@@ -133,7 +133,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
       <<-CASK.undent
         cask 'foo' do
           name 'Foo'
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'FancyFoo'
           version :latest
           app 'Foo.app'
@@ -147,7 +147,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
         cask 'foo' do
           version :latest
           sha256 :no_check
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
           name 'FancyFoo'
           name 'FunkyFoo'
@@ -199,7 +199,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
       format(<<-CASK.undent, caveats: caveats.strip)
         cask 'foo' do
           name 'Foo'
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           %{caveats}
           version :latest
           app 'Foo.app'
@@ -212,7 +212,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
         cask 'foo' do
           version :latest
           sha256 :no_check
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
           app 'Foo.app'
           %{caveats}
@@ -260,7 +260,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
       <<-CASK.undent
         cask 'foo' do
           name 'Foo'
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           postflight do
             puts 'We have liftoff!'
           end
@@ -275,7 +275,7 @@ describe RuboCop::Cop::Cask::StanzaOrder do
         cask 'foo' do
           version :latest
           sha256 :no_check
-          url 'https://foo.example.com/foo.zip'
+          url 'https://foo.brew.sh/foo.zip'
           name 'Foo'
           app 'Foo.app'
           postflight do

--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -7,8 +7,8 @@ describe RuboCop::Cop::FormulaAudit::Caveats do
     it "When there is setuid mentioned in caveats" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          homepage "https://example.com/foo"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
            def caveats
             "setuid"
              ^^^^^^ Don\'t recommend setuid in the caveats, suggest sudo instead.

--- a/Library/Homebrew/test/rubocops/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::FormulaAudit::Checksum do
     it "When the checksum is empty" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 ""
@@ -26,7 +26,7 @@ describe RuboCop::Cop::FormulaAudit::Checksum do
     it "When the checksum is not 64 characters" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0a645b426c0474cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9ad"
@@ -45,7 +45,7 @@ describe RuboCop::Cop::FormulaAudit::Checksum do
     it "When the checksum has invalid chars" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0a645b426c0k7cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9a"
@@ -70,7 +70,7 @@ describe RuboCop::Cop::FormulaAudit::ChecksumCase do
     it "When the checksum has upper case characters" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0A645b426c0a7cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9a"
@@ -89,7 +89,7 @@ describe RuboCop::Cop::FormulaAudit::ChecksumCase do
     it "When auditing stable blocks outside spec blocks" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           resource "foo-outside" do
             url "https://github.com/foo-lang/foo-outside/archive/0.18.0.tar.gz"
             sha256 "A4cc7cd3f7d1605ffa1ac5755cf6e1ae0a645b426b047a6a39a8b2268ddc7ea9"
@@ -113,7 +113,7 @@ describe RuboCop::Cop::FormulaAudit::ChecksumCase do
     it "When there is uppercase sha256" do
       source = <<~RUBY
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0A645b426c0a7cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9a"
@@ -128,7 +128,7 @@ describe RuboCop::Cop::FormulaAudit::ChecksumCase do
 
       corrected_source = <<~RUBY
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           stable do
             url "https://github.com/foo-lang/foo-compiler/archive/0.18.0.tar.gz"
             sha256 "5cf6e1ae0a645b426c0a7cc7cd3f7d1605ffa1ac5756a39a8b2268ddc7ea0e9a"

--- a/Library/Homebrew/test/rubocops/class_spec.rb
+++ b/Library/Homebrew/test/rubocops/class_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::FormulaAudit::ClassName do
     expect_offense(<<~RUBY)
       class Foo < ScriptFileFormula
                   ^^^^^^^^^^^^^^^^^ ScriptFileFormula is deprecated, use Formula instead
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
   end
@@ -16,7 +16,7 @@ describe RuboCop::Cop::FormulaAudit::ClassName do
     expect_offense(<<~RUBY)
       class Foo < GithubGistFormula
                   ^^^^^^^^^^^^^^^^^ GithubGistFormula is deprecated, use Formula instead
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
   end
@@ -25,7 +25,7 @@ describe RuboCop::Cop::FormulaAudit::ClassName do
     expect_offense(<<~RUBY)
       class Foo < AmazonWebServicesFormula
                   ^^^^^^^^^^^^^^^^^^^^^^^^ AmazonWebServicesFormula is deprecated, use Formula instead
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
   end
@@ -33,13 +33,13 @@ describe RuboCop::Cop::FormulaAudit::ClassName do
   it "supports auto-correcting deprecated parent classes" do
     source = <<~RUBY
       class Foo < AmazonWebServicesFormula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
 
     corrected_source = <<~RUBY
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
 
@@ -54,7 +54,7 @@ describe RuboCop::Cop::FormulaAudit::TestCalls do
   it "reports an offense when /usr/local/bin is found in test calls" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
 
         test do
           system "/usr/local/bin/test"
@@ -67,7 +67,7 @@ describe RuboCop::Cop::FormulaAudit::TestCalls do
   it "reports an offense when passing 0 as the second parameter to shell_output" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
 
         test do
           shell_output("\#{bin}/test", 0)
@@ -80,7 +80,7 @@ describe RuboCop::Cop::FormulaAudit::TestCalls do
   it "supports auto-correcting test calls" do
     source = <<~RUBY
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
 
         test do
           shell_output("/usr/local/sbin/test", 0)
@@ -90,7 +90,7 @@ describe RuboCop::Cop::FormulaAudit::TestCalls do
 
     corrected_source = <<~RUBY
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
 
         test do
           shell_output("\#{sbin}/test")
@@ -110,7 +110,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Test do
     expect_offense(<<~RUBY)
       class Foo < Formula
       ^^^^^^^^^^^^^^^^^^^ A `test do` test block should be added
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
   end
@@ -118,7 +118,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Test do
   it "reports an offense when there is an empty test block" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
 
         test do
         ^^^^^^^ `test do` should not be empty
@@ -130,7 +130,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Test do
   it "reports an offense when test is falsely true" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
 
         test do
         ^^^^^^^ `test do` should contain a real test

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -7,9 +7,9 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     it "When url precedes homepage" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `homepage` (line 3) should be put before `url` (line 2)
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ `homepage` (line 3) should be put before `url` (line 2)
         end
       RUBY
     end
@@ -17,10 +17,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     it "When `resource` precedes `depends_on`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
+          url "https://brew.sh/foo-1.0.tgz"
 
           resource "foo2" do
-            url "https://example.com/foo-2.0.tgz"
+            url "https://brew.sh/foo-2.0.tgz"
           end
 
           depends_on "openssl"
@@ -32,7 +32,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     it "When `test` precedes `plist`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
+          url "https://brew.sh/foo-1.0.tgz"
 
           test do
             expect(shell_output("./dogs")).to match("Dogs are terrific")
@@ -64,15 +64,15 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     it "When url precedes homepage" do
       source = <<~RUBY
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
         end
       RUBY
 
       correct_source = <<~RUBY
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
         end
       RUBY
 
@@ -83,10 +83,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     it "When `resource` precedes `depends_on`" do
       source = <<~RUBY
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
+          url "https://brew.sh/foo-1.0.tgz"
 
           resource "foo2" do
-            url "https://example.com/foo-2.0.tgz"
+            url "https://brew.sh/foo-2.0.tgz"
           end
 
           depends_on "openssl"
@@ -95,12 +95,12 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
 
       correct_source = <<~RUBY
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
+          url "https://brew.sh/foo-1.0.tgz"
 
           depends_on "openssl"
 
           resource "foo2" do
-            url "https://example.com/foo-2.0.tgz"
+            url "https://brew.sh/foo-2.0.tgz"
           end
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -7,8 +7,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
     it "When url outside stable block" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `url` should be put inside `stable` block
+          url "https://brew.sh/foo-1.0.tgz"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `url` should be put inside `stable` block
           stable do
             # stuff
           end
@@ -23,7 +23,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
     it "When both `head` and `head do` are present" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          head "https://example.com/foo.git"
+          head "https://brew.sh/foo.git"
           head do
           ^^^^^^^ `head` and `head do` should not be simultaneously present
             # stuff
@@ -35,7 +35,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
     it "When both `bottle :modifier` and `bottle do` are present" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
+          url "https://brew.sh/foo-1.0.tgz"
           bottle do
           ^^^^^^^^^ `bottle :modifier` and `bottle do` should not be simultaneously present
             # bottles go here
@@ -48,7 +48,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
     it "When `stable do` is present with a `head` method" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
-          head "https://example.com/foo.git"
+          head "https://brew.sh/foo.git"
 
           stable do
             # stuff

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::FormulaAudit::Conflicts do
     it "multiple conflicts_with" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo@2.0.rb")
         class FooAT20 < Formula
-          url 'https://example.com/foo-2.0.tgz'
+          url 'https://brew.sh/foo-2.0.tgz'
           conflicts_with "mysql", "mariadb", "percona-server",
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Versioned formulae should not use `conflicts_with`. Use `keg_only :versioned_formula` instead.
                            :because => "both install plugins"
@@ -18,7 +18,7 @@ describe RuboCop::Cop::FormulaAudit::Conflicts do
     it "no conflicts_with" do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo@2.0.rb")
         class FooAT20 < Formula
-          url 'https://example.com/foo-2.0.tgz'
+          url 'https://brew.sh/foo-2.0.tgz'
           desc 'Bar'
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -7,8 +7,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     it "wrong conditional depends_on order" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
           depends_on "apple" if build.with? "foo"
           depends_on "foo" => :optional
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency "foo" (line 5) should be put before dependency "apple" (line 4)
@@ -19,8 +19,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     it "wrong alphabetical depends_on order" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
           depends_on "foo"
           depends_on "bar"
           ^^^^^^^^^^^^^^^^ dependency "bar" (line 5) should be put before dependency "foo" (line 4)
@@ -31,8 +31,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     it "supports requirement constants" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
           depends_on FooRequirement
           depends_on "bar"
           ^^^^^^^^^^^^^^^^ dependency "bar" (line 5) should be put before dependency "FooRequirement" (line 4)
@@ -43,8 +43,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     it "wrong conditional depends_on order with block" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
           head do
             depends_on "apple" if build.with? "foo"
             depends_on "bar"
@@ -62,8 +62,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     it "correct depends_on order for multiple tags" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
           depends_on "bar" => [:build, :test]
           depends_on "foo" => :build
           depends_on "apple"
@@ -76,8 +76,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     it "wrong conditional depends_on order" do
       source = <<~RUBY
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
           depends_on "apple" if build.with? "foo"
           depends_on "foo" => :optional
         end
@@ -85,8 +85,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
 
       correct_source = <<~RUBY
         class Foo < Formula
-          homepage "https://example.com"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
           depends_on "foo" => :optional
           depends_on "apple" if build.with? "foo"
         end

--- a/Library/Homebrew/test/rubocops/formula_desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::FormulaAudit::DescLength do
       expect_offense(<<~RUBY)
         class Foo < Formula
         ^^^^^^^^^^^^^^^^^^^ Formula should have a desc (Description).
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
         end
       RUBY
     end
@@ -16,7 +16,7 @@ describe RuboCop::Cop::FormulaAudit::DescLength do
     it "reports an offense when desc is an empty string" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc ''
           ^^^^^^^ The desc (description) should not be an empty string.
         end
@@ -26,7 +26,7 @@ describe RuboCop::Cop::FormulaAudit::DescLength do
     it "When desc is too long" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'Bar#{"bar" * 29}'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description is too long. "name: desc" should be less than 80 characters. Length is calculated as foo + desc. (currently 95)
         end
@@ -36,7 +36,7 @@ describe RuboCop::Cop::FormulaAudit::DescLength do
     it "When desc is multiline string" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'Bar#{"bar" * 9}'\
             '#{"foo" * 21}'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description is too long. "name: desc" should be less than 80 characters. Length is calculated as foo + desc. (currently 98)
@@ -53,7 +53,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "When wrong \"command-line\" usage in desc" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'command line'
                 ^ Description should start with a capital letter
                 ^^^^^^^^^^^^ Description should use \"command-line\" instead of \"command line\"
@@ -64,7 +64,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "When an article is used in desc" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'An aardvark'
                 ^^^ Description shouldn\'t start with an indefinite article i.e. \"An\"
         end
@@ -74,7 +74,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "When an lowercase letter starts a desc" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'bar'
                 ^ Description should start with a capital letter
         end
@@ -84,7 +84,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "When formula name is in desc" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'Foo is a foobar'
                 ^^^^ Description shouldn\'t start with the formula name
         end
@@ -94,7 +94,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "When the description ends with a full stop" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'Description with a full stop at the end.'
                                                        ^ Description shouldn\'t end with a full stop
         end
@@ -104,7 +104,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "When the description starts with a leading space" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc ' Description with a leading space'
                 ^ Description shouldn\'t have a leading space
         end
@@ -114,7 +114,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "When the description ends with a trailing space" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'Description with a trailing space '
                                                  ^ Description shouldn\'t have a trailing space
         end
@@ -124,14 +124,14 @@ describe RuboCop::Cop::FormulaAuditStrict::Desc do
     it "autocorrects all rules" do
       source = <<~RUBY
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc ' an bar: commandline foo '
         end
       RUBY
 
       correct_source = <<~RUBY
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           desc 'an bar: command-line'
         end
       RUBY

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
     it "When there is no homepage" do
       source = <<~RUBY
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
         end
       RUBY
 
@@ -27,13 +27,13 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
     it "Homepage with ftp" do
       source = <<~RUBY
         class Foo < Formula
-          homepage "ftp://example.com/foo"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "ftp://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
         end
       RUBY
 
       expected_offenses = [{ message:  "The homepage should start with http or " \
-                                        "https (URL is ftp://example.com/foo).",
+                                        "https (URL is ftp://brew.sh/foo).",
                              severity: :convention,
                              line:     2,
                              column:   2,
@@ -66,7 +66,7 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
         source = <<~RUBY
           class #{name.capitalize} < Formula
             homepage "#{homepage}"
-            url "https://example.com/#{name}-1.0.tgz"
+            url "https://brew.sh/#{name}-1.0.tgz"
           end
         RUBY
 

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::FormulaAudit::Lines do
   it "reports an offense when using depends_on :automake" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         depends_on :automake
         ^^^^^^^^^^^^^^^^^^^^ :automake is deprecated. Usage should be \"automake\".
       end
@@ -16,7 +16,7 @@ describe RuboCop::Cop::FormulaAudit::Lines do
   it "reports an offense when using depends_on :autoconf" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         depends_on :autoconf
         ^^^^^^^^^^^^^^^^^^^^ :autoconf is deprecated. Usage should be \"autoconf\".
       end
@@ -26,7 +26,7 @@ describe RuboCop::Cop::FormulaAudit::Lines do
   it "reports an offense when using depends_on :libtool" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         depends_on :libtool
         ^^^^^^^^^^^^^^^^^^^ :libtool is deprecated. Usage should be \"libtool\".
       end
@@ -36,7 +36,7 @@ describe RuboCop::Cop::FormulaAudit::Lines do
   it "reports an offense when using depends_on :apr" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         depends_on :apr
         ^^^^^^^^^^^^^^^ :apr is deprecated. Usage should be \"apr-util\".
       end
@@ -46,7 +46,7 @@ describe RuboCop::Cop::FormulaAudit::Lines do
   it "reports an offense when using depends_on :tex" do
     expect_offense(<<~RUBY)
       class Foo < Formula
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         depends_on :tex
         ^^^^^^^^^^^^^^^ :tex is deprecated.
       end
@@ -62,7 +62,7 @@ describe RuboCop::Cop::FormulaAudit::ClassInheritance do
       class Foo<Formula
                 ^^^^^^^ Use a space in class inheritance: class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
       end
     RUBY
   end
@@ -76,7 +76,7 @@ describe RuboCop::Cop::FormulaAudit::Comments do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           # system "cmake", ".", *std_cmake_args
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please remove default template comments
         end
@@ -89,7 +89,7 @@ describe RuboCop::Cop::FormulaAudit::Comments do
           # PLEASE REMOVE
           ^^^^^^^^^^^^^^^ Please remove default template comments
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
         end
       RUBY
     end
@@ -98,7 +98,7 @@ describe RuboCop::Cop::FormulaAudit::Comments do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           # depends_on "foo"
           ^^^^^^^^^^^^^^^^^^ Commented-out dependency "foo"
         end
@@ -114,7 +114,7 @@ describe RuboCop::Cop::FormulaAudit::AssertStatements do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         assert File.read("inbox").include?("Sample message 1")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `assert_match` instead of `assert ...include?`
       end
@@ -125,7 +125,7 @@ describe RuboCop::Cop::FormulaAudit::AssertStatements do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         assert File.exist? "default.ini"
                ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `assert_predicate <path_to_file>, :exist?` instead of `assert File.exist? "default.ini"`
       end
@@ -136,7 +136,7 @@ describe RuboCop::Cop::FormulaAudit::AssertStatements do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         assert !File.exist?("default.ini")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `refute_predicate <path_to_file>, :exist?` instead of `assert !File.exist?("default.ini")`
       end
@@ -147,7 +147,7 @@ describe RuboCop::Cop::FormulaAudit::AssertStatements do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         assert File.executable? f
                ^^^^^^^^^^^^^^^^^^ Use `assert_predicate <path_to_file>, :executable?` instead of `assert File.executable? f`
       end
@@ -162,7 +162,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return unless build.without? "bar"
                         ^^^^^^^^^^^^^^^^^^^^ Use if build.with? "bar" instead of unless build.without? "bar"
@@ -175,7 +175,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return unless build.with? "bar"
                         ^^^^^^^^^^^^^^^^^ Use if build.without? "bar" instead of unless build.with? "bar"
@@ -188,7 +188,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return if !build.with? "bar"
                     ^^^^^^^^^^^^^^^^^^ Don't negate 'build.with?': use 'build.without?'
@@ -201,7 +201,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return if !build.without? "bar"
                     ^^^^^^^^^^^^^^^^^^^^^ Don't negate 'build.without?': use 'build.with?'
@@ -214,7 +214,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return if build.without? "--without-bar"
                                     ^^^^^^^^^^^^^ Don't duplicate 'without': Use `build.without? \"bar\"` to check for \"--without-bar\"
@@ -227,7 +227,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return if build.with? "--with-bar"
                                  ^^^^^^^^^^ Don't duplicate 'with': Use `build.with? \"bar\"` to check for \"--with-bar\"
@@ -240,7 +240,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return if build.include? "without-bar"
                                     ^^^^^^^^^^^ Use build.without? \"bar\" instead of build.include? 'without-bar'
@@ -253,7 +253,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
         def post_install
           return if build.include? "--bar"
                                     ^^^^^ Reference 'bar' without dashes
@@ -266,7 +266,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
     expect_offense(<<~RUBY)
       class Foo < Formula
         desc "foo"
-        url 'https://example.com/foo-1.0.tgz'
+        url 'https://brew.sh/foo-1.0.tgz'
 
         def options
         ^^^^^^^^^^^ Use new-style option definitions
@@ -285,7 +285,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           FileUtils.mv "hello"
           ^^^^^^^^^^^^^^^^^^^^ Don\'t need \'FileUtils.\' before mv
         end
@@ -296,7 +296,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           inreplace "foo" do |longvar|
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ \"inreplace <filenames> do |s|\" is preferred over \"|longvar|\".
             somerandomCall(longvar)
@@ -309,7 +309,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           bottle do
             rebuild 0
             ^^^^^^^^^ 'rebuild 0' should be removed
@@ -323,7 +323,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           bottle do
             if OS.linux?
                ^^^^^^^^^ Don\'t use OS.linux?; Homebrew/core only supports macOS
@@ -339,7 +339,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           bottle do
             sha256 "fe0679b932dd43a87fd415b609a7fbac7a069d117642ae8ebaac46ae1fb9f0b3" => :sierra
           end
@@ -356,7 +356,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
 
           def test
           ^^^^^^^^ Use new-style test definitions (test do)
@@ -370,7 +370,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           skip_clean :all
           ^^^^^^^^^^^^^^^ `skip_clean :all` is deprecated; brew no longer strips symbols. Pass explicit paths to prevent Homebrew from removing empty folders.
         end
@@ -381,7 +381,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           if build.universal?
              ^^^^^^^^^^^^^^^^ macOS has been 64-bit only since 10.6 so build.universal? is deprecated.
              "foo"
@@ -394,7 +394,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/wine.rb")
         class Wine < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           if build.universal?
              "foo"
           end
@@ -406,7 +406,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           if build?
              ENV.universal_binary
              ^^^^^^^^^^^^^^^^^^^^ macOS has been 64-bit only since 10.6 so ENV.universal_binary is deprecated.
@@ -419,7 +419,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/wine.rb")
         class Wine < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           if build?
             ENV.universal_binary
           end
@@ -431,7 +431,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           if build?
              ENV.x11
              ^^^^^^^ Use "depends_on :x11" instead of "ENV.x11"
@@ -444,7 +444,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           system "install_name_tool", "-id"
                   ^^^^^^^^^^^^^^^^^ Use ruby-macho instead of calling "install_name_tool"
         end
@@ -455,7 +455,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/cctools.rb")
         class Cctools < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           system "install_name_tool", "-id"
         end
       RUBY
@@ -465,7 +465,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           system "npm", "install"
           ^^^^^^^^^^^^^^^^^^^^^^^ Use Language::Node for npm install args
         end
@@ -476,7 +476,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/kibana@4.4.rb")
         class KibanaAT44 < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           system "npm", "install"
         end
       RUBY
@@ -486,7 +486,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on FOO::BAR.new
                      ^^^^^^^^^^^^ `depends_on` can take requirement classes instead of instances
         end
@@ -497,7 +497,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on :foo if MacOS.snow_leopard?
                              ^^^^^^^^^^^^^^^^^^^ \"MacOS.snow_leopard?\" is deprecated, use a comparison to MacOS.version instead
         end
@@ -508,7 +508,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           rm_rf Dir["src/{llvm,test,librustdoc,etc/snapshot.pyc}"]
           rm_rf Dir["src/snapshot.pyc"]
                      ^^^^^^^^^^^^^^^^ Dir(["src/snapshot.pyc"]) is unnecessary; just use "src/snapshot.pyc"
@@ -520,7 +520,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           system "mkdir", "foo"
                   ^^^^^ Use the `mkdir` Ruby method instead of `system "mkdir", "foo"`
         end
@@ -535,7 +535,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
         end
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
         end
       RUBY
     end
@@ -544,7 +544,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             verbose = ARGV.verbose?
           end
@@ -556,7 +556,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             man1.install man+"man8" => "faad.1"
                               ^^^^ "man+"man8"" should be "man8"
@@ -569,7 +569,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "/usr/bin/gcc", "foo"
                     ^^^^^^^^^^^^ Use "#{ENV.cc}" instead of hard-coding "gcc"
@@ -582,7 +582,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "/usr/bin/g++", "-o", "foo", "foo.cc"
                     ^^^^^^^^^^^^ Use "#{ENV.cxx}" instead of hard-coding "g++"
@@ -595,7 +595,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             ENV["COMPILER_PATH"] = "/usr/bin/llvm-g++"
                                     ^^^^^^^^^^^^^^^^^ Use "#{ENV.cxx}" instead of hard-coding "llvm-g++"
@@ -608,7 +608,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             ENV["COMPILER_PATH"] = "/usr/bin/gcc"
                                     ^^^^^^^^^^^^ Use \"\#{ENV.cc}\" instead of hard-coding \"gcc\"
@@ -621,7 +621,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             mv "#{share}/man", share
                          ^^^^ "#{share}/man" should be "#{man}"
@@ -634,7 +634,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             mv "#{prefix}/libexec", share
                           ^^^^^^^^ "#{prefix}/libexec" should be "#{libexec}"
@@ -647,7 +647,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "./configure", "--INFODIR=#{prefix}/share/info"
                                                        ^^^^^^ "#{prefix}/share" should be "#{share}"
@@ -661,7 +661,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~'RUBY')
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           def install
             system "./configure", "--MANDIR=#{prefix}/share/man/man8"
                                                       ^^^^^^ "#{prefix}/share" should be "#{share}"
@@ -675,7 +675,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on "lpeg" => :lua51
                                 ^^^^^ lua modules should be vendored rather than use deprecated depends_on \"lpeg\" => :lua51`
         end
@@ -686,7 +686,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           system "export", "var=value"
                   ^^^^^^ Use ENV instead of invoking 'export' to modify the environment
         end
@@ -697,7 +697,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on "foo" => "with-bar"
                                ^^^^^^^^ Dependency foo should not use option with-bar
         end
@@ -708,7 +708,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on "httpd" => [:build, :test]
           depends_on "foo" => [:optional, "with-bar"]
                                            ^^^^^^^^ Dependency foo should not use option with-bar
@@ -722,7 +722,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           if version == "HEAD"
              ^^^^^^^^^^^^^^^^^ Use 'build.head?' instead of inspecting 'version'
             foo()
@@ -735,7 +735,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           test do
             head = ARGV.include? "--HEAD"
                                   ^^^^^^ Use "if build.head?" instead
@@ -749,7 +749,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           needs :openmp
           ^^^^^^^^^^^^^ 'needs :openmp' should be replaced with 'depends_on \"gcc\"'
         end
@@ -760,7 +760,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           test do
             version = MACOS_VERSION
                       ^^^^^^^^^^^^^ Use MacOS.version instead of MACOS_VERSION
@@ -773,7 +773,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on "foo" if build.with? "foo"
           ^^^^^^^^^^^^^^^^ Replace depends_on "foo" if build.with? "foo" with depends_on "foo" => :optional
         end
@@ -784,7 +784,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on :foo unless build.without? "foo"
           ^^^^^^^^^^^^^^^ Replace depends_on :foo unless build.without? "foo" with depends_on :foo => :recommended
         end
@@ -795,7 +795,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           depends_on :foo unless build.include? "without-foo"
           ^^^^^^^^^^^^^^^ Replace depends_on :foo unless build.include? "without-foo" with depends_on :foo => :recommended
         end

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::FormulaAudit::Options do
     it "reports an offense when using the 32-bit option" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           option "with-32-bit"
                        ^^^^^^ macOS has been 64-bit only since 10.6 so 32-bit options are deprecated.
         end
@@ -17,7 +17,7 @@ describe RuboCop::Cop::FormulaAudit::Options do
     it "with universal" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           option :universal
           ^^^^^^^^^^^^^^^^^ macOS has been 64-bit only since 10.6 so universal options are deprecated.
         end
@@ -27,7 +27,7 @@ describe RuboCop::Cop::FormulaAudit::Options do
     it "with deprecated options" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           option :cxx11
           option "examples", "with-examples"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Options should begin with with/without. Migrate '--examples' with `deprecated_option`.
@@ -38,7 +38,7 @@ describe RuboCop::Cop::FormulaAudit::Options do
     it "with misc deprecated options" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           option "without-check"
           ^^^^^^^^^^^^^^^^^^^^^^ Use '--without-test' instead of '--without-check'. Migrate '--without-check' with `deprecated_option`.
         end
@@ -54,7 +54,7 @@ describe RuboCop::Cop::NewFormulaAudit::Options do
     it "with deprecated options" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           deprecated_option "examples" => "with-examples"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ New formulae should not use `deprecated_option`
         end
@@ -64,7 +64,7 @@ describe RuboCop::Cop::NewFormulaAudit::Options do
     it "with options" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
           option "with-examples"
           ^^^^^^^^^^^^^^^^^^^^^^ Formulae should not have an `option`
         end

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
     it "When there is no legacy patch" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
-          url 'https://example.com/foo-1.0.tgz'
+          url 'https://brew.sh/foo-1.0.tgz'
         end
       RUBY
     end
@@ -15,8 +15,8 @@ describe RuboCop::Cop::FormulaAudit::Patches do
     it "Formula with `def patches`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          homepage "ftp://example.com/foo"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "ftp://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
           def patches
           ^^^^^^^^^^^ Use the patch DSL instead of defining a 'patches' method
             DATA
@@ -37,8 +37,8 @@ describe RuboCop::Cop::FormulaAudit::Patches do
       patch_urls.each do |patch_url|
         source = <<~EOS
           class Foo < Formula
-            homepage "ftp://example.com/foo"
-            url "https://example.com/foo-1.0.tgz"
+            homepage "ftp://brew.sh/foo"
+            url "https://brew.sh/foo-1.0.tgz"
             def patches
               "#{patch_url}"
             end
@@ -121,8 +121,8 @@ describe RuboCop::Cop::FormulaAudit::Patches do
     it "Formula with nested `def patches`" do
       source = <<~RUBY
         class Foo < Formula
-          homepage "ftp://example.com/foo"
-          url "https://example.com/foo-1.0.tgz"
+          homepage "ftp://brew.sh/foo"
+          url "https://brew.sh/foo-1.0.tgz"
           def patches
             files = %w[patch-domain_resolver.c patch-colormask.c patch-trafshow.c patch-trafshow.1 patch-configure]
             {
@@ -171,8 +171,8 @@ describe RuboCop::Cop::FormulaAudit::Patches do
       patch_urls.each do |patch_url|
         source = <<~RUBY
           class Foo < Formula
-            homepage "ftp://example.com/foo"
-            url "https://example.com/foo-1.0.tgz"
+            homepage "ftp://brew.sh/foo"
+            url "https://brew.sh/foo-1.0.tgz"
             patch do
               url "#{patch_url}"
               sha256 "63376b8fdd6613a91976106d9376069274191860cd58f039b29ff16de1925621"

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -7,8 +7,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "with both openssl and libressl optional dependencies" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           depends_on "openssl"
           depends_on "libressl" => :optional
@@ -20,8 +20,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "with both openssl and libressl dependencies" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           depends_on "openssl"
           depends_on "libressl"
@@ -33,8 +33,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When xcodebuild is called without SYMROOT" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             xcodebuild "-project", "meow.xcodeproject"
@@ -47,8 +47,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When xcodebuild is called without any args" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             xcodebuild
@@ -61,8 +61,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When go get is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             system "go", "get", "bar"
@@ -75,8 +75,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When xcodebuild is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             system "xcodebuild", "foo", "bar"
@@ -89,8 +89,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When scons is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             system "scons", "foo", "bar"
@@ -103,8 +103,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When plist_options are not defined when using a formula-defined plist", :ruby23 do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             system "xcodebuild", "foo", "bar"
@@ -134,8 +134,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
         ^^^^^^^^^^^^^^^^^^^^^ require "language/go" is unnecessary unless using `go_resource`s
 
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             system "go", "get", "bar"
@@ -148,8 +148,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When formula uses virtualenv and also `setuptools` resource" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           resource "setuptools" do
           ^^^^^^^^^^^^^^^^^^^^^ Formulae using virtualenvs do not need a `setuptools` resource.
@@ -167,8 +167,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When Formula.factory(name) is used" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             Formula.factory(name)
@@ -181,8 +181,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When dep ensure is used without `-vendor-only`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             system "dep", "ensure"
@@ -195,8 +195,8 @@ describe RuboCop::Cop::FormulaAudit::Text do
     it "When cargo build is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
-          url "https://example.com/foo-1.0.tgz"
-          homepage "https://example.com"
+          url "https://brew.sh/foo-1.0.tgz"
+          homepage "https://brew.sh"
 
           def install
             system "cargo", "build"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/appdir-interpolation.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/appdir-interpolation.rb
@@ -3,7 +3,7 @@ cask 'appdir-interpolation' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://example.com/appdir-interpolation'
+  homepage 'https://brew.sh/appdir-interpolation'
 
   binary "#{appdir}/some/path"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
@@ -3,7 +3,7 @@ cask 'auto-updates' do
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
-  homepage 'https://example.com/MyFancyApp'
+  homepage 'https://brew.sh/MyFancyApp'
 
   auto_updates true
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
@@ -3,7 +3,7 @@ cask 'bad-checksum' do
   sha256 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
@@ -2,8 +2,8 @@ cask 'basic-cask' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
-  url 'https://example.com/TestCask.dmg'
-  homepage 'https://example.com/'
+  url 'https://brew.sh/TestCask.dmg'
+  homepage 'https://brew.sh/'
 
   app 'TestCask.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-7z.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-7z.rb
@@ -3,7 +3,7 @@ cask 'container-7z' do
   sha256 '3f9542ace85ed5f88549e2d0ea82210f8ddc87e0defbb78469d3aed719b3c964'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.7z"
-  homepage 'https://example.com/container-7z'
+  homepage 'https://brew.sh/container-7z'
 
   depends_on formula: 'unar'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-bzip2.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-bzip2.rb
@@ -3,7 +3,7 @@ cask 'container-bzip2' do
   sha256 'eaf67b3a62cb9275f96e45d05c70b94bef9ef1dae344083e93eda6b0b388a61c'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.bz2"
-  homepage 'https://example.com/container-bzip2'
+  homepage 'https://brew.sh/container-bzip2'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-cab.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-cab.rb
@@ -3,7 +3,7 @@ cask 'container-cab' do
   sha256 'c267f5cebb14814c8e612a8b7d2bda02aec913f869509b6f1d3883427c0f552b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.cab"
-  homepage 'https://example.com/container-cab'
+  homepage 'https://brew.sh/container-cab'
 
   depends_on formula: 'cabextract'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-dmg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-dmg.rb
@@ -3,7 +3,7 @@ cask 'container-dmg' do
   sha256 '74d89d4fa5cef175cf43666ce11fefa3741aa1522114042ac75e656be37141a1'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.dmg"
-  homepage 'https://example.com/container-dmg'
+  homepage 'https://brew.sh/container-dmg'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-gzip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-gzip.rb
@@ -3,7 +3,7 @@ cask 'container-gzip' do
   sha256 'fa4ebb5246583c4b6e62e1df4e3b71b4e38a1d7d91c025665827195d36214b20'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.gz"
-  homepage 'https://example.com/container-gzip'
+  homepage 'https://brew.sh/container-gzip'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-pkg.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-pkg.rb
@@ -3,5 +3,5 @@ cask 'container-pkg' do
   sha256 '611c50c8a2a2098951d2cd0fd54787ed81b92cd97b4b08bd7cba17f1e1d8e40b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.pkg"
-  homepage 'https://example.com/container-pkg'
+  homepage 'https://brew.sh/container-pkg'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-tar-gz.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-tar-gz.rb
@@ -3,7 +3,7 @@ cask 'container-tar-gz' do
   sha256 'fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
-  homepage 'https://example.com/container-tar-gz'
+  homepage 'https://brew.sh/container-tar-gz'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/container-xar.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/container-xar.rb
@@ -3,7 +3,7 @@ cask 'container-xar' do
   sha256 '5bb8e09a6fc630ebeaf266b1fd2d15e2ae7d32d7e4da6668a8093426fa1ba509'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.xar"
-  homepage 'https://example.com/container-xar'
+  homepage 'https://brew.sh/container-xar'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-with-appcast.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-with-appcast.rb
@@ -6,7 +6,7 @@ cask 'devmate-with-appcast' do
   url "https://dl.devmate.com/com.my.fancyapp/app_#{version}.zip"
   appcast 'https://updates.devmate.com/com.my.fancyapp.app.xml'
   name 'DevMate'
-  homepage 'https://www.example.com/'
+  homepage 'https://www.brew.sh/'
 
   app 'DevMate.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-without-appcast.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/devmate-without-appcast.rb
@@ -5,7 +5,7 @@ cask 'devmate-without-appcast' do
   # dl.devmate.com/com.my.fancyapp was verified as official when first introduced to the cask
   url "https://dl.devmate.com/com.my.fancyapp/app_#{version}.zip"
   name 'DevMate'
-  homepage 'https://www.example.com/'
+  homepage 'https://www.brew.sh/'
 
   app 'DevMate.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-with-appcast.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-with-appcast.rb
@@ -6,7 +6,7 @@ cask 'hockeyapp-with-appcast' do
   url "https://rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1/app_versions/#{version.after_comma}?format=zip"
   appcast 'https://rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1'
   name 'HockeyApp'
-  homepage 'https://www.example.com/'
+  homepage 'https://www.brew.sh/'
 
   app 'HockeyApp.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-without-appcast.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/hockeyapp-without-appcast.rb
@@ -5,7 +5,7 @@ cask 'hockeyapp-without-appcast' do
   # rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1 was verified as official when first introduced to the cask
   url "https://rink.hockeyapp.net/api/2/apps/67503a7926431872c4b6c1549f5bd6b1/app_versions/#{version.after_comma}?format=zip"
   name 'HockeyApp'
-  homepage 'https://www.example.com/'
+  homepage 'https://www.brew.sh/'
 
   app 'HockeyApp.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/installer-with-uninstall.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/installer-with-uninstall.rb
@@ -3,7 +3,7 @@ cask 'installer-with-uninstall' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   installer manual: 'Caffeine.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-multiple.rb
@@ -3,9 +3,9 @@ cask 'invalid-appcast-multiple' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  appcast 'https://example.com/appcast1.xml'
-  appcast 'https://example.com/appcast2.xml'
-  homepage 'https://example.com/invalid-appcast-multiple'
+  appcast 'https://brew.sh/appcast1.xml'
+  appcast 'https://brew.sh/appcast2.xml'
+  homepage 'https://brew.sh/invalid-appcast-multiple'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-appcast-url.rb
@@ -4,7 +4,7 @@ cask 'invalid-appcast-url' do
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   appcast 1
-  homepage 'https://example.com/invalid-appcast-url'
+  homepage 'https://brew.sh/invalid-appcast-url'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-conflicts-with-key.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-conflicts-with-key.rb
@@ -3,7 +3,7 @@ cask 'invalid-conflicts-with-key' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/invalid-conflicts-with-key'
+  homepage 'https://brew.sh/invalid-conflicts-with-key'
 
   conflicts_with no_such_key: 'unar'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-arch-value.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-arch-value.rb
@@ -3,7 +3,7 @@ cask 'invalid-depends-on-arch-value' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/invalid-depends-on-arch-value'
+  homepage 'https://brew.sh/invalid-depends-on-arch-value'
 
   depends_on arch: :no_such_arch
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-key.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-key.rb
@@ -3,7 +3,7 @@ cask 'invalid-depends-on-key' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/invalid-depends-on-key'
+  homepage 'https://brew.sh/invalid-depends-on-key'
 
   depends_on no_such_key: 'unar'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bad-release.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-bad-release.rb
@@ -3,7 +3,7 @@ cask 'invalid-depends-on-macos-bad-release' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/invalid-depends-on-macos-bad-release'
+  homepage 'https://brew.sh/invalid-depends-on-macos-bad-release'
 
   depends_on macos: :no_such_release
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-conflicting-forms.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-macos-conflicting-forms.rb
@@ -3,7 +3,7 @@ cask 'invalid-depends-on-macos-conflicting-forms' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/invalid-depends-on-macos-conflicting-forms'
+  homepage 'https://brew.sh/invalid-depends-on-macos-conflicting-forms'
 
   depends_on macos: :yosemite
   depends_on macos: '>= :mavericks'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-x11-value.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-depends-on-x11-value.rb
@@ -3,7 +3,7 @@ cask 'invalid-depends-on-x11-value' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/invalid-depends-on-x11-value'
+  homepage 'https://brew.sh/invalid-depends-on-x11-value'
 
   depends_on x11: :no_such_value
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-generic-artifact-no-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-generic-artifact-no-target.rb
@@ -3,7 +3,7 @@ cask 'invalid-generic-artifact-no-target' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-generic-artifact'
+  homepage 'https://brew.sh/with-generic-artifact'
 
   artifact 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
@@ -3,7 +3,7 @@ cask => 'invalid-header-format' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
@@ -3,7 +3,7 @@ cask 'invalid-header-token-mismatch-this-text-does-not-belong' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
@@ -3,7 +3,7 @@ cask 'invalid-header-version' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-stage-only-conflict.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-stage-only-conflict.rb
@@ -3,7 +3,7 @@ cask 'invalid-stage-only-conflict' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://example.com/invalid-stage-only-conflict'
+  homepage 'https://brew.sh/invalid-stage-only-conflict'
 
   app 'Transmission.app'
   stage_only true

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
@@ -3,8 +3,8 @@ cask 'invalid-two-homepage' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
-  homepage 'https://www.example.com/local-caffeine'
+  homepage 'https://brew.sh'
+  homepage 'https://www.brew.sh/local-caffeine'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
@@ -3,8 +3,8 @@ cask 'invalid-two-url' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  url 'https://example.com/caffeine.zip'
-  homepage 'https://example.com'
+  url 'https://brew.sh/caffeine.zip'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
@@ -4,7 +4,7 @@ cask 'invalid-two-version' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-appcast.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-appcast.rb
@@ -3,8 +3,8 @@ cask 'latest-with-appcast' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  appcast 'https://example.com/appcast.xml'
-  homepage 'https://example.com/with-appcast'
+  appcast 'https://brew.sh/appcast.xml'
+  homepage 'https://brew.sh/with-appcast'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
@@ -3,7 +3,7 @@ cask 'latest-with-auto-updates' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/latest-with-auto-updates'
+  homepage 'https://brew.sh/latest-with-auto-updates'
 
   auto_updates true
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
@@ -3,7 +3,7 @@ cask 'local-caffeine' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
@@ -4,7 +4,7 @@ cask 'local-transmission' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Transmission.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
@@ -2,7 +2,7 @@ cask 'missing-checksum' do
   version '1.2.3'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
@@ -1,5 +1,5 @@
 cask 'missing-url' do
   version '1.2.3'
 
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
@@ -1,4 +1,4 @@
 cask 'missing-version' do
   url 'https://localhost/something.dmg'
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/naked-executable.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/naked-executable.rb
@@ -3,7 +3,7 @@ cask 'naked-executable' do
   sha256 '306c6ca7407560340797866e077e053627ad409277d1b9da58106fce4cf717cb'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/naked_executable"
-  homepage 'https://example.com/naked-executable'
+  homepage 'https://brew.sh/naked-executable'
 
   container type: :naked
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/nested-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/nested-app.rb
@@ -3,7 +3,7 @@ cask 'nested-app' do
   sha256 '1866dfa833b123bb8fe7fa7185ebf24d28d300d0643d75798bc23730af734216'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/NestedApp.dmg.zip"
-  homepage 'https://example.com/nested-app'
+  homepage 'https://brew.sh/nested-app'
 
   container nested: 'NestedApp.dmg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
@@ -3,7 +3,7 @@ cask 'no-checksum' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/no-dsl-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/no-dsl-version.rb
@@ -2,8 +2,8 @@ cask 'no-dsl-version' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
-  url 'https://example.com/TestCask.dmg'
-  homepage 'https://example.com/'
+  url 'https://brew.sh/TestCask.dmg'
+  homepage 'https://brew.sh/'
 
   app 'TestCask.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/auto-updates.rb
@@ -3,7 +3,7 @@ cask 'auto-updates' do
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
-  homepage 'https://example.com/MyFancyApp'
+  homepage 'https://brew.sh/MyFancyApp'
 
   auto_updates true
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum.rb
@@ -3,7 +3,7 @@ cask 'bad-checksum' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-caffeine.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-caffeine.rb
@@ -3,7 +3,7 @@ cask 'local-caffeine' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission.rb
@@ -3,7 +3,7 @@ cask 'local-transmission' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Transmission.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/version-latest.rb
@@ -3,7 +3,7 @@ cask 'version-latest' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine Mini.app'
   app 'Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/will-fail-if-upgraded.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/will-fail-if-upgraded.rb
@@ -3,7 +3,7 @@ cask 'will-fail-if-upgraded' do
   sha256 'fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
-  homepage 'https://example.com/container-tar-gz'
+  homepage 'https://brew.sh/container-tar-gz'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/pkg-without-uninstall.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/pkg-without-uninstall.rb
@@ -3,7 +3,7 @@ cask 'pkg-without-uninstall' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/stage-only.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/stage-only.rb
@@ -3,7 +3,7 @@ cask 'stage-only' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://example.com/stage-only'
+  homepage 'https://brew.sh/stage-only'
 
   stage_only true
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
@@ -3,7 +3,7 @@ cask 'version-latest' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine Mini.app'
   app 'Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/will-fail-if-upgraded.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/will-fail-if-upgraded.rb
@@ -3,7 +3,7 @@ cask 'will-fail-if-upgraded' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-allow-untrusted.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-allow-untrusted.rb
@@ -3,7 +3,7 @@ cask 'with-allow-untrusted' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg', allow_untrusted: true
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
@@ -3,7 +3,7 @@ cask 'with-alt-target' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app', target: 'AnotherName.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-appcast.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-appcast.rb
@@ -3,8 +3,8 @@ cask 'with-appcast' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  appcast 'https://example.com/appcast.xml'
-  homepage 'https://example.com/with-appcast'
+  appcast 'https://brew.sh/appcast.xml'
+  homepage 'https://brew.sh/with-appcast'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-auto-updates.rb
@@ -2,9 +2,9 @@ cask 'with-auto-updates' do
   version '1.0'
   sha256 'e5be907a51cd0d5b128532284afe1c913608c584936a5e55d94c75a9f48c4322'
 
-  url "https://example.com/autoupdates_#{version}.zip"
+  url "https://brew.sh/autoupdates_#{version}.zip"
   name 'AutoUpdates'
-  homepage 'https://example.com/autoupdates'
+  homepage 'https://brew.sh/autoupdates'
 
   auto_updates true
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
@@ -3,7 +3,7 @@ cask 'with-binary' do
   sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/AppWithBinary.zip"
-  homepage 'https://example.com/with-binary'
+  homepage 'https://brew.sh/with-binary'
 
   app 'App.app'
   binary 'binary'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
@@ -3,7 +3,7 @@ cask 'with-caveats' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-choices.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-choices.rb
@@ -3,7 +3,7 @@ cask 'with-choices' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg',
       choices: [

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
@@ -3,7 +3,7 @@ cask 'with-conditional-caveats' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conflicts-with.rb
@@ -3,7 +3,7 @@ cask 'with-conflicts-with' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-conflicts-with'
+  homepage 'https://brew.sh/with-conflicts-with'
 
   conflicts_with cask: 'local-caffeine'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-arch' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-arch'
+  homepage 'https://brew.sh/with-depends-on-arch'
 
   # covers all known hardware; always succeeds
   depends_on arch: :intel

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic-helper.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic-helper.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-cask-cyclic-helper' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-cask-cyclic-helper'
+  homepage 'https://brew.sh/with-depends-on-cask-cyclic-helper'
 
   depends_on cask: 'with-depends-on-cask-cyclic'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-cyclic.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-cask-cyclic' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-cask-cyclic'
+  homepage 'https://brew.sh/with-depends-on-cask-cyclic'
 
   depends_on cask: 'local-caffeine'
   depends_on cask: 'with-depends-on-cask-cyclic-helper'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask-multiple.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-cask-multiple' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-cask-multiple'
+  homepage 'https://brew.sh/with-depends-on-cask-multiple'
 
   depends_on cask: 'local-caffeine'
   depends_on cask: 'local-transmission'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-cask.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-cask' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-cask'
+  homepage 'https://brew.sh/with-depends-on-cask'
 
   depends_on cask: 'local-transmission'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula-multiple.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-formula-multiple' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-formula-multiple'
+  homepage 'https://brew.sh/with-depends-on-formula-multiple'
 
   depends_on formula: 'unar'
   depends_on formula: 'fileutils'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-formula.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-formula' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-formula'
+  homepage 'https://brew.sh/with-depends-on-formula'
 
   depends_on formula: 'unar'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-array.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-array.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-macos-array' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-macos-array'
+  homepage 'https://brew.sh/with-depends-on-macos-array'
 
   # since all OS releases are included, this should always pass
   depends_on macos: ['10.4', '10.5', '10.6', '10.7', '10.8', '10.9', '10.10', MacOS.version.to_s]

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-comparison.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-comparison.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-macos-comparison' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-macos-comparison'
+  homepage 'https://brew.sh/with-depends-on-macos-comparison'
 
   depends_on macos: '>= 10.4'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-failure.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-macos-failure' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-macos-failure'
+  homepage 'https://brew.sh/with-depends-on-macos-failure'
 
   # guarantee a mismatched release
   depends_on macos: MacOS.version.to_s == '10.4' ? '10.5' : '10.4'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-string.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-string.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-macos-string' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-macos-string'
+  homepage 'https://brew.sh/with-depends-on-macos-string'
 
   depends_on macos: MacOS.version.to_s
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-symbol.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-macos-symbol.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-macos-symbol' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-macos-symbol'
+  homepage 'https://brew.sh/with-depends-on-macos-symbol'
 
   depends_on macos: MacOS.version.to_sym
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11-false.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11-false.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-x11-false' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-x11-false'
+  homepage 'https://brew.sh/with-depends-on-x11-false'
 
   depends_on x11: false
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-x11.rb
@@ -3,7 +3,7 @@ cask 'with-depends-on-x11' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-depends-on-x11'
+  homepage 'https://brew.sh/with-depends-on-x11'
 
   depends_on x11: true
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-embedded-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-embedded-binary.rb
@@ -3,7 +3,7 @@ cask 'with-embedded-binary' do
   sha256 'fe052d3e77d92676775fd916ddb8942e72a565b844ea7f6d055474c99bb4e47b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/AppWithEmbeddedBinary.zip"
-  homepage 'https://example.com/with-binary'
+  homepage 'https://brew.sh/with-binary'
 
   app 'App.app'
   binary "#{appdir}/App.app/Contents/MacOS/App/binary"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-generic-artifact.rb
@@ -3,7 +3,7 @@ cask 'with-generic-artifact' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-generic-artifact'
+  homepage 'https://brew.sh/with-generic-artifact'
 
   artifact 'Caffeine.app', target: "#{appdir}/Caffeine.app"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
@@ -3,7 +3,7 @@ cask 'with-installable' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
@@ -3,7 +3,7 @@ cask 'with-installer-manual' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   installer manual: 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-script.rb
@@ -3,7 +3,7 @@ cask 'with-installer-script' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com/with-install-script'
+  homepage 'https://brew.sh/with-install-script'
 
   installer script: '/usr/bin/true',
             args:   ['--flag']

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -12,7 +12,7 @@ cask 'with-languages' do
   end
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-macosx-dir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-macosx-dir.rb
@@ -3,7 +3,7 @@ cask 'with-macosx-dir' do
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
-  homepage 'https://example.com/MyFancyApp'
+  homepage 'https://brew.sh/MyFancyApp'
 
   app 'MyFancyApp/MyFancyApp.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
@@ -3,7 +3,7 @@ cask 'with-non-executable-binary' do
   sha256 'd5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/naked_non_executable"
-  homepage 'https://example.com/with-binary'
+  homepage 'https://brew.sh/with-binary'
 
   binary "naked_non_executable"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkgutil-zap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-pkgutil-zap.rb
@@ -3,7 +3,7 @@ cask 'with-pkgutil-zap' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
@@ -3,7 +3,7 @@ cask 'with-postflight-multi' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight.rb
@@ -3,7 +3,7 @@ cask 'with-postflight' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
@@ -3,7 +3,7 @@ cask 'with-preflight-multi' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight.rb
@@ -3,7 +3,7 @@ cask 'with-preflight' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-suite.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-suite.rb
@@ -4,7 +4,7 @@ cask 'with-suite' do
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine-suite.zip"
   name 'Caffeine'
-  homepage 'https://example.com/with-suite'
+  homepage 'https://brew.sh/with-suite'
 
   suite 'Caffeine'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
@@ -3,7 +3,7 @@ cask 'with-two-apps-correct' do
   sha256 '3178fbfd1ea5d87a2a0662a4eb599ebc9a03888e73f37538d9f3f6ee69d2368e'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine Mini.app'
   app 'Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
@@ -3,7 +3,7 @@ cask 'with-two-apps-subdir' do
   sha256 'd687c22a21c02bd8f07da9302c8292b93a04df9a929e3f04d09aea6c76f75c65'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines-subdir.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeines/Caffeine Mini.app'
   app 'Caffeines/Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-delete.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-delete.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-delete' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-early-script' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-kext.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-kext.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-kext' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-launchctl.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-launchctl' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
-  homepage 'https://example.com/fancy'
+  homepage 'https://brew.sh/fancy'
 
   app 'Fancy.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-login-item.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-login-item.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-login-item' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-multi' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-pkgutil.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-pkgutil.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-pkgutil' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-postflight-multi' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-postflight' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-preflight-multi' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-preflight' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-quit.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-quit' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-rmdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-rmdir.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-rmdir' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-script-app' do
   sha256 '5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
-  homepage 'https://example.com/MyFancyApp'
+  homepage 'https://brew.sh/MyFancyApp'
 
   app 'MyFancyApp/MyFancyApp.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-script' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-signal.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-signal' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-trash.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-trash.rb
@@ -3,7 +3,7 @@ cask 'with-uninstall-trash' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-delete.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-delete.rb
@@ -3,7 +3,7 @@ cask 'with-zap-delete' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
@@ -3,7 +3,7 @@ cask 'with-zap-early-script' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-kext.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-kext.rb
@@ -3,7 +3,7 @@ cask 'with-zap-kext' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-launchctl.rb
@@ -3,7 +3,7 @@ cask 'with-zap-launchctl' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
-  homepage 'https://example.com/fancy'
+  homepage 'https://brew.sh/fancy'
 
   app 'Fancy.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-login-item.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-login-item.rb
@@ -3,7 +3,7 @@ cask 'with-zap-login-item' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
@@ -3,7 +3,7 @@ cask 'with-zap-multi' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-pkgutil.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-pkgutil.rb
@@ -3,7 +3,7 @@ cask 'with-zap-pkgutil' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-quit.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-quit.rb
@@ -3,7 +3,7 @@ cask 'with-zap-quit' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-rmdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-rmdir.rb
@@ -3,7 +3,7 @@ cask 'with-zap-rmdir' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
@@ -3,7 +3,7 @@ cask 'with-zap-script' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-signal.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-signal.rb
@@ -3,7 +3,7 @@ cask 'with-zap-signal' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-trash.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-trash.rb
@@ -3,7 +3,7 @@ cask 'with-zap-trash' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
@@ -3,7 +3,7 @@ cask 'with-zap' do
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
-  homepage 'https://example.com/fancy-pkg'
+  homepage 'https://brew.sh/fancy-pkg'
 
   pkg 'MyFancyPkg/Fancy.pkg'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
@@ -3,7 +3,7 @@ cask 'without-languages' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://example.com'
+  homepage 'https://brew.sh'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/third-party/Casks/third-party-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/third-party/Casks/third-party-cask.rb
@@ -2,8 +2,8 @@ cask 'third-party-cask' do
   version '1.2.3'
   sha256 '8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b'
 
-  url 'https://example.com/ThirdParty.dmg'
-  homepage 'https://example.com/'
+  url 'https://brew.sh/ThirdParty.dmg'
+  homepage 'https://brew.sh/'
 
   app 'ThirdParty.app'
 end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -130,7 +130,7 @@ RSpec.shared_context "integration test" do
       end
       content = <<~RUBY
         desc "Some test"
-        homepage "https://example.com/#{name}"
+        homepage "https://brew.sh/#{name}"
         url "file://#{tarball}"
         sha256 "#{tarball.sha256}"
 
@@ -151,16 +151,16 @@ RSpec.shared_context "integration test" do
       RUBY
     when "foo"
       content = <<~RUBY
-        url "https://example.com/#{name}-1.0"
+        url "https://brew.sh/#{name}-1.0"
       RUBY
     when "bar"
       content = <<~RUBY
-        url "https://example.com/#{name}-1.0"
+        url "https://brew.sh/#{name}-1.0"
         depends_on "foo"
       RUBY
     when "patchelf"
       content = <<~RUBY
-        url "https://example.com/#{name}-1.0"
+        url "https://brew.sh/#{name}-1.0"
       RUBY
     end
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -20,7 +20,7 @@ describe Tap do
   def setup_tap_files
     formula_file.write <<~RUBY
       class Foo < Formula
-        url "https://example.com/foo-1.0.tar.gz"
+        url "https://brew.sh/foo-1.0.tar.gz"
       end
     RUBY
 
@@ -368,7 +368,7 @@ describe CoreTap do
     formula_file = subject.formula_dir/"foo.rb"
     formula_file.write <<~RUBY
       class Foo < Formula
-        url "https://example.com/foo-1.0.tar.gz"
+        url "https://brew.sh/foo-1.0.tar.gz"
       end
     RUBY
 

--- a/Library/Homebrew/test/update_migrator_spec.rb
+++ b/Library/Homebrew/test/update_migrator_spec.rb
@@ -5,7 +5,7 @@ describe UpdateMigrator do
     let(:formula_name) { "foo" }
     let(:f) {
       formula formula_name do
-        url "https://example.com/foo-1.2.3.tar.gz"
+        url "https://brew.sh/foo-1.2.3.tar.gz"
         version "1.2.3"
       end
     }
@@ -48,14 +48,14 @@ describe UpdateMigrator do
     let(:formula_name) { "foo" }
     let(:f) {
       formula formula_name do
-        url "https://example.com/foo-1.2.3.tar.gz"
+        url "https://brew.sh/foo-1.2.3.tar.gz"
         version "1.2.3"
       end
     }
     let(:old_cache_file) { HOMEBREW_CACHE/"#{formula_name}--1.2.3.tar.gz" }
     let(:new_cache_symlink) { HOMEBREW_CACHE/"#{formula_name}--1.2.3.tar.gz" }
     let(:new_cache_file) {
-      HOMEBREW_CACHE/"downloads/5994e3a27baa3f448a001fb071ab1f0bf25c87aebcb254d91a6d0b02f46eef86--foo-1.2.3.tar.gz"
+      HOMEBREW_CACHE/"downloads/4a81b0e17a7540b7afe1685671a0a126645117e6c0bc6c66f5ad13b7a5912f80--foo-1.2.3.tar.gz"
     }
 
     before do
@@ -70,7 +70,7 @@ describe UpdateMigrator do
       expect(old_cache_file).to eq(new_cache_symlink)
       expect(new_cache_symlink).to be_a_symlink
       expect(new_cache_symlink.readlink.to_s)
-        .to eq "downloads/5994e3a27baa3f448a001fb071ab1f0bf25c87aebcb254d91a6d0b02f46eef86--foo-1.2.3.tar.gz"
+        .to eq "downloads/4a81b0e17a7540b7afe1685671a0a126645117e6c0bc6c66f5ad13b7a5912f80--foo-1.2.3.tar.gz"
       expect(new_cache_file).to exist
       expect(new_cache_file).to be_a_file
     end

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -244,7 +244,7 @@ describe Version do
 
   describe "::parse" do
     it "returns a NULL version when the URL cannot be parsed" do
-      expect(described_class.parse("https://example.com/blah.tar")).to be_null
+      expect(described_class.parse("https://brew.sh/blah.tar")).to be_null
       expect(described_class.parse("foo")).to be_null
     end
   end
@@ -267,17 +267,17 @@ describe Version do
 
     specify "version all dots" do
       expect(described_class.create("1.14"))
-        .to be_detected_from("https://example.com/foo.bar.la.1.14.zip")
+        .to be_detected_from("https://brew.sh/foo.bar.la.1.14.zip")
     end
 
     specify "version underscore separator" do
       expect(described_class.create("1.1"))
-        .to be_detected_from("https://example.com/grc_1.1.tar.gz")
+        .to be_detected_from("https://brew.sh/grc_1.1.tar.gz")
     end
 
     specify "boost version style" do
       expect(described_class.create("1.39.0"))
-        .to be_detected_from("https://example.com/boost_1_39_0.tar.bz2")
+        .to be_detected_from("https://brew.sh/boost_1_39_0.tar.bz2")
     end
 
     specify "erlang version style" do
@@ -340,27 +340,27 @@ describe Version do
 
     specify "version internal dash" do
       expect(described_class.create("1.1-2"))
-        .to be_detected_from("https://example.com/foo-arse-1.1-2.tar.gz")
+        .to be_detected_from("https://brew.sh/foo-arse-1.1-2.tar.gz")
     end
 
     specify "version single digit" do
       expect(described_class.create("45"))
-        .to be_detected_from("https://example.com/foo_bar.45.tar.gz")
+        .to be_detected_from("https://brew.sh/foo_bar.45.tar.gz")
     end
 
     specify "noseparator single digit" do
       expect(described_class.create("45"))
-        .to be_detected_from("https://example.com/foo_bar45.tar.gz")
+        .to be_detected_from("https://brew.sh/foo_bar45.tar.gz")
     end
 
     specify "version developer that hates us format" do
       expect(described_class.create("1.2.3"))
-        .to be_detected_from("https://example.com/foo-bar-la.1.2.3.tar.gz")
+        .to be_detected_from("https://brew.sh/foo-bar-la.1.2.3.tar.gz")
     end
 
     specify "version regular" do
       expect(described_class.create("1.21"))
-        .to be_detected_from("https://example.com/foo_bar-1.21.tar.gz")
+        .to be_detected_from("https://brew.sh/foo_bar-1.21.tar.gz")
     end
 
     specify "version sourceforge download" do
@@ -382,7 +382,7 @@ describe Version do
 
     specify "yet another version" do
       expect(described_class.create("0.15.1b"))
-        .to be_detected_from("https://example.com/mad-0.15.1b.tar.gz")
+        .to be_detected_from("https://brew.sh/mad-0.15.1b.tar.gz")
     end
 
     specify "lame version style" do
@@ -472,7 +472,7 @@ describe Version do
 
     specify "date-based version style" do
       expect(described_class.create("2017-04-17"))
-        .to be_detected_from("https://example.com/dada-v2017-04-17.tar.gz")
+        .to be_detected_from("https://brew.sh/dada-v2017-04-17.tar.gz")
     end
 
     specify "devel spec version style" do


### PR DESCRIPTION
In a number of Cask specs, the value of the `homepage` stanza is currently set to the dummy value `https://example.com` As of 2018-11-28, the TLS certificate served by example.com seems to be expired, possibly due to an oversight on ICANN’s side.

![image](https://user-images.githubusercontent.com/1239874/49178563-5e4f7900-f350-11e8-969a-8727b4b70311.png)

The expired certificate [causes issues with all Cask specs using example.com as a homepage](https://github.com/Homebrew/brew/pull/5358).

While the certificate is certainly going to be renewed soon, it would be desirable for Homebrew’s test result to be less dependent on ICANN’s actions. This PR changes the homepages of all test Casks to https://brew.sh, whose domain and TLS certificate are both controlled by Homebrew.

Another benefit of this PR is that it serves as a canary that lets us detect an expired cert on brew.sh before our users do.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **Not applicable**
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
