### PR TITLE
utils: fix frozen string usage in odeprecated.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -107,7 +107,7 @@ def odeprecated(method, replacement = nil, disable: false, disable_on: nil, call
     next unless match = line.match(HOMEBREW_TAP_PATH_REGEX)
 
     tap = Tap.fetch(match[:user], match[:repo])
-    tap_message = "\nPlease report this to the #{tap} tap"
+    tap_message = +"\nPlease report this to the #{tap} tap"
     tap_message += ", or even better, submit a PR to fix it" if replacement
     tap_message << ":\n  #{line.sub(/^(.*\:\d+)\:.*$/, '\1')}\n\n"
     break


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/6053

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----