### PR TITLE
cleanup: fix for formula/cask name collision

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -59,7 +59,11 @@ module CleanupRefinement
     def stale?(scrub = false)
       return false unless resolved_path.file?
 
-      stale_formula?(scrub) || stale_cask?(scrub)
+      if dirname.basename.to_s == "Cask"
+        stale_cask?(scrub)
+      else
+        stale_formula?(scrub)
+      end
     end
 
     private
@@ -112,8 +116,6 @@ module CleanupRefinement
 
     def stale_cask?(scrub)
       return false unless name = basename.to_s[/\A(.*?)\-\-/, 1]
-
-      return if dirname.basename.to_s != "Cask"
 
       cask = begin
         Cask::CaskLoader.load(name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When a formula and cask share the same name, a download can be incorrectly considered stale. This is the case for the name `docker`:

```
$ brew cleanup
...
$ brew cask fetch docker
==> Downloading external files for Cask docker
==> Downloading https://download.docker.com/mac/stable/31259/Docker.dmg
######################################################################## 100.0%
==> Verifying SHA-256 checksum for Cask 'docker'.
==> Success! Downloaded to -> /Users/chase/Library/Caches/Homebrew/downloads/be9b9366a4a96478a04d2711baad17a8d5dc1342a82facd388f211b741965149--Docker.dmg
$ brew cleanup -n
Would remove: /Users/chase/Library/Caches/Homebrew/Cask/docker--2.0.0.3-ce-mac81,31259.dmg (521.5MB)
==> This operation would free approximately 521.5MB of disk space.
```

This is because the download for the *cask* `docker` (`/Users/chase/Library/Caches/Homebrew/Cask/docker--2.0.0.3-ce-mac81,31259.dmg`) is considered a stale download for the *formula* `docker`.

The fix is to call either `stale_formula?` or `stale_cask?` on the download based on the containing directory, but not both. Also, a check on the containing directory in `stale_cask?` is no longer necessary.