### PR TITLE
Revert "argv: move options_only to cli/args"

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -12,22 +12,6 @@ module Homebrew
         super
         @argv = argv
       end
-
-      def to_cli_option(name)
-        if name.length == 2
-          "-#{name.tr("?", "")}"
-        else
-          "--#{name.tr("_", "-").tr("?", "")}"
-        end
-      end
-
-      def options_only
-        to_h.keys
-            .map(&:to_s)
-            .reject { |name| %w[argv remaining].include?(name) }
-            .map(&method(:to_cli_option))
-            .select { |arg| arg.start_with?("-") }
-      end
     end
   end
 end

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -10,7 +10,7 @@ OPTION_DESC_WIDTH = 43
 module Homebrew
   module CLI
     class Parser
-      attr_reader :processed_options, :hide_from_man_page, :args
+      attr_reader :processed_options, :hide_from_man_page
 
       def self.parse(args = ARGV, &block)
         new(&block).parse(args)

--- a/Library/Homebrew/cmd/cat.rb
+++ b/Library/Homebrew/cmd/cat.rb
@@ -25,6 +25,6 @@ module Homebrew
     raise "`brew cat` doesn't support multiple arguments" if args.remaining.size > 1
 
     cd HOMEBREW_REPOSITORY
-    safe_system "cat", formulae.first.path, *Homebrew.args.options_only
+    safe_system "cat", formulae.first.path, *ARGV.options_only
   end
 end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -70,7 +70,7 @@ module Homebrew
         puts Formatter.columns(full_names)
       else
         ENV["CLICOLOR"] = nil
-        safe_system "ls", *Homebrew.args.options_only << HOMEBREW_CELLAR
+        safe_system "ls", *ARGV.options_only << HOMEBREW_CELLAR
       end
     elsif args.verbose? || !$stdout.tty?
       system_command! "find", args: ARGV.kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true

--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -57,7 +57,7 @@ module Homebrew
           git -C "#{git_cd}" fetch --unshallow
       EOS
     end
-    args = Homebrew.args.options_only
+    args = ARGV.options_only
     args += ["--follow", "--", path] unless path.nil?
     system "git", "log", *args
   end

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -82,7 +82,7 @@ module Homebrew
           --
           #{HOMEBREW_LIBRARY_PATH}/test.rb
           #{f.path}
-        ].concat(Homebrew.args.options_only)
+        ].concat(ARGV.options_only)
 
         if f.head?
           args << "--HEAD"

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -210,20 +210,4 @@ describe Homebrew::CLI::Parser do
       expect { parser.parse(["--switch-b"]) }.to raise_error(RuntimeError, /Arguments were already parsed!/)
     end
   end
-
-  describe "test argv extensions" do
-    subject(:parser) {
-      described_class.new do
-        switch "--foo"
-        switch "-v"
-        switch "-d"
-        switch "-s"
-      end
-    }
-
-    it "#options_only" do
-      parser.parse(["--foo", "-vds", "a", "b", "cdefg"])
-      expect(Homebrew.args.options_only).to eq %w[--foo -v -d -s]
-    end
-  end
 end


### PR DESCRIPTION
Reverts Homebrew/brew#6411

Due to https://github.com/Homebrew/brew/pull/6411#issuecomment-531148110