### PR TITLE
create: add --go-mod option

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -23,6 +23,8 @@ module Homebrew
              description: "Create a basic template for an Autotools-style build."
       switch "--cmake",
              description: "Create a basic template for a CMake-style build."
+      switch "--go-mod",
+             description: "Create a basic template for a Go-Modules-style build."
       switch "--meson",
              description: "Create a basic template for a Meson-style build."
       switch "--no-fetch",
@@ -40,7 +42,7 @@ module Homebrew
       switch :force
       switch :verbose
       switch :debug
-      conflicts "--autotools", "--cmake", "--meson"
+      conflicts "--autotools", "--cmake", "--go-mod", "--meson"
     end
   end
 
@@ -73,6 +75,8 @@ module Homebrew
       :autotools
     elsif args.meson?
       :meson
+    elsif args.go_mod?
+      :go_mod
     end
 
     if fc.name.nil? || fc.name.strip.empty?

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -23,8 +23,8 @@ module Homebrew
              description: "Create a basic template for an Autotools-style build."
       switch "--cmake",
              description: "Create a basic template for a CMake-style build."
-      switch "--go-mod",
-             description: "Create a basic template for a Go-Modules-style build."
+      switch "--go",
+             description: "Create a basic template for a Go build."
       switch "--meson",
              description: "Create a basic template for a Meson-style build."
       switch "--no-fetch",
@@ -42,7 +42,7 @@ module Homebrew
       switch :force
       switch :verbose
       switch :debug
-      conflicts "--autotools", "--cmake", "--go-mod", "--meson"
+      conflicts "--autotools", "--cmake", "--go", "--meson"
     end
   end
 
@@ -75,8 +75,8 @@ module Homebrew
       :autotools
     elsif args.meson?
       :meson
-    elsif args.go_mod?
-      :go_mod
+    elsif args.go?
+      :go
     end
 
     if fc.name.nil? || fc.name.strip.empty?

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -99,6 +99,8 @@ module Homebrew
 
         <% if mode == :cmake %>
           depends_on "cmake" => :build
+        <% elsif mode == :go_mod %>
+          depends_on "go" => :build
         <% elsif mode == :meson %>
           depends_on "meson" => :build
           depends_on "ninja" => :build
@@ -116,6 +118,8 @@ module Homebrew
                                   "--disable-dependency-tracking",
                                   "--disable-silent-rules",
                                   "--prefix=\#{prefix}"
+        <% elsif mode == :go_mod %>
+            system "go", "build", "-o", "\#{bin}/\#{name}"
         <% elsif mode == :meson %>
             mkdir "build" do
               system "meson", "--prefix=\#{prefix}", ".."
@@ -130,7 +134,7 @@ module Homebrew
                                   "--prefix=\#{prefix}"
             # system "cmake", ".", *std_cmake_args
         <% end %>
-        <% if mode != :meson %>
+        <% if mode != :meson and mode != :go_mod %>
             system "make", "install" # if this fails, try separate make/make install steps
         <% end %>
           end

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -99,7 +99,7 @@ module Homebrew
 
         <% if mode == :cmake %>
           depends_on "cmake" => :build
-        <% elsif mode == :go_mod %>
+        <% elsif mode == :go %>
           depends_on "go" => :build
         <% elsif mode == :meson %>
           depends_on "meson" => :build
@@ -118,7 +118,7 @@ module Homebrew
                                   "--disable-dependency-tracking",
                                   "--disable-silent-rules",
                                   "--prefix=\#{prefix}"
-        <% elsif mode == :go_mod %>
+        <% elsif mode == :go %>
             system "go", "build", "-o", "\#{bin}/\#{name}"
         <% elsif mode == :meson %>
             mkdir "build" do
@@ -134,7 +134,7 @@ module Homebrew
                                   "--prefix=\#{prefix}"
             # system "cmake", ".", *std_cmake_args
         <% end %>
-        <% if mode != :meson and mode != :go_mod %>
+        <% if mode != :meson and mode != :go %>
             system "make", "install" # if this fails, try separate make/make install steps
         <% end %>
           end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -801,8 +801,8 @@ a simple example. For the complete API, see:
   Create a basic template for an Autotools-style build.
 * `--cmake`:
   Create a basic template for a CMake-style build.
-* `--go-mod`:
-  Create a basic template for a Go-Modules-style build.
+* `--go`:
+  Create a basic template for a Go build.
 * `--meson`:
   Create a basic template for a Meson-style build.
 * `--no-fetch`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -801,6 +801,8 @@ a simple example. For the complete API, see:
   Create a basic template for an Autotools-style build.
 * `--cmake`:
   Create a basic template for a CMake-style build.
+* `--go-mod`:
+  Create a basic template for a Go-Modules-style build.
 * `--meson`:
   Create a basic template for a Meson-style build.
 * `--no-fetch`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1020,6 +1020,10 @@ Create a basic template for an Autotools\-style build\.
 Create a basic template for a CMake\-style build\.
 .
 .TP
+\fB\-\-go\-mod\fR
+Create a basic template for a Go\-Modules\-style build\.
+.
+.TP
 \fB\-\-meson\fR
 Create a basic template for a Meson\-style build\.
 .

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1020,8 +1020,8 @@ Create a basic template for an Autotools\-style build\.
 Create a basic template for a CMake\-style build\.
 .
 .TP
-\fB\-\-go\-mod\fR
-Create a basic template for a Go\-Modules\-style build\.
+\fB\-\-go\fR
+Create a basic template for a Go build\.
 .
 .TP
 \fB\-\-meson\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds new `--go-mod` option to `create` command.
When using this option, `brew` creates a basic template for software written in Go and using Modules as build system.