### PR TITLE
Remove unneeded `curl_openssl_or_deps` invocation

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1134,7 +1134,7 @@ module Homebrew
           # pull request.
           next if url =~ %r{^https://dl.bintray.com/homebrew/mirror/}
 
-          if http_content_problem = curl_check_http_content(url, require_http: curl_openssl_or_deps)
+          if http_content_problem = curl_check_http_content(url)
             problem http_content_problem
           end
         elsif strategy <= GitDownloadStrategy

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -69,12 +69,12 @@ def curl_output(*args, **options)
                  print_stderr: false)
 end
 
-def curl_check_http_content(url, user_agents: [:default], check_content: false, strict: false, require_http: false)
+def curl_check_http_content(url, user_agents: [:default], check_content: false, strict: false)
   return unless url.start_with? "http"
 
   details = nil
   user_agent = nil
-  hash_needed = url.start_with?("http:") && !require_http
+  hash_needed = url.start_with?("http:")
   user_agents.each do |ua|
     details = curl_http_content_headers_and_checksum(url, hash_needed: hash_needed, user_agent: ua)
     user_agent = ua


### PR DESCRIPTION
@Homebrew/maintainers Please review, as this issue is blocking CI. Thanks!

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **Removed code has never been covered by tests.**
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This fixes a regression introduced in #5626, which removed `curl_openssl_or_deps` and left a single call in the code.

Fixes #5629.
