### PR TITLE
Whitelist TERMINFO environment variable

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -72,7 +72,7 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TERM COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM TERMINFO COLUMNS LOGNAME USER CI TRAVIS SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `TERMINFO` environment variable is used by ncurses et al to find files describing current terminal's capabilities (see e.g. `man ncurses`). When the variable is filtered out, code using `ncurses` down the line gets confused if the terminal is not included in the default termcap database. An example of this is the "Cannot read termcap database; using dumb terminal settings" message described in #4527. This is written by libedit, loaded from irb, loaded from debrew. With this patch the message is not printed any more.

An alternative solution is to place termcap files under `~/.terminfo` instead. Some terminals do not do this by default, for instance Kitty.