### PR TITLE
Revert "Do not run patchelf on portable-ruby [Linux]"

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -3,9 +3,10 @@
 class Keg
   def relocate_dynamic_linkage(relocation)
     # Patching the dynamic linker of glibc breaks it.
+    return if name == "glibc"
+
     # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
-    # Patching portable-ruby causes brew tests to segfault.
-    return if ["glibc", "patchelf", "portable-ruby"].include?(name)
+    return if name == "patchelf"
 
     elf_files.each do |file|
       file.ensure_writable do


### PR DESCRIPTION
This didn't fix anything.

Reverts Homebrew/brew#6569
CC @sjackman 