### PR TITLE
Zsh/completion cache for 'brew search' / formulae name

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -39,8 +39,8 @@ __brew_formulae_or_ruby_files() {
     'files:files:{_files -g *.rb}'
 }
 
-# formulae completions are cached as long as homebrew does have new commits
-__brew_formulae_caching_policy() {
+# completions are cached as long as homebrew does have new commits
+__brew_completion_caching_policy() {
   # rebuild cache if no cache file exists (anyway we cannot proceed further down)
   ! [[ -f "$1" ]] && return 0
   # cache file modification date (seconds since epoch)
@@ -52,7 +52,7 @@ __brew_formulae_caching_policy() {
 }
 
 __brew_formulae() {
-  zstyle ":completion:${curcontext}:" cache-policy __brew_formulae_caching_policy
+  zstyle ":completion:${curcontext}:" cache-policy __brew_completion_caching_policy
   local -a formulae
   local comp_cachename=brew_formulae
   if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then
@@ -146,15 +146,8 @@ __brew_common_commands() {
   _describe -t common-commands 'common commands' commands
 }
 
-# completions are cached for 24 hour
-__brew_commands_caching_policy() {
-  local -a oldp
-  oldp=( "$1"(Nmh+24) )
-  (( $#oldp ))
-}
-
 __brew_all_commands() {
-  zstyle ":completion:${curcontext}:" cache-policy __brew_commands_caching_policy
+  zstyle ":completion:${curcontext}:" cache-policy __brew_completion_caching_policy
   local -a commands
   local comp_cachename=brew_all_commands
   if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -39,7 +39,7 @@ __brew_formulae_or_ruby_files() {
     'files:files:{_files -g *.rb}'
 }
 
-# completions are cached as long as homebrew does have new commits
+# completions remain in cache until any tap has new commits
 __brew_completion_caching_policy() {
   # rebuild cache if no cache file exists (anyway we cannot proceed further down)
   ! [[ -f "$1" ]] && return 0

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -39,9 +39,28 @@ __brew_formulae_or_ruby_files() {
     'files:files:{_files -g *.rb}'
 }
 
+# formulae completions are cached as long as homebrew does have new commits
+__brew_formulae_caching_policy() {
+  # rebuild cache if no cache file exists (anyway we cannot proceed further down)
+  ! [[ -f "$1" ]] && return 0
+  # cache file modification date (seconds since epoch)
+  local -i cache_mtime=$(date -r "$1" +%s)
+  # latest homebrew commit on HEAD (branch 'stable' by default)
+  local brew_repo=${HOMEBREW_PREFIX:-/usr/local}/Homebrew/.git
+  local latest_commit=$(git --git-dir=${brew_repo} rev-parse HEAD) # --branches=refs/stable
+  # latest homebrew commit date (seconds since epoch)
+  local -i commit_mtime=$(git --git-dir=${brew_repo} rev-list -1 --format=format:'%at' $latest_commit | tail +2)
+  (( $cache_mtime < $commit_mtime ))
+}
+
 __brew_formulae() {
+  zstyle ":completion:${curcontext}:" cache-policy __brew_formulae_caching_policy
   local -a formulae
-  formulae=($(brew search))
+  local comp_cachename=brew_formulae
+  if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then
+    formulae=($(brew search))
+    _store_cache $comp_cachename formulae
+  fi
   _describe -t formulae 'all formulae' formulae
 }
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -45,11 +45,9 @@ __brew_formulae_caching_policy() {
   ! [[ -f "$1" ]] && return 0
   # cache file modification date (seconds since epoch)
   local -i cache_mtime=$(date -r "$1" +%s)
-  # latest homebrew commit on HEAD (branch 'stable' by default)
-  local brew_repo=${HOMEBREW_PREFIX:-/usr/local}/Homebrew/.git
-  local latest_commit=$(git --git-dir=${brew_repo} rev-parse HEAD) # --branches=refs/stable
-  # latest homebrew commit date (seconds since epoch)
-  local -i commit_mtime=$(git --git-dir=${brew_repo} rev-list -1 --format=format:'%at' $latest_commit | tail +2)
+  # latest modified homebrew tap index file
+  local latest_modified_git_index=(${HOMEBREW_REPOSITORY:-/usr/local/Homebrew}/Library/Taps/*/*/.git/index(om[1]))
+  local -i commit_mtime=$(date -r "$latest_modified_git_index" +%s)
   (( $cache_mtime < $commit_mtime ))
 }
 

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -137,15 +137,10 @@ __brew_commands_caching_policy() {
 }
 
 __brew_all_commands() {
-  local cache_policy
-  zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
-  if [[ -z "$cache_policy" ]]; then
-    zstyle ":completion:${curcontext}:" cache-policy __brew_commands_caching_policy
-  fi
+  zstyle ":completion:${curcontext}:" cache-policy __brew_commands_caching_policy
   local -a commands
   local comp_cachename=brew_all_commands
-
-  if  _cache_invalid $comp_cachename  || ! _retrieve_cache $comp_cachename; then
+  if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then
     commands=($(_call_program brew brew commands --quiet --include-aliases))
     _store_cache $comp_cachename commands
   fi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hi, in #5388 @MikeMcQuaid mentioned caching the names of formulae: here is an implementation.

## Cache invalidation for names of formulae
As formulae may be updated anytime, I think it is appropriate to declare the cache file for formulae names as invalid as soon as new commits have been made to the Homebrew working dir. This is what the implementation below does, it simply compares epoch times of the cache file and the latest commit on HEAD in Homebrew working dir. In order to access the working dir, I use `HOMEBREW_PREFIX` and fallback onto `/usr/local` and use this as `--git-dir` option to `git`. Also, I chose to check for commits on HEAD, which normally corresponds to the branch 'stable' for most people (including me). What's your opinion on this?

I conducted the following tests:

- with no existing cache file at ~/.zcompcache/brew_formulae: the cache gets created
- with an invalid cache file (older than latest commit): the cache gets recreated.
- with a valid cache file (newer than latest commit): the cache is simply used and should age indefinitely until new commits.

In the end, it looks like the same cache invalidation semantics can be used for `brew_all_commands()`. If you feel like so, just tell me, I'll merge both cache policies.

## Note
I took the liberty in `__brew_all_commands` to simplify a bit the code that sets the `cache-policy` zstyle circa line 140. In practice the `cache-policy` zstyle must anyway always be set to  `__brew_commands_cache_policy` for the "semantics" to be correct, so I think there is no actual need for the little dance about the zstyle existence. I simply set its value to `__brew_commands_cache_policy` every time, it is more straightforward. 

Are you ok with this? Should this go to a separate PR?

Thanks in advance for your review, cheers!