### PR TITLE
bump-formula-pr: add update-alias option to rename formula aliases if necessary

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -273,6 +273,12 @@ module Homebrew
       EOS
     end
 
+    alias_rename = alias_update_pair(formula, new_formula_version)
+    if alias_rename.present?
+      ohai "renaming alias #{alias_rename.first} to #{alias_rename.last}"
+      alias_rename.map! { |a| formula.tap.alias_dir/a }
+    end
+
     if args.dry_run?
       if args.no_audit?
         ohai "Skipping `brew audit`"
@@ -282,6 +288,7 @@ module Homebrew
         ohai "brew audit #{formula.path.basename}"
       end
     else
+      FileUtils.mv alias_rename.first, alias_rename.last if alias_rename.present?
       failed_audit = false
       if args.no_audit?
         ohai "Skipping `brew audit`"
@@ -294,6 +301,7 @@ module Homebrew
       end
       if failed_audit
         formula.path.atomic_write(backup_file)
+        FileUtils.mv alias_rename.last, alias_rename.first if alias_rename.present?
         odie "brew audit failed!"
       end
     end
@@ -302,13 +310,16 @@ module Homebrew
       branch = "#{formula.name}-#{new_formula_version}"
       git_dir = Utils.popen_read("git rev-parse --git-dir").chomp
       shallow = !git_dir.empty? && File.exist?("#{git_dir}/shallow")
+      changed_files = [formula.path]
+      changed_files += alias_rename if alias_rename.present?
 
       if args.dry_run?
         ohai "try to fork repository with GitHub API"
         ohai "git fetch --unshallow origin" if shallow
+        ohai "git add #{alias_rename.first} #{alias_rename.last}" if alias_rename.present?
         ohai "git checkout --no-track -b #{branch} origin/master"
         ohai "git commit --no-edit --verbose --message='#{formula.name} " \
-             "#{new_formula_version}#{devel_message}' -- #{formula.path}"
+             "#{new_formula_version}#{devel_message}' -- #{changed_files.join(" ")}"
         ohai "git push --set-upstream $HUB_REMOTE #{branch}:#{branch}"
         ohai "git checkout --quiet -"
         ohai "create pull request with GitHub API"
@@ -338,10 +349,11 @@ module Homebrew
         end
 
         safe_system "git", "fetch", "--unshallow", "origin" if shallow
+        safe_system "git", "add", *alias_rename if alias_rename.present?
         safe_system "git", "checkout", "--no-track", "-b", branch, "origin/master"
         safe_system "git", "commit", "--no-edit", "--verbose",
                     "--message=#{formula.name} #{new_formula_version}#{devel_message}",
-                    "--", formula.path
+                    "--", *changed_files
         safe_system "git", "push", "--set-upstream", remote_url, "#{branch}:#{branch}"
         safe_system "git", "checkout", "--quiet", "-"
         pr_message = <<~EOS
@@ -439,5 +451,17 @@ module Homebrew
         #{error_message}
       EOS
     end
+  end
+
+  def alias_update_pair(formula, new_formula_version)
+    versioned_alias = formula.aliases.grep(/^.*@\d+(\.\d+)?$/).first
+    return if versioned_alias.nil?
+
+    name, old_alias_version = versioned_alias.split("@")
+    new_alias_regex = (old_alias_version.split(".").length == 1) ? /^\d+/ : /^\d+\.\d+/
+    new_alias_version, = *new_formula_version.to_s.match(new_alias_regex)
+    return if Version.create(new_alias_version) <= Version.create(old_alias_version)
+
+    [versioned_alias, "#{name}@#{new_alias_version}"]
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **=> currently there are no tests for bump-formula-pr**
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds an `--update-alias` to `brew bump-formula-pr` to updated the versioned alias pointing to a formula (e.g. `node@12` => `node`), if the version bump makes it necessary to update said alias (e.g. bumping to `node` 13 needs an `node@13` alias).

Without this change I usually run into issues when trying to bump `v8` with `brew bump-formula-pr`, because every minor `v8` update requires a rename of the (currently) `v8@7.5` alias. Using `brew bump-formula-pr` for such a minor `v8` version bump will fail with a audit error correctly complaining about the incorrect alias. Even worse: If you think you are clever and are doing the alias rename by yourself before running `brew bump-formula-pr` it will complete (`audit` passes), but it will result in a broken PR (without the alias rename) because `brew bump-formula-pr` does only commit changes to the formula itself atm and just does not commit your alias rename.

With this PR you could simple run `brew bump-formula-pr --strict --update-alias v8 ...` and it will notice the outdated alias, make the rename for you and also commits the renamed alias in addition to the formula changes for you. I've conservatively put it behind the `--update-alias` option now, but you might want to consider making it the default behavior later after enough testing.

This first commit https://github.com/Homebrew/brew/pull/6299/commits/78dbf0cfcce7b92ad04a4b4628481ec0c208a8e3 contains the actual change to support `--update-alias` and the second commit https://github.com/Homebrew/brew/pull/6299/commits/9fa30264648bb5a801ef1d484e6a271f9f2ad9ba is just a little refactor necessary to avoid `brew style`'s `Cyclomatic complexity for bump_formula_pr is too high. [77/75]` error. I've left them separated for easier review, but I can squash them before merging.
