### PR TITLE
deps: fix --1 and --annotate options

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -112,6 +112,8 @@ show the intersection of dependencies for *`formula`*.
   Include requirements in addition to dependencies for *`formula`*.
 * `--tree`:
   Show dependencies as a tree. When given multiple formula arguments output individual trees for every formula.
+* `--annotate`:
+  Mark any build, test, optional, or recommended dependencies as such in the output.
 * `--for-each`:
   Switch into the mode used by `deps --all`, but only list dependencies for specified formula one specified formula per line. This is used for debugging the `--installed`/`--all` display mode.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -131,6 +131,10 @@ Include requirements in addition to dependencies for \fIformula\fR\.
 Show dependencies as a tree\. When given multiple formula arguments output individual trees for every formula\.
 .
 .TP
+\fB\-\-annotate\fR
+Mark any build, test, optional, or recommended dependencies as such in the output\.
+.
+.TP
 \fB\-\-for\-each\fR
 Switch into the mode used by \fBdeps \-\-all\fR, but only list dependencies for specified formula one specified formula per line\. This is used for debugging the \fB\-\-installed\fR/\fB\-\-all\fR display mode\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
1. `brew deps` was giving non-recursive results with `--for-each`, and recursive results with `--1 --installed`. This PR fixes both issues. 

<details>
  <summary>Before:</summary>
  <pre>
$ brew deps --for-each fontconfig
fontconfig: freetype
$ brew deps --1 --installed | grep fontconfig:
fontconfig: freetype libpng
  </pre>
</details>

<details>
  <summary>After:</summary>
  <pre>
$ brew deps --for-each fontconfig
fontconfig: freetype libpng
$ brew deps --1 --installed | grep fontconfig:
fontconfig: freetype
  </pre>
</details>


2. Restored the `--annotate` flag, and adjusted its output so each annotation only has two leading spaces in `--tree` mode.

```
$ brew deps --include-build --tree --annotate fontconfig
fontconfig
├── pkg-config  [build]
└── freetype 
    └── libpng 

$ brew deps --include-build --annotate fontconfig
freetype
libpng
pkg-config [build]
$ brew deps --include-build --annotate --for-each fontconfig
fontconfig: freetype libpng pkg-config [build]
```