### PR TITLE
bottle: Ignore matches to source code

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -342,7 +342,9 @@ module Homebrew
           prefix_check = prefix
         end
 
-        ignores = []
+        # Ignore matches to source code, which is not required at run time.
+        # These matches may be caused by debugging symbols.
+        ignores = [%r{/include/|\.(c|cc|cpp|h|hpp)$}]
         any_go_deps = f.deps.any? do |dep|
           dep.name =~ Version.formula_optionally_versioned_regex(:go)
         end


### PR DESCRIPTION
Source code is not required at run time.
These matches may be caused by debugging symbols.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----