### PR TITLE
update-reset: avoid hanging on shallow-since.

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -35,14 +35,7 @@ homebrew-update-reset() {
     [[ -d "$DIR/.git" ]] || continue
     cd "$DIR" || continue
     echo "==> Fetching $DIR..."
-
-    if [[ "$DIR" = "$HOMEBREW_REPOSITORY" ]]; then
-      latest_tag="$(git ls-remote --tags --refs -q origin | tail -n1 | cut -f2)"
-      git fetch --force origin --shallow-since="$latest_tag"
-    else
-      git fetch --force --tags origin
-    fi
-
+    git fetch --force --tags origin
     echo
 
     echo "==> Resetting $DIR..."


### PR DESCRIPTION
For some reason this seems to hang when there's been no commits since the latest tag. Not a problem in `brew update`.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----