### PR TITLE
Add `#unstable?` method for cask versions.

### DIFF
--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -12,6 +12,8 @@ module Cask
 
       MAJOR_MINOR_PATCH_REGEX = /^(\d+)(?:\.(\d+)(?:\.(\d+))?)?/.freeze
 
+      INVALID_CHARACTERS = /[^0-9a-zA-Z\.\,\:\-\_]/.freeze
+
       class << self
         private
 
@@ -58,6 +60,23 @@ module Cask
       def initialize(raw_version)
         @raw_version = raw_version
         super(raw_version.to_s)
+      end
+
+      def invalid_characters
+        return [] if latest?
+
+        raw_version.scan(INVALID_CHARACTERS)
+      end
+
+      def unstable?
+        return false if latest?
+
+        s = downcase.delete(".").gsub(/[^a-z\d]+/, "-")
+
+        return true if s.match?(/(\d+|\b)(alpha|beta|preview|rc|dev|canary|snapshot)(\d+|\b)/i)
+        return true if s.match?(/\A[a-z\d]+(\-\d+)*\-?(a|b|pre)(\d+|\b)/i)
+
+        false
       end
 
       def latest?

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -206,21 +206,6 @@ describe Cask::DSL::Version, :cask do
                        "1.2.3_4-5" => "1.2.3/4-5"
     end
 
-    describe "#slashes_to_dots" do
-      include_examples "version expectations hash", :slashes_to_dots,
-                       "1.2.3/abc" => "1.2.3.abc"
-    end
-
-    describe "#slashes_to_hyphens" do
-      include_examples "version expectations hash", :slashes_to_hyphens,
-                       "1.2.3/abc" => "1.2.3-abc"
-    end
-
-    describe "#slashes_to_underscores" do
-      include_examples "version expectations hash", :slashes_to_underscores,
-                       "1.2.3/abc" => "1.2.3_abc"
-    end
-
     describe "#no_dots" do
       include_examples "version expectations hash", :no_dots,
                        "1.2.3_4-5" => "123_4-5"
@@ -236,14 +221,155 @@ describe Cask::DSL::Version, :cask do
                        "1.2.3_4-5" => "1.2.34-5"
     end
 
-    describe "#no_slashes" do
-      include_examples "version expectations hash", :no_slashes,
-                       "1.2.3/abc" => "1.2.3abc"
-    end
-
     describe "#no_dividers" do
       include_examples "version expectations hash", :no_dividers,
                        "1.2.3_4-5" => "12345"
+    end
+  end
+
+  describe "#unstable?" do
+    [
+      "0.0.11-beta.7",
+      "0.0.23b-alpha",
+      "0.1-beta",
+      "0.1.0-beta.6",
+      "0.10.0b",
+      "0.2.0-alpha",
+      "0.2.0-beta",
+      "0.2.4-beta.9",
+      "0.2.588-dev",
+      "0.3-beta",
+      "0.3.0-SNAPSHOT-624369f",
+      "0.4.1-alpha",
+      "0.4.9-alpha",
+      "0.5.3,beta",
+      "0.6-alpha1,a",
+      "0.7.1b2",
+      "0.7a19",
+      "0.8.0b8",
+      "0.8b3",
+      "0.9.10-alpha",
+      "0.9.3b",
+      "08b2",
+      "1.0-b9",
+      "1.0-beta",
+      "1.0-beta-7.0",
+      "1.0-beta.3",
+      "1.0.0-alpha.5",
+      "1.0.0-alpha5",
+      "1.0.0-beta-2.2,20160421",
+      "1.0.0-beta.16",
+      "1.0.0-rc",
+      "1.0.6b1",
+      "1.0.beta-43",
+      "1.004,alpha",
+      "1.0b10",
+      "1.0b12",
+      "1.1-alpha-20181201a",
+      "1.1.16-beta-rc2",
+      "1.1.58.BETA",
+      "1.10.1,b87:8941241e",
+      "1.13.0-beta.7",
+      "1.13beta8",
+      "1.15.0.b20190302001",
+      "1.16.2-Beta",
+      "1.1b23",
+      "1.2.0,b200",
+      "1.2.1pre1",
+      "1.2.2-beta.2845",
+      "1.20.0-beta.3",
+      "1.2b24",
+      "1.3.0,b102",
+      "1.3.7a",
+      "1.36.0-beta0",
+      "1.4.3a",
+      "1.6.0_65-b14-468",
+      "1.6.4-beta0-4e46f007",
+      "1.7,b566",
+      "1.7b5",
+      "1.9.3a",
+      "1.9.3b8",
+      "17.03.1-beta",
+      "18.0-Leia_rc4",
+      "18.2-rc-3",
+      "1875Beta",
+      "19.3.2,b4188-155116",
+      "2.0-rc.22",
+      "2.0.0-beta.2",
+      "2.0.0-beta14",
+      "2.0.0-dev.11,1902221558.a6b3c4a8",
+      "2.0.12,b1807-50472cde",
+      "2.0b",
+      "2.0b2",
+      "2.0b3-2020",
+      "2.0b5",
+      "2.1.1-dev.3",
+      "2.12.12beta3",
+      "2.12b1",
+      "2.2-Beta",
+      "2.2.0-RC1",
+      "2.2b2",
+      "2.3.0-beta1u1",
+      "2.3.1,rc4",
+      "2.3b19",
+      "2.4.0-beta2",
+      "2.4.6-beta3u2",
+      "2.6.1-dev_2019-02-09_14-04_git-master-c1f194a",
+      "2.7.4a1",
+      "2.79b",
+      "2.99pre5",
+      "2019.1-Beta2",
+      "2019.1-b112",
+      "2019.1-beta1",
+      "2019a",
+      "26.1-rc1-1",
+      "3.0.0-beta.5",
+      "3.0.0-beta19",
+      "3.0.0-canary.8",
+      "3.0.0-preview-27122-01",
+      "3.0.0-rc.14",
+      "3.0.1-beta.19",
+      "3.0.100-preview-010184",
+      "3.0.6a",
+      "3.00b5",
+      "3.1.0-beta.1",
+      "3.1.0_b15007",
+      "3.2.8beta1",
+      "3.21-beta",
+      "3.7.9beta03,5210",
+      "3b19",
+      "4.0.0a",
+      "4.2.0-preview",
+      "4.3-beta5",
+      "4.3b3",
+      "4.99beta",
+      "5.0.0-RC7",
+      "5.5.0-beta-9",
+      "6.0.0-beta3,20181228T124823",
+      "6.0.0_BETA3,127054",
+      "6.1.1b176",
+      "6.2.0-preview.4",
+      "6.2.0.0.beta1",
+      "6.3.9_b16229",
+      "6.44b",
+      "7.0.6-7A69",
+      "7.3.BETA-3",
+      "8.5a8",
+      "8u202,b08:1961070e4c9b4e26a04e7f5a083f551e",
+    ].each do |unstable_version|
+      it "detects #{unstable_version.inspect} as unstable" do
+        expect(described_class.new(unstable_version)).to be_unstable
+      end
+    end
+
+    [
+      "0.20.1,63d9b84e-bbcf-4a00-9427-0bb3f713c769",
+      "1.5.4,13:53d8a307-a8ae-4f9b-9a59-a1adb8c67012",
+      "b226",
+    ].each do |stable_version|
+      it "does not detect #{stable_version.inspect} as unstable" do
+        expect(described_class.new(stable_version)).not_to be_unstable
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

To be used in `automerge`. Also, remove tests for `slashes_to_*` and `no_slashes`, since slashes shouldn't be used in versions.