### PR TITLE
Add varenc/ffmpeg to list of interesting taps

### DIFF
--- a/docs/Interesting-Taps-and-Forks.md
+++ b/docs/Interesting-Taps-and-Forks.md
@@ -6,6 +6,7 @@ Homebrew has the capability to add (and remove) multiple taps to your local inst
 Your taps are Git repositories located at `$(brew --repository)/Library/Taps`.
 
 ## Unsupported interesting taps
+*   [varenc/ffmpeg](https://github.com/varenc/homebrew-ffmpeg): A tap for FFmpeg with additional options, including nonfree additions. 
 
 *   [denji/nginx](https://github.com/denji/homebrew-nginx): A tap for NGINX modules, intended for its `nginx-full` formula which includes more module options.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It would be helpful to include this link in the list for users that wish to have custom-built versions of `ffmpeg`, especially with nonfree features enabled (which Homebrew cannot distribute), such as `--with-fdk-aac`.