### PR TITLE
fix copying top level symlinks to folders in directory unpack_strategy

### DIFF
--- a/Library/Homebrew/test/unpack_strategy/directory_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/directory_spec.rb
@@ -9,6 +9,8 @@ describe UnpackStrategy::Directory do
     mktmpdir.tap do |path|
       FileUtils.touch path/"file"
       FileUtils.ln_s "file", path/"symlink"
+      FileUtils.mkdir path/"folder"
+      FileUtils.ln_s "folder", path/"folderSymlink"
     end
   }
 
@@ -17,6 +19,11 @@ describe UnpackStrategy::Directory do
   it "does not follow symlinks" do
     strategy.extract(to: unpack_dir)
     expect(unpack_dir/"symlink").to be_a_symlink
+  end
+
+  it "does not follow top level symlinks to directories" do
+    strategy.extract(to: unpack_dir)
+    expect(unpack_dir/"folderSymlink").to be_a_symlink
   end
 
   it "preserves permissions of contained files" do

--- a/Library/Homebrew/unpack_strategy/directory.rb
+++ b/Library/Homebrew/unpack_strategy/directory.rb
@@ -19,7 +19,8 @@ module UnpackStrategy
     def extract_to_dir(unpack_dir, basename:, verbose:)
       path.children.each do |child|
         system_command! "cp",
-                        args:    ["-pR", child.directory? ? "#{child}/." : child, unpack_dir/child.basename],
+                        args:    ["-pR", (child.directory? && !child.symlink?) ? "#{child}/." : child,
+                                  unpack_dir/child.basename],
                         verbose: verbose
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR fixes a issue in the directory unpack_strategy, which currently does not preserve top level symlinks pointing to directories. Instead of copying the symlink (as a singe file) we are currently recursively copying the content of the folder to which the symlink points to. At the end the unpacked source does not contain the top level symlink (pointing to a folder within the source) anymore, because `brew` has converted it to a complete copy of said folder.

This breaks `deno` (see: https://github.com/Homebrew/homebrew-core/pull/35645#discussion_r284924995) and the added test case.

The current code is broken because `child.directory?` is true for symlinks pointing to folders too, but we should preserve them. That's why an additional check if the `child` is not a symlink was added to determine if we should recursively copy the contents of the `child` (in case it's a non symlink folder) or just the file itself.