### PR TITLE
pkgconfig: add uuid.pc

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/10.10/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.10/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.11/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.11/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.12/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.12/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.13/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.13/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.5/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.5/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.6/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.6/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.7/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.7/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.8/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.8/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid

--- a/Library/Homebrew/os/mac/pkgconfig/10.9/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.9/uuid.pc
@@ -1,0 +1,13 @@
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}/uuid


### PR DESCRIPTION
The util-linux uuid library is provided by macOS, through its header at
/usr/include/uuid/uuid.h, and implementation included in libSystem.B.dylib
Using this it is possible to reduce dependency on the unmaintained ossp-uuid formula in a couple of cases.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----