### PR TITLE
keg_relocate: relocate the interpreter for elf files with INTERP header (Linux)

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -39,7 +39,7 @@ class Keg
     new_rpath = rpath.join(":")
     cmd = [patchelf, "--force-rpath", "--set-rpath", new_rpath]
 
-    if file.binary_executable?
+    if file.with_interpreter?
       old_interpreter = Utils.safe_popen_read(patchelf, "--print-interpreter", file).strip
       new_interpreter = if File.readable? "#{new_prefix}/lib/ld.so"
         "#{new_prefix}/lib/ld.so"

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -68,6 +68,24 @@ module ELFShim
     elf_type == :executable
   end
 
+  def with_interpreter?
+    return @with_interpreter if defined? @with_interpreter
+
+    @with_interpreter = if binary_executable?
+      true
+    elsif dylib?
+      if which "readelf"
+        Utils.popen_read("readelf", "-l", to_path).include?(" INTERP ")
+      elsif which "file"
+        Utils.popen_read("file", "-L", "-b", to_path).include?(" interpreter ")
+      else
+        raise "Please install either readelf (from binutils) or file."
+      end
+    else
+      false
+    end
+  end
+
   def dynamic_elf?
     return @dynamic_elf if defined? @dynamic_elf
 

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -71,7 +71,7 @@ module ELFShim
   def dynamic_elf?
     return @dynamic_elf if defined? @dynamic_elf
 
-    if which "readelf"
+    @dynamic_elf = if which "readelf"
       Utils.popen_read("readelf", "-l", to_path).include?(" DYNAMIC ")
     elsif which "file"
       !Utils.popen_read("file", "-L", "-b", to_path)[/dynamic|shared/].nil?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Some elf files (e.g. created by rust compiler) have INTERP header despite
their magic header denotes shared object instead of executable.

We should relocate the interpreter elf files as long as they have INTERP header.

This should fix the broken bottles for rust based formulae.

cc @sjackman @jonchang 