### PR TITLE
test/cmd/uninstall: Prevent can't modify frozen object

### DIFF
--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -60,7 +60,9 @@ describe Homebrew do
     end
 
     specify "when not developer and --ignore-dependencies is specified" do
+      described_class.args = described_class.args.dup if described_class.args.frozen?
       expect(described_class.args).to receive(:ignore_dependencies?).and_return(true)
+      described_class.args.freeze
 
       expect {
         described_class.handle_unsatisfied_dependents(opts)


### PR DESCRIPTION
Fix the error:
```
  RuntimeError:
    can't modify frozen object
  # ./test/cmd/uninstall_spec.rb:63:in `block (3 levels) in <top (required)>'
```

This issue arose after merging PR https://github.com/Homebrew/brew/pull/5300.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See the build failures at https://hub.docker.com/r/linuxbrew/brew/builds/
for example https://hub.docker.com/r/linuxbrew/brew/builds/beftysjyvxj5fr6rbnwaipd/