### PR TITLE
Improve readability of `brew upgrade`

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -105,7 +105,7 @@ module Homebrew
           "#{f.full_specified_name} #{f.pkg_version}"
         end
       end
-      puts formulae_upgrades.join(", ")
+      puts formulae_upgrades.join("\n")
     end
     return if args.dry_run?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Hi, this is just a small cosmetic change that I find useful.

When upgrading lots of packages at the same time, the list of packages can be hard to read due to the length of the list and the fact that most terminals by default do their line breaks exactly when the line is full and not on word endings. This often leads to chopped up package names and versions. It is not easy to quickly find a package at a glance.

For example, on my machine:
![before](https://user-images.githubusercontent.com/13871367/64524481-d777f580-d2fe-11e9-826c-7d9c2e9fecb6.png)
Note the line endings and beginnings.

With this change every package is printed on a new line. Package names are sorted alphabetically:
![after](https://user-images.githubusercontent.com/13871367/64524899-e57a4600-d2ff-11e9-841c-1ef61918c83e.png)

I'm assuming that the output is for human interaction only and will not be parsed by other tools?

Also, Is the order of the packages important? They are sorted alphabetically now to make packages easy to find at a glance. Should we rather display them in the order they will be upgraded?

Not sure if this change is wanted at all, but I'd be happy for ideas for improvements.