### PR TITLE
Fix repo name consistency

### DIFF
--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -36,7 +36,7 @@ file here.
 If they want to get your tap without installing any formula at the same time,
 users can add it with the [`brew tap` command](Taps.md).
 
-If it’s on GitHub, they can use `brew tap user/repo`, where `user` is your
+If it’s on GitHub, they can use `brew tap user/homebrew-repo`, where `user` is your
 GitHub username and `homebrew-repo` your repository.
 
 If it’s hosted outside of GitHub, they have to use `brew tap user/repo <URL>`,


### PR DESCRIPTION
It seems `homebrew-repo` refers to `user/repo`. It probably should be `user/homebrew-repo`.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
