### PR TITLE
Fix bug in CLI arg/env var prioritization + corresponding tests

### DIFF
--- a/Library/Homebrew/cli_parser.rb
+++ b/Library/Homebrew/cli_parser.rb
@@ -234,7 +234,7 @@ module Homebrew
           next if violations.count < 2
 
           env_var_options = violations.select do |option|
-            @switch_sources[option_to_name(option)] == :env_var
+            @switch_sources[option_to_name(option)] == :env
           end
 
           select_cli_arg = violations.count - env_var_options.count == 1

--- a/Library/Homebrew/test/cli_parser_spec.rb
+++ b/Library/Homebrew/test/cli_parser_spec.rb
@@ -179,19 +179,19 @@ describe Homebrew::CLI::Parser do
     end
 
     it "prioritizes cli arguments over env vars when they conflict" do
-      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_A").and_return("1")
-      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_B").and_return("0")
       allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_A").and_return("1")
+      allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_B").and_return(nil)
       parser.parse(["--switch-b"])
       expect(Homebrew.args.switch_a).to be_falsy
       expect(Homebrew.args).to be_switch_b
     end
 
     it "raises an exception on constraint violation when both are env vars" do
+      allow(ENV).to receive(:[])
       allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_A").and_return("1")
       allow(ENV).to receive(:[]).with("HOMEBREW_SWITCH_B").and_return("1")
-      allow(ENV).to receive(:[])
-      expect { parser.parse(["--switch-a", "--switch-b"]) }.to raise_error(Homebrew::CLI::OptionConflictError)
+      expect { parser.parse([]) }.to raise_error(Homebrew::CLI::OptionConflictError)
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes bug in https://github.com/Homebrew/brew/pull/5738
Fixes https://github.com/Homebrew/brew/issues/5736

Explanation of what happened:

 - When I changed the names of the :env_var value to :env, I left one unchanged
 - The tests were passingly misleadingly because the stubbing order made it so that all env vars were actually ignored (and one of my tests was testing the non-env-var behavior due to my mistake in the test)
