### PR TITLE
Add HOMEBREW_ARCH environment variable

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -3,6 +3,20 @@
 module Hardware
   class CPU
     class << self
+      native_arch = (ENV["HOMEBREW_ARCH"] || "native").freeze
+      OPTIMIZATION_FLAGS_LINUX = {
+        native:  "-march=#{native_arch}",
+        nehalem: "-march=nehalem",
+        core2:   "-march=core2",
+        core:    "-march=prescott",
+        armv6:   "-march=armv6",
+        armv8:   "-march=armv8-a",
+      }.freeze
+
+      def optimization_flags
+        OPTIMIZATION_FLAGS_LINUX
+      end
+
       def cpuinfo
         @cpuinfo ||= File.read("/proc/cpuinfo")
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I want to use HOMEBREW_ARCH environment variable proposed at #4831.
This is because my home directory is shared by NFS through hosts with variety architectures.
Now I do `brew install` at an oldest host carefully, but this is inconvenience.
