### PR TITLE
Dockerfile.test.yml: Run brew test-bot as linuxbrew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 
 # Install portable-ruby and tap homebrew/core.
 RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
+	&& chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
 	&& rm -rf ~/.cache

--- a/Dockerfile.test.yml
+++ b/Dockerfile.test.yml
@@ -1,3 +1,3 @@
 sut:
   build: .
-  command: env USER=root brew test-bot
+  command: "sudo -i -u linuxbrew /home/linuxbrew/.linuxbrew/bin/brew test-bot"


### PR DESCRIPTION
Running brew test-bot as root fails.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

```
==> brew update-test --to-tag
==> FAILED
Start commit: 1facac803ee3e4bfe78adcbff5dcd476abc1f378
End commit: d27320087aa8f8a6653db93ff925e7b9c05bea8d
==> Setup test environment...
Cloning into '.'...
done.
Cloning into bare repository 'remote.git'...
done.
Reset branch 'master'
Your branch is up to date with 'origin/master'.
Everything up-to-date
HEAD is now at 1920eecb7 Merge pull request #5651 from retokromer/patch-1
==> Running brew update...
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
Error: Failure while executing; `brew update --verbose` exited with 1.
```

My best guess is that
- `brew update-test --to-tag` switches to the most stable release of Homebrew
- the most recent stable release of Homebrew does not permit being run as root
- `brew udpate` fails

The change to `Dockerfile.test.yml` could likely be reverted after the next stable release of Homebrew (2.0.2).