### PR TITLE
info: Fix style: Use a guard clause

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -85,11 +85,8 @@ module Homebrew
   def info
     info_args.parse
     if args.json
-      if args.json == "v1" || args.json == true
-        print_json
-      else
-        raise UsageError, "invalid JSON version: #{args.json}"
-      end
+      raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
+      print_json
     elsif args.github?
       exec_browser(*ARGV.formulae.map { |f| github_info(f) })
     else


### PR DESCRIPTION
Fix the style error:
```
Library/Homebrew/cmd/info.rb:88:7: C:
Use a guard clause instead of wrapping the code inside a conditional expression.
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?