### PR TITLE
Require Xcode 10.2 on macOS 10.14

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -27,7 +27,7 @@ module OS
 
       def minimum_version
         case MacOS.version
-        when "10.14" then "10.0"
+        when "10.14" then "10.2"
         when "10.13" then "9.0"
         when "10.12" then "8.0"
         else "2.0"

--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -14,7 +14,6 @@ class XcodeRequirement < Requirement
 
   def xcode_installed_version
     return false unless MacOS::Xcode.installed?
-    return false unless xcode_swift_compatability?
     return true unless @version
 
     MacOS::Xcode.version >= @version
@@ -26,12 +25,6 @@ class XcodeRequirement < Requirement
       A full installation of Xcode.app#{version} is required to compile
       this software. Installing just the Command Line Tools is not sufficient.
     EOS
-    unless xcode_swift_compatability?
-      message += <<~EOS
-
-        Xcode >=10.2 requires macOS >=10.14.4 to build many formulae.
-      EOS
-    end
     if @version && Version.new(MacOS::Xcode.latest_version) < Version.new(@version)
       message + <<~EOS
 
@@ -48,16 +41,5 @@ class XcodeRequirement < Requirement
 
   def inspect
     "#<#{self.class.name}: #{tags.inspect} version=#{@version.inspect}>"
-  end
-
-  private
-
-  # TODO: when 10.14.4 and 10.2 have been around for long enough remove this
-  # method in favour of requiring 10.14.4 and 10.2.
-  def xcode_swift_compatability?
-    return true if MacOS::Xcode.version < "10.2"
-    return true if MacOS.full_version >= "10.14.4"
-
-    MacOS.full_version < "10.14"
   end
 end


### PR DESCRIPTION
Xcode >=10.2 is required to build all Swift formulae on macOS >=10.14.4.

Rather than requiring per-formula workarounds (e.g. Homebrew/homebrew-core#39446) this provides a more stable platform Homebrew can rely on for building Swift formulae.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----