### PR TITLE
Use same logic for `installer script:` and `uninstall script:`.

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -20,6 +20,24 @@ module Cask
         @dirmethod ||= "#{dsl_key}dir".to_sym
       end
 
+      def staged_path_join_executable(path)
+        path = Pathname(path)
+
+        absolute_path = if path.absolute?
+          path
+        else
+          cask.staged_path.join(path)
+        end
+
+        FileUtils.chmod "+x", absolute_path if absolute_path.exist? && !absolute_path.executable?
+
+        if absolute_path.exist?
+          absolute_path
+        else
+          path
+        end
+      end
+
       def <=>(other)
         return unless other.class < AbstractArtifact
         return 0 if self.class == other.class

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -243,9 +243,10 @@ module Cask
         ohai "Running uninstall script #{executable}"
         raise CaskInvalidError.new(cask, "#{stanza} :#{directive_name} without :executable.") if executable.nil?
 
-        executable_path = cask.staged_path.join(executable)
+        executable_path = staged_path_join_executable(executable)
 
-        unless executable_path.exist?
+        if (executable_path.absolute? && !executable_path.exist?) ||
+           (!executable_path.absolute? && (which executable_path).nil?)
           message = "uninstall script #{executable} does not exist"
           raise CaskError, "#{message}." unless force
 
@@ -253,7 +254,6 @@ module Cask
           return
         end
 
-        command.run("/bin/chmod", args: ["--", "+x", executable_path])
         command.run(executable_path, script_arguments)
         sleep 1
       end

--- a/Library/Homebrew/cask/artifact/installer.rb
+++ b/Library/Homebrew/cask/artifact/installer.rb
@@ -26,22 +26,10 @@ module Cask
         def install_phase(command: nil, **_)
           ohai "Running #{self.class.dsl_key} script '#{path}'"
 
-          absolute_path = if path.absolute?
-            path
-          else
-            cask.staged_path.join(path)
-          end
-
-          FileUtils.chmod "+x", absolute_path if absolute_path.exist? && !absolute_path.executable?
-
-          executable = if absolute_path.exist?
-            absolute_path
-          else
-            path
-          end
+          executable_path = staged_path_join_executable(path)
 
           command.run!(
-            executable,
+            executable_path,
             **args,
             env: { "PATH" => PATH.new(
               HOMEBREW_PREFIX/"bin", HOMEBREW_PREFIX/"sbin", ENV["PATH"]

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -229,11 +229,6 @@ shared_examples "#uninstall_phase or #zap_phase" do
         allow(fake_system_command).to receive(:run).with(any_args).and_call_original
 
         expect(fake_system_command).to receive(:run).with(
-          "/bin/chmod",
-          args: ["--", "+x", script_pathname],
-        )
-
-        expect(fake_system_command).to receive(:run).with(
           cask.staged_path.join("MyFancyPkg", "FancyUninstaller.tool"),
           args:         ["--please"],
           must_succeed: true,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Previously `uninstall script:` only supported absolute paths, now it supports both absolute paths and executable names. i.e. `osascript`.