### PR TITLE
Cask: remove malware caveat

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -141,21 +141,6 @@ module Cask
             #{web_page}
         EOS
       end
-
-      caveat :malware do |radar_number|
-        <<~EOS
-          #{@cask} has been reported to bundle malware. Like with any app, use at your own risk.
-
-          A report has been made to Apple about this app. Their certificate will hopefully be revoked.
-          See the public report at
-            #{Formatter.url("https://openradar.appspot.com/#{radar_number}")}
-
-          If this report is accurate, please duplicate it at
-            #{Formatter.url("https://bugreport.apple.com/")}
-          If this report is a mistake, please let us know by opening an issue at
-            #{Formatter.url("https://github.com/Homebrew/homebrew-cask/issues/new")}
-        EOS
-      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Part of a [suggestion on modifying our rules on dealing with malware](https://github.com/Homebrew/homebrew-cask/pull/56283). The proposal is to be more liberal regarding what we consider malware, hence removing more casks, erring more on the side of caution. So the `caveat` will no longer be necessary, we’ll outright remove the cask.

No need to edit any cask, as currently no cask in any official repo uses this `caveat`.