### PR TITLE
link: prevent :provided_by_macos links everywhere.

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -78,24 +78,10 @@ module Homebrew
       if keg_only
         if Homebrew.default_prefix?
           f = keg.to_formula
-          caveats = Caveats.new(f)
-
-          if f.keg_only_reason.reason == :provided_by_macos &&
-             (MacOS.version >= :mojave ||
-              MacOS::Xcode.version >= "10.0" ||
-              MacOS::CLT.version >= "10.0")
+          if f.keg_only_reason.reason == :provided_by_macos
+            caveats = Caveats.new(f)
             opoo <<~EOS
               Refusing to link macOS-provided software: #{keg.name}
-              #{caveats.keg_only_text(skip_reason: true).strip}
-            EOS
-            next
-          end
-
-          if keg.name.start_with?("openssl", "libressl")
-            opoo <<~EOS
-              Refusing to link: #{keg.name}
-              Linking keg-only #{keg.name} means you may end up linking against the insecure,
-              deprecated system OpenSSL while using the headers from Homebrew's #{keg.name}.
               #{caveats.keg_only_text(skip_reason: true).strip}
             EOS
             next

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -531,7 +531,13 @@ module Homebrew
       return unless @versioned_formula
       return unless @core_tap
 
-      return if formula.keg_only? && formula.keg_only_reason.reason == :versioned_formula
+      if formula.keg_only?
+        return if formula.keg_only_reason.reason == :versioned_formula
+        if formula.name.start_with?("openssl", "libressl") &&
+           formula.keg_only_reason.reason == :provided_by_macos
+          return
+        end
+      end
 
       keg_only_whitelist = %w[
         autoconf@2.13


### PR DESCRIPTION
We've not seen complaints about these and they are the default behaviour on High Sierra and Mojave so it's easier to apply them consistently everywhere.

Also, combined with https://github.com/Homebrew/homebrew-core/pull/34854, simplify the linkage of *SSL.

This would have avoided https://github.com/Homebrew/homebrew-core/issues/34754.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----