### PR TITLE
missing_formula: add message for Asymptote

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -27,10 +27,9 @@ module Homebrew
             brew cask install basictex
         EOS
         when "asymptote" then <<~EOS
-          Asymptote is bundled with MacTeX / TeX Live. When that is installed, Asymptote
-          may have been installed with it or can be added using the TeX Live Utility via
-          either its GUI or command line:
-            tlmgr install asymptote
+          The recommended way to install Asymptote is as part of the MacTeX collection.
+          With that installed, try `which asy` to confirm Asymptote has been installed
+          as part of the collection, or use MacTeX's TeX Live Utility to add it.
         EOS
         when "pip" then <<~EOS
           pip is part of the python formula:

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -14,7 +14,7 @@ module Homebrew
           macOS provides gem as part of Ruby. To install a newer version:
             brew install ruby
         EOS
-        when "tex", "tex-live", "texlive", "latex" then <<~EOS
+        when "tex", "tex-live", "texlive", "mactex", "latex" then <<~EOS
           There are three versions of MacTeX.
 
           Full installation:

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -27,9 +27,8 @@ module Homebrew
             brew cask install basictex
         EOS
         when "asymptote" then <<~EOS
-          The recommended way to install Asymptote is as part of the MacTeX collection.
-          With that installed, try `which asy` to confirm Asymptote has been installed
-          as part of the collection, or use MacTeX's TeX Live Utility to add it.
+          Asymptote is part of MacTeX:
+            brew cask install mactex
         EOS
         when "pip" then <<~EOS
           pip is part of the python formula:

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -27,7 +27,9 @@ module Homebrew
             brew cask install basictex
         EOS
         when "asymptote" then <<~EOS
-          Asymptote is bundled with MacTeX. Install it via TeX Live Utility or:
+          Asymptote is bundled with MacTeX / TeX Live. When that is installed, Asymptote
+          may have been installed with it or can be added using the TeX Live Utility via
+          either its GUI or command line:
             tlmgr install asymptote
         EOS
         when "pip" then <<~EOS

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -26,6 +26,10 @@ module Homebrew
           Minimal installation:
             brew cask install basictex
         EOS
+        when "asymptote" then <<~EOS
+          Asymptote is bundled with MacTeX. Install it via TeX Live Utility or:
+            tlmgr install asymptote
+        EOS
         when "pip" then <<~EOS
           pip is part of the python formula:
             brew install python


### PR DESCRIPTION
Hoping to install Asymptote produces

```
$ brew install asymptote
Error: No available formula with the name "asymptote" 
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
==> Searching taps on GitHub...
Error: No formulae found in taps.
```

After further searching I came across Homebrew/legacy-homebrew#23029, which removed the previous asymptote formula on the basis that it was better to install it via MacTeX. This patch helps future users to side-step that searching for information stage:

```
$ brew install asymptote
Updating Homebrew...
Error: No available formula with the name "asymptote" 
Asymptote is bundled with MacTeX. Install it via TeX Live Utility or:
  tlmgr install asymptote
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----