### PR TITLE
tap: skip auto-update if called with no args

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -414,7 +414,8 @@ update-preinstall() {
   [[ -z "$HOMEBREW_AUTO_UPDATE_CHECKED" ]] || return
   [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]] || return
 
-  if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" || "$HOMEBREW_COMMAND" = "tap" ||
+  if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" ||
+        "$HOMEBREW_COMMAND" = "tap" && $HOMEBREW_ARG_COUNT -gt 1 ||
         "$HOMEBREW_CASK_COMMAND" = "install" || "$HOMEBREW_CASK_COMMAND" = "upgrade" ]]
   then
     export HOMEBREW_AUTO_UPDATING="1"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Any invocation of `brew tap` may currently lead to an auto-update, even though `brew tap` with no arguments simply lists the current taps on the local machine. It was noted recently (https://github.com/Homebrew/brew/issues/5743#issuecomment-464645856):

> "In the "no argument `brew tap` case": we could handle that more intelligently and not run `brew tap`."

So that's what I've done here. It makes it run faster, and also avoids the auto-update text being printed by this command that isn't part of the list of taps.