### PR TITLE
Improve ZSH completion so local formula files are completable

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -33,10 +33,8 @@ __brew_list_aliases() {
 }
 
 __brew_formulae_or_ruby_files() {
-  local -a formulae
-  formulae=($(brew search))
   _alternative 'formulae::__brew_formulae' \
-    'files:files:{_files -g *.rb}'
+    'files:files:{_files -g "*.rb"}'
 }
 
 # completions remain in cache until any tap has new commits
@@ -222,7 +220,7 @@ _brew_audit() {
     '(--online --strict)--new-formula[check if a new formula is eligible for Homebrew. Implies --strict and --online]' \
     '--display-cop-names[include RuboCop cop name for each violation in the output]' \
     '--display-filename[prefix every line of output with the name of the file or formula being audited]' \
-    '*:formula:__brew_formulae'
+    '*:formula:__brew_formulae_or_ruby_files'
 }
 
 # brew bottle [--verbose] [--no-rebuild] [--keep-old] [--skip-relocation] [--root-url=root_url]
@@ -253,11 +251,11 @@ _brew_bump_formula_pr() {
     - set1 \
       '--url=-[new url]:url:_urls' \
       '--sha256=-[new sha256 checksum]:sha256: ' \
-      ': :__brew_formulae' \
+      ': :__brew_formulae_or_ruby_files' \
     - set2 \
       '--tag=-[new tag]: ' \
       '--revision=-[new revision]: ' \
-      ': :__brew_formulae'
+      ': :__brew_formulae_or_ruby_files'
 }
 
 # brew cat formula
@@ -368,7 +366,7 @@ _brew_doctor() {
 # brew edit formulae
 _brew_edit() {
   _arguments \
-    '*:: :__brew_formulae'
+    '*:: :__brew_formulae_or_ruby_files'
 }
 
 # brew fetch [--force] [--retry] [-v] [--devel|--HEAD] [--deps] [--build-from-source|--force-bottle] formulae
@@ -661,7 +659,7 @@ _brew_test() {
     '(--devel --HEAD)'{--devel,--HEAD}'[use the development / head version of the formula]' \
     '--debug[launch an interactive debugger if test fails]' \
     '--keep-tmp[don''t delete temporary files]' \
-    '*:formula:__brew_formulae'
+    '*:formula:__brew_formulae_or_ruby_files'
 }
 
 # brew test-bot [options]  url|formula:


### PR DESCRIPTION
* brew completion in ZSH currently doesn't complete local formula files for most commands.
* Updating the completion script to complete local formula files as well as known formulas in places that it would makes sense to do so.

  e.x. if you're working in the homebrew-core directory and want to run `brew test Formula/myformula.rb`
   *  previously if you typed `brew test Formula/my` you wouldn't get any tab completions
   * now it will complete as `brew test Formula/myformula.rb`

* This includesFixes to the method`__brew_formula_or_ruby_files` which existed already but was somewhat problematic
  * Remove redundant call to uncached brew search
  * Add missing ""

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).  
   It's unclear to me what if any tests I should write for this.  Are the completion scripts tested?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
