### PR TITLE
ErrorDuringExecution: Fix wrong number of arguments

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -539,7 +539,8 @@ class ErrorDuringExecution < RuntimeError
     s = "Failure while executing; `#{cmd.shelljoin.gsub(/\\=/, "=")}` exited with #{exitstatus}."
 
     unless [*output].empty?
-      format_output_line = lambda do |type, line|
+      format_output_line = lambda do |type_line|
+        type, line = *type_line
         if type == :stderr
           Formatter.error(line)
         else


### PR DESCRIPTION
Error: wrong number of arguments (given 1, expected 2)
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/exceptions.rb:548:in `block in initialize'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/exceptions.rb:557:in `map'

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The lambda function expects two arguments. `map` calls the lambda function with one argument.