### PR TITLE
(cask): change cask template url `'` to `"` to allow string interpolation on version

### DIFF
--- a/Library/Homebrew/cask/cmd/create.rb
+++ b/Library/Homebrew/cask/cmd/create.rb
@@ -26,7 +26,7 @@ module Cask
             version ''
             sha256 ''
 
-            url 'https://'
+            url "https://"
             name ''
             homepage ''
 

--- a/Library/Homebrew/test/cask/cmd/create_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/create_spec.rb
@@ -33,7 +33,7 @@ describe Cask::Cmd::Create, :cask do
         version ''
         sha256 ''
 
-        url 'https://'
+        url "https://"
         name ''
         homepage ''
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

### Summary
changed the line for `url` from single quote `'` to double quote `"`

### Fixed issues

with the current templeate i get a:
```
  url 'https://github.com/joshwcomeau/guppy/releases/download/v#{version}/Guppy-#{version}.dmg'
```

and this error:
```
Error: Cask 'guppy' definition is invalid: 'url' stanza failed with: bad URI(is not URI?): 
https://github.com/joshwcomeau/guppy/releases/download/v#{version}/Guppy-#{version}.dmg  
```