### PR TITLE
azure-pipelines: test both 10.13 and 10.14

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -53,8 +53,14 @@ module Homebrew
     azure = <<~YAML
       jobs:
       - job: macOS
+        strategy:
+          matrix:
+            mojave:
+              imageName: "macOS-10.14"
+            high_sierra:
+              imageName: "macOS-10.13"
         pool:
-          vmImage: macOS-10.13
+          vmImage: $(imageName)
         steps:
           - bash: |
               set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,13 @@
 jobs:
 - job: macOS
+  strategy:
+    matrix:
+      mojave:
+        imageName: "macOS-10.14"
+      high_sierra:
+        imageName: "macOS-10.13"
   pool:
-    vmImage: macOS-10.13
+    vmImage: $(imageName)
   steps:
     - bash: |
         set -e


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There is now a `macOS-10.14` image at Azure pipelines:

* https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md

I'm not sure if we want to run our CI on both macOS platforms, but I thought I would show the syntax for doing so for `brew` itself, and in the script generated by `dev-cmd/tap-new`.