### PR TITLE
Tweak diagnostic checks

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -135,6 +135,7 @@ module Homebrew
     raise FormulaUnspecifiedError if ARGV.resolved_formulae.length != 1
 
     Install.perform_preinstall_checks(all_fatal: true)
+    Install.perform_build_from_source_checks(all_fatal: true)
     gistify_logs(ARGV.resolved_formulae.first)
   end
 end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -73,9 +73,15 @@ module Homebrew
       end
       ############# END HELPERS
 
-      def fatal_install_checks
+      def fatal_preinstall_checks
         %w[
           check_access_directories
+        ].freeze
+      end
+
+      def fatal_build_from_source_checks
+        %w[
+          check_for_installed_developer_tools
         ].freeze
       end
 
@@ -83,20 +89,12 @@ module Homebrew
         [].freeze
       end
 
-      def development_tools_checks
-        %w[
-          check_for_installed_developer_tools
-        ].freeze
-      end
-
-      def fatal_development_tools_checks
-        %w[
-        ].freeze
+      def build_from_source_checks
+        [].freeze
       end
 
       def build_error_checks
-        (development_tools_checks + %w[
-        ]).freeze
+        supported_configuration_checks + build_from_source_checks
       end
 
       def please_create_pull_requests(what = "unsupported configuration")

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -1,38 +1,31 @@
 module Homebrew
   module Diagnostic
     class Checks
-      undef supported_configuration_checks, development_tools_checks,
-            fatal_development_tools_checks, build_error_checks
+      undef fatal_build_from_source_checks, supported_configuration_checks,
+            build_from_source_checks
 
-      def supported_configuration_checks
+      def fatal_build_from_source_checks
         %w[
-          check_build_from_source
-          check_homebrew_prefix
-          check_for_unsupported_macos
-        ].freeze
-      end
-
-      def development_tools_checks
-        %w[
-          check_for_installed_developer_tools
           check_xcode_license_approved
-          check_xcode_up_to_date
-          check_clt_up_to_date
-        ].freeze
-      end
-
-      def fatal_development_tools_checks
-        %w[
           check_xcode_minimum_version
           check_clt_minimum_version
           check_if_xcode_needs_clt_installed
         ].freeze
       end
 
-      def build_error_checks
-        (development_tools_checks + %w[
+      def supported_configuration_checks
+        %w[
+          check_build_from_source
           check_for_unsupported_macos
-        ]).freeze
+        ].freeze
+      end
+
+      def build_from_source_checks
+        %w[
+          check_for_installed_developer_tools
+          check_xcode_up_to_date
+          check_clt_up_to_date
+        ].freeze
       end
 
       def check_for_non_prefixed_findutils
@@ -198,7 +191,7 @@ module Homebrew
 
         <<~EOS
           You have not agreed to the Xcode license.
-          Builds will fail! Agree to the license by opening Xcode.app or running:
+          Agree to the license by opening Xcode.app or running:
             sudo xcodebuild -license
         EOS
       end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -209,7 +209,7 @@ class FormulaInstaller
   def install
     start_time = Time.now
     if !formula.bottle_unneeded? && !pour_bottle? && DevelopmentTools.installed?
-      Homebrew::Install.perform_development_tools_checks
+      Homebrew::Install.perform_build_from_source_checks
     end
 
     # not in initialize so upgrade can unlink the active keg before calling this

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -17,16 +17,6 @@ module Homebrew
       end
     end
 
-    def check_cc_argv
-      return unless ARGV.cc
-
-      @checks ||= Diagnostic::Checks.new
-      opoo <<~EOS
-        You passed `--cc=#{ARGV.cc}`.
-        #{@checks.please_create_pull_requests}
-      EOS
-    end
-
     def attempt_directory_creation
       Keg::MUST_EXIST_DIRECTORIES.each do |dir|
         begin
@@ -37,8 +27,14 @@ module Homebrew
       end
     end
 
-    def perform_development_tools_checks
-      diagnostic_checks(:fatal_development_tools_checks)
+    def check_cc_argv
+      return unless ARGV.cc
+
+      @checks ||= Diagnostic::Checks.new
+      opoo <<~EOS
+        You passed `--cc=#{ARGV.cc}`.
+        #{@checks.please_create_pull_requests}
+      EOS
     end
 
     def perform_preinstall_checks(all_fatal: false)
@@ -46,10 +42,15 @@ module Homebrew
       attempt_directory_creation
       check_cc_argv
       diagnostic_checks(:supported_configuration_checks, fatal: all_fatal)
-      diagnostic_checks(:fatal_install_checks)
+      diagnostic_checks(:fatal_preinstall_checks)
     end
     alias generic_perform_preinstall_checks perform_preinstall_checks
     module_function :generic_perform_preinstall_checks
+
+    def perform_build_from_source_checks(all_fatal: false)
+      diagnostic_checks(:fatal_build_from_source_checks)
+      diagnostic_checks(:build_from_source_checks, fatal: all_fatal)
+    end
 
     def diagnostic_checks(type, fatal: true)
       @checks ||= Diagnostic::Checks.new


### PR DESCRIPTION
- Make `gist-logs` perform more checks
- Don't complain about a non-/usr/local install at install time unless actually building from source.
- Show more checks output on a build error
- Improve naming of checks methods