### PR TITLE
xcode_requirement: clarify the error message

### DIFF
--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -28,7 +28,9 @@ class XcodeRequirement < Requirement
       message += <<~EOS
 
         For Xcode >=10.2, we require macOS >=10.14.4
-        because it is necessary to build many formulae.
+        to work around a problem in Xcode 10.2; see
+        https://github.com/Homebrew/brew/pull/5940#issuecomment-477583315
+        for details.
       EOS
     end
     if @version && Version.new(MacOS::Xcode.latest_version) < Version.new(@version)

--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -21,13 +21,14 @@ class XcodeRequirement < Requirement
   def message
     version = " #{@version}" if @version
     message = <<~EOS
-      A full installation of Xcode.app#{version} is required to compile
+      A full installation of Xcode.app#{version} is required for
       this software. Installing just the Command Line Tools is not sufficient.
     EOS
     unless xcode_swift_compatability?
       message += <<~EOS
 
-        Xcode >=10.2 requires macOS >=10.14.4 to build many formulae.
+        For Xcode >=10.2, we require macOS >=10.14.4
+        because it is necessary to build many formulae.
       EOS
     end
     if @version && Version.new(MacOS::Xcode.latest_version) < Version.new(@version)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In https://travis-ci.community/t/xcode-10-2-requires-macos-10-14-4-to-build-many-formulae/2985, it turned out that the current error message is highly confusing:

* XCode can also be a _runtime_ rather than compile requirement
* Where the OSX 10.14.4 requirement is coming from is unclear