### PR TITLE
Fix symlink validation in Mojave

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
 
         # symlinks to system directories (commonly to /Applications)
         def system_dir_symlink?
-          symlink? && MacOS.system_dir?(readlink)
+          symlink? && MacOS.system_dir?(realpath)
         end
 
         def bom


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

In Mojave, Casks that have a symlink of the form `../../../../../..` (many directories backwards, without ending in a file) are parsed by the `MacOS.system_dir?` logic as a link to the root of the filesystem. This is because the working directory is `/usr/local/Homebrew`.

This bug triggers the filtering logic when creating the Bill-of-Materials for the given DMG, and the symlink is not extracted in later steps. I've fixed it by asking for the definitive path before verifying it.

This pull request fixes Homebrew/homebrew-cask#70154.
