### PR TITLE
system_config: hide HOMEBREW_BUNDLE_* env vars.

### DIFF
--- a/Library/Homebrew/system_config.rb
+++ b/Library/Homebrew/system_config.rb
@@ -169,6 +169,7 @@ class SystemConfig
       unless ENV["HOMEBREW_ENV"]
         ENV.sort.each do |key, value|
           next unless key.start_with?("HOMEBREW_")
+          next if key.start_with?("HOMEBREW_BUNDLE_")
           next if boring_keys.include?(key)
           next if defaults_hash[key.to_sym]
 


### PR DESCRIPTION
These are being introduced in e.g. https://github.com/Homebrew/homebrew-bundle/pull/486 and we don't care about them in Homebrew bug reports.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----