### PR TITLE
Use original URL to parse basename

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -373,7 +373,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
            .map(&Time.public_method(:parse))
            .last
 
-    basename = filenames.last || parse_basename(redirect_url)
+    basename = filenames.last || parse_basename(url)
 
     @resolved_info_cache[url] = [redirect_url, basename, time]
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
When I was trying to create a custom bottle, I found that brew reported an error "File name to long @ rb_sysopen". That's because the download link has a 302 redirection to a long URL and brew tried to use that long name to create file.

In download_strategy.rb:
```ruby
basename = filenames.last || parse_basename(redirect_url)
```

I don't think using `redirect_url` here to parse base name is wise here. In principal, the original URL is a short, permanent one and named formally; while the redirected URL usually contains a long temporary ID which is not stable. Therefore I recommend to change it to `url`.

---

For instance, for my custom bottle, the original URL is 
https://files.hguandl.com/bottles-custom/nginx-1.15.8.mojave.bottle.tar.gz.
The redirected URL (changes from time to time) is
https://mfedu-my.sharepoint.com/personal/byzyquhpx_ac_stu_office_gy/_layouts/15/download.aspx?UniqueId=c6f075de-32cc-48e4-ad74-8a7ad3e3ca10&Translate=false&tempauth=eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIwMDAwMDAwMy0wMDAwLTBmZjEtY2UwMC0wMDAwMDAwMDAwMDAvbWZlZHUtbXkuc2hhcmVwb2ludC5jb21AZDI0NDU5YjgtOTZjMS00YjJlLWFjMWItMDI1YTU0ZjExOTQ1IiwiaXNzIjoiMDAwMDAwMDMtMDAwMC0wZmYxLWNlMDAtMDAwMDAwMDAwMDAwIiwibmJmIjoiMTU0ODc4NTgxOSIsImV4cCI6IjE1NDg3ODk0MTkiLCJlbmRwb2ludHVybCI6IldCcVNJRE9OdklLSzlKdGFrZEI3QzNYYTVxQmlDMitsYzdFdmdZVFNuTGM9IiwiZW5kcG9pbnR1cmxMZW5ndGgiOiIxNTUiLCJpc2xvb3BiYWNrIjoiVHJ1ZSIsImNpZCI6Ik1qUmhZV1k1WkdNdFlqWXpNQzAwWlRJekxXSmhNemt0TkdJME4ySTVOemRtWldObCIsInZlciI6Imhhc2hlZHByb29mdG9rZW4iLCJzaXRlaWQiOiJaak0zTW1VME5tTXRaV0ZoTUMwMFptTTFMVGsxWXpVdE1XTmxNbVkwWkRrNU5XTmoiLCJhcHBfZGlzcGxheW5hbWUiOiJvbmVpbmRleCIsImFwcGlkIjoiZmEwMTBmYjQtNWEwMC00M2MzLWI1ZmQtMjBlNWE2ZjZkZGExIiwidGlkIjoiZDI0NDU5YjgtOTZjMS00YjJlLWFjMWItMDI1YTU0ZjExOTQ1IiwidXBuIjoiYnl6eXF1aHB4QGFjLnN0dS5vZmZpY2UuZ3kiLCJwdWlkIjoiMTAwMzIwMDAzMDlGOTdENyIsInNjcCI6ImFsbGZpbGVzLndyaXRlIiwidHQiOiIyIiwidXNlUGVyc2lzdGVudENvb2tpZSI6bnVsbH0.WkVGbW1jdDQ4am5oaGl2c0tsUlFzV2p3WURrSHBZNDVIOGVXalByc01Vdz0&ApiVersion=2.0