### PR TITLE
README: remove Azure Pipelines badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Second, read the [Troubleshooting Checklist](https://docs.brew.sh/Troubleshootin
 **If you don't read these it will take us far longer to help you with your problem.**
 
 ## Contributing
-[![Azure Pipelines](https://img.shields.io/vso/build/Homebrew/56a87eb4-3180-495a-9117-5ed6c79da737/1.svg)](https://dev.azure.com/Homebrew/Homebrew/_build/latest?definitionId=1)
-
 We'd love you to contribute to Homebrew. First, please read our [Contribution Guide](CONTRIBUTING.md) and [Code of Conduct](https://github.com/Homebrew/.github/blob/master/CODE_OF_CONDUCT.md#code-of-conduct).
 
 We explicitly welcome contributions from people who have never contributed to open-source before: we were all beginners once! We can help build on a partially working pull request with the aim of getting it merged. We are also actively seeking to diversify our contributors and especially welcome contributions from women from all backgrounds and people of colour.


### PR DESCRIPTION
We're using GitHub Actions now.