### PR TITLE
bin/brew: Pass CIRCLECI environment variable

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -72,7 +72,7 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM COLUMNS LOGNAME USER CI CIRCLECI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

CircleCI has limited memory available (4 GB). It's pretty easy to exceed available memory when using too many concurrent `g++` processes. In the Brewsci/bio tap, we reduce the number of threads for certain particularly memory-hungry formulae like so:
```ruby
ENV["MAKEFLAGS"] = "-j4" if ENV["CIRCLECI"]
```