### PR TITLE
Cask: refuse to trash root-owned files

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -362,6 +362,8 @@ module Cask
       def trash_paths(*paths, command: nil, **_)
         return if paths.empty?
 
+        raise CaskError, "Some files are owned by `root` and cannot be moved to the user's Trash." unless paths.all?(&:writable?)
+
         result = command.run!("/usr/bin/swift", args: [TRASH_SCRIPT, *paths])
 
         # Remove AppleScript's automatic newline.

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -362,7 +362,7 @@ module Cask
       def trash_paths(*paths, command: nil, **_)
         return if paths.empty?
 
-        raise CaskError, "Some files are owned by `root` and cannot be moved to the user's Trash." unless paths.all?(&:writable?)
+        raise CaskError, "Some files cannot be moved to the user's Trash." unless paths.all?(&:writable?)
 
         result = command.run!("/usr/bin/swift", args: [TRASH_SCRIPT, *paths])
 

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -364,8 +364,8 @@ module Cask
 
         trashable, untrashable = paths.partition(&:writable?)
         unless untrashable.empty?
-          opoo "These files cannot be moved to the user's Trash: "
-          puts untrashable
+          opoo "These files cannot be moved to the user's Trash:"
+          $stderr.puts untrashable
         end
 
         result = command.run!("/usr/bin/swift", args: [TRASH_SCRIPT, *trashable])

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -362,9 +362,13 @@ module Cask
       def trash_paths(*paths, command: nil, **_)
         return if paths.empty?
 
-        raise CaskError, "Some files cannot be moved to the user's Trash." unless paths.all?(&:writable?)
+        trashable, untrashable = paths.split(&:writable?)
+        unless untrashable.empty?
+          opoo "These files cannot be moved to the user's Trash: "
+          puts untrashable
+        end
 
-        result = command.run!("/usr/bin/swift", args: [TRASH_SCRIPT, *paths])
+        result = command.run!("/usr/bin/swift", args: [TRASH_SCRIPT, *trashable])
 
         # Remove AppleScript's automatic newline.
         result.tap { |r| r.stdout.sub!(/\n$/, "") }

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -362,7 +362,7 @@ module Cask
       def trash_paths(*paths, command: nil, **_)
         return if paths.empty?
 
-        trashable, untrashable = paths.split(&:writable?)
+        trashable, untrashable = paths.partition(&:writable?)
         unless untrashable.empty?
           opoo "These files cannot be moved to the user's Trash: "
           puts untrashable

--- a/Library/Homebrew/cask/utils/trash.swift
+++ b/Library/Homebrew/cask/utils/trash.swift
@@ -2,6 +2,11 @@
 
 import Foundation
 
+struct swifterr: TextOutputStream {
+  public static var stream = swifterr()
+  mutating func write(_ string: String) { fputs(string, stderr) }
+}
+
 if (CommandLine.arguments.count < 2) {
   exit(2)
 }
@@ -12,10 +17,11 @@ for item in CommandLine.arguments[1...] {
   do {
     let path: URL = URL(fileURLWithPath: item)
     try manager.trashItem(at: path, resultingItemURL: nil)
-    print(path)
+    print(path, terminator: "\0")
   }
   catch {
-    print("\0")
+    print(error.localizedDescription, to: &swifterr.stream)
+    exit(1)
   }
 }
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

These files cannot be trashed from CLI without sudo, which trashes them
instead to root's Trash. AppleScript isn't of use here because it will
break Travis (as it will fail when asking for admin permissions).

Fixes homebrew/homebrew-cask#69897

