### PR TITLE
cat: check for HOMEBREW_BAT and set 'bat' as pager

### DIFF
--- a/Library/Homebrew/cmd/cat.rb
+++ b/Library/Homebrew/cmd/cat.rb
@@ -25,7 +25,11 @@ module Homebrew
     raise "`brew cat` doesn't support multiple arguments" if args.remaining.size > 1
 
     cd HOMEBREW_REPOSITORY
-    pager = ENV["HOMEBREW_VISUAL"] || "cat"
+    pager = if ENV["HOMEBREW_BAT"].nil?
+      "cat"
+    else
+      "#{HOMEBREW_PREFIX}/bin/bat"
+    end
     safe_system pager, formulae.first.path, *Homebrew.args.passthrough
   end
 end

--- a/Library/Homebrew/cmd/cat.rb
+++ b/Library/Homebrew/cmd/cat.rb
@@ -25,6 +25,7 @@ module Homebrew
     raise "`brew cat` doesn't support multiple arguments" if args.remaining.size > 1
 
     cd HOMEBREW_REPOSITORY
-    safe_system "cat", formulae.first.path, *Homebrew.args.passthrough
+    pager = ENV["HOMEBREW_VISUAL"] || "cat"
+    safe_system pager, formulae.first.path, *Homebrew.args.passthrough
   end
 end

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -143,6 +143,9 @@ Note that environment variables must have a value set to be detected. For exampl
     to retrieve these access credentials from AWS). If they are not set,
     the `S3` download strategy will download with a public (unsigned) URL.
 
+  * `HOMEBREW_BAT`:
+    If set, Homebrew will use `bat` for the `brew cat` command.
+
   * `HOMEBREW_BOTTLE_DOMAIN`:
     By default, Homebrew uses `https://homebrew.bintray.com/` as its download
     mirror for bottles. If set, instructs Homebrew to instead use the specified

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1077,6 +1077,9 @@ Note that environment variables must have a value set to be detected. For exampl
     to retrieve these access credentials from AWS). If they are not set,
     the `S3` download strategy will download with a public (unsigned) URL.
 
+  * `HOMEBREW_BAT`:
+    If set, Homebrew will use `bat` for the `brew cat` command.
+
   * `HOMEBREW_BOTTLE_DOMAIN`:
     By default, Homebrew uses `https://homebrew.bintray.com/` as its download
     mirror for bottles. If set, instructs Homebrew to instead use the specified

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "September 2019" "Homebrew" "brew"
+.TH "BREW" "1" "October 2019" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -1334,6 +1334,10 @@ If set, Homebrew will only check for autoupdates once per this seconds interval\
 .TP
 \fBHOMEBREW_AWS_ACCESS_KEY_ID\fR, \fBHOMEBREW_AWS_SECRET_ACCESS_KEY\fR
 When using the \fBS3\fR download strategy, Homebrew will look in these variables for access credentials (see \fIhttps://docs\.aws\.amazon\.com/cli/latest/userguide/cli\-chap\-getting\-started\.html#cli\-environment\fR to retrieve these access credentials from AWS)\. If they are not set, the \fBS3\fR download strategy will download with a public (unsigned) URL\.
+.
+.TP
+\fBHOMEBREW_BAT\fR
+If set, Homebrew will use \fBbat\fR for the \fBbrew cat\fR command\.
 .
 .TP
 \fBHOMEBREW_BOTTLE_DOMAIN\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

With this change something like that would be possible:
```shell
HOMEBREW_VISUAL=$HOMEBREW_PREFIX/bin/bat brew cat <formula>
```
.. and one would get a nice syntax highlighted formula.