### PR TITLE
[Linux] Don't prompt users to `brew cask install`

### DIFF
--- a/Library/Homebrew/extend/os/mac/missing_formula.rb
+++ b/Library/Homebrew/extend/os/mac/missing_formula.rb
@@ -13,6 +13,17 @@ module Homebrew
           generic_blacklisted_reason(name)
         end
       end
+
+      def cask_reason(name, silent: false, show_info: false)
+        return if silent
+
+        cask = Cask::CaskLoader.load(name)
+        reason = +"Found a cask named \"#{name}\" instead.\n"
+        reason << Cask::Cmd::Info.get_info(cask) if show_info
+        reason.freeze
+      rescue Cask::CaskUnavailableError
+        nil
+      end
     end
   end
 end

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -196,16 +196,7 @@ module Homebrew
         end
       end
 
-      def cask_reason(name, silent: false, show_info: false)
-        return if silent
-
-        cask = Cask::CaskLoader.load(name)
-        reason = +"Found a cask named \"#{name}\" instead.\n"
-        reason << Cask::Cmd::Info.get_info(cask) if show_info
-        reason.freeze
-      rescue Cask::CaskUnavailableError
-        nil
-      end
+      def cask_reason(name, silent: false, show_info: false); end
 
       require "extend/os/missing_formula"
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
- I tried to install `keybase`, thinking I'd get the CLI, but no. On Linux,
  casks don't work, yet I was still prompted to `brew cask install
  keybase`. When I tried that (just to make sure), I got the "casks are
  only supported on MacOS" error.
- This change makes it so we don't prompt people to install casks if
  they're on platforms other than MacOS.

Before:

```
$ brew install keybase
Error: No available formula with the name "keybase"
Found a cask named "keybase" instead.
```

After:

```
Error: No available formula with the name "keybase"
==> Searching for a previously deleted formula (in the last month)...
Warning: homebrew/core is shallow clone. To get complete history run:
  git -C "$(brew --repo homebrew/core)" fetch --unshallow
Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
==> Searching taps...
==> Searching taps on GitHub...
Error: No formulae found in taps.
```

which is long, but still better messaging than "found a cask".

This is a _draft PR_. Things still to do include:

- [ ] Tests. I can't find many places in the tests that differentiate between OSes. I might need some help here. :grimacing:
- [ ] This doesn't account for the cases where people try to install blacklisted formulae on Linux, for which the help text hardcodes "brew cask install". I'd welcome ideas on how to do this, because I couldn't see how to break the massive case statement up without excluding some formulae from _either_, using the common `unless OS.mac?` condition.

(I couldn't see anything in the contributing guide about whether draft PRs are good or not, so feel free to close this for that reason, or if this is not a feature you'd support!)