### PR TITLE
deps: allow passing both --installed & --include-requirements

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -10,40 +10,42 @@ module Homebrew
       usage_banner <<~EOS
         `deps` [<options>] <formula>
 
-        Show dependencies for <formula>. When given multiple formula arguments,
-        show the intersection of dependencies for <formula>.
+        Show dependencies for <formula>. Additional options specific to <formula>
+        may be appended to the command. When given multiple formula arguments,
+        show the intersection of dependencies for each formula.
       EOS
-      switch "--1",
-        description: "Only show dependencies one level down, instead of recursing."
       switch "-n",
         description: "Show dependencies in topological order."
+      switch "--1",
+        description: "Only show dependencies one level down, instead of recursing."
       switch "--union",
-        description: "Show the union of dependencies for <formula>, instead of the intersection."
+        description: "Show the union of dependencies for multiple <formula>, instead of the intersection."
       switch "--full-name",
         description: "List dependencies by their full name."
-      switch "--installed",
-        description: "Only list those dependencies that are currently installed."
-      switch "--all",
-        description: "List all the dependencies for all available formulae."
       switch "--include-build",
-        description: "Show `:build` type dependencies for <formula>."
+        description: "Include `:build` dependencies for <formula>."
       switch "--include-optional",
-        description: "Show `:optional` dependencies for <formula>."
+        description: "Include `:optional` dependencies for <formula>."
       switch "--include-test",
-        description: "Show `:test` dependencies for <formula> (non-recursive)."
+        description: "Include `:test` dependencies for <formula> (non-recursive)."
       switch "--skip-recommended",
-        description: "Skip `:recommended` type dependencies for <formula>."
+        description: "Skip `:recommended` dependencies for <formula>."
       switch "--include-requirements",
         description: "Include requirements in addition to dependencies for <formula>."
       switch "--tree",
-        description: "Show dependencies as a tree. When given multiple formula arguments "\
-                     "output individual trees for every formula."
+        description: "Show dependencies as a tree. When given multiple formula arguments, "\
+                     "show individual trees for each formula."
       switch "--annotate",
         description: "Mark any build, test, optional, or recommended dependencies as "\
                      "such in the output."
+      switch "--installed",
+        description: "List dependencies for formulae that are currently installed. If <formula> is "\
+                     "specified, list only its dependencies that are currently installed."
+      switch "--all",
+        description: "List dependencies for all available formulae."
       switch "--for-each",
-        description: "Switch into the mode used by `deps --all`, but only list dependencies "\
-                     "for specified formula one specified formula per line. This is used for "\
+        description: "Switch into the mode used by the `--all` option, but only list dependencies "\
+                     "for the specified <formula>, one formula per line. This is used for "\
                      "debugging the `--installed`/`--all` display mode."
       switch :verbose
       switch :debug

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -60,6 +60,7 @@ class Requirement
 
     true
   end
+  alias installed? satisfied?
 
   # Overriding {#fatal?} is unsupported.
   # Pass a boolean to the fatal DSL method instead.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -84,37 +84,38 @@ report, you will likely be asked for this information if you do not provide it.
 
 ### `deps` [*`options`*] *`formula`*
 
-Show dependencies for *`formula`*. When given multiple formula arguments, show the
-intersection of dependencies for *`formula`*.
+Show dependencies for *`formula`*. Additional options specific to *`formula`* may be
+appended to the command. When given multiple formula arguments, show the
+intersection of dependencies for each formula.
 
-* `--1`:
-  Only show dependencies one level down, instead of recursing.
 * `-n`:
   Show dependencies in topological order.
+* `--1`:
+  Only show dependencies one level down, instead of recursing.
 * `--union`:
-  Show the union of dependencies for *`formula`*, instead of the intersection.
+  Show the union of dependencies for multiple *`formula`*, instead of the intersection.
 * `--full-name`:
   List dependencies by their full name.
-* `--installed`:
-  Only list those dependencies that are currently installed.
-* `--all`:
-  List all the dependencies for all available formulae.
 * `--include-build`:
-  Show `:build` type dependencies for *`formula`*.
+  Include `:build` dependencies for *`formula`*.
 * `--include-optional`:
-  Show `:optional` dependencies for *`formula`*.
+  Include `:optional` dependencies for *`formula`*.
 * `--include-test`:
-  Show `:test` dependencies for *`formula`* (non-recursive).
+  Include `:test` dependencies for *`formula`* (non-recursive).
 * `--skip-recommended`:
-  Skip `:recommended` type dependencies for *`formula`*.
+  Skip `:recommended` dependencies for *`formula`*.
 * `--include-requirements`:
   Include requirements in addition to dependencies for *`formula`*.
 * `--tree`:
-  Show dependencies as a tree. When given multiple formula arguments output individual trees for every formula.
+  Show dependencies as a tree. When given multiple formula arguments, show individual trees for each formula.
 * `--annotate`:
   Mark any build, test, optional, or recommended dependencies as such in the output.
+* `--installed`:
+  List dependencies for formulae that are currently installed. If *`formula`* is specified, list only its dependencies that are currently installed.
+* `--all`:
+  List dependencies for all available formulae.
 * `--for-each`:
-  Switch into the mode used by `deps --all`, but only list dependencies for specified formula one specified formula per line. This is used for debugging the `--installed`/`--all` display mode.
+  Switch into the mode used by the `--all` option, but only list dependencies for the specified *`formula`*, one formula per line. This is used for debugging the `--installed`/`--all` display mode.
 
 ### `desc` [*`options`*] (*`text`*|`/`*`text`*`/`|*`formula`*)
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -80,47 +80,39 @@ Include the aliases of internal commands\.
 Show Homebrew and system configuration useful for debugging\. If you file a bug report, you will likely be asked for this information if you do not provide it\.
 .
 .SS "\fBdeps\fR [\fIoptions\fR] \fIformula\fR"
-Show dependencies for \fIformula\fR\. When given multiple formula arguments, show the intersection of dependencies for \fIformula\fR\.
-.
-.TP
-\fB\-\-1\fR
-Only show dependencies one level down, instead of recursing\.
+Show dependencies for \fIformula\fR\. Additional options specific to \fIformula\fR may be appended to the command\. When given multiple formula arguments, show the intersection of dependencies for each formula\.
 .
 .TP
 \fB\-n\fR
 Show dependencies in topological order\.
 .
 .TP
+\fB\-\-1\fR
+Only show dependencies one level down, instead of recursing\.
+.
+.TP
 \fB\-\-union\fR
-Show the union of dependencies for \fIformula\fR, instead of the intersection\.
+Show the union of dependencies for multiple \fIformula\fR, instead of the intersection\.
 .
 .TP
 \fB\-\-full\-name\fR
 List dependencies by their full name\.
 .
 .TP
-\fB\-\-installed\fR
-Only list those dependencies that are currently installed\.
-.
-.TP
-\fB\-\-all\fR
-List all the dependencies for all available formulae\.
-.
-.TP
 \fB\-\-include\-build\fR
-Show \fB:build\fR type dependencies for \fIformula\fR\.
+Include \fB:build\fR dependencies for \fIformula\fR\.
 .
 .TP
 \fB\-\-include\-optional\fR
-Show \fB:optional\fR dependencies for \fIformula\fR\.
+Include \fB:optional\fR dependencies for \fIformula\fR\.
 .
 .TP
 \fB\-\-include\-test\fR
-Show \fB:test\fR dependencies for \fIformula\fR (non\-recursive)\.
+Include \fB:test\fR dependencies for \fIformula\fR (non\-recursive)\.
 .
 .TP
 \fB\-\-skip\-recommended\fR
-Skip \fB:recommended\fR type dependencies for \fIformula\fR\.
+Skip \fB:recommended\fR dependencies for \fIformula\fR\.
 .
 .TP
 \fB\-\-include\-requirements\fR
@@ -128,15 +120,23 @@ Include requirements in addition to dependencies for \fIformula\fR\.
 .
 .TP
 \fB\-\-tree\fR
-Show dependencies as a tree\. When given multiple formula arguments output individual trees for every formula\.
+Show dependencies as a tree\. When given multiple formula arguments, show individual trees for each formula\.
 .
 .TP
 \fB\-\-annotate\fR
 Mark any build, test, optional, or recommended dependencies as such in the output\.
 .
 .TP
+\fB\-\-installed\fR
+List dependencies for formulae that are currently installed\. If \fIformula\fR is specified, list only its dependencies that are currently installed\.
+.
+.TP
+\fB\-\-all\fR
+List dependencies for all available formulae\.
+.
+.TP
 \fB\-\-for\-each\fR
-Switch into the mode used by \fBdeps \-\-all\fR, but only list dependencies for specified formula one specified formula per line\. This is used for debugging the \fB\-\-installed\fR/\fB\-\-all\fR display mode\.
+Switch into the mode used by the \fB\-\-all\fR option, but only list dependencies for the specified \fIformula\fR, one formula per line\. This is used for debugging the \fB\-\-installed\fR/\fB\-\-all\fR display mode\.
 .
 .SS "\fBdesc\fR [\fIoptions\fR] (\fItext\fR|\fB/\fR\fItext\fR\fB/\fR|\fIformula\fR)"
 Display \fIformula\fR\'s name and one\-line description\. Formula descriptions are cached; the cache is created on the first search, making that search slower than subsequent ones\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Aliased `Requirement.installed?` to `Requirement.satisfied?` to allow `brew deps` to check if a requirement is met before listing it with `brew deps --include-requirements --installed <formula>`, and updated docs to mention this use of `--installed`, plus other improvements.

Fixes #5878.
