### PR TITLE
Endorse AdoptOpenJDK instead of Oracle OpenJDK

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -4,19 +4,17 @@ class JavaRequirement < Requirement
   attr_reader :java_home
 
   fatal true
-  download "https://www.oracle.com/technetwork/java/javase/downloads/index.html"
 
   # A strict Java 8 requirement (1.8) should prompt the user to install
-  # the legacy java8 cask because versions newer than Java 8 are not
+  # an OpenJDK 1.8 distribution. Versions newer than Java 8 are not
   # completely backwards compatible, and contain breaking changes such as
   # strong encapsulation of JDK-internal APIs and a modified version scheme
   # (*.0 not 1.*).
-  def cask
-    if @version.nil? || @version.to_s.end_with?("+") ||
-       @version.to_f >= JAVA_CASK_MAP.keys.max.to_f
-      JAVA_CASK_MAP.fetch(JAVA_CASK_MAP.keys.max)
+  def suggestion
+    if fits_latest?
+      JAVA_SUGGESTION_MAP.fetch(JAVA_SUGGESTION_MAP.keys.max)
     else
-      JAVA_CASK_MAP.fetch("1.8")
+      JAVA_SUGGESTION_MAP.fetch("1.8")
     end
   end
 
@@ -34,9 +32,8 @@ class JavaRequirement < Requirement
 
   def message
     version_string = " #{@version}" if @version
-
     s = "Java#{version_string} is required to install this formula.\n"
-    s += super
+    s += suggestion
     s
   end
 
@@ -59,9 +56,22 @@ class JavaRequirement < Requirement
 
   private
 
-  JAVA_CASK_MAP = {
-    "1.8"  => "homebrew/cask-versions/java8",
-    "11.0" => "java",
+  CaskSuggestion = Struct.new(:token, :title) do
+    def to_str
+      title_string = " #{title}" if title
+      <<~EOS
+        Install#{title_string} with Homebrew Cask:
+          brew cask install #{token}
+      EOS
+    end
+  end
+
+  JAVA_SUGGESTION_MAP = {
+    "1.8"  => CaskSuggestion.new(
+      "homebrew/cask-versions/adoptopenjdk8",
+        "AdoptOpenJDK 8",
+    ),
+    "12.0" => CaskSuggestion.new("adoptopenjdk", "AdoptOpenJDK"),
   }.freeze
 
   def version_without_plus
@@ -74,6 +84,12 @@ class JavaRequirement < Requirement
 
   def exact_version?
     @version && @version.to_s.chars.last != "+"
+  end
+
+  def fits_latest?
+    @version.nil? ||
+      @version.to_s.end_with?("+") ||
+      @version.to_f >= JAVA_SUGGESTION_MAP.keys.max.to_f
   end
 
   def setup_java


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **No new automated tests but tested all branches manually**
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **There were several errors but unrelated to the PR at hand.**

-----

Homebrew picks up any Java it finds on the user’s system. That’s a good thing; users should remain free to install any Java they see fit.

This PR changes the message that appears when Homebrew detects that a Java requirement is unmet.

The new message will say:

```
Install AdoptOpenJDK with Homebrew Cask:
  brew cask install adoptopenjdk
```

And for Java 8:

```
Install AdoptOpenJDK 8 with Homebrew Cask:
  brew cask install homebrew/cask-versions/adoptopenjdk8
```

Note that Homebrew’s build servers will now use AdoptOpenJDK to test formulas that depend on Java.

This PR supersedes #6035; see that for more details.

Fixes https://github.com/Homebrew/homebrew-core/issues/39037