### PR TITLE
Fix check_for_unsupported_macos() on outdated releases

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -47,15 +47,16 @@ module Homebrew
       def check_for_unsupported_macos
         return if ARGV.homebrew_developer?
 
-        who = "We"
+        who = +"We"
         if OS::Mac.prerelease?
           what = "pre-release version"
         elsif OS::Mac.outdated_release?
-          +who << " (and Apple)"
+          who << " (and Apple)"
           what = "old version"
         else
           return
         end
+        who.freeze
 
         <<~EOS
           You are using macOS #{MacOS.version}.

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -51,7 +51,7 @@ module Homebrew
         if OS::Mac.prerelease?
           what = "pre-release version"
         elsif OS::Mac.outdated_release?
-          who << " (and Apple)"
+          +who << " (and Apple)"
           what = "old version"
         else
           return


### PR DESCRIPTION
Recent commit https://github.com/Homebrew/brew/commit/36dbad3922ad984f7c396a9757fe8ae9750c44b0 means Ruby now defaults to frozen string literals (via `frozen_string_literal`) which broke `check_for_unsupported_macos()` on outdated releases--due to attempted modification of a frozen string literal.

This breaks `install` and `doctor`.

It's like the change wasn't tested on an unsupported outdated release or something... :D

Adding a `+` prefix is apparently one way around this issue according to https://stackoverflow.com/questions/37799296/what-does-the-comment-frozen-string-literal-true-do#37799399. The change worked for me.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
