### PR TITLE
Add configuration to new appcast check

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -304,9 +304,9 @@ module Cask
       return if cask.appcast.configuration == :no_check
 
       appcast_stanza = cask.appcast.to_s
-      appcast_contents, = curl_output("-L", "--max-time", "5", appcast_stanza)
+      appcast_contents, = curl_output("--location", "--max-time", "5", appcast_stanza)
       version_stanza = cask.version.to_s
-      if cask.appcast.configuration.to_s.empty?
+      if cask.appcast.configuration.blank?
         adjusted_version_stanza = version_stanza.split(",")[0].split("-")[0].split("_")[0]
       else
         adjusted_version_stanza = cask.appcast.configuration

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -301,11 +301,16 @@ module Cask
     def check_appcast_contains_version
       return unless check_appcast?
       return if cask.appcast.to_s.empty?
+      return if cask.appcast.configuration == :no_check
 
       appcast_stanza = cask.appcast.to_s
-      appcast_contents, = curl_output("--max-time", "5", appcast_stanza)
+      appcast_contents, = curl_output("-L", "--max-time", "5", appcast_stanza)
       version_stanza = cask.version.to_s
-      adjusted_version_stanza = version_stanza.split(",")[0].split("-")[0].split("_")[0]
+      if cask.appcast.configuration.to_s.empty?
+        adjusted_version_stanza = version_stanza.split(",")[0].split("-")[0].split("_")[0]
+      else
+        adjusted_version_stanza = cask.appcast.configuration
+      end
       return if appcast_contents.include? adjusted_version_stanza
 
       add_warning "appcast at URL '#{appcast_stanza}' does not contain"\

--- a/Library/Homebrew/cask/dsl/appcast.rb
+++ b/Library/Homebrew/cask/dsl/appcast.rb
@@ -3,21 +3,12 @@
 module Cask
   class DSL
     class Appcast
-      ATTRIBUTES = [
-        :configuration,
-      ].freeze
-      attr_reader :uri, :parameters
-      attr_reader(*ATTRIBUTES)
+      attr_reader :uri, :parameters, :configuration
 
       def initialize(uri, **parameters)
         @uri        = URI(uri)
         @parameters = parameters
-
-        ATTRIBUTES.each do |attribute|
-          next unless parameters.key?(attribute)
-
-          instance_variable_set("@#{attribute}", parameters[attribute])
-        end
+        @configuration = parameters[:configuration] if parameters.key?(:configuration)
       end
 
       def to_yaml

--- a/Library/Homebrew/cask/dsl/appcast.rb
+++ b/Library/Homebrew/cask/dsl/appcast.rb
@@ -3,11 +3,21 @@
 module Cask
   class DSL
     class Appcast
+      ATTRIBUTES = [
+        :configuration,
+      ].freeze
       attr_reader :uri, :parameters
+      attr_reader(*ATTRIBUTES)
 
       def initialize(uri, **parameters)
         @uri        = URI(uri)
         @parameters = parameters
+
+        ATTRIBUTES.each do |attribute|
+          next unless parameters.key?(attribute)
+
+          instance_variable_set("@#{attribute}", parameters[attribute])
+        end
       end
 
       def to_yaml


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

****
This a followup to PR #5972 
Recap: PR #5972 introduced an optional new flag '--appcast' to 'brew cask audit' that checks whether the version stanza is contained in the downloaded appcast. This allows the Travis CI check to fail for submitted PRs that are for unofficial/beta versions, this preventing automerging by @BrewTestBot.

However, this also prevents auto-merging Cask PRs for a lot of fine PRs. This PR is meant to address that. Changes:
1.) the 'curl_output' call to download the appcast is changed to follow redirects. we've seen quite a lot of failures because the appcast URL actually leads to an redirect. following the redirect in the cask itself is not always appropriate, so the appcast check should be adjusted to be able to follow the redirect
2.) as discussed many times previously the new appcast check is not 'perfect' because many appcasts do not contain the whole version stanza in unmodified form. this PR fixes this problem by allowing the appcast stanza to be annotated to specify which part or which transformation of the version stanza is actually contained in the appcast, therefore allowing the appcast check to succeed and those PRs to be automerged
3.) some appcasts do not contain the version number at all, but automerging PRs for these casks may still be desired. therefore this patch allows to disable the appcast check as needed

examples:

cask 'visual-paradigm'
the appcast ( https://www.visual-paradigm.com/downloads/vp/checksum.html ) does not contain the while version number ( currently 15.2,20190501 ) but just the last part which constitutes the build number. currently all PRs for visual-paradigm fail Travis and can not be automerged. using this PR we can now annotate the appcast stanza with the 'configuration' option which properly makes the appcast check search just for the build number in the appcast:
```
  appcast 'https://www.visual-paradigm.com/downloads/vp/checksum.html',
          configuration: version.after_comma.to_s
```

other transformations work similarly. i guess you could even specify 'context', if you want the appcast e.g. to contain "Version #{version} released"

another example, cask 'p4v' the appcast ( https://cdist2.perforce.com/perforce/r18.4/bin.macosx1013x86_64/SHA256SUMS ) only contains checksums and therefore doesn't contain the version number at all. the appcast is still useful because it can be observed for changes. however, we don't want the fact that it doesn't contain version numbers prevent auto-merging for this cask. now we can just change the appcast to

```
  appcast 'https://blabla',
          configuration: :no_check
```
which instructs the appcast check to skip checking the appcast despite the --appcast flag which travis passes.

cc @reitermarkus @vitorgalvao 