### PR TITLE
Fix some bottling logic

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -174,9 +174,7 @@ module Homebrew
     end
 
     if devel = f.devel
-      s = "devel #{devel.version}"
-      s += " (bottled)" if devel.bottled?
-      specs << s
+      specs << "devel #{devel.version}"
     end
 
     specs << "HEAD" if f.head

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -147,7 +147,7 @@ module Homebrew
 
     fi = FormulaInstaller.new(f)
     fi.options = options
-    fi.build_bottle = ARGV.build_bottle? || (!f.bottled? && f.build.bottle?)
+    fi.build_bottle = ARGV.build_bottle? || (!f.bottle_defined? && f.build.bottle?)
     fi.installed_on_request = !ARGV.named.empty?
     fi.link_keg           ||= keg_was_linked if keg_had_linked_opt
     if tab

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -21,7 +21,7 @@ module Homebrew
     fi = FormulaInstaller.new(f)
     fi.options              = options
     fi.invalid_option_names = build_options.invalid_option_names
-    fi.build_bottle         = ARGV.build_bottle? || (!f.bottled? && f.build.bottle?)
+    fi.build_bottle         = ARGV.build_bottle? || (!f.bottle_defined? && f.build.bottle?)
     fi.interactive          = ARGV.interactive?
     fi.git                  = ARGV.git?
     fi.link_keg           ||= keg_was_linked if keg_had_linked_opt


### PR DESCRIPTION
- We've never supported `devel` bottles so don't bother outputting their status to `brew info`
- Don't `brew upgrade` or `brew reinstall` bottles if they were previously built as a bottle unless there's no bottles defined at all (rather than there was no compatible bottles). Fixes #5532.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----