### PR TITLE
man: support multi-line paragraphs in comment-based docs

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -3,7 +3,7 @@
 #:  Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 #:
 #:  The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-#:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`) with: `eval $(brew shellenv)`
+#:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile` or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 homebrew-shellenv() {
   case "$SHELL" in
@@ -24,12 +24,12 @@ homebrew-shellenv() {
       echo "setenv INFOPATH $HOMEBREW_PREFIX/share/info:\$INFOPATH;"
       ;;
     *)
-      echo "export HOMEBREW_PREFIX=\"$HOMEBREW_PREFIX\""
-      echo "export HOMEBREW_CELLAR=\"$HOMEBREW_CELLAR\""
-      echo "export HOMEBREW_REPOSITORY=\"$HOMEBREW_REPOSITORY\""
-      echo "export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:\$PATH\""
-      echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man:\$MANPATH\""
-      echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info:\$INFOPATH\""
+      echo "export HOMEBREW_PREFIX=\"$HOMEBREW_PREFIX\";"
+      echo "export HOMEBREW_CELLAR=\"$HOMEBREW_CELLAR\";"
+      echo "export HOMEBREW_REPOSITORY=\"$HOMEBREW_REPOSITORY\";"
+      echo "export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:\$PATH\";"
+      echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man:\$MANPATH\";"
+      echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info:\$INFOPATH\";"
       ;;
   esac
 }

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -196,8 +196,11 @@ module Homebrew
     lines = [format_usage_banner(comment_lines.first).chomp]
     comment_lines.slice(1..-1)
                  .each do |line|
-      line = line.slice(4..-1)
-      next unless line
+      line = line.slice(4..-2)
+      unless line
+        lines.last << "\n"
+        next
+      end
 
       # Omit the common global_options documented separately in the man page.
       next if line =~ /--(debug|force|help|quiet|verbose) /
@@ -206,6 +209,7 @@ module Homebrew
       lines << line.gsub(/^ +(-+[a-z-]+), (-+[a-z-]+) +/, "* `\\1`, `\\2`:\n  ")
                    .gsub(/^ +(-+[a-z-]+) +/, "* `\\1`:\n  ")
     end
+    lines.last << "\n"
     lines
   end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -423,11 +423,11 @@ build systems would not find otherwise.
   Use the standard `PATH` instead of superenv's when `std` is passed.
 
 ### `shellenv`
+
 Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 
 The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-
-Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`) with: `eval $(brew shellenv)`
+Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile` or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 ### `style` [*`options`*] [*`file`*|*`tap`*|*`formula`*]
 
@@ -527,12 +527,14 @@ also `pin`.
 Remove a tapped formula repository.
 
 ### `update`, `up` [*`options`*]
+
 Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations.
 
 * `--merge`:
   Use `git merge` to apply updates (rather than `git rebase`).
 
 ### `update-reset` [*`repository`*]
+
 Fetch and reset Homebrew and all tap repositories (or any specified *`repository`*) using `git`(1) to their latest `origin/master`.
 
 *Note:* this will destroy all your uncommitted or committed changes.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -530,10 +530,7 @@ Use the standard \fBPATH\fR instead of superenv\'s when \fBstd\fR is passed\.
 Print export statements\. When run in a shell, this installation of Homebrew will be added to your \fBPATH\fR, \fBMANPATH\fR, and \fBINFOPATH\fR\.
 .
 .P
-The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\.
-.
-.P
-Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR) with: \fBeval $(brew shellenv)\fR
+The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
 .
 .SS "\fBstyle\fR [\fIoptions\fR] [\fIfile\fR|\fItap\fR|\fIformula\fR]"
 Check formulae or files for conformance to Homebrew style guidelines\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Allow commands using comment-based docs to split single paragraphs across multiple lines.

Also improved `brew shellenv` for zsh users.