### PR TITLE
Change default compile option to O2

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -37,8 +37,8 @@ module Stdenv
       self["CMAKE_FRAMEWORK_PATH"] = frameworks.to_s
     end
 
-    # Os is the default Apple uses for all its stuff so let's trust them
-    define_cflags "-Os #{SAFE_CFLAGS_FLAGS}"
+    # O2 enables the optimizations that do not involve a space-speed tradeoff
+    define_cflags "-O2 #{SAFE_CFLAGS_FLAGS}"
 
     append "LDFLAGS", "-Wl,-headerpad_max_install_names"
 


### PR DESCRIPTION
Definition from GCC docs: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

It's because Os harms performance a little, and O2 stays neutral.

Meanwhile: 1) Should I add `-mtune=native`, which doesn't change the instruction set 2) Should I apply the same change for CXXFLAGS?

This change is subjective, so comments are (especially) welcome.