### PR TITLE
CompilerSelector: prefer the gcc version offered by the gcc formula

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -105,11 +105,19 @@ class CompilerSelector
 
   private
 
+  def gnu_gcc_versions
+    # prioritize gcc version provided by gcc formula.
+    v = Formulary.factory("gcc").version.to_s.slice(/\d/)
+    GNU_GCC_VERSIONS - [v] + [v] # move the version to the end of the list
+  rescue FormulaUnavailableError
+    GNU_GCC_VERSIONS
+  end
+
   def find_compiler
     compilers.each do |compiler|
       case compiler
       when :gnu
-        GNU_GCC_VERSIONS.reverse_each do |v|
+        gnu_gcc_versions.reverse_each do |v|
           name = "gcc-#{v}"
           version = compiler_version(name)
           yield Compiler.new(name, version) unless version.null?

--- a/Library/Homebrew/test/compiler_selector_spec.rb
+++ b/Library/Homebrew/test/compiler_selector_spec.rb
@@ -39,6 +39,12 @@ describe CompilerSelector do
       expect(subject.compiler).to eq("gcc-7")
     end
 
+    it "returns gcc-6 if gcc formula offers gcc-6" do
+      software_spec.fails_with(:clang)
+      allow(Formulary).to receive(:factory).with("gcc").and_return(double(version: "6.0"))
+      expect(subject.compiler).to eq("gcc-6")
+    end
+
     it "raises an error when gcc or llvm is missing" do
       software_spec.fails_with(:clang)
       software_spec.fails_with(gcc: "7")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When GCC is used (default for Linux), we should prefer the gcc offered
by the gcc formula. As such even if users install a gcc with higher
version from `gcc@*` formula, it will not be picked up to build other
formulae. This would also allow users to safely delete `gcc@*` formula.

Closes #5953.