### PR TITLE
diagnostic: ignore case in origin comparison

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -583,7 +583,7 @@ module Homebrew
             properly. You can solve this by adding the Homebrew remote:
               git -C "#{coretap_path}" remote add origin #{Formatter.url(CoreTap.instance.default_remote)}
           EOS
-        elsif origin !~ %r{#{CoreTap.instance.full_name}(\.git|/)?$}
+        elsif origin !~ %r{#{CoreTap.instance.full_name}(\.git|/)?$}i
           <<~EOS
             Suspicious #{CoreTap.instance} git origin remote found.
 


### PR DESCRIPTION
On circle-ci we use:
git remote set-url origin $CIRCLE_REPOSITORY_URL

which is defined as: https://github.com/linuxbrew/homebrew-core

This is being compared to:
https://github.com/Linuxbrew/homebrew-core

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
