### PR TITLE
java_requirement: set cask attribute

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -30,6 +30,7 @@ class JavaRequirement < Requirement
   def initialize(tags = [])
     @version = tags.shift if /^\d/ =~ tags.first
     super(tags)
+    @cask = suggestion.token
   end
 
   def message

--- a/Library/Homebrew/test/java_requirement_spec.rb
+++ b/Library/Homebrew/test/java_requirement_spec.rb
@@ -105,4 +105,25 @@ describe JavaRequirement do
       end
     end
   end
+
+  describe "#suggestion" do
+    context "without specific version" do
+      its(:suggestion) { is_expected.to match(/brew cask install adoptopenjdk/) }
+      its(:cask) { is_expected.to eq("adoptopenjdk") }
+    end
+
+    context "with version 1.8" do
+      subject { described_class.new(%w[1.8]) }
+
+      its(:suggestion) { is_expected.to match(%r{brew cask install homebrew/cask-versions/adoptopenjdk8}) }
+      its(:cask) { is_expected.to eq("homebrew/cask-versions/adoptopenjdk8") }
+    end
+
+    context "with version 1.8+" do
+      subject { described_class.new(%w[1.8+]) }
+
+      its(:suggestion) { is_expected.to match(/brew cask install adoptopenjdk/) }
+      its(:cask) { is_expected.to eq("adoptopenjdk") }
+    end
+  end
 end


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Set `@cask` attribute for JavaRequirement, which is used by
`brew info` to track cask requirement for formulae and
`brew bundle dump` to sort the formulae and casks.

Before:
```
$ brew info --json languagetool | jq '.[0].requirements'
[
  {
    "name": "java",
    "cask": null,
    "download": null
  }
]
$ brew cask install adoptopenjdk; brew install languagetool
$ brew bundle dump
brew "languagetool"
cask "adoptopenjdk"
```

After:
```
$ brew info --json languagetool | jq '.[0].requirements'
[
  {
    "name": "java",
    "cask": "adoptopenjdk",
    "download": null
  }
]
$ brew cask install adoptopenjdk; brew install languagetool
$ brew bundle dump
cask "adoptopenjdk"
brew "languagetool"
```

Also added relevant test cases.
