### PR TITLE
bottle_publisher: fix bottle info accessor

### DIFF
--- a/Library/Homebrew/bottle_publisher.rb
+++ b/Library/Homebrew/bottle_publisher.rb
@@ -107,14 +107,14 @@ class BottlePublisher
 
         # Poll for publication completion using a quick partial HEAD, to avoid spurious error messages
         # 401 error is normal while file is still in async publishing process
-        url = URI(bottle_info.url)
+        url = URI(bottle_info["url"])
         puts "Verifying bottle: #{File.basename(url.path)}"
         http = Net::HTTP.new(url.host, url.port)
         http.use_ssl = true
         retry_count = 0
         http.start do
           loop do
-            req = Net::HTTP::Head.new bottle_info.url
+            req = Net::HTTP::Head.new url
             req.initialize_http_header "User-Agent" => HOMEBREW_USER_AGENT_RUBY
             res = http.request req
             break if res.is_a?(Net::HTTPSuccess) || res.code == "302"
@@ -154,7 +154,7 @@ class BottlePublisher
             retry_count += 1
           end
         end
-        checksum = Checksum.new(:sha256, bottle_info.sha256)
+        checksum = Checksum.new(:sha256, bottle_info["sha256"])
         Pathname.new(filename).verify_checksum(checksum)
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The old `BottleInfo` has been removed in https://github.com/Homebrew/brew/pull/5758/files#diff-de3bb69738cf9f6002692059922a16fbL533, the `bottle_info` is now a `Hash`.