### PR TITLE
Fix diagnostic when only keep_file is in sbin.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -424,7 +424,9 @@ module Homebrew
 
         # Don't complain about sbin not being in the path if it doesn't exist
         sbin = HOMEBREW_PREFIX/"sbin"
-        return unless sbin.directory? && !sbin.children.empty?
+        return unless sbin.directory?
+        return if sbin.children.empty?
+        return if sbin.children.one? && sbin.children.first.basename.to_s == ".keepme"
 
         <<~EOS
           Homebrew's sbin was not found in your PATH but you have installed


### PR DESCRIPTION
Brew creates the keep_file itself and then complains about files in sbin.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew install` creates the keepfile and `brew doctor` complains about it. This fix checks if keepfile is the only file in sbin and if so doesn't complain about it.
See https://github.com/Homebrew/brew/issues/6263#issuecomment-538461772 
