### PR TITLE
Warn more on unsupported configurations

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -134,6 +134,7 @@ module Homebrew
   def gist_logs
     raise FormulaUnspecifiedError if ARGV.resolved_formulae.length != 1
 
+    Install.perform_preinstall_checks(all_fatal: true)
     gistify_logs(ARGV.resolved_formulae.first)
   end
 end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -79,6 +79,10 @@ module Homebrew
         ].freeze
       end
 
+      def supported_configuration_checks
+        [].freeze
+      end
+
       def development_tools_checks
         %w[
           check_for_installed_developer_tools
@@ -97,11 +101,10 @@ module Homebrew
 
       def please_create_pull_requests(what = "unsupported configuration")
         <<~EOS
-          You may encounter build failures and other breakages.
-          Please create pull requests instead of asking for help on
-          Homebrew's GitHub, Discourse, Twitter or IRC. You are
-          responsible for resolving any issues you experience, as
-          you are running this #{what}.
+          You will encounter build failures with some formulae.
+          Please create pull requests instead of asking for help on Homebrew's GitHub,
+          Discourse, Twitter or IRC. You are responsible for resolving any issues you
+          experience, as you are running this #{what}.
         EOS
       end
 
@@ -118,10 +121,8 @@ module Homebrew
         return unless ENV["HOMEBREW_BUILD_FROM_SOURCE"]
 
         <<~EOS
-          You have HOMEBREW_BUILD_FROM_SOURCE set. This environment variable is
-          intended for use by Homebrew developers. If you are encountering errors,
-          please try unsetting this. Please do not file issues if you encounter
-          errors when using this environment variable.
+          You have HOMEBREW_BUILD_FROM_SOURCE set.
+          #{please_create_pull_requests}
         EOS
       end
 
@@ -806,9 +807,9 @@ module Homebrew
 
         <<~EOS
           Your Homebrew's prefix is not #{Homebrew::DEFAULT_PREFIX}.
-          You can install Homebrew anywhere you want but some bottles (binary packages)
-          can only be used with a standard prefix and some formulae (packages)
-          may not build correctly with a non-standard prefix.
+          Some of Homebrew's bottles (binary packages) can only be used with the default
+          prefix (#{Homebrew::DEFAULT_PREFIX}).
+          #{please_create_pull_requests}
         EOS
       end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -802,7 +802,7 @@ module Homebrew
       end
 
       def check_homebrew_prefix
-        return if HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX
+        return if Homebrew.default_prefix?
 
         <<~EOS
           Your Homebrew's prefix is not #{Homebrew::DEFAULT_PREFIX}.

--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -7,6 +7,13 @@ require "os/linux/kernel"
 module Homebrew
   module Diagnostic
     class Checks
+      def supported_configuration_checks
+        %w[
+          check_glibc_minimum_version
+          check_kernel_minimum_version
+        ].freeze
+      end
+
       def check_tmpdir_sticky_bit
         message = generic_check_tmpdir_sticky_bit
         return if message.nil?

--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -26,8 +26,8 @@ module Homebrew
       FileUtils.ln_sf ld_so, brew_ld_so
     end
 
-    def perform_preinstall_checks
-      generic_perform_preinstall_checks
+    def perform_preinstall_checks(all_fatal: false)
+      generic_perform_preinstall_checks(all_fatal: all_fatal)
       symlink_ld_so
     end
   end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -1,12 +1,19 @@
 module Homebrew
   module Diagnostic
     class Checks
-      undef development_tools_checks, fatal_development_tools_checks,
-            build_error_checks
+      undef supported_configuration_checks, development_tools_checks,
+            fatal_development_tools_checks, build_error_checks
+
+      def supported_configuration_checks
+        %w[
+          check_build_from_source
+          check_homebrew_prefix
+          check_for_unsupported_macos
+        ].freeze
+      end
 
       def development_tools_checks
         %w[
-          check_for_unsupported_macos
           check_for_installed_developer_tools
           check_xcode_license_approved
           check_xcode_up_to_date

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -11,7 +11,6 @@ module Homebrew
           check_xcode_license_approved
           check_xcode_up_to_date
           check_clt_up_to_date
-          check_for_other_package_managers
         ].freeze
       end
 
@@ -136,21 +135,6 @@ module Homebrew
         EOS
       end
 
-      def check_for_other_package_managers
-        ponk = MacOS.macports_or_fink
-        return if ponk.empty?
-
-        <<~EOS
-          You have MacPorts or Fink installed:
-            #{ponk.join(", ")}
-
-          This can cause trouble. You don't have to uninstall them, but you may want to
-          temporarily move them out of the way, e.g.
-
-            sudo mv /opt/local ~/macports
-        EOS
-      end
-
       def check_ruby_version
         ruby_version = "2.3.7"
         return if RUBY_VERSION == ruby_version
@@ -200,19 +184,6 @@ module Homebrew
         EOS
       end
 
-      def check_for_bad_curl
-        return unless MacOS.version <= "10.8"
-        return if Formula["curl"].installed?
-
-        <<~EOS
-          The system curl on 10.8 and below is often incapable of supporting
-          modern secure connections & will fail on fetching formulae.
-
-          We recommend you:
-            brew install curl
-        EOS
-      end
-
       def check_xcode_license_approved
         # If the user installs Xcode-only, they have to approve the
         # license or no "xc*" tool will work.
@@ -233,18 +204,6 @@ module Homebrew
           Please install XQuartz #{MacOS::XQuartz.latest_version} (or delete the current version).
           XQuartz can be updated using Homebrew Cask by running
             brew cask reinstall xquartz
-        EOS
-      end
-
-      def check_for_beta_xquartz
-        return unless MacOS::XQuartz.version.to_s.include?("beta")
-
-        <<~EOS
-          The following beta release of XQuartz is installed: #{MacOS::XQuartz.version}
-
-          XQuartz beta releases include address sanitization, and do not work with
-          all software; notably, wine will not work with beta releases of XQuartz.
-          We recommend only installing stable releases of XQuartz.
         EOS
       end
 

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -15,8 +15,12 @@ module OS
 
   if OS.mac?
     require "os/mac"
-    # Don't tell people to report issues on unsupported versions of macOS.
-    if !OS::Mac.prerelease? && !OS::Mac.outdated_release?
+    # Don't tell people to report issues on unsupported configurations.
+    if !OS::Mac.prerelease? &&
+       !OS::Mac.outdated_release? &&
+       !ENV["HOMEBREW_BUILD_FROM_SOURCE"] &&
+       ARGV.none? { |v| v.start_with?("--cc=") } &&
+       ENV["HOMEBREW_PREFIX"] == "/usr/local"
       ISSUES_URL = "https://docs.brew.sh/Troubleshooting".freeze
     end
     PATH_OPEN = "/usr/bin/open".freeze

--- a/Library/Homebrew/os/linux/global.rb
+++ b/Library/Homebrew/os/linux/global.rb
@@ -1,5 +1,5 @@
 module Homebrew
-  DEFAULT_PREFIX = if ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
+  DEFAULT_PREFIX ||= if ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
     "/usr/local".freeze
   else
     "/home/linuxbrew/.linuxbrew".freeze

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -164,7 +164,7 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_homebrew_prefix" do
-    # the integration tests are run in a special prefix
+    allow(Homebrew).to receive(:default_prefix?).and_return(false)
     expect(subject.check_homebrew_prefix)
       .to match("Your Homebrew's prefix is not #{Homebrew::DEFAULT_PREFIX}")
   end

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -1,25 +1,12 @@
 require "diagnostic"
 
 describe Homebrew::Diagnostic::Checks do
-  specify "#check_for_other_package_managers" do
-    allow(MacOS).to receive(:macports_or_fink).and_return(["fink"])
-    expect(subject.check_for_other_package_managers)
-      .to match("You have MacPorts or Fink installed:")
-  end
-
   specify "#check_for_unsupported_macos" do
     ENV.delete("HOMEBREW_DEVELOPER")
     allow(OS::Mac).to receive(:prerelease?).and_return(true)
 
     expect(subject.check_for_unsupported_macos)
       .to match("We do not provide support for this pre-release version.")
-  end
-
-  specify "#check_for_beta_xquartz" do
-    allow(MacOS::XQuartz).to receive(:version).and_return("2.7.10_beta2")
-
-    expect(subject.check_for_beta_xquartz)
-      .to match("The following beta release of XQuartz is installed: 2.7.10_beta2")
   end
 
   specify "#check_if_xcode_needs_clt_installed" do

--- a/Library/Homebrew/test/support/lib/config.rb
+++ b/Library/Homebrew/test/support/lib/config.rb
@@ -41,3 +41,8 @@ PATCH_B_SHA256 = "57958271bb802a59452d0816e0670d16c8b70bdf6530bcf6f78726489ad89b
 
 TEST_SHA1   = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
 TEST_SHA256 = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".freeze
+
+# For testing's sake always assume the default prefix
+module Homebrew
+  DEFAULT_PREFIX = HOMEBREW_PREFIX.to_s.freeze
+end

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -9,18 +9,17 @@ describe Utils::Analytics do
       end
 
       it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix" do
-        stub_const("HOMEBREW_PREFIX", "blah")
+        allow(Homebrew).to receive(:default_prefix?).and_return(false)
         expect(described_class.os_prefix_ci).to include("#{OS_VERSION}, #{described_class.custom_prefix_label}")
+      end
+
+      it "does not include prefix when HOMEBREW_PREFIX is the default prefix" do
+        expect(described_class.os_prefix_ci).not_to include(described_class.custom_prefix_label)
       end
 
       it "includes CI when ENV['CI'] is set" do
         ENV["CI"] = "true"
         expect(described_class.os_prefix_ci).to include("CI")
-      end
-
-      it "does not include prefix when HOMEBREW_PREFIX is the default prefix" do
-        stub_const("HOMEBREW_PREFIX", Homebrew::DEFAULT_PREFIX)
-        expect(described_class.os_prefix_ci).not_to include(described_class.custom_prefix_label)
       end
     end
   end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -16,7 +16,7 @@ module Utils
       def os_prefix_ci
         @os_prefix_ci ||= begin
           os = OS_VERSION
-          prefix = ", #{custom_prefix_label}" if HOMEBREW_PREFIX.to_s != Homebrew::DEFAULT_PREFIX
+          prefix = ", #{custom_prefix_label}" if Homebrew.default_prefix?
           ci = ", CI" if ENV["CI"]
           "#{os}#{prefix}#{ci}"
         end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -16,7 +16,7 @@ module Utils
       def os_prefix_ci
         @os_prefix_ci ||= begin
           os = OS_VERSION
-          prefix = ", #{custom_prefix_label}" if Homebrew.default_prefix?
+          prefix = ", #{custom_prefix_label}" unless Homebrew.default_prefix?
           ci = ", CI" if ENV["CI"]
           "#{os}#{prefix}#{ci}"
         end


### PR DESCRIPTION
- gist-logs: don’t upload on unsupported configurations.
- Output more `brew doctor` and `brew install` warnings on unsupported configurations
- os: no “READ THIS” in unsupported configurations.
- os/mac/diagnostic: remove some old/unneeded checks.
- Use Homebrew.default_prefix? in more places.
- Improve use of default_prefix? in tests.