### PR TITLE
docs: Remove Linux from the unsupported tap list

### DIFF
--- a/docs/Interesting-Taps-and-Forks.md
+++ b/docs/Interesting-Taps-and-Forks.md
@@ -32,5 +32,3 @@ Your taps are Git repositories located at `$(brew --repository)/Library/Taps`.
 ## Unsupported interesting forks
 
 *   [mistydemeo/tigerbrew](https://github.com/mistydemeo/tigerbrew): Experimental Tiger PowerPC version.
-
-*   [Linuxbrew/brew](https://github.com/Linuxbrew/brew): Experimental Linux version.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
-----
Linux is now officially supported.