### PR TITLE
spec_helper: tweak parallel tests handling.

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -11,6 +11,13 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
 
     formatters << Coveralls::SimpleCov::Formatter
 
+    if ENV["TEST_ENV_NUMBER"]
+      SimpleCov.at_exit do
+        result = SimpleCov.result
+        result.format! if ParallelTests.number_of_running_processes <= 1
+      end
+    end
+
     ENV["CI_NAME"] = ENV["HOMEBREW_CI_NAME"]
     ENV["CI_JOB_ID"] = ENV["TEST_ENV_NUMBER"] || "1"
     ENV["CI_BUILD_NUMBER"] = ENV["HOMEBREW_CI_BUILD_NUMBER"]
@@ -65,7 +72,7 @@ RSpec.configure do |config|
 
   config.filter_run_when_matching :focus
 
-  config.silence_filter_announcements = true
+  config.silence_filter_announcements = true if ENV["TEST_ENV_NUMBER"]
 
   # TODO: when https://github.com/rspec/rspec-expectations/pull/1056
   #       makes it into a stable release:


### PR DESCRIPTION
- only hide filtered runs in parallel (where they are super noisy)
- only send SimpleCov coverage once to Coveralls

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----