### PR TITLE
docs/Homebrew-on-Linux: Fedora 30 needs libxcrypt-compat

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -63,7 +63,9 @@ sudo apt-get install build-essential curl file git
 ### Fedora, CentOS, or Red Hat
 
 ```sh
-sudo yum groupinstall 'Development Tools' && sudo yum install curl file git
+sudo yum groupinstall 'Development Tools'
+sudo yum install curl file git
+sudo yum install libxcrypt-compat # needed by Fedora 30 and up
 ```
 
 ### ARM


### PR DESCRIPTION
`portable-ruby` requires the library `libcrypt.so.1`.
On Fedora 30, that file is provided by `libxcrypt-compat`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----