### PR TITLE
Handle continuation lines

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -897,7 +897,7 @@ module Homebrew
     end
 
     def audit_lines
-      text.without_patch.split("\n").each_with_index do |line, lineno|
+      text.without_patch.gsub(/"\s*\\\n\s*"/,'').split("\n").each_with_index do |line, lineno|
         line_problems(line, lineno + 1)
       end
     end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -897,7 +897,7 @@ module Homebrew
     end
 
     def audit_lines
-      text.without_patch.gsub(/"\s*\\\n\s*"/,'').split("\n").each_with_index do |line, lineno|
+      text.without_patch.gsub(/"\s*\\\n\s*"/, "").split("\n").each_with_index do |line, lineno|
         line_problems(line, lineno + 1)
       end
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
`brew audit --strict kafka`
gave this problem:
```
* Use 
`system "#{bin}/kafka-topics", "--zookeeper", "localhost:2181", "--create", "--if-not-exists", "--replication-factor", "1", ""` 
instead of 
`system "#{bin}/kafka-topics --zookeeper localhost:2181 --create --if-not-exists --replication-factor 1 "` 
```
and one similar.

This problem is triggered at audit.rb [here](https://github.com/Homebrew/brew/blob/1544988201e5daf58518bc40a5cc9a28e34853f4/Library/Homebrew/dev-cmd/audit.rb#L938).

The offending line in the [kafka formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kafka.rb#L101-L102) is this:
```
system "#{bin}/kafka-topics --zookeeper localhost:2181 --create --if-not-exists --replication-factor 1 " \
"--partitions 1 --topic test > #{testpath}/kafka/demo.out 2>/dev/null"
```

This audit checks that system commands use the parameterised, non-shell form instead of the string shell form. But sometimes you need to use the shell e.g. for redirecting output. (The system command in question is **not** Kernel#system but [brew's system command](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula.rb#L1828) which calls Kernel#exec and which redirects stdout and stderr for its own logging purposes.)
There is an allowance for this `unless %w[| < > & ; *].any?` [here](https://github.com/Homebrew/brew/blob/1544988201e5daf58518bc40a5cc9a28e34853f4/Library/Homebrew/dev-cmd/audit.rb#L936) but because the system command in question has it on the **second** line not the first, the allowance does not apply. 

This PR attempts to join continuation lines together so the allowance then works.


- [ ] Have you written new tests for your changes? [Here's an example]
No tests written because there is no output from the `audit_lines` method and the change is using an existing `String` method.
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
