### PR TITLE
Drop unzip usage for Homebrew Cask

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -161,7 +161,7 @@ module Cask
 
     def primary_container
       @primary_container ||= begin
-        UnpackStrategy.detect(@downloaded_path, type: @cask.container&.type)
+        UnpackStrategy.detect(@downloaded_path, type: @cask.container&.type, merge_xattrs: true)
       end
     end
 
@@ -179,7 +179,7 @@ module Cask
 
           FileUtils.chmod_R "+rw", tmpdir/nested_container, force: true, verbose: verbose?
 
-          UnpackStrategy.detect(tmpdir/nested_container)
+          UnpackStrategy.detect(tmpdir/nested_container, merge_xattrs: true)
                         .extract_nestedly(to: @cask.staged_path, verbose: verbose?)
         end
       else

--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -88,7 +88,7 @@ module UnpackStrategy
     strategies.find { |s| s.can_extract?(path) }
   end
 
-  def self.detect(path, prioritise_extension: false, type: nil, ref_type: nil, ref: nil)
+  def self.detect(path, prioritise_extension: false, type: nil, ref_type: nil, ref: nil, merge_xattrs: nil)
     strategy = from_type(type) if type
 
     if prioritise_extension && path.extname.present?
@@ -102,15 +102,16 @@ module UnpackStrategy
 
     strategy ||= Uncompressed
 
-    strategy.new(path, ref_type: ref_type, ref: ref)
+    strategy.new(path, ref_type: ref_type, ref: ref, merge_xattrs: merge_xattrs)
   end
 
-  attr_reader :path
+  attr_reader :path, :merge_xattrs
 
-  def initialize(path, ref_type: nil, ref: nil)
+  def initialize(path, ref_type: nil, ref: nil, merge_xattrs: nil)
     @path = Pathname(path).expand_path
     @ref_type = ref_type
     @ref = ref
+    @merge_xattrs = merge_xattrs
   end
 
   def extract(to: nil, basename: nil, verbose: false)

--- a/Library/Homebrew/unpack_strategy/zip.rb
+++ b/Library/Homebrew/unpack_strategy/zip.rb
@@ -14,6 +14,10 @@ module UnpackStrategy
 
     private
 
+    def contains_extended_attributes?(path)
+      path.zipinfo.grep(/(^__MACOSX|\._)/).any?
+    end
+
     def extract_to_dir(unpack_dir, basename:, verbose:)
       quiet_flags = verbose ? [] : ["-qq"]
       result = system_command! "unzip",


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
This pull request drops `unzip` altogether when handling Zip artifacts for Cask. It seems that in High Sierra and above, `unzip` no longer unpacks the `__MACOSX` folder containing the extended attributes, and the provided `-J` flag does not restore this behaviour.

Fixes Homebrew/homebrew-cask#61386.
