### PR TITLE
.rubocop.yml: brew style fixes.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -77,8 +77,8 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/MethodLength:
   Enabled: false
-# Metrics/ModuleLength:
-#   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 
@@ -109,6 +109,8 @@ Style/GuardClause:
 # depends_on a: :b looks weird in formulae.
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
+  Exclude:
+  - '**/cmd/*.rb'
 
 # ruby style guide favorite
 Style/StringLiterals:


### PR DESCRIPTION
- uncomment `ModuleLength` disable.
- don't enforce hash rockets for external commands

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----