### PR TITLE
Add TMP to bin/brew whitelist to use TMP for downloading bottles

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -643,7 +643,7 @@ module Homebrew
       def check_tmp_variable
         tmp = ENV["TMP"]
         return if tmp.nil?
-        return if File.directory?(tmp) && tmp.length() < 20
+        return if File.directory?(tmp) && tmp.length < 20
 
         <<~EOS
           TMP #{tmp.inspect} is set

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -640,6 +640,19 @@ module Homebrew
         EOS
       end
 
+      def check_tmp_variable
+        tmp = ENV["TMP"]
+        return if tmp.nil?
+        return if File.directory?(tmp) && tmp.length() < 20
+
+        <<~EOS
+          TMP #{tmp.inspect} is set
+          and the path is longer than 20 characters.
+          It may cause problems while processing bottles. You should try to use a
+          shorter path like /tmp or /var/tmp
+        EOS
+      end
+
       def check_missing_deps
         return unless HOMEBREW_CELLAR.exist?
 

--- a/bin/brew
+++ b/bin/brew
@@ -81,6 +81,7 @@ then
   # Filter all but the specific variables.
   for VAR in HOME SHELL PATH TERM TERMINFO COLUMNS LOGNAME USER CI SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
+             TMP \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do
     # Skip if variable value is empty.


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Ruby uses TMPDIR, TEMP or TMP or /tmp for its temporary directory.
Because Brew does not whitelist TMPDIR, TEMP or TMP, Ruby will
always use /tmp to download and process bottles. If /tmp is full
and you do not have control over /tmp, you cannot use bottles.
TMPDIR is used by *nix and TEMP is used by Windows. TMP does not
seem to be used by any OS so it can be used as a variable to store
an alternative temporary directory without impacting the OS.