### PR TITLE
shims/super/cc: Add HOMEBREW_CACHE to white list

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -26,7 +26,7 @@ def linux?
 end
 
 class Cmd
-  attr_reader :config, :prefix, :cellar, :opt, :tmpdir, :sysroot, :deps
+  attr_reader :config, :prefix, :cellar, :opt, :cachedir, :tmpdir, :sysroot, :deps
   attr_reader :archflags, :optflags, :keg_regex, :formula_prefix
 
   def initialize(arg0, args)
@@ -35,6 +35,7 @@ class Cmd
     @config = ENV.fetch("HOMEBREW_CCCFG") { "" }
     @prefix = ENV["HOMEBREW_PREFIX"]
     @cellar = ENV["HOMEBREW_CELLAR"]
+    @cachedir = ENV["HOMEBREW_CACHE"]
     @opt = ENV["HOMEBREW_OPT"]
     @tmpdir = ENV["HOMEBREW_TEMP"]
     @sysroot = ENV["HOMEBREW_SDKROOT"]
@@ -242,7 +243,7 @@ class Cmd
     elsif path.start_with?(cellar) || path.start_with?(opt)
       dep = path[keg_regex, 2]
       dep && @deps.include?(dep)
-    elsif path.start_with?(prefix, tmpdir)
+    elsif path.start_with?(prefix, cachedir, tmpdir)
       true
     elsif path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")
       # ignore MacPorts, Boxen's Homebrew, X11, fink


### PR DESCRIPTION
Compiling rust projects requires -I$HOMEBREW_CACHE/cargo_cache/...

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew install -s exa` fails on Linux because Superenv removes `-I/home/linuxbrew/.cache/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/libgit2-sys-0.6.14/libgit2/src`

See PR https://github.com/Linuxbrew/homebrew-core/pull/10162