### PR TITLE
Set HOMEBREW_PROCESSOR to arm64v8 for ARM64 [Linux]

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -129,6 +129,10 @@ then
   HOMEBREW_SYSTEM_TEMP="/private/tmp"
 else
   HOMEBREW_PROCESSOR="$(uname -m)"
+  if [[ "$HOMEBREW_PROCESSOR" == "aarch64" ]]
+  then
+    HOMEBREW_PROCESSOR="arm64v8"
+  fi
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
   [[ -n "$HOMEBREW_LINUX" ]] && HOMEBREW_OS_VERSION="$(lsb_release -sd 2>/dev/null)"
   : "${HOMEBREW_OS_VERSION:=$(uname -r)}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The value of `HOMEBREW_PROCESSOR` is used for the bottle tag. Options are…

1. `aarch64` (like GNU)
2. `arm64` (like Debian)
3. `armv8` (like Homebrew ARM32 which uses `armv6`)
4. `arm64v8` (like Docker)