### PR TITLE
cleanup: add --prune-prefix option.

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -22,6 +22,8 @@ module Homebrew
         description: "Scrub the cache, including downloads for even the latest versions. "\
                      "Note downloads for any installed formula or cask will still not be deleted. "\
                      "If you want to delete those too: `rm -rf \"$(brew --cache)\"`"
+      switch "--prune-prefix",
+        description: "Only prune the symlinks and directories from the prefix and remove no other files."
       switch :verbose
       switch :debug
     end
@@ -31,6 +33,10 @@ module Homebrew
     cleanup_args.parse
 
     cleanup = Cleanup.new(*args.remaining, dry_run: args.dry_run?, scrub: args.s?, days: args.prune&.to_i)
+    if args.prune_prefix?
+      cleanup.prune_prefix_symlinks_and_directories
+      return
+    end
 
     cleanup.clean!
 

--- a/Library/Homebrew/cmd/prune.rb
+++ b/Library/Homebrew/cmd/prune.rb
@@ -23,6 +23,6 @@ module Homebrew
   def prune
     prune_args.parse
 
-    odisabled("'brew prune'", "'brew cleanup'")
+    odisabled("'brew prune'", "'brew cleanup --prune-prefix'")
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -63,6 +63,8 @@ only do this for the specified formulae and casks.
   Show what would be removed, but do not actually remove anything.
 * `-s`:
   Scrub the cache, including downloads for even the latest versions. Note downloads for any installed formula or cask will still not be deleted. If you want to delete those too: `rm -rf "$(brew --cache)"`
+* `--prune-prefix`:
+  Only prune the symlinks and directories from the prefix and remove no other files.
 
 ### `command` *`cmd`*
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -62,6 +62,10 @@ Show what would be removed, but do not actually remove anything\.
 \fB\-s\fR
 Scrub the cache, including downloads for even the latest versions\. Note downloads for any installed formula or cask will still not be deleted\. If you want to delete those too: \fBrm \-rf "$(brew \-\-cache)"\fR
 .
+.TP
+\fB\-\-prune\-prefix\fR
+Only prune the symlinks and directories from the prefix and remove no other files\.
+.
 .SS "\fBcommand\fR \fIcmd\fR"
 Display the path to the file which is used when invoking \fBbrew\fR \fIcmd\fR\.
 .


### PR DESCRIPTION
From https://discourse.brew.sh/t/error-calling-brew-prune-is-disabled/4142/4 and https://github.com/github/homebrew-bootstrap/pull/72 it seems this is worth having as a dedicated flag.

CC @mistydemeo

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----