### PR TITLE
Do not run patchelf on portable-ruby [Linux]

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -3,10 +3,9 @@
 class Keg
   def relocate_dynamic_linkage(relocation)
     # Patching the dynamic linker of glibc breaks it.
-    return if name == "glibc"
-
     # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
-    return if name == "patchelf"
+    # Patching portable-ruby causes brew tests to segfault.
+    return if ["glibc", "patchelf", "portable-ruby"].include?(name)
 
     elf_files.each do |file|
       file.ensure_writable do


### PR DESCRIPTION
Running patchelf on portable-ruby causes brew tests to segfault.

See https://github.com/Homebrew/brew/pull/6556

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?