### PR TITLE
cmd/list.rb: fix `brew ls` in verbose mode

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -54,7 +54,7 @@ module Homebrew
         end
         process_option(*names, description)
         @parser.on(*names, *wrap_option_desc(description)) do
-          enable_switch(*names.last, from: :args)
+          enable_switch(*names, from: :args)
         end
 
         names.each do |name|

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -54,7 +54,7 @@ module Homebrew
         end
         process_option(*names, description)
         @parser.on(*names, *wrap_option_desc(description)) do
-          enable_switch(*names, from: :args)
+          enable_switch(*names.last, from: :args)
         end
 
         names.each do |name|

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -70,7 +70,7 @@ module Homebrew
         puts Formatter.columns(full_names)
       else
         ENV["CLICOLOR"] = nil
-        ls_args = Homebrew.args.options_only.reject { |opt| ["-v", "--verbose"].include? opt }
+        ls_args = Homebrew.args.options_only.reject { |opt| ["--debug", "--verbose"].include? opt }
         safe_system "ls", *ls_args << HOMEBREW_CELLAR
       end
     elsif args.verbose? || !$stdout.tty?

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -70,7 +70,7 @@ module Homebrew
         puts Formatter.columns(full_names)
       else
         ENV["CLICOLOR"] = nil
-        ls_args = Homebrew.args.options_only.reject { |opt| ["--debug", "--verbose"].include? opt }
+        ls_args = Homebrew.args.options_only - ["--debug", "--verbose"]
         safe_system "ls", *ls_args << HOMEBREW_CELLAR
       end
     elsif args.verbose? || !$stdout.tty?

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -70,7 +70,8 @@ module Homebrew
         puts Formatter.columns(full_names)
       else
         ENV["CLICOLOR"] = nil
-        safe_system "ls", *Homebrew.args.options_only << HOMEBREW_CELLAR
+        ls_args = Homebrew.args.options_only.reject { |opt| ["-v", "--verbose"].include? opt }
+        safe_system "ls", *ls_args << HOMEBREW_CELLAR
       end
     elsif args.verbose? || !$stdout.tty?
       system_command! "find", args: ARGV.kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related issue: Homebrew/brew#6445

When `HOMEBREW_VERBOSE` is set, `brew ls` passes `-v` and `--verbose`
arguments to the system's `ls` command. This fails with:

```
ls: illegal option -- -

usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]

Error: Failure while executing; ls -v --verbose /Users/username/homebrew/Cellar exited with 1.
```

To circumvent this issue, we filter out `-v` and `--verbose` flags from the list of flags passed to `ls`.

There is probably a smarter way to do that... but looking at the Homebrew tests it looks like Homebrew/brew can't mutate `Homebrew.args` once they have been parsed.