### PR TITLE
Add exception for veclibfort linking to Accelerate

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -15,9 +15,9 @@ module Homebrew
          present, "revision 1" will be added.
       EOS
       switch "-n", "--dry-run",
-        description: "Print what would be done rather than doing it."
+             description: "Print what would be done rather than doing it."
       flag "--message=",
-        description: "Append the provided <message> to the default commit message."
+           description: "Append the provided <message> to the default commit message."
 
       switch :force
       switch :quiet
@@ -76,7 +76,7 @@ module Homebrew
     else
       formula.path.parent.cd do
         safe_system "git", "commit", "--no-edit", "--verbose",
-          "--message=#{message}", "--", formula.path
+                    "--message=#{message}", "--", formula.path
       end
     end
   end

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -51,6 +51,7 @@ module FormulaCellarChecks
   def check_accelerate_framework_links
     return unless @core_tap
     return unless formula.prefix.directory?
+    return if formula.name == "veclibfort" # veclibfort exists to wrap accelerate
 
     keg = Keg.new(formula.prefix)
     system_accelerate = keg.mach_o_files.select do |obj|
@@ -63,7 +64,8 @@ module FormulaCellarChecks
       object files were linked against system Accelerate
       These object files were linked against the outdated system Accelerate framework.
       Core tap formulae should link against OpenBLAS instead.
-      Adding `depends_on "openblas"` to the formula may help.
+      Removing `depends_on "veclibfort" and/or adding `depends_on "openblas"` to the
+      formula may help.
         #{system_accelerate * "\n  "}
     EOS
   end


### PR DESCRIPTION
 - veclibfort exists solely to wrap Apple's accelerate and provide BLAS/LAPACK
   access to Accelerate
 - Improve the help message for that audit to mention veclibfort
 - See discussion in #6130 

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?

Add an Accelerate linkage audit exception for `veclibfort` since its *raison d'etre* is to wrap accelerate.

- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
