### PR TITLE
Disable cop for #set_cpu_flags, #set_cpu_cflags

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -198,7 +198,7 @@ module Stdenv
   # Sets architecture-specific flags for every environment variable
   # given in the list `flags`.
   # @private
-  def set_cpu_flags(flags, map = Hardware::CPU.optimization_flags)
+  def set_cpu_flags(flags, map = Hardware::CPU.optimization_flags) # rubocop:disable Naming/AccessorMethodName
     cflags =~ /(-Xarch_#{Hardware::CPU.arch_32_bit} )-march=/
     xarch = Regexp.last_match(1).to_s
     remove flags, /(-Xarch_#{Hardware::CPU.arch_32_bit} )?-march=\S*/
@@ -213,7 +213,7 @@ module Stdenv
   def x11; end
 
   # @private
-  def set_cpu_cflags(map = Hardware::CPU.optimization_flags)
+  def set_cpu_cflags(map = Hardware::CPU.optimization_flags) # rubocop:disable Naming/AccessorMethodName
     set_cpu_flags CC_FLAG_VARS, map
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **No tests, just disabling a cop**
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **No tests**

-----

In `extend/ENV/std.rb`, the methods `set_cpu_flags` and `set_cpu_cflags` have been violating the `Naming/AccessorMethodName` cop.

One of the changes in #5491 appears to have awakened the cop. That means we’re likely dealing with legacy code here, predating the introduction of RuboCop into Homebrew.

This PR disables the cop for either method. I believe refactoring wouldn’t currently be worth the effort, especially given that `#set_cpu_cflags` is now mostly called without arguments.
