### PR TITLE
audit: no longer need openssl/curl HTTP mirrors.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1122,20 +1122,9 @@ module Homebrew
     end
 
     def audit_urls
-      urls = [url] + mirrors
-
-      curl_openssl_or_deps = ResourceAuditor.curl_openssl_and_deps.include?(owner.name)
-
-      if spec_name == :stable && curl_openssl_or_deps
-        problem "should not use xz tarballs" if url.end_with?(".xz")
-
-        unless urls.find { |u| u.start_with?("http://") }
-          problem "should always include at least one HTTP mirror"
-        end
-      end
-
       return unless @online
 
+      urls = [url] + mirrors
       urls.each do |url|
         next if !@strict && mirrors.include?(url)
 


### PR DESCRIPTION
Mavericks' `curl` can download these fine over HTTPS.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----