### PR TITLE
cask home: update to brew.sh

### DIFF
--- a/Library/Homebrew/cask/cmd/home.rb
+++ b/Library/Homebrew/cask/cmd/home.rb
@@ -4,7 +4,7 @@ module Cask
       def run
         if casks.none?
           odebug "Opening project homepage"
-          self.class.open_url "https://caskroom.github.io/"
+          self.class.open_url "https://brew.sh/"
         else
           casks.each do |cask|
             odebug "Opening homepage for Cask #{cask}"

--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -48,7 +48,7 @@ graphical user interface.
   * `home` or `homepage` [ <token> ... ]:
     Display the homepage associated with a given Cask in a browser.
 
-    With no arguments, display the project page <https://caskroom.github.io/>.
+    With no arguments, display the project page <https://brew.sh/>.
 
   * `info` or `abv` <token> [ <token> ... ]:
     Display information about the given Cask.
@@ -249,7 +249,7 @@ Other environment variables:
 
 ## SEE ALSO
 
-The Homebrew Cask home page: <https://caskroom.github.io/>
+The Homebrew home page: <https://brew.sh/>
 
 The Homebrew Cask GitHub page: <https://github.com/Homebrew/homebrew-cask>
 

--- a/Library/Homebrew/test/cask/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/home_spec.rb
@@ -19,7 +19,7 @@ describe Cask::Cmd::Home, :cask do
   end
 
   it "opens the project page when no Cask is specified" do
-    expect(described_class).to receive(:open_url).with("https://caskroom.github.io/")
+    expect(described_class).to receive(:open_url).with("https://brew.sh/")
     described_class.run
   end
 end

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -53,7 +53,7 @@ Download remote application files for the given Cask to the local cache\. With \
 Display the homepage associated with a given Cask in a browser\.
 .
 .IP
-With no arguments, display the project page \fIhttps://caskroom\.github\.io/\fR\.
+With no arguments, display the project page \fIhttps://brew\.sh/\fR\.
 .
 .TP
 \fBinfo\fR or \fBabv\fR \fItoken\fR [ \fItoken\fR \.\.\. ]
@@ -288,7 +288,7 @@ Other environment variables:
 When this variable is set, Homebrew Cask will call \fBsudo\fR(8) with the \fB\-A\fR option\.
 .
 .SH "SEE ALSO"
-The Homebrew Cask home page: \fIhttps://caskroom\.github\.io/\fR
+The Homebrew home page: \fIhttps://brew\.sh/\fR
 .
 .P
 The Homebrew Cask GitHub page: \fIhttps://github\.com/Homebrew/homebrew\-cask\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Affects `man brew-cask` and `brew cask home` with no arguments. Before this change it would open `https://caskroom.github.io/`, which was redirecting to `https://brew.sh/` anyway.