### PR TITLE
Add `*_to_slashes` methods to `compat`.

### DIFF
--- a/Library/Homebrew/cask/cmd/edit.rb
+++ b/Library/Homebrew/cask/cmd/edit.rb
@@ -17,7 +17,7 @@ module Cask
 
       def cask_path
         casks.first.sourcefile_path
-      rescue CaskInvalidError, CaskUnreadableError
+      rescue CaskInvalidError, CaskUnreadableError, MethodDeprecatedError
         path = CaskLoader.path(args.first)
         return path if path.file?
 

--- a/Library/Homebrew/compat.rb
+++ b/Library/Homebrew/compat.rb
@@ -1,0 +1,1 @@
+require "compat/cask/dsl/version"

--- a/Library/Homebrew/compat/cask/dsl/version.rb
+++ b/Library/Homebrew/compat/cask/dsl/version.rb
@@ -1,0 +1,24 @@
+module Cask
+  class DSL
+    class Version < ::String
+      module Compat
+        def dots_to_slashes
+          odeprecated "#dots_to_slashes"
+          version { tr(".", "/") }
+        end
+
+        def hyphens_to_slashes
+          odeprecated "#hyphens_to_slashes"
+          version { tr("-", "/") }
+        end
+
+        def underscores_to_slashes
+          odeprecated "#underscores_to_slashes"
+          version { tr("_", "/") }
+        end
+      end
+
+      prepend Compat
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes missing compatibility layer for https://github.com/Homebrew/brew/pull/6027.