### PR TITLE
Keep deprecated OS version definitions

### DIFF
--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -4,12 +4,18 @@ module OS
   module Mac
     class Version < ::Version
       SYMBOLS = {
-        mojave:      "10.14",
-        high_sierra: "10.13",
-        sierra:      "10.12",
-        el_capitan:  "10.11",
-        yosemite:    "10.10",
-        mavericks:   "10.9",
+        mojave:        "10.14",
+        high_sierra:   "10.13",
+        sierra:        "10.12",
+        el_capitan:    "10.11",
+        yosemite:      "10.10",
+        mavericks:     "10.9",
+        mountain_lion: "10.8",
+        lion:          "10.7",
+        snow_leopard:  "10.6",
+        leopard_64:    "10.5",
+        leopard:       "10.5",
+        tiger:         "10.4",
       }.freeze
 
       def self.from_symbol(sym)


### PR DESCRIPTION
.metadata files might refer to old OS versions, so keep
the old version names/numbers defined.
This solves issues https://github.com/Homebrew/homebrew-cask/issues/58046 https://github.com/Homebrew/homebrew-cask/issues/58046 #5640
The .metadata can stay as they are.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----