### PR TITLE
improve printed message when tapping private repo

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -308,7 +308,9 @@ class Tap
     puts <<~EOS
       It looks like you tapped a private repository. To avoid entering your
       credentials each time you update, you can use git HTTP credential
-      caching or issue the following command:
+      caching by issuing the following command:
+        git config --global credential.helper osxkeychain
+      or switch to ssh using the following command:
         cd #{path}
         git remote set-url origin git@github.com:#{full_name}.git
     EOS


### PR DESCRIPTION
Improves the printed message when tapping a private repo by telling the user how to do git http credential cacheing.

I realize after making this PR that this is macOS specific so happy to change to add linux instructions as well (`git config --global credential.helper store`).

EDIT 1: added better description