### PR TITLE
Update bash completion docs

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -7,13 +7,14 @@ Homebrew comes with completion definitions for the `brew` command. Some packages
 You must configure your shell to enable the completion support. This is because the Homebrew-managed completions are stored under `HOMEBREW_PREFIX`, which your system shell may not be aware of, and because it is difficult to automatically configure `bash` and `zsh` completions in a robust manner, so the Homebrew installer cannot do it for you.
 
 ## Configuring Completions in `bash`
+
 To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell startup. Add the following to your `~/.bashrc` file:
 
 ```sh
 if type brew 2&>/dev/null; then
-  for completion_file in $(brew --prefix)/etc/bash_completion.d/*; do
-    source "$completion_file"
-  done
+  source "$(brew --prefix)/etc/bash_completion"
+else
+  echo "run: brew install git bash-completion"
 fi
 ```
 


### PR DESCRIPTION
When I try to run the proposed script in my `~/.bashrc` file I get this output:

```
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: have: command not found
-bash: [: =: unary operator expected
# ...
```

It goes on for quite some time and does not give me bash completion.

When I execute `source "$(brew --prefix)/etc/bash_completion"` it works and I get bash completion.

This script also emits a helpful error message letting people know if bash completion was not installed already.

I'll also add that the bash completion script takes a fairly long amount of time. I've seen between one quarter and a half of a second to execute it:

```
$ time source "$(brew --prefix)/etc/bash_completion"

real	0m0.254s
```

Though that's unrelated to this PR, making a note of it.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
