### PR TITLE
Allow head in new formulas

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -640,18 +640,14 @@ module Homebrew
 
       problem "Formulae should not have a `devel` spec" if formula.devel
 
-      if formula.head
+      if formula.head && @versioned_formula
         head_spec_message = "Formulae should not have a `HEAD` spec"
-        if @new_formula
-          new_formula_problem head_spec_message
-        elsif @versioned_formula
-          versioned_head_spec = %w[
-            bash-completion@2
-            imagemagick@6
-            python@2
-          ]
-          problem head_spec_message unless versioned_head_spec.include?(formula.name)
-        end
+        versioned_head_spec = %w[
+          bash-completion@2
+          imagemagick@6
+          python@2
+        ]
+        problem head_spec_message unless versioned_head_spec.include?(formula.name)
       end
 
       throttled = %w[


### PR DESCRIPTION
I would like us to allow `head` in new formulas. The current policy does not make much sense, since people are allowed to add `head` once the formula has been accepted into Homebrew core. We spend a lot of time asking people to remove `head` from the new formula PRs, for actually little effect.

(I can't run `brew style` and `brew test` locally, because of the Mojave Ruby issues.)