### PR TITLE
Skip CVS dependency collection test if CVS is already installed

### DIFF
--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -64,6 +64,7 @@ describe DependencyCollector do
     end
 
     it "creates a resource dependency from a CVS URL" do
+      skip "cvs already installed" if which("cvs")
       resource = Resource.new
       resource.url(":pserver:anonymous:@brew.sh:/cvsroot/foo/bar", using: :cvs)
       expect(subject.add(resource)).to eq(Dependency.new("cvs", [:build]))


### PR DESCRIPTION
Same issue described & discussed here:

https://discourse.brew.sh/t/brew-tests-fails/4330/18.

I also have the same issues with `ruby.h:1431: error: wrong number of
arguments specified for ‘deprecated’ attribute` but it's not clear to
me what is wrong there (and a Java test failure).

Change-Id: I0cd4677d35f56d6513d611bedd3848172ef721a9


- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

I have other issues that already exist in master and are similar to
https://discourse.brew.sh/t/brew-tests-fails/4330/18.

-----