### PR TITLE
update-test: fix for mkdir block form

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -88,7 +88,8 @@ module Homebrew
     puts "Start commit: #{start_commit}"
     puts "End   commit: #{end_commit}"
 
-    mkdir "update-test" do
+    mkdir "update-test"
+    chdir "update-test" do
       curdir = Pathname.new(Dir.pwd)
 
       oh1 "Setup test environment..."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes a bug caused by old deprecations https://github.com/Homebrew/brew/pull/4392 (256dfc1af9c3ef8fb09b11bad03f632ac0d94cc7).

I couldn't write tests for `brew update-test` because the integration test framework does not seem to copy over the `.git` directory.