### PR TITLE
Remove cask-eid tap from automerge

### DIFF
--- a/Library/Homebrew/cask/cmd/automerge.rb
+++ b/Library/Homebrew/cask/cmd/automerge.rb
@@ -11,7 +11,6 @@ module Cask
       OFFICIAL_CASK_TAPS = [
         "homebrew/cask",
         "homebrew/cask-drivers",
-        "homebrew/cask-eid",
         "homebrew/cask-fonts",
         "homebrew/cask-versions",
       ].freeze


### PR DESCRIPTION
Since the homebrew-cask-eid tap is no longer in use, it should be removed from the automerge command as well. This seems to be the only reference to it in the codebase.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
