### PR TITLE
brew install --ignore-dependencies: unsupported, developer flag.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -32,8 +32,10 @@ module Homebrew
                      "If `super` is passed, use superenv even if the formula specifies the "\
                      "standard build environment."
       switch "--ignore-dependencies",
-        description: "Skip installing any dependencies of any kind. If they are not already "\
-                     "present, the formula will probably fail to install."
+        description: "An unsupported Homebrew development flag to skip installing any dependencies of "\
+                     "any kind. If the dependencies are not already present, the formula will have issues. "\
+                     "If you're not developing Homebrew, consider adjusting your PATH rather than "\
+                     "using this flag."
       switch "--only-dependencies",
         description: "Install the dependencies with specified options but do not install the "\
                      "specified formula."
@@ -91,6 +93,15 @@ module Homebrew
   def install
     install_args.parse
     raise FormulaUnspecifiedError if args.remaining.empty?
+
+    if args.ignore_dependencies?
+      opoo <<~EOS
+        #{Tty.bold}--ignore-dependencies is an unsupported Homebrew developer flag!#{Tty.reset}
+        Adjust your PATH to put any preferred versions of applications earlier in the
+        PATH rather than using this unsupported flag!
+
+      EOS
+    end
 
     unless args.force?
       ARGV.named.each do |name|

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -14,7 +14,7 @@ module Homebrew
       usage_banner <<~EOS
         `upgrade` [<options>] <formula>
 
-        Upgrade outdated, unpinned brews (with existing and any appended install options).
+        Upgrade outdated, unpinned formulae (with existing and any appended brew formula options).
 
         If <formula> are given, upgrade only the specified brews (unless they
         are pinned; see `pin`, `unpin`).

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -229,7 +229,7 @@ installed formulae or, every 30 days, for all formulae.
 * `--env`:
   If `std` is passed, use the standard build environment instead of superenv.If `super` is passed, use superenv even if the formula specifies the standard build environment.
 * `--ignore-dependencies`:
-  Skip installing any dependencies of any kind. If they are not already present, the formula will probably fail to install.
+  An unsupported Homebrew development flag to skip installing any dependencies of any kind. If the dependencies are not already present, the formula will have issues. If you're not developing Homebrew, consider adjusting your PATH rather than using this flag.
 * `--only-dependencies`:
   Install the dependencies with specified options but do not install the specified formula.
 * `--cc`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -545,7 +545,7 @@ Fetches and resets Homebrew and all tap repositories (or any specified `reposito
 
 ### `upgrade` [*`options`*] *`formula`*
 
-Upgrade outdated, unpinned brews (with existing and any appended install
+Upgrade outdated, unpinned formulae (with existing and any appended brew formula
 options).
 
 If *`formula`* are given, upgrade only the specified brews (unless they are

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "March 2019" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "April 2019" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -664,7 +664,7 @@ Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\f
 Fetches and resets Homebrew and all tap repositories (or any specified \fBrepository\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\. Note this will destroy all your uncommitted or committed changes\.
 .
 .SS "\fBupgrade\fR [\fIoptions\fR] \fIformula\fR"
-Upgrade outdated, unpinned brews (with existing and any appended install options)\.
+Upgrade outdated, unpinned formulae (with existing and any appended brew formula options)\.
 .
 .P
 If \fIformula\fR are given, upgrade only the specified brews (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "March 2019" "Homebrew" "brew"
+.TH "BREW" "1" "April 2019" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -279,7 +279,7 @@ If \fBstd\fR is passed, use the standard build environment instead of superenv\.
 .
 .TP
 \fB\-\-ignore\-dependencies\fR
-Skip installing any dependencies of any kind\. If they are not already present, the formula will probably fail to install\.
+An unsupported Homebrew development flag to skip installing any dependencies of any kind\. If the dependencies are not already present, the formula will have issues\. If you\'re not developing Homebrew, consider adjusting your PATH rather than using this flag\.
 .
 .TP
 \fB\-\-only\-dependencies\fR


### PR DESCRIPTION
People are using this instead of adjusting their PATH.

Also, make clear `brew upgrade` formula options are used (not install options).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----