### PR TITLE
remove extra command output when running brew list -v <formula>

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -71,7 +71,7 @@ module Homebrew
         safe_system "ls", *ARGV.options_only << HOMEBREW_CELLAR
       end
     elsif args.verbose? || !$stdout.tty?
-      safe_system "find", *ARGV.kegs.map(&:to_s) + %w[-not -type d -print]
+      system_command! "find", args: ARGV.kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true
     else
       ARGV.kegs.each { |keg| PrettyListing.new keg }
     end


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew list -v <formula>` is used to list all files inside formula's keg.

However since 70b93f65eab70cd84d221059a2864a52202df141, an extra
`find /usr/local/Cellar/<formula>/<version> -not -type d -print` will be
printed out. Fix the problem by using `system_command!` instead of
`safe_system`.
