### PR TITLE
missing_formula.rb: add help message for uconv

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -95,6 +95,10 @@ module Homebrew
           cargo is part of the rust formula:
             brew install rust
         EOS
+        when "uconv" then <<~EOS
+          uconv is part of the icu4c formula:
+            brew install icu4c
+        EOS
         end
       end
       alias generic_blacklisted_reason blacklisted_reason


### PR DESCRIPTION
This is similar to #5678 but for the [uvconv](https://en.wikipedia.org/wiki/Uconv) tool.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

Thanks to [this post](https://apple.stackexchange.com/a/213163/160169) to pointing me in the right direction.