### PR TITLE
speedup bash completion loading suggestion in docs

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -11,14 +11,15 @@ You must configure your shell to enable the completion support. This is because 
 To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell startup. Add the following to your `~/.bash_profile` file:
 
 ```sh
+HOMEBREW_PREFIX=$(brew --prefix)
 if type brew &>/dev/null; then
-  for COMPLETION in $(brew --prefix)/etc/bash_completion.d/*
+  for COMPLETION in "$HOMEBREW_PREFIX"/etc/bash_completion.d/*
   do
     [[ -f $COMPLETION ]] && source "$COMPLETION"
   done
-  if [[ -f $(brew --prefix)/etc/profile.d/bash_completion.sh ]];
+  if [[ -f ${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh ]];
   then
-    source "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+    source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
   fi
 fi
 ```


### PR DESCRIPTION
The current suggestion for bash users shells out to `brew --prefix` three separate times, which has a non-zero overhead (as per quick benchmark below, approx 20ms per invocation). By making a minor change, the first invocation can be stored in a local variable to reduce shell startup time (1 invocation instead of 3).

```
$ hyperfine --warmup=3 'brew --prefix'       
Benchmark #1: brew --prefix
  Time (mean ± σ):      21.3 ms ±   1.5 ms    [User: 8.8 ms, System: 10.6 ms]
  Range (min … max):    20.3 ms …  37.0 ms    128 runs
```

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?

(I believe the below are N/A as this is a documentation change for the website)
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----