### PR TITLE
Create '.keepme' files in directories

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -25,6 +25,9 @@ module Homebrew
         begin
           FileUtils.mkdir_p(dir) unless dir.exist?
 
+          # Create these files to ensure that these directories aren't removed
+          # by the Catalina installer.
+          # (https://github.com/Homebrew/brew/issues/6263)
           keep_file = dir/".keepme"
           FileUtils.touch(keep_file) unless keep_file.exist?
         rescue

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -24,6 +24,9 @@ module Homebrew
       Keg::MUST_EXIST_DIRECTORIES.each do |dir|
         begin
           FileUtils.mkdir_p(dir) unless dir.exist?
+
+          keep_file = "#{dir}/.keepme"
+          FileUtils.touch(keep_file) unless keep_file.exist?
         rescue
           nil
         end

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -25,7 +25,7 @@ module Homebrew
         begin
           FileUtils.mkdir_p(dir) unless dir.exist?
 
-          keep_file = "#{dir}/.keepme"
+          keep_file = dir/".keepme"
           FileUtils.touch(keep_file) unless keep_file.exist?
         rescue
           nil


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In favor of https://github.com/Homebrew/brew/issues/6263
```
The top-level directories in /usr/local e.g. /usr/local/sbin should have a .keepme file or similar created in them to avoid their removal in the macOS Catalina 10.15 installer.
```
I'm not sure about specs – is any example how I could test `install` routine?