### PR TITLE
subversion_spec: fix svnadmin calls on Linux.

### DIFF
--- a/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy/subversion_spec.rb
@@ -8,7 +8,9 @@ describe UnpackStrategy::Subversion, :needs_svn do
   let(:path) { working_copy }
 
   before do
-    safe_system "xcrun", "svnadmin", "create", repo
+    svnadmin = ["svnadmin"]
+    svnadmin = ["xcrun", *svnadmin] if OS.mac? && MacOS.version >= :catalina
+    safe_system(*svnadmin, "create", repo)
     safe_system "svn", "checkout", "file://#{repo}", working_copy
 
     FileUtils.touch working_copy/"test"


### PR DESCRIPTION
Ensure that we only use `xcrun` on Catalina or newer.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----