### PR TITLE
remove incorrect cask completion cleanup

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -746,7 +746,7 @@ _brew_cask ()
     done
 
     if [[ $i -eq $COMP_CWORD ]]; then
-        __brew_caskcomp "abv audit cat cleanup create doctor edit fetch home info install list ls outdated reinstall remove rm search style uninstall upgrade zap -S --force --verbose --appdir --colorpickerdir --prefpanedir --qlplugindir --fontdir --servicedir --input_methoddir --internet_plugindir --screen_saverdir --no-binaries --debug --version"
+        __brew_caskcomp "abv audit cat create doctor edit fetch home info install list ls outdated reinstall remove rm search style uninstall upgrade zap -S --force --verbose --appdir --colorpickerdir --prefpanedir --qlplugindir --fontdir --servicedir --input_methoddir --internet_plugindir --screen_saverdir --no-binaries --debug --version"
         return
     fi
 


### PR DESCRIPTION
The brew file contains an incorrect completion for brew cask cleanup, which will yield an error as cleanup is deprecated from brew cask.

- [√ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [√] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [√] Have you added an explanation of what your changes do and why you'd like us to include them?
- [√] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [√] Have you successfully run `brew style` with your changes locally?
- [√] Have you successfully run `brew tests` with your changes locally?

-----
