### PR TITLE
Improve speed of HOMEBREW_AUTO_UPDATE_SECS

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -466,6 +466,20 @@ update-preinstall() {
   then
     export HOMEBREW_AUTO_UPDATING="1"
 
+    # Skip auto-update if the cask/core tap has been updated in the
+    # last $HOMEBREW_AUTO_UPDATE_SECS.
+    if [[ "$HOMEBREW_COMMAND" = "cask" ]]
+    then
+      tap_fetch_head="$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-cask/.git/FETCH_HEAD"
+    else
+      tap_fetch_head="$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core/.git/FETCH_HEAD"
+    fi
+    if [[ -f "$tap_fetch_head" &&
+          -n "$(find "$tap_fetch_head" -type f -mtime -"${HOMEBREW_AUTO_UPDATE_SECS}"s 2>/dev/null)" ]]
+    then
+      return
+    fi
+
     if [[ -z "$HOMEBREW_VERBOSE" ]]
     then
       update-preinstall-timer &

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -337,7 +337,7 @@ EOS
 
   if [[ -z "$HOMEBREW_AUTO_UPDATE_SECS" ]]
   then
-    HOMEBREW_AUTO_UPDATE_SECS="60"
+    HOMEBREW_AUTO_UPDATE_SECS="300"
   fi
 
   # check permissions
@@ -451,12 +451,6 @@ EOS
     # origin branch name is, and use that. If not set, fall back to "master".
     # the refspec ensures that the default upstream branch gets updated
     (
-      if [[ -n "$HOMEBREW_UPDATE_PREINSTALL" ]]
-      then
-        # Skip taps checked/fetched recently
-        [[ -n "$(find "$DIR/.git/FETCH_HEAD" -type f -mtime -"${HOMEBREW_AUTO_UPDATE_SECS}"s 2>/dev/null)" ]] && exit
-      fi
-
       UPSTREAM_REPOSITORY_URL="$(git config remote.origin.url)"
       if [[ "$UPSTREAM_REPOSITORY_URL" = "https://github.com/"* ]]
       then

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -134,7 +134,7 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_AUTO_UPDATE_SECS`:
     If set, Homebrew will only check for autoupdates once per this seconds interval.
 
-    *Default:* `60`.
+    *Default:* `300`.
 
   * `HOMEBREW_AWS_ACCESS_KEY_ID`, `HOMEBREW_AWS_SECRET_ACCESS_KEY`:
     When using the `S3` download strategy, Homebrew will look in

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1068,7 +1068,7 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_AUTO_UPDATE_SECS`:
     If set, Homebrew will only check for autoupdates once per this seconds interval.
 
-    *Default:* `60`.
+    *Default:* `300`.
 
   * `HOMEBREW_AWS_ACCESS_KEY_ID`, `HOMEBREW_AWS_SECRET_ACCESS_KEY`:
     When using the `S3` download strategy, Homebrew will look in

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "September 2019" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "October 2019" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1329,7 +1329,7 @@ If set, instructs Homebrew to prefix all download URLs, including those for bott
 If set, Homebrew will only check for autoupdates once per this seconds interval\.
 .
 .IP
-\fIDefault:\fR \fB60\fR\.
+\fIDefault:\fR \fB300\fR\.
 .
 .TP
 \fBHOMEBREW_AWS_ACCESS_KEY_ID\fR, \fBHOMEBREW_AWS_SECRET_ACCESS_KEY\fR


### PR DESCRIPTION
This variable allows a user to configure how often `brew update` runs.

With the previous implementation, however, it was still pretty slow as it would run some of `brew update` even within the timeout. This feels related to complaints about Homebrew "feeling slow" since we enabled this. Address this by:

- making `HOMEBREW_AUTO_UPDATE_SECS` behave more like `HOMEBREW_NO_AUTO_UPDATE` and entirely skip the invocation of
  `brew update` if the relevant tap (homebrew-core or homebrew-cask depending on command invoked) has been checked in the last `HOMEBREW_AUTO_UPDATE_SECS`
- Only require/check the update of a single tap rather than every tap
- Increase the default value of `HOMEBREW_AUTO_UPDATE_SECS` from 1m to 5m to cut people a bit more slack. We're not updating things often enough for 1m not to feel a bit overkill and 5m feels appropriate for a Homebrew "session" to only require a single update.

Fixes https://github.com/Homebrew/brew/issues/6517

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----