### PR TITLE
Cleanup from dev-cmd test changes

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -17,7 +17,6 @@ class Keg
     return if !file.elf? || !file.dynamic_elf?
 
     patchelf = DevelopmentTools.locate "patchelf"
-
     cmd_rpath = [patchelf, "--print-rpath", file]
     old_rpath = Utils.popen_read(*cmd_rpath, err: :out).strip
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -191,6 +191,7 @@ RSpec.configure do |config|
         CoreTap.instance.alias_dir,
         CoreTap.instance.path/"formula_renames.json",
         *Pathname.glob("#{HOMEBREW_CELLAR}/*/"),
+        *Pathname.glob("testball*.bottle.tar.gz"),
       ]
 
       files_after_test = find_files


### PR DESCRIPTION
From https://github.com/Homebrew/brew/pull/5937:

- Remove added whitespace in `extend/os/linux/keg_relocate`
- Cleanup testball bottles

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----