### PR TITLE
Bottles: allow skipping or_later tags

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -123,6 +123,10 @@ module HomebrewArgvExtension
     !ENV["HOMEBREW_DEVELOPER"].nil?
   end
 
+  def skip_or_later_bottles?
+    homebrew_developer? && !ENV["HOMEBREW_SKIP_OR_LATER_BOTTLES"].nil?
+  end
+
   def no_sandbox?
     include?("--no-sandbox") || !ENV["HOMEBREW_NO_SANDBOX"].nil?
   end

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -16,8 +16,13 @@ module Utils
       alias generic_find_matching_tag find_matching_tag
 
       def find_matching_tag(tag)
-        generic_find_matching_tag(tag) ||
-          find_older_compatible_tag(tag)
+        # Used primarily by developers testing beta macOS releases.
+        if OS::Mac.prerelease? && ARGV.skip_or_later_bottles?
+          generic_find_matching_tag(tag)
+        else
+          generic_find_matching_tag(tag) ||
+            find_older_compatible_tag(tag)
+        end
       end
 
       def tag_without_or_later(tag)

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -20,9 +20,25 @@ describe Utils::Bottles::Collector do
     end
 
     it "uses older tags when needed", :needs_macos do
-      subject[:yosemite] = "foo"
-      expect(subject.fetch_checksum_for(:yosemite)).to eq(["foo", :yosemite])
-      expect(subject.fetch_checksum_for(:mavericks)).to be nil
+      subject[:mavericks] = "foo"
+      expect(subject.send(:find_matching_tag, :mavericks)).to eq(:mavericks)
+      expect(subject.send(:find_matching_tag, :yosemite)).to eq(:mavericks)
+    end
+
+    it "does not use older tags when requested not to", :needs_macos do
+      allow(ARGV).to receive(:skip_or_later_bottles?).and_return(true)
+      allow(OS::Mac).to receive(:prerelease?).and_return(true)
+      subject[:mavericks] = "foo"
+      expect(subject.send(:find_matching_tag, :mavericks)).to eq(:mavericks)
+      expect(subject.send(:find_matching_tag, :yosemite)).to be_nil
+    end
+
+    it "ignores HOMEBREW_SKIP_OR_LATER_BOTTLES on release versions", :needs_macos do
+      allow(ARGV).to receive(:skip_or_later_bottles?).and_return(true)
+      allow(OS::Mac).to receive(:prerelease?).and_return(false)
+      subject[:mavericks] = "foo"
+      expect(subject.send(:find_matching_tag, :mavericks)).to eq(:mavericks)
+      expect(subject.send(:find_matching_tag, :yosemite)).to eq(:mavericks)
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a developer-only feature, so it's gated via `HOMEBREW_DEVELOPER`.

This is intended to enable testing of macOS 10.15; users building software manually to test compatibility of early betas need to be able to build software from source instead of via pouring 10.14 bottles. This isn't intended to be a general-purpose `HOMEBREW_BUILD_FROM_SOURCE` replacement, and has no effect on released versions of macOS.

I've rewritten the existing "uses older tags when needed" test in order to make it look more like my new test, for clarity.