### PR TITLE
Include test casks in the cask style check.

### DIFF
--- a/Library/.rubocop_cask.yml
+++ b/Library/.rubocop_cask.yml
@@ -3,6 +3,8 @@ inherit_from: ./.rubocop_shared.yml
 Cask/HomepageMatchesUrl:
   Description: 'Ensure that the homepage and url match, otherwise add a comment. More info at https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment'
   Enabled: true
+  Exclude:
+  - '**/test/support/fixtures/cask/Casks/**/*.rb'
 
 Cask/HomepageUrlTrailingSlash:
   Description: 'Ensure that the homepage url has a slash after the domain name.'

--- a/Library/Homebrew/cask/cmd/style.rb
+++ b/Library/Homebrew/cask/cmd/style.rb
@@ -31,7 +31,7 @@ module Cask
 
       def cask_paths
         @cask_paths ||= if args.empty?
-          Tap.map(&:cask_dir).select(&:directory?)
+          Tap.map(&:cask_dir).select(&:directory?).concat(test_cask_paths)
         elsif args.any? { |file| File.exist?(file) }
           args.map { |path| Pathname(path).expand_path }
         else
@@ -48,6 +48,13 @@ module Cask
           "--force-exclusion",
           "--config", "#{HOMEBREW_LIBRARY}/.rubocop_cask.yml",
           "--format", "simple"
+        ]
+      end
+
+      def test_cask_paths
+        [
+          Pathname.new("#{HOMEBREW_LIBRARY}/Homebrew/test/support/fixtures/cask/Casks"),
+          Pathname.new("#{HOMEBREW_LIBRARY}/Homebrew/test/support/fixtures/third-party/Casks"),
         ]
       end
 

--- a/Library/Homebrew/test/cask/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/home_spec.rb
@@ -10,13 +10,13 @@ describe Cask::Cmd::Home, :cask do
   it_behaves_like "a command that handles invalid options"
 
   it "opens the homepage for the specified Cask" do
-    expect(described_class).to receive(:open_url).with("https://brew.sh")
+    expect(described_class).to receive(:open_url).with("https://brew.sh/")
     described_class.run("local-caffeine")
   end
 
   it "works for multiple Casks" do
-    expect(described_class).to receive(:open_url).with("https://brew.sh")
-    expect(described_class).to receive(:open_url).with("https://brew.sh")
+    expect(described_class).to receive(:open_url).with("https://brew.sh/")
+    expect(described_class).to receive(:open_url).with("https://brew.sh/")
     described_class.run("local-caffeine", "local-transmission")
   end
 

--- a/Library/Homebrew/test/cask/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/info_spec.rb
@@ -12,7 +12,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("local-caffeine")
     }.to output(<<~EOS).to_stdout
       local-caffeine: 1.2.3
-      https://brew.sh
+      https://brew.sh/
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/local-caffeine.rb
       ==> Name
@@ -41,7 +41,7 @@ describe Cask::Cmd::Info, :cask do
     let(:expected_output) {
       <<~EOS
         local-caffeine: 1.2.3
-        https://brew.sh
+        https://brew.sh/
         Not installed
         From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/local-caffeine.rb
         ==> Name
@@ -50,7 +50,7 @@ describe Cask::Cmd::Info, :cask do
         Caffeine.app (App)
 
         local-transmission: 2.61
-        https://brew.sh
+        https://brew.sh/
         Not installed
         From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/local-transmission.rb
         ==> Name
@@ -72,7 +72,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("with-caveats")
     }.to output(<<~EOS).to_stdout
       with-caveats: 1.2.3
-      https://brew.sh
+      https://brew.sh/
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-caveats.rb
       ==> Name
@@ -97,7 +97,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("with-conditional-caveats")
     }.to output(<<~EOS).to_stdout
       with-conditional-caveats: 1.2.3
-      https://brew.sh
+      https://brew.sh/
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-conditional-caveats.rb
       ==> Name
@@ -112,7 +112,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("with-languages")
     }.to output(<<~EOS).to_stdout
       with-languages: 1.2.3
-      https://brew.sh
+      https://brew.sh/
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/with-languages.rb
       ==> Name
@@ -129,7 +129,7 @@ describe Cask::Cmd::Info, :cask do
       described_class.run("without-languages")
     }.to output(<<~EOS).to_stdout
       without-languages: 1.2.3
-      https://brew.sh
+      https://brew.sh/
       Not installed
       From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/without-languages.rb
       ==> Name

--- a/Library/Homebrew/test/cask/cmd/internal_stanza_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/internal_stanza_spec.rb
@@ -5,7 +5,7 @@ describe Cask::Cmd::InternalStanza, :cask do
     command = described_class.new("homepage", "local-caffeine")
     expect {
       command.run
-    }.to output("https://brew.sh\n").to_stdout
+    }.to output("https://brew.sh/\n").to_stdout
   end
 
   it "raises an exception when stanza is unknown/unsupported" do

--- a/Library/Homebrew/test/cask/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/style_spec.rb
@@ -80,8 +80,12 @@ describe Cask::Cmd::Style, :cask do
       end
 
       it {
-        expect(subject).to contain_exactly(a_path_ending_with("/homebrew/homebrew-cask/Casks"),
-                                           a_path_ending_with("/third-party/homebrew-tap/Casks"))
+        expect(subject).to contain_exactly(
+          a_path_ending_with("/homebrew/homebrew-cask/Casks"),
+          a_path_ending_with("/third-party/homebrew-tap/Casks"),
+          a_path_ending_with("/Homebrew/test/support/fixtures/cask/Casks"),
+          a_path_ending_with("/Homebrew/test/support/fixtures/third-party/Casks"),
+        )
       }
     end
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/bad-checksum.rb
@@ -3,7 +3,7 @@ cask 'bad-checksum' do
   sha256 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/booby-trap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/booby-trap.rb
@@ -3,6 +3,6 @@ cask 'booby-trap' do
 
   url do
     # to be lazily evaluated
-    fail 'Boom'
+    raise 'Boom'
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/installer-with-uninstall.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/installer-with-uninstall.rb
@@ -3,7 +3,7 @@ cask 'installer-with-uninstall' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   installer manual: 'Caffeine.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-format.rb
@@ -1,9 +1,9 @@
-cask => 'invalid-header-format' do
+cask 'invalid-header-format', :invalid do
   version '1.2.3'
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-token-mismatch.rb
@@ -3,7 +3,7 @@ cask 'invalid-header-token-mismatch-this-text-does-not-belong' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-header-version.rb
@@ -3,7 +3,7 @@ cask 'invalid-header-version' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-homepage.rb
@@ -3,7 +3,7 @@ cask 'invalid-two-homepage' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
   homepage 'https://www.brew.sh/local-caffeine'
 
   app 'Caffeine.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-url.rb
@@ -4,7 +4,7 @@ cask 'invalid-two-url' do
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
   url 'https://brew.sh/caffeine.zip'
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/invalid/invalid-two-version.rb
@@ -4,7 +4,7 @@ cask 'invalid-two-version' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-caffeine.rb
@@ -3,7 +3,7 @@ cask 'local-caffeine' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/local-transmission.rb
@@ -1,10 +1,10 @@
 cask 'local-transmission' do
-  name 'Transmission'
   version '2.61'
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://brew.sh'
+  name 'Transmission'
+  homepage 'https://brew.sh/'
 
   app 'Transmission.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-checksum.rb
@@ -2,7 +2,7 @@ cask 'missing-checksum' do
   version '1.2.3'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-url.rb
@@ -1,5 +1,5 @@
 cask 'missing-url' do
   version '1.2.3'
 
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/missing-version.rb
@@ -1,4 +1,4 @@
 cask 'missing-version' do
-  url 'https://localhost/something.dmg'
-  homepage 'https://brew.sh'
+  url 'https://brew.sh/TestCask.dmg'
+  homepage 'https://brew.sh/'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/no-checksum.rb
@@ -3,7 +3,7 @@ cask 'no-checksum' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/bad-checksum.rb
@@ -3,7 +3,7 @@ cask 'bad-checksum' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-caffeine.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-caffeine.rb
@@ -3,7 +3,7 @@ cask 'local-caffeine' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/local-transmission.rb
@@ -3,7 +3,7 @@ cask 'local-transmission' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Transmission.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/outdated/version-latest.rb
@@ -3,7 +3,7 @@ cask 'version-latest' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine Mini.app'
   app 'Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
@@ -3,7 +3,7 @@ cask 'version-latest' do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine Mini.app'
   app 'Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/will-fail-if-upgraded.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/will-fail-if-upgraded.rb
@@ -3,7 +3,7 @@ cask 'will-fail-if-upgraded' do
   sha256 'e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/transmission-2.61.dmg"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'container'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-alt-target.rb
@@ -3,7 +3,7 @@ cask 'with-alt-target' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app', target: 'AnotherName.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-caveats.rb
@@ -3,7 +3,7 @@ cask 'with-caveats' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
@@ -3,12 +3,12 @@ cask 'with-conditional-caveats' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 
   # a do block may print and use a DSL
   caveats do
-    puts 'This caveat is conditional' if false # rubocop:disable Lint/LiteralInCondition
+    puts 'This caveat is conditional' if false # rubocop:disable Lint/LiteralAsCondition
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installable.rb
@@ -7,7 +7,7 @@ cask 'with-installable' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  uninstall script:     { executable: 'MyFancyPkg/FancyUninstaller.tool', args: %w[--please] },
+  uninstall script:     { executable: 'MyFancyPkg/FancyUninstaller.tool', args: ['--please'] },
             quit:       'my.fancy.package.app',
             login_item: 'Fancy',
             delete:     [

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
@@ -3,7 +3,7 @@ cask 'with-installer-manual' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   installer manual: 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -1,18 +1,18 @@
 cask 'with-languages' do
   version '1.2.3'
 
-  language "zh" do
-    sha256 "abc123"
-    "zh-CN"
+  language 'zh' do
+    sha256 'abc123'
+    'zh-CN'
   end
 
-  language "en-US", default: true do
-    sha256 "xyz789"
-    "en-US"
+  language 'en-US', default: true do
+    sha256 'xyz789'
+    'en-US'
   end
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-non-executable-binary.rb
@@ -5,5 +5,5 @@ cask 'with-non-executable-binary' do
   url "file://#{TEST_FIXTURE_DIR}/cask/naked_non_executable"
   homepage 'https://brew.sh/with-binary'
 
-  binary "naked_non_executable"
+  binary 'naked_non_executable'
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-postflight-multi.rb
@@ -9,7 +9,6 @@ cask 'with-postflight-multi' do
 
   postflight do
   end
-
   postflight do
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-preflight-multi.rb
@@ -9,7 +9,6 @@ cask 'with-preflight-multi' do
 
   preflight do
   end
-
   preflight do
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-correct.rb
@@ -3,7 +3,7 @@ cask 'with-two-apps-correct' do
   sha256 '3178fbfd1ea5d87a2a0662a4eb599ebc9a03888e73f37538d9f3f6ee69d2368e'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine Mini.app'
   app 'Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-two-apps-subdir.rb
@@ -3,7 +3,7 @@ cask 'with-two-apps-subdir' do
   sha256 'd687c22a21c02bd8f07da9302c8292b93a04df9a929e3f04d09aea6c76f75c65'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines-subdir.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeines/Caffeine Mini.app'
   app 'Caffeines/Caffeine Pro.app'

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-early-script.rb
@@ -7,5 +7,5 @@ cask 'with-uninstall-early-script' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  uninstall early_script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: %w[--please] }
+  uninstall early_script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: ['--please'] }
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-multi.rb
@@ -8,6 +8,5 @@ cask 'with-uninstall-multi' do
   pkg 'MyFancyPkg/Fancy.pkg'
 
   uninstall rmdir: "#{TEST_TMPDIR}/empty_directory_path"
-
   uninstall delete: "#{TEST_TMPDIR}/empty_directory_path"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-postflight-multi.rb
@@ -9,7 +9,6 @@ cask 'with-uninstall-postflight-multi' do
 
   uninstall_postflight do
   end
-
   uninstall_postflight do
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-preflight-multi.rb
@@ -9,7 +9,6 @@ cask 'with-uninstall-preflight-multi' do
 
   uninstall_preflight do
   end
-
   uninstall_preflight do
   end
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-app.rb
@@ -16,6 +16,6 @@ cask 'with-uninstall-script-app' do
 
   uninstall script: {
                       executable: "#{appdir}/MyFancyApp.app/uninstall.sh",
-                      sudo: false
+                      sudo:       false,
                     }
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script.rb
@@ -7,5 +7,5 @@ cask 'with-uninstall-script' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  uninstall script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: %w[--please] }
+  uninstall script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: ['--please'] }
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-early-script.rb
@@ -7,5 +7,5 @@ cask 'with-zap-early-script' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  zap early_script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: %w[--please] }
+  zap early_script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: ['--please'] }
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-multi.rb
@@ -8,6 +8,5 @@ cask 'with-zap-multi' do
   pkg 'MyFancyPkg/Fancy.pkg'
 
   zap rmdir: "#{TEST_TMPDIR}/empty_directory_path"
-
   zap delete: "#{TEST_TMPDIR}/empty_directory_path"
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap-script.rb
@@ -7,5 +7,5 @@ cask 'with-zap-script' do
 
   pkg 'MyFancyPkg/Fancy.pkg'
 
-  zap script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: %w[--please] }
+  zap script: { executable: 'MyFancyPkg/FancyUninstaller.tool', args: ['--please'] }
 end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-zap.rb
@@ -11,7 +11,7 @@ cask 'with-zap' do
 
   zap script:     {
                     executable: 'MyFancyPkg/FancyUninstaller.tool',
-                    args:       %w[--please],
+                    args:       ['--please'],
                   },
       quit:       'my.fancy.package.app',
       login_item: 'Fancy',

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/without-languages.rb
@@ -3,7 +3,7 @@ cask 'without-languages' do
   sha256 '67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94'
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-  homepage 'https://brew.sh'
+  homepage 'https://brew.sh/'
 
   app 'Caffeine.app'
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
RE: https://github.com/Homebrew/brew/pull/6435#discussion_r324257785

Currently the tests casks found in ["/Homebrew/test/support/fixtures/cask/Casks"](https://github.com/Homebrew/brew/tree/master/Library/Homebrew/test/support/fixtures/cask/Casks) and ["/Homebrew/test/support/fixtures/third-party/Casks"](https://github.com/Homebrew/brew/tree/master/Library/Homebrew/test/support/fixtures/third-party/Casks) aren't included in the paths checked when running "brew cask style".

This change includes these test cask paths in the checked paths, and also includes the auto style fixes made by running `brew cask style --fix`.
