### PR TITLE
Add support for customizable config-file whitelisting

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -58,6 +58,15 @@ module Homebrew
     end
 
     class Checks
+      ############# CONSTANTS
+      CONFIG_SCRIPT_WHITELIST_FILE = File.join(
+        ENV['HOME'],
+        '.config',
+        'Homebrew',
+        'config_script_whitelist'
+      )
+      ############# END CONSTANTS
+
       ############# HELPERS
       # Finds files in `HOMEBREW_PREFIX` *and* /usr/local.
       # Specify paths relative to a prefix e.g. "include/foo.h".
@@ -445,6 +454,12 @@ module Homebrew
           /Applications/Server.app/Contents/ServerRoot/usr/bin
           /Applications/Server.app/Contents/ServerRoot/usr/sbin
         ].map(&:downcase)
+
+        if File.exist?(CONFIG_SCRIPT_WHITELIST_FILE)
+          File.foreach(CONFIG_SCRIPT_WHITELIST_FILE) do |line|
+            whitelist << line.chomp.downcase
+          end
+        end
 
         paths.each do |p|
           next if whitelist.include?(p.downcase) || !File.directory?(p)


### PR DESCRIPTION
- [_yes_] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [_yes_] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [_yes_] Have you added an explanation of what your changes do and why you'd like us to include them?
- [_no_ - this does not augment the default behavior] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [_yes_] Have you successfully run `brew style` with your changes locally?
- [_yes_] Have you successfully run `brew tests` with your changes locally?

-----

This change adds support for customizable config-file whitelisting and sets an unintrusive pattern that can be used to allow other nags, from `brew doctor`, to be acknowledged / ignored.

In my particular use-case we are installing `pyenv`, as well as other _env(s)_, and I'd really like to not see warnings like the following when they are not actionable:

```
**Having additional scripts in your path can confuse software installed via
Homebrew if the config script overrides a system or Homebrew provided
script of the same name. We found the following "config" scripts:
  /Users/jzaleski/.pyenv/shims/python3.6m-config
  /Users/jzaleski/.pyenv/shims/python-config
  /Users/jzaleski/.pyenv/shims/python3-config
  /Users/jzaleski/.pyenv/shims/app-config
  /Users/jzaleski/.pyenv/shims/python3.6-config**
```

Lastly, this change is opt-in and therefore **off** by _default_ -- please let me know if you have any questions or require any changes.

Thanks