### PR TITLE
Add a USER linuxbrew directive to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,5 @@ RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
 	&& chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
 	&& chmod -R o-w /home/linuxbrew/.linuxbrew \
 	&& rm -rf ~/.cache
+
+USER linuxbrew


### PR DESCRIPTION
Is there any reason we default to the 'root' user when using this docker image? We explicitly don't allow root users to run things, and it's increadibly annoying to have to remember to add `-u` flags.
