### PR TITLE
Remove usage of Thread.new

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -8,30 +8,6 @@ CLEANUP_DEFAULT_DAYS = 30
 CLEANUP_MAX_AGE_DAYS = 120
 
 module CleanupRefinement
-  refine Enumerator do
-    def parallel
-      queue = Queue.new
-
-      each do |element|
-        queue.enq(element)
-      end
-
-      workers = (0...Hardware::CPU.cores).map do
-        Thread.new do
-          Kernel.loop do
-            begin
-              yield queue.deq(true)
-            rescue ThreadError
-              break # if queue is empty
-            end
-          end
-        end
-      end
-
-      workers.each(&:join)
-    end
-  end
-
   refine Pathname do
     def incomplete?
       extname.end_with?(".incomplete")
@@ -403,7 +379,7 @@ module Homebrew
           HOMEBREW_PREFIX/"Caskroom",
         ]
       end
-      dirs.select(&:directory?).each.parallel do |dir|
+      dirs.select(&:directory?).each do |dir|
         system_command "find",
           args:         [dir, "-name", ".DS_Store", "-delete"],
           print_stderr: false

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -3,22 +3,11 @@ require "formula"
 module Readall
   class << self
     def valid_ruby_syntax?(ruby_files)
-      ruby_files_queue = Queue.new
-      ruby_files.each { |f| ruby_files_queue << f }
       failed = false
-      workers = (0...Hardware::CPU.cores).map do
-        Thread.new do
-          Kernel.loop do
-            begin
-              # As a side effect, print syntax errors/warnings to `$stderr`.
-              failed = true if syntax_errors_or_warnings?(ruby_files_queue.deq(true))
-            rescue ThreadError
-              break
-            end
-          end
-        end
+      ruby_files.each do |ruby_file|
+        # As a side effect, print syntax errors/warnings to `$stderr`.
+        failed = true if syntax_errors_or_warnings?(ruby_file)
       end
-      workers.each(&:join)
       !failed
     end
 


### PR DESCRIPTION
I benchmarked these both locally and neither use of `Thread.new` provides any measurable speedup (and in the `readall` case appears to slow things down) on my 8 core machine.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----