### PR TITLE
Fix `#system_dir_symlink?` not working when target doesn't exist.

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -29,7 +29,7 @@ module UnpackStrategy
 
         # symlinks to system directories (commonly to /Applications)
         def system_dir_symlink?
-          symlink? && MacOS.system_dir?(realpath)
+          symlink? && MacOS.system_dir?(dirname.join(readlink))
         end
 
         def bom


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`realpath` fails when the symlink target doesn't exist.

Fixes https://github.com/Homebrew/homebrew-cask/issues/70353.