### PR TITLE
download_strategy: permit shorter revisions

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -141,10 +141,10 @@ class VCSDownloadStrategy < AbstractDownloadStrategy
 
     return unless @ref_type == :tag
     return unless @revision && current_revision
-    return if current_revision == @revision
+    return if current_revision =~ /^#{@revision}/
 
     raise <<~EOS
-      #{@ref} tag should be #{@revision}
+      #{@ref} tag should match #{@revision}
       but is actually #{current_revision}
     EOS
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When specifying formulae `url`s in the revision/tag format, you normally need to specify the full SHA1 hash of the commit. This pull request relaxes this requirement to only require a prefix of the revision.

I'd be open to writing an audit as well to ensure that the prefix of the revision hash is of sufficient length (e.g, 8-10 chars?)