### PR TITLE
docs/_config.yml: shorten search placeholder.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,7 +22,7 @@ defaults:
       path: ""
     values:
       image: /assets/img/homebrew-256x256.png
-      search_name: Homebrew Documentation
+      search_name: Documentation
       search_site: docs
 
 logo: /assets/img/homebrew-256x256.png


### PR DESCRIPTION
Current one is truncated on macOS.