### PR TITLE
utils/curl.rb: accept 1xx HTTP status codes

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -94,7 +94,7 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
   user_agents.each do |ua|
     details = curl_http_content_headers_and_checksum(url, hash_needed: hash_needed, user_agent: ua)
     user_agent = ua
-    break if (100..299).include?(details[:status].to_i)
+    break if http_status_ok?(details[:status])
   end
 
   unless details[:status]
@@ -104,7 +104,7 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
     return "The URL #{url} is not reachable"
   end
 
-  unless (100..299).include?(details[:status].to_i)
+  unless http_status_ok?(details[:status])
     return "The URL #{url} is not reachable (HTTP status code #{details[:status]})"
   end
 
@@ -119,8 +119,8 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
   secure_details =
     curl_http_content_headers_and_checksum(secure_url, hash_needed: true, user_agent: user_agent)
 
-  if !(100..299).include?(details[:status].to_i) ||
-     !(100..299).include?(secure_details[:status].to_i)
+  if !http_status_ok?(details[:status]) ||
+     !http_status_ok?(secure_details[:status])
     return
   end
 
@@ -191,4 +191,8 @@ def curl_http_content_headers_and_checksum(url, hash_needed: false, user_agent: 
     file_hash:      output_hash,
     file:           output,
   }
+end
+
+def http_status_ok?(status)
+  (100..299).cover?(status.to_i)
 end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -94,7 +94,7 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
   user_agents.each do |ua|
     details = curl_http_content_headers_and_checksum(url, hash_needed: hash_needed, user_agent: ua)
     user_agent = ua
-    break if details[:status].to_s.start_with?("2")
+    break if (100..299).include?(details[:status].to_i)
   end
 
   unless details[:status]
@@ -104,7 +104,7 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
     return "The URL #{url} is not reachable"
   end
 
-  unless details[:status].start_with? "2"
+  unless (100..299).include?(details[:status].to_i)
     return "The URL #{url} is not reachable (HTTP status code #{details[:status]})"
   end
 
@@ -119,8 +119,8 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
   secure_details =
     curl_http_content_headers_and_checksum(secure_url, hash_needed: true, user_agent: user_agent)
 
-  if !details[:status].to_s.start_with?("2") ||
-     !secure_details[:status].to_s.start_with?("2")
+  if !(100..299).include?(details[:status].to_i) ||
+     !(100..299).include?(secure_details[:status].to_i)
     return
   end
 


### PR DESCRIPTION
RFC 2616 states:

A client MUST be prepared to accept one or more 1xx status responses
prior to a regular response, even if the client does not expect a 100
(Continue) status message. Unexpected 1xx status responses MAY be
ignored by a user agent.

In the rare cases that we encounter a formula URL with a server that
provides a preliminary 1xx status code, it seems that (at least during
audit) we are failing on encountering this status code, even though
retrieving the file will succeed without issues.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This change addresses #6431.