### PR TITLE
audit: Keg-only :provided_by_macos dep okay on Linux

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -386,10 +386,10 @@ module Homebrew
             problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
           end
 
-          if @new_formula && dep_f.keg_only_reason &&
-             !["openssl", "apr", "apr-util"].include?(dep.name) &&
-             !["openblas"].include?(dep.name) &&
-             dep_f.keg_only_reason.reason == :provided_by_macos
+          if @new_formula &&
+             dep_f.keg_only_reason&.reason == :provided_by_macos &&
+             dep_f.keg_only_reason.valid? &&
+             !["apr", "apr-util", "openblas", "openssl"].include?(dep.name)
             new_formula_problem(
               "Dependency '#{dep.name}' may be unnecessary as it is provided " \
               "by macOS; try to build this formula without it.",

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -252,7 +252,7 @@ module Homebrew
           its(:problems) { are_expected.to be_empty }
         end
 
-        describe "which is not whitelisted" do
+        describe "which is not whitelisted", :needs_macos do
           subject { fa }
 
           let(:fa) do


### PR DESCRIPTION
Disable this brew audit error on Linux:
```
* Dependency 'zlib' may be unnecessary as it is provided by macOS;
try to build this formula without it.
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?