### PR TITLE
test: Avoid pgrep -q, not available with GNU pgrep

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -33,7 +33,7 @@ rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.puts e.to_json
   error_pipe.close
   pid = Process.pid.to_s
-  if which("pgrep") && which("pkill") && system("pgrep", "-qP", pid)
+  if which("pgrep") && which("pkill") && system("pgrep", "-P", pid, out: :close)
     $stderr.puts "Killing child processes..."
     system "pkill", "-P", pid
     sleep 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

macOS `pgrep` has `-q` but Linux does not: https://linux.die.net/man/1/pgrep
From macOS: `-q Do not write anything to standard output.`
`pgrep >/dev/null` would be more portable.