### PR TITLE
Quiet SVN output

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -549,7 +549,8 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     # Use "svn update" when the repository already exists locally.
     # This saves on bandwidth and will have a similar effect to verifying the
     # cache as it will make any changes to get the right revision.
-    args = ["--quiet"]
+    args = []
+    args << "--quiet" unless ARGV.verbose?
 
     if revision
       ohai "Checking out #{@ref}"

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -549,7 +549,7 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
     # Use "svn update" when the repository already exists locally.
     # This saves on bandwidth and will have a similar effect to verifying the
     # cache as it will make any changes to get the right revision.
-    args = []
+    args = ["--quiet"]
 
     if revision
       ohai "Checking out #{@ref}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
When using the `SubversionDownloadStrategy`, SVN prints every file checked out, which can be a lot with large repos. This PR simply adds the `--quiet` flag to the SVN command.