### PR TITLE
Add a blank line between `brew cask info` output for multiple casks

### DIFF
--- a/Library/Homebrew/cask/cmd/info.rb
+++ b/Library/Homebrew/cask/cmd/info.rb
@@ -17,7 +17,8 @@ module Cask
         if json == "v1"
           puts JSON.generate(casks.map(&:to_h))
         else
-          casks.each do |cask|
+          casks.each_with_index do |cask, i|
+            puts unless i.zero?
             odebug "Getting info for Cask #{cask}"
             self.class.info(cask)
           end

--- a/Library/Homebrew/test/cask/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/info_spec.rb
@@ -48,6 +48,7 @@ describe Cask::Cmd::Info, :cask do
         None
         ==> Artifacts
         Caffeine.app (App)
+
         local-transmission: 2.61
         https://brew.sh
         Not installed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
- `brew info` adds a blank line between info output for multiple
  formulae. This replicates that display for `brew cask info`, as
  requested in #6126.
- Fixes #6126.