### PR TITLE
prof: use ruby-prof 0.18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@
 **/vendor/bundle/ruby/*/gems/rspec-support-*/
 **/vendor/bundle/ruby/*/gems/rspec-wait-*/
 **/vendor/bundle/ruby/*/gems/rubocop-0*/
+**/vendor/bundle/ruby/*/gems/ruby-prof-*/
 **/vendor/bundle/ruby/*/gems/ruby-progressbar-*/
 **/vendor/bundle/ruby/*/gems/simplecov-*/
 **/vendor/bundle/ruby/*/gems/simplecov-cobertura-*/

--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -18,7 +18,7 @@ module Homebrew
   def prof
     prof_args.parse
 
-    Homebrew.install_gem_setup_path! "ruby-prof"
+    Homebrew.install_gem_setup_path! "ruby-prof", version: "0.18.0"
     FileUtils.mkdir_p "prof"
     brew_rb = (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path
     safe_system "ruby-prof", "--printer=multi", "--file=prof", brew_rb, "--", *ARGV


### PR DESCRIPTION
This is the newest version that works with Ruby 2.3.

Also, update the `.gitignore` to hide it while we're here.

Fixes https://github.com/Homebrew/brew/issues/6437

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----