### PR TITLE
Run `uninstall rmdir:` after uninstalling artifacts.

### DIFF
--- a/Library/Homebrew/cask/artifact/uninstall.rb
+++ b/Library/Homebrew/cask/artifact/uninstall.rb
@@ -4,7 +4,14 @@ module Cask
   module Artifact
     class Uninstall < AbstractUninstall
       def uninstall_phase(**options)
-        dispatch_uninstall_directives(**options)
+        ORDERED_DIRECTIVES.reject { |directive_sym| directive_sym == :rmdir }
+                          .each do |directive_sym|
+                            dispatch_uninstall_directive(directive_sym, **options)
+                          end
+      end
+
+      def post_uninstall_phase(**options)
+        dispatch_uninstall_directive(:rmdir, **options)
       end
     end
   end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -217,6 +217,13 @@ module Cask
           odebug "Reverting installation of artifact of class #{artifact.class}"
           artifact.uninstall_phase(command: @command, verbose: verbose?, force: force?)
         end
+
+        already_installed_artifacts.each do |artifact|
+          next unless artifact.respond_to?(:post_uninstall_phase)
+
+          odebug "Reverting installation of artifact of class #{artifact.class}"
+          artifact.post_uninstall_phase(command: @command, verbose: verbose?, force: force?)
+        end
       ensure
         purge_versioned_files
         raise e
@@ -425,8 +432,17 @@ module Cask
       artifacts.each do |artifact|
         next unless artifact.respond_to?(:uninstall_phase)
 
-        odebug "Un-installing artifact of class #{artifact.class}"
+        odebug "Uninstalling artifact of class #{artifact.class}"
         artifact.uninstall_phase(command: @command, verbose: verbose?, skip: clear, force: force?, upgrade: upgrade?)
+      end
+
+      artifacts.each do |artifact|
+        next unless artifact.respond_to?(:post_uninstall_phase)
+
+        odebug "Post-uninstalling artifact of class #{artifact.class}"
+        artifact.post_uninstall_phase(
+          command: @command, verbose: verbose?, skip: clear, force: force?, upgrade: upgrade?,
+        )
       end
     end
 

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -218,32 +218,6 @@ shared_examples "#uninstall_phase or #zap_phase" do
     end
   end
 
-  context "using :rmdir" do
-    let(:fake_system_command) { NeverSudoSystemCommand }
-    let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-rmdir")) }
-    let(:empty_directory) { Pathname.new("#{TEST_TMPDIR}/empty_directory_path") }
-    let(:ds_store) { empty_directory.join(".DS_Store") }
-
-    before do
-      empty_directory.mkdir
-      FileUtils.touch ds_store
-    end
-
-    after do
-      FileUtils.rm_rf empty_directory
-    end
-
-    it "is supported" do
-      expect(empty_directory).to exist
-      expect(ds_store).to exist
-
-      subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
-
-      expect(ds_store).not_to exist
-      expect(empty_directory).not_to exist
-    end
-  end
-
   [:script, :early_script].each do |script_type|
     context "using #{script_type.inspect}" do
       let(:fake_system_command) { NeverSudoSystemCommand }

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -4,4 +4,34 @@ describe Cask::Artifact::Uninstall, :cask do
   describe "#uninstall_phase" do
     include_examples "#uninstall_phase or #zap_phase"
   end
+
+  describe "#post_uninstall_phase" do
+    subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+
+    context "using :rmdir" do
+      let(:fake_system_command) { NeverSudoSystemCommand }
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-rmdir")) }
+      let(:empty_directory) { Pathname.new("#{TEST_TMPDIR}/empty_directory_path") }
+      let(:ds_store) { empty_directory.join(".DS_Store") }
+
+      before do
+        empty_directory.mkdir
+        FileUtils.touch ds_store
+      end
+
+      after do
+        FileUtils.rm_rf empty_directory
+      end
+
+      it "is supported" do
+        expect(empty_directory).to exist
+        expect(ds_store).to exist
+
+        artifact.post_uninstall_phase(command: fake_system_command)
+
+        expect(ds_store).not_to exist
+        expect(empty_directory).not_to exist
+      end
+    end
+  end
 end

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -3,5 +3,33 @@ require_relative "shared_examples/uninstall_zap"
 describe Cask::Artifact::Zap, :cask do
   describe "#zap_phase" do
     include_examples "#uninstall_phase or #zap_phase"
+
+    context "using :rmdir" do
+      subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
+
+      let(:fake_system_command) { NeverSudoSystemCommand }
+      let(:cask) { Cask::CaskLoader.load(cask_path("with-zap-rmdir")) }
+      let(:empty_directory) { Pathname.new("#{TEST_TMPDIR}/empty_directory_path") }
+      let(:ds_store) { empty_directory.join(".DS_Store") }
+
+      before do
+        empty_directory.mkdir
+        FileUtils.touch ds_store
+      end
+
+      after do
+        FileUtils.rm_rf empty_directory
+      end
+
+      it "is supported" do
+        expect(empty_directory).to exist
+        expect(ds_store).to exist
+
+        artifact.zap_phase(command: fake_system_command)
+
+        expect(ds_store).not_to exist
+        expect(empty_directory).not_to exist
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If a directory is empty only after an artifact is uninstalled, it would not be removed before because `uninstall rmdir:` would already have been run.