### PR TITLE
.editorconfig: extend rules to non-homebrew taps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ insert_final_newline = true
 [{Library/Homebrew/**.rb,.simplecov}]
 trim_trailing_whitespace = true
 
-[Library/Taps/homebrew/**.rb]
+[Library/Taps/**.rb]
 # trailing whitespace is crucial for patches
 trim_trailing_whitespace = false
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Extend the effect of editorconfig to all taps