### PR TITLE
Prioritize CLI arguments over env vars when they conflict

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -27,6 +27,7 @@ module Homebrew
         Homebrew.args.instance_eval { undef tap }
         @constraints = []
         @conflicts = []
+        @switch_sources = {}
         @processed_options = []
         @desc_line_length = 43
         @hide_from_man_page = false
@@ -58,7 +59,7 @@ module Homebrew
           set_constraints(name, required_for: required_for, depends_on: depends_on)
         end
 
-        enable_switch(*names) if !env.nil? && !ENV["HOMEBREW_#{env.to_s.upcase}"].nil?
+        enable_switch(*names, source: :env_var) if !env.nil? && !ENV["HOMEBREW_#{env.to_s.upcase}"].nil?
       end
       alias switch_option switch
 
@@ -172,9 +173,16 @@ module Homebrew
 
       private
 
-      def enable_switch(*names)
+      def enable_switch(*names, source: :cli_arg)
         names.each do |name|
+          @switch_sources[option_to_name(name)] = source
           Homebrew.args["#{option_to_name(name)}?"] = true
+        end
+      end
+
+      def disable_switch(*names)
+        names.each do |name|
+          Homebrew.args.delete_field("#{option_to_name(name)}?")
         end
       end
 
@@ -225,7 +233,17 @@ module Homebrew
 
           next if violations.count < 2
 
-          raise OptionConflictError, violations.map(&method(:name_to_option))
+          env_var_options = violations.select do |option|
+            @switch_sources[option_to_name(option)] == :env_var
+          end
+
+          if violations.count - env_var_options.count == 1
+            env_var_options.each do |option|
+              disable_switch option
+            end
+          else
+            raise OptionConflictError, violations.map(&method(:name_to_option))
+          end
         end
       end
 

--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -59,7 +59,7 @@ module Homebrew
           set_constraints(name, required_for: required_for, depends_on: depends_on)
         end
 
-        enable_switch(*names, source: :env_var) if !env.nil? && !ENV["HOMEBREW_#{env.to_s.upcase}"].nil?
+        enable_switch(*names, from: :env) if !env.nil? && !ENV["HOMEBREW_#{env.to_s.upcase}"].nil?
       end
       alias switch_option switch
 
@@ -173,9 +173,9 @@ module Homebrew
 
       private
 
-      def enable_switch(*names, source: :cli_arg)
+      def enable_switch(*names, from: :arg)
         names.each do |name|
-          @switch_sources[option_to_name(name)] = source
+          @switch_sources[option_to_name(name)] = from
           Homebrew.args["#{option_to_name(name)}?"] = true
         end
       end

--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -52,7 +52,7 @@ module Homebrew
         end
         process_option(*names, description)
         @parser.on(*names, *wrap_option_desc(description)) do
-          enable_switch(*names)
+          enable_switch(*names, from: :args)
         end
 
         names.each do |name|
@@ -173,7 +173,7 @@ module Homebrew
 
       private
 
-      def enable_switch(*names, from: :arg)
+      def enable_switch(*names, from:)
         names.each do |name|
           @switch_sources[option_to_name(name)] = from
           Homebrew.args["#{option_to_name(name)}?"] = true

--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -237,13 +237,9 @@ module Homebrew
             @switch_sources[option_to_name(option)] == :env_var
           end
 
-          if violations.count - env_var_options.count == 1
-            env_var_options.each do |option|
-              disable_switch option
-            end
-          else
-            raise OptionConflictError, violations.map(&method(:name_to_option))
-          end
+          select_cli_arg = violations.count - env_var_options.count == 1
+          raise OptionConflictError, violations.map(&method(:name_to_option)) unless select_cli_arg
+          env_var_options.each(&method(:disable_switch))
         end
       end
 

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -183,8 +183,8 @@ describe Homebrew::CLI::Parser do
       allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_B").and_return("0")
       allow(ENV).to receive(:[])
       parser.parse(["--switch-b"])
-      expect(Homebrew.args.switch_a?).to be_falsy
-      expect(Homebrew.args.switch_b?).to be true
+      expect(Homebrew.args.switch_a).to be_falsy
+      expect(Homebrew.args).to be_switch_b
     end
 
     it "raises an exception on constraint violation when both are env vars" do

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -145,8 +145,8 @@ describe Homebrew::CLI::Parser do
   describe "test constraints for switch options" do
     subject(:parser) {
       described_class.new do
-        switch      "-a", "--switch-a"
-        switch      "-b", "--switch-b"
+        switch      "-a", "--switch-a", env: "switch_a"
+        switch      "-b", "--switch-b", env: "switch_b"
         switch      "--switch-c", required_for: "--switch-a"
         switch      "--switch-d", depends_on: "--switch-b"
 
@@ -176,6 +176,21 @@ describe Homebrew::CLI::Parser do
     it "raises no exception for optional dependency" do
       parser.parse(["--switch-b"])
       expect(Homebrew.args.switch_b?).to be true
+    end
+
+    it "prioritizes cli arguments over env vars when they conflict" do
+      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_A").and_return("1")
+      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_B").and_return("0")
+      parser.parse(["--switch-b"])
+      expect(Homebrew.args.switch_a?).to be_falsy
+      expect(Homebrew.args.switch_b?).to be true
+    end
+
+    it "raises an exception on constraint violation when both are env vars" do
+      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_A").and_return("1")
+      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_B").and_return("1")
+      allow(ENV).to receive(:[])
+      expect { parser.parse(["--switch-a", "--switch-b"]) }.to raise_error(Homebrew::CLI::OptionConflictError)
     end
   end
 

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -181,6 +181,7 @@ describe Homebrew::CLI::Parser do
     it "prioritizes cli arguments over env vars when they conflict" do
       allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_A").and_return("1")
       allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_B").and_return("0")
+      allow(ENV).to receive(:[])
       parser.parse(["--switch-b"])
       expect(Homebrew.args.switch_a?).to be_falsy
       expect(Homebrew.args.switch_b?).to be true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally? **(Note: Brew style fails, but the failure is there to keep it consistent with other tests in the file. Happy to change it if y'all prefer)**
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Addresses an issue mentioned here: https://github.com/Homebrew/brew/issues/5736

(Caveat: The issue linked also points out a disconnect between the help text of the command and its actual behavior, which should probably be fixed separately)

I agree with that issue that CLI flags should take priority over environment variables when they conflict, and it's behavior I'm used to in other applications. This PR does that by selecting the CLI-passed argument when there are conflicting switches and all but one of the switches are specified via an env var.

Not 100% tied to this being the correct behavior -- just opening this in case y'all agree that it is

Also, I think there's also an opportunity for a richer API to resolve conflicts here, something along the lines of:

```ruby
def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil, env_priority: 1, cli_priority: 2)
```

Then, you could specify the priority of an argument so that it would always take priority over another when they conflict, etc. But that seems like it may be more code than is worth maintaining