### PR TITLE
Use `bundle install` in more places.

### DIFF
--- a/Library/Homebrew/cask/cmd/style.rb
+++ b/Library/Homebrew/cask/cmd/style.rb
@@ -20,7 +20,7 @@ module Cask
       def install_rubocop
         capture_stderr do
           begin
-            Homebrew.install_gem_setup_path! "rubocop"
+            Homebrew.install_bundler_gems!
           rescue SystemExit
             raise CaskError, Tty.strip_ansi($stderr.string).chomp.sub(/\AError: /, "")
           end

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -73,7 +73,7 @@ module Homebrew
   end
 
   def regenerate_man_pages
-    Homebrew.install_gem_setup_path! "ronn"
+    Homebrew.install_bundler_gems!
 
     markup = build_man_page
     convert_man_page(markup, TARGET_DOC_PATH/"Manpage.md")

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -76,8 +76,6 @@ module Homebrew
         FileUtils.rm_f "test/coverage/.resultset.json"
       end
 
-      ENV["BUNDLE_GEMFILE"] = "#{HOMEBREW_LIBRARY_PATH}/test/Gemfile"
-
       # Override author/committer as global settings might be invalid and thus
       # will cause silent failure during the setup of dummy Git repositories.
       %w[AUTHOR COMMITTER].each do |role|
@@ -86,8 +84,7 @@ module Homebrew
         ENV["GIT_#{role}_DATE"]  = "Sun Jan 22 19:59:13 2017 +0000"
       end
 
-      Homebrew.install_gem_setup_path! "bundler", "<2"
-      system "bundle", "install" unless quiet_system("bundle", "check")
+      Homebrew.install_bundler_gems!
 
       parallel = true
 

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -17,7 +17,7 @@ module Homebrew
       switch :debug
     end.parse
 
-    Homebrew.install_gem_setup_path! "bundler", "<2"
+    Homebrew.install_bundler!
 
     ohai "cd #{HOMEBREW_LIBRARY_PATH}/vendor"
     (HOMEBREW_LIBRARY_PATH/"vendor").cd do

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -17,8 +17,7 @@ module Homebrew
     def check_style_impl(files, output_type, options = {})
       fix = options[:fix]
 
-      Homebrew.install_gem_setup_path! "rubocop"
-      Homebrew.install_gem! "rubocop-rspec"
+      Homebrew.install_bundler_gems!
       require "rubocop"
       require "rubocops"
 

--- a/Library/Homebrew/test/.bundle/config
+++ b/Library/Homebrew/test/.bundle/config
@@ -1,4 +1,6 @@
 ---
+BUNDLE_BIN: "../bin"
 BUNDLE_PATH: "../vendor/bundle"
 BUNDLE_DISABLE_SHARED_GEMS: "true"
-BUNDLE_BIN: "../bin"
+BUNDLE_JOBS: "4"
+BUNDLE_RETRY: "3"

--- a/Library/Homebrew/test/Gemfile.lock
+++ b/Library/Homebrew/test/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     rspec-support (3.8.0)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
-    rubocop (0.62.0)
+    rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -203,7 +203,7 @@ module Homebrew
     _system(cmd, *args, **options)
   end
 
-  def install_gem!(name, version = nil)
+  def setup_gem_environment!
     # Match where our bundler gems are.
     ENV["GEM_HOME"] = "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
     ENV["GEM_PATH"] = ENV["GEM_HOME"]
@@ -217,12 +217,15 @@ module Homebrew
     path.prepend(RUBY_BIN) if which("ruby") != RUBY_PATH
     path.prepend(Gem.bindir)
     ENV["PATH"] = path
+  end
 
-    return unless Gem::Specification.find_all_by_name(name, version).empty?
+  def install_gem!(name)
+    setup_gem_environment!
+
+    return unless Gem::Specification.find_all_by_name(name).empty?
 
     ohai "Installing or updating '#{name}' gem"
     install_args = %W[--no-ri --no-rdoc #{name}]
-    install_args << "--version" << version if version
 
     # Do `gem install [...]` without having to spawn a separate process or
     # having to find the right `gem` binary for the running Ruby interpreter.
@@ -238,15 +241,26 @@ module Homebrew
     odie "Failed to install/update the '#{name}' gem." if exit_code.nonzero?
   end
 
-  def install_gem_setup_path!(name, version = nil, executable = name)
-    install_gem!(name, version)
+  def install_gem_setup_path!(name)
+    install_gem!(name)
 
-    return if which(executable)
+    return if which(name)
 
     odie <<~EOS
-      The '#{name}' gem is installed but couldn't find '#{executable}' in the PATH:
+      The '#{name}' gem is installed but couldn't find '#{name}' in the PATH:
       #{ENV["PATH"]}
     EOS
+  end
+
+  def install_bundler!
+    install_gem_setup_path! "bundler"
+  end
+
+  def install_bundler_gems!
+    install_bundler!
+    ENV["BUNDLE_GEMFILE"] = "#{HOMEBREW_LIBRARY_PATH}/test/Gemfile"
+    system "bundle", "install" unless quiet_system("bundle", "check")
+    setup_gem_environment!
   end
 
   # rubocop:disable Style/GlobalVars

--- a/Library/Homebrew/vendor/Gemfile.lock
+++ b/Library/Homebrew/vendor/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     plist (3.5.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
-    rubocop (0.62.0)
+    rubocop (0.61.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)


### PR DESCRIPTION
This provides a more consistent version for `rubocop` than relying on `Homebrew.install_gem_setup_path!` (and we really want `brew style` to provide consistent output).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----