### PR TITLE
dev-cmd: only one integration test per command.

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -17,6 +17,7 @@ class Keg
     return if !file.elf? || !file.dynamic_elf?
 
     patchelf = DevelopmentTools.locate "patchelf"
+
     cmd_rpath = [patchelf, "--print-rpath", file]
     old_rpath = Utils.popen_read(*cmd_rpath, err: :out).strip
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -15,6 +15,7 @@ require "cache_store"
 require "linkage_checker"
 require "install"
 require "messages"
+require "cask/cask_loader"
 
 class FormulaInstaller
   include FormulaCellarChecks
@@ -66,6 +67,10 @@ class FormulaInstaller
 
   def self.attempted
     @attempted ||= Set.new
+  end
+
+  def self.clear_attempted
+    @attempted = Set.new
   end
 
   # When no build tools are available and build flags are passed through ARGV,

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -1,36 +1,29 @@
 describe "brew bottle", :integration_test do
   it "builds a bottle for the given Formula" do
-    begin
-      expect { brew "install", "--build-bottle", testball }
-        .to be_a_success
-
+    # create stub patchelf
+    if OS.linux?
       setup_test_formula "patchelf"
-      (HOMEBREW_CELLAR/"patchelf/1.0/bin").mkpath
-
-      expect { brew "bottle", "--no-rebuild", testball }
-        .to output(/Formula not from core or any installed taps/).to_stderr
-        .and not_to_output.to_stdout
-        .and be_a_failure
-
-      expect { brew "bottle", "--root-url" }
-        .to output(/missing argument: --root-url/).to_stderr
-        .and not_to_output.to_stdout
-        .and be_a_failure
-
-      setup_test_formula "testball"
-
-      # `brew bottle` should not fail with dead symlink
-      # https://github.com/Homebrew/legacy-homebrew/issues/49007
-      (HOMEBREW_CELLAR/"testball/0.1").cd do
-        FileUtils.ln_s "not-exist", "symlink"
-      end
-
-      expect { brew "bottle", "--no-rebuild", "testball" }
-        .to output(/testball--0\.1.*\.bottle\.tar\.gz/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    ensure
-      FileUtils.rm_f Dir.glob("testball--0.1*.bottle.tar.gz")
+      patchelf = HOMEBREW_CELLAR/"patchelf/1.0/bin/patchelf"
+      patchelf.dirname.mkpath
+      patchelf.write <<~EOS
+        #!/bin/sh
+        exit 0
+      EOS
+      FileUtils.chmod "+x", patchelf
+      FileUtils.ln_s patchelf, HOMEBREW_PREFIX/"bin/patchelf"
     end
+
+    install_test_formula "testball", build_bottle: true
+
+    # `brew bottle` should not fail with dead symlink
+    # https://github.com/Homebrew/legacy-homebrew/issues/49007
+    (HOMEBREW_CELLAR/"testball/0.1").cd do
+      FileUtils.ln_s "not-exist", "symlink"
+    end
+
+    expect { brew "bottle", "--no-rebuild", "testball" }
+      .to output(/testball--0\.1.*\.bottle\.tar\.gz/).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
   end
 end

--- a/Library/Homebrew/test/dev-cmd/extract_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/extract_spec.rb
@@ -15,12 +15,6 @@ describe "brew extract", :integration_test do
       system "git", "add", "--all"
       system "git", "commit", "-m", "testball 0.2"
     end
-    expect { brew "extract", "testball", target.name }
-      .to be_a_success
-
-    expect(path/"Formula/testball@0.2.rb").to exist
-
-    expect(Formulary.factory(path/"Formula/testball@0.2.rb").version).to be == "0.2"
 
     expect { brew "extract", "testball", target.name, "--version=0.1" }
       .to be_a_success

--- a/Library/Homebrew/test/dev-cmd/irb_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/irb_spec.rb
@@ -14,11 +14,4 @@ describe "brew irb", :integration_test do
       .and not_to_output.to_stderr
       .and be_a_success
   end
-
-  specify "--examples" do
-    expect { brew "irb", "--examples" }
-      .to output(/'v8'\.f # => instance of the v8 formula/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
 end

--- a/Library/Homebrew/test/dev-cmd/linkage_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/linkage_spec.rb
@@ -10,10 +10,4 @@ describe "brew linkage", :integration_test do
       .and not_to_output.to_stdout
       .and not_to_output.to_stderr
   end
-
-  it "works when one argument is provided" do
-    expect { brew "linkage", "testball" }
-      .to be_a_success
-      .and not_to_output.to_stderr
-  end
 end

--- a/Library/Homebrew/test/dev-cmd/pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pull_spec.rb
@@ -5,24 +5,6 @@ describe "brew pull", :integration_test do
       system "git", "checkout", "-b", "new-branch"
     end
 
-    expect { brew "pull", "https://jenkins.brew.sh/job/Homebrew\%20Testing/1028/" }
-      .to output(/Testing URLs require `\-\-bottle`!/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
-    # Needs Homebrew/homebrew-core
-    if OS.mac?
-      expect { brew "pull", "1" }
-        .to output(/Fetching patch/).to_stdout
-        .and output(/Current branch is new\-branch/).to_stderr
-        .and be_a_failure
-    end
-
-    expect { brew "pull", "--bump", "https://api.github.com/repos/Homebrew/homebrew-core/pulls/122" }
-      .to output(/Fetching patch/).to_stdout
-      .and output(/Can only bump one changed formula/).to_stderr
-      .and be_a_failure
-
     expect { brew "pull", "https://github.com/Homebrew/brew/pull/1249" }
       .to output(/Fetching patch/).to_stdout
       .and output(/Patch failed to apply/).to_stderr

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -1,27 +1,12 @@
 describe "brew test", :integration_test do
   it "tests a given Formula" do
-    setup_test_formula "testball", <<~RUBY
-      head "https://github.com/example/testball2.git"
-
-      devel do
-        url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
-        sha256 "#{TESTBALL_SHA256}"
-      end
-
-      keg_only "just because"
-
+    install_test_formula "testball", <<~'RUBY'
       test do
+        assert_equal "test", shell_output("#{bin}/test")
       end
     RUBY
 
-    expect { brew "install", "testball" }.to be_a_success
-
-    expect { brew "test", "--HEAD", "testball" }
-      .to output(/Testing testball/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "test", "--devel", "testball" }
+    expect { brew "test", "--verbose", "testball" }
       .to output(/Testing testball/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -140,6 +140,7 @@ RSpec.configure do |config|
 
     begin
       Tap.clear_cache
+      FormulaInstaller.clear_attempted
 
       TEST_DIRECTORIES.each(&:mkpath)
 
@@ -189,6 +190,7 @@ RSpec.configure do |config|
         CoreTap.instance.path/".git",
         CoreTap.instance.alias_dir,
         CoreTap.instance.path/"formula_renames.json",
+        *Pathname.glob("#{HOMEBREW_CELLAR}/*/"),
       ]
 
       files_after_test = find_files

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -1,5 +1,7 @@
 require "open3"
 
+require "formula_installer"
+
 RSpec::Matchers.define_negated_matcher :be_a_failure, :be_a_success
 
 RSpec.shared_context "integration test" do
@@ -140,7 +142,7 @@ RSpec.shared_context "integration test" do
           (prefix/"foo"/"test").write("test") if build.with? "foo"
           prefix.install Dir["*"]
           (buildpath/"test.c").write \
-            "#include <stdio.h>\\nint main(){return printf(\\"test\\");}"
+            "#include <stdio.h>\\nint main(){printf(\\"test\\");return 0;}"
           bin.mkpath
           system ENV.cc, "test.c", "-o", bin/"test"
         end
@@ -171,6 +173,15 @@ RSpec.shared_context "integration test" do
         end
       RUBY
     end
+  end
+
+  def install_test_formula(name, content = nil, build_bottle: false)
+    setup_test_formula(name, content)
+    fi = FormulaInstaller.new(Formula[name])
+    fi.build_bottle = build_bottle
+    fi.prelude
+    fi.install
+    fi.finish
   end
 
   def setup_remote_tap(name)


### PR DESCRIPTION
Integration tests are useful in detecting breakages but much slower so let's only use one per command and install formula outside the integration test framework (which is also slow).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----