### PR TITLE
Fixed checking absolute path of brew

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -7,6 +7,24 @@ if ! [[ -d "$PWD" ]]; then
   exit 1
 fi
 
+resolve_link() {
+  $(type -p greadlink readlink | head -1) "$1"
+}
+
+abs_dirname() {
+  local cwd="$(pwd)"
+  local path="$1"
+
+  while [ -n "$path" ]; do
+    cd "${path%/*}"
+    local name="${path##*/}"
+    path="$(resolve_link "$name" || true)"
+  done
+
+  pwd
+  cd "$cwd"
+}
+
 quiet_cd() {
   cd "$@" >/dev/null || return
 }
@@ -19,7 +37,7 @@ symlink_target_directory() {
   quiet_cd "$directory" && quiet_cd "$target_dirname" && pwd -P
 }
 
-BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
+BREW_FILE_DIRECTORY="$(abs_dirname "$0")"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"
 

--- a/bin/brew
+++ b/bin/brew
@@ -12,17 +12,19 @@ resolve_link() {
 }
 
 abs_dirname() {
-  local cwd="$(pwd)"
-  local path="$1"
+  local cwd path
+  cwd="$(pwd)"
+  path="$1"
 
   while [ -n "$path" ]; do
-    cd "${path%/*}"
-    local name="${path##*/}"
+    cd "${path%/*}" || return
+    local name
+    name="${path##*/}"
     path="$(resolve_link "$name" || true)"
   done
 
   pwd
-  cd "$cwd"
+  cd "$cwd" || return
 }
 
 quiet_cd() {


### PR DESCRIPTION
Here is fix for **Cowardly refusing to continue at this prefix: /usr**
Functions borrowed from [basher](https://github.com/basherpm/basher.git).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
