### PR TITLE
sandbox: allow more TTYs.

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -163,7 +163,7 @@ class Sandbox
           (literal "/dev/random")
           (literal "/dev/zero")
           (regex #"^/dev/fd/[0-9]+$")
-          (regex #"^/dev/ttys?[0-9]*$")
+          (regex #"^/dev/tty[a-z0-9]*$")
           )
       (deny file-write*) ; deny non-whitelist file write operations
       (allow process-exec


### PR DESCRIPTION
This is needed on Catalina.

Fixes #6546

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----