### PR TITLE
docs/_config.yml: enable documentation search.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,6 +22,8 @@ defaults:
       path: ""
     values:
       image: /assets/img/homebrew-256x256.png
+      search_name: Homebrew Documentation
+      search_site: docs
 
 logo: /assets/img/homebrew-256x256.png
 


### PR DESCRIPTION
Set the search placeholder badge, the index and trigger a new GitHub Pages build (by merging this).