### PR TITLE
hardware: tweak macOS CFLAGS.

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -1,7 +1,9 @@
 module Hardware
   def self.oldest_cpu
-    if MacOS.version >= :sierra
+    if MacOS.version >= :mojave
       :nehalem
+    elsif MacOS.version >= :sierra
+      :penryn
     else
       generic_oldest_cpu
     end

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -7,7 +7,8 @@ module Hardware
 
     class << self
       OPTIMIZATION_FLAGS = {
-        nehalem: "-march=nehalem -msse4.2",
+        nehalem: "-march=nehalem",
+        penryn:  "-march=penryn",
         core2:   "-march=core2",
         core:    "-march=prescott",
         armv6:   "-march=armv6",


### PR DESCRIPTION
- High Sierra and Sierra support Penryn CPUs.
- `-march` implies the relevant `-msse*` flags.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----