### PR TITLE
allow invalid options in certain cases

### DIFF
--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -29,6 +29,8 @@ module Homebrew
       switch "--pry",
              env:         :pry,
              description: "Use Pry instead of IRB. Implied if `HOMEBREW_PRY` is set."
+
+      allow_invalid_option
     end
   end
 

--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -12,6 +12,8 @@ module Homebrew
 
         Run Homebrew with the Ruby profiler e.g. `brew prof readall`.
       EOS
+
+      allow_invalid_option
     end
   end
 

--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -17,6 +17,8 @@ module Homebrew
              description: "Execute the provided string argument as a script."
       switch :verbose
       switch :debug
+
+      allow_invalid_option
     end
   end
 

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -210,4 +210,22 @@ describe Homebrew::CLI::Parser do
       expect { parser.parse(["--switch-b"]) }.to raise_error(RuntimeError, /Arguments were already parsed!/)
     end
   end
+
+  describe "test #allow_invalid_option" do
+    subject(:parser) {
+      described_class.new do
+        allow_invalid_option do |args|
+          args[0] == "--switch-a"
+        end
+      end
+    }
+
+    it "does not raise exeption if the invalid option is allowed" do
+      expect { parser.parse(["--switch-a"]) }.not_to raise_error
+    end
+
+    it "raises exeption if the invalid option is not allowed" do
+      expect { parser.parse(["--switch-b"]) }.to raise_error(OptionParser::InvalidOption, /--switch-b/)
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR addresses the issue of brew reporting invalid option when it is actually OK. There are two cases:

* `brew ruby`/`brew irb`/`brew prof` call out external commands. We should allow any invalid option for them.
* `brew install` should allow unknown formulae options when the tap is not installed. (#6242)