### PR TITLE
Retry with `ditto` when “End-of-central-directory signature not found.”.

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -548,6 +548,10 @@ class ErrorDuringExecution < RuntimeError
 
     super s
   end
+
+  def stderr
+    [*output].select { |type,| type == :stderr }.map(&:last).join
+  end
 end
 
 # Raised by {Pathname#verify_checksum} when "expected" is nil or empty.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes failure in https://github.com/Homebrew/homebrew-cask/pull/60779.