### PR TITLE
MacOSRequirement: add to_json method

### DIFF
--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -42,11 +42,11 @@ class MacOSRequirement < Requirement
           versions newer than #{@version.pretty_name} due to an upstream incompatibility.
         EOS
       when :cask
-        "This cask does not on macOS versions newer than #{@version.pretty_name}."
+        "This cask does not run on macOS versions newer than #{@version.pretty_name}."
       end
     else
       if @version.respond_to?(:to_ary)
-        *versions, last = @version.map(:pretty_name)
+        *versions, last = @version.map(&:pretty_name)
         return "macOS #{versions.join(", ")} or #{last} is required."
       end
 
@@ -58,5 +58,12 @@ class MacOSRequirement < Requirement
     return "macOS is required" unless version_specified?
 
     "macOS #{@comparator} #{@version}"
+  end
+
+  def to_json(*args)
+    comp = @comparator.to_s
+    return { comp => @version.map(&:to_s) }.to_json(*args) if @version.is_a?(Array)
+
+    { comp => [@version.to_s] }.to_json(*args)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a customized JSON representation for `MacOSRequirement` that's been needed for casks since #6366, as seen in [this automated commit](https://github.com/Homebrew/formulae.brew.sh/commit/c00aea3769b7ce6541da2486c3679eb6e1832380#diff-85022ccfab41a971058dcbcadb3ffee8) to Homebrew/formulae.brew.sh (and each subsequent commit). 

Before:
```
$ brew cask info --json=v1 1password | jq ".[0].depends_on"
{
  "macos": "#<MacOSRequirement:0x00007f960e8b33b8>"
}
$ brew cask info --json=v1 openzfs | jq ".[0].depends_on"
{
  "macos": "#<MacOSRequirement:0x00007f8eec420d38>"
}
```
After:
```
$ brew cask info --json=v1 1password | jq ".[0].depends_on"
{
  "macos": {
    ">=": [
      "10.12"
    ]
  }
}
$ brew cask info --json=v1 openzfs | jq ".[0].depends_on"
{
  "macos": {
    "==": [
      "10.9",
      "10.10",
      "10.11",
      "10.12",
      "10.13",
      "10.14"
    ]
  }
}
```