### PR TITLE
formula_installer: output better tapped formula message.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -574,7 +574,7 @@ class FormulaInstaller
     end
 
     tab_tap = tab.source["tap"]
-    if df.tap.to_s != tab_tap
+    if tab_tap.present? && df.tap.present? && df.tap.to_s != tab_tap.to_s
       odie <<~EOS
         #{df} is already installed from #{tab_tap}!
         Please `brew uninstall #{df}` first."


### PR DESCRIPTION
If we don't have a tab in the receipt then don't print this message and just continue as-is.

References https://discourse.brew.sh/t/install-of-several-formulas-fails-with-error-python-is-already-installed-from/5746/9

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----