### PR TITLE
mac/keg_relocate: Rewrite rpaths in install names

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -79,10 +79,10 @@ class Keg
     suffix = bad_name.sub(/^@rpath/, "")
 
     # short circuit: we expect lib to be usually correct, so we try it first
-    return (lib + suffix) if (lib + suffix).exist?
+    return (lib / suffix) if (lib / suffix).exist?
 
     file.rpaths.each do |rpath|
-      return (rpath + suffix) if (rpath + suffix).exist?
+      return (rpath / suffix) if (rpath / suffix).exist?
     end
 
     opoo "Could not expand an RPATH in #{file}"
@@ -101,7 +101,7 @@ class Keg
       "@loader_path/#{bad_name}"
     elsif file.mach_o_executable? && (lib + bad_name).exist?
       "#{lib}/#{bad_name}"
-    elsif bad_name.start_with? "@rpath"
+    elsif bad_name.start_with? "@rpath" && ENV["HOMEBREW_RELOCATE_RPATHS"]
       expand_rpath bad_name
     elsif (abs_name = find_dylib(bad_name)) && abs_name.exist?
       abs_name.to_s

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -95,6 +95,14 @@ class Keg
     bad_name
   end
 
+  def expand_loader_path(file, bad_name)
+    suffix = bad_name.sub(/^@loader_path/, "")
+
+    # Note: Weak dylibs are allowed to not exist on disk, so
+    # we don't check for existence & complain here.
+    file.parent/suffix
+  end
+
   # If file is a dylib or bundle itself, look for the dylib named by
   # bad_name relative to the lib directory, so that we can skip the more
   # expensive recursive search if possible.
@@ -104,11 +112,13 @@ class Keg
     elsif bad_name.start_with? CELLAR_PLACEHOLDER
       bad_name.sub(CELLAR_PLACEHOLDER, HOMEBREW_CELLAR)
     elsif (file.dylib? || file.mach_o_bundle?) && (file.parent + bad_name).exist?
-      "@loader_path/#{bad_name}"
+      file.parent/bad_name
     elsif file.mach_o_executable? && (lib + bad_name).exist?
       "#{lib}/#{bad_name}"
-    elsif bad_name.start_with?("@rpath") && ENV["HOMEBREW_RELOCATE_RPATHS"]
-      expand_rpath bad_name
+    elsif bad_name.start_with?("@rpath") && ENV["HOMEBREW_RELOCATE_METAVARS"]
+      expand_rpath file, bad_name
+    elsif bad_name.start_with?("@loader_path") && ENV["HOMEBREW_RELOCATE_METAVARS"]
+      expand_loader_path file, bad_name
     elsif (abs_name = find_dylib(bad_name)) && abs_name.exist?
       abs_name.to_s
     else
@@ -119,7 +129,7 @@ class Keg
 
   def each_install_name_for(file, &block)
     dylibs = file.dynamically_linked_libraries
-    dylibs.reject! { |fn| fn =~ /^@(loader_|executable_)path/ }
+    dylibs.reject! { |fn| fn =~ /^@executable_path/ }
     dylibs.each(&block)
   end
 

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -78,14 +78,11 @@ class Keg
   def expand_rpath(file, bad_name)
     suffix = bad_name.sub(/^@rpath/, "")
 
-    # short circuit: we expect lib to be usually correct, so we try it first
-    return (lib / suffix) if (lib / suffix).exist?
-
     file.rpaths.each do |rpath|
-      return (rpath / suffix) if (rpath / suffix).exist?
+      return (rpath/suffix) if (rpath/suffix).exist?
     end
 
-    opoo "Could not expand an RPATH in #{file}"
+    opoo "Could not find library #{bad_name} for #{file}"
     bad_name
   end
 

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -79,7 +79,7 @@ class Keg
     suffix = bad_name.sub(/^@rpath/, "")
 
     file.rpaths.each do |rpath|
-      return (rpath/suffix) if (rpath/suffix).exist?
+      return rpath/suffix if (rpath/suffix).exist?
     end
 
     opoo "Could not find library #{bad_name} for #{file}"

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -69,6 +69,15 @@ class Keg
           new_name = fixed_name(file, bad_name)
           change_install_name(bad_name, new_name, file) unless new_name == bad_name
         end
+
+        # If none of the install names reference RPATH(s), then we can safely
+        # remove all RPATHs from the file.
+        if file.dynamically_linked_libraries.none? { |lib| lib.start_with?("@rpath") }
+          # Note: This could probably be made more efficient by reverse-sorting
+          # the RPATHs by offset and calling MachOFile#delete_command
+          # with repopulate: false.
+          file.rpaths.each { |r| file.delete_rpath(r) }
+        end
       end
     end
 

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -87,6 +87,8 @@ class Keg
       "@loader_path/#{bad_name}"
     elsif file.mach_o_executable? && (lib + bad_name).exist?
       "#{lib}/#{bad_name}"
+    elsif bad_name.start_with? "@rpath"
+      bad_name.sub("@rpath", lib)
     elsif (abs_name = find_dylib(bad_name)) && abs_name.exist?
       abs_name.to_s
     else
@@ -97,7 +99,7 @@ class Keg
 
   def each_install_name_for(file, &block)
     dylibs = file.dynamically_linked_libraries
-    dylibs.reject! { |fn| fn =~ /^@(loader_|executable_|r)path/ }
+    dylibs.reject! { |fn| fn =~ /^@(loader_|executable_)path/ }
     dylibs.each(&block)
   end
 

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -98,7 +98,7 @@ class Keg
       "@loader_path/#{bad_name}"
     elsif file.mach_o_executable? && (lib + bad_name).exist?
       "#{lib}/#{bad_name}"
-    elsif bad_name.start_with? "@rpath" && ENV["HOMEBREW_RELOCATE_RPATHS"]
+    elsif bad_name.start_with?("@rpath") && ENV["HOMEBREW_RELOCATE_RPATHS"]
       expand_rpath bad_name
     elsif (abs_name = find_dylib(bad_name)) && abs_name.exist?
       abs_name.to_s

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -2,6 +2,10 @@ require "macho"
 require "os/mac/architecture_list"
 
 module MachOShim
+  extend Forwardable
+
+  delegate [:dylib_id, :rpaths, :delete_rpath] => :macho
+
   # @private
   def macho
     @macho ||= begin
@@ -54,18 +58,6 @@ module MachOShim
     lcs = macho.dylib_load_commands.reject { |lc| lc.type == except }
 
     lcs.map(&:name).map(&:to_s).uniq
-  end
-
-  def dylib_id
-    macho.dylib_id
-  end
-
-  def rpaths
-    macho.rpaths
-  end
-
-  def delete_rpath(rpath)
-    macho.delete_rpath(rpath)
   end
 
   def archs

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -60,6 +60,10 @@ module MachOShim
     macho.dylib_id
   end
 
+  def rpaths
+    macho.rpaths
+  end
+
   def archs
     mach_data.map { |m| m.fetch :arch }.extend(ArchitectureListExtension)
   end

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -64,6 +64,10 @@ module MachOShim
     macho.rpaths
   end
 
+  def delete_rpath(rpath)
+    macho.delete_rpath(rpath)
+  end
+
   def archs
     mach_data.map { |m| m.fetch :arch }.extend(ArchitectureListExtension)
   end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This removes `@rpath` as a special case for not performing relocations, leaving only `@loader_path` and `@executable_path`. I still need to do some local testing (and write some unit tests) for this change, so WIP until then.

Note to self: Remove the remaining `LC_RPATH`s from the files as well, since they'll be vestigial once we rewrite each install name.

cc @tschoonj @sjackman @MikeMcQuaid 