### PR TITLE
Resource#fetch: verify downloads by default.

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -133,7 +133,7 @@ module Homebrew
     already_fetched = f.cached_download.exist?
 
     begin
-      download = f.fetch
+      download = f.fetch(verify_download_integrity: false)
     rescue DownloadError
       retry if retry_fetch? f
       raise

--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -47,7 +47,6 @@ module Homebrew
       downloader = f.downloader
 
       downloader.fetch
-      f.verify_download_integrity(downloader.cached_location)
 
       filename = downloader.basename
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1688,8 +1688,8 @@ class Formula
   end
 
   # @private
-  def fetch
-    active_spec.fetch
+  def fetch(verify_download_integrity: true)
+    active_spec.fetch(verify_download_integrity: verify_download_integrity)
   end
 
   # @private
@@ -2057,10 +2057,7 @@ class Formula
     active_spec.add_legacy_patches(patches) if respond_to?(:patches)
 
     patchlist.grep(DATAPatch) { |p| p.path = path }
-
-    patchlist.each do |patch|
-      patch.verify_download_integrity(patch.fetch) if patch.external?
-    end
+    patchlist.select(&:external?).each(&:fetch)
   end
 
   # The methods below define the formula DSL.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -948,8 +948,9 @@ class FormulaInstaller
       downloader = LocalBottleDownloadStrategy.new(bottle_path)
     else
       downloader = formula.bottle
-      downloader.verify_download_integrity(downloader.fetch)
+      downloader.fetch
     end
+
     HOMEBREW_CELLAR.cd do
       downloader.stage
     end


### PR DESCRIPTION
This API is used internally correctly and externally mostly correctly but #6230 reveals the external usage is fairly confusing and a bit unsafe by default. Preserve the existing API while verifying the checksum by default and providing an opt-out. Using the existing, safe method will result in a double verification of the checksum which is
harmless. A Homebrew/homebrew-core PR will follow shortly to address those cases.

Fixes #6230

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----