### PR TITLE
Fix issue close bot's config file

### DIFF
--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -5,8 +5,8 @@ From the issue template:
 \> **Please note that we will close your issue without comment if you delete, do not read or do not fill out the issue checklist below and provide ALL the requested information. If you repeatedly fail to use the issue template, we will block you from ever submitting issues to Homebrew again.**
 
 If you add the necessary information to this issue (don't create a new one, please) then this issue may be reopened.
-# There can be several configs for different kind of issues.
 issueConfigs:
+# There can be several configs for different kind of issues.
 - content:
 # new feature suggestion
   - "A detailed description of the proposed feature"

--- a/.github/issue-close-app.yml
+++ b/.github/issue-close-app.yml
@@ -6,6 +6,7 @@ From the issue template:
 
 If you add the necessary information to this issue (don't create a new one, please) then this issue may be reopened.
 # There can be several configs for different kind of issues.
+issueConfigs:
 - content:
 # new feature suggestion
   - "A detailed description of the proposed feature"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- According to the [README](https://github.com/offu/close-issue-app#usage) it was missing an `issueConfigs` key. This caused the bot to post error messages to new issues instead of the intended text.
