### PR TITLE
Adding the `header` option to `CurlDownloadStrategy`.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -421,6 +421,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
+    args += ["-H", meta.fetch(:header)] if meta.key?(:header)
+
     args
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -421,7 +421,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
-    args += ["-H", meta.fetch(:header)] if meta.key?(:header)
+    args += ["--header", meta.fetch(:header)] if meta.key?(:header)
 
     args
   end


### PR DESCRIPTION
e.g.
It's easy to access github private resources later through specific `header` settings.

```
cask 'XXXX' do
...
  url "https://raw.githubusercontent.com/....",
      header : "Authorization: token #{ENV['HOMEBREW_GITHUB_API_TOKEN']}"
...
end
 ```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
-  [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
