### PR TITLE
shims/super/cc: Do not remove -Xpreprocessor argument

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -187,6 +187,9 @@ class Cmd
       "-fuse-linker-plugin", "-frounding-math"
       # clang doesn't support these flags
       args << arg unless tool =~ /^clang/
+    when "-Xpreprocessor"
+      # used for -Xpreprocessor -fopenmp
+      args << arg << enum.next
     when /-mmacosx-version-min=10\.(\d)/
       arg = "-mmacosx-version-min=10.9" if high_sierra_or_later? && $1.to_i < 9
       args << arg


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

`brew tests` is failing because `Ignoring rainbow-2.2.2 because its extensions are not built.  Try: gem pristine rainbow --version 2.2.2`. If I run the recommended command, it's complaining that `You don't have write permissions for the /Library/Ruby/Gems/2.3.0 directory`. 😩 

-----

`-Xpreprocessor` is used to pass the next flag to the `clang` preprocessor. It is a rather obscure flag, and currently only used in the idiom `-Xpreprocessor -fopenmp` to force Apple's `clang` to compile OpenMP source files (which are later linked against our `libomp`).

However, currently superenv removes `-fopenmp` when it sees it, even though we want to keep it when it's used after `-Xpreprocessor`. This patch does that by passing any argument after `-Xpreprocessor` straight.

Even though I am not aware of any other use of `-Xpreprocessor` out there, I would argue that it's a better behaviour anyway (we never want `-Xpreprocessor foo bar` to become `-Xpreprocessor bar`).