### PR TITLE
formula_creator: fix meson template

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -99,7 +99,7 @@ module Homebrew
         <% if mode == :cmake %>
           depends_on "cmake" => :build
         <% elsif mode == :meson %>
-          depends_on "meson-internal" => :build
+          depends_on "meson" => :build
           depends_on "ninja" => :build
           depends_on "python" => :build
         <% elsif mode.nil? %>
@@ -117,12 +117,10 @@ module Homebrew
                                   "--disable-silent-rules",
                                   "--prefix=\#{prefix}"
         <% elsif mode == :meson %>
-            ENV.refurbish_args
-
             mkdir "build" do
               system "meson", "--prefix=\#{prefix}", ".."
-              system "ninja"
-              system "ninja", "install"
+              system "ninja", "-v"
+              system "ninja", "install", "-v"
             end
         <% else %>
             # Remove unrecognized options if warned by configure


### PR DESCRIPTION
* meson-internal should not be used for new formulas anymore, as the
latest releases of meson have proper support for macOS now.
* make ninja commands verbose


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----