### PR TITLE
Fix incorrect formula name from file name

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -142,7 +142,7 @@ module Homebrew
 
     # The class name has to be renamed to match the new filename,
     # e.g. Foo version 1.2.3 becomes FooAT123 and resides in Foo@1.2.3.rb.
-    class_name = name.capitalize
+    class_name = Formulary.class_s(name.to_s)
     versioned_name = Formulary.class_s("#{class_name}@#{version}")
     result.gsub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Currently `brew extract` will create wrong formula file for files with hyphen in their name.

```
brew extract --version=1.10.5 kubernetes-cli custom/formulae

==> Searching repository history
==> Writing formula for kubernetes-cli from revision d09d972 to /usr/local/Homebrew/Library/Taps/custom/homebrew-formulae/Formula/kubernetes-cli@1.10.5.rb

brew install custom/formulae/kubernetes-cli@1.10.5

Error: No available formula with the name "custom/formulae/kubernetes-cli@1.10.5"
In formula file: /usr/local/Homebrew/Library/Taps/custom/homebrew-formulae/Formula/kubernetes-cli@1.10.5.rb
Expected to find class KubernetesCliAT1105, but only found: KubernetesCli.
```

The reason is L145, `kubernetes-cli` would become `Kubernetes-cli`, not `KubernetesCli`, so the extracted versioned formula file will still have class name `KubernetesCli` instead of `KubernetesCliAT1105`.
https://github.com/Homebrew/brew/blob/0f07fe5c5cdfdf0f424bba7b879faa38aedc8ee4/Library/Homebrew/dev-cmd/extract.rb#L143-L147

@etheleon