### PR TITLE
atomic_write: repair permissions after writing

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -163,7 +163,7 @@ class Pathname
 
   # NOTE: This always overwrites.
   def atomic_write(content)
-    old_stat = (stat if exist?)
+    old_stat = stat if exist?
     File.atomic_write(self) do |file|
       file.write(content)
     end
@@ -177,14 +177,16 @@ class Pathname
       # Set correct permissions on new file
       chown(old_stat.uid, nil)
       chown(nil, old_stat.gid)
-    rescue Errno::EPERM, Errno::EACCES # rubocop:disable Lint/HandleExceptions
+    rescue Errno::EPERM, Errno::EACCES
       # Changing file ownership failed, moving on.
+      nil
     end
     begin
       # This operation will affect filesystem ACL's
       chmod(old_stat.mode)
-    rescue Errno::EPERM, Errno::EACCES # rubocop:disable Lint/HandleExceptions
+    rescue Errno::EPERM, Errno::EACCES
       # Changing file permissions failed, moving on.
+      nil
     end
   end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This restores the original file uid, gid and permissions separately.
(ActiveSupport does it in a single step - atomically. This is not
useful in our use case because it may lead to ACL changes.)

Fixes #5916
