### PR TITLE
'brew cask upgrade' will continue upgrading casks after a failure

### DIFF
--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -1,6 +1,19 @@
 module Cask
   class CaskError < RuntimeError; end
 
+  class MultipleCaskErrors < CaskError
+    def initialize(errors)
+      @errors = errors
+    end
+
+    def to_s
+      <<~EOS
+        Problems with multiple casks:
+        #{@errors.map(&:to_s).join("\n")}
+      EOS
+    end
+  end
+
   class AbstractCaskErrorWithToken < CaskError
     attr_reader :token
     attr_reader :reason

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum2.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum2.rb
@@ -1,0 +1,9 @@
+cask 'bad-checksum2' do
+  version '1.2.3'
+  sha256 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
+  homepage 'https://brew.sh/container-tar-gz'
+
+  app 'container'
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum2.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum2.rb
@@ -1,0 +1,9 @@
+cask 'bad-checksum2' do
+  version '1.2.2'
+  sha256 'fab685fabf73d5a9382581ce8698fce9408f5feaa49fa10d9bc6c510493300f5'
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/container.tar.gz"
+  homepage 'https://brew.sh/container-tar-gz'
+
+  app 'container'
+end


### PR DESCRIPTION
'cask upgrade' command collects all exceptions thrown
from individual casks during the upgrade process. If
there were more than one cask that raised exceptions
during the upgrade process, a MultipleCaskErrors
exception will be thrown.

- [x ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ x] Have you successfully run `brew style` with your changes locally?
- [x ] Have you successfully run `brew tests` with your changes locally?

-----
Issue #5203