### PR TITLE
[`JavaRequirement#satisfies_version`] `java_version_s`:  Fix Regular Expression

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -129,7 +129,7 @@ class JavaRequirement < Requirement
   end
 
   def satisfies_version(java)
-    java_version_s = system_command(java, args: ["-version"], print_stderr: false).stderr[/\d+.\d/]
+    java_version_s = system_command(java, args: ["-version"], print_stderr: false).stderr[/\d+\.\d/]
     return false unless java_version_s
 
     java_version = Version.create(java_version_s)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?  
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?  
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?  
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).  (No, but I don't think there's anything I've changed here that the existing test or tests for the code involved already cover.  Please correct me if I'm wrong on this.)  
- [x] Have you successfully run `brew style` with your changes locally?  
- [ ] Have you successfully run `brew tests` with your changes locally?  (All tests pass except '`test/os/mac_spec.rb`,' which fails with an error stating that, "`Locale::parse`' failed to parse '`OS::Mac::language`," but that's unrelated.)  

-----

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Address the second to last part of https://github.com/Homebrew/brew/pull/5280#issuecomment-437165119 per this PR's only commit's message.  