### PR TITLE
python: support pypy3

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -14,7 +14,7 @@ module Language
     end
 
     def self.site_packages(python = "python3.7")
-      if python == "pypy"
+      if (python == "pypy") || (python == "pypy3")
         "site-packages"
       else
         "lib/python#{major_minor_version python}/site-packages"
@@ -23,7 +23,11 @@ module Language
 
     def self.each_python(build, &block)
       original_pythonpath = ENV["PYTHONPATH"]
-      { "python@3" => "python3", "python@2" => "python2.7", "pypy" => "pypy" }.each do |python_formula, python|
+      pythons = { "python@3" => "python3",
+                  "python@2" => "python2.7",
+                  "pypy"     => "pypy",
+                  "pypy3"    => "pypy3" }
+      pythons.each do |python_formula, python|
         python_formula = Formulary.factory(python_formula)
         next if build.without? python_formula.to_s
 
@@ -147,7 +151,7 @@ module Language
       def virtualenv_install_with_resources(options = {})
         python = options[:using]
         if python.nil?
-          wanted = %w[python python@2 python2 python3 python@3 pypy].select { |py| needs_python?(py) }
+          wanted = %w[python python@2 python2 python3 python@3 pypy pypy3].select { |py| needs_python?(py) }
           raise FormulaAmbiguousPythonError, self if wanted.size > 1
 
           python = wanted.first || "python2.7"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

A follow up to https://github.com/Homebrew/brew/pull/4833, now that Python 2 is soon-to-be end-of-lifed, we can look at supporting PyPy3 a bit better as well. I tested this with a third-party formula that had a gnarly scipy/numpy dependency stack and it worked perfectly.
