### PR TITLE
Fix class name for brew extract

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -142,8 +142,8 @@ module Homebrew
 
     # The class name has to be renamed to match the new filename,
     # e.g. Foo version 1.2.3 becomes FooAT123 and resides in Foo@1.2.3.rb.
-    class_name = Formulary.class_s(name.to_s)
-    versioned_name = Formulary.class_s("#{class_name}@#{version}")
+    class_name = Formulary.class_s(name)
+    versioned_name = Formulary.class_s("#{name}@#{version}")
     result.gsub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
 
     path = destination_tap.path/"Formula/#{name}@#{version}.rb"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Fix an oversight in #5868. When run
```sh
brew extract --version=1.10.5 kubernetes-cli custom/formulae
```
class name for `kubernetes-cli@1.10.5` is `KubernetescliAT1105` instead of `KubernetesCliAT1105` as expected.

So sorry for not testing this out properly earlier. Wanted to add a test case for this but looks like can't `setup_test_formula` a formula name with hyphen.