### PR TITLE
unpack_strategy: prioritise extension instead.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -54,11 +54,11 @@ class AbstractDownloadStrategy
   # Unlike {Resource#stage}, this does not take a block.
   def stage
     UnpackStrategy.detect(cached_location,
-                          extension_only: true,
+                          prioritise_extension: true,
                           ref_type: @ref_type, ref: @ref)
-                  .extract_nestedly(basename:       basename,
-                                    extension_only: true,
-                                    verbose:        ARGV.verbose? && !shutup)
+                  .extract_nestedly(basename:             basename,
+                                    prioritise_extension: true,
+                                    verbose:              ARGV.verbose? && !shutup)
     chdir
   end
 

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -88,10 +88,10 @@ module UnpackStrategy
     strategies.find { |s| s.can_extract?(path) }
   end
 
-  def self.detect(path, extension_only: false, type: nil, ref_type: nil, ref: nil)
+  def self.detect(path, prioritise_extension: false, type: nil, ref_type: nil, ref: nil)
     strategy = from_type(type) if type
 
-    if extension_only
+    if prioritise_extension && path.extname.present?
       strategy ||= from_extension(path.extname)
       strategy ||= strategies.select { |s| s < Directory || s == Fossil }
                              .find { |s| s.can_extract?(path) }
@@ -120,7 +120,7 @@ module UnpackStrategy
     extract_to_dir(unpack_dir, basename: basename, verbose: verbose)
   end
 
-  def extract_nestedly(to: nil, basename: nil, verbose: false, extension_only: false)
+  def extract_nestedly(to: nil, basename: nil, verbose: false, prioritise_extension: false)
     Dir.mktmpdir do |tmp_unpack_dir|
       tmp_unpack_dir = Pathname(tmp_unpack_dir)
 
@@ -131,9 +131,9 @@ module UnpackStrategy
       if children.count == 1 && !children.first.directory?
         FileUtils.chmod "+rw", children.first, verbose: verbose
 
-        s = UnpackStrategy.detect(children.first, extension_only: extension_only)
+        s = UnpackStrategy.detect(children.first, prioritise_extension: prioritise_extension)
 
-        s.extract_nestedly(to: to, verbose: verbose, extension_only: extension_only)
+        s.extract_nestedly(to: to, verbose: verbose, prioritise_extension: prioritise_extension)
         next
       end
 

--- a/Library/Homebrew/unpack_strategy/uncompressed.rb
+++ b/Library/Homebrew/unpack_strategy/uncompressed.rb
@@ -2,7 +2,7 @@ module UnpackStrategy
   class Uncompressed
     include UnpackStrategy
 
-    def extract_nestedly(extension_only: false, **options)
+    def extract_nestedly(prioritise_extension: false, **options)
       extract(**options)
     end
 


### PR DESCRIPTION
Instead of only looking at the extension when invoked as part of Homebrew's formulae' download strategies instead prioritise the extension if it actually exists. When it does not, fall back to the magic detection logic which is likely to be more reliable.

Fixes https://github.com/Homebrew/brew/issues/5895

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----