### PR TITLE
os/mac: support Catalina, drop Sierra

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -44,14 +44,14 @@ module OS
       # TODO: bump version when new macOS is released and also update
       # references in docs/Installation.md and
       # https://github.com/Homebrew/install/blob/master/install
-      Version.new "10.14"
+      Version.new "10.15"
     end
 
     def outdated_release?
       # TODO: bump version when new macOS is released and also update
       # references in docs/Installation.md and
       # https://github.com/Homebrew/install/blob/master/install
-      version < "10.12"
+      version < "10.13"
     end
 
     def prerelease?

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -17,12 +17,12 @@ module OS
         when "10.12" then "9.2"
         when "10.13" then "10.1"
         when "10.14" then "10.2.1"
-        when "10.15" then "11.0"
+        when "10.15" then "11.1"
         else
           raise "macOS '#{MacOS.version}' is invalid" unless OS::Mac.prerelease?
 
           # Default to newest known version of Xcode for unreleased macOS versions.
-          "11.0"
+          "11.1"
         end
       end
 
@@ -177,7 +177,8 @@ module OS
         when 91      then "9.4"
         when 100     then "10.2.1"
         when 110     then "11.0"
-        else              "11.0"
+        when 111     then "11.1"
+        else              "11.1"
         end
       end
 
@@ -245,7 +246,7 @@ module OS
         # on the older supported platform for that Xcode release, i.e there's no
         # CLT package for 10.11 that contains the Clang version from Xcode 8.
         case MacOS.version
-        when "10.15" then "1100.0.20.17"
+        when "10.15" then "1100.0.33.8"
         when "10.14" then "1001.0.46.4"
         when "10.13" then "1000.10.44.2"
         when "10.12" then "900.0.39.2"

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -11,7 +11,7 @@ it does it too. You have to confirm everything it will do before it starts.
 ## macOS Requirements
 
 * A 64-bit Intel CPU <sup>[1](#1)</sup>
-* macOS 10.12 (or higher) <sup>[2](#2)</sup>
+* macOS High Sierra (10.13) (or higher) <sup>[2](#2)</sup>
 * Command Line Tools (CLT) for Xcode: `xcode-select --install`,
   [developer.apple.com/downloads](https://developer.apple.com/downloads) or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
@@ -51,7 +51,7 @@ Uninstallation is documented in the [FAQ](FAQ.md).
 <a name="1"><sup>1</sup></a> For 32-bit or PPC support see
 [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
-<a name="2"><sup>2</sup></a> 10.12 or higher is recommended. 10.9–10.11 are
+<a name="2"><sup>2</sup></a> 10.13 or higher is recommended. 10.9–10.12 are
 supported on a best-effort basis. For 10.4-10.6 see
 [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 


### PR DESCRIPTION
Now that Catalina is almost out, and we have it on our CI, we want it marked as supported to avoid the many warnings during testing.

Fixes https://github.com/Homebrew/homebrew-core/issues/44988