### PR TITLE
Print full tap path for all deprecated taps found by brew doctor

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -611,7 +611,7 @@ module Homebrew
 
         <<~EOS
           You have the following deprecated, official taps tapped:
-            Homebrew/homebrew-#{tapped_deprecated_taps.join("\n  ")}
+            Homebrew/homebrew-#{tapped_deprecated_taps.join("\n  Homebrew/homebrew-")}
           Untap them with `brew untap`.
         EOS
       end


### PR DESCRIPTION
Print full tap path for all deprecated taps found so that it can be copy-pasted as `brew untap` argument.


When there are multiple deprecated taps, 
current `brew doctor` command only print first deprecated tap with full prefix,
and rest without prefix.
e.g.,
```
Warning: You have the following deprecated, official taps tapped:
  Homebrew/homebrew-dupes
  completions
  science
  versions
Untap them with `brew untap`.
```
Untapping by copy & pasting listed tap names succeeds for the first item,
 `brew untap Homebrew/homebrew-dupes`, but others such as `brew untap science` will fail.

This patch attempts to print all deprecated tap names in full.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
