### PR TITLE
Cleanup cmd/* tests

### DIFF
--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -1,11 +1,10 @@
-describe "brew --cache", :integration_test do
-  it "print the location of Homebrew's cache when no argument is given" do
-    expect { brew "--cache" }
-      .to output("#{HOMEBREW_CACHE}\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
+require "cmd/shared_examples/args_parse"
 
+describe "Homebrew.__cache_args" do
+  it_behaves_like "parseable arguments"
+end
+
+describe "brew --cache", :integration_test do
   it "prints all cache files for a given Formula" do
     expect { brew "--cache", testball }
       .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}\-\-testball\-}).to_stdout

--- a/Library/Homebrew/test/cmd/--cellar_spec.rb
+++ b/Library/Homebrew/test/cmd/--cellar_spec.rb
@@ -1,11 +1,10 @@
-describe "brew --cellar", :integration_test do
-  it "print the location of Homebrew's Cellar when no argument is given" do
-    expect { brew "--cellar" }
-      .to output("#{HOMEBREW_CELLAR}\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
+require "cmd/shared_examples/args_parse"
 
+describe "Homebrew.__cellar_args" do
+  it_behaves_like "parseable arguments"
+end
+
+describe "brew --cellar", :integration_test do
   it "returns the Cellar subdirectory for a given Formula" do
     expect { brew "--cellar", testball }
       .to output(%r{#{HOMEBREW_CELLAR}/testball}).to_stdout

--- a/Library/Homebrew/test/cmd/--env_spec.rb
+++ b/Library/Homebrew/test/cmd/--env_spec.rb
@@ -1,42 +1,14 @@
-describe "brew --env", :integration_test do
-  it "prints the Homebrew build environment variables" do
-    expect { brew "--env" }
-      .to output(/CMAKE_PREFIX_PATH="#{Regexp.escape(HOMEBREW_PREFIX)}[:"]/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
+require "cmd/shared_examples/args_parse"
 
+describe "Homebrew.__env_args" do
+  it_behaves_like "parseable arguments"
+end
+
+describe "brew --env", :integration_test do
   describe "--shell=bash" do
     it "prints the Homebrew build environment variables in Bash syntax" do
       expect { brew "--env", "--shell=bash" }
         .to output(/export CMAKE_PREFIX_PATH="#{Regexp.quote(HOMEBREW_PREFIX)}"/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
-
-  describe "--shell=fish" do
-    it "prints the Homebrew build environment variables in Fish syntax" do
-      expect { brew "--env", "--shell=fish" }
-        .to output(/set [-]gx CMAKE_PREFIX_PATH "#{Regexp.quote(HOMEBREW_PREFIX)}"/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
-
-  describe "--shell=tcsh" do
-    it "prints the Homebrew build environment variables in Tcsh syntax" do
-      expect { brew "--env", "--shell=tcsh" }
-        .to output(/setenv CMAKE_PREFIX_PATH #{Regexp.quote(HOMEBREW_PREFIX)};/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
-
-  describe "--plain" do
-    it "prints the Homebrew build environment variables without quotes" do
-      expect { brew "--env", "--plain" }
-        .to output(/CMAKE_PREFIX_PATH: #{Regexp.quote(HOMEBREW_PREFIX)}/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     end

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -1,11 +1,10 @@
-describe "brew --prefix", :integration_test do
-  it "prints the Homebrew prefix when no argument is given" do
-    expect { brew "--prefix" }
-      .to output("#{HOMEBREW_PREFIX}\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
+require "cmd/shared_examples/args_parse"
 
+describe "Homebrew.__prefix_args" do
+  it_behaves_like "parseable arguments"
+end
+
+describe "brew --prefix", :integration_test do
   it "prints a given Formula's prefix" do
     expect { brew "--prefix", testball }
       .to output(%r{#{HOMEBREW_CELLAR}/testball}).to_stdout

--- a/Library/Homebrew/test/cmd/--repository_spec.rb
+++ b/Library/Homebrew/test/cmd/--repository_spec.rb
@@ -1,11 +1,10 @@
-describe "brew --repository", :integration_test do
-  it "prints the path of the Homebrew repository" do
-    expect { brew "--repository" }
-      .to output("#{HOMEBREW_REPOSITORY}\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
+require "cmd/shared_examples/args_parse"
 
+describe "Homebrew.__repository_args" do
+  it_behaves_like "parseable arguments"
+end
+
+describe "brew --repository", :integration_test do
   it "prints the path of a given Tap" do
     expect { brew "--repository", "foo/bar" }
       .to output("#{HOMEBREW_LIBRARY}/Taps/foo/homebrew-bar\n").to_stdout

--- a/Library/Homebrew/test/cmd/--version_spec.rb
+++ b/Library/Homebrew/test/cmd/--version_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.__version_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew --version", :integration_test do
   it "prints the Homebrew version" do
     expect { brew "--version" }

--- a/Library/Homebrew/test/cmd/analytics_spec.rb
+++ b/Library/Homebrew/test/cmd/analytics_spec.rb
@@ -1,36 +1,19 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.analytics_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew analytics", :integration_test do
-  before do
+  it "when HOMEBREW_NO_ANALYTICS is unset is disabled after running `brew analytics off`" do
     HOMEBREW_REPOSITORY.cd do
       system "git", "init"
     end
-  end
 
-  it "is disabled when HOMEBREW_NO_ANALYTICS is set" do
-    expect { brew "analytics", "HOMEBREW_NO_ANALYTICS" => "1" }
-      .to output(/Analytics is disabled \(by HOMEBREW_NO_ANALYTICS\)/).to_stdout
+    brew "analytics", "off"
+    expect { brew "analytics", "HOMEBREW_NO_ANALYTICS" => nil }
+      .to output(/Analytics is disabled/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
-  end
-
-  context "when HOMEBREW_NO_ANALYTICS is unset" do
-    it "is disabled after running `brew analytics off`" do
-      brew "analytics", "off"
-      expect { brew "analytics", "HOMEBREW_NO_ANALYTICS" => nil }
-        .to output(/Analytics is disabled/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-
-    it "is enabled after running `brew analytics on`" do
-      brew "analytics", "on"
-      expect { brew "analytics", "HOMEBREW_NO_ANALYTICS" => nil }
-        .to output(/Analytics is enabled/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
-
-  it "can generate a new UUID" do
-    expect { brew "analytics", "regenerate-uuid" }.to be_a_success
   end
 end

--- a/Library/Homebrew/test/cmd/cat_spec.rb
+++ b/Library/Homebrew/test/cmd/cat_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.cat_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew cat", :integration_test do
   it "prints the content of a given Formula" do
     formula_file = setup_test_formula "testball"
@@ -7,14 +13,5 @@ describe "brew cat", :integration_test do
       .to output(content).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
-  end
-
-  it "fails when given multiple arguments" do
-    setup_test_formula "foo"
-    setup_test_formula "bar"
-    expect { brew "cat", "foo", "bar" }
-      .to output(/doesn't support multiple arguments/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
   end
 end

--- a/Library/Homebrew/test/cmd/cleanup_spec.rb
+++ b/Library/Homebrew/test/cmd/cleanup_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.cleanup_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew cleanup", :integration_test do
   describe "--prune=all" do
     it "removes all files in Homebrew's cache" do

--- a/Library/Homebrew/test/cmd/command_spec.rb
+++ b/Library/Homebrew/test/cmd/command_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.command_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew command", :integration_test do
   it "returns the file for a given command" do
     expect { brew "command", "info" }

--- a/Library/Homebrew/test/cmd/commands_spec.rb
+++ b/Library/Homebrew/test/cmd/commands_spec.rb
@@ -2,19 +2,18 @@ require "cmd/command"
 require "cmd/commands"
 require "fileutils"
 
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.commands_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew commands", :integration_test do
   it "prints a list of all available commands" do
     expect { brew "commands" }
       .to output(/Built-in commands/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
-  end
-
-  it "prints a list without headers with the --quiet flag" do
-    expect { brew "commands", "--quiet" }
-      .to be_a_success
-      .and not_to_output.to_stderr
-      .and not_to_output(/Built-in commands/).to_stdout
   end
 end
 

--- a/Library/Homebrew/test/cmd/config_spec.rb
+++ b/Library/Homebrew/test/cmd/config_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.config_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew config", :integration_test do
   it "prints information about the current Homebrew configuration" do
     expect { brew "config" }

--- a/Library/Homebrew/test/cmd/deps_spec.rb
+++ b/Library/Homebrew/test/cmd/deps_spec.rb
@@ -1,21 +1,12 @@
 describe "brew deps", :integration_test do
-  before do
+  it "outputs all of a Formula's dependencies and their dependencies on separate lines" do
     setup_test_formula "foo"
     setup_test_formula "bar"
     setup_test_formula "baz", <<~RUBY
       url "https://brew.sh/baz-1.0"
       depends_on "bar"
     RUBY
-  end
 
-  it "outputs no dependencies for a Formula that has no dependencies" do
-    expect { brew "deps", "foo" }
-      .to be_a_success
-      .and not_to_output.to_stdout
-      .and not_to_output.to_stderr
-  end
-
-  it "outputs all of a Formula's dependencies and their dependencies on separate lines" do
     expect { brew "deps", "baz" }
       .to be_a_success
       .and output("bar\nfoo\n").to_stdout

--- a/Library/Homebrew/test/cmd/desc_spec.rb
+++ b/Library/Homebrew/test/cmd/desc_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.desc_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew desc", :integration_test do
   it "shows a given Formula's description" do
     setup_test_formula "testball"

--- a/Library/Homebrew/test/cmd/diy_spec.rb
+++ b/Library/Homebrew/test/cmd/diy_spec.rb
@@ -1,0 +1,5 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.diy_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/Library/Homebrew/test/cmd/doctor_spec.rb
+++ b/Library/Homebrew/test/cmd/doctor_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.doctor_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew doctor", :integration_test do
   specify "check_integration_test" do
     expect { brew "doctor", "check_integration_test" }

--- a/Library/Homebrew/test/cmd/fetch_spec.rb
+++ b/Library/Homebrew/test/cmd/fetch_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.fetch_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew fetch", :integration_test do
   it "downloads the Formula's URL" do
     setup_test_formula "testball"

--- a/Library/Homebrew/test/cmd/gist-logs_spec.rb
+++ b/Library/Homebrew/test/cmd/gist-logs_spec.rb
@@ -1,0 +1,5 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.gist_logs_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -1,39 +1,9 @@
 describe "brew", :integration_test do
-  it "prints help when no argument is given" do
-    expect { brew }
-      .to output(/Example usage:\n/).to_stderr
-      .and be_a_failure
-  end
-
   describe "help" do
-    it "prints help" do
-      expect { brew "help" }
-        .to output(/Example usage:\n/).to_stdout
-        .and be_a_success
-    end
-
     it "prints help for a documented Ruby command" do
       expect { brew "help", "cat" }
         .to output(/^Usage: brew cat/).to_stdout
         .and be_a_success
-    end
-
-    it "prints help for a documented shell command" do
-      expect { brew "help", "update" }
-        .to output(/^Usage: brew update/).to_stdout
-        .and be_a_success
-    end
-
-    it "prints help for a documented Ruby developer command" do
-      expect { brew "help", "update-test" }
-        .to output(/^Usage: brew update-test/).to_stdout
-        .and be_a_success
-    end
-
-    it "fails when given an unknown command" do
-      expect { brew "help", "command-that-does-not-exist" }
-        .to output(/Unknown command: command-that-does-not-exist/).to_stderr
-        .and be_a_failure
     end
   end
 

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -1,11 +1,10 @@
-describe "brew home", :integration_test do
-  it "opens the Homebrew homepage when no argument is given" do
-    expect { brew "home", "HOMEBREW_BROWSER" => "echo" }
-      .to output("#{HOMEBREW_WWW}\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
+require "cmd/shared_examples/args_parse"
 
+describe "Homebrew.home_args" do
+  it_behaves_like "parseable arguments"
+end
+
+describe "brew home", :integration_test do
   it "opens the homepage for a given Formula" do
     setup_test_formula "testballhome"
 

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -1,18 +1,15 @@
 require "cmd/info"
 
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.info_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew info", :integration_test do
-  before do
-    setup_test_formula "testball"
-  end
-
-  it "prints information about a given Formula" do
-    expect { brew "info", "testball" }
-      .to output(/testball: stable 0.1/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
-
   it "prints as json with the --json=v1 flag" do
+    setup_test_formula "testball"
+
     expect { brew "info", "testball", "--json=v1" }
       .to output(a_json_string).to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cmd/install_spec.rb
@@ -1,96 +1,21 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.install_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew install", :integration_test do
-  it "installs Formulae" do
+  it "installs formulae" do
     setup_test_formula "testball1"
 
     expect { brew "install", "testball1" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
-
-    expect { brew "install", "testball1" }
-      .to output(/testball1\ 0\.1 is already installed/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_success
-
-    expect { brew "install", "formula" }
-      .to output(/No available formula/).to_stderr
-      .and output(/Searching for similarly named formulae/).to_stdout
-      .and be_a_failure
-
-    setup_test_formula "testball2"
-    install_and_rename_coretap_formula "testball1", "testball2"
-    expect { brew "install", "testball2" }
-      .to output(/testball1 already installed, it's just not migrated/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_success
-  end
-
-  specify "install failures" do
-    path = setup_test_formula "testball1", <<~RUBY
-      version "1.0"
-    RUBY
-
-    expect { brew "install", "testball1" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/1\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    FileUtils.rm path
-    setup_test_formula "testball1", <<~RUBY
-      version "2.0"
-
-      devel do
-        url "#{Formulary.factory("testball1").stable.url}"
-        sha256 "#{Formulary.factory("testball1").stable.checksum.hexdigest}"
-        version "3.0"
-      end
-    RUBY
-
-    expect { brew "install", "testball1" }
-      .to output(/`brew upgrade testball1`/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-
-    expect { brew "unlink", "testball1" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/1\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "install", "testball1", "--devel" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/3\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "unlink", "testball1" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/3\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "install", "testball1" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/2\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "switch", "testball1", "3.0" }.to be_a_success
-
-    expect { brew "install", "testball1" }
-      .to output(/2.0 is already installed/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_success
-
-    expect { brew "unlink", "testball1" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/3\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "install", "testball1" }
-      .to output(/just not linked/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_success
   end
 
   it "can install keg-only Formulae" do
-    path_keg_only = setup_test_formula "testball1", <<~RUBY
+    setup_test_formula "testball1", <<~RUBY
       version "1.0"
 
       keg_only "test reason"
@@ -98,23 +23,6 @@ describe "brew install", :integration_test do
 
     expect { brew "install", "testball1" }
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/1\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    FileUtils.rm path_keg_only
-    setup_test_formula "testball1", <<~RUBY
-      version "2.0"
-
-      keg_only "test reason"
-    RUBY
-
-    expect { brew "install", "testball1" }
-      .to output(/testball1 1.0 is already installed/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_success
-
-    expect { brew "install", "testball1", "--force" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/2\.0}).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end
@@ -149,59 +57,5 @@ describe "brew install", :integration_test do
       .to output(%r{#{HOMEBREW_CELLAR}/testball1/HEAD\-d5eb689}).to_stdout
       .and output(/Cloning into/).to_stderr
       .and be_a_success
-
-    expect { brew "install", "testball1", "--HEAD", "--ignore-dependencies" }
-      .to output(/testball1 HEAD\-d5eb689 is already installed/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_success
-
-    expect { brew "unlink", "testball1" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/HEAD\-d5eb689}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "install", "testball1" }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball1/1\.0}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
-
-  it "rejects invalid options" do
-    setup_test_formula "testball1"
-    expect { brew "install", "testball1", "--invalid" }
-      .to output(/Error: invalid option: --invalid/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  it "succeeds when a non-fatal requirement isn't satisfied" do
-    setup_test_formula "testball1", <<~RUBY
-      class NonFatalRequirement < Requirement
-        satisfy(build_env: false) { false }
-      end
-
-      depends_on NonFatalRequirement
-    RUBY
-
-    expect { brew "install", "testball1" }
-      .to output(/NonFatalRequirement unsatisfied!/).to_stderr
-      .and output(/built in/).to_stdout
-      .and be_a_success
-  end
-
-  it "fails when a fatal requirement isn't satisfied" do
-    setup_test_formula "testball1", <<~RUBY
-      class FatalRequirement < Requirement
-        fatal true
-        satisfy { false }
-      end
-
-      depends_on FatalRequirement
-    RUBY
-
-    expect { brew "install", "testball1" }
-      .to output(/FatalRequirement unsatisfied!/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
   end
 end

--- a/Library/Homebrew/test/cmd/leaves_spec.rb
+++ b/Library/Homebrew/test/cmd/leaves_spec.rb
@@ -1,22 +1,17 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.leaves_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew leaves", :integration_test do
   it "prints all Formulae that are not dependencies of other Formulae" do
     setup_test_formula "foo"
     setup_test_formula "bar"
-
-    expect { brew "leaves" }
-      .to be_a_success
-      .and not_to_output.to_stdout
-      .and not_to_output.to_stderr
-
     (HOMEBREW_CELLAR/"foo/0.1/somedir").mkpath
+
     expect { brew "leaves" }
       .to output("foo\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    (HOMEBREW_CELLAR/"bar/0.1/somedir").mkpath
-    expect { brew "leaves" }
-      .to output("bar\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -1,44 +1,17 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.link_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew link", :integration_test do
-  it "does not fail if the given Formula is already linked" do
-    setup_test_formula "testball1"
-
-    expect { brew "install", "testball1" }.to be_a_success
-    expect { brew "link", "testball1" }.to be_a_success
-  end
-
   it "links a given Formula" do
-    setup_test_formula "testball1"
+    install_test_formula "testball"
+    Formula["testball"].opt_or_installed_prefix_keg.unlink
 
-    expect { brew "install", "testball1" }.to be_a_success
-    expect { brew "unlink", "testball1" }.to be_a_success
-
-    expect { brew "link", "--dry-run", "testball1" }
-      .to output(/Would link/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "link", "--dry-run", "--overwrite", "testball1" }
-      .to output(/Would remove/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
-    expect { brew "link", "testball1" }
+    expect { brew "link", "testball" }
       .to output(/Linking/).to_stdout
       .and not_to_output.to_stderr
-      .and be_a_success
-  end
-
-  it "refuses to link keg-only Formulae" do
-    setup_test_formula "testball1", <<~RUBY
-      keg_only "just because"
-    RUBY
-
-    expect { brew "install", "testball1" }.to be_a_success
-
-    expect { brew "link", "testball1", "SHELL" => "/bin/zsh" }
-      .to output(/testball1 is keg-only/).to_stderr
-      .and output(a_string_matching(/If you need to have this software first in your PATH instead consider running:/)
-        .and(including("echo 'export PATH=\"#{HOMEBREW_PREFIX}/opt/testball1/bin:$PATH\"' >> ~/.zshrc"))).to_stdout
       .and be_a_success
   end
 end

--- a/Library/Homebrew/test/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cmd/list_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.list_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew list", :integration_test do
   let(:formulae) { %w[bar foo qux] }
 

--- a/Library/Homebrew/test/cmd/log_spec.rb
+++ b/Library/Homebrew/test/cmd/log_spec.rb
@@ -1,16 +1,10 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.log_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew log", :integration_test do
-  it "shows the Git log for the Homebrew repository when no argument is given" do
-    HOMEBREW_REPOSITORY.cd do
-      system "git", "init"
-      system "git", "commit", "--allow-empty", "-m", "This is a test commit"
-    end
-
-    expect { brew "log" }
-      .to output(/This is a test commit/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
-
   it "shows the Git log for a given Formula" do
     setup_test_formula "testball"
 

--- a/Library/Homebrew/test/cmd/migrate_spec.rb
+++ b/Library/Homebrew/test/cmd/migrate_spec.rb
@@ -1,10 +1,13 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.migrate_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew migrate", :integration_test do
-  before do
+  it "migrates a renamed Formula" do
     setup_test_formula "testball1"
     setup_test_formula "testball2"
-  end
-
-  it "migrates a renamed Formula" do
     install_and_rename_coretap_formula "testball1", "testball2"
 
     expect { brew "migrate", "testball1" }

--- a/Library/Homebrew/test/cmd/missing_spec.rb
+++ b/Library/Homebrew/test/cmd/missing_spec.rb
@@ -1,41 +1,19 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.missing_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew missing", :integration_test do
-  before do
+  it "prints missing dependencies" do
     setup_test_formula "foo"
     setup_test_formula "bar"
-  end
 
-  def make_prefix(name)
-    (HOMEBREW_CELLAR/name/"1.0").mkpath
-  end
-
-  it "prints missing dependencies" do
-    make_prefix "bar"
+    (HOMEBREW_CELLAR/"bar/1.0").mkpath
 
     expect { brew "missing" }
       .to output("foo\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_failure
-  end
-
-  it "prints nothing if all dependencies are installed" do
-    make_prefix "foo"
-    make_prefix "bar"
-
-    expect { brew "missing" }
-      .to be_a_success
-      .and not_to_output.to_stdout
-      .and not_to_output.to_stderr
-  end
-
-  describe "--hide=" do
-    it "pretends that the specified Formulae are not installed" do
-      make_prefix "foo"
-      make_prefix "bar"
-
-      expect { brew "missing", "--hide=foo" }
-        .to output("bar: foo\n").to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_failure
-    end
   end
 end

--- a/Library/Homebrew/test/cmd/options_spec.rb
+++ b/Library/Homebrew/test/cmd/options_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.options_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew options", :integration_test do
   it "prints a given Formula's options" do
     setup_test_formula "testball", <<~RUBY

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -1,86 +1,27 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.outdated_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew outdated", :integration_test do
-  context "quiet output" do
-    it "prints outdated Formulae" do
-      setup_test_formula "testball"
-      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+  it "outputs JSON" do
+    setup_test_formula "testball"
+    (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 
-      setup_test_formula "foo"
-      (HOMEBREW_CELLAR/"foo/0.0.1/foo").mkpath
+    expected_json = [
+      {
+        name:               "testball",
+        installed_versions: ["0.0.1"],
+        current_version:    "0.1",
+        pinned:             false,
+        pinned_version:     nil,
+      },
+    ].to_json
 
-      expect { brew "outdated" }
-        .to output("foo\ntestball\n").to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
-
-  context "verbose output" do
-    it "prints out the installed and newer versions" do
-      setup_test_formula "testball"
-      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
-
-      expect { brew "outdated", "--verbose" }
-        .to output("testball (0.0.1) < 0.1\n").to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
-
-  context "pinned formula, verbose output" do
-    it "prints out the pinned version" do
-      setup_test_formula "testball"
-      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
-
-      expect { brew "pin", "testball" }.to be_a_success
-
-      expect { brew "outdated", "--verbose" }
-        .to output("testball (0.0.1) < 0.1 [pinned at 0.0.1]\n").to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-  end
-
-  context "json output" do
-    it "includes pinned version in the json output" do
-      setup_test_formula "testball"
-      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
-
-      expect { brew "pin", "testball" }.to be_a_success
-
-      expected_json = [
-        {
-          name:               "testball",
-          installed_versions: ["0.0.1"],
-          current_version:    "0.1",
-          pinned:             true,
-          pinned_version:     "0.0.1",
-        },
-      ].to_json
-
-      expect { brew "outdated", "--json=v1" }
-        .to output(expected_json + "\n").to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
-
-    it "has no pinned version when the formula isn't pinned" do
-      setup_test_formula "testball"
-      (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
-
-      expected_json = [
-        {
-          name:               "testball",
-          installed_versions: ["0.0.1"],
-          current_version:    "0.1",
-          pinned:             false,
-          pinned_version:     nil,
-        },
-      ].to_json
-
-      expect { brew "outdated", "--json=v1" }
-        .to output(expected_json + "\n").to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
+    expect { brew "outdated", "--json=v1" }
+      .to output(expected_json + "\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
   end
 end

--- a/Library/Homebrew/test/cmd/pin_spec.rb
+++ b/Library/Homebrew/test/cmd/pin_spec.rb
@@ -1,11 +1,13 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.pin_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew pin", :integration_test do
   it "pins a Formula's version" do
-    setup_test_formula "testball"
-    (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+    install_test_formula "testball"
 
     expect { brew "pin", "testball" }.to be_a_success
-    expect { brew "upgrade" }.to be_a_failure
-
-    expect(HOMEBREW_CELLAR/"testball/0.1").not_to be_a_directory
   end
 end

--- a/Library/Homebrew/test/cmd/postinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/postinstall_spec.rb
@@ -1,0 +1,5 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.postinstall_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/Library/Homebrew/test/cmd/readall_spec.rb
+++ b/Library/Homebrew/test/cmd/readall_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.readall_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew readall", :integration_test do
   it "imports all Formulae for a given Tap" do
     formula_file = setup_test_formula "testball"
@@ -8,11 +14,6 @@ describe "brew readall", :integration_test do
     FileUtils.ln_s formula_file, alias_file
 
     expect { brew "readall", "--aliases", "--syntax" }
-      .to be_a_success
-      .and not_to_output.to_stdout
-      .and not_to_output.to_stderr
-
-    expect { brew "readall", "homebrew/core" }
       .to be_a_success
       .and not_to_output.to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -1,42 +1,22 @@
 require "extend/ENV"
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.reinstall_args" do
+  it_behaves_like "parseable arguments"
+end
 
 describe "brew reinstall", :integration_test do
-  before do
-    setup_test_formula "testball"
-
-    expect { brew "install", "testball", "--with-foo" }.to be_a_success
-  end
-
   it "reinstalls a Formula" do
-    foo_dir = HOMEBREW_CELLAR/"testball/0.1/foo"
+    install_test_formula "testball"
+    foo_dir = HOMEBREW_CELLAR/"testball/0.1/bin"
     expect(foo_dir).to exist
     foo_dir.rmtree
 
     expect { brew "reinstall", "testball" }
-      .to output(/Reinstalling testball --with-foo/).to_stdout
+      .to output(/Reinstalling testball/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
 
     expect(foo_dir).to exist
-  end
-
-  it "reinstalls a Formula even when one of the options is invalid" do
-    expect { brew "reinstall", "testball", "--invalid" }
-      .to output(/Error: invalid option: --invalid/).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_failure
-  end
-
-  it "refuses to reinstall a pinned Formula, but doesn't fail" do
-    (HOMEBREW_CELLAR/"testball/0.1").mkpath
-    HOMEBREW_PINNED_KEGS.mkpath
-    FileUtils.ln_s HOMEBREW_CELLAR/"testball/0.1", HOMEBREW_PINNED_KEGS/"testball"
-
-    expect { brew "reinstall", "testball" }
-      .to output(/testball is pinned. You must unpin it to reinstall./).to_stderr
-      .and not_to_output.to_stdout
-      .and be_a_success
-
-    HOMEBREW_PINNED_KEGS.rmtree
   end
 end

--- a/Library/Homebrew/test/cmd/search_spec.rb
+++ b/Library/Homebrew/test/cmd/search_spec.rb
@@ -1,66 +1,17 @@
 require "cmd/search"
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.search_args" do
+  it_behaves_like "parseable arguments"
+end
 
 describe "brew search", :integration_test do
-  before do
-    setup_test_formula "testball"
-  end
-
-  it "lists all available Formulae when no argument is given" do
-    expect { brew "search" }
-      .to output(/testball/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
-
-  it "supports searching by name" do
-    expect { brew "search", "testball" }
-      .to output(/testball/).to_stdout
-      .and be_a_success
-  end
-
-  it "supports searching a fully-qualified name " do
-    expect { brew "search", "homebrew/homebrew-core/testball" }
-      .to output(/testball/).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-  end
-
   it "falls back to a GitHub tap search when no formula is found", :needs_network do
+    setup_test_formula "testball"
     setup_remote_tap "homebrew/cask"
 
     expect { brew "search", "homebrew/cask/firefox" }
       .to output(/firefox/).to_stdout
       .and be_a_success
-  end
-
-  describe "--desc" do
-    let(:desc_cache) { HOMEBREW_CACHE/"descriptions.json" }
-
-    it "supports searching in descriptions and creates a description cache" do
-      expect(desc_cache).not_to exist
-
-      expect { brew "search", "--desc", "Some test" }
-        .to output(/testball/).to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-
-      expect(desc_cache).to exist
-    end
-  end
-
-  {
-    "macports" => "https://www.macports.org/ports.php?by=name&substr=testball",
-    "fink"     => "http://pdb.finkproject.org/pdb/browse.php?summary=testball",
-    "debian"   => "https://packages.debian.org/search?keywords=testball&searchon=names&suite=all&section=all",
-    "opensuse" => "https://software.opensuse.org/search?q=testball",
-    "fedora"   => "https://apps.fedoraproject.org/packages/s/testball",
-    "ubuntu"   => "https://packages.ubuntu.com/search?keywords=testball&searchon=names&suite=all&section=all",
-  }.each do |flag, url|
-    specify "--#{flag}" do
-      expect { brew "search", "--#{flag}", "testball", "HOMEBREW_BROWSER" => "echo" }
-        .to output("#{url}\n").to_stdout
-        .and not_to_output.to_stderr
-        .and be_a_success
-    end
   end
 end

--- a/Library/Homebrew/test/cmd/sh_spec.rb
+++ b/Library/Homebrew/test/cmd/sh_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.sh_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew sh", :integration_test do
   it "runs a shell with the Homebrew environment" do
     expect { brew "sh", "SHELL" => which("true") }

--- a/Library/Homebrew/test/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cmd/style_spec.rb
@@ -1,4 +1,9 @@
 require "cmd/style"
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.style_args" do
+  it_behaves_like "parseable arguments"
+end
 
 describe "brew style" do
   around do |example|

--- a/Library/Homebrew/test/cmd/switch_spec.rb
+++ b/Library/Homebrew/test/cmd/switch_spec.rb
@@ -1,16 +1,18 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.switch_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew switch", :integration_test do
   it "allows switching between Formula versions" do
-    setup_test_formula "testball", <<~RUBY
-      keg_only "just because"
-    RUBY
-
-    expect { brew "install", "testball" }.to be_a_success
+    install_test_formula "testball"
 
     testball_rack = HOMEBREW_CELLAR/"testball"
     FileUtils.cp_r testball_rack/"0.1", testball_rack/"0.2"
 
     expect { brew "switch", "testball", "0.2" }
-      .to output(/link created/).to_stdout
+      .to output(/links created/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/tap-info_spec.rb
+++ b/Library/Homebrew/test/cmd/tap-info_spec.rb
@@ -8,11 +8,6 @@ describe "brew tap-info", :integration_test do
   it "gets information for a given Tap" do
     setup_test_tap
 
-    expect { brew "tap-info", "homebrew/foo" }
-      .to output(%r{https://github\.com/Homebrew/homebrew-foo}).to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
-
     expect { brew "tap-info", "--json=v1", "--installed" }
       .to output(%r{https://github\.com/Homebrew/homebrew-foo}).to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -1,10 +1,16 @@
 require "cmd/uninstall"
 
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.uninstall_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew uninstall", :integration_test do
   it "uninstalls a given Formula" do
-    expect { brew "install", testball }.to be_a_success
+    install_test_formula "testball"
 
-    expect { brew "uninstall", "--force", testball }
+    expect { brew "uninstall", "--force", "testball" }
       .to output(/Uninstalling testball/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success

--- a/Library/Homebrew/test/cmd/unlink_spec.rb
+++ b/Library/Homebrew/test/cmd/unlink_spec.rb
@@ -1,11 +1,15 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.unlink_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew unlink", :integration_test do
   it "unlinks a Formula" do
-    setup_test_formula "testball"
+    install_test_formula "testball"
 
-    expect { brew "install", "testball" }.to be_a_success
-
-    expect { brew "unlink", "--dry-run", "testball" }
-      .to output(/Would remove/).to_stdout
+    expect { brew "unlink", "testball" }
+      .to output(/Unlinking /).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/unpack_spec.rb
+++ b/Library/Homebrew/test/cmd/unpack_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.unpack_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew unpack", :integration_test do
   it "unpacks a given Formula's archive" do
     setup_test_formula "testball"

--- a/Library/Homebrew/test/cmd/unpin_spec.rb
+++ b/Library/Homebrew/test/cmd/unpin_spec.rb
@@ -1,12 +1,14 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.unpin_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew unpin", :integration_test do
   it "unpins a Formula's version" do
-    setup_test_formula "testball"
-    (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
+    install_test_formula "testball"
+    Formula["testball"].pin
 
-    expect { brew "pin", "testball" }.to be_a_success
     expect { brew "unpin", "testball" }.to be_a_success
-    expect { brew "upgrade" }.to be_a_success
-
-    expect(HOMEBREW_CELLAR/"testball/0.1").to be_a_directory
   end
 end

--- a/Library/Homebrew/test/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cmd/upgrade_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.upgrade_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew upgrade", :integration_test do
   it "upgrades a Formula and cleans up old versions" do
     setup_test_formula "testball"

--- a/Library/Homebrew/test/cmd/uses_spec.rb
+++ b/Library/Homebrew/test/cmd/uses_spec.rb
@@ -1,3 +1,9 @@
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.uses_args" do
+  it_behaves_like "parseable arguments"
+end
+
 describe "brew uses", :integration_test do
   it "prints the Formulae a given Formula is used by" do
     setup_test_formula "foo"
@@ -6,16 +12,6 @@ describe "brew uses", :integration_test do
       url "https://brew.sh/baz-1.0"
       depends_on "bar"
     RUBY
-
-    expect { brew "uses", "baz" }
-      .to be_a_success
-      .and not_to_output.to_stdout
-      .and not_to_output.to_stderr
-
-    expect { brew "uses", "bar" }
-      .to output("baz\n").to_stdout
-      .and not_to_output.to_stderr
-      .and be_a_success
 
     expect { brew "uses", "--recursive", "foo" }
       .to output(/(bar\nbaz|baz\nbar)/).to_stdout


### PR DESCRIPTION
- Test `_args` methods
- Remove multiple integration tests (except where essential e.g. `install`, `help`)

On my machine this vs. the commit before https://github.com/Homebrew/brew/pull/5928 results in a 22% speedup in test time and a 2.5% increase in coverage.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----