### PR TITLE
azure-pipelines: use 10.14 (and Swift)

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -24,6 +24,8 @@ module Cask
         :rmdir,
       ].freeze
 
+      TRASH_SCRIPT = (HOMEBREW_LIBRARY_PATH/"cask/utils/trash.swift").freeze
+
       def self.from_args(cask, **directives)
         new(cask, directives)
       end
@@ -318,35 +320,7 @@ module Cask
       end
 
       def trash_paths(*paths, command: nil, **_)
-        result = command.run!("osascript", args: ["-e", <<~APPLESCRIPT, *paths])
-          on run argv
-            repeat with i from 1 to (count argv)
-              set item i of argv to (item i of argv as POSIX file)
-            end repeat
-
-            try
-              with timeout of 30 seconds
-                tell application "Finder"
-                  set trashedItems to (move argv to trash)
-                  set output to ""
-
-                  repeat with i from 1 to (count trashedItems)
-                    set trashedItem to POSIX path of (item i of trashedItems as string)
-                    set output to output & trashedItem
-                    if i < count trashedItems then
-                      set output to output & character id 0
-                    end if
-                  end repeat
-
-                  return output
-                end tell
-              end timeout
-            on error
-              -- Ignore errors (probably running under Azure)
-              return 0
-            end try
-          end run
-        APPLESCRIPT
+        result = command.run!("/usr/bin/swift", args: [TRASH_SCRIPT, *paths])
 
         # Remove AppleScript's automatic newline.
         result.tap { |r| r.stdout.sub!(/\n$/, "") }

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -324,20 +324,27 @@ module Cask
               set item i of argv to (item i of argv as POSIX file)
             end repeat
 
-            tell application "Finder"
-              set trashedItems to (move argv to trash)
-              set output to ""
+            try
+              with timeout of 30 seconds
+                tell application "Finder"
+                  set trashedItems to (move argv to trash)
+                  set output to ""
 
-              repeat with i from 1 to (count trashedItems)
-                set trashedItem to POSIX path of (item i of trashedItems as string)
-                set output to output & trashedItem
-                if i < count trashedItems then
-                  set output to output & character id 0
-                end if
-              end repeat
+                  repeat with i from 1 to (count trashedItems)
+                    set trashedItem to POSIX path of (item i of trashedItems as string)
+                    set output to output & trashedItem
+                    if i < count trashedItems then
+                      set output to output & character id 0
+                    end if
+                  end repeat
 
-              return output
-            end tell
+                  return output
+                end tell
+              end timeout
+            on error
+              -- Ignore errors (probably running under Azure)
+              return 0
+            end try
           end run
         APPLESCRIPT
 

--- a/Library/Homebrew/cask/utils/trash.swift
+++ b/Library/Homebrew/cask/utils/trash.swift
@@ -1,0 +1,22 @@
+#!/usr/bin/swift
+
+import Foundation
+
+if (CommandLine.arguments.count < 2) {
+  exit(2)
+}
+
+let manager: FileManager = FileManager()
+
+for item in CommandLine.arguments[1...] {
+  do {
+    let path: URL = URL(fileURLWithPath: item)
+    try manager.trashItem(at: path, resultingItemURL: nil)
+    print(path)
+  }
+  catch {
+    print("\0")
+  }
+}
+
+exit(0)

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -58,7 +58,7 @@ module Homebrew
         steps:
           - bash: |
               set -e
-              sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
+              sudo xcode-select --switch /Applications/Xcode_10.2.app/Contents/Developer
               brew update
               HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/#{tap.full_name}"
               mkdir -p "$HOMEBREW_TAP_DIR"

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -54,7 +54,7 @@ module Homebrew
       jobs:
       - job: macOS
         pool:
-          vmImage: macOS-10.13
+          vmImage: macOS-10.14
         steps:
           - bash: |
               set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: macOS
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   steps:
     - bash: |
         set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
   steps:
     - bash: |
         set -e
-        sudo xcode-select --switch /Applications/Xcode_10.1.app/Contents/Developer
+        sudo xcode-select --switch /Applications/Xcode_10.2.app/Contents/Developer
         HOMEBREW_REPOSITORY="$(brew --repo)"
         mv "$HOMEBREW_REPOSITORY/Library/Taps" "$PWD/Library"
         sudo rm -rf "$HOMEBREW_REPOSITORY"


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

(Followup to #6062)

Alternative to #6061: there is now a macOS-10.14 image at Azure pipelines:

 - https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md

Per #6061 (comment), switch brew's azure script and the script generated by tap-new to use 10.14 instead of 10.13.

(@amyspark here) Also switch to Swift for trashing files in Cask, as AppleScript is currently timing out in CI.
