### PR TITLE
With symlinked Cellar, don't try to find /usr/local prefix

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -39,7 +39,7 @@ then
 fi
 
 # Try to find a /usr/local HOMEBREW_PREFIX where possible (for bottles)
-if [[ -L "/usr/local/bin/brew" ]]
+if [[ -L "/usr/local/bin/brew" && ! -L "$HOMEBREW_PREFIX/Cellar" ]]
 then
   USR_LOCAL_BREW_FILE_DIRECTORY="$(symlink_target_directory "/usr/local/bin/brew" "/usr/local/bin")"
   USR_LOCAL_HOMEBREW_REPOSITORY="${USR_LOCAL_BREW_FILE_DIRECTORY%/*}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR permits Cellar to be a symlink. A Cellar may be a symlink to a common shared Cellar. For example, `~/work/project1/Cellar` may be a symlink to `/usr/local/Cellar`. This change allows using a private prefix of `~/work/project1/bin` with a shared Cellar of `/usr/local/Cellar`. This change enables a `brew env` feature that @jonchang is working on.