### PR TITLE
bottle: detect vim's lack of relocatableness.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -365,6 +365,7 @@ module Homebrew
             relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg)
             relocatable = false if keg_contain?("#{prefix}/etc", keg, ignores)
             relocatable = false if keg_contain?("#{prefix}/var", keg, ignores)
+            relocatable = false if keg_contain?("#{prefix}/share/vim", keg, ignores)
           end
           skip_relocation = relocatable && !keg.require_relocation?
         end


### PR DESCRIPTION
References https://github.com/Homebrew/homebrew-core/issues/35236.