### PR TITLE
Show correct message when invalid arguments are passed to brew

### DIFF
--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -221,9 +221,14 @@ module Cask
         usage
 
         return if @command.nil?
-        return if @command == "help" && @args.empty?
 
-        raise ArgumentError, "help does not take arguments."
+        if @command == "help"
+          return if @args.empty?
+
+          raise ArgumentError, "help does not take arguments." if @args.length
+        end
+
+        raise ArgumentError, "brew cask does not recognise this command"
       end
 
       def purpose

--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -228,7 +228,7 @@ module Cask
           raise ArgumentError, "help does not take arguments." if @args.length
         end
 
-        raise ArgumentError, "brew cask does not recognise this command"
+        raise ArgumentError, "Unknown Cask command: #{command}"
       end
 
       def purpose


### PR DESCRIPTION

-----

Explanation:

Closes [#69937](https://github.com/Homebrew/homebrew-cask/issues/69937)
I have added a block to check specifically for help arguments. If it is not the help command then it will fail saying brew cask did not recognize the command. 

Help needed:

For running the tests/style checks, I made changes directly to my homebrew code and ran `brew style` and `brew tests`. Not sure if this is the correct way to do it. Please correct if there is a betetr way of testing or if I have missed anything. 

@unitof Tagging you here since you were also working on this. 

