### PR TITLE
xcode_requirement: fix Swift compatability check.

### DIFF
--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -12,8 +12,8 @@ class XcodeRequirement < Requirement
 
   def xcode_installed_version
     return false unless MacOS::Xcode.installed?
+    return false unless xcode_swift_compatability?
     return true unless @version
-    return true if xcode_swift_compatability?
 
     MacOS::Xcode.version >= @version
   end
@@ -54,8 +54,8 @@ class XcodeRequirement < Requirement
   # method in favour of requiring 10.14.4 and 10.2.
   def xcode_swift_compatability?
     return true if MacOS::Xcode.version < "10.2"
-    return true if MacOS::Xcode.version >= "10.14.4"
+    return true if MacOS.full_version >= "10.14.4"
 
-    MacOS.version < "10.14"
+    MacOS.full_version < "10.14"
   end
 end


### PR DESCRIPTION
Ensure we're using the full macOS version so that `MacOS::Xcode.version >= "10.14.4"` can ever be true.

Spotted in https://github.com/Homebrew/homebrew-core/pull/38749. CC @zbeekman 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----