### PR TITLE
cleanup: fix stale cask detection.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -112,6 +112,8 @@ module CleanupRefinement
     def stale_cask?(scrub)
       return false unless name = basename.to_s[/\A(.*?)\-\-/, 1]
 
+      return if dirname.basename.to_s != "Cask"
+
       cask = begin
         Cask::CaskLoader.load(name)
       rescue Cask::CaskUnavailableError


### PR DESCRIPTION
This method is also run to check formulae and if a formula and cask have the same name (e.g. `cmake`) then this method would mark all formulae downloads to being stale.

Instead, check the `dirname` (which we're using for globs anyway) to double check that this is definitely a stale cask.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----