### PR TITLE
Enable/fix optional Ruby frozen string literal usage

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -348,6 +348,9 @@ else
   RUBY_DISABLE_OPTIONS="--disable=gems,rubyopt"
 fi
 
+# Don't set this for anyone (yet)
+unset HOMEBREW_FROZEN_STRING_LITERAL
+
 if [[ -z "$HOMEBREW_RUBY_WARNINGS" ]]
 then
   export HOMEBREW_RUBY_WARNINGS="-W0"
@@ -499,5 +502,5 @@ else
 
   # Unshift command back into argument list (unless argument list was empty).
   [[ "$HOMEBREW_ARG_COUNT" -gt 0 ]] && set -- "$HOMEBREW_COMMAND" "$@"
-  { update-preinstall "$@"; exec "$HOMEBREW_RUBY_PATH" $HOMEBREW_RUBY_WARNINGS "$RUBY_DISABLE_OPTIONS" "$HOMEBREW_LIBRARY/Homebrew/brew.rb" "$@"; }
+  { update-preinstall "$@"; exec "$HOMEBREW_RUBY_PATH" $HOMEBREW_FROZEN_STRING_LITERAL $HOMEBREW_RUBY_WARNINGS "$RUBY_DISABLE_OPTIONS" "$HOMEBREW_LIBRARY/Homebrew/brew.rb" "$@"; }
 fi

--- a/Library/Homebrew/cask/cmd/info.rb
+++ b/Library/Homebrew/cask/cmd/info.rb
@@ -56,7 +56,7 @@ module Cask
       end
 
       def self.installation_info(cask)
-        install_info = ""
+        install_info = +""
         if cask.installed?
           cask.versions.each do |version|
             versioned_staged_path = cask.caskroom_path.join(version)
@@ -69,7 +69,7 @@ module Cask
                               end,
                             ).concat(")\n")
           end
-          install_info
+          install_info.freeze
         else
           "Not installed\n"
         end

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -389,9 +389,6 @@ module Homebrew
                   /usr/bin occurs before #{HOMEBREW_PREFIX}/bin
                   This means that system-provided programs will be used instead of those
                   provided by Homebrew. The following tools exist at both paths:
-                EOS
-
-                message += <<~EOS
 
                   Consider setting your PATH so that #{HOMEBREW_PREFIX}/bin
                   occurs before /usr/bin. Here is a one-liner:

--- a/Library/Homebrew/extend/io.rb
+++ b/Library/Homebrew/extend/io.rb
@@ -1,7 +1,7 @@
 class IO
   def readline_nonblock(sep = $INPUT_RECORD_SEPARATOR)
-    line = ""
-    buffer = ""
+    line = +""
+    buffer = +""
 
     loop do
       break if buffer == sep
@@ -10,10 +10,10 @@ class IO
       line.concat(buffer)
     end
 
-    line
+    line.freeze
   rescue IO::WaitReadable, EOFError => e
     raise e if line.empty?
 
-    line
+    line.freeze
   end
 end

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -87,12 +87,12 @@ module Superenv
   end
 
   def determine_cccfg
-    s = ""
+    s = +""
     # Fix issue with sed barfing on unicode characters on Mountain Lion
     s << "s"
     # Fix issue with >= Mountain Lion apr-1-config having broken paths
     s << "a"
-    s
+    s.freeze
   end
 
   def effective_sysroot

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -17,10 +17,11 @@ module DiskUsageExtension
   end
 
   def abv
-    out = ""
+    out = +""
     compute_disk_usage
     out << "#{number_readable(@file_count)} files, " if @file_count > 1
     out << disk_usage_readable(@disk_usage).to_s
+    out.freeze
   end
 
   private
@@ -344,8 +345,8 @@ class Pathname
 
   # Writes an exec script that sets environment variables
   def write_env_script(target, env)
-    env_export = ""
-    env.each { |key, value| env_export += "#{key}=\"#{value}\" " }
+    env_export = +""
+    env.each { |key, value| env_export << "#{key}=\"#{value}\" " }
     dirname.mkpath
     write <<~SH
       #!/bin/bash

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -668,7 +668,7 @@ class FormulaInstaller
     s << "#{Emoji.install_badge}  " if Emoji.enabled?
     s << "#{formula.prefix.resolved_path}: #{formula.prefix.abv}"
     s << ", built in #{pretty_duration build_time}" if build_time
-    s
+    s.freeze
   end
 
   def build_time

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -84,7 +84,7 @@ class DATAPatch < EmbeddedPatch
   end
 
   def contents
-    data = ""
+    data = +""
     path.open("rb") do |f|
       loop do
         line = f.gets
@@ -94,7 +94,7 @@ class DATAPatch < EmbeddedPatch
         data << line
       end
     end
-    data
+    data.freeze
   end
 end
 

--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -178,13 +178,13 @@ class Sandbox
     end
 
     def add_rule(rule)
-      s = "("
+      s = +"("
       s << (rule[:allow] ? "allow" : "deny")
       s << " #{rule[:operation]}"
       s << " (#{rule[:filter]})" if rule[:filter]
       s << " (with #{rule[:modifier]})" if rule[:modifier]
       s << ")"
-      @rules << s
+      @rules << s.freeze
     end
 
     def dump

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -5,7 +5,7 @@ then
   echo "${0##*/}: The build tool has reset ENV; --env=std required." >&2
   exit 1
 fi
-exec "$HOMEBREW_RUBY_PATH" --disable=gems,did_you_mean,rubyopt -x "$0" "$@"
+exec "$HOMEBREW_RUBY_PATH" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -x "$0" "$@"
 #!/usr/bin/env ruby -W0
 
 require "pathname"
@@ -404,7 +404,7 @@ def log(basename, argv, tool, args)
   adds = args - argv
   dels = argv - args
 
-  s = ""
+  s = +""
   s << "#{basename} called with: #{argv.join(" ")}\n"
   s << "superenv removed:  #{dels.join(" ")}\n" unless dels.empty?
   s << "superenv added:    #{adds.join(" ")}\n" unless adds.empty?

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -156,12 +156,13 @@ def pretty_duration(s)
     m = s / 60
     s %= 60
     res = "#{m} #{"minute".pluralize(m)}"
-    return res if s.zero?
+    return res.freeze if s.zero?
 
     res << " "
   end
 
   res << "#{s} #{"second".pluralize(s)}"
+  res.freeze
 end
 
 def interactive_shell(f = nil)

--- a/Library/Homebrew/utils/formatter.rb
+++ b/Library/Homebrew/utils/formatter.rb
@@ -94,7 +94,7 @@ module Formatter
 
     gap_string = "".rjust(gap_size)
 
-    output = ""
+    output = +""
 
     rows.times do |row_index|
       item_indices_for_row = row_index.step(objects.size - 1, rows).to_a
@@ -106,9 +106,11 @@ module Formatter
       # don't add trailing whitespace to last column
       last = objects.values_at(item_indices_for_row.last)
 
-      output.concat((first_n + last).join(gap_string)).concat("\n")
+      output.concat((first_n + last)
+            .join(gap_string))
+            .concat("\n")
     end
 
-    output
+    output.freeze
   end
 end

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -40,7 +40,7 @@ setup-ruby-path() {
         ruby_version_new_enough="true"
       elif [[ -n "$HOMEBREW_RUBY_PATH" && -z "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
       then
-        ruby_version_new_enough="$("$HOMEBREW_RUBY_PATH" --disable=gems -rrubygems -e "puts Gem::Version.new(RUBY_VERSION.to_s.dup) >= Gem::Version.new('$minimum_ruby_version')")"
+        ruby_version_new_enough="$("$HOMEBREW_RUBY_PATH" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e "puts Gem::Version.new(RUBY_VERSION.to_s.dup) >= Gem::Version.new('$minimum_ruby_version')")"
       fi
 
       if [[ -z "$HOMEBREW_RUBY_PATH" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" || "$ruby_version_new_enough" != "true" ]]


### PR DESCRIPTION
Combined with https://github.com/Homebrew/homebrew-test-bot/pull/247 this will test Homebrew's use of frozen strings in CI. After this we will then enable it for Homebrew developers and eventually all Homebrew users.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----