### PR TITLE
brew.sh: make update --preinstall exec.

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -36,13 +36,11 @@ HOMEBREW_CACHE = Pathname.new(ENV["HOMEBREW_CACHE"])
 HOMEBREW_CACHE_FORMULA = HOMEBREW_CACHE/"Formula"
 
 # Where build, postinstall, and test logs of formulae are written to
-HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"] || "~/Library/Logs/Homebrew/").expand_path
+HOMEBREW_LOGS = Pathname.new(ENV["HOMEBREW_LOGS"]).expand_path
 
 # Must use `/tmp` instead of `TMPDIR` because long paths break Unix domain sockets
 HOMEBREW_TEMP = begin
-  # /tmp fallback is here for people auto-updating from a version where
-  # HOMEBREW_TEMP isn't set.
-  tmp = Pathname.new(ENV["HOMEBREW_TEMP"] || "/tmp")
+  tmp = Pathname.new(ENV["HOMEBREW_TEMP"])
   tmp.mkpath unless tmp.exist?
   tmp.realpath
 end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -50,18 +50,8 @@ HOMEBREW_USER_AGENT_FAKE_SAFARI =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/602.4.8 " \
   "(KHTML, like Gecko) Version/10.0.3 Safari/602.4.8".freeze
 
-# Bintray fallback is here for people auto-updating from a version where
-# `HOMEBREW_BOTTLE_DEFAULT_DOMAIN` isn't set.
-HOMEBREW_BOTTLE_DEFAULT_DOMAIN = if ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"]
-  ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"]
-elsif OS.mac? || ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
-  "https://homebrew.bintray.com".freeze
-else
-  "https://linuxbrew.bintray.com".freeze
-end
-
-HOMEBREW_BOTTLE_DOMAIN = ENV["HOMEBREW_BOTTLE_DOMAIN"] ||
-                         HOMEBREW_BOTTLE_DEFAULT_DOMAIN
+HOMEBREW_BOTTLE_DEFAULT_DOMAIN = ENV["HOMEBREW_BOTTLE_DEFAULT_DOMAIN"]
+HOMEBREW_BOTTLE_DOMAIN = ENV["HOMEBREW_BOTTLE_DOMAIN"]
 
 require "fileutils"
 require "os"


### PR DESCRIPTION
This means that any new environment variables or changes to `bin/brew` or `brew.sh` will be used in the new process. This also allows the removal of various fallbacks from autoupdates from old versions.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----