### PR TITLE
Fix #6188 - Remove ambiguity from branch reset command

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -746,7 +746,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
     end
 
     system_command! "git",
-                    args:  ["reset", "--hard", *ref],
+                    args:  ["reset", "--hard", *ref, "--"],
                     chdir: cached_location
   end
 


### PR DESCRIPTION
Add trailing -- to git reset when performing a branch reset to remove
ambiguity between revision and file.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
