### PR TITLE
Add `brew update -f` option and improve help string format

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -2,8 +2,11 @@
 #:
 #:  Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations.
 #:
-#:       --merge                         `git merge` is used to include updates (rather than `git rebase`).
-#:       --force                         Always do a slower, full update check (even if unnecessary).
+#:          --merge                      `git merge` is used to include updates (rather than `git rebase`).
+#:      -f, --force                      Always do a slower, full update check (even if unnecessary).
+#:      -v, --verbose                    Print the directories checked and `git` operations performed.
+#:      -d, --debug                      Display a trace of all shell commands as they are executed.
+#:      -h, --help                       Show this message.
 
 # Don't need shellcheck to follow this `source`.
 # shellcheck disable=SC1090

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -306,6 +306,7 @@ homebrew-update() {
       -*)
         [[ "$option" = *v* ]] && HOMEBREW_VERBOSE=1
         [[ "$option" = *d* ]] && HOMEBREW_DEBUG=1
+        [[ "$option" = *f* ]] && HOMEBREW_UPDATE_FORCE=1
         ;;
       *)
         odie <<EOS

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -195,7 +195,9 @@ module Homebrew
       line = line.slice(4..-1)
       next unless line
 
-      lines << line.gsub(/^ +(-+[a-z-]+) */, "* `\\1`:\n  ")
+      # Format one option or a comma-separated pair of short and long options.
+      lines << line.gsub(/^ +(-+[a-z-]+), (-+[a-z-]+) +/, "* `\\1`, `\\2`:\n  ")
+                   .gsub(/^ +(-+[a-z-]+) +/, "* `\\1`:\n  ")
     end
     lines
   end

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -195,6 +195,9 @@ module Homebrew
       line = line.slice(4..-1)
       next unless line
 
+      # Omit the common global_options documented separately in the man page.
+      next if line =~ /--(debug|force|help|quiet|verbose) /
+
       # Format one option or a comma-separated pair of short and long options.
       lines << line.gsub(/^ +(-+[a-z-]+), (-+[a-z-]+) +/, "* `\\1`, `\\2`:\n  ")
                    .gsub(/^ +(-+[a-z-]+) +/, "* `\\1`:\n  ")

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -540,9 +540,6 @@ Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1)
 * `--merge`:
   `git merge` is used to include updates (rather than `git rebase`).
 
-* `--force`:
-  Always do a slower, full update check (even if unnecessary).
-
 ### `update-reset` [*`repository`*]
 Fetches and resets Homebrew and all tap repositories (or any specified `repository`) using `git`(1) to their latest `origin/master`. Note this will destroy all your uncommitted or committed changes.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -660,10 +660,6 @@ Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\f
 \fB\-\-merge\fR
 \fBgit merge\fR is used to include updates (rather than \fBgit rebase\fR)\.
 .
-.TP
-\fB\-\-force\fR
-Always do a slower, full update check (even if unnecessary)\.
-.
 .SS "\fBupdate\-reset\fR [\fIrepository\fR]"
 Fetches and resets Homebrew and all tap repositories (or any specified \fBrepository\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This change adds `brew update -f` as an alias for `brew update --force` and improves the help string format to include both long and short options. This format improves readability by making the help output consistent with ruby-based commands that use `OptionParser`.

Also documents existing common options that weren't listed in the `brew update` help string but should have been (`--verbose`, `--debug`, and `--help`).

I did not document the options `--preinstall` and `--simulate-from-current-branch` because they seem internal or developer-use only and I'm honestly not sure how to describe them.