### PR TITLE
tests: Set environment variable USER if not set

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -49,6 +49,8 @@ module Homebrew
       ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if args.generic?
       ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
 
+      ENV["USER"] ||= Utils.popen_read("id", "-nu").chomp
+
       # Avoid local configuration messing with tests e.g. git being configured
       # to use GPG to sign by default
       ENV["HOME"] = "#{HOMEBREW_LIBRARY_PATH}/test"

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -49,7 +49,7 @@ module Homebrew
       ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if args.generic?
       ENV["HOMEBREW_TEST_ONLINE"] = "1" if args.online?
 
-      ENV["USER"] ||= Utils.popen_read("id", "-nu").chomp
+      ENV["USER"] ||= system_command!("id", args: ["-nu"]).stdout.chomp
 
       # Avoid local configuration messing with tests e.g. git being configured
       # to use GPG to sign by default


### PR DESCRIPTION
These two tests fail if the enivornment variable USER is not set:

```
./test/utils/user_spec.rb:6 # User should eq nil
./test/utils/user_spec.rb:22 # User#gui? when the current user is in a console session gui? should equal true
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The environment variable `USER` is not set in Docker by default.