### PR TITLE
_brew | allow 'brew commands' to be cached by zsh

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -129,9 +129,26 @@ __brew_common_commands() {
   _describe -t common-commands 'common commands' commands
 }
 
+# completions are cached for 24 hour
+__brew_commands_caching_policy() {
+  local -a oldp
+  oldp=( "$1"(Nmh+24) )
+  (( $#oldp ))
+}
+
 __brew_all_commands() {
+  local cache_policy
+  zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
+  if [[ -z "$cache_policy" ]]; then
+    zstyle ":completion:${curcontext}:" cache-policy __brew_commands_caching_policy
+  fi
   local -a commands
-  commands=($(_call_program brew brew commands --quiet --include-aliases))
+  local comp_cachename=brew_all_commands
+
+  if  _cache_invalid $comp_cachename  || ! _retrieve_cache $comp_cachename; then
+    commands=($(_call_program brew brew commands --quiet --include-aliases))
+    _store_cache $comp_cachename commands
+  fi
   _describe -t all-commands 'all commands' commands
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hi,

Here is an update to `_brew` where the most expensive command (`__brew_all_commands`) has its results cached. This results in faster (immediate?) completion. This should help people with slow machine (my mac at work is hugely slowed down by the security measures).

I tried my best and used the standard mechanism; the code follows along the many available examples. 

The user will have its results cached if his/her shell is configured to do so: meaning that the standard zstyle (`use-cache`) has to be set to `'yes'` and that the cache will be saved by default in `~/.zcompcache/brew_all_commands` (also configurable using the zstyle `cache-path`). The delay for cache invalidation is set to 24h [completions/zsh/_brew#135](https://github.com/Homebrew/brew/pull/5388/files#r240019986). I expect no kitten to be harmed with this PR.

Regarding tests, I only conducted manual checks:
- with no existing cache file at `~/.zcompcache/brew_all_commands`: the cache gets created
- with an invalid (>24h) cache file: the cache gets recreated
- with a valid cache file (<=24h): the cache is simply used and thus will eventually get older than 24h.

I hope you'll review it and it eventually gets accepted.
Have a great day.