### PR TITLE
Fiks HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK description

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -219,7 +219,7 @@ Note that environment variables must have a value set to be detected. For exampl
     `brew upgrade` or `brew tap`.
 
   * `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK`:
-    If set, Homebrew will fail if on the failure of installation from a bottle
+    If set, Homebrew will fail on the failure of installation from a bottle
     rather than falling back to building from source.
 
   * `HOMEBREW_NO_COLOR`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1212,7 +1212,7 @@ Note that environment variables must have a value set to be detected. For exampl
     `brew upgrade` or `brew tap`.
 
   * `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK`:
-    If set, Homebrew will fail if on the failure of installation from a bottle
+    If set, Homebrew will fail on the failure of installation from a bottle
     rather than falling back to building from source.
 
   * `HOMEBREW_NO_COLOR`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1342,7 +1342,7 @@ If set, Homebrew will not auto\-update before running \fBbrew install\fR, \fBbre
 .
 .TP
 \fBHOMEBREW_NO_BOTTLE_SOURCE_FALLBACK\fR
-If set, Homebrew will fail if on the failure of installation from a bottle rather than falling back to building from source\.
+If set, Homebrew will fail on the failure of installation from a bottle rather than falling back to building from source\.
 .
 .TP
 \fBHOMEBREW_NO_COLOR\fR


### PR DESCRIPTION
This change fixes a syntax error introduced in b278165da

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
