### PR TITLE
completions/zsh: Hide *instal from all commands

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -152,6 +152,7 @@ __brew_all_commands() {
   local comp_cachename=brew_all_commands
   if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then
     commands=($(_call_program brew brew commands --quiet --include-aliases))
+    commands=(${commands:#*instal}) # Exclude instal, uninstal, etc.
     _store_cache $comp_cachename commands
   fi
   _describe -t all-commands 'all commands' commands


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

After my other completion PR was merged, someone contacted me to ask if i could help with [this Discourse post](https://discourse.brew.sh/t/zsh-brew-completion-feature-bug-or-external-conflict/4228). The user is bothered by the fact that the zsh completion function offers one-letter-short aliases like `instal` and `uninstal`. I agree that they aren't helpful, as they produce confusing-looking output and force unnecessary disambiguation when the user enters (e.g.) `unin`<kbd>tab</kbd>.

These aliases were already hidden in the bash completion function in PR #3052. This change just does the equivalent for the zsh function.

Note for anyone testing this: If you have caching enabled, you may need to delete the cache files (under `~/.zcompcache` by default) to see the change right away.