### PR TITLE
extend/ARGV: don't warn on --bottle-arch=.

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -15,6 +15,7 @@ module HomebrewArgvExtension
       --no-sandbox
       --build-bottle
       --force-bottle
+      --bottle-arch=
       --include-test
       --verbose
       --force


### PR DESCRIPTION
Fixes #5504.

CC @sjackman

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----