### PR TITLE
Add HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK variable

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -296,7 +296,9 @@ class FormulaInstaller
           formula.prefix.rmtree if formula.prefix.directory?
           formula.rack.rmdir_if_possible
         end
-        raise if ARGV.homebrew_developer? || e.is_a?(Interrupt)
+        raise if ARGV.homebrew_developer? ||
+                 e.is_a?(Interrupt) ||
+                 ENV["HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK"]
 
         @pour_failed = true
         onoe e.message

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -218,6 +218,10 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will not auto-update before running `brew install`,
     `brew upgrade` or `brew tap`.
 
+  * `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK`:
+    If set, Homebrew will fail if on the failure of installation from a bottle
+    rather than falling back to building from source.
+
   * `HOMEBREW_NO_COLOR`:
     If set, Homebrew will not print text with color added.
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1211,6 +1211,10 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will not auto-update before running `brew install`,
     `brew upgrade` or `brew tap`.
 
+  * `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK`:
+    If set, Homebrew will fail if on the failure of installation from a bottle
+    rather than falling back to building from source.
+
   * `HOMEBREW_NO_COLOR`:
     If set, Homebrew will not print text with color added.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1341,6 +1341,10 @@ If set, Homebrew will not send analytics\. See: \fIhttps://docs\.brew\.sh/Analyt
 If set, Homebrew will not auto\-update before running \fBbrew install\fR, \fBbrew upgrade\fR or \fBbrew tap\fR\.
 .
 .TP
+\fBHOMEBREW_NO_BOTTLE_SOURCE_FALLBACK\fR
+If set, Homebrew will fail if on the failure of installation from a bottle rather than falling back to building from source\.
+.
+.TP
 \fBHOMEBREW_NO_COLOR\fR
 If set, Homebrew will not print text with color added\.
 .


### PR DESCRIPTION
If set, Homebrew will fail if on the failure of installation from a
bottle rather than falling back to building from source.


- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----