### PR TITLE
tests: Disable tests that require being non-root

### DIFF
--- a/Dockerfile.test.yml
+++ b/Dockerfile.test.yml
@@ -1,3 +1,3 @@
 sut:
   build: .
-  command: brew test-bot
+  command: env USER=root brew test-bot

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -24,6 +24,7 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_access_directories" do
+    skip "User is root so everything is writable." if Process.euid.zero?
     begin
       dirs = [
         HOMEBREW_CACHE,

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -118,6 +118,7 @@ describe Pathname do
 
   describe "#ensure_writable" do
     it "makes a file writable and restores permissions afterwards" do
+      skip "User is root so everything is writable." if Process.euid.zero?
       touch file
       chmod 0555, file
       expect(file).not_to be_writable


### PR DESCRIPTION
Set the environment variable USER=root which is required by
brew tests --only=utils/user

Fix these tests:
```
rspec ./test/diagnostic_checks_spec.rb:26 # Homebrew::Diagnostic::Checks #check_access_directories
rspec ./test/pathname_spec.rb:120 # Pathname#ensure_writable makes a file writable and restores permissions
rspec ./test/utils/user_spec.rb:22 # User#gui? when the current user is in a console session gui? should equal true
rspec ./test/utils/user_spec.rb:6 # User should eq nil
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?