### PR TITLE
cleanup: run and replace `brew prune`.

### DIFF
--- a/Library/Homebrew/cmd/prune.rb
+++ b/Library/Homebrew/cmd/prune.rb
@@ -1,12 +1,9 @@
 #:  * `prune` [`--dry-run`]:
-#:    Remove dead symlinks from the Homebrew prefix. This is generally not
-#:    needed, but can be useful when doing DIY installations.
-#:
-#:    If `--dry-run` or `-n` is passed, show what would be removed, but do not
-#:    actually remove anything.
+#:    Deprecated. Use `brew cleanup` instead.
 
 require "keg"
 require "cli_parser"
+require "cleanup"
 
 module Homebrew
   module_function
@@ -16,8 +13,7 @@ module Homebrew
       usage_banner <<~EOS
         `prune` [<options>]
 
-        Remove dead symlinks from the Homebrew prefix. This is generally not
-        needed, but can be useful when doing DIY installations.
+        Deprecated. Use `brew cleanup` instead.
       EOS
       switch "-n", "--dry-run",
         description: "Show what would be removed, but do not actually remove anything."
@@ -29,50 +25,8 @@ module Homebrew
   def prune
     prune_args.parse
 
-    ObserverPathnameExtension.reset_counts!
-
-    dirs = []
-
-    Keg::MUST_EXIST_SUBDIRECTORIES.each do |dir|
-      next unless dir.directory?
-
-      dir.find do |path|
-        path.extend(ObserverPathnameExtension)
-        if path.symlink?
-          unless path.resolved_path_exists?
-            if path.to_s =~ Keg::INFOFILE_RX
-              path.uninstall_info unless ARGV.dry_run?
-            end
-
-            if args.dry_run?
-              puts "Would remove (broken link): #{path}"
-            else
-              path.unlink
-            end
-          end
-        elsif path.directory? && !Keg::MUST_EXIST_SUBDIRECTORIES.include?(path)
-          dirs << path
-        end
-      end
-    end
-
-    dirs.reverse_each do |d|
-      if ARGV.dry_run? && d.children.empty?
-        puts "Would remove (empty directory): #{d}"
-      else
-        d.rmdir_if_possible
-      end
-    end
-
-    return if args.dry_run?
-
-    if ObserverPathnameExtension.total.zero?
-      puts "Nothing pruned" if args.verbose?
-    else
-      n, d = ObserverPathnameExtension.counts
-      print "Pruned #{n} symbolic links "
-      print "and #{d} directories " if d.positive?
-      puts "from #{HOMEBREW_PREFIX}"
-    end
+    # TODO: deprecate and hide from manpage for next minor release.
+    # odeprecated("'brew prune'", "'brew cleanup'")
+    Cleanup.new(dry_run: args.dry_run?).prune_prefix_symlinks_and_directories
   end
 end

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -342,8 +342,8 @@ class Reporter
           ohai "#{name} has been moved to Homebrew Cask."
           ohai "brew unlink #{name}"
           system HOMEBREW_BREW_FILE, "unlink", name
-          ohai "brew prune"
-          system HOMEBREW_BREW_FILE, "prune"
+          ohai "brew cleanup"
+          system HOMEBREW_BREW_FILE, "cleanup"
           ohai "brew cask install #{new_name}"
           system HOMEBREW_BREW_FILE, "cask", "install", new_name
           ohai <<~EOS

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -288,7 +288,7 @@ module Homebrew
         return if broken_symlinks.empty?
 
         inject_file_list broken_symlinks, <<~EOS
-          Broken symlinks were found. Remove them with `brew prune`:
+          Broken symlinks were found. Remove them with `brew cleanup`:
         EOS
       end
 

--- a/Library/Homebrew/test/cmd/prune_spec.rb
+++ b/Library/Homebrew/test/cmd/prune_spec.rb
@@ -19,10 +19,5 @@ describe "brew prune", :integration_test do
     expect(share/"pruneable").not_to be_a_directory
     expect(share/"notpruneable").to be_a_directory
     expect(share/"pruneable_symlink").not_to be_a_symlink
-
-    expect { brew "prune", "--verbose" }
-      .to output(/Nothing pruned/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -409,11 +409,7 @@ these flags should only appear after a command.
     Rerun the post-install steps for *`formula`*.
 
   * `prune` [`--dry-run`]:
-    Remove dead symlinks from the Homebrew prefix. This is generally not
-    needed, but can be useful when doing DIY installations.
-
-    If `--dry-run` or `-n` is passed, show what would be removed, but do not
-    actually remove anything.
+    Deprecated. Use `brew cleanup` instead.
 
   * `readall` [`--aliases`] [`--syntax`] [*`taps`*]:
     Import all formulae from specified *`taps`* (defaults to all installed taps).

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "December 2018" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "January 2019" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "December 2018" "Homebrew" "brew"
+.TH "BREW" "1" "January 2019" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -416,10 +416,7 @@ Rerun the post\-install steps for \fIformula\fR\.
 .
 .TP
 \fBprune\fR [\fB\-\-dry\-run\fR]
-Remove dead symlinks from the Homebrew prefix\. This is generally not needed, but can be useful when doing DIY installations\.
-.
-.IP
-If \fB\-\-dry\-run\fR or \fB\-n\fR is passed, show what would be removed, but do not actually remove anything\.
+Deprecated\. Use \fBbrew cleanup\fR instead\.
 .
 .TP
 \fBreadall\fR [\fB\-\-aliases\fR] [\fB\-\-syntax\fR] [\fItaps\fR]


### PR DESCRIPTION
It's always seemed a bit pointless to me that we have both of these commands. Given we're doing more and more to recommend (and eventually, safely, automatically run (see #4760) `brew cleanup` let's roll their functionality into a single command.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----