### PR TITLE
Fix check_coretap_git_origin

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -581,11 +581,9 @@ module Homebrew
 
             Without a correctly configured origin, Homebrew won't update
             properly. You can solve this by adding the Homebrew remote:
-              git -C "#{coretap_path}" remote add origin #{Formatter.url("https://github.com/Homebrew/homebrew-core.git")}
+              git -C "#{coretap_path}" remote add origin #{Formatter.url(CoreTap.instance.default_remote)}
           EOS
-        elsif origin !~ %r{Homebrew/homebrew-core(\.git|/)?$}
-          return if ENV["CI"] && origin.include?("Homebrew/homebrew-test-bot")
-
+        elsif origin !~ %r{#{CoreTap.instance.full_name}(\.git|/)?$}
           <<~EOS
             Suspicious #{CoreTap.instance} git origin remote found.
 
@@ -595,17 +593,22 @@ module Homebrew
 
             Unless you have compelling reasons, consider setting the
             origin remote to point at the main repository by running:
-              git -C "#{coretap_path}" remote set-url origin #{Formatter.url("https://github.com/Homebrew/homebrew-core.git")}
+              git -C "#{coretap_path}" remote set-url origin #{Formatter.url(CoreTap.instance.default_remote)}
           EOS
         end
+      end
 
+      def check_coretap_git_branch
         return if ENV["CI"]
+
+        coretap_path = CoreTap.instance.path
+        return if !Utils.git_available? || !(coretap_path/".git").exist?
 
         branch = coretap_path.git_branch
         return if branch.nil? || branch =~ /master/
 
         <<~EOS
-          Homebrew/homebrew-core is not on the master branch
+          #{CoreTap.instance.full_name} is not on the master branch
 
           Check out the master branch by running:
             git -C "$(brew --repo homebrew/core)" checkout master

--- a/Library/Homebrew/extend/os/linux/tap.rb
+++ b/Library/Homebrew/extend/os/linux/tap.rb
@@ -1,9 +1,7 @@
 class CoreTap < Tap
-  def default_remote
-    if ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
-      "https://github.com/Homebrew/homebrew-core".freeze
-    else
-      "https://github.com/Linuxbrew/homebrew-core".freeze
-    end
+  # @private
+  def initialize
+    super "Homebrew", "core"
+    @full_name = "Linuxbrew/homebrew-core" unless ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
   end
 end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -635,10 +635,6 @@ end
 
 # A specialized {Tap} class for the core formulae.
 class CoreTap < Tap
-  def default_remote
-    "https://github.com/Homebrew/homebrew-core".freeze
-  end
-
   # @private
   def initialize
     super "Homebrew", "core"


### PR DESCRIPTION
check_coretap_git_origin was not working as intended.
Permit Linuxbrew/homebrew-core as a valid origin.
Factor out check_coretap_git_branch.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?