### PR TITLE
Docs: Add cask instructions to tap docs

### DIFF
--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -1,7 +1,7 @@
 # How to Create and Maintain a Tap
 
-[Taps](Taps.md) are external sources of Homebrew formulae and/or external commands. They
-can be created by anyone to provide their own formulae and/or external commands
+[Taps](Taps.md) are external sources of Homebrew formulae, casks  and/or external commands. They
+can be created by anyone to provide their own formulae, casks  and/or external commands
 to any Homebrew user.
 
 ## Creating a tap
@@ -57,6 +57,19 @@ making modifications, apart from committing and pushing your changes.
 Once your tap is installed, Homebrew will update it each time a user runs
 `brew update`. Outdated formulae will be upgraded when a user runs
 `brew upgrade`, like core formulae.
+
+## Casks
+
+Casks can also be installed from a tap.
+Casks can be included in taps with formulae, or in a tap with just casks.
+Place any cask files you wish to make available in a `Casks` directory at the top level of your tap.
+
+See [homebrew/cask](https://github.com/Homebrew/homebrew-cask) for an example of a tap with a `Casks` subdirectory.
+
+### Naming
+
+Unlike formulae, casks must have globally unique names to avoid clashes.
+This can be achieved by e.g. prepending the cask name with you github username: `username-formula-name`.
 
 ## External commands
 


### PR DESCRIPTION
Loosely based on (now deleted) https://github.com/Homebrew/homebrew-cask/blob/4c72606867d7aa92987c550082769d0f20e6121c/doc/alternate_cask_taps.md
Cask naming issues are from experimentation.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] **N/A**Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] **N/A** Have you successfully run `brew style` with your changes locally?
- [ ] **N/A** Have you successfully run `brew tests` with your changes locally?

-----
There is currently no documentation on having a tap with casks in it (see [here](https://github.com/Homebrew/homebrew-cask/blob/4c72606867d7aa92987c550082769d0f20e6121c/doc/alternate_cask_taps.md#uses) for reasons you might want to do that). This fixes that.