### PR TITLE
messages_spec: handle frozen Homebrew.args.

### DIFF
--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -72,9 +72,11 @@ describe Messages do
       end
     end
 
+    # Homebrew.args OpenStruct usage cannot use verified doubles.
+    # rubocop:disable RSpec/VerifiedDoubles
     context "when the --display-times argument is present" do
       before do
-        allow(Homebrew.args).to receive(:display_times?).and_return(true)
+        allow(Homebrew).to receive(:args).and_return(double(display_times?: true))
       end
 
       context "when install_times is empty" do
@@ -101,12 +103,13 @@ describe Messages do
 
     context "when the --display-times argument isn't present" do
       before do
-        allow(ARGV).to receive(:include?).with("--display-times").and_return(false)
+        allow(Homebrew).to receive(:args).and_return(double(display_times?: false))
       end
 
       it "doesn't print installation times" do
         expect { messages.display_messages }.not_to output.to_stdout
       end
     end
+    # rubocop:enable RSpec/VerifiedDoubles
   end
 end


### PR DESCRIPTION
This is an order dependent test failure fix as seen in
https://travis-ci.org/Homebrew/homebrew-test-bot/builds/574559080

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----