### PR TITLE
linux.rb: define language/languages methods

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -15,6 +15,18 @@ module OS
       Version::NULL
     end
 
+    def languages
+      @languages ||= [
+        *ARGV.value("language")&.split(","),
+        *ENV["HOMEBREW_LANGUAGES"]&.split(","),
+        *ENV["LANG"]&.slice(/[a-z]+/),
+      ].uniq
+    end
+
+    def language
+      languages.first
+    end
+
     module Xcode
       module_function
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Port the `language` and `languages` methods to Linux so that casks with a [`language`](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/all_stanzas.md#optional-stanzas) stanza can be parsed. Fixes issue mentioned in Homebrew/formulae.brew.sh#118.