### PR TITLE
bash completion example should not call brew if brew doesn't exist

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -12,7 +12,7 @@ To make Homebrew's completions available in `bash`, you must source the definiti
 
 ```sh
 if type brew &>/dev/null; then
-  HOMEBREW_PREFIX=$(brew --prefix)
+  HOMEBREW_PREFIX="$(brew --prefix)"
   if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
     source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
   else

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -11,8 +11,8 @@ You must configure your shell to enable its completion support. This is because 
 To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.bash_profile` file:
 
 ```sh
-HOMEBREW_PREFIX=$(brew --prefix)
 if type brew &>/dev/null; then
+  HOMEBREW_PREFIX=$(brew --prefix)
   if [[ -r "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
     source "${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
   else


### PR DESCRIPTION
In the section "Configuring Completions in `bash`", there's a line of code that sets `HOMEBREW_PREFIX` by calling `brew --prefix`, but it's done before calling `type brew` to see if brew exists.  This gives a "-bash: brew: command not found" if you don't have brew installed. That line should be moved inside the `if`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
