### PR TITLE
Set DISPLAY environment variable for browser on Linux

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -162,6 +162,12 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will tweak behaviour to be more relevant for Homebrew
     developers (active or budding), e.g. turning warnings into errors.
 
+  * `HOMEBREW_DISPLAY`:
+    If set, Homebrew will use this X11 display when opening a page in a browser,
+    for example with `brew home`. Primarily useful on Linux.
+
+    *Default:* the value of the user's `DISPLAY` environment variable.
+
   * `HOMEBREW_EDITOR`:
     If set, Homebrew will use this editor when editing a single formula, or
     several formulae in the same directory.

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -388,9 +388,7 @@ def exec_browser(*args)
   browser ||= OS::PATH_OPEN if defined?(OS::PATH_OPEN)
   return unless browser
 
-  if ENV["HOMEBREW_DISPLAY"]
-    ENV["DISPLAY"] = ENV["HOMEBREW_DISPLAY"]
-  end
+  ENV["DISPLAY"] = ENV["HOMEBREW_DISPLAY"]
 
   safe_exec(browser, *args)
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -388,6 +388,10 @@ def exec_browser(*args)
   browser ||= OS::PATH_OPEN if defined?(OS::PATH_OPEN)
   return unless browser
 
+  if ENV["HOMEBREW_DISPLAY"]
+    ENV["DISPLAY"] = ENV["HOMEBREW_DISPLAY"]
+  end
+
   safe_exec(browser, *args)
 end
 

--- a/bin/brew
+++ b/bin/brew
@@ -54,7 +54,7 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 # Whitelist and copy to HOMEBREW_* all variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
 for VAR in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY BINTRAY_USER BINTRAY_KEY \
-           BROWSER EDITOR GIT NO_COLOR PATH VISUAL
+           BROWSER DISPLAY EDITOR GIT NO_COLOR PATH VISUAL
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1037,6 +1037,12 @@ Note that environment variables must have a value set to be detected. For exampl
     If set, Homebrew will tweak behaviour to be more relevant for Homebrew
     developers (active or budding), e.g. turning warnings into errors.
 
+  * `HOMEBREW_DISPLAY`:
+    If set, Homebrew will use this X11 display when opening a page in a browser,
+    for example with `brew home`. Primarily useful on Linux.
+
+    *Default:* the value of the user's `DISPLAY` environment variable.
+
   * `HOMEBREW_EDITOR`:
     If set, Homebrew will use this editor when editing a single formula, or
     several formulae in the same directory.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1266,6 +1266,13 @@ If set, any commands that can emit debugging information will do so\.
 If set, Homebrew will tweak behaviour to be more relevant for Homebrew developers (active or budding), e\.g\. turning warnings into errors\.
 .
 .TP
+\fBHOMEBREW_DISPLAY\fR
+If set, Homebrew will use this X11 display when opening a page in a browser, for example with \fBbrew home\fR\. Primarily useful on Linux\.
+.
+.IP
+\fIDefault:\fR the value of the user\'s \fBDISPLAY\fR environment variable\.
+.
+.TP
 \fBHOMEBREW_EDITOR\fR
 If set, Homebrew will use this editor when editing a single formula, or several formulae in the same directory\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This change stashes the user's original `DISPLAY` into `HOMEBREW_DISPLAY` and restores it when calling out to the browser. See #5692.

I suspect this should also be documented in docs and/or manpages, right? Should I also add a test case, something like `HOMEBREW_BROWSER='echo $DISPLAY'? Any other ways I can make this better?

Cc @sjackman for review/advice