### PR TITLE
Add bump-revision command

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "formula"
+require "cli/parser"
+
+module Homebrew
+  module_function
+
+  def bump_revision_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `bump-revision` [<options>] [<formula>]
+
+        Create a commit to increment the revision of the formula. If no revision is
+         present, "revision 1" will be added.
+      EOS
+      switch "-n", "--dry-run",
+        description: "Print what would be done rather than doing it."
+      flag "--message=",
+        description: "Append the provided <message> to the default commit message."
+
+      switch :force
+      switch :quiet
+      switch :verbose
+      switch :debug
+    end
+  end
+
+  def bump_revision
+    bump_revision_args.parse
+
+    # As this command is simplifying user run commands then let's just use a
+    # user path, too.
+    ENV["PATH"] = ENV["HOMEBREW_PATH"]
+
+    raise "Multiple formulae given, only one is allowed." if ARGV.formulae.length > 1
+
+    formula = ARGV.formulae.first
+    current_revision = formula.revision
+
+    if current_revision.zero?
+      formula_spec = formula.stable
+      hash_type, old_hash = if (checksum = formula_spec.checksum)
+        [checksum.hash_type, checksum.hexdigest]
+      end
+
+      if hash_type
+        # insert replacement revision after hash
+        old = <<~EOS
+          #{hash_type} "#{old_hash}"
+        EOS
+      else
+        # insert replacement revision after :revision
+        old = <<~EOS
+          :revision => "#{formula_spec.specs[:revision]}"
+        EOS
+      end
+      replacement = old + "  revision 1\n"
+
+    else
+      old = "revision #{current_revision}"
+      replacement = "revision #{current_revision+1}"
+    end
+
+    if args.dry_run?
+      ohai "replace #{old.inspect} with #{replacement.inspect}" unless Homebrew.args.quiet?
+    else
+      Utils::Inreplace.inreplace(formula.path) do |s|
+        s.gsub!(old, replacement)
+      end
+    end
+
+    message = "#{formula.name}: revision bump #{args.message}"
+    if args.dry_run?
+      ohai "git commit --no-edit --verbose --message=#{message} -- #{formula.path}"
+    else
+      formula.path.parent.cd do
+        safe_system "git", "commit", "--no-edit", "--verbose",
+          "--message=#{message}", "--", formula.path
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump-revision_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.bump_revision_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -739,6 +739,16 @@ formula already uses.
 * `--revision`:
   Specify the new git commit *`revision`* corresponding to a specified *`tag`*.
 
+### `bump-revision` [*`options`*] [*`formula`*]
+
+Create a commit to increment the revision of the formula. If no revision is
+ present, "revision 1" will be added.
+
+* `-n`, `--dry-run`:
+  Print what would be done rather than doing it.
+* `--message`:
+  Append the provided *`message`* to the default commit message.
+
 ### `create` [*`options`*] *`URL`*
 
 Generate a formula for the downloadable file at *`URL`* and open it in the editor.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -936,6 +936,17 @@ Specify the new git commit \fItag\fR for the formula\.
 \fB\-\-revision\fR
 Specify the new git commit \fIrevision\fR corresponding to a specified \fItag\fR\.
 .
+.SS "\fBbump\-revision\fR [\fIoptions\fR] [\fIformula\fR]"
+Create a commit to increment the revision of the formula\. If no revision is present, "revision 1" will be added\.
+.
+.TP
+\fB\-n\fR, \fB\-\-dry\-run\fR
+Print what would be done rather than doing it\.
+.
+.TP
+\fB\-\-message\fR
+Append the provided \fImessage\fR to the default commit message\.
+.
 .SS "\fBcreate\fR [\fIoptions\fR] \fIURL\fR"
 Generate a formula for the downloadable file at \fIURL\fR and open it in the editor\. Homebrew will attempt to automatically derive the formula name and version, but if it fails, you\'ll have to make your own template\. The \fBwget\fR formula serves as a simple example\. For the complete API, see: \fIhttp://www\.rubydoc\.info/github/Homebrew/brew/master/Formula\fR
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew bump-revision` will increase by one the revision of the formula or add "revision 1" if it doesn't exist.

I took the liberty of not opening an issue before the pull request since this is a feature I quickly discussed during the February 2019 meeting.

Points I am unsure:
- It currently only allows one formula as argument, should it handle many?
- The test is based on `bump-formula-pr`, should it extend to more cases?