### PR TITLE
audit: whitelist numpy@1.16 without being versioned keg only

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -515,6 +515,7 @@ module Homebrew
         gnupg@1.4
         lua@5.1
         python@2
+        numpy@1.16
       ].freeze
 
       return if keg_only_whitelist.include?(formula.name) || formula.name.start_with?("gcc@")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Homebrew/homebrew-core#42494

`numpy@1.16` only installs relevant files for Python 2, while `numpy` now only installs relevant files for Python 3. Therefore, their installed files do not conflict.

However, if we do want to make `numpy@1.6` as a versioned key only formula, we will then need to handle `PYTHONPATH` for all its reverse dependencies.