### PR TITLE
docs/Linuxbrew: Fix location of the Linuxbrew logo

### DIFF
--- a/docs/Linuxbrew.md
+++ b/docs/Linuxbrew.md
@@ -1,4 +1,4 @@
-![Linuxbrew logo](https://linuxbrew.sh/images/linuxbrew-256x256.png)
+![Linuxbrew logo](https://brew.sh/assets/img/linuxbrew-256x256.png)
 
 # Linuxbrew
 


### PR DESCRIPTION
See PR https://github.com/Homebrew/brew.sh/pull/337
and PR https://github.com/Linuxbrew/linuxbrew.github.io/pull/12