### PR TITLE
Fix version parsing

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -61,7 +61,8 @@ git() {
 numeric() {
   # Condense the exploded argument into a single return value.
   # shellcheck disable=SC2086,SC2183
-  printf "%01d%02d%02d%02d" ${1//[.rc]/ }
+  local version=$(echo $1 | grep -oE '([0-9]*[\.]?)+')
+  printf "%01d%02d%02d%02d" ${version//[.rc]/ }
 }
 
 HOMEBREW_VERSION="$(git -C "$HOMEBREW_REPOSITORY" describe --tags --dirty --abbrev=7 2>/dev/null)"


### PR DESCRIPTION
It is possible that the installed version of git returns a version such
as:  2.22.0.657.bf8f0af685-blah

This version string would not get properly parsed. We now use grep with
a regular expression to extract only the version component.

- [ X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
