### PR TITLE
Removed cleanup from cask manpage

### DIFF
--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -35,10 +35,6 @@ graphical user interface.
   * `cat` <token> [ <token> ... ]:
     Dump the given Cask definition file to the standard output.
 
-  * `cleanup` [--outdated]:
-    Clean up cached downloads and tracker symlinks. With `--outdated`,
-    only clean up cached downloads older than 10 days old.
-
   * `create` <token>:
     Generate a Cask definition file for the Cask identified by <token>
     and open a template for it in your favorite editor.

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -40,10 +40,6 @@ Check the given Casks for installability\. If no tokens are given on the command
 Dump the given Cask definition file to the standard output\.
 .
 .TP
-\fBcleanup\fR [\-\-outdated]
-Clean up cached downloads and tracker symlinks\. With \fB\-\-outdated\fR, only clean up cached downloads older than 10 days old\.
-.
-.TP
 \fBcreate\fR \fItoken\fR
 Generate a Cask definition file for the Cask identified by \fItoken\fR and open a template for it in your favorite editor\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Reported in https://github.com/Homebrew/homebrew-cask/issues/57875. https://github.com/Homebrew/brew/issues/4660 Missed removing this.

Same as https://github.com/Homebrew/brew/pull/5595, haven’t run the tests because I’m on an old version of macOS with a semi-broken ruby install (I really need to do a clean upgrade to this machine) and it fails to even install the proper gems. Edited the files manually, but the changes are simple enough that I expect them not to fail.