### PR TITLE
formula_cellar_checks: Add scheme library exts

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -57,7 +57,7 @@ module FormulaCellarChecks
     EOS
   end
 
-  VALID_LIBRARY_EXTENSIONS = %w[.a .jnilib .la .o .so .jar .prl .pm .sh].freeze
+  VALID_LIBRARY_EXTENSIONS = %w[.a .jnilib .la .o .so .jar .prl .pm .sh .scm .o1 .ss].freeze
 
   def valid_library_extension?(filename)
     VALID_LIBRARY_EXTENSIONS.include? filename.extname


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds three new extensions to our list of `VALID_LIBRARY_EXTENSIONS`: `.scm`, `.o1`, and `.ss`, all used by gerbil-scheme.

Some thoughts:

The presence of `.prl`, `.pm`, and `.sh` provides the precedent for adding additional language-specific suffixes, but adding three suffixes for a formula that hasn't been merged yet feels slightly overkill. I'm opening this to hear other maintainer's thoughts.


See https://github.com/Homebrew/homebrew-core/pull/35348

cc @ober
cc @Homebrew/maintainers 