### PR TITLE
Cleanup periodically if HOMEBREW_INSTALL_CLEANUP is set.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -73,15 +73,13 @@
 #:
 #:    If `--git` (or `-g`) is passed, Homebrew will create a Git repository, useful for
 #:    creating patches to the software.
-#:
-#:    If `HOMEBREW_INSTALL_CLEANUP` is set then remove previously installed versions
-#:    of upgraded <formulae> as well as the HOMEBREW_CACHE for that formula.
 
 require "missing_formula"
 require "formula_installer"
 require "development_tools"
 require "install"
 require "search"
+require "cleanup"
 
 module Homebrew
   module_function
@@ -257,7 +255,7 @@ module Homebrew
       formulae.each do |f|
         Migrator.migrate_if_needed(f)
         install_formula(f)
-        Cleanup.new.cleanup_formula(f) if ENV["HOMEBREW_INSTALL_CLEANUP"]
+        Cleanup.install_formula_clean!(f)
       end
       Homebrew.messages.display_messages
     rescue FormulaUnreadableError, FormulaClassUnavailableError,

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -12,6 +12,7 @@ require "development_tools"
 require "messages"
 require "reinstall"
 require "cli_parser"
+require "cleanup"
 
 module Homebrew
   module_function
@@ -49,7 +50,7 @@ module Homebrew
       end
       Migrator.migrate_if_needed(f)
       reinstall_formula(f)
-      Cleanup.new.cleanup_formula(f) if ENV["HOMEBREW_INSTALL_CLEANUP"]
+      Cleanup.install_formula_clean!(f)
     end
     Homebrew.messages.display_messages
   end

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -86,7 +86,7 @@ module Homebrew
         ENV["GIT_#{role}_DATE"]  = "Sun Jan 22 19:59:13 2017 +0000"
       end
 
-      Homebrew.install_gem_setup_path! "bundler"
+      Homebrew.install_gem_setup_path! "bundler", "<2"
       system "bundle", "install" unless quiet_system("bundle", "check")
 
       parallel = true

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -17,7 +17,7 @@ module Homebrew
       switch :debug
     end.parse
 
-    Homebrew.install_gem_setup_path! "bundler"
+    Homebrew.install_gem_setup_path! "bundler", "<2"
 
     ohai "cd #{HOMEBREW_LIBRARY_PATH}/vendor"
     (HOMEBREW_LIBRARY_PATH/"vendor").cd do

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -198,6 +198,16 @@ Note that environment variables must have a value set to be detected. For exampl
 
     *Default:* the beer emoji.
 
+  * `HOMEBREW_INSTALL_CLEANUP`:
+    If set, `brew install`, `brew upgrade` and `brew reinstall` will remove
+    previously installed version(s) of the installed/upgraded formulae.
+
+    If `brew cleanup` has not been run in 30 days then it will be run at this
+    time.
+
+    This will become the default in a later version of Homebrew. To opt-out see
+    `HOMEBREW_NO_INSTALL_CLEANUP`.
+
   * `HOMEBREW_LOGS`:
     If set, Homebrew will use the specified directory to store log files.
 
@@ -235,6 +245,11 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will not use the GitHub API, e.g. for searches or
     fetching relevant issues on a failed install.
 
+  * `HOMEBREW_NO_INSTALL_CLEANUP`:
+    If set, `brew install`, `brew upgrade` and `brew reinstall` will never
+    automatically remove the previously installed version(s) of the
+    installed/upgraded formulae.
+
   * `HOMEBREW_PRY`:
     If set, Homebrew will use Pry for the `brew irb` command.
 
@@ -255,9 +270,6 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_UPDATE_TO_TAG`:
     If set, instructs Homebrew to always use the latest stable tag (even if
     developer commands have been run).
-
-  * `HOMEBREW_UPGRADE_CLEANUP`:
-    If set, `brew upgrade` always assumes `--cleanup` has been passed.
 
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -178,10 +178,10 @@ describe Homebrew::Cleanup do
         expect(download).to exist
       end
 
-      it "removes the download for the latest version after a week" do
+      it "removes the download for the latest version after 30 days" do
         download = Cask::Cache.path/"#{cask.token}--#{cask.version}"
 
-        FileUtils.touch download, mtime: 7.days.ago - 1.hour
+        FileUtils.touch download, mtime: 30.days.ago - 1.hour
 
         subject.cleanup_cask(cask)
 
@@ -202,14 +202,14 @@ describe Homebrew::Cleanup do
       expect(path).not_to exist
     end
 
-    it "cleans up logs if older than 14 days" do
-      allow_any_instance_of(Pathname).to receive(:mtime).and_return(15.days.ago)
+    it "cleans up logs if older than 30 days" do
+      allow_any_instance_of(Pathname).to receive(:mtime).and_return(31.days.ago)
       subject.cleanup_logs
       expect(path).not_to exist
     end
 
-    it "does not clean up logs less than 14 days old" do
-      allow_any_instance_of(Pathname).to receive(:mtime).and_return(2.days.ago)
+    it "does not clean up logs less than 30 days old" do
+      allow_any_instance_of(Pathname).to receive(:mtime).and_return(15.days.ago)
       subject.cleanup_logs
       expect(path).to exist
     end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -312,9 +312,6 @@ these flags should only appear after a command.
     If `--git` (or `-g`) is passed, Homebrew will create a Git repository, useful for
     creating patches to the software.
 
-    If `HOMEBREW_INSTALL_CLEANUP` is set then remove previously installed versions
-    of upgraded *`formulae`* as well as the HOMEBREW_CACHE for that formula.
-
   * `leaves`:
     Show installed formulae that are not dependencies of another installed formula.
 
@@ -599,13 +596,10 @@ these flags should only appear after a command.
     `repositories`) using `git`(1) to their latest `origin/master`. Note this
     will destroy all your uncommitted or committed changes.
 
-  * `upgrade` [*`install-options`*] [`--cleanup`] [`--fetch-HEAD`] [`--ignore-pinned`] [`--display-times`] [*`formulae`*]:
+  * `upgrade` [*`install-options`*] [`--fetch-HEAD`] [`--ignore-pinned`] [`--display-times`] [*`formulae`*]:
     Upgrade outdated, unpinned brews (with existing install options).
 
     Options for the `install` command are also valid here.
-
-    If `--cleanup` is specified or `HOMEBREW_INSTALL_CLEANUP` is set then remove
-    previously installed version(s) of upgraded *`formulae`*.
 
     If `--fetch-HEAD` is passed, fetch the upstream repository to detect if
     the HEAD installation of the formula is outdated. Otherwise, the
@@ -1198,6 +1192,16 @@ Note that environment variables must have a value set to be detected. For exampl
 
     *Default:* the beer emoji.
 
+  * `HOMEBREW_INSTALL_CLEANUP`:
+    If set, `brew install`, `brew upgrade` and `brew reinstall` will remove
+    previously installed version(s) of the installed/upgraded formulae.
+
+    If `brew cleanup` has not been run in 30 days then it will be run at this
+    time.
+
+    This will become the default in a later version of Homebrew. To opt-out see
+    `HOMEBREW_NO_INSTALL_CLEANUP`.
+
   * `HOMEBREW_LOGS`:
     If set, Homebrew will use the specified directory to store log files.
 
@@ -1235,6 +1239,11 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will not use the GitHub API, e.g. for searches or
     fetching relevant issues on a failed install.
 
+  * `HOMEBREW_NO_INSTALL_CLEANUP`:
+    If set, `brew install`, `brew upgrade` and `brew reinstall` will never
+    automatically remove the previously installed version(s) of the
+    installed/upgraded formulae.
+
   * `HOMEBREW_PRY`:
     If set, Homebrew will use Pry for the `brew irb` command.
 
@@ -1255,9 +1264,6 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_UPDATE_TO_TAG`:
     If set, instructs Homebrew to always use the latest stable tag (even if
     developer commands have been run).
-
-  * `HOMEBREW_UPGRADE_CLEANUP`:
-    If set, `brew upgrade` always assumes `--cleanup` has been passed.
 
   * `HOMEBREW_VERBOSE`:
     If set, Homebrew always assumes `--verbose` when running commands.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -315,9 +315,6 @@ If \fB\-\-interactive\fR (or \fB\-i\fR) is passed, download and patch \fIformula
 .IP
 If \fB\-\-git\fR (or \fB\-g\fR) is passed, Homebrew will create a Git repository, useful for creating patches to the software\.
 .
-.IP
-If \fBHOMEBREW_INSTALL_CLEANUP\fR is set then remove previously installed versions of upgraded \fIformulae\fR as well as the HOMEBREW_CACHE for that formula\.
-.
 .TP
 \fBleaves\fR
 Show installed formulae that are not dependencies of another installed formula\.
@@ -610,14 +607,11 @@ If \fB\-\-force\fR (or \fB\-f\fR) is specified then always do a slower, full upd
 Fetches and resets Homebrew and all tap repositories (or the specified \fBrepositories\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
 .TP
-\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-cleanup\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fB\-\-display\-times\fR] [\fIformulae\fR]
+\fBupgrade\fR [\fIinstall\-options\fR] [\fB\-\-fetch\-HEAD\fR] [\fB\-\-ignore\-pinned\fR] [\fB\-\-display\-times\fR] [\fIformulae\fR]
 Upgrade outdated, unpinned brews (with existing install options)\.
 .
 .IP
 Options for the \fBinstall\fR command are also valid here\.
-.
-.IP
-If \fB\-\-cleanup\fR is specified or \fBHOMEBREW_INSTALL_CLEANUP\fR is set then remove previously installed version(s) of upgraded \fIformulae\fR\.
 .
 .IP
 If \fB\-\-fetch\-HEAD\fR is passed, fetch the upstream repository to detect if the HEAD installation of the formula is outdated\. Otherwise, the repository\'s HEAD will be checked for updates when a new stable or devel version has been released\.
@@ -1322,6 +1316,16 @@ Text printed before the installation summary of each successful build\.
 \fIDefault:\fR the beer emoji\.
 .
 .TP
+\fBHOMEBREW_INSTALL_CLEANUP\fR
+If set, \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew reinstall\fR will remove previously installed version(s) of the installed/upgraded formulae\.
+.
+.IP
+If \fBbrew cleanup\fR has not been run in 30 days then it will be run at this time\.
+.
+.IP
+This will become the default in a later version of Homebrew\. To opt\-out see \fBHOMEBREW_NO_INSTALL_CLEANUP\fR\.
+.
+.TP
 \fBHOMEBREW_LOGS\fR
 If set, Homebrew will use the specified directory to store log files\.
 .
@@ -1363,6 +1367,10 @@ While ensuring your downloads are fully secure, this is likely to cause from\-so
 If set, Homebrew will not use the GitHub API, e\.g\. for searches or fetching relevant issues on a failed install\.
 .
 .TP
+\fBHOMEBREW_NO_INSTALL_CLEANUP\fR
+If set, \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew reinstall\fR will never automatically remove the previously installed version(s) of the installed/upgraded formulae\.
+.
+.TP
 \fBHOMEBREW_PRY\fR
 If set, Homebrew will use Pry for the \fBbrew irb\fR command\.
 .
@@ -1383,10 +1391,6 @@ This issue typically occurs when using FileVault or custom SSD configurations\.
 .TP
 \fBHOMEBREW_UPDATE_TO_TAG\fR
 If set, instructs Homebrew to always use the latest stable tag (even if developer commands have been run)\.
-.
-.TP
-\fBHOMEBREW_UPGRADE_CLEANUP\fR
-If set, \fBbrew upgrade\fR always assumes \fB\-\-cleanup\fR has been passed\.
 .
 .TP
 \fBHOMEBREW_VERBOSE\fR


### PR DESCRIPTION
Follows on from https://github.com/Homebrew/brew/pull/5165.

Part of https://github.com/Homebrew/brew/issues/4760.

This will become the default in a later version of Homebrew but has an opt-out through `HOMEBREW_NO_INSTALL_CLEANUP`.

Also, always cleanup files older than 120 days and set the general default value for "old" logs, casks etc. to 30 days.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----