### PR TITLE
bottle: Mismatch in cellar is a warning

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -390,7 +390,10 @@ module Homebrew
       mismatches = [:root_url, :prefix, :cellar, :rebuild].reject do |key|
         old_spec.send(key) == bottle.send(key)
       end
-      mismatches.delete(:cellar) if old_spec.cellar == :any && bottle.cellar == :any_skip_relocation
+      if old_spec.cellar == :any && bottle.cellar == :any_skip_relocation
+        mismatches.delete(:cellar)
+        bottle.cellar :any
+      end
       unless mismatches.empty?
         bottle_path.unlink if bottle_path.exist?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When there is no previous linux bottle, and the bottle block looks like this:
```
bottle do
  sha256 "5cbcce4556b41ece91f01778068f481514bc3a0d5447ddbff048797236cc9b29" => :mojave
  sha256 "15748ef1ffefa088f7c958e6935c6eec794781858e6190196e18e94ab768adc2" => :high_sierra
  sha256 "49eb0e5d27b8868b2dba20efbde3ef75becc0cbf5ea230c00e5745e2df697cb6" => :sierra
end
```

then the bottling fails with:
```
Error: --keep-old was passed but there are changes in:
cellar: old: "/home/linuxbrew/.linuxbrew/Cellar", new: :any_skip_relocation
==> FAILED
```

This change allows to run the bottling step for these cases.