### PR TITLE
missing_formula.rb: add help message for cargo

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -15,7 +15,7 @@ module Homebrew
         EOS
         when "tex", "tex-live", "texlive", "latex" then <<~EOS
           Installing TeX from source is weird and gross, requires a lot of patches,
-          and only builds 32-bit (and thus can't use Homebrew dependencies)
+          and only builds 32-bit (and thus can’t use Homebrew dependencies)
 
           We recommend using a MacTeX distribution: https://www.tug.org/mactex/
 
@@ -36,8 +36,10 @@ module Homebrew
           You can read more about it at:
             #{Formatter.url("https://github.com/MacRuby/MacRuby")}
         EOS
-        when /(lib)?lzma/
-          "lzma is now part of the xz formula."
+        when /(lib)?lzma/ then <<~EOS
+          lzma is now part of the xz formula, and can be installed with:
+            brew install xz.
+        EOS
         when "gtest", "googletest", "google-test" then <<~EOS
           Installing gtest system-wide is not recommended; it should be vendored
           in your projects that use it.
@@ -54,7 +56,7 @@ module Homebrew
           Install gsutil with `pip2 install gsutil`
         EOS
         when "gfortran" then <<~EOS
-          GNU Fortran is now provided as part of GCC, and can be installed with:
+          GNU Fortran is now part of the GCC formula, and can be installed with:
             brew install gcc
         EOS
         when "play" then <<~EOS
@@ -78,6 +80,9 @@ module Homebrew
 
           If you wish to use the 2.x release you can install with Homebrew Cask:
             brew cask install ngrok
+        EOS
+        when "cargo" then <<~EOS
+          Homebrew provides cargo via: `brew install rust`.
         EOS
         end
       end

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -15,7 +15,7 @@ module Homebrew
         EOS
         when "tex", "tex-live", "texlive", "latex" then <<~EOS
           Installing TeX from source is weird and gross, requires a lot of patches,
-          and only builds 32-bit (and thus can’t use Homebrew dependencies)
+          and only builds 32-bit (and thus can't use Homebrew dependencies)
 
           We recommend using a MacTeX distribution: https://www.tug.org/mactex/
 
@@ -23,9 +23,10 @@ module Homebrew
             brew cask install mactex
         EOS
         when "pip" then <<~EOS
-          Homebrew provides pip via: `brew install python`. However you will then
-          have two Pythons installed on your Mac, so alternatively you can install
-          pip via the instructions at:
+          pip is part of the python formula, and can be installed with:
+            brew install python
+          However you will then have two Pythons installed on your Mac,
+          so alternatively you can install pip via the instructions at:
             #{Formatter.url("https://pip.readthedocs.io/en/stable/installing/")}
         EOS
         when "pil" then <<~EOS
@@ -38,7 +39,7 @@ module Homebrew
         EOS
         when /(lib)?lzma/ then <<~EOS
           lzma is now part of the xz formula, and can be installed with:
-            brew install xz.
+            brew install xz
         EOS
         when "gtest", "googletest", "google-test" then <<~EOS
           Installing gtest system-wide is not recommended; it should be vendored
@@ -82,7 +83,8 @@ module Homebrew
             brew cask install ngrok
         EOS
         when "cargo" then <<~EOS
-          Homebrew provides cargo via: `brew install rust`.
+          cargo is part of the rust formula, and can be installed with:
+            brew install rust
         EOS
         end
       end


### PR DESCRIPTION
...modeled after the existing message for pip.

Also sync format of the gfortran and lzma messages,
and use typographic apostrophe in the *tex message.

Fixes https://github.com/Homebrew/homebrew-core/issues/36560.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?