### PR TITLE
upgrade: reject formulae checked in earlier levels

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -255,7 +255,7 @@ module Homebrew
     [formulae_to_upgrade, formulae_pinned]
   end
 
-  def broken_dependents(kegs, formulae)
+  def broken_dependents(kegs, formulae, scanned = [])
     formulae_to_reinstall = Set.new
     formulae_pinned_and_outdated = Set.new
 
@@ -266,6 +266,8 @@ module Homebrew
         dependents = kegs.select do |keg|
           keg.runtime_dependencies
              .any? { |d| d["full_name"] == formula.full_name }
+        end.reject do |keg|
+          scanned.include?(keg)
         end
 
         next if dependents.empty?
@@ -290,7 +292,9 @@ module Homebrew
           descendants << f
         end
 
-        descendants_to_reinstall, descendants_pinned = broken_dependents(kegs, descendants)
+        scanned << dependents
+
+        descendants_to_reinstall, descendants_pinned = broken_dependents(kegs, descendants, scanned)
 
         formulae_to_reinstall.merge descendants_to_reinstall
         formulae_pinned_and_outdated.merge descendants_pinned

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -255,7 +255,7 @@ module Homebrew
     [formulae_to_upgrade, formulae_pinned]
   end
 
-  def broken_dependents(kegs, formulae, scanned = [])
+  def broken_dependents(kegs, formulae, scanned = Set.new)
     formulae_to_reinstall = Set.new
     formulae_pinned_and_outdated = Set.new
 
@@ -264,10 +264,9 @@ module Homebrew
         descendants = Set.new
 
         dependents = kegs.select do |keg|
-          keg.runtime_dependencies
-             .any? { |d| d["full_name"] == formula.full_name }
-        end.reject do |keg|
-          scanned.include?(keg)
+          keg = keg.runtime_dependencies
+                   .any? { |d| d["full_name"] == formula.full_name }
+          keg unless scanned.include?(keg)
         end
 
         next if dependents.empty?
@@ -292,7 +291,7 @@ module Homebrew
           descendants << f
         end
 
-        scanned << dependents
+        scanned.merge dependents
 
         descendants_to_reinstall, descendants_pinned = broken_dependents(kegs, descendants, scanned)
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

@MikeMcQuaid  -- I finally hit that depth level issue you had previously told me about in #6397, when upgrading the packages below:

```
amalia@Sakura:~ $ brew outdated
ffmpeg (4.2.1) < 4.2.1_1
gdk-pixbuf (2.38.2) < 2.40.0
gtk+3 (3.24.12) < 3.24.12_1
libsoup (2.68.1) < 2.68.2
vala (0.46.2) < 0.46.3
x264 (r2917) < r2917_1
yarn (1.19.0) < 1.19.1
```

This pull request ensures that only new kegs are scanned in each level. I've attached the stacktrace in a separate file, because it is TOO BIG.
[massive-log.txt](https://github.com/Homebrew/brew/files/3720870/massive-log.txt)

CAVEAT: I know `brew style` will fail -- I'm happy to get any suggestions in order to fix that double-block chain.
