### PR TITLE
release-notes: use stderr for header output.

### DIFF
--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -49,7 +49,7 @@ module Homebrew
       end
     end
 
-    puts "Release notes between #{previous_tag} and #{end_ref}:"
+    $stderr.puts "Release notes between #{previous_tag} and #{end_ref}:"
     puts output
   end
 end


### PR DESCRIPTION
This makes the use of `brew release-notes | pbcopy` a bit easier.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----