### PR TITLE
teach brew about mksh

### DIFF
--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -11,7 +11,7 @@ module Utils
       shell_name = File.basename(path)
       # handle possible version suffix like `zsh-5.2`
       shell_name.sub!(/-.*\z/m, "")
-      shell_name.to_sym if %w[bash csh fish ksh sh tcsh zsh].include?(shell_name)
+      shell_name.to_sym if %w[bash csh fish ksh mksh sh tcsh zsh].include?(shell_name)
     end
 
     def preferred
@@ -25,7 +25,7 @@ module Utils
     # quote values. quoting keys is overkill
     def export_value(key, value, shell = preferred)
       case shell
-      when :bash, :ksh, :sh, :zsh
+      when :bash, :ksh, :mksh, :sh, :zsh
         "export #{key}=\"#{sh_quote(value)}\""
       when :fish
         # fish quoting is mostly Bourne compatible except that
@@ -55,7 +55,7 @@ module Utils
 
     def prepend_path_in_profile(path)
       case preferred
-      when :bash, :ksh, :sh, :zsh, nil
+      when :bash, :ksh, :mksh, :sh, :zsh, nil
         "echo 'export PATH=\"#{sh_quote(path)}:$PATH\"' >> #{profile}"
       when :csh, :tcsh
         "echo 'setenv PATH #{csh_quote(path)}:$PATH' >> #{profile}"
@@ -69,6 +69,7 @@ module Utils
       csh:  "~/.cshrc",
       fish: "~/.config/fish/config.fish",
       ksh:  "~/.kshrc",
+      mksh: "~/.kshrc",
       sh:   "~/.bash_profile",
       tcsh: "~/.tcshrc",
       zsh:  "~/.zshrc",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Teach `brew` about `mksh`.

Before:

```
$ brew info openssl                                                                                                                                [120/120]
openssl: stable 1.0.2r (bottled) [keg-only]
SSL/TLS cryptography library
https://openssl.org/
/usr/local/Cellar/openssl/1.0.2r (1,795 files, 12.1MB)
  Poured from bottle on 2019-05-03 at 14:10:40
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl.rb
==> Caveats
A CA file has been bootstrapped using certificates from the SystemRoots
keychain. To add additional certificates (e.g. the certificates added in
the System keychain), place .pem files in
  /usr/local/etc/openssl/certs

and run
  /usr/local/opt/openssl/bin/c_rehash

openssl is keg-only, which means it was not symlinked into /usr/local,
because Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries.

If you need to have openssl first in your PATH run:
  echo 'export PATH="/usr/local/opt/openssl/bin:$PATH"' >> ~/.bash_profile

For compilers to find openssl you may need to set:



For pkg-config to find openssl you may need to set:

```

After:

```
$ brew info openssl
openssl: stable 1.0.2r (bottled) [keg-only]
SSL/TLS cryptography library
https://openssl.org/
/usr/local/Cellar/openssl/1.0.2r (1,795 files, 12.1MB)
  Poured from bottle on 2019-05-12 at 20:24:19
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/openssl.rb
==> Caveats
A CA file has been bootstrapped using certificates from the SystemRoots
keychain. To add additional certificates (e.g. the certificates added in
the System keychain), place .pem files in
  /usr/local/etc/openssl/certs

and run
  /usr/local/opt/openssl/bin/c_rehash

openssl is keg-only, which means it was not symlinked into /usr/local,
because Apple has deprecated use of OpenSSL in favor of its own TLS and crypto libraries.

If you need to have openssl first in your PATH run:
  echo 'export PATH="/usr/local/opt/openssl/bin:$PATH"' >> ~/.kshrc

For compilers to find openssl you may need to set:
  export LDFLAGS="-L/usr/local/opt/openssl/lib"
  export CPPFLAGS="-I/usr/local/opt/openssl/include"

For pkg-config to find openssl you may need to set:
  export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig"

```