### PR TITLE
cleaner: only skip non-.la symlinks

### DIFF
--- a/Library/Homebrew/cleaner.rb
+++ b/Library/Homebrew/cleaner.rb
@@ -88,10 +88,12 @@ class Cleaner
 
       Find.prune if @f.skip_clean? path
 
-      next if path.symlink? || path.directory?
+      next if path.directory?
 
       if path.extname == ".la"
         path.unlink
+      elsif path.symlink?
+        # Skip it.
       elsif path.basename.to_s == "perllocal.pod"
         # Both this file & the .packlist one below are completely unnecessary
         # to package & causes pointless conflict with other formulae. They are


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?  
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?  
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?  (Yes, see my commit message.)  
- [ ] Have you written new tests for your changes?  [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).  (No, as I believe the existing tests already cover this sufficiently well.  This can be changed on request.)  
- [x] Have you successfully run `brew style` with your changes locally?  
- [ ] Have you successfully run `brew tests` with your changes locally?  (All tests pass locally except for:  
   - '`test/os/mac_spec.rb`,' which fails with an unrelated error stating that, "`'Locale::parse' failed to parse 'OS::Mac::language'`."
   - Some formula package installation tests due only to unhandled OS version warnings.)  

-----

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;I decided only to fix the logic used for cleaning the results of builds from source to handle symbolic links to static libraries and have punted on tracking down where the logic for cleaning up after bottle builds is and unifying that with the former for now.  

Reopens and closes Homebrew/homebrew-core#35269.  