### PR TITLE
Add support for java version strings without periods, e.g. "12-ea"

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -129,7 +129,7 @@ class JavaRequirement < Requirement
   end
 
   def satisfies_version(java)
-    java_version_s = system_command(java, args: ["-version"], print_stderr: false).stderr[/\d+(\.\d)?/]
+    java_version_s = system_command(java, args: ["-version"], print_stderr: false).stderr[/\d+(\.\d+)?/]
     return false unless java_version_s
 
     java_version = Version.create(java_version_s)

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -129,7 +129,7 @@ class JavaRequirement < Requirement
   end
 
   def satisfies_version(java)
-    java_version_s = system_command(java, args: ["-version"], print_stderr: false).stderr[/\d+\.\d/]
+    java_version_s = system_command(java, args: ["-version"], print_stderr: false).stderr[/\d+(\.\d)?/]
     return false unless java_version_s
 
     java_version = Version.create(java_version_s)


### PR DESCRIPTION
Make the minor version number optional when extracting the version number from `java -version` output.  This should allow version strings such as "12-ea" (present in the latest `java-beta` cask) to be recognized.

Fixes https://github.com/Homebrew/brew/issues/5671.