### PR TITLE
Cask audit: decompress appcast and use user agent

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -304,7 +304,7 @@ module Cask
       return if cask.appcast.configuration == :no_check
 
       appcast_stanza = cask.appcast.to_s
-      appcast_contents, = curl_output("--location", "--max-time", "5", appcast_stanza)
+      appcast_contents, = curl_output("--compressed", "--location", "--max-time", "5", appcast_stanza)
       version_stanza = cask.version.to_s
       if cask.appcast.configuration.blank?
         adjusted_version_stanza = version_stanza.split(",")[0].split("-")[0].split("_")[0]

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -304,7 +304,8 @@ module Cask
       return if cask.appcast.configuration == :no_check
 
       appcast_stanza = cask.appcast.to_s
-      appcast_contents, = curl_output("--compressed", "--location", "--max-time", "5", appcast_stanza)
+      appcast_contents, = curl_output("--compressed", "--user-agent", HOMEBREW_USER_AGENT_FAKE_SAFARI, "--location",
+                                      "--max-time", "5", appcast_stanza)
       version_stanza = cask.version.to_s
       if cask.appcast.configuration.blank?
         adjusted_version_stanza = version_stanza.split(",")[0].split("-")[0].split("_")[0]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix for cases like https://github.com/Homebrew/homebrew-cask/pull/64970, where `audit` fails on an `appcast` because it’s gzipped. This should handle both cases.

Something wrong with my ruby installation so I wasn’t able to run `style` and `tests`, but I don’t expect such a simple change to cause a problem.