### PR TITLE
hbc: remove all *_to_slashes

### DIFF
--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -5,7 +5,6 @@ module Cask
         "." => :dots,
         "-" => :hyphens,
         "_" => :underscores,
-        "/" => :slashes,
       }.freeze
 
       DIVIDER_REGEX = /(#{DIVIDERS.keys.map { |v| Regexp.quote(v) }.join('|')})/.freeze

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -171,11 +171,6 @@ describe Cask::DSL::Version, :cask do
                        "1.2.3_4-5" => "1_2_3_4-5"
     end
 
-    describe "#dots_to_slashes" do
-      include_examples "version expectations hash", :dots_to_slashes,
-                       "1.2.3_4-5" => "1/2/3_4-5"
-    end
-
     describe "#hyphens_to_dots" do
       include_examples "version expectations hash", :hyphens_to_dots,
                        "1.2.3_4-5" => "1.2.3_4.5"
@@ -186,11 +181,6 @@ describe Cask::DSL::Version, :cask do
                        "1.2.3_4-5" => "1.2.3_4_5"
     end
 
-    describe "#hyphens_to_slashes" do
-      include_examples "version expectations hash", :hyphens_to_slashes,
-                       "1.2.3_4-5" => "1.2.3_4/5"
-    end
-
     describe "#underscores_to_dots" do
       include_examples "version expectations hash", :underscores_to_dots,
                        "1.2.3_4-5" => "1.2.3.4-5"
@@ -199,11 +189,6 @@ describe Cask::DSL::Version, :cask do
     describe "#underscores_to_hyphens" do
       include_examples "version expectations hash", :underscores_to_hyphens,
                        "1.2.3_4-5" => "1.2.3-4-5"
-    end
-
-    describe "#underscores_to_slashes" do
-      include_examples "version expectations hash", :underscores_to_slashes,
-                       "1.2.3_4-5" => "1.2.3/4-5"
     end
 
     describe "#no_dots" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Continuation of https://github.com/Homebrew/brew/pull/5893, which only removed `slashes_to_*`. Reasoning for removing `*_to_sashes` is given in https://github.com/Homebrew/homebrew-cask/pull/60917#issuecomment-477194122:

> `*_to_slashes` is seldom used (if ever) and also needs to be removed, because otherwise it’s another possible attack vector: a malicious actor would find a cask with a `*_to_slashes` and put the `*` in the version to have it converted.
>
> (…)
>
> `slashes_to_*` was always useless, because we never have slashes in `versions`, since it makes problematic directory names when installing. So since they’re both seldom used and one is an attack vector, might as well remove both and avoid confusion.

I’ve already fixed the casks in the main repos that were affected.