### PR TITLE
Revert "brew: remove sudo call"

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -111,9 +111,13 @@ begin
 
     odie "Unknown command: #{cmd}" if !possible_tap || possible_tap.installed?
 
+    brew_uid = HOMEBREW_BREW_FILE.stat.uid
+    tap_commands = []
+    tap_commands += %W[/usr/bin/sudo -u ##{brew_uid}] if Process.uid.zero? && !brew_uid.zero?
     # Unset HOMEBREW_HELP to avoid confusing the tap
     ENV.delete("HOMEBREW_HELP") if help_flag
-    safe_system HOMEBREW_BREW_FILE, "tap", possible_tap.name
+    tap_commands += %W[#{HOMEBREW_BREW_FILE} tap #{possible_tap}]
+    safe_system(*tap_commands)
     ENV["HOMEBREW_HELP"] = "1" if help_flag
     exec HOMEBREW_BREW_FILE, cmd, *ARGV
   end


### PR DESCRIPTION
This broke the use of `sudo brew services` if it wasn't already tapped.

Reverts Homebrew/brew#5917
Fixes #6009