### PR TITLE
libunwind.pc: add os/mac/pkg-config files

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/10.12/libunwind.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.12/libunwind.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib/system
+includedir=${prefix}/include
+
+Name: libunwind
+Description: libunwind base library
+Version: 35.3
+Libs: -L${libdir} -lunwind
+Libs.private: -L${exec_prefix}/lib -llzma
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/libunwind.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/libunwind.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib/system
+includedir=${prefix}/include
+
+Name: libunwind
+Description: libunwind base library
+Version: 35.3
+Libs: -L${libdir} -lunwind
+Libs.private: -L${exec_prefix}/lib -llzma
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libunwind.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libunwind.pc
@@ -1,0 +1,11 @@
+prefix=/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib/system
+includedir=${prefix}/include
+
+Name: libunwind
+Description: libunwind base library
+Version: 35.4
+Libs: -L${libdir} -lunwind
+Libs.private: -L${exec_prefix}/lib -llzma
+Cflags: -I${includedir}


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The libunwind library is provided by macOS but without a pkg-config file. That wasn't a problem until the recent zeromq 4.3.1 release changed its `libzmq.pc` pkg-config file to require `libunwind.pc` ( https://github.com/Homebrew/homebrew-core/pull/35940#issuecomment-454177261 ). I first noticed this in downstream software outside of homebrew-core, but it has also caused a [build failure of libbitcoin-protocol](https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/36348/version=mojave/consoleFull) in the boost 1.69 pull request ( https://github.com/Homebrew/homebrew-core/pull/35030 ).

I created these `libunwind.pc` files from the [libunwind.pc.in template](https://github.com/libunwind/libunwind/blob/master/src/unwind/libunwind.pc.in) in the upstream repository and copied the version numbers for 10.12, 10.13, and 10.14 from https://opensource.apple.com/release

* https://opensource.apple.com/release/macos-10141.html
* https://opensource.apple.com/release/macos-10136.html
* https://opensource.apple.com/release/macos-10126.html