### PR TITLE
GitDownloadStrategy: disable automatic tag following

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -683,6 +683,9 @@ class GitDownloadStrategy < VCSDownloadStrategy
     system_command! "git",
                     args:  ["config", "remote.origin.fetch", refspec],
                     chdir: cached_location
+    system_command! "git",
+                    args:  ["config", "remote.origin.tagOpt", "--no-tags"],
+                    chdir: cached_location
   end
 
   def update_repo


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

From `git-fetch(1)`,

> Until Git version 2.20, and unlike when pushing with git-push(1), any updates to refs/tags/*
> would be accepted without + in the refspec (or --force). When fetching, we promiscuously
> considered all tag updates from a remote to be forced fetches. Since Git version 2.20, fetching
> to update refs/tags/* works the same way as when pushing. I.e. any updates will be rejected
> without + in the refspec (or --force).

and,

> By default, any tag that points into the histories being fetched is also fetched; the effect is to
> fetch tags that point at branches that you are interested in. This default behavior can be changed by
> using the --tags or --no-tags options or by configuring remote.<name>.tagOpt. By using a refspec that
> fetches tags explicitly, you can fetch tags that do not point into branches you are interested in as
> well.

While upgrading a `HEAD` formula, any tag that points into the `HEAD` branch will also be fetched by default. If upstream retags any of those aforementioned tags, `git fetch origin` will reject such updates starting Git 2.20. For example, [`neovim`](https://github.com/neovim/neovim) has a tag, namely [`nightly`](https://github.com/neovim/neovim/releases/tag/nightly), which is being regularly retagged.

This pull request simply disables the automatic tag following mechanism.