### PR TITLE
Expose `uses_from_macos` list in formula API

### DIFF
--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -23,9 +23,9 @@ class SoftwareSpec
   def add_mac_dependency?(args)
     args.each { |key, version| args[key] = OS::Mac::Version.from_symbol(version) }
 
-    return false if args[:after] && OS::Mac.version < args[:after]
+    return false if args[:after] && OS::Mac.version >= args[:after]
 
-    return false if args[:before] && OS::Mac.version >= args[:before]
+    return false if args[:before] && OS::Mac.version < args[:before]
 
     args.present?
   end

--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -4,12 +4,18 @@ class SoftwareSpec
   undef uses_from_macos
 
   def uses_from_macos(deps, **args)
+    @uses_from_macos_elements ||= []
+
     if deps.is_a?(Hash)
       args = deps
       deps = Hash[*args.shift]
     end
 
-    depends_on(deps) if add_mac_dependency?(args)
+    if add_mac_dependency?(args)
+      depends_on(deps)
+    else
+      @uses_from_macos_elements << deps
+    end
   end
 
   private

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -428,6 +428,9 @@ class Formula
   # The {Dependency}s for the currently active {SoftwareSpec}.
   delegate deps: :active_spec
 
+  # Dependencies provided by macOS for the currently active {SoftwareSpec}.
+  delegate uses_from_macos_elements: :active_spec
+
   # The {Requirement}s for the currently active {SoftwareSpec}.
   delegate requirements: :active_spec
 
@@ -1589,6 +1592,7 @@ class Formula
   # @private
   def to_hash
     dependencies = deps
+    uses_from_macos = uses_from_macos_elements || []
 
     hsh = {
       "name"                     => name,
@@ -1624,6 +1628,7 @@ class Formula
       "optional_dependencies"    => dependencies.select(&:optional?)
                                                 .map(&:name)
                                                 .uniq,
+      "uses_from_macos"          => uses_from_macos.uniq,
       "requirements"             => [],
       "conflicts_with"           => conflicts.map(&:name),
       "caveats"                  => caveats&.gsub(HOMEBREW_PREFIX, "$(brew --prefix)"),

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -26,6 +26,7 @@ class SoftwareSpec
   attr_reader :dependency_collector
   attr_reader :bottle_specification
   attr_reader :compiler_failures
+  attr_reader :uses_from_macos_elements
 
   def_delegators :@resource, :stage, :fetch, :verify_download_integrity, :source_modified_time
   def_delegators :@resource, :download_name, :cached_download, :clear_cache

--- a/Library/Homebrew/test/os/mac/software_spec_spec.rb
+++ b/Library/Homebrew/test/os/mac/software_spec_spec.rb
@@ -13,27 +13,30 @@ describe SoftwareSpec do
       allow(OS::Mac).to receive(:version).and_return(OS::Mac::Version.new(sierra_os_version))
     end
 
-    it "allows specifying dependencies before certain version" do
+    it "allows specifying macOS dependencies before a certain version" do
       spec.uses_from_macos("foo", before: :high_sierra)
 
-      expect(spec.deps.first.name).to eq("foo")
+      expect(spec.deps).to be_empty
+      expect(spec.uses_from_macos_elements.first).to eq("foo")
     end
 
-    it "allows specifying dependencies after certain version" do
+    it "allows specifying macOS dependencies after a certain version" do
       spec.uses_from_macos("foo", after: :el_capitan)
 
-      expect(spec.deps.first.name).to eq("foo")
+      expect(spec.deps).to be_empty
+      expect(spec.uses_from_macos_elements.first).to eq("foo")
     end
 
-    it "doesn't adds a dependency if it doesn't meet OS version requirements" do
+    it "doesn't add a macOS dependency if the OS version doesn't meet requirements" do
       spec.uses_from_macos("foo", after: :high_sierra)
       spec.uses_from_macos("bar", before: :el_capitan)
 
-      expect(spec.deps).to be_empty
+      expect(spec.deps.first.name).to eq("foo")
+      expect(spec.uses_from_macos_elements).to be_empty
     end
 
     it "works with tags" do
-      spec.uses_from_macos("foo" => :head, :after => :el_capitan)
+      spec.uses_from_macos("foo" => :head, :after => :high_sierra)
 
       dep = spec.deps.first
 
@@ -41,7 +44,7 @@ describe SoftwareSpec do
       expect(dep.tags).to include(:head)
     end
 
-    it "doesn't adds the dependency without OS version requirements" do
+    it "doesn't add a dependency if no OS version is specified" do
       spec.uses_from_macos("foo")
       spec.uses_from_macos("bar" => :head)
 
@@ -49,7 +52,7 @@ describe SoftwareSpec do
     end
 
     it "respects OS version requirements with tags" do
-      spec.uses_from_macos("foo" => :head, :after => :mojave)
+      spec.uses_from_macos("foo" => :head, :before => :mojave)
 
       expect(spec.deps).to be_empty
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As suggested in [#6162](https://github.com/Homebrew/brew/pull/6162#issuecomment-499133446). 

This also fixes some inverted logic in how `before:` and `after:` are handled, as [mentioned earlier](https://github.com/Homebrew/brew/pull/6162#discussion_r287556446), i.e. `add_mac_dependency?` needs to return false (causing the dependency version shipped with macOS to be used) if the current OS version is greater than or equal to the `after:` value, or less than the `before:` value.