### PR TITLE
brew.sh: don’t always autoupdate with no params.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -416,8 +416,22 @@ update-preinstall() {
   [[ -z "$HOMEBREW_HELP" ]] || return
   [[ -z "$HOMEBREW_NO_AUTO_UPDATE" ]] || return
   [[ -z "$HOMEBREW_AUTO_UPDATING" ]] || return
-  [[ -z "$HOMEBREW_AUTO_UPDATE_CHECKED" ]] || return
   [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]] || return
+  [[ -z "$HOMEBREW_AUTO_UPDATE_CHECKED" ]] || return
+
+  # If we've checked for updates, we don't need to check again.
+  export HOMEBREW_AUTO_UPDATE_CHECKED="1"
+
+  if [[ "$HOMEBREW_COMMAND" = "cask" ]]
+  then
+    if [[ "$HOMEBREW_CASK_COMMAND" != "upgrade" && $HOMEBREW_ARG_COUNT -lt 3 ]]
+    then
+      return
+    fi
+  elif [[ "$HOMEBREW_COMMAND" != "upgrade" && $HOMEBREW_ARG_COUNT -lt 2 ]]
+  then
+    return
+  fi
 
   if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" ||
         "$HOMEBREW_COMMAND" = "bump-formula-pr" ||
@@ -432,9 +446,6 @@ update-preinstall() {
       timer_pid=$!
     fi
 
-    # Allow auto-update migration now we have a fix in place (below in this function).
-    export HOMEBREW_ENABLE_AUTO_UPDATE_MIGRATION="1"
-
     brew update --preinstall
 
     if [[ -n "$timer_pid" ]]
@@ -445,15 +456,9 @@ update-preinstall() {
 
     unset HOMEBREW_AUTO_UPDATING
 
-    # If we've checked for updates, we don't need to check again.
-    export HOMEBREW_AUTO_UPDATE_CHECKED="1"
-
     # exec a new process to set any new environment variables.
     exec "$HOMEBREW_BREW_FILE" "$@"
   fi
-
-  # If we've checked for updates, we don't need to check again.
-  export HOMEBREW_AUTO_UPDATE_CHECKED="1"
 }
 
 if [[ -n "$HOMEBREW_BASH_COMMAND" ]]


### PR DESCRIPTION
Only `brew upgrade` and `brew cask upgrade` actually do anything if no additional parameters are specified. As a result, we don’t need to always update in those cases when we’re just showing help output anyway (as has been done for `brew tap`).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----