### PR TITLE
cleanup: avoid auto-running immediately on fresh installs

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -150,9 +150,12 @@ module Homebrew
 
     def periodic_clean_due?
       return false if ENV["HOMEBREW_NO_INSTALL_CLEANUP"]
-      return true unless PERIODIC_CLEAN_FILE.exist?
 
-      PERIODIC_CLEAN_FILE.mtime < CLEANUP_DEFAULT_DAYS.days.ago
+      if PERIODIC_CLEAN_FILE.exist?
+        PERIODIC_CLEAN_FILE.mtime < CLEANUP_DEFAULT_DAYS.days.ago
+      else
+        (HOMEBREW_REPOSITORY/"Library/Taps").mtime < CLEANUP_DEFAULT_DAYS.days.ago
+      end
     end
 
     def periodic_clean!


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Rather than auto-running `cleanup` right after the first action on a fresh Homebrew installation, check the mtime of a different path indicating when Homebrew was installed until the `.cleaned` file is first created.