### PR TITLE
elf.rb: avoid corrupted elf files

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -133,8 +133,10 @@ module ELFShim
       soname = nil
       needed = []
       command = ["readelf", "-d", path.expand_path.to_s]
-      lines = Utils.safe_popen_read(*command).split("\n")
+      lines = Utils.popen_read(*command, err: :out).split("\n")
       lines.each do |s|
+        next if s.start_with?("readelf: Warning: possibly corrupt ELF header")
+
         filename = s[/\[(.*)\]/, 1]
         next if filename.nil?
 


### PR DESCRIPTION
Some elf files like unittest files or memory dumps may not be completely
readable by readelf.

Readelf will fail after the following message:
readelf: Warning: possibly corrupt ELF header - it has a non-zero program header offset, but no program headers

This patches avoid these files when there is a non zero offset but no
program headers

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
