### PR TITLE
cmd/search: fix truncated regex warning.

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -125,7 +125,7 @@ module Homebrew
       end
     end
 
-    ohai <<~EOS
+    opoo <<~EOS
       Did you mean to perform a regular expression search?
       Surround your query with /slashes/ to search locally by regex.
     EOS


### PR DESCRIPTION
`ohai` doesn't really work for this case.

Fixes #5520.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----