### PR TITLE
formula_installer: handle attempts to load invalid casks

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -790,7 +790,7 @@ class FormulaInstaller
 
     cask_installed_with_formula_name = begin
       Cask::CaskLoader.load(formula.name).installed?
-    rescue Cask::CaskUnavailableError
+    rescue Cask::CaskUnavailableError, Cask::CaskInvalidError
       false
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Certain casks in the main cask repository may be invalid, for whatever reason. Without handling this exception, the user will get a cask-related exception while the formula of the same name is installed, and their installation will abort half-completed.

For example, the `fish` cask is currently broken and attempting to `brew cask info fish` will return an error. This also leads to attempts to install the `fish` formula to fail like this:

```
==> Upgrading fish
==> Downloading https://homebrew.bintray.com/bottles/fish-3.0.1.mojave.bottle.tar.gz
######################################################################## 100.0%
==> Pouring fish-3.0.1.mojave.bottle.tar.gz
Error: Cask 'fish' definition is invalid: invalid 'depends_on macos' value: ":snow_leopard"
```

Fixes #5709.