### PR TITLE
compat: correct MacOS.prefer_64_bit? deprecation

### DIFF
--- a/Library/Homebrew/compat/os/mac.rb
+++ b/Library/Homebrew/compat/os/mac.rb
@@ -1,14 +1,14 @@
 module OS
   module Mac
-    module Compat
-      module_function
-
-      def prefer_64_bit?
-        odeprecated("MacOS.prefer_64_bit?")
-        Hardware::CPU.is_64_bit?
+    class << self
+      module Compat
+        def prefer_64_bit?
+          odeprecated("MacOS.prefer_64_bit?")
+          Hardware::CPU.is_64_bit?
+        end
       end
-    end
 
-    prepend Compat
+      prepend Compat
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

[Reported via the Discourse forum.](https://discourse.brew.sh/t/undefined-method-prefer-64-bit-for-os-module/3837) It seems like https://github.com/Homebrew/brew/pull/5477 had a small bug where `MacOS.prefer_64_bit?` was prematurely disabled by being inaccessible.

Steps to reproduce:

```bash
echo 'MacOS.prefer_64_bit?' | brew irb
```

Incorrect behavior:

```console
$ echo 'MacOS.prefer_64_bit?' | brew irb
==> Interactive Homebrew Shell
Example commands available with: brew irb --examples
Switch to inspect mode.
MacOS.prefer_64_bit?
NoMethodError: undefined method `prefer_64_bit?' for OS::Mac:Module
	from (irb):1
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:88:in `<main>'
```

Correct behavior:

```console
$ echo 'MacOS.prefer_64_bit?' | brew irb
==> Interactive Homebrew Shell
Example commands available with: brew irb --examples
Switch to inspect mode.
MacOS.prefer_64_bit?
MethodDeprecatedError: Calling MacOS.prefer_64_bit? is deprecated! There is no replacement.
	from /usr/local/Homebrew/Library/Homebrew/compat/os/mac.rb:6:in `prefer_64_bit?'
	from (irb):1
	from /usr/local/Homebrew/Library/Homebrew/brew.rb:88:in `<main>'
```