### PR TITLE
test: Fix ENV.cxx11

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -320,7 +320,7 @@ module SharedEnvExtension
     return if compiler_any_clang?(cc)
 
     version = if cc == :gcc
-      non_apple_gcc_version "gcc"
+      DevelopmentTools.non_apple_gcc_version "gcc"
     else
       cc[/^gcc-(\d+(?:\.\d+)?)$/, 1]
     end


### PR DESCRIPTION
`ENV.cxx11` in a test block fails on Linux with
```
Error: ibex: failed
An exception occurred within a child process:
NoMethodError: undefined method `non_apple_gcc_version'
```
See for example `brew test ibex` on Linux.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?