### PR TITLE
Fix deprecated Rubygems options

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -221,7 +221,7 @@ module Homebrew
     return unless Gem::Specification.find_all_by_name(name, version).empty?
 
     ohai "Installing or updating '#{name}' gem"
-    install_args = %W[--no-ri --no-rdoc #{name}]
+    install_args = %W[--no-document #{name}]
     install_args << "--version" << version if version
 
     # Do `gem install [...]` without having to spawn a separate process or

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -230,7 +230,7 @@ module Homebrew
     # having to find the right `gem` binary for the running Ruby interpreter.
     require "rubygems/commands/install_command"
     install_cmd = Gem::Commands::InstallCommand.new
-    install_cmd.handle_options("--no-document", name)
+    install_cmd.handle_options(["--no-document", name])
     exit_code = 1 # Should not matter as `install_cmd.execute` always throws.
     begin
       install_cmd.execute


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **No tests**
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **No tests**

-----

## Description

In February 2013, [Rubygems 2.0.0 deprecated](https://blog.rubygems.org/2013/02/24/2.0.0-released.html) the `--[no-]ri` and `--[no-]rdoc` options, replacing them with the new `--[no-]document` option.

Almost five years later, Rubygems [finally dropped support](https://github.com/rubygems/rubygems/pull/2354) for the long-deprecated `--[no-]ri` and `--[no-]rdoc` options.

## Impact

This removal causes `bundle install` to **fail for fresh Homebrew checkouts** if Rubygems 3.0.x or newer is installed, which will happen if the user runs `gem update --system` [on Ruby 2.3.0 or later](https://rubygems.org/gems/rubygems-update/versions).

This also affects the system Ruby built into macOS 10.13 and 10.14.

## Steps to reproduce

```
$ sudo /usr/bin/gem update -N --system
[…]
Installing RubyGems 3.0.2
ERROR:  While executing gem ... (Errno::EPERM)
    Operation not permitted @ rb_sysopen - /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/bin/gem
$ gem --version 2>/dev/null
3.0.2
$ cd "$(mktemp -d)"
$ git clone --depth=1 https://github.com/Homebrew/brew.git
[…]
$ cd brew
$ export HOMEBREW_PATH=bin  # in case shellcheck is not installed
$ bin/brew style Library/Homebrew/extend/ENV/std.rb
==> Installing or updating 'rubocop' gem
Error: invalid option: --no-ri
```

(Note: The above steps will not touch an existing Homebrew installation, and won’t even require Homebrew to be installed.)

## Fix

This PR replaces the deprecated options with the new `--no-document` option, which has been around since Rubygems 2.0.0. It is therefore safe for use on all supported platforms.

## See also

- #5497
- #5500
