### PR TITLE
[Linux] Amazon Linux users should also install pre-requisite packages

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -60,7 +60,7 @@ Paste at a terminal prompt:
 sudo apt-get install build-essential curl file git
 ```
 
-### Fedora, CentOS, or Red Hat
+### Amazon Linux, CentOS, Fedora or Red Hat
 
 ```sh
 sudo yum groupinstall 'Development Tools'
@@ -78,7 +78,7 @@ Homebrew does not currently support 32-bit x86 platforms. It would be possible f
 
 ## Alternative Installation
 
-Extract or `git clone` Homebrew wherever you want. Use `/home/linuxbrew/.linuxbrew` if possible (to enabled the use of binary packages).
+Extract or `git clone` Homebrew wherever you want. Use `/home/linuxbrew/.linuxbrew` if possible (to enable the use of binary packages).
 
 ```sh
 git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- Users may not realise that Amazon Linux is based on
  RHEL/CentOS/Fedora, so they may not install the pre-requisite
  `yum` packages.
- Also fix a typo: "to enabled" => "to enable".