### PR TITLE
formula_installer: don't always install test deps.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -483,8 +483,12 @@ class FormulaInstaller
 
       if dep.prune_from_option?(build)
         Dependency.prune
-      elsif include_test? && dep.test? && !dep.installed?
-        Dependency.keep_but_prune_recursive_deps
+      elsif dep.test?
+        if !include_test?
+          Dependency.prune
+        elsif !dep.installed?
+          Dependency.keep_but_prune_recursive_deps
+        end
       elsif dep.build? && install_bottle_for?(dependent, build)
         Dependency.prune
       elsif dep.prune_if_build_and_not_dependent?(dependent)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

The formula_installer logic in expand_dependencies wasn't missing logic to prune test dependencies when `--include-test` was not passed. Fixes #6470.