### PR TITLE
Support running the Linuxbrew docker image in Kubernetes

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -375,8 +375,8 @@ fi
 check-run-command-as-root() {
   [[ "$(id -u)" = 0 ]] || return
 
-  # Allow Azure Pipelines/Docker to do everything as root (as it's normal there)
-  [[ -f /proc/1/cgroup ]] && grep -E "azpl_job|docker" -q /proc/1/cgroup && return
+  # Allow Azure Pipelines/Docker/Kubernetes to do everything as root (as it's normal there)
+  [[ -f /proc/1/cgroup ]] && grep -E "azpl_job|docker|kubepods" -q /proc/1/cgroup && return
 
   # Homebrew Services may need `sudo` for system-wide daemons.
   [[ "$HOMEBREW_COMMAND" = "services" ]] && return


### PR DESCRIPTION
On Kubernetes there is no `docker` in `/proc/1/cgroup`:

```
$ cat /proc/1/cgroup
11:devices:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
10:perf_event:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
9:pids:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
8:cpuset:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
7:cpu,cpuacct:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
6:blkio:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
5:net_cls,net_prio:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
4:freezer:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
3:memory:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
2:hugetlb:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
1:name=systemd:/kubepods/besteffort/podc072e428-830d-11e9-9979-02dce0d67d6a/a6ebc1887d3fc237d5151e7a20bc888a560b47f69fc14e80d29275bd87cb1042
```

This allows this image to be used with CI systems that run on Kubernetes.