### PR TITLE
Add pkg-config shim to Linux super env

### DIFF
--- a/Library/Homebrew/shims/linux/super/pkg-config
+++ b/Library/Homebrew/shims/linux/super/pkg-config
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+pathremove () {
+        local IFS=':' NEWPATH="" DIR="" PATHVARIABLE=${2:-PATH}
+        for DIR in ${!PATHVARIABLE} ; do
+                if [ "$DIR" != "$1" ] ; then
+                  NEWPATH=${NEWPATH:+$NEWPATH:}$DIR
+                fi
+        done
+        export $PATHVARIABLE="$NEWPATH"
+}
+
+if [[ -n "$HOMEBREW_PKG_CONFIG" && "$HOMEBREW_PKG_CONFIG" != "pkg-config" ]]
+then
+  export PKG_CONFIG="$HOMEBREW_PKG_CONFIG"
+else
+  SAVED_PATH="$PATH"
+  pathremove "$HOMEBREW_LIBRARY/Homebrew/shims/linux/super"
+  export PKG_CONFIG="$HOMEBREW_PREFIX/bin/pkg-config"
+  export PATH="$SAVED_PATH"
+fi
+
+export HOMEBREW_CCCFG="O$HOMEBREW_CCCFG"
+
+exec "$PKG_CONFIG" "$@"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [*] Have you successfully run `brew style` with your changes locally?
- [*] Have you successfully run `brew tests` with your changes locally?

-----

I tried installing Python's `cffi` on Linux in superenv, but it failed to locate `libffi.h`. By default, it looks in `/usr/include` and only overrides the list of includes if `pkg-config` is found, but that wasn't the case with superenv.

Unfortunately, I couldn't run `tests` and `styles` due to a problem with `nokogiri` installation:

```
zlib is missing; necessary for building libxml2
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```