### PR TITLE
Remove search from brew-cask man page

### DIFF
--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -19,13 +19,6 @@ graphical user interface.
   * `uninstall` [--force] <token> [ <token> ... ]:
     Uninstall Cask identified by <token>.
 
-  * `search` <text> | /<regexp>/:
-    Perform a substring search of known Cask tokens for <text>. If the text
-    is delimited by slashes, it is interpreted as a Ruby regular expression.
-
-    The tokens returned by `search` are suitable as arguments for most other
-    commands, such as `install` or `uninstall`.
-
 ## COMMANDS
 
   * `audit` [--language=<iso-language>[,<iso-language> ... ]] [ <token> ... ]:
@@ -91,13 +84,6 @@ graphical user interface.
 
   * `reinstall` [--no-quarantine] <token> [ <token> ... ]:
     Reinstall the given Cask.
-
-  * `search` or `-S` [<text> | /<regexp>/]:
-    Without an argument, display all locally available Casks for install; no
-    online search is performed.
-    Otherwise perform a substring search of known Cask tokens for <text> or,
-    if the text is delimited by slashes (/<regexp>/), it is interpreted as a
-    Ruby regular expression.
 
   * `style` [--fix] [ <token> ... ]:
     Check the given Casks for correct style using RuboCop (with custom Cask cops).

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -22,13 +22,6 @@ Install Cask identified by \fItoken\fR\.
 \fBuninstall\fR [\-\-force] \fItoken\fR [ \fItoken\fR \.\.\. ]
 Uninstall Cask identified by \fItoken\fR\.
 .
-.TP
-\fBsearch\fR \fItext\fR | /\fIregexp\fR/
-Perform a substring search of known Cask tokens for \fItext\fR\. If the text is delimited by slashes, it is interpreted as a Ruby regular expression\.
-.
-.IP
-The tokens returned by \fBsearch\fR are suitable as arguments for most other commands, such as \fBinstall\fR or \fBuninstall\fR\.
-.
 .SH "COMMANDS"
 .
 .TP
@@ -93,10 +86,6 @@ Without token arguments, display all the installed Casks that have newer version
 .TP
 \fBreinstall\fR [\-\-no\-quarantine] \fItoken\fR [ \fItoken\fR \.\.\. ]
 Reinstall the given Cask\.
-.
-.TP
-\fBsearch\fR or \fB\-S\fR [\fItext\fR | /\fIregexp\fR/]
-Without an argument, display all locally available Casks for install; no online search is performed\. Otherwise perform a substring search of known Cask tokens for \fItext\fR or, if the text is delimited by slashes (/\fIregexp\fR/), it is interpreted as a Ruby regular expression\.
 .
 .TP
 \fBstyle\fR [\-\-fix] [ \fItoken\fR \.\.\. ]


### PR DESCRIPTION
`brew cask` no longer supports the `search` command, which was removed from
the `homebrew/brew-cask` documentation. However, it's still in the
`brew` repo's man page for `brew-cask`.

Remove search from the man page.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [N/A] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
