### PR TITLE
setup_build_environment: Set search path [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -1,4 +1,17 @@
 module Stdenv
+  def setup_build_environment(formula = nil)
+    generic_setup_build_environment(formula)
+
+    prepend_path "CPATH", HOMEBREW_PREFIX/"include"
+    prepend_path "LIBRARY_PATH", HOMEBREW_PREFIX/"lib"
+    prepend_path "LD_RUN_PATH", HOMEBREW_PREFIX/"lib"
+    return unless formula
+
+    prepend_path "CPATH", formula.include
+    prepend_path "LIBRARY_PATH", formula.lib
+    prepend_path "LD_RUN_PATH", formula.lib
+  end
+
   def libxml2
     append "CPPFLAGS", "-I#{Formula["libxml2"].include/"libxml2"}"
   rescue FormulaUnavailableError


### PR DESCRIPTION
Set the header and library search path for Stdenv.
Fix brew test for Linux, which uses Stdenv.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?