### PR TITLE
Dockerfile: set cache location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN cd /home/linuxbrew/.linuxbrew \
 
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
-	SHELL=/bin/bash
+	SHELL=/bin/bash \
+	XDG_CACHE_HOME=/home/linuxbrew/.cache
 
 # Install portable-ruby and tap homebrew/core.
 RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \


### PR DESCRIPTION
When running `docker pull linuxbrew/brew && docker run linuxbrew/brew brew test-bot` it fails with:

```
==> brew update-test
Error: Permission denied @ dir_s_mkdir - /root/.cache
```

This sets `XDG_CACHE_HOME` to `/home/linuxbrew/.cache` to prevent this issue.