### PR TITLE
Respect --greedy in cask upgrade completion

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -629,7 +629,8 @@ __brew_cask_complete_caskroom ()
 __brew_cask_complete_outdated ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local outdated=$(brew cask outdated --quiet)
+    local greedy=$(__brew_caskcomp_words_include "--greedy" && echo "--greedy")
+    local outdated=$(brew cask outdated --quiet $greedy)
     COMPREPLY=($(compgen -W "$outdated" -- "$cur"))
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The Bash autocompletion for `brew cask upgrade` does not complete outdated casks properly when `--greedy` is given. `__brew_cask_complete_outdated` should check whether it is present and act accordingly.