### PR TITLE
remove /usr/bin/xattr unsupported -s option in macOS 10.15

### DIFF
--- a/Library/Homebrew/cask/quarantine.rb
+++ b/Library/Homebrew/cask/quarantine.rb
@@ -154,7 +154,6 @@ module Cask
                                      "--",
                                      xattr,
                                      "-w",
-                                     "-s",
                                      QUARANTINE_ATTRIBUTE,
                                      quarantine_status,
                                    ],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Related Issue: https://github.com/Homebrew/homebrew-cask/issues/70603