### PR TITLE
Support different shells for `brew shellenv`

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -7,10 +7,30 @@
 #:  Consider adding evaluating the output in your dotfiles (e.g. `~/.profile`) with `eval $(brew shellenv)`
 
 homebrew-shellenv() {
-  echo "export HOMEBREW_PREFIX=\"$HOMEBREW_PREFIX\""
-  echo "export HOMEBREW_CELLAR=\"$HOMEBREW_CELLAR\""
-  echo "export HOMEBREW_REPOSITORY=\"$HOMEBREW_REPOSITORY\""
-  echo "export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:\$PATH\""
-  echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man:\$MANPATH\""
-  echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info:\$INFOPATH\""
+  case "$SHELL" in
+    */fish)
+      echo "set -gx HOMEBREW_PREFIX \"$HOMEBREW_PREFIX\";"
+      echo "set -gx HOMEBREW_CELLAR \"$HOMEBREW_CELLAR\";"
+      echo "set -gx HOMEBREW_REPOSITORY \"$HOMEBREW_REPOSITORY\";"
+      echo "set -g fish_user_paths \"$HOMEBREW_PREFIX/bin\" \"$HOMEBREW_PREFIX/sbin\" \$fish_user_paths;"
+      echo "set -q MANPATH || set MANPATH ''; set -gx MANPATH \"$HOMEBREW_PREFIX/share/man\" \$MANPATH;"
+      echo "set -q INFOPATH || set INFOPATH ''; set -gx INFOPATH \"$HOMEBREW_PREFIX/share/info\" \$INFOPATH;"
+      ;;
+    */csh|*/tcsh)
+      echo "setenv HOMEBREW_PREFIX $HOMEBREW_PREFIX;"
+      echo "setenv HOMEBREW_CELLAR $HOMEBREW_CELLAR;"
+      echo "setenv HOMEBREW_REPOSITORY $HOMEBREW_REPOSITORY;"
+      echo "setenv PATH $HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:\$PATH;"
+      echo "setenv MANPATH $HOMEBREW_PREFIX/share/man:\$MANPATH;"
+      echo "setenv INFOPATH $HOMEBREW_PREFIX/share/info:\$INFOPATH;"
+      ;;
+    *)
+      echo "export HOMEBREW_PREFIX=\"$HOMEBREW_PREFIX\""
+      echo "export HOMEBREW_CELLAR=\"$HOMEBREW_CELLAR\""
+      echo "export HOMEBREW_REPOSITORY=\"$HOMEBREW_REPOSITORY\""
+      echo "export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:\$PATH\""
+      echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man:\$MANPATH\""
+      echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info:\$INFOPATH\""
+      ;;
+  esac
 }


### PR DESCRIPTION
This PR rewrites `brew shellenv` again in ruby to support all kinds of shell via `Utils::Shell` helpers.

`shellenv` now also takes `--shell` option, which allows user to print commands for different shells.

``` sh
$ brew shellenv 
export HOMEBREW_PREFIX="/usr/local"
export HOMEBREW_CELLAR="/usr/local/Cellar"
export HOMEBREW_REPOSITORY="/usr/local/Homebrew"
export PATH="/usr/local/bin:/usr/local/sbin:$PATH"
export MANPATH="/usr/local/share/man:$MANPATH"
export INFOPATH="/usr/local/share/info:$INFOPATH"
$ eval `brew shellenv`
```

``` csh
# csh substitution captures the output as one line
# so that it needs a semicolon at the end of each line for `eval` to work properly
$ brew shellenv --shell=csh
setenv HOMEBREW_PREFIX /usr/local;
setenv HOMEBREW_CELLAR /usr/local/Cellar;
setenv HOMEBREW_REPOSITORY /usr/local/Homebrew;
setenv PATH /usr/local/bin:/usr/local/sbin:$PATH;
setenv MANPATH /usr/local/share/man:$MANPATH;
setenv INFOPATH /usr/local/share/info:$INFOPATH;
$ eval `brew shellenv`
```

``` fish
# fish substitution is similar to csh
# however, in fish it's possible to pipe the output to the `source` command
$ brew shellenv --shell=fish
set -gx HOMEBREW_PREFIX "/usr/local"
set -gx HOMEBREW_CELLAR "/usr/local/Cellar"
set -gx HOMEBREW_REPOSITORY "/usr/local/Homebrew"
set -g fish_user_paths "/usr/local/bin" "/usr/local/sbin" $fish_user_paths
set -q MANPATH || set MANPATH ''; set -gx MANPATH "/usr/local/share/man" $MANPATH
set -q INFOPATH || set INFOPATH ''; set -gx INFOPATH "/usr/local/share/info" $INFOPATH
$ brew shellenv --shell=fish | source
```

This `--shell` options is slightly different from `brew --env --shell`:

https://github.com/Homebrew/brew/blob/605c0e82398f7e90ae92e42dd4dc7af134736e0d/Library/Homebrew/cmd/--env.rb#L35-L39

`brew --env --shell` output in bash format when `--shell` is not defined and stdout is not tty. As it says `# legacy behavior`, I decided to let `brew shellenv` to behave as `--shell=auto` by default when it's not set. 

Let me know if we prefer to stick with the legacy behavior.

Code changes to existing `Utils::Shell`:
  - Remove duplicated logic by reuse `export_value` method in `set_variable_in_profile`.
  - Add `export_prepend_path`, which is similar to `export_value` but deal with path like variables.
  - Use the `export_prepend_path` in `prepend_path_in_profile`.
  - PATH like variable in fish is weird, see the comment in code.