### PR TITLE
Allow Accelerate linkage, deny veclibfort & lapack

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -16,6 +16,10 @@ module RuboCop
             problem "Formulae should not depend on both OpenSSL and LibreSSL (even optionally)."
           end
 
+          if depends_on?("veclibfort") || depends_on?("lapack")
+            problem "Formulae should use OpenBLAS as the default serial linear algebra library."
+          end
+
           if method_called_ever?(body_node, :virtualenv_create) ||
              method_called_ever?(body_node, :virtualenv_install_with_resources)
             find_method_with_args(body_node, :resource, "setuptools") do


### PR DESCRIPTION
 - Accelerate provides more than just BLAS and LAPACK functionality, see
   https://developer.apple.com/documentation/accelerate
 - Veclibfort exists only to wrap Accelerate's BLAS/LAPACK
 - LAPACK is a slow, seldom updated reference implementation
 - Encourage usage of OpenBLAS
 - Reverts PR #6130

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
