### PR TITLE
caveats: non-macOS platforms warn on services

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -136,7 +136,18 @@ class Caveats
     EOS
   end
 
-  def plist_caveats; end
+  def plist_caveats
+    return unless f.plist_manual
+
+    # default to brew services not being supported.
+    # macOS will overwrite this behavior.
+
+    <<~EOS
+      #{Formatter.warning("Warning:")} #{f.name} wants to install a service, which is currently only supported on macOS!
+      You can manually execute the service with:
+      #{f.plist_manual}
+    EOS
+  end
 
   def plist_path
     destination = if f.plist_startup

--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -139,13 +139,11 @@ class Caveats
   def plist_caveats
     return unless f.plist_manual
 
-    # default to brew services not being supported.
-    # macOS will overwrite this behavior.
-
+    # Default to brew services not being supported. macOS overrides this behavior.
     <<~EOS
-      #{Formatter.warning("Warning:")} #{f.name} wants to install a service, which is currently only supported on macOS!
-      You can manually execute the service with:
-      #{f.plist_manual}
+      #{Formatter.warning("Warning:")} #{f.name} provides a launchd plist which can only be used on macOS!
+      You can manually execute the service instead with:
+        #{f.plist_manual}
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
I have one failure, but I am unsure it is related:
```
rspec ./test/cask/pkg_spec.rb:7 # Cask::Pkg#uninstall removes files and dirs referenced by the pkg
```

-----

Services is only currently supported by macOS. Attempting to use services should produce a warning for now.  It is possible it might be supported in the future.

Fixes #5847