### PR TITLE
Fix mutable string syntax

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -47,7 +47,7 @@ module GitHub
   class AuthenticationFailedError < Error
     def initialize(github_message)
       @github_message = github_message
-      message += "GitHub #{github_message}:"
+      message = +"GitHub #{github_message}:"
       if ENV["HOMEBREW_GITHUB_API_TOKEN"]
         message << <<~EOS
           HOMEBREW_GITHUB_API_TOKEN may be invalid or expired; check:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix ```Error: undefined method `+' for nil:NilClass``` when running `brew bump-formula-pr` without having Github logged in.

```
brew bump-formula-pr --url=https://cran.r-project.org/src/base/R-3/R-3.6.0.tar.gz r
Updating Homebrew...
==> Downloading https://cran.r-project.org/src/base/R-3/R-3.6.0.tar.gz
Already downloaded: /Users/kien/Library/Caches/Homebrew/downloads/6876dd27fe6c862a0f3d0ebc03db521c670a656b6e4e5c0b0f23ddc21c91aa6c--R-3.6.0.tar.gz
==> replace /https:\/\/cran\.r\-project\.org\/src\/base\/R\-3\/R\-3\.5\.3\.tar\.gz/ with "https://cran.r-project.org/src/b
==> replace "2bfa37b7bd709f003d6b8a172ddfb6d03ddd2d672d6096439523039f7a8e678c" with "36fcac3e452666158e62459c6fc810adc247c
Error: undefined method `+' for nil:NilClass
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/utils/github.rb:50:in `initialize'
/usr/local/Homebrew/Library/Homebrew/utils/github.rb:250:in `exception'
/usr/local/Homebrew/Library/Homebrew/utils/github.rb:250:in `raise'
/usr/local/Homebrew/Library/Homebrew/utils/github.rb:250:in `raise_api_error'
/usr/local/Homebrew/Library/Homebrew/utils/github.rb:209:in `open_api'
/usr/local/Homebrew/Library/Homebrew/utils/github.rb:322:in `create_fork'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:318:in `block in bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:281:in `block in cd'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:281:in `chdir'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:281:in `cd'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:301:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:102:in `<main>'
```