### PR TITLE
Treat future SDKs as "latest"

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -44,7 +44,7 @@ module OS
       end
 
       def latest_sdk_version?
-        OS::Mac.version == OS::Mac.latest_sdk_version
+        OS::Mac.version >= OS::Mac.latest_sdk_version
       end
 
       def needs_clt_installed?


### PR DESCRIPTION
Some SDKs return a number higher than the hard-coded `latest_version`
in this file. With the current `==` check, those higher version numbers
are treated as "not the latest". This prevents machines with
higher-versioned SDKs from being able to use Homebrew.

To resolve that problem, this PR changes the check to `>=`, which allows
machines with higher-versioned SDKs to also use Homebrew to install
packages.