### PR TITLE
Use Homebrew/linuxbrew-core

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -25,7 +25,7 @@ git_init_if_necessary() {
   then
     CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/homebrew-core"
   else
-    CORE_OFFICIAL_REMOTE="https://github.com/Linuxbrew/homebrew-core"
+    CORE_OFFICIAL_REMOTE="https://github.com/Homebrew/linuxbrew-core"
   fi
 
   safe_cd "$HOMEBREW_REPOSITORY"

--- a/Library/Homebrew/extend/os/linux/tap.rb
+++ b/Library/Homebrew/extend/os/linux/tap.rb
@@ -2,6 +2,6 @@ class CoreTap < Tap
   # @private
   def initialize
     super "Homebrew", "core"
-    @full_name = "Linuxbrew/homebrew-core" unless ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
+    @full_name = "Homebrew/linuxbrew-core" unless ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"]
   end
 end

--- a/Library/Homebrew/test/dev-cmd/pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pull_spec.rb
@@ -10,10 +10,13 @@ describe "brew pull", :integration_test do
       .and not_to_output.to_stdout
       .and be_a_failure
 
-    expect { brew "pull", "1" }
-      .to output(/Fetching patch/).to_stdout
-      .and output(/Current branch is new\-branch/).to_stderr
-      .and be_a_failure
+    # Needs Homebrew/homebrew-core
+    if OS.mac?
+      expect { brew "pull", "1" }
+        .to output(/Fetching patch/).to_stdout
+        .and output(/Current branch is new\-branch/).to_stderr
+        .and be_a_failure
+    end
 
     expect { brew "pull", "--bump", "https://api.github.com/repos/Homebrew/homebrew-core/pulls/122" }
       .to output(/Fetching patch/).to_stdout

--- a/docs/Linuxbrew.md
+++ b/docs/Linuxbrew.md
@@ -83,7 +83,7 @@ eval $(~/.linuxbrew/bin/brew shellenv)
 ## Linuxbrew Community
 
 - [@Linuxbrew on Twitter](https://twitter.com/Linuxbrew)
-- [Linuxbrew/core on GitHub](https://github.com/Linuxbrew/homebrew-core)
+- [Homebrew/linuxbrew-core on GitHub](https://github.com/Homebrew/linuxbrew-core)
 - [Linuxbrew category](https://discourse.brew.sh/c/linuxbrew) of [Homebrew's Discourse](https://discourse.brew.sh)
 
 ## Sponsors


### PR DESCRIPTION
This would allow the Linuxbrew core tap to live in the Homebrew organisation.

CC @Homebrew/linux for reviews and thoughts.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----