### PR TITLE
Bugfix: Calculate actual delta in usage

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -321,7 +321,7 @@ module Homebrew
         yield
       end
 
-      @disk_cleanup_size += disk_usage
+      @disk_cleanup_size += disk_usage - path.disk_usage
     end
 
     def cleanup_lockfiles(*lockfiles)

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -316,12 +316,13 @@ module Homebrew
 
       if dry_run?
         puts "Would remove: #{path} (#{path.abv})"
+        @disk_cleanup_size += disk_usage
       else
         puts "Removing: #{path}... (#{path.abv})"
         yield
+        @disk_cleanup_size += disk_usage - path.disk_usage
       end
 
-      @disk_cleanup_size += disk_usage - path.disk_usage
     end
 
     def cleanup_lockfiles(*lockfiles)

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -322,7 +322,6 @@ module Homebrew
         yield
         @disk_cleanup_size += disk_usage - path.disk_usage
       end
-
     end
 
     def cleanup_lockfiles(*lockfiles)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
I read the guidelines three times, I do not understand it. Most of it seems to apply to formula changes only? Maybe needs better headline/section structure.

Changes:
This fixes a bug, that when you do a cleanup and the cleanup fails for a path (e.g. no permissions to remove path), the size of that path would still be added to the cleanup estimate. By calculating the delta of disk usage before and after the removal, we get a clear picture of how much disk space was saved.