### PR TITLE
Fix regexp to allow multiple digits in Mac OS minor version.

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -190,7 +190,7 @@ class Cmd
     when "-Xpreprocessor"
       # used for -Xpreprocessor -fopenmp
       args << arg << enum.next
-    when /-mmacosx-version-min=10\.(\d)/
+    when /-mmacosx-version-min=10\.(\d+)/
       arg = "-mmacosx-version-min=10.9" if high_sierra_or_later? && $1.to_i < 9
       args << arg
     when "--fast-math"


### PR DESCRIPTION
The regular expression check for the -mmacosx-version-min value only
looked at a single digit in the minor version number, so it did not
compare correctly if the option was setting the minimum version
to (say) 10.11.

I did not add a test for this because I couldn't find a comparable condition (though I might have missed it) and I don't know enough about the setup to have any confidence in getting it right.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
