### PR TITLE
add `--squash-pristine` command to brew pull

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -159,7 +159,7 @@ module Homebrew
       if do_squash
         odie "No changed formulae found to squash" if patch_changes[:formulae].empty?
         if patch_changes[:formulae].length > 1
-          odie "Can only quash one changed formula; squashed #{patch_changes[:formulae]}"
+          odie "Can only squash one changed formula; squashed #{patch_changes[:formulae]}"
         end
         odie "Can not squash if non-formula files are changed" unless patch_changes[:others].empty?
       end

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -253,7 +253,7 @@ module Homebrew
 
       if do_squash && is_squashable && !args.clean?
         safe_system "git", "reset", "--soft", orig_revision
-        safe_system "git", "add", patch_changes[:files]
+        safe_system "git", "add", *patch_changes[:files]
         safe_system "git", "commit", "--signoff", "--allow-empty", "-q", "-m", message
       elsif message != orig_message && !args.clean?
         safe_system "git", "commit", "--amend", "--signoff", "--allow-empty", "-q", "-m", message

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -830,6 +830,8 @@ testing job URL.
   Handle bottles, pulling the bottle-update commit and publishing files on Bintray.
 * `--bump`:
   For one-formula PRs, automatically reword commit message to our preferred format.
+* `--squash-pristine`:
+  For one-formula PRs, squash multiple commits into a single commit and use the canonical re-worded commit message.
 * `--clean`:
   Do not rewrite or otherwise modify the commits found in the pulled PR.
 * `--ignore-whitespace`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1039,6 +1039,10 @@ Handle bottles, pulling the bottle\-update commit and publishing files on Bintra
 For one\-formula PRs, automatically reword commit message to our preferred format\.
 .
 .TP
+\fB\-\-squash\-pristine\fR
+For one\-formula PRs, squash multiple commits into a single commit and use the canonical re\-worded commit message\.
+.
+.TP
 \fB\-\-clean\fR
 Do not rewrite or otherwise modify the commits found in the pulled PR\.
 .


### PR DESCRIPTION
I wanted to open this PR for discussion before it's completely finalized.

 - Squashes multiple commits for 1 formula simple changes into a single commit
   and applies the same message provided by --bump

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?

I find that users often push multiple commits to formula upgrades and new formula. I would like to automate the process of squashing these all down to a single commit with only the canonical commit message before adding the bottle bottle commits. This will prevent maintainers from running rebases after `brew pull`.

- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

~~I can't run `brew tests` no matter what I do. I've tried using `brew sh` to get a pristine environment, I've tried using `HOMEBRE_FORCE_VENDOR_RUBY=1` as well as native system ruby.~~ 

[DELETED]

-----
