### PR TITLE
Add `brew vendor-gems` command.

### DIFF
--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -1,0 +1,39 @@
+#:  * `vendor-gems`:
+#:    Install and commit Homebrew's vendored gems.
+
+require "formula"
+require "cli_parser"
+
+module Homebrew
+  module_function
+
+  def vendor_gems
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `vendor-gems`
+
+        Install and commit Homebrew's vendored gems.
+      EOS
+      switch :debug
+    end.parse
+
+    Homebrew.install_gem_setup_path! "bundler"
+
+    ohai "cd #{HOMEBREW_LIBRARY_PATH}/vendor"
+    (HOMEBREW_LIBRARY_PATH/"vendor").cd do
+      ohai "bundle install --standalone"
+      safe_system "bundle", "install", "--standalone"
+
+      ohai "git add bundle-standalone"
+      system "git", "add", "bundle-standalone"
+
+      if Formula["gpg"].installed?
+        ENV["PATH"] = PATH.new(ENV["PATH"])
+                          .prepend(Formula["gpg"].opt_bin)
+      end
+
+      ohai "git commit"
+      system "git", "commit", "--message", "brew vendor-gems: commit updates."
+    end
+  end
+end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -984,6 +984,9 @@ If no arguments are passed, use `origin/master` as the start commit.
 * `--before`:
   Use the commit at provided *`date`* as the start commit.
 
+  * `vendor-gems`:
+    Install and commit Homebrew's vendored gems.
+
 ## GLOBAL OPTIONS
 
 These options are applicable across all sub-commands.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1092,6 +1092,11 @@ Use provided \fIcommit\fR as the start commit\.
 \fB\-\-before\fR
 Use the commit at provided \fIdate\fR as the start commit\.
 .
+.TP
+\fBvendor\-gems\fR
+Install and commit Homebrew\'s vendored gems\.
+
+.
 .SH "GLOBAL OPTIONS"
 These options are applicable across all sub\-commands\.
 .


### PR DESCRIPTION
This simplifies the process of vendoring gems given `Gemfile` or `Gemfile.lock` changes.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----