### PR TITLE
man:  Remove `HOMEBREW_DEBUG_INSTALL` nor `HOMEBREW_DEBUG_PREFIX`

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -159,16 +159,6 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_DEBUG`:
     If set, any commands that can emit debugging information will do so.
 
-  * `HOMEBREW_DEBUG_INSTALL`:
-    When `brew install -d` or `brew install -i` drops into a shell,
-    `HOMEBREW_DEBUG_INSTALL` will be set to the name of the formula being
-    brewed.
-
-  * `HOMEBREW_DEBUG_PREFIX`:
-    When `brew install -d` or `brew install -i` drops into a shell,
-    `HOMEBREW_DEBUG_PREFIX` will be set to the target prefix in the Cellar
-    of the formula being brewed.
-
   * `HOMEBREW_DEVELOPER`:
     If set, Homebrew will tweak behaviour to be more relevant for Homebrew
     developers (active or budding) e.g. turning warnings into errors.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1160,16 +1160,6 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_DEBUG`:
     If set, any commands that can emit debugging information will do so.
 
-  * `HOMEBREW_DEBUG_INSTALL`:
-    When `brew install -d` or `brew install -i` drops into a shell,
-    `HOMEBREW_DEBUG_INSTALL` will be set to the name of the formula being
-    brewed.
-
-  * `HOMEBREW_DEBUG_PREFIX`:
-    When `brew install -d` or `brew install -i` drops into a shell,
-    `HOMEBREW_DEBUG_PREFIX` will be set to the target prefix in the Cellar
-    of the formula being brewed.
-
   * `HOMEBREW_DEVELOPER`:
     If set, Homebrew will tweak behaviour to be more relevant for Homebrew
     developers (active or budding) e.g. turning warnings into errors.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1283,14 +1283,6 @@ If set, Homebrew will pass \fB\-\-verbose\fR when invoking \fBcurl\fR(1)\.
 If set, any commands that can emit debugging information will do so\.
 .
 .TP
-\fBHOMEBREW_DEBUG_INSTALL\fR
-When \fBbrew install \-d\fR or \fBbrew install \-i\fR drops into a shell, \fBHOMEBREW_DEBUG_INSTALL\fR will be set to the name of the formula being brewed\.
-.
-.TP
-\fBHOMEBREW_DEBUG_PREFIX\fR
-When \fBbrew install \-d\fR or \fBbrew install \-i\fR drops into a shell, \fBHOMEBREW_DEBUG_PREFIX\fR will be set to the target prefix in the Cellar of the formula being brewed\.
-.
-.TP
 \fBHOMEBREW_DEVELOPER\fR
 If set, Homebrew will tweak behaviour to be more relevant for Homebrew developers (active or budding) e\.g\. turning warnings into errors\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?  
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?  
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?  (Yes, see the commit message.)  
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).   (N/A, as I'm only updating documentation, not modifying any code.)  
- [x] Have you successfully run `brew style` with your changes locally?  
- [x] Have you successfully run `brew tests` with your changes locally?  

-----

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;As requested by @MikeMcQuaid in https://github.com/Homebrew/brew/pull/5361#issuecomment-443239066.  