### PR TITLE
build: Propagate entire ErrorDuringExecution

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -202,6 +202,10 @@ rescue Exception => e # rubocop:disable Lint/RescueException
     error_hash["cmd"] = e.cmd
     error_hash["args"] = e.args
     error_hash["env"] = e.env
+  elsif error_hash["json_class"] = "ErrorDuringExecution"
+    error_hash["cmd"] = e.cmd
+    error_hash["status"] = e.status.exitstatus
+    error_hash["output"] = e.output
   end
 
   error_pipe.puts error_hash.to_json

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -300,7 +300,7 @@ end
 def safe_system(cmd, *args, **options)
   return if Homebrew.system(cmd, *args, **options)
 
-  raise(ErrorDuringExecution.new([cmd, *args], status: $CHILD_STATUS))
+  raise ErrorDuringExecution.new([cmd, *args], status: $CHILD_STATUS)
 end
 
 # Prints no output


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/5427.

The underlying issue here is that we propagate child errors twice -- once in `Utils.safe_fork`, and again within the specific scripts that get executed within the forked child (e.g., `build.rb`). However, the propagation in `build.rb` wasn't special-casing `ErrorDuringExecution`, so the first exception received over the error pipe was missing the expected `cmd` field.

