### PR TITLE
utils: fix SVN remote test on Mojave.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -291,7 +291,7 @@ module Homebrew
 
     $times = {}
     at_exit do
-      col_width = [$times.keys.map(&:size).max + 2, 15].max
+      col_width = [$times.keys.map(&:size).max.to_i + 2, 15].max
       $times.sort_by { |_k, v| v }.each do |method, time|
         puts format("%-*s %0.4f sec", col_width, "#{method}:", time)
       end

--- a/Library/Homebrew/utils/svn.rb
+++ b/Library/Homebrew/utils/svn.rb
@@ -12,7 +12,9 @@ module Utils
   def self.svn_remote_exists?(url)
     return true unless svn_available?
 
-    ssl_args = ["--non-interactive", "--trust-server-cert"] if ENV["HOMEBREW_TEST_ONLINE"]
-    quiet_system "svn", "ls", url, "--depth", "empty", *ssl_args
+    # OK to unconditionally trust here because we're just checking if
+    # a URL exists.
+    quiet_system "svn", "ls", url, "--depth", "empty",
+                 "--non-interactive", "--trust-server-cert"
   end
 end


### PR DESCRIPTION
For some reason Mojave needs the SSL args always set otherwise this will always fail waiting for interactivity.

Also, while debugging this I noticed that `utils.rb` had a failure expecting an integer so fix that too.