### PR TITLE
formula_installer: skip linking formulae with already installed casks.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -793,6 +793,17 @@ class FormulaInstaller
       return
     end
 
+    cask_installed_with_formula_name = begin
+      Cask::CaskLoader.load(formula.name).installed?
+    rescue Cask::CaskUnavailableError
+      false
+    end
+
+    if cask_installed_with_formula_name
+      ohai "#{formula.name} cask is installed, skipping link."
+      return
+    end
+
     if keg.linked?
       opoo "This keg was marked linked already, continuing anyway"
       keg.remove_linked_keg_record


### PR DESCRIPTION
If you have the `emacs` or `docker` formulae and casks both
installed the formula will fail to link. Skip trying to link the formula
if the cask is already installed.

Fixes https://github.com/Homebrew/homebrew-core/issues/36310.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----