### PR TITLE
Allow incomplete downloads to be resumed even when server rejects HEAD requests

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -52,7 +52,7 @@ def curl_download(*args, to: nil, **options)
   destination.dirname.mkpath
 
   continue_at = if destination.exist? &&
-                   curl_output("--location", "--head", "--range", "0-1",
+                   curl_output("--location", "--range", "0-1",
                                "--write-out", "%{http_code}",
                                "--output", "/dev/null", *args, **options).stdout.to_i == 206 # Partial Content
     "-"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). _In order to write a test for this I'd have to refactor `curl_download` or (I guess) mock `curl_output` and `curl` and I don't know how to do that. Old behavior wasn't unit-tested either so I don't think it's a huge deal._
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Use GET rather than HEAD when checking for range support in curl_download.
   * Some HTTP servers apparently support ranges but don't support HEAD.
   * This is a more realistic check anyway since the actual download request
     will use GET (not HEAD).
   * This fixes Homebrew/brew#5420.
