### PR TITLE
java_dep_if_needed: Install adoptopenjdk for Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/linux/dependency_collector.rb
@@ -4,7 +4,7 @@ class DependencyCollector
   def java_dep_if_needed(tags)
     req = JavaRequirement.new(tags)
     begin
-      dep = Dependency.new("openjdk", tags)
+      dep = Dependency.new("adoptopenjdk", tags)
       return dep if dep.installed?
       return req if req.satisfied?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Install adoptopenjdk rather than openjdk for Linux. openjdk is superseded by adoptopenjdk.