### PR TITLE
azuze-pipelines-yml: early exit on errors.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -55,10 +55,11 @@ module Homebrew
       jobs:
       - job: macOS
         pool:
-          vmImage: xcode9-macos10.13
+          vmImage: macOS-10.13
         steps:
           - bash: |
-              sudo xcode-select --switch /Applications/Xcode_10.app/Contents/Developer
+              set -e
+              sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
               brew update
               HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/#{tap}"
               mkdir -p "$HOMEBREW_TAP_DIR"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ jobs:
     vmImage: macOS-10.13
   steps:
     - bash: |
+        set -e
         sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
         HOMEBREW_REPOSITORY="$(brew --repo)"
         mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library"
@@ -36,6 +37,7 @@ jobs:
     vmImage: ubuntu-16.04
   steps:
     - bash: |
+        set -e
         HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew
         sudo mkdir -p /home/linuxbrew
         sudo mv "$PWD" "$HOMEBREW_REPOSITORY"


### PR DESCRIPTION
We don't want to silently ignore failing commands.

Also, while we're editing the `tap-new` generated `azure-pipelines.yml`
also add the changes missed here from #5600.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----