### PR TITLE
arch: actually show required architecture

### DIFF
--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -18,4 +18,8 @@ class ArchRequirement < Requirement
   def message
     "This formula requires an #{@arch} architecture."
   end
+
+  def display_s
+    "#{@arch} architecture"
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`depends_on :arch => :x86_64` and similar incantations did not actually show the required CPU architecture when running `brew info <formula>`. This pull request fixes the display of such Requirements.

Before:

```console
$ brew info sslyze
sslyze: stable 1.4.3 (bottled), HEAD
SSL scanner
https://github.com/nabla-c0d3/sslyze
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/sslyze.rb
==> Dependencies
Required: python@2 (installed)
==> Requirements
Required: arch (installed)
```

After:

```console
$ brew info sslyze
[snip]
==> Requirements
Required: x86_64 architecture (installed)
```