### PR TITLE
cleanup: disable auto-cleanup in CI

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -160,6 +160,7 @@ module Homebrew
 
     def self.install_formula_clean!(f)
       return if ENV["HOMEBREW_NO_INSTALL_CLEANUP"]
+      return if ENV["CI"]
 
       cleanup = Cleanup.new
       if cleanup.periodic_clean_due?
@@ -171,6 +172,7 @@ module Homebrew
 
     def periodic_clean_due?
       return false if ENV["HOMEBREW_NO_INSTALL_CLEANUP"]
+      return false if ENV["CI"]
       return true unless PERIODIC_CLEAN_FILE.exist?
 
       PERIODIC_CLEAN_FILE.mtime < CLEANUP_DEFAULT_DAYS.days.ago


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A user pointed out to me that Travis builds which use Homebrew are now always, 100% of the time starting with a `cleanup` run. The reason for this is that Travis's images include a preinstalled Homebrew which is more than 30 days old, and so these images are always eligible for an auto-cleanup. In a CI environment where the Homebrew installation is clean, we don't need to worry about cleaning up; running it adds time to every build.

I chose `CI` as the variable to use since [it's one of the ones Travis defines](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables) and it is likely to be used by several CI systems.