### PR TITLE
Use AppleScript to check if GUI apps are running.

### DIFF
--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -119,7 +119,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
     it "is skipped when the user does not have automation access" do
       allow(User).to receive(:automation_access?).and_return false
       allow(User.current).to receive(:gui?).and_return true
-      allow(subject).to receive(:running_processes).with(bundle_id).and_return([[0, "", bundle_id]])
+      allow(subject).to receive(:running?).with(bundle_id).and_return(true)
 
       expect {
         subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
@@ -128,7 +128,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
 
     it "is skipped when the user is not a GUI user" do
       allow(User.current).to receive(:gui?).and_return false
-      allow(subject).to receive(:running_processes).with(bundle_id).and_return([[0, "", bundle_id]])
+      allow(subject).to receive(:running?).with(bundle_id).and_return(true)
 
       expect {
         subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
@@ -139,10 +139,10 @@ shared_examples "#uninstall_phase or #zap_phase" do
       allow(User).to receive(:automation_access?).and_return true
       allow(User.current).to receive(:gui?).and_return true
 
-      expect(subject).to receive(:running_processes).with(bundle_id).ordered.and_return([[0, "", bundle_id]])
+      expect(subject).to receive(:running?).with(bundle_id).ordered.and_return(true)
       expect(subject).to receive(:quit).with(bundle_id)
                                        .and_return(instance_double("SystemCommand::Result", success?: true))
-      expect(subject).to receive(:running_processes).with(bundle_id).ordered.and_return([])
+      expect(subject).to receive(:running?).with(bundle_id).ordered.and_return(false)
 
       expect {
         subject.public_send(:"#{artifact_dsl_key}_phase", command: fake_system_command)
@@ -153,7 +153,7 @@ shared_examples "#uninstall_phase or #zap_phase" do
       allow(User).to receive(:automation_access?).and_return true
       allow(User.current).to receive(:gui?).and_return true
 
-      allow(subject).to receive(:running_processes).with(bundle_id).and_return([[0, "", bundle_id]])
+      allow(subject).to receive(:running?).with(bundle_id).and_return(true)
       allow(subject).to receive(:quit).with(bundle_id)
                                       .and_return(instance_double("SystemCommand::Result", success?: false))
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`launchctl list` doesn't work in all cases for GUI apps.

For this particular case, if you launch `DeepL Helper`, it will actually show up as 

```
com.linguee.DeepLStatusBar.133220
```

But if you launch `DeepL` which in turn launches `DeepL Helper` itself, it will show up as 

```
com.apple.xpc.launchd.oneshot.0x1000000d.DeepL Helper
```

And then again, if `DeepL` is opened with the keyboard shortcut, it shows up as 


```
com.apple.xpc.launchd.oneshot.0x1000000f.DeepL
```

instead of 

```
com.linguee.DeepLCopyTranslator.133516
```

Fixes https://github.com/Homebrew/homebrew-cask/issues/69000.