### PR TITLE
brew.sh: set correct log path [Linux]

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -113,6 +113,7 @@ then
   fi
 
   HOMEBREW_CACHE="${HOMEBREW_CACHE:-${HOME}/Library/Caches/Homebrew}"
+  HOMEBREW_LOGS="${HOMEBREW_LOGS:-${HOME}/Library/Logs/Homebrew}"
   HOMEBREW_SYSTEM_TEMP="/private/tmp"
 else
   HOMEBREW_PROCESSOR="$(uname -m)"
@@ -142,6 +143,7 @@ else
 
   CACHE_HOME="${XDG_CACHE_HOME:-${HOME}/.cache}"
   HOMEBREW_CACHE="${HOMEBREW_CACHE:-${CACHE_HOME}/Homebrew}"
+  HOMEBREW_LOGS="${HOMEBREW_LOGS:-${CACHE_HOME}/Homebrew/Logs}"
   HOMEBREW_SYSTEM_TEMP="/tmp"
 fi
 
@@ -194,6 +196,7 @@ export HOMEBREW_TEMP
 # Declared in brew.sh
 export HOMEBREW_VERSION
 export HOMEBREW_CACHE
+export HOMEBREW_LOGS
 export HOMEBREW_CELLAR
 export HOMEBREW_SYSTEM
 export HOMEBREW_CURL


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

On Linux using the Homebrew/brew remote, log files are stored in `~/Library/Logs/Homebrew`. This is the macOS path and is incorrect for Linux. This pull request moves the log path to `~/.cache/Homebrew/Logs`, respecting XDG environment variables if specified.

Tested on macOS 10.14.2 and on a Linux HPC cluster with a user install. `brew install hello` confirms that logs are stored in their appropriate places.

Potential issues for followup:

* Logs and Cache are in completely separate folders on macOS; on Linux the log path is a subdirectory of the cache path.
* Should all OS-specific environment variables be defined in `brew.sh` vs `config.rb`?
* `brew config` will always print the cache path on Linux, since the macOS default path is hard coded into `system_config.rb` 

c.f. https://github.com/Homebrew/brew/issues/4758