### PR TITLE
Fix bogus comparison operation that was breaking error handling

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -202,7 +202,7 @@ rescue Exception => e # rubocop:disable Lint/RescueException
     error_hash["cmd"] = e.cmd
     error_hash["args"] = e.args
     error_hash["env"] = e.env
-  elsif error_hash["json_class"] = "ErrorDuringExecution"
+  elsif error_hash["json_class"] == "ErrorDuringExecution"
     error_hash["cmd"] = e.cmd
     error_hash["status"] = e.status.exitstatus
     error_hash["output"] = e.output


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #5443.

There's a mistaken assignment (`=`) instead of comparison (`==`) in `build.rb` that's breaking error handling when a FormulaUnavailableError or other errors occur during the build.

This patch fixes it.