### PR TITLE
Add checking whether an appcast contains the version number

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -9,11 +9,16 @@ require "utils/git"
 module Cask
   class Audit
     include Checkable
+    extend Predicable
 
     attr_reader :cask, :commit_range, :download
 
-    def initialize(cask, download: false, check_token_conflicts: false, commit_range: nil, command: SystemCommand)
+    attr_predicate :check_appcast?
+
+    def initialize(cask, check_appcast: false, download: false, check_token_conflicts: false,
+                   commit_range: nil, command: SystemCommand)
       @cask = cask
+      @check_appcast = check_appcast
       @download = download
       @commit_range = commit_range
       @check_token_conflicts = check_token_conflicts
@@ -40,6 +45,7 @@ module Cask
       check_latest_with_appcast
       check_latest_with_auto_updates
       check_stanza_requires_uninstall
+      check_appcast_contains_version
       self
     rescue => e
       odebug "#{e.message}\n#{e.backtrace.join("\n")}"
@@ -290,6 +296,22 @@ module Cask
       Verify.all(cask, downloaded_path)
     rescue => e
       add_error "download not possible: #{e.message}"
+    end
+
+    def check_appcast_contains_version
+      return unless check_appcast?
+      return if cask.appcast.to_s.empty?
+
+      appcast_stanza = cask.appcast.to_s
+      appcast_contents, = curl_output("--max-time", "5", appcast_stanza)
+      version_stanza = cask.version.to_s
+      adjusted_version_stanza = version_stanza.split(",")[0].split("-")[0].split("_")[0]
+      return if appcast_contents.include? adjusted_version_stanza
+
+      add_warning "appcast at URL '#{appcast_stanza}' does not contain"\
+                  " the version number: '#{adjusted_version_stanza}'"
+    rescue
+      add_error "appcast at URL '#{appcast_stanza}' offline or looping"
     end
 
     def check_https_availability

--- a/Library/Homebrew/cask/cmd/audit.rb
+++ b/Library/Homebrew/cask/cmd/audit.rb
@@ -4,6 +4,7 @@ module Cask
   class Cmd
     class Audit < AbstractCommand
       option "--download",        :download,        false
+      option "--appcast",         :appcast,         false
       option "--token-conflicts", :token_conflicts, false
 
       def self.help
@@ -22,6 +23,7 @@ module Cask
       def audit(cask)
         odebug "Auditing Cask #{cask}"
         Auditor.audit(cask, audit_download:        download?,
+                            audit_appcast:         appcast?,
                             check_token_conflicts: token_conflicts?,
                             quarantine:            quarantine?)
       end

--- a/Library/Homebrew/test/cask/cmd/audit_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/audit_spec.rb
@@ -21,7 +21,7 @@ describe Cask::Cmd::Audit, :cask do
       expect(Cask::CaskLoader).to receive(:load).with(cask_token).and_return(cask)
 
       expect(Cask::Auditor).to receive(:audit)
-        .with(cask, audit_download: false, check_token_conflicts: false, quarantine: true)
+        .with(cask, audit_download: false, audit_appcast: false, check_token_conflicts: false, quarantine: true)
         .and_return(true)
 
       described_class.run(cask_token)
@@ -32,7 +32,7 @@ describe Cask::Cmd::Audit, :cask do
     it "does not download the Cask per default" do
       allow(Cask::CaskLoader).to receive(:load).and_return(cask)
       expect(Cask::Auditor).to receive(:audit)
-        .with(cask, audit_download: false, check_token_conflicts: false, quarantine: true)
+        .with(cask, audit_download: false, audit_appcast: false, check_token_conflicts: false, quarantine: true)
         .and_return(true)
 
       described_class.run("casktoken")
@@ -41,7 +41,7 @@ describe Cask::Cmd::Audit, :cask do
     it "download a Cask if --download flag is set" do
       allow(Cask::CaskLoader).to receive(:load).and_return(cask)
       expect(Cask::Auditor).to receive(:audit)
-        .with(cask, audit_download: true, check_token_conflicts: false, quarantine: true)
+        .with(cask, audit_download: true, audit_appcast: false, check_token_conflicts: false, quarantine: true)
         .and_return(true)
 
       described_class.run("casktoken", "--download")
@@ -52,7 +52,7 @@ describe Cask::Cmd::Audit, :cask do
     it "does not check for token conflicts per default" do
       allow(Cask::CaskLoader).to receive(:load).and_return(cask)
       expect(Cask::Auditor).to receive(:audit)
-        .with(cask, audit_download: false, check_token_conflicts: false, quarantine: true)
+        .with(cask, audit_download: false, audit_appcast: false, check_token_conflicts: false, quarantine: true)
         .and_return(true)
 
       described_class.run("casktoken")
@@ -61,7 +61,7 @@ describe Cask::Cmd::Audit, :cask do
     it "checks for token conflicts if --token-conflicts flag is set" do
       allow(Cask::CaskLoader).to receive(:load).and_return(cask)
       expect(Cask::Auditor).to receive(:audit)
-        .with(cask, audit_download: false, check_token_conflicts: true, quarantine: true)
+        .with(cask, audit_download: false, audit_appcast: false, check_token_conflicts: true, quarantine: true)
         .and_return(true)
 
       described_class.run("casktoken", "--token-conflicts")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This pull request a new flag --appcast for 'brew cask audit' that checks if the version (from the version stanza) is contained in the downloaded appcast (from the appcast stanza). The new flag is off by default. The idea here is that the Travis CI check can pass this optional flag so that beta versions submitted to Homebrew Cask will fail the Travis check (assuming they are not contained in the appcast) and will therefore not be automatically merged by @BrewTestBot 
Please see here for the discussion that lead up to this PR:
https://github.com/Homebrew/brew/pull/5888