### PR TITLE
Added a flurry of improvements to the brew fish completions

### DIFF
--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -851,6 +851,7 @@ __fish_brew_complete_sub_cmd 'cask' 'install'   "Install the given Cask"
 __fish_brew_complete_sub_arg 'cask' 'install' -l force          -d "Reinstall even if the Cask is already present"
 __fish_brew_complete_sub_arg 'cask' 'install' -l skip-cask-deps -d "Skip any Cask dependencies"
 __fish_brew_complete_sub_arg 'cask' 'install' -l require-sha    -d "Abort if the Cask doesn't define a checksum"
+__fish_brew_complete_sub_arg 'cask' 'audit install' -rl language -d "Set language of the Cask to install. The first matching language is used, otherwise the default language on the Cask. The default value is the language of your system."
 
 __fish_brew_complete_sub_cmd 'cask' 'list'      "List installed Casks or staged files of the given installed Casks"
 __fish_brew_complete_sub_arg 'cask' 'list ls' -s 1        -d "Format output in a single column"

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -480,10 +480,6 @@ __fish_brew_complete_cmd 'postinstall' "Rerun the post-install steps for formula
 __fish_brew_complete_arg 'postinstall' -a '(__fish_brew_suggest_formulae_installed)'
 
 
-__fish_brew_complete_cmd 'prune' "Remove dead symlinks"
-__fish_brew_complete_arg 'prune' -s n -l dry-run -d "Show what files would be removed"
-
-
 __fish_brew_complete_cmd 'reinstall' "Uninstall and then install again"
 __fish_brew_complete_arg 'reinstall' -a '(__fish_brew_suggest_formulae_installed)'
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -868,6 +868,7 @@ __fish_brew_complete_sub_arg 'cask' 'style' -l fix -d "Auto-correct any style er
 
 __fish_brew_complete_sub_cmd 'cask' 'upgrade'     "Upgrades all outdated casks"
 __fish_brew_complete_sub_arg 'cask' 'upgrade' -l force
+__fish_brew_complete_sub_arg 'cask' 'upgrade' -l dry-run
 
 __fish_brew_complete_sub_cmd 'cask' 'uninstall' "Uninstall the given Cask"
 __fish_brew_complete_sub_arg 'cask' 'uninstall remove rm' -l force -d "Uninstall even if the Cask is not present"

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -253,6 +253,7 @@ __fish_brew_complete_arg 'cat' -a '(__fish_brew_suggest_formulae_all)'
 
 __fish_brew_complete_cmd 'cleanup' "Remove old installed versions"
 __fish_brew_complete_arg 'cleanup' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'cleanup' -a '(__fish_brew_suggest_casks_installed)'
 __fish_brew_complete_arg 'cleanup'      -l prune   -d "Remove all cache files older than given number of days" -a '(seq 1 5)'
 __fish_brew_complete_arg 'cleanup' -s n -l dry-run -d "Show what files would be removed"
 __fish_brew_complete_arg 'cleanup' -s s            -d "Scrub the cache, removing downloads for even the latest versions of formulae"

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -2,7 +2,7 @@
 
 Homebrew comes with completion definitions for the `brew` command. Some packages also provide completion definitions for their own programs.
 
-`zsh`, `bash` and `fish` are currently supported. (Homebrew provides `brew` completions for `zsh`, `bash`, and `fish`.)
+`zsh`, `bash` and `fish` are currently supported.
 
 You must configure your shell to enable its completion support. This is because the Homebrew-managed completions are stored under `HOMEBREW_PREFIX` which your system shell may not be aware of, and since it is difficult to automatically configure `bash` and `zsh` completions in a robust manner, the Homebrew installer does not do it for you.
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -2,7 +2,7 @@
 
 Homebrew comes with completion definitions for the `brew` command. Some packages also provide completion definitions for their own programs.
 
-`zsh`, `bash` and `fish` are currently supported. (Homebrew provides `brew` completions for `zsh` and `bash`; `fish` provides its own `brew` completions.)
+`zsh`, `bash` and `fish` are currently supported. (Homebrew provides `brew` completions for `zsh`, `bash`, and `fish`.)
 
 You must configure your shell to enable its completion support. This is because the Homebrew-managed completions are stored under `HOMEBREW_PREFIX` which your system shell may not be aware of, and since it is difficult to automatically configure `bash` and `zsh` completions in a robust manner, the Homebrew installer does not do it for you.
 


### PR DESCRIPTION
* Add `--language` option to `brew install` and `brew audit` completion
* Add `brew cask upgrade --dry-run` completion
* Add cask completions to `brew cleanup`
* Drop completions for now-deleted `brew prune` command

Also, fixed documentation on website to reflect that brew ships fish completions now.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----