### PR TITLE
exceptions.rb: move alternative solution to a new line

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -471,7 +471,7 @@ class BuildFlagsError < RuntimeError
     EOS
 
     message << <<~EOS.chomp! if bottled
-      Alternatively, remove the #{flag_text} to attempt bottle installation.
+      \nAlternatively, remove the #{flag_text} to attempt bottle installation.
     EOS
 
     super message

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -463,15 +463,15 @@ class BuildFlagsError < RuntimeError
       require_text = "requires"
     end
 
-    message = <<~EOS.chomp!
+    message = <<~EOS
       The following #{flag_text}:
         #{flags.join(", ")}
       #{require_text} building tools, but none are installed.
       #{DevelopmentTools.installation_instructions}
     EOS
 
-    message << <<~EOS.chomp! if bottled
-      \nAlternatively, remove the #{flag_text} to attempt bottle installation.
+    message << <<~EOS if bottled
+      Alternatively, remove the #{flag_text} to attempt bottle installation.
     EOS
 
     super message


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The message that Homebrew spits out when build tools are not available is not formatted appropriately:

```
Error: The following flag:
  --build-from-source
requires building tools, but none are installed.
Install Clang or brew install gccAlternatively, remove the flag to attempt bottle installation.
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula_installer.rb:79:in `prevent_build_flags'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/install.rb:119:in `install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:105:in `<main>'
```

This PR adds a new line before `Alternatively, ...`.
