### PR TITLE
python_virtualenv_constants: upgrade virtualenv to 16.2.0

### DIFF
--- a/Library/Homebrew/language/python_virtualenv_constants.rb
+++ b/Library/Homebrew/language/python_virtualenv_constants.rb
@@ -1,6 +1,4 @@
 PYTHON_VIRTUALENV_URL =
-  "https://files.pythonhosted.org/packages/4e/8b" \
-  "/75469c270ac544265f0020aa7c4ea925c5284b23e445cf3aa8b99f662690" \
-  "/virtualenv-16.1.0.tar.gz".freeze
+  "https://github.com/pypa/virtualenv/archive/16.2.0.tar.gz".freeze
 PYTHON_VIRTUALENV_SHA256 =
-  "f899fafcd92e1150f40c8215328be38ff24b519cd95357fa6e78e006c7638208".freeze
+  "448def1220df9960e6d18fb5424107ffb1249eb566a5a311257860ab6b52b3fd".freeze


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

PyPI does not provided a source tarball for `virtualenv` 16.2.0, only the wheel is available.