### PR TITLE
outdated & tap-info: set default value for --json

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -19,15 +19,16 @@ module Homebrew
         description: "List only the names of outdated brews (takes precedence over `--verbose`)."
       switch :verbose,
         description: "Display detailed version information."
-      flag "--json=",
-        description: "Show output in JSON format for provided <version>. Currently the only "\
-                     "accepted value of <version> is `v1`."
+      flag "--json",
+        description: "Print output in JSON format. Currently the default and only accepted "\
+                     "value for <version> is `v1`. See the docs for examples of using the JSON "\
+                     "output: <https://docs.brew.sh/Querying-Brew>"
       switch "--fetch-HEAD",
         description: "Fetch the upstream repository to detect if the HEAD installation of the "\
                      "formula is outdated. Otherwise, the repository's HEAD will be checked for "\
                      "updates when a new stable or development version has been released."
       switch :debug
-      conflicts "--quiet", "--verbose", "--json="
+      conflicts "--quiet", "--verbose", "--json"
     end
   end
 
@@ -39,7 +40,9 @@ module Homebrew
     else
       ARGV.resolved_formulae
     end
-    if args.json == "v1"
+    if args.json
+      raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
+
       outdated = print_outdated_json(formulae)
     else
       outdated = print_outdated(formulae)

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -13,10 +13,10 @@ module Homebrew
       EOS
       switch "--installed",
         description: "Display information on all installed taps."
-      flag "--json=",
-        description: "Print a JSON representation of <taps>. Currently the only accepted value for "\
-                     "<version> is `v1`. See the docs for examples of using the JSON output: "\
-                     "<https://docs.brew.sh/Querying-Brew>"
+      flag "--json",
+        description: "Print a JSON representation of <taps>. Currently the default and only accepted "\
+                     "value for <version> is `v1`. See the docs for examples of using the JSON "\
+                     "output: <https://docs.brew.sh/Querying-Brew>"
       switch :debug
     end
   end
@@ -32,7 +32,9 @@ module Homebrew
       end
     end
 
-    if args.json == "v1"
+    if args.json
+      raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
+
       print_tap_json(taps.sort_by(&:to_s))
     else
       print_tap_info(taps.sort_by(&:to_s))

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -339,7 +339,7 @@ By default, version information is displayed in interactive shells, and
 suppressed otherwise.
 
 * `--json`:
-  Show output in JSON format for provided *`version`*. Currently the only accepted value of *`version`* is `v1`.
+  Print output in JSON format. Currently the default and only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>
 * `--fetch-HEAD`:
   Fetch the upstream repository to detect if the HEAD installation of the formula is outdated. Otherwise, the repository's HEAD will be checked for updates when a new stable or development version has been released.
 
@@ -479,7 +479,7 @@ Display a brief summary of all installed taps if no *`tap`* are passed.
 * `--installed`:
   Display information on all installed taps.
 * `--json`:
-  Print a JSON representation of *`taps`*. Currently the only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>
+  Print a JSON representation of *`taps`*. Currently the default and only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>
 
 ### `tap-pin` *`tap`*
 

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "February 2019" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "March 2019" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "February 2019" "Homebrew" "brew"
+.TH "BREW" "1" "March 2019" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -438,7 +438,7 @@ By default, version information is displayed in interactive shells, and suppress
 .
 .TP
 \fB\-\-json\fR
-Show output in JSON format for provided \fIversion\fR\. Currently the only accepted value of \fIversion\fR is \fBv1\fR\.
+Print output in JSON format\. Currently the default and only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
 .TP
 \fB\-\-fetch\-HEAD\fR
@@ -603,7 +603,7 @@ Display information on all installed taps\.
 .
 .TP
 \fB\-\-json\fR
-Print a JSON representation of \fItaps\fR\. Currently the only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
+Print a JSON representation of \fItaps\fR\. Currently the default and only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
 .SS "\fBtap\-pin\fR \fItap\fR"
 Pin \fItap\fR, prioritising its formulae over core when formula names are supplied by the user\. See also \fBtap\-unpin\fR\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Set the default value for both commands' `--json` option to `v1`, matching what's already been done for `brew info`.
