### PR TITLE
Cask: fixes for caveats output

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -147,7 +147,7 @@ module Cask
         "version"        => version,
         "sha256"         => sha256,
         "artifacts"      => artifacts.map(&method(:to_h_gsubs)),
-        "caveats"        => to_h_string_gsubs(caveats),
+        "caveats"        => (to_h_string_gsubs(caveats) unless caveats.empty?),
         "depends_on"     => depends_on,
         "conflicts_with" => conflicts_with,
         "container"      => container,

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -87,17 +87,17 @@ module Cask
         if java_version == :any
           <<~EOS
             #{@cask} requires Java. You can install the latest version with:
-              brew cask install java
+              brew cask install adoptopenjdk
           EOS
         elsif java_version.include?("11") || java_version.include?("+")
           <<~EOS
             #{@cask} requires Java #{java_version}. You can install the latest version with:
-              brew cask install java
+              brew cask install adoptopenjdk
           EOS
         else
           <<~EOS
             #{@cask} requires Java #{java_version}. You can install it with:
-              brew cask install homebrew/cask-versions/java#{java_version}
+              brew cask install homebrew/cask-versions/adoptopenjdk#{java_version}
           EOS
         end
       end

--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -118,7 +118,6 @@ module Cask
         <<~EOS
           #{@cask} has been officially discontinued upstream.
           It may stop working correctly (or at all) in recent versions of macOS.
-
         EOS
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Casks with no caveats now return `null` in their JSON representation instead of `""`. This fixes an empty table being shown on their cask pages at https://formulae.brew.sh.
- Recommend `adoptopenjdk` for casks that require Java as per https://github.com/Homebrew/brew/pull/6040.