### PR TITLE
Fix issue extracting tar files while root on Linux

### DIFF
--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -38,7 +38,7 @@ module UnpackStrategy
         end
 
         system_command! "tar",
-                        args:    ["xf", tar_path, "-C", unpack_dir],
+                        args:    ["xof", tar_path, "-C", unpack_dir],
                         verbose: verbose
       end
     end


### PR DESCRIPTION
unpack_strategy/tar.rb changed BUT haven't rubocoped(brew style) at all.
extent/os/linux/gnu_tar.rb created, rubocoped(brew style).
extent/os/install.rb now includes gnu_tar.rb, rubocoped(brew style).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
**need help if it important**
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
```tar --no-same-owner``` **tested**.
```--user=0 --group=0``` **didn't**.
 gnu_tar.rb's lines number 10 and 11 needs **extra attention**
-----

#https://github.com/Homebrew/linuxbrew-core/pull/1172
many bottles can't be build in CircleCI cause these `annot change ownership to 115242:89939` (https://github.com/Homebrew/linuxbrew-core/pull/11729 https://github.com/Homebrew/linuxbrew-core/pull/11691)