### PR TITLE
Use -march=native for non-bottle source builds [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/extend/ENV/shared.rb
@@ -1,1 +1,5 @@
-require "extend/os/mac/extend/ENV/shared" if OS.mac?
+if OS.mac?
+  require "extend/os/mac/extend/ENV/shared"
+elsif OS.linux?
+  require "extend/os/linux/extend/ENV/shared"
+end

--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -1,0 +1,10 @@
+module SharedEnvExtension
+  # @private
+  def effective_arch
+    if ARGV.build_bottle?
+      ARGV.bottle_arch || Hardware.oldest_cpu
+    else
+      :native
+    end
+  end
+end

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -7,6 +7,7 @@ module Hardware
 
     class << self
       OPTIMIZATION_FLAGS = {
+        native:  "-march=native",
         nehalem: "-march=nehalem",
         penryn:  "-march=penryn",
         core2:   "-march=core2",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Use `-march=native` for source builds on Linux. Brew currently uses `-march=core2` by default for both bottle and source builds. Previous behaviour was `-march=core2` for bottle builds and `-march=native` for source builds.