### PR TITLE
docs/Shell-Completion: read both types of bash completions.

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -12,13 +12,19 @@ To make Homebrew's completions available in `bash`, you must source the definiti
 
 ```sh
 if type brew 2&>/dev/null; then
-  source "$(brew --prefix)/etc/bash_completion.d/*"
-else
-  echo "run: brew install git bash-completion"
+  for COMPLETION in $(brew --prefix)/etc/bash_completion.d/*
+  do
+    [[ -f $COMPLETION ]] && source "$COMPLETION"
+  done
+  if [[ -f $(brew --prefix)/etc/profile.d/bash_completion.sh ]];
+  then
+    source "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+  fi
 fi
 ```
 
 ## Configuring Completions in `zsh`
+
 To make Homebrew's completions available in `zsh`, you must get the Homebrew-managed zsh site-functions on your `FPATH` before initialising `zsh`'s completion facility. Add the following to your `~/.zshrc` file:
 
 ```sh
@@ -42,4 +48,5 @@ Additionally, if you receive "zsh compinit: insecure directories" warnings when 
 ```
 
 ## Configuring Completions in `fish`
+
 No configuration is needed in `fish`. Friendly!


### PR DESCRIPTION
And guard against either of them being missing.

Fixes #5610

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----