### PR TITLE
formula_creator: remove redundant dep for meson

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -96,12 +96,12 @@ module Homebrew
         <% end %>
           sha256 "#{sha256}"
         <% end %>
+
         <% if mode == :cmake %>
           depends_on "cmake" => :build
         <% elsif mode == :meson %>
           depends_on "meson" => :build
           depends_on "ninja" => :build
-          depends_on "python" => :build
         <% elsif mode.nil? %>
           # depends_on "cmake" => :build
         <% end %>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Wish of https://github.com/Homebrew/homebrew-core/pull/42014#discussion_r303885750

As `depends_on "meson"` implies depending `python` explicitly including this dependency is redundant.