### PR TITLE
tap-new: use real repo name

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -58,7 +58,7 @@ module Homebrew
               set -e
               sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
               brew update
-              HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/#{tap}"
+              HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/#{tap.full_name}"
               mkdir -p "$HOMEBREW_TAP_DIR"
               rm -rf "$HOMEBREW_TAP_DIR"
               ln -s "$PWD" "$HOMEBREW_TAP_DIR"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The variable `tap` of class `Tap` stringifies as e.g., `homebrew/core`; when the actual folder it's stored in is called `homebrew/homebrew-core`. This pull request corrects this oversight.