### PR TITLE
Bump Rubocop's `TargetRubyVersion` to 2.6 and fix all offenses

### DIFF
--- a/Library/.rubocop_shared.yml
+++ b/Library/.rubocop_shared.yml
@@ -3,7 +3,7 @@
 require: ./Homebrew/rubocops.rb
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.6
   DisplayCopNames: false
 
 # Use `<<~` for heredocs.

--- a/Library/Homebrew/bottle_publisher.rb
+++ b/Library/Homebrew/bottle_publisher.rb
@@ -142,17 +142,15 @@ class BottlePublisher
         retry_count = 0
         # We're in the cache; make sure to force re-download
         loop do
-          begin
-            curl_download url, to: filename
-            break
-          rescue
-            raise "Failed to download #{f} bottle from #{url}!" if retry_count >= max_curl_retries
+          curl_download url, to: filename
+          break
+        rescue
+          raise "Failed to download #{f} bottle from #{url}!" if retry_count >= max_curl_retries
 
-            puts "curl download failed; retrying in #{curl_retry_delay_seconds} sec"
-            sleep curl_retry_delay_seconds
-            curl_retry_delay_seconds *= 2
-            retry_count += 1
-          end
+          puts "curl download failed; retrying in #{curl_retry_delay_seconds} sec"
+          sleep curl_retry_delay_seconds
+          curl_retry_delay_seconds *= 2
+          retry_count += 1
         end
         checksum = Checksum.new(:sha256, bottle_info["sha256"])
         Pathname.new(filename).verify_checksum(checksum)

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -91,7 +91,7 @@ module Cask
               args: ["list", service],
               sudo: with_sudo, print_stderr: false
             ).stdout
-            if plist_status =~ /^\{/
+            if /^\{/.match?(plist_status)
               command.run!("/bin/launchctl", args: ["remove", service], sudo: with_sudo)
               sleep 1
             end

--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -91,7 +91,7 @@ module Cask
               args: ["list", service],
               sudo: with_sudo, print_stderr: false
             ).stdout
-            if /^\{/.match?(plist_status)
+            if plist_status.match?(/^\{/)
               command.run!("/bin/launchctl", args: ["remove", service], sudo: with_sudo)
               sleep 1
             end

--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -65,13 +65,11 @@ module Cask
         return yield nil if choices.empty?
 
         Tempfile.open(["choices", ".xml"]) do |file|
-          begin
-            file.write Plist::Emit.dump(choices)
-            file.close
-            yield file.path
-          ensure
-            file.unlink
-          end
+          file.write Plist::Emit.dump(choices)
+          file.close
+          yield file.path
+        ensure
+          file.unlink
         end
       end
     end

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -246,7 +246,7 @@ module Cask
     end
 
     def bad_url_format?(regex, valid_formats_array)
-      return false unless cask.url.to_s =~ regex
+      return false unless cask.url.to_s.match?(regex)
 
       valid_formats_array.none? { |format| cask.url.to_s =~ format }
     end

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -19,11 +19,9 @@ module Cask
       return to_enum unless block_given?
 
       Tap.flat_map(&:cask_files).each do |f|
-        begin
-          yield CaskLoader::FromTapPathLoader.new(f).load
-        rescue CaskUnreadableError => e
-          opoo e.message
-        end
+        yield CaskLoader::FromTapPathLoader.new(f).load
+      rescue CaskUnreadableError => e
+        opoo e.message
       end
     end
 

--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -200,11 +200,9 @@ module Cask
       end
 
       remaining = all_args.select do |arg|
-        begin
-          !process_arguments([arg]).empty?
-        rescue OptionParser::InvalidOption, OptionParser::MissingArgument, OptionParser::AmbiguousOption
-          true
-        end
+        !process_arguments([arg]).empty?
+      rescue OptionParser::InvalidOption, OptionParser::MissingArgument, OptionParser::AmbiguousOption
+        true
       end
 
       remaining + non_options

--- a/Library/Homebrew/cask/cmd/install.rb
+++ b/Library/Homebrew/cask/cmd/install.rb
@@ -14,16 +14,14 @@ module Cask
       def run
         odie "Installing casks is supported only on macOS" unless OS.mac?
         casks.each do |cask|
-          begin
-            Installer.new(cask, binaries:       binaries?,
-                                verbose:        verbose?,
-                                force:          force?,
-                                skip_cask_deps: skip_cask_deps?,
-                                require_sha:    require_sha?,
-                                quarantine:     quarantine?).install
-          rescue CaskAlreadyInstalledError => e
-            opoo e.message
-          end
+          Installer.new(cask, binaries:       binaries?,
+                              verbose:        verbose?,
+                              force:          force?,
+                              skip_cask_deps: skip_cask_deps?,
+                              require_sha:    require_sha?,
+                              quarantine:     quarantine?).install
+        rescue CaskAlreadyInstalledError => e
+          opoo e.message
         end
       end
 

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -45,12 +45,10 @@ module Cask
         return if dry_run?
 
         upgradable_casks.each do |(old_cask, new_cask)|
-          begin
-            upgrade_cask(old_cask, new_cask)
-          rescue CaskError => e
-            caught_exceptions << e
-            next
-          end
+          upgrade_cask(old_cask, new_cask)
+        rescue CaskError => e
+          caught_exceptions << e
+          next
         end
 
         return if caught_exceptions.empty?

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -137,11 +137,9 @@ module Cask
 
       locales = MacOS.languages
                      .map do |language|
-                       begin
-                         Locale.parse(language)
-                       rescue Locale::ParserError
-                         nil
-                       end
+                       Locale.parse(language)
+                     rescue Locale::ParserError
+                       nil
                      end
                      .compact
 
@@ -255,18 +253,16 @@ module Cask
 
     ORDINARY_ARTIFACT_CLASSES.each do |klass|
       define_method(klass.dsl_key) do |*args|
-        begin
-          if [*artifacts.map(&:class), klass].include?(Artifact::StageOnly) &&
-             (artifacts.map(&:class) & ACTIVATABLE_ARTIFACT_CLASSES).any?
-            raise CaskInvalidError.new(cask, "'stage_only' must be the only activatable artifact.")
-          end
-
-          artifacts.add(klass.from_args(cask, *args))
-        rescue CaskInvalidError
-          raise
-        rescue => e
-          raise CaskInvalidError.new(cask, "invalid '#{klass.dsl_key}' stanza: #{e}")
+        if [*artifacts.map(&:class), klass].include?(Artifact::StageOnly) &&
+           (artifacts.map(&:class) & ACTIVATABLE_ARTIFACT_CLASSES).any?
+          raise CaskInvalidError.new(cask, "'stage_only' must be the only activatable artifact.")
         end
+
+        artifacts.add(klass.from_args(cask, *args))
+      rescue CaskInvalidError
+        raise
+      rescue => e
+        raise CaskInvalidError.new(cask, "invalid '#{klass.dsl_key}' stanza: #{e}")
       end
     end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -111,12 +111,10 @@ module Cask
       return unless @cask.conflicts_with
 
       @cask.conflicts_with[:cask].each do |conflicting_cask|
-        begin
-          conflicting_cask = CaskLoader.load(conflicting_cask)
-          raise CaskConflictError.new(@cask, conflicting_cask) if conflicting_cask.installed?
-        rescue CaskUnavailableError
-          next # Ignore conflicting Casks that do not exist.
-        end
+        conflicting_cask = CaskLoader.load(conflicting_cask)
+        raise CaskConflictError.new(@cask, conflicting_cask) if conflicting_cask.installed?
+      rescue CaskUnavailableError
+        next # Ignore conflicting Casks that do not exist.
       end
     end
 

--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -86,11 +86,9 @@ class Caveats
 
   def keg
     @keg ||= [f.prefix, f.opt_prefix, f.linked_keg].map do |d|
-      begin
-        Keg.new(d.resolved_path)
-      rescue
-        nil
-      end
+      Keg.new(d.resolved_path)
+    rescue
+      nil
     end.compact.first
   end
 

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -400,7 +400,7 @@ module Homebrew
           path.extend(ObserverPathnameExtension)
           if path.symlink?
             unless path.resolved_path_exists?
-              if Keg::INFOFILE_RX.match?(path.to_s)
+              if path.to_s.match?(Keg::INFOFILE_RX)
                 path.uninstall_info unless dry_run?
               end
 

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -400,7 +400,7 @@ module Homebrew
           path.extend(ObserverPathnameExtension)
           if path.symlink?
             unless path.resolved_path_exists?
-              if path.to_s =~ Keg::INFOFILE_RX
+              if Keg::INFOFILE_RX.match?(path.to_s)
                 path.uninstall_info unless dry_run?
               end
 

--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -25,11 +25,9 @@ module Homebrew
 
     deps_of_installed = installed.flat_map do |f|
       f.runtime_dependencies.map do |dep|
-        begin
-          dep.to_formula.full_name
-        rescue FormulaUnavailableError
-          dep.name
-        end
+        dep.to_formula.full_name
+      rescue FormulaUnavailableError
+        dep.name
       end
     end
 

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -382,21 +382,19 @@ module Homebrew
     end
 
     reinstallable.each do |f|
-      begin
-        reinstall_formula(f, build_from_source: true)
-      rescue FormulaInstallationAlreadyAttemptedError
-        # We already attempted to reinstall f as part of the dependency tree of
-        # another formula. In that case, don't generate an error, just move on.
-        nil
-      rescue CannotInstallFormulaError => e
-        ofail e
-      rescue BuildError => e
-        e.dump
-        puts
-        Homebrew.failed = true
-      rescue DownloadError => e
-        ofail e
-      end
+      reinstall_formula(f, build_from_source: true)
+    rescue FormulaInstallationAlreadyAttemptedError
+      # We already attempted to reinstall f as part of the dependency tree of
+      # another formula. In that case, don't generate an error, just move on.
+      nil
+    rescue CannotInstallFormulaError => e
+      ofail e
+    rescue BuildError => e
+      e.dump
+      puts
+      Homebrew.failed = true
+    rescue DownloadError => e
+      ofail e
     end
   end
 end

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -68,26 +68,22 @@ module Homebrew
 
     uses = formulae.select do |f|
       used_formulae.all? do |ff|
-        begin
-          deps = f.runtime_dependencies if only_installed_arg
-          deps ||= if recursive
-            recursive_includes(Dependency, f, includes, ignores)
-          else
-            reject_ignores(f.deps, ignores, includes)
-          end
-
-          deps.any? do |dep|
-            begin
-              dep.to_formula.full_name == ff.full_name
-            rescue
-              dep.name == ff.name
-            end
-          end
-        rescue FormulaUnavailableError
-          # Silently ignore this case as we don't care about things used in
-          # taps that aren't currently tapped.
-          next
+        deps = f.runtime_dependencies if only_installed_arg
+        deps ||= if recursive
+          recursive_includes(Dependency, f, includes, ignores)
+        else
+          reject_ignores(f.deps, ignores, includes)
         end
+
+        deps.any? do |dep|
+          dep.to_formula.full_name == ff.full_name
+        rescue
+          dep.name == ff.name
+        end
+      rescue FormulaUnavailableError
+        # Silently ignore this case as we don't care about things used in
+        # taps that aren't currently tapped.
+        next
       end
     end
 

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -109,7 +109,7 @@ class DependencyCollector
   end
 
   def parse_string_spec(spec, tags)
-    if HOMEBREW_TAP_FORMULA_REGEX.match?(spec)
+    if spec.match?(HOMEBREW_TAP_FORMULA_REGEX)
       TapDependency.new(spec, tags)
     elsif tags.empty?
       Dependency.new(spec, tags)

--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -109,7 +109,7 @@ class DependencyCollector
   end
 
   def parse_string_spec(spec, tags)
-    if spec =~ HOMEBREW_TAP_FORMULA_REGEX
+    if HOMEBREW_TAP_FORMULA_REGEX.match?(spec)
       TapDependency.new(spec, tags)
     elsif tags.empty?
       Dependency.new(spec, tags)

--- a/Library/Homebrew/description_cache_store.rb
+++ b/Library/Homebrew/description_cache_store.rb
@@ -63,11 +63,9 @@ class DescriptionCacheStore < CacheStore
     return populate_if_empty! if database.empty?
 
     formula_names.each do |name|
-      begin
-        update!(name, Formula[name].desc)
-      rescue FormulaUnavailableError, *FormulaVersions::IGNORED_EXCEPTIONS
-        delete!(name)
-      end
+      update!(name, Formula[name].desc)
+    rescue FormulaUnavailableError, *FormulaVersions::IGNORED_EXCEPTIONS
+      delete!(name)
     end
   end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -264,7 +264,7 @@ module Homebrew
 
       problem "'__END__' was found, but 'DATA' is not used" if text.end? && !text.data?
 
-      if /inreplace [^\n]* do [^\n]*\n[^\n]*\.gsub![^\n]*\n\ *end/m.match?(text.to_s)
+      if text.to_s.match?(/inreplace [^\n]* do [^\n]*\n[^\n]*\.gsub![^\n]*\n\ *end/m)
         problem "'inreplace ... do' was used for a single substitution (use the non-block form instead)."
       end
 
@@ -888,7 +888,7 @@ module Homebrew
       end
       bin_names.each do |name|
         ["system", "shell_output", "pipe_output"].each do |cmd|
-          if /test do.*#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]/m.match?(text.to_s)
+          if text.to_s.match?(/test do.*#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]/m)
             problem %Q(fully scope test #{cmd} calls, e.g. #{cmd} "\#{bin}/#{name}")
           end
         end
@@ -940,7 +940,7 @@ module Homebrew
 
       problem "`#{Regexp.last_match(1)}` is now unnecessary" if line =~ /(require ["']formula["'])/
 
-      if %r{#\{share\}/#{Regexp.escape(formula.name)}[/'"]}.match?(line)
+      if line.match?(%r{#\{share\}/#{Regexp.escape(formula.name)}[/'"]})
         problem "Use \#{pkgshare} instead of \#{share}/#{formula.name}"
       end
 
@@ -1067,7 +1067,7 @@ module Homebrew
 
       problem "version #{version} should not have a leading 'v'" if version.to_s.start_with?("v")
 
-      return unless /_\d+$/.match?(version.to_s)
+      return unless version.to_s.match?(/_\d+$/)
 
       problem "version #{version} should not end with an underline and a number"
     end
@@ -1090,7 +1090,7 @@ module Homebrew
 
         problem "Redundant :module value in URL" if mod == name
 
-        if %r{:[^/]+$}.match?(url)
+        if url.match?(%r{:[^/]+$})
           mod = url.split(":").last
 
           if mod == name
@@ -1129,7 +1129,7 @@ module Homebrew
         if strategy <= CurlDownloadStrategy && !url.start_with?("file")
           # A `brew mirror`'ed URL is usually not yet reachable at the time of
           # pull request.
-          next if %r{^https://dl.bintray.com/homebrew/mirror/}.match?(url)
+          next if url.match?(%r{^https://dl.bintray.com/homebrew/mirror/})
 
           if http_content_problem = curl_check_http_content(url)
             problem http_content_problem

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -264,7 +264,7 @@ module Homebrew
 
       problem "'__END__' was found, but 'DATA' is not used" if text.end? && !text.data?
 
-      if text =~ /inreplace [^\n]* do [^\n]*\n[^\n]*\.gsub![^\n]*\n\ *end/m
+      if /inreplace [^\n]* do [^\n]*\n[^\n]*\.gsub![^\n]*\n\ *end/m.match?(text)
         problem "'inreplace ... do' was used for a single substitution (use the non-block form instead)."
       end
 
@@ -890,7 +890,7 @@ module Homebrew
       end
       bin_names.each do |name|
         ["system", "shell_output", "pipe_output"].each do |cmd|
-          if text =~ /test do.*#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]/m
+          if /test do.*#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]/m.match?(text)
             problem %Q(fully scope test #{cmd} calls, e.g. #{cmd} "\#{bin}/#{name}")
           end
         end
@@ -942,7 +942,7 @@ module Homebrew
 
       problem "`#{Regexp.last_match(1)}` is now unnecessary" if line =~ /(require ["']formula["'])/
 
-      if line =~ %r{#\{share\}/#{Regexp.escape(formula.name)}[/'"]}
+      if %r{#\{share\}/#{Regexp.escape(formula.name)}[/'"]}.match?(line)
         problem "Use \#{pkgshare} instead of \#{share}/#{formula.name}"
       end
 
@@ -1069,7 +1069,7 @@ module Homebrew
 
       problem "version #{version} should not have a leading 'v'" if version.to_s.start_with?("v")
 
-      return unless version.to_s =~ /_\d+$/
+      return unless /_\d+$/.match?(version.to_s)
 
       problem "version #{version} should not end with an underline and a number"
     end
@@ -1092,7 +1092,7 @@ module Homebrew
 
         problem "Redundant :module value in URL" if mod == name
 
-        if url =~ %r{:[^/]+$}
+        if %r{:[^/]+$}.match?(url)
           mod = url.split(":").last
 
           if mod == name
@@ -1131,7 +1131,7 @@ module Homebrew
         if strategy <= CurlDownloadStrategy && !url.start_with?("file")
           # A `brew mirror`'ed URL is usually not yet reachable at the time of
           # pull request.
-          next if url =~ %r{^https://dl.bintray.com/homebrew/mirror/}
+          next if %r{^https://dl.bintray.com/homebrew/mirror/}.match?(url)
 
           if http_content_problem = curl_check_http_content(url)
             problem http_content_problem

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -434,16 +434,14 @@ module Homebrew
 
     def audit_conflicts
       formula.conflicts.each do |c|
-        begin
-          Formulary.factory(c.name)
-        rescue TapFormulaUnavailableError
-          # Don't complain about missing cross-tap conflicts.
-          next
-        rescue FormulaUnavailableError
-          problem "Can't find conflicting formula #{c.name.inspect}."
-        rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
-          problem "Ambiguous conflicting formula #{c.name.inspect}."
-        end
+        Formulary.factory(c.name)
+      rescue TapFormulaUnavailableError
+        # Don't complain about missing cross-tap conflicts.
+        next
+      rescue FormulaUnavailableError
+        problem "Can't find conflicting formula #{c.name.inspect}."
+      rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
+        problem "Ambiguous conflicting formula #{c.name.inspect}."
       end
     end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -264,7 +264,7 @@ module Homebrew
 
       problem "'__END__' was found, but 'DATA' is not used" if text.end? && !text.data?
 
-      if /inreplace [^\n]* do [^\n]*\n[^\n]*\.gsub![^\n]*\n\ *end/m.match?(text)
+      if /inreplace [^\n]* do [^\n]*\n[^\n]*\.gsub![^\n]*\n\ *end/m.match?(text.to_s)
         problem "'inreplace ... do' was used for a single substitution (use the non-block form instead)."
       end
 
@@ -888,7 +888,7 @@ module Homebrew
       end
       bin_names.each do |name|
         ["system", "shell_output", "pipe_output"].each do |cmd|
-          if /test do.*#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]/m.match?(text)
+          if /test do.*#{cmd}[\(\s]+['"]#{Regexp.escape(name)}[\s'"]/m.match?(text.to_s)
             problem %Q(fully scope test #{cmd} calls, e.g. #{cmd} "\#{bin}/#{name}")
           end
         end

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -156,7 +156,7 @@ module Homebrew
         gnu_tar_gtar_path = HOMEBREW_PREFIX/"opt/gnu-tar/bin/gtar"
         gnu_tar_gtar = gnu_tar_gtar_path if gnu_tar_gtar_path.executable?
         tar = which("gtar") || gnu_tar_gtar || which("tar")
-        if %r{/.*\.}.match?(Utils.popen_read(tar, "-tf", resource_path))
+        if Utils.popen_read(tar, "-tf", resource_path).match?(%r{/.*\.})
           new_hash = resource_path.sha256
         else
           odie "#{resource_path} is not a valid tar file!"
@@ -310,7 +310,7 @@ module Homebrew
           end
           username = response.fetch("owner").fetch("login")
         rescue GitHub::AuthenticationFailedError => e
-          raise unless /forking is disabled/.match?(e.github_message)
+          raise unless e.github_message.match?(/forking is disabled/)
 
           # If the repository is private, forking might be disabled.
           # Create branches in the repository itself instead.

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -156,7 +156,7 @@ module Homebrew
         gnu_tar_gtar_path = HOMEBREW_PREFIX/"opt/gnu-tar/bin/gtar"
         gnu_tar_gtar = gnu_tar_gtar_path if gnu_tar_gtar_path.executable?
         tar = which("gtar") || gnu_tar_gtar || which("tar")
-        if Utils.popen_read(tar, "-tf", resource_path) =~ %r{/.*\.}
+        if %r{/.*\.}.match?(Utils.popen_read(tar, "-tf", resource_path))
           new_hash = resource_path.sha256
         else
           odie "#{resource_path} is not a valid tar file!"
@@ -310,7 +310,7 @@ module Homebrew
           end
           username = response.fetch("owner").fetch("login")
         rescue GitHub::AuthenticationFailedError => e
-          raise unless e.github_message =~ /forking is disabled/
+          raise unless /forking is disabled/.match?(e.github_message)
 
           # If the repository is private, forking might be disabled.
           # Create branches in the repository itself instead.

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -203,7 +203,7 @@ module Homebrew
       end
 
       # Omit the common global_options documented separately in the man page.
-      next if /--(debug|force|help|quiet|verbose) /.match?(line)
+      next if line.match?(/--(debug|force|help|quiet|verbose) /)
 
       # Format one option or a comma-separated pair of short and long options.
       lines << line.gsub(/^ +(-+[a-z-]+), (-+[a-z-]+) +/, "* `\\1`, `\\2`:\n  ")

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -203,7 +203,7 @@ module Homebrew
       end
 
       # Omit the common global_options documented separately in the man page.
-      next if line =~ /--(debug|force|help|quiet|verbose) /
+      next if /--(debug|force|help|quiet|verbose) /.match?(line)
 
       # Format one option or a comma-separated pair of short and long options.
       lines << line.gsub(/^ +(-+[a-z-]+), (-+[a-z-]+) +/, "* `\\1`, `\\2`:\n  ")

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -88,7 +88,7 @@ module Homebrew
       readme.read[/(Former maintainers .*\.)/, 1]
             .gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
 
-    ERB.new(template, nil, ">").result(variables.instance_eval { binding })
+    ERB.new(template, trim_mode: ">").result(variables.instance_eval { binding })
   end
 
   def sort_key_for_path(path)

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -718,15 +718,13 @@ module Homebrew
       def check_for_unreadable_installed_formula
         formula_unavailable_exceptions = []
         Formula.racks.each do |rack|
-          begin
-            Formulary.from_rack(rack)
-          rescue FormulaUnreadableError, FormulaClassUnavailableError,
-                 TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
-            formula_unavailable_exceptions << e
-          rescue FormulaUnavailableError,
-                 TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
-            nil
-          end
+          Formulary.from_rack(rack)
+        rescue FormulaUnreadableError, FormulaClassUnavailableError,
+               TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
+          formula_unavailable_exceptions << e
+        rescue FormulaUnavailableError,
+               TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
+          nil
         end
         return if formula_unavailable_exceptions.empty?
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -122,7 +122,7 @@ module Homebrew
             properly. You can solve this by adding the remote:
               git -C "#{repository_path}" remote add origin #{Formatter.url("https://github.com/#{desired_origin}.git")}
           EOS
-        elsif current_origin !~ %r{#{desired_origin}(\.git|/)?$}i
+        elsif !%r{#{desired_origin}(\.git|/)?$}i.match?(current_origin)
           <<~EOS
             Suspicious #{desired_origin} git origin remote found.
             The current git origin is:

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -122,7 +122,7 @@ module Homebrew
             properly. You can solve this by adding the remote:
               git -C "#{repository_path}" remote add origin #{Formatter.url("https://github.com/#{desired_origin}.git")}
           EOS
-        elsif !%r{#{desired_origin}(\.git|/)?$}i.match?(current_origin)
+        elsif !current_origin.match?(%r{#{desired_origin}(\.git|/)?$}i)
           <<~EOS
             Suspicious #{desired_origin} git origin remote found.
             The current git origin is:

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -242,7 +242,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
   end
 
   def parse_basename(url)
-    uri_path = if URI::DEFAULT_PARSER.make_regexp&.match?(url)
+    uri_path = if url.match?(URI::DEFAULT_PARSER.make_regexp)
       uri = URI(url)
 
       if uri.query
@@ -860,7 +860,7 @@ class CVSDownloadStrategy < VCSDownloadStrategy
 
     if meta.key?(:module)
       @module = meta.fetch(:module)
-    elsif !%r{:[^/]+$}.match?(@url)
+    elsif !@url.match?(%r{:[^/]+$})
       @module = name
     else
       @module, @url = split_url(@url)

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -242,7 +242,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
   end
 
   def parse_basename(url)
-    uri_path = if URI::DEFAULT_PARSER.make_regexp =~ url
+    uri_path = if URI::DEFAULT_PARSER.make_regexp&.match?(url)
       uri = URI(url)
 
       if uri.query
@@ -860,7 +860,7 @@ class CVSDownloadStrategy < VCSDownloadStrategy
 
     if meta.key?(:module)
       @module = meta.fetch(:module)
-    elsif @url !~ %r{:[^/]+$}
+    elsif !%r{:[^/]+$}.match?(@url)
       @module = name
     else
       @module, @url = split_url(@url)

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -213,11 +213,9 @@ module SharedEnvExtension
     path.append(
       # user paths
       ORIGINAL_PATHS.map do |p|
-        begin
-          p.realpath.to_s
-        rescue
-          nil
-        end
+        p.realpath.to_s
+      rescue
+        nil
       end - %w[/usr/X11/bin /opt/X11/bin],
     )
     self["PATH"] = path

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -342,7 +342,7 @@ module SharedEnvExtension
   end
 
   def check_for_compiler_universal_support
-    return unless GNU_GCC_REGEXP.match?(homebrew_cc)
+    return unless homebrew_cc.match?(GNU_GCC_REGEXP)
 
     raise "Non-Apple GCC can't build universal binaries"
   end

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -344,7 +344,7 @@ module SharedEnvExtension
   end
 
   def check_for_compiler_universal_support
-    return unless homebrew_cc =~ GNU_GCC_REGEXP
+    return unless GNU_GCC_REGEXP.match?(homebrew_cc)
 
     raise "Non-Apple GCC can't build universal binaries"
   end

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -17,12 +17,10 @@ module Superenv
   def homebrew_extra_paths
     paths = []
     paths += %w[binutils make].map do |f|
-      begin
-        bin = Formula[f].opt_bin
-        bin if bin.directory?
-      rescue FormulaUnavailableError
-        nil
-      end
+      bin = Formula[f].opt_bin
+      bin if bin.directory?
+    rescue FormulaUnavailableError
+      nil
     end.compact
     paths
   end

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -9,7 +9,7 @@ module FormulaCellarChecks
       formula.name.start_with?(formula_name)
     end
 
-    return if formula.name =~ Version.formula_optionally_versioned_regex(:php)
+    return if formula.name&.match?(Version.formula_optionally_versioned_regex(:php))
 
     return if MacOS.version < :mavericks && formula.name.start_with?("postgresql")
     return if MacOS.version < :yosemite  && formula.name.start_with?("memcached")

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -22,7 +22,7 @@ class SystemConfig
     def describe_homebrew_ruby
       s = describe_homebrew_ruby_version
 
-      if RUBY_PATH.to_s !~ %r{^/System/Library/Frameworks/Ruby\.framework/Versions/[12]\.[089]/usr/bin/ruby}
+      if !%r{^/System/Library/Frameworks/Ruby\.framework/Versions/[12]\.[089]/usr/bin/ruby}.match?(RUBY_PATH.to_s)
         "#{s} => #{RUBY_PATH}"
       else
         s

--- a/Library/Homebrew/extend/os/mac/system_config.rb
+++ b/Library/Homebrew/extend/os/mac/system_config.rb
@@ -22,7 +22,7 @@ class SystemConfig
     def describe_homebrew_ruby
       s = describe_homebrew_ruby_version
 
-      if !%r{^/System/Library/Frameworks/Ruby\.framework/Versions/[12]\.[089]/usr/bin/ruby}.match?(RUBY_PATH.to_s)
+      if !RUBY_PATH.to_s.match?(%r{^/System/Library/Frameworks/Ruby\.framework/Versions/[12]\.[089]/usr/bin/ruby})
         "#{s} => #{RUBY_PATH}"
       else
         s

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -266,7 +266,7 @@ class Formula
   # and is specified to this instance.
   def installed_alias_path
     path = build.source["path"] if build.is_a?(Tab)
-    return unless %r{#{HOMEBREW_TAP_DIR_REGEX}/Aliases}.match?(path)
+    return unless path&.match?(%r{#{HOMEBREW_TAP_DIR_REGEX}/Aliases})
     return unless File.symlink?(path)
 
     path

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -266,7 +266,7 @@ class Formula
   # and is specified to this instance.
   def installed_alias_path
     path = build.source["path"] if build.is_a?(Tab)
-    return unless path =~ %r{#{HOMEBREW_TAP_DIR_REGEX}/Aliases}
+    return unless %r{#{HOMEBREW_TAP_DIR_REGEX}/Aliases}.match?(path)
     return unless File.symlink?(path)
 
     path

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -387,11 +387,9 @@ class Formula
     return [] if versioned_formula?
 
     Pathname.glob(path.to_s.gsub(/\.rb$/, "@*.rb")).map do |path|
-      begin
-        Formula[path.basename(".rb").to_s]
-      rescue FormulaUnavailableError
-        nil
-      end
+      Formula[path.basename(".rb").to_s]
+    rescue FormulaUnavailableError
+      nil
     end.compact.sort
   end
 
@@ -1387,14 +1385,12 @@ class Formula
   # @private
   def self.each
     files.each do |file|
-      begin
-        yield Formulary.factory(file)
-      rescue => e
-        # Don't let one broken formula break commands. But do complain.
-        onoe "Failed to import: #{file}"
-        puts e
-        next
-      end
+      yield Formulary.factory(file)
+    rescue => e
+      # Don't let one broken formula break commands. But do complain.
+      onoe "Failed to import: #{file}"
+      puts e
+      next
     end
   end
 
@@ -1425,11 +1421,9 @@ class Formula
   # @private
   def self.installed
     @installed ||= racks.flat_map do |rack|
-      begin
-        Formulary.from_rack(rack)
-      rescue
-        []
-      end
+      Formulary.from_rack(rack)
+    rescue
+      []
     end.uniq(&:name)
   end
 
@@ -1568,11 +1562,9 @@ class Formula
       read_from_tab: read_from_tab,
       undeclared:    undeclared,
     ).map do |d|
-      begin
-        d.to_formula
-      rescue FormulaUnavailableError
-        nil
-      end
+      d.to_formula
+    rescue FormulaUnavailableError
+      nil
     end.compact
   end
 

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -76,7 +76,7 @@ module Homebrew
         end
       end
 
-      path.write ERB.new(template, nil, ">").result(binding)
+      path.write ERB.new(template, trim_mode: ">").result(binding)
     end
 
     def template

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -369,8 +369,8 @@ class FormulaInstaller
 
       $stderr.puts "Please report this to the #{formula.tap} tap!"
       false
-                else
-                  f.linked_keg.exist? && f.opt_prefix.exist?
+    else # rubocop:disable Lint/ElseAlignment
+      f.linked_keg.exist? && f.opt_prefix.exist?
     end
 
     raise FormulaConflictError.new(formula, conflicts) unless conflicts.empty?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -361,8 +361,8 @@ class FormulaInstaller
       # If the formula name doesn't exist any more then complain but don't
       # stop installation from continuing.
       opoo <<~EOS
-          #{formula}: #{e.message}
-          'conflicts_with \"#{c.name}\"' should be removed from #{formula.path.basename}.
+        #{formula}: #{e.message}
+        'conflicts_with \"#{c.name}\"' should be removed from #{formula.path.basename}.
         EOS
 
       raise if ARGV.homebrew_developer?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -363,7 +363,7 @@ class FormulaInstaller
       opoo <<~EOS
         #{formula}: #{e.message}
         'conflicts_with \"#{c.name}\"' should be removed from #{formula.path.basename}.
-        EOS
+      EOS
 
       raise if ARGV.homebrew_developer?
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -351,28 +351,26 @@ class FormulaInstaller
     return if ARGV.force?
 
     conflicts = formula.conflicts.select do |c|
-      begin
-        f = Formulary.factory(c.name)
-      rescue TapFormulaUnavailableError
-        # If the formula name is a fully-qualified name let's silently
-        # ignore it as we don't care about things used in taps that aren't
-        # currently tapped.
-        false
-      rescue FormulaUnavailableError => e
-        # If the formula name doesn't exist any more then complain but don't
-        # stop installation from continuing.
-        opoo <<~EOS
+      f = Formulary.factory(c.name)
+    rescue TapFormulaUnavailableError
+      # If the formula name is a fully-qualified name let's silently
+      # ignore it as we don't care about things used in taps that aren't
+      # currently tapped.
+      false
+    rescue FormulaUnavailableError => e
+      # If the formula name doesn't exist any more then complain but don't
+      # stop installation from continuing.
+      opoo <<~EOS
           #{formula}: #{e.message}
           'conflicts_with \"#{c.name}\"' should be removed from #{formula.path.basename}.
         EOS
 
-        raise if ARGV.homebrew_developer?
+      raise if ARGV.homebrew_developer?
 
-        $stderr.puts "Please report this to the #{formula.tap} tap!"
-        false
-      else
-        f.linked_keg.exist? && f.opt_prefix.exist?
-      end
+      $stderr.puts "Please report this to the #{formula.tap} tap!"
+      false
+    else
+      f.linked_keg.exist? && f.opt_prefix.exist?
     end
 
     raise FormulaConflictError.new(formula, conflicts) unless conflicts.empty?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -370,7 +370,7 @@ class FormulaInstaller
       $stderr.puts "Please report this to the #{formula.tap} tap!"
       false
                 else
-      f.linked_keg.exist? && f.opt_prefix.exist?
+                  f.linked_keg.exist? && f.opt_prefix.exist?
     end
 
     raise FormulaConflictError.new(formula, conflicts) unless conflicts.empty?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -369,7 +369,7 @@ class FormulaInstaller
 
       $stderr.puts "Please report this to the #{formula.tap} tap!"
       false
-    else
+                else
       f.linked_keg.exist? && f.opt_prefix.exist?
     end
 

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -106,11 +106,9 @@ require "PATH"
 
 ENV["HOMEBREW_PATH"] ||= ENV["PATH"]
 ORIGINAL_PATHS = PATH.new(ENV["HOMEBREW_PATH"]).map do |p|
-  begin
-    Pathname.new(p).expand_path
-  rescue
-    nil
-  end
+  Pathname.new(p).expand_path
+rescue
+  nil
 end.compact.freeze
 
 HOMEBREW_INTERNAL_COMMAND_ALIASES = {

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -22,17 +22,15 @@ module Homebrew
 
     def attempt_directory_creation
       Keg::MUST_EXIST_DIRECTORIES.each do |dir|
-        begin
-          FileUtils.mkdir_p(dir) unless dir.exist?
+        FileUtils.mkdir_p(dir) unless dir.exist?
 
-          # Create these files to ensure that these directories aren't removed
-          # by the Catalina installer.
-          # (https://github.com/Homebrew/brew/issues/6263)
-          keep_file = dir/".keepme"
-          FileUtils.touch(keep_file) unless keep_file.exist?
-        rescue
-          nil
-        end
+        # Create these files to ensure that these directories aren't removed
+        # by the Catalina installer.
+        # (https://github.com/Homebrew/brew/issues/6263)
+        keep_file = dir/".keepme"
+        FileUtils.touch(keep_file) unless keep_file.exist?
+      rescue
+        nil
       end
     end
 

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -270,7 +270,7 @@ class Keg
 
     aliases.each do |a|
       # versioned aliases are handled below
-      next if a =~ /.+@./
+      next if /.+@./.match?(a)
 
       alias_symlink = opt/a
       if alias_symlink.symlink? && alias_symlink.exist?
@@ -340,7 +340,7 @@ class Keg
           next
         end
 
-        dst.uninstall_info if dst.to_s =~ INFOFILE_RX
+        dst.uninstall_info if INFOFILE_RX.match?(dst.to_s)
         dst.unlink
         remove_old_aliases
         Find.prune if src.directory?
@@ -492,7 +492,7 @@ class Keg
       # the :link strategy. However, for Foo.framework and
       # Foo.framework/Versions we have to use :mkpath so that multiple formulae
       # can link their versions into it and `brew [un]link` works.
-      if relative_path.to_s =~ %r{[^/]*\.framework(/Versions)?$}
+      if %r{[^/]*\.framework(/Versions)?$}.match?(relative_path.to_s)
         :mkpath
       else
         :link

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -128,8 +128,8 @@ class Keg
     keg_names = kegs.select(&:optlinked?).map(&:name)
     keg_formulae = []
     kegs_by_source = kegs.group_by do |keg|
-        # First, attempt to resolve the keg to a formula
-        # to get up-to-date name and tap information.
+      # First, attempt to resolve the keg to a formula
+      # to get up-to-date name and tap information.
       f = keg.to_formula
       keg_formulae << f
       [f.name, f.tap]

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -128,17 +128,15 @@ class Keg
     keg_names = kegs.select(&:optlinked?).map(&:name)
     keg_formulae = []
     kegs_by_source = kegs.group_by do |keg|
-      begin
         # First, attempt to resolve the keg to a formula
         # to get up-to-date name and tap information.
-        f = keg.to_formula
-        keg_formulae << f
-        [f.name, f.tap]
-      rescue FormulaUnavailableError
-        # If the formula for the keg can't be found,
-        # fall back to the information in the tab.
-        [keg.name, keg.tab.tap]
-      end
+      f = keg.to_formula
+      keg_formulae << f
+      [f.name, f.tap]
+    rescue FormulaUnavailableError
+      # If the formula for the keg can't be found,
+      # fall back to the information in the tab.
+      [keg.name, keg.tab.tap]
     end
 
     all_required_kegs = Set.new

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -268,7 +268,7 @@ class Keg
 
     aliases.each do |a|
       # versioned aliases are handled below
-      next if /.+@./.match?(a)
+      next if a.match?(/.+@./)
 
       alias_symlink = opt/a
       if alias_symlink.symlink? && alias_symlink.exist?
@@ -338,7 +338,7 @@ class Keg
           next
         end
 
-        dst.uninstall_info if INFOFILE_RX.match?(dst.to_s)
+        dst.uninstall_info if dst.to_s.match?(INFOFILE_RX)
         dst.unlink
         remove_old_aliases
         Find.prune if src.directory?
@@ -490,7 +490,7 @@ class Keg
       # the :link strategy. However, for Foo.framework and
       # Foo.framework/Versions we have to use :mkpath so that multiple formulae
       # can link their versions into it and `brew [un]link` works.
-      if %r{[^/]*\.framework(/Versions)?$}.match?(relative_path.to_s)
+      if relative_path.to_s.match?(%r{[^/]*\.framework(/Versions)?$})
         :mkpath
       else
         :link

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -13,7 +13,7 @@ class Locale
   def self.parse(string)
     string = string.to_s
 
-    raise ParserError, "'#{string}' cannot be parsed to a #{self}" unless LOCALE_REGEX.match?(string)
+    raise ParserError, "'#{string}' cannot be parsed to a #{self}" unless string.match?(LOCALE_REGEX)
 
     scan = proc do |regex|
       string.scan(/(?:\-|^)(#{regex})(?:\-|$)/).flatten.first

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -13,7 +13,7 @@ class Locale
   def self.parse(string)
     string = string.to_s
 
-    raise ParserError, "'#{string}' cannot be parsed to a #{self}" if string !~ LOCALE_REGEX
+    raise ParserError, "'#{string}' cannot be parsed to a #{self}" if !LOCALE_REGEX.match?(string)
 
     scan = proc do |regex|
       string.scan(/(?:\-|^)(#{regex})(?:\-|$)/).flatten.first
@@ -39,7 +39,7 @@ class Locale
       next if value.nil?
 
       regex = self.class.const_get("#{key.upcase}_REGEX")
-      raise ParserError, "'#{value}' does not match #{regex}" unless value =~ regex
+      raise ParserError, "'#{value}' does not match #{regex}" unless value&.match?(regex)
 
       instance_variable_set(:"@#{key}", value)
     end

--- a/Library/Homebrew/locale.rb
+++ b/Library/Homebrew/locale.rb
@@ -13,7 +13,7 @@ class Locale
   def self.parse(string)
     string = string.to_s
 
-    raise ParserError, "'#{string}' cannot be parsed to a #{self}" if !LOCALE_REGEX.match?(string)
+    raise ParserError, "'#{string}' cannot be parsed to a #{self}" unless LOCALE_REGEX.match?(string)
 
     scan = proc do |regex|
       string.scan(/(?:\-|^)(#{regex})(?:\-|$)/).flatten.first

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -21,11 +21,11 @@ module ELFShim
   ARCHITECTURE_AARCH64 = 0xB7
 
   def read_uint8(offset)
-    read(1, offset).unpack("C").first
+    read(1, offset).unpack1("C")
   end
 
   def read_uint16(offset)
-    read(2, offset).unpack("v").first
+    read(2, offset).unpack1("v")
   end
 
   def elf?

--- a/Library/Homebrew/readall.rb
+++ b/Library/Homebrew/readall.rb
@@ -37,15 +37,13 @@ module Readall
     def valid_formulae?(formulae)
       failed = false
       formulae.each do |file|
-        begin
-          Formulary.factory(file)
-        rescue Interrupt
-          raise
-        rescue Exception => e # rubocop:disable Lint/RescueException
-          onoe "Invalid formula: #{file}"
-          puts e
-          failed = true
-        end
+        Formulary.factory(file)
+      rescue Interrupt
+        raise
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        onoe "Invalid formula: #{file}"
+        puts e
+        failed = true
       end
       !failed
     end

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -28,7 +28,7 @@ class JavaRequirement < Requirement
   end
 
   def initialize(tags = [])
-    @version = tags.shift if /^\d/ =~ tags.first
+    @version = tags.shift if /^\d/.match?(tags.first)
     super(tags)
     @cask = suggestion.token
   end

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -28,7 +28,7 @@ class JavaRequirement < Requirement
   end
 
   def initialize(tags = [])
-    @version = tags.shift if /^\d/.match?(tags.first)
+    @version = tags.shift if tags.first&.match?(/^\d/)
     super(tags)
     @cask = suggestion.token
   end

--- a/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
+++ b/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
@@ -17,7 +17,7 @@ module RuboCop
           url_node = stanza.stanza_node.first_argument
           url = url_node.str_content
 
-          return unless %r{^.+://[^/]+$}.match?(url)
+          return unless url.match?(%r{^.+://[^/]+$})
 
           add_offense(url_node, location: :expression,
                                 message:  format(MSG_NO_SLASH, url: url))

--- a/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
+++ b/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
@@ -17,7 +17,7 @@ module RuboCop
           url_node = stanza.stanza_node.first_argument
           url = url_node.str_content
 
-          return if url !~ %r{^.+://[^/]+$}
+          return if !%r{^.+://[^/]+$}.match?(url)
 
           add_offense(url_node, location: :expression,
                                 message:  format(MSG_NO_SLASH, url: url))

--- a/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
+++ b/Library/Homebrew/rubocops/cask/homepage_url_trailing_slash.rb
@@ -17,7 +17,7 @@ module RuboCop
           url_node = stanza.stanza_node.first_argument
           url = url_node.str_content
 
-          return if !%r{^.+://[^/]+$}.match?(url)
+          return unless %r{^.+://[^/]+$}.match?(url)
 
           add_offense(url_node, location: :expression,
                                 message:  format(MSG_NO_SLASH, url: url))

--- a/Library/Homebrew/rubocops/homepage.rb
+++ b/Library/Homebrew/rubocops/homepage.rb
@@ -17,7 +17,7 @@ module RuboCop
 
           problem "Formula should have a homepage." if homepage_node.nil? || homepage.empty?
 
-          unless homepage =~ %r{^https?://}
+          unless %r{^https?://}.match?(homepage)
             problem "The homepage should start with http or https (URL is #{homepage})."
           end
 

--- a/Library/Homebrew/rubocops/homepage.rb
+++ b/Library/Homebrew/rubocops/homepage.rb
@@ -17,7 +17,7 @@ module RuboCop
 
           problem "Formula should have a homepage." if homepage_node.nil? || homepage.empty?
 
-          unless %r{^https?://}.match?(homepage)
+          unless homepage.match?(%r{^https?://})
             problem "The homepage should start with http or https (URL is #{homepage})."
           end
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -335,7 +335,7 @@ module RuboCop
 
           find_every_method_call_by_name(body_node, :system).each do |method_node|
             # Skip Kibana: npm cache edge (see formula for more details)
-            next if @formula_name =~ /^kibana(@\d[\d.]*)?$/
+            next if /^kibana(@\d[\d.]*)?$/.match?(@formula_name)
 
             first_param, second_param = parameters(method_node)
             next if !node_equals?(first_param, "npm") ||

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -335,7 +335,7 @@ module RuboCop
 
           find_every_method_call_by_name(body_node, :system).each do |method_node|
             # Skip Kibana: npm cache edge (see formula for more details)
-            next if /^kibana(@\d[\d.]*)?$/.match?(@formula_name)
+            next if @formula_name.match?(/^kibana(@\d[\d.]*)?$/)
 
             first_param, second_param = parameters(method_node)
             next if !node_equals?(first_param, "npm") ||

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -30,7 +30,7 @@ module RuboCop
           patch_url = string_content(patch)
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch, gh_patch_param_pattern)
-            if patch_url !~ /\?full_index=\w+$/
+            if !/\?full_index=\w+$/.match?(patch_url)
               problem <<~EOS
                 GitHub patches should use the full_index parameter:
                   #{patch_url}?full_index=1
@@ -43,7 +43,7 @@ module RuboCop
                                             %r{gist\.github\.com/.+/raw},
                                             %r{gist\.githubusercontent\.com/.+/raw}])
           if regex_match_group(patch, gh_patch_patterns)
-            if patch_url !~ /[a-fA-F0-9]{40}/
+            if !/[a-fA-F0-9]{40}/.match?(patch_url)
               problem <<~EOS.chomp
                 GitHub/Gist patches should specify a revision:
                   #{patch_url}

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -30,7 +30,7 @@ module RuboCop
           patch_url = string_content(patch)
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch, gh_patch_param_pattern)
-            unless /\?full_index=\w+$/.match?(patch_url)
+            unless patch_url.match?(/\?full_index=\w+$/)
               problem <<~EOS
                 GitHub patches should use the full_index parameter:
                   #{patch_url}?full_index=1
@@ -43,7 +43,7 @@ module RuboCop
                                             %r{gist\.github\.com/.+/raw},
                                             %r{gist\.githubusercontent\.com/.+/raw}])
           if regex_match_group(patch, gh_patch_patterns)
-            unless /[a-fA-F0-9]{40}/.match?(patch_url)
+            unless patch_url.match?(/[a-fA-F0-9]{40}/)
               problem <<~EOS.chomp
                 GitHub/Gist patches should specify a revision:
                   #{patch_url}

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -30,7 +30,7 @@ module RuboCop
           patch_url = string_content(patch)
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch, gh_patch_param_pattern)
-            if !/\?full_index=\w+$/.match?(patch_url)
+            unless /\?full_index=\w+$/.match?(patch_url)
               problem <<~EOS
                 GitHub patches should use the full_index parameter:
                   #{patch_url}?full_index=1
@@ -43,7 +43,7 @@ module RuboCop
                                             %r{gist\.github\.com/.+/raw},
                                             %r{gist\.githubusercontent\.com/.+/raw}])
           if regex_match_group(patch, gh_patch_patterns)
-            if !/[a-fA-F0-9]{40}/.match?(patch_url)
+            unless /[a-fA-F0-9]{40}/.match?(patch_url)
               problem <<~EOS.chomp
                 GitHub/Gist patches should specify a revision:
                   #{patch_url}

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -123,18 +123,18 @@ module RuboCop
 
             problem "Don't use /download in SourceForge urls (url is #{url})." if url.end_with?("/download")
 
-            if url =~ %r{^https?://sourceforge\.}
+            if %r{^https?://sourceforge\.}.match?(url)
               problem "Use https://downloads.sourceforge.net to get geolocation (url is #{url})."
             end
 
-            if url =~ %r{^https?://prdownloads\.}
+            if %r{^https?://prdownloads\.}.match?(url)
               problem <<~EOS.chomp
                 Don't use prdownloads in SourceForge urls (url is #{url}).
                         See: http://librelist.com/browser/homebrew/2011/1/12/prdownloads-is-bad/
               EOS
             end
 
-            if url =~ %r{^http://\w+\.dl\.}
+            if %r{^http://\w+\.dl\.}.match?(url)
               problem "Don't use specific dl mirrors in SourceForge urls (url is #{url})."
             end
 
@@ -195,7 +195,7 @@ module RuboCop
           # Use new-style archive downloads
           archive_gh_pattern = %r{https://.*github.*/(?:tar|zip)ball/}
           audit_urls(urls, archive_gh_pattern) do |_, url|
-            next unless url !~ /\.git$/
+            next unless !/\.git$/.match?(url)
 
             problem "Use /archive/ URLs for GitHub tarballs (url is #{url})."
           end
@@ -203,7 +203,7 @@ module RuboCop
           # Don't use GitHub .zip files
           zip_gh_pattern = %r{https://.*github.*/(archive|releases)/.*\.zip$}
           audit_urls(urls, zip_gh_pattern) do |_, url|
-            next unless url !~ %r{releases/download}
+            next unless !%r{releases/download}.match?(url)
 
             problem "Use GitHub tarballs rather than zipballs (url is #{url})."
           end

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -195,7 +195,7 @@ module RuboCop
           # Use new-style archive downloads
           archive_gh_pattern = %r{https://.*github.*/(?:tar|zip)ball/}
           audit_urls(urls, archive_gh_pattern) do |_, url|
-            next unless !/\.git$/.match?(url)
+            next if /\.git$/.match?(url)
 
             problem "Use /archive/ URLs for GitHub tarballs (url is #{url})."
           end
@@ -203,7 +203,7 @@ module RuboCop
           # Don't use GitHub .zip files
           zip_gh_pattern = %r{https://.*github.*/(archive|releases)/.*\.zip$}
           audit_urls(urls, zip_gh_pattern) do |_, url|
-            next unless !%r{releases/download}.match?(url)
+            next if %r{releases/download}.match?(url)
 
             problem "Use GitHub tarballs rather than zipballs (url is #{url})."
           end

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -123,18 +123,18 @@ module RuboCop
 
             problem "Don't use /download in SourceForge urls (url is #{url})." if url.end_with?("/download")
 
-            if %r{^https?://sourceforge\.}.match?(url)
+            if url.match?(%r{^https?://sourceforge\.})
               problem "Use https://downloads.sourceforge.net to get geolocation (url is #{url})."
             end
 
-            if %r{^https?://prdownloads\.}.match?(url)
+            if url.match?(%r{^https?://prdownloads\.})
               problem <<~EOS.chomp
                 Don't use prdownloads in SourceForge urls (url is #{url}).
                         See: http://librelist.com/browser/homebrew/2011/1/12/prdownloads-is-bad/
               EOS
             end
 
-            if %r{^http://\w+\.dl\.}.match?(url)
+            if url.match?(%r{^http://\w+\.dl\.})
               problem "Don't use specific dl mirrors in SourceForge urls (url is #{url})."
             end
 
@@ -195,7 +195,7 @@ module RuboCop
           # Use new-style archive downloads
           archive_gh_pattern = %r{https://.*github.*/(?:tar|zip)ball/}
           audit_urls(urls, archive_gh_pattern) do |_, url|
-            next if /\.git$/.match?(url)
+            next if url.match?(/\.git$/)
 
             problem "Use /archive/ URLs for GitHub tarballs (url is #{url})."
           end
@@ -203,7 +203,7 @@ module RuboCop
           # Don't use GitHub .zip files
           zip_gh_pattern = %r{https://.*github.*/(archive|releases)/.*\.zip$}
           audit_urls(urls, zip_gh_pattern) do |_, url|
-            next if %r{releases/download}.match?(url)
+            next if url.match?(%r{releases/download})
 
             problem "Use GitHub tarballs rather than zipballs (url is #{url})."
           end

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -184,13 +184,11 @@ class SoftwareSpec
   def recursive_dependencies
     deps_f = []
     recursive_dependencies = deps.map do |dep|
-      begin
-        deps_f << dep.to_formula
-        dep
-      rescue TapFormulaUnavailableError
-        # Don't complain about missing cross-tap dependencies
-        next
-      end
+      deps_f << dep.to_formula
+      dep
+    rescue TapFormulaUnavailableError
+      # Don't complain about missing cross-tap dependencies
+      next
     end.compact.uniq
     deps_f.compact.each do |f|
       f.recursive_dependencies.each do |dep|
@@ -386,11 +384,10 @@ class BottleSpecification
   def checksums
     tags = collector.keys.sort_by do |tag|
       # Sort non-MacOS tags below MacOS tags.
-      begin
-        OS::Mac::Version.from_symbol tag
-      rescue ArgumentError
-        "0.#{tag}"
-      end
+
+      OS::Mac::Version.from_symbol tag
+    rescue ArgumentError
+      "0.#{tag}"
     end
     checksums = {}
     tags.reverse_each do |tag|

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -225,7 +225,7 @@ class SystemCommand
 
     def warn_plist_garbage(garbage)
       return unless ARGV.verbose?
-      return unless garbage =~ /\S/
+      return unless /\S/.match?(garbage)
 
       opoo "Received non-XML output from #{Formatter.identifier(command.first)}:"
       $stderr.puts garbage.strip

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -223,7 +223,7 @@ class SystemCommand
 
     def warn_plist_garbage(garbage)
       return unless ARGV.verbose?
-      return unless /\S/.match?(garbage)
+      return unless garbage.match?(/\S/)
 
       opoo "Received non-XML output from #{Formatter.identifier(command.first)}:"
       $stderr.puts garbage.strip

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -148,13 +148,11 @@ class SystemCommand
       break if readable_sources.empty?
 
       readable_sources.each do |source|
-        begin
-          line = source.readline_nonblock || ""
-          type = (source == sources[0]) ? :stdout : :stderr
-          yield(type, line)
-        rescue IO::WaitReadable, EOFError
-          next
-        end
+        line = source.readline_nonblock || ""
+        type = (source == sources[0]) ? :stdout : :stderr
+        yield(type, line)
+      rescue IO::WaitReadable, EOFError
+        next
       end
     end
 

--- a/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
+++ b/Library/Homebrew/test/cask/artifact/shared_examples/uninstall_zap.rb
@@ -199,15 +199,13 @@ shared_examples "#uninstall_phase or #zap_phase" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-#{artifact_dsl_key}-#{directive}")) }
 
       around do |example|
-        begin
-          ENV["HOME"] = dir
+        ENV["HOME"] = dir
 
-          FileUtils.touch paths
+        FileUtils.touch paths
 
-          example.run
-        ensure
-          FileUtils.rm_f paths
-        end
+        example.run
+      ensure
+        FileUtils.rm_f paths
       end
 
       before do

--- a/Library/Homebrew/test/cask/cmd/create_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/create_spec.rb
@@ -5,12 +5,10 @@ require_relative "shared_examples/invalid_option"
 
 describe Cask::Cmd::Create, :cask do
   around do |example|
-    begin
-      example.run
-    ensure
-      %w[new-cask additional-cask another-cask yet-another-cask local-caff].each do |cask|
-        FileUtils.rm_f Cask::CaskLoader.path(cask)
-      end
+    example.run
+  ensure
+    %w[new-cask additional-cask another-cask yet-another-cask local-caff].each do |cask|
+      FileUtils.rm_f Cask::CaskLoader.path(cask)
     end
   end
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -473,18 +473,16 @@ describe Cask::DSL, :cask do
     end
 
     it "does not include a trailing slash" do
-      begin
-        original_appdir = Cask::Config.global.appdir
-        Cask::Config.global.appdir = "#{original_appdir}/"
+      original_appdir = Cask::Config.global.appdir
+      Cask::Config.global.appdir = "#{original_appdir}/"
 
-        cask = Cask::Cask.new("appdir-trailing-slash") do
-          binary "#{appdir}/some/path"
-        end
-
-        expect(cask.artifacts.first.source).to eq(original_appdir/"some/path")
-      ensure
-        Cask::Config.global.appdir = original_appdir
+      cask = Cask::Cask.new("appdir-trailing-slash") do
+        binary "#{appdir}/some/path"
       end
+
+      expect(cask.artifacts.first.source).to eq(original_appdir/"some/path")
+    ensure
+      Cask::Config.global.appdir = original_appdir
     end
   end
 

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -34,15 +34,13 @@ describe Homebrew::Cleanup do
   let(:lock_file) { Pathname.new("#{HOMEBREW_LOCKS}/foo") }
 
   around do |example|
-    begin
-      FileUtils.touch ds_store
-      FileUtils.touch lock_file
+    FileUtils.touch ds_store
+    FileUtils.touch lock_file
 
-      example.run
-    ensure
-      FileUtils.rm_f ds_store
-      FileUtils.rm_f lock_file
-    end
+    example.run
+  ensure
+    FileUtils.rm_f ds_store
+    FileUtils.rm_f lock_file
   end
 
   describe "::cleanup" do

--- a/Library/Homebrew/test/cmd/commands_spec.rb
+++ b/Library/Homebrew/test/cmd/commands_spec.rb
@@ -33,15 +33,13 @@ RSpec.shared_context "custom internal commands" do
   end
 
   around do |example|
-    begin
-      cmds.each do |f|
-        FileUtils.touch f
-      end
-
-      example.run
-    ensure
-      FileUtils.rm_f cmds
+    cmds.each do |f|
+      FileUtils.touch f
     end
+
+    example.run
+  ensure
+    FileUtils.rm_f cmds
   end
 end
 

--- a/Library/Homebrew/test/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cmd/style_spec.rb
@@ -9,17 +9,15 @@ end
 
 describe "brew style" do
   around do |example|
-    begin
-      FileUtils.ln_s HOMEBREW_LIBRARY_PATH, HOMEBREW_LIBRARY/"Homebrew"
-      FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".rubocop_audit.yml"
-      FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop_shared.yml", HOMEBREW_LIBRARY/".rubocop_shared.yml"
+    FileUtils.ln_s HOMEBREW_LIBRARY_PATH, HOMEBREW_LIBRARY/"Homebrew"
+    FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop.yml", HOMEBREW_LIBRARY/".rubocop_audit.yml"
+    FileUtils.ln_s HOMEBREW_LIBRARY_PATH.parent/".rubocop_shared.yml", HOMEBREW_LIBRARY/".rubocop_shared.yml"
 
-      example.run
-    ensure
-      FileUtils.rm_f HOMEBREW_LIBRARY/"Homebrew"
-      FileUtils.rm_f HOMEBREW_LIBRARY/".rubocop_audit.yml"
-      FileUtils.rm_f HOMEBREW_LIBRARY/".rubocop_shared.yml"
-    end
+    example.run
+  ensure
+    FileUtils.rm_f HOMEBREW_LIBRARY/"Homebrew"
+    FileUtils.rm_f HOMEBREW_LIBRARY/".rubocop_audit.yml"
+    FileUtils.rm_f HOMEBREW_LIBRARY/".rubocop_shared.yml"
   end
 
   before do

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -73,20 +73,18 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_user_path_3" do
-    begin
-      sbin = HOMEBREW_PREFIX/"sbin"
-      ENV["HOMEBREW_PATH"] =
-        "#{HOMEBREW_PREFIX}/bin#{File::PATH_SEPARATOR}" +
-        ENV["HOMEBREW_PATH"].gsub(/(?:^|#{Regexp.escape(File::PATH_SEPARATOR)})#{Regexp.escape(sbin)}/, "")
-      (sbin/"something").mkpath
+    sbin = HOMEBREW_PREFIX/"sbin"
+    ENV["HOMEBREW_PATH"] =
+      "#{HOMEBREW_PREFIX}/bin#{File::PATH_SEPARATOR}" +
+      ENV["HOMEBREW_PATH"].gsub(/(?:^|#{Regexp.escape(File::PATH_SEPARATOR)})#{Regexp.escape(sbin)}/, "")
+    (sbin/"something").mkpath
 
-      expect(subject.check_user_path_1).to be nil
-      expect(subject.check_user_path_2).to be nil
-      expect(subject.check_user_path_3)
-        .to match("Homebrew's sbin was not found in your PATH")
-    ensure
-      sbin.rmtree
-    end
+    expect(subject.check_user_path_1).to be nil
+    expect(subject.check_user_path_2).to be nil
+    expect(subject.check_user_path_3)
+      .to match("Homebrew's sbin was not found in your PATH")
+  ensure
+    sbin.rmtree
   end
 
   specify "#check_for_config_scripts" do
@@ -103,18 +101,16 @@ describe Homebrew::Diagnostic::Checks do
   end
 
   specify "#check_for_symlinked_cellar" do
-    begin
-      HOMEBREW_CELLAR.rmtree
+    HOMEBREW_CELLAR.rmtree
 
-      mktmpdir do |path|
-        FileUtils.ln_s path, HOMEBREW_CELLAR
+    mktmpdir do |path|
+      FileUtils.ln_s path, HOMEBREW_CELLAR
 
-        expect(subject.check_for_symlinked_cellar).to match(path)
-      end
-    ensure
-      HOMEBREW_CELLAR.unlink
-      HOMEBREW_CELLAR.mkpath
+      expect(subject.check_for_symlinked_cellar).to match(path)
     end
+  ensure
+    HOMEBREW_CELLAR.unlink
+    HOMEBREW_CELLAR.mkpath
   end
 
   specify "#check_ld_vars catches LD vars" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1266,42 +1266,40 @@ describe Formula do
       let(:testball_repo) { HOMEBREW_PREFIX/"testball_repo" }
 
       example do
-        begin
-          outdated_stable_prefix = HOMEBREW_CELLAR/"testball/1.0"
-          head_prefix_a = HOMEBREW_CELLAR/"testball/HEAD"
-          head_prefix_b = HOMEBREW_CELLAR/"testball/HEAD-aaaaaaa_1"
-          head_prefix_c = HOMEBREW_CELLAR/"testball/HEAD-18a7103"
+        outdated_stable_prefix = HOMEBREW_CELLAR/"testball/1.0"
+        head_prefix_a = HOMEBREW_CELLAR/"testball/HEAD"
+        head_prefix_b = HOMEBREW_CELLAR/"testball/HEAD-aaaaaaa_1"
+        head_prefix_c = HOMEBREW_CELLAR/"testball/HEAD-18a7103"
 
-          setup_tab_for_prefix(outdated_stable_prefix)
-          tab_a = setup_tab_for_prefix(head_prefix_a, versions: { "stable" => "1.0" })
-          setup_tab_for_prefix(head_prefix_b)
+        setup_tab_for_prefix(outdated_stable_prefix)
+        tab_a = setup_tab_for_prefix(head_prefix_a, versions: { "stable" => "1.0" })
+        setup_tab_for_prefix(head_prefix_b)
 
-          testball_repo.mkdir
-          testball_repo.cd do
-            FileUtils.touch "LICENSE"
+        testball_repo.mkdir
+        testball_repo.cd do
+          FileUtils.touch "LICENSE"
 
-            system("git", "init")
-            system("git", "add", "--all")
-            system("git", "commit", "-m", "Initial commit")
-          end
-
-          expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
-
-          tab_a.source["versions"] = { "stable" => f.version.to_s }
-          tab_a.write
-          reset_outdated_kegs
-          expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
-
-          head_prefix_a.rmtree
-          reset_outdated_kegs
-          expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
-
-          setup_tab_for_prefix(head_prefix_c, source_modified_time: 1)
-          reset_outdated_kegs
-          expect(f.outdated_kegs(fetch_head: true)).to be_empty
-        ensure
-          testball_repo.rmtree if testball_repo.exist?
+          system("git", "init")
+          system("git", "add", "--all")
+          system("git", "commit", "-m", "Initial commit")
         end
+
+        expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
+
+        tab_a.source["versions"] = { "stable" => f.version.to_s }
+        tab_a.write
+        reset_outdated_kegs
+        expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
+
+        head_prefix_a.rmtree
+        reset_outdated_kegs
+        expect(f.outdated_kegs(fetch_head: true)).not_to be_empty
+
+        setup_tab_for_prefix(head_prefix_c, source_modified_time: 1)
+        reset_outdated_kegs
+        expect(f.outdated_kegs(fetch_head: true)).to be_empty
+      ensure
+        testball_repo.rmtree if testball_repo.exist?
       end
     end
 

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -73,8 +73,8 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
         RUBY
 
         inspect_source(source)
-        if %r{http:\/\/www\.freedesktop\.org}.match?(homepage)
-          if /Software/.match?(homepage)
+        if homepage.match?(%r{http:\/\/www\.freedesktop\.org})
+          if homepage.match?(/Software/)
             expected_offenses = [{  message:  "#{homepage} should be styled " \
                                              "`https://wiki.freedesktop.org/www/Software/project_name`",
                                     severity: :convention,
@@ -89,13 +89,13 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
                                     column:   2,
                                     source:   source }]
           end
-        elsif %r{https:\/\/code\.google\.com}.match?(homepage)
+        elsif homepage.match?(%r{https:\/\/code\.google\.com})
           expected_offenses = [{  message:  "#{homepage} should end with a slash",
                                   severity: :convention,
                                   line:     2,
                                   column:   2,
                                   source:   source }]
-        elsif /foo\.(sf|sourceforge)\.net/.match?(homepage)
+        elsif homepage.match?(/foo\.(sf|sourceforge)\.net/)
           expected_offenses = [{  message:  "#{homepage} should be `https://foo.sourceforge.io/`",
                                   severity: :convention,
                                   line:     2,

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -73,8 +73,8 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
         RUBY
 
         inspect_source(source)
-        if homepage =~ %r{http:\/\/www\.freedesktop\.org}
-          if homepage =~ /Software/
+        if %r{http:\/\/www\.freedesktop\.org}.match?(homepage)
+          if /Software/.match?(homepage)
             expected_offenses = [{  message:  "#{homepage} should be styled " \
                                              "`https://wiki.freedesktop.org/www/Software/project_name`",
                                     severity: :convention,
@@ -89,13 +89,13 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
                                     column:   2,
                                     source:   source }]
           end
-        elsif homepage =~ %r{https:\/\/code\.google\.com}
+        elsif %r{https:\/\/code\.google\.com}.match?(homepage)
           expected_offenses = [{  message:  "#{homepage} should end with a slash",
                                   severity: :convention,
                                   line:     2,
                                   column:   2,
                                   source:   source }]
-        elsif homepage =~ /foo\.(sf|sourceforge)\.net/
+        elsif /foo\.(sf|sourceforge)\.net/.match?(homepage)
           expected_offenses = [{  message:  "#{homepage} should be `https://foo.sourceforge.io/`",
                                   severity: :convention,
                                   line:     2,

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -48,7 +48,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         EOS
 
         inspect_source(source)
-        expected_offense = if %r{/raw\.github\.com/}.match?(patch_url)
+        expected_offense = if patch_url.match?(%r{/raw\.github\.com/})
           [{ message:
                        <<~EOS.chomp,
                          GitHub/Gist patches should specify a revision:
@@ -58,7 +58,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   12,
              source:   source }]
-        elsif %r{macports/trunk}.match?(patch_url)
+        elsif patch_url.match?(%r{macports/trunk})
           [{ message:
                        <<~EOS.chomp,
                          MacPorts patches should specify a revision instead of trunk:
@@ -68,7 +68,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   33,
              source:   source }]
-        elsif %r{^http://trac\.macports\.org}.match?(patch_url)
+        elsif patch_url.match?(%r{^http://trac\.macports\.org})
           [{ message:
                        <<~EOS.chomp,
                          Patches from MacPorts Trac should be https://, not http:
@@ -78,7 +78,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   5,
              source:   source }]
-        elsif %r{^http://bugs\.debian\.org}.match?(patch_url)
+        elsif patch_url.match?(%r{^http://bugs\.debian\.org})
           [{ message:
                        <<~EOS.chomp,
                          Patches from Debian should be https://, not http:
@@ -89,7 +89,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              column:   5,
              source:   source }]
         # rubocop:disable Metrics/LineLength
-        elsif %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}.match?(patch_url)
+        elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Metrics/LineLength
           [{ message:
                        <<~EOS,
@@ -102,7 +102,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   5,
              source:   source }]
-        elsif %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}.match?(patch_url)
+        elsif patch_url.match?(%r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)})
           [{ message:
                        <<~EOS,
                          GitHub patches should use the full_index parameter:
@@ -185,7 +185,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         RUBY
 
         inspect_source(source)
-        expected_offense = if %r{/raw\.github\.com/}.match?(patch_url)
+        expected_offense = if patch_url.match?(%r{/raw\.github\.com/})
           [{ message:
                        <<~EOS.chomp,
                          GitHub/Gist patches should specify a revision:
@@ -195,7 +195,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   16,
              source:   source }]
-        elsif %r{macports/trunk}.match?(patch_url)
+        elsif patch_url.match?(%r{macports/trunk})
           [{ message:
                        <<~EOS.chomp,
                          MacPorts patches should specify a revision instead of trunk:
@@ -205,7 +205,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   37,
              source:   source }]
-        elsif %r{^http://trac\.macports\.org}.match?(patch_url)
+        elsif patch_url.match?(%r{^http://trac\.macports\.org})
           [{ message:
                        <<~EOS.chomp,
                          Patches from MacPorts Trac should be https://, not http:
@@ -215,7 +215,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   9,
              source:   source }]
-        elsif %r{^http://bugs\.debian\.org}.match?(patch_url)
+        elsif patch_url.match?(%r{^http://bugs\.debian\.org})
           [{ message:
                        <<~EOS.chomp,
                          Patches from Debian should be https://, not http:
@@ -226,7 +226,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              column:   9,
              source:   source }]
         # rubocop:disable Metrics/LineLength
-        elsif %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}.match?(patch_url)
+        elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Metrics/LineLength
           [{ message:
                        <<~EOS,

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -88,7 +88,9 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   5,
              source:   source }]
+        # rubocop:disable Metrics/LineLength
         elsif %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}.match?(patch_url)
+          # rubocop:enable Metrics/LineLength
           [{ message:
                        <<~EOS,
                          use GitHub pull request URLs:
@@ -223,7 +225,9 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   9,
              source:   source }]
+        # rubocop:disable Metrics/LineLength
         elsif %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}.match?(patch_url)
+          # rubocop:enable Metrics/LineLength
           [{ message:
                        <<~EOS,
                          use GitHub pull request URLs:

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -48,7 +48,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         EOS
 
         inspect_source(source)
-        expected_offense = if patch_url =~ %r{/raw\.github\.com/}
+        expected_offense = if %r{/raw\.github\.com/}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          GitHub/Gist patches should specify a revision:
@@ -58,7 +58,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   12,
              source:   source }]
-        elsif patch_url =~ %r{macports/trunk}
+        elsif %r{macports/trunk}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          MacPorts patches should specify a revision instead of trunk:
@@ -68,7 +68,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   33,
              source:   source }]
-        elsif patch_url =~ %r{^http://trac\.macports\.org}
+        elsif %r{^http://trac\.macports\.org}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          Patches from MacPorts Trac should be https://, not http:
@@ -78,7 +78,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   5,
              source:   source }]
-        elsif patch_url =~ %r{^http://bugs\.debian\.org}
+        elsif %r{^http://bugs\.debian\.org}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          Patches from Debian should be https://, not http:
@@ -88,7 +88,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   5,
              source:   source }]
-        elsif patch_url =~ %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}
+        elsif %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}.match?(patch_url)
           [{ message:
                        <<~EOS,
                          use GitHub pull request URLs:
@@ -100,7 +100,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   5,
              source:   source }]
-        elsif patch_url =~ %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
+        elsif %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}.match?(patch_url)
           [{ message:
                        <<~EOS,
                          GitHub patches should use the full_index parameter:
@@ -183,7 +183,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         RUBY
 
         inspect_source(source)
-        expected_offense = if patch_url =~ %r{/raw\.github\.com/}
+        expected_offense = if %r{/raw\.github\.com/}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          GitHub/Gist patches should specify a revision:
@@ -193,7 +193,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   16,
              source:   source }]
-        elsif patch_url =~ %r{macports/trunk}
+        elsif %r{macports/trunk}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          MacPorts patches should specify a revision instead of trunk:
@@ -203,7 +203,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   37,
              source:   source }]
-        elsif patch_url =~ %r{^http://trac\.macports\.org}
+        elsif %r{^http://trac\.macports\.org}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          Patches from MacPorts Trac should be https://, not http:
@@ -213,7 +213,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   9,
              source:   source }]
-        elsif patch_url =~ %r{^http://bugs\.debian\.org}
+        elsif %r{^http://bugs\.debian\.org}.match?(patch_url)
           [{ message:
                        <<~EOS.chomp,
                          Patches from Debian should be https://, not http:
@@ -223,7 +223,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   9,
              source:   source }]
-        elsif patch_url =~ %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}
+        elsif %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}.match?(patch_url)
           [{ message:
                        <<~EOS,
                          use GitHub pull request URLs:

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -217,11 +217,9 @@ RSpec::Matchers.alias_matcher :a_string_containing, :include
 
 RSpec::Matchers.define :a_json_string do
   match do |actual|
-    begin
-      JSON.parse(actual)
-      true
-    rescue JSON::ParserError
-      false
-    end
+    JSON.parse(actual)
+    true
+  rescue JSON::ParserError
+    false
   end
 end

--- a/Library/Homebrew/test/support/helper/cask/fake_system_command.rb
+++ b/Library/Homebrew/test/support/helper/cask/fake_system_command.rb
@@ -66,10 +66,8 @@ end
 
 RSpec.configure do |config|
   config.after do
-    begin
-      FakeSystemCommand.verify_expectations!
-    ensure
-      FakeSystemCommand.clear
-    end
+    FakeSystemCommand.verify_expectations!
+  ensure
+    FakeSystemCommand.clear
   end
 end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -41,14 +41,12 @@ RSpec.shared_context "integration test" do
   end
 
   around do |example|
-    begin
-      (HOMEBREW_PREFIX/"bin").mkpath
-      FileUtils.touch HOMEBREW_PREFIX/"bin/brew"
+    (HOMEBREW_PREFIX/"bin").mkpath
+    FileUtils.touch HOMEBREW_PREFIX/"bin/brew"
 
-      example.run
-    ensure
-      FileUtils.rm_r HOMEBREW_PREFIX/"bin"
-    end
+    example.run
+  ensure
+    FileUtils.rm_r HOMEBREW_PREFIX/"bin"
   end
 
   # Generate unique ID to be able to
@@ -94,11 +92,9 @@ RSpec.shared_context "integration test" do
         simplecov_spec = Gem.loaded_specs["simplecov"]
         specs = [simplecov_spec]
         simplecov_spec.runtime_dependencies.each do |dep|
-          begin
-            specs += dep.to_specs
-          rescue Gem::LoadError => e
-            onoe e
-          end
+          specs += dep.to_specs
+        rescue Gem::LoadError => e
+          onoe e
         end
         libs = specs.flat_map do |spec|
           full_gem_path = spec.full_gem_path

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -267,14 +267,12 @@ describe SystemCommand do
       it "does not leak the secrets set by environment" do
         redacted_msg = /#{Regexp.escape("username:******")}/
         expect do
-          begin
-            ENV["PASSWORD"] = "hunter2"
-            described_class.run! "curl",
-                                 args:    %w[--user username:hunter2],
-                                 verbose: true
-          ensure
-            ENV.delete "PASSWORD"
-          end
+          ENV["PASSWORD"] = "hunter2"
+          described_class.run! "curl",
+                               args:    %w[--user username:hunter2],
+                               verbose: true
+        ensure
+          ENV.delete "PASSWORD"
         end.to raise_error.with_message(redacted_msg).and output(redacted_msg).to_stdout
       end
     end

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -61,27 +61,25 @@ describe Tap do
   end
 
   specify "::fetch" do
-    begin
-      expect(described_class.fetch("Homebrew", "core")).to be_kind_of(CoreTap)
-      expect(described_class.fetch("Homebrew", "homebrew")).to be_kind_of(CoreTap)
-      tap = described_class.fetch("Homebrew", "foo")
-      expect(tap).to be_kind_of(described_class)
-      expect(tap.name).to eq("homebrew/foo")
+    expect(described_class.fetch("Homebrew", "core")).to be_kind_of(CoreTap)
+    expect(described_class.fetch("Homebrew", "homebrew")).to be_kind_of(CoreTap)
+    tap = described_class.fetch("Homebrew", "foo")
+    expect(tap).to be_kind_of(described_class)
+    expect(tap.name).to eq("homebrew/foo")
 
-      expect {
-        described_class.fetch("foo")
-      }.to raise_error(/Invalid tap name/)
+    expect {
+      described_class.fetch("foo")
+    }.to raise_error(/Invalid tap name/)
 
-      expect {
-        described_class.fetch("homebrew/homebrew/bar")
-      }.to raise_error(/Invalid tap name/)
+    expect {
+      described_class.fetch("homebrew/homebrew/bar")
+    }.to raise_error(/Invalid tap name/)
 
-      expect {
-        described_class.fetch("homebrew", "homebrew/baz")
-      }.to raise_error(/Invalid tap name/)
-    ensure
-      described_class.clear_cache
-    end
+    expect {
+      described_class.fetch("homebrew", "homebrew/baz")
+    }.to raise_error(/Invalid tap name/)
+  ensure
+    described_class.clear_cache
   end
 
   describe "::from_path" do
@@ -113,23 +111,21 @@ describe Tap do
   end
 
   specify "#issues_url" do
-    begin
-      t = described_class.new("someone", "foo")
-      path = Tap::TAP_DIRECTORY/"someone/homebrew-foo"
-      path.mkpath
-      cd path do
-        system "git", "init"
-        system "git", "remote", "add", "origin",
-               "https://github.com/someone/homebrew-foo"
-      end
-      expect(t.issues_url).to eq("https://github.com/someone/homebrew-foo/issues")
-      expect(subject.issues_url).to eq("https://github.com/Homebrew/homebrew-foo/issues")
-
-      (Tap::TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
-      expect(described_class.new("someone", "no-git").issues_url).to be nil
-    ensure
-      path.parent.rmtree
+    t = described_class.new("someone", "foo")
+    path = Tap::TAP_DIRECTORY/"someone/homebrew-foo"
+    path.mkpath
+    cd path do
+      system "git", "init"
+      system "git", "remote", "add", "origin",
+             "https://github.com/someone/homebrew-foo"
     end
+    expect(t.issues_url).to eq("https://github.com/someone/homebrew-foo/issues")
+    expect(subject.issues_url).to eq("https://github.com/Homebrew/homebrew-foo/issues")
+
+    (Tap::TAP_DIRECTORY/"someone/homebrew-no-git").mkpath
+    expect(described_class.new("someone", "no-git").issues_url).to be nil
+  ensure
+    path.parent.rmtree
   end
 
   specify "files" do
@@ -272,53 +268,49 @@ describe Tap do
   end
 
   specify "#install and #uninstall" do
-    begin
-      setup_tap_files
-      setup_git_repo
+    setup_tap_files
+    setup_git_repo
 
-      tap = described_class.new("Homebrew", "bar")
+    tap = described_class.new("Homebrew", "bar")
 
-      tap.install clone_target: subject.path/".git"
+    tap.install clone_target: subject.path/".git"
 
-      expect(tap).to be_installed
-      expect(HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").to be_a_file
-      expect(HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").to be_a_file
-      expect(HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").to be_a_file
-      expect(HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").to be_a_file
-      tap.uninstall
+    expect(tap).to be_installed
+    expect(HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").to be_a_file
+    expect(HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").to be_a_file
+    expect(HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").to be_a_file
+    expect(HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").to be_a_file
+    tap.uninstall
 
-      expect(tap).not_to be_installed
-      expect(HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").not_to exist
-      expect(HOMEBREW_PREFIX/"share/man/man1").not_to exist
-      expect(HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").not_to exist
-      expect(HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").not_to exist
-      expect(HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").not_to exist
-    ensure
-      (HOMEBREW_PREFIX/"etc").rmtree if (HOMEBREW_PREFIX/"etc").exist?
-      (HOMEBREW_PREFIX/"share").rmtree if (HOMEBREW_PREFIX/"share").exist?
-    end
+    expect(tap).not_to be_installed
+    expect(HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").not_to exist
+    expect(HOMEBREW_PREFIX/"share/man/man1").not_to exist
+    expect(HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").not_to exist
+    expect(HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").not_to exist
+    expect(HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").not_to exist
+  ensure
+    (HOMEBREW_PREFIX/"etc").rmtree if (HOMEBREW_PREFIX/"etc").exist?
+    (HOMEBREW_PREFIX/"share").rmtree if (HOMEBREW_PREFIX/"share").exist?
   end
 
   specify "#link_completions_and_manpages" do
-    begin
-      setup_tap_files
-      setup_git_repo
-      tap = described_class.new("Homebrew", "baz")
-      tap.install clone_target: subject.path/".git"
-      (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
-      (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete
-      (HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").delete
-      (HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").delete
-      tap.link_completions_and_manpages
-      expect(HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").to be_a_file
-      expect(HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").to be_a_file
-      expect(HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").to be_a_file
-      expect(HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").to be_a_file
-      tap.uninstall
-    ensure
-      (HOMEBREW_PREFIX/"etc").rmtree if (HOMEBREW_PREFIX/"etc").exist?
-      (HOMEBREW_PREFIX/"share").rmtree if (HOMEBREW_PREFIX/"share").exist?
-    end
+    setup_tap_files
+    setup_git_repo
+    tap = described_class.new("Homebrew", "baz")
+    tap.install clone_target: subject.path/".git"
+    (HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").delete
+    (HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").delete
+    (HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").delete
+    (HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").delete
+    tap.link_completions_and_manpages
+    expect(HOMEBREW_PREFIX/"share/man/man1/brew-tap-cmd.1").to be_a_file
+    expect(HOMEBREW_PREFIX/"etc/bash_completion.d/brew-tap-cmd").to be_a_file
+    expect(HOMEBREW_PREFIX/"share/zsh/site-functions/_brew-tap-cmd").to be_a_file
+    expect(HOMEBREW_PREFIX/"share/fish/vendor_completions.d/brew-tap-cmd.fish").to be_a_file
+    tap.uninstall
+  ensure
+    (HOMEBREW_PREFIX/"etc").rmtree if (HOMEBREW_PREFIX/"etc").exist?
+    (HOMEBREW_PREFIX/"share").rmtree if (HOMEBREW_PREFIX/"share").exist?
   end
 
   specify "#pin and #unpin" do

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -50,13 +50,11 @@ module Homebrew
 
         method = instance_method(name)
         define_method(name) do |*args, &block|
-          begin
-            time = Time.now
-            method.bind(self).call(*args, &block)
-          ensure
-            $times[name] ||= 0
-            $times[name] += Time.now - time
-          end
+          time = Time.now
+          method.bind(self).call(*args, &block)
+        ensure
+          $times[name] ||= 0
+          $times[name] += Time.now - time
         end
       end
     end
@@ -388,11 +386,9 @@ module Kernel
 
   def paths
     @paths ||= PATH.new(ENV["HOMEBREW_PATH"]).map do |p|
-      begin
-        File.expand_path(p).chomp("/")
-      rescue ArgumentError
-        onoe "The following PATH component is invalid: #{p}"
-      end
+      File.expand_path(p).chomp("/")
+    rescue ArgumentError
+      onoe "The following PATH component is invalid: #{p}"
     end.uniq.compact
   end
 

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -53,7 +53,7 @@ module Utils
           write.close
 
           exit!
-        else
+              else
           exit!(true)
         end
 

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -54,7 +54,7 @@ module Utils
 
           exit!
               else
-          exit!(true)
+                exit!(true)
         end
 
         ignore_interrupts(:quietly) do # the child will receive the interrupt and marshal it back

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -32,31 +32,29 @@ module Utils
         read, write = IO.pipe
 
         pid = fork do
-          begin
-            ENV["HOMEBREW_ERROR_PIPE"] = server.path
-            server.close
-            read.close
-            write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
-            yield
-          rescue Exception => e # rubocop:disable Lint/RescueException
-            error_hash = JSON.parse e.to_json
+          ENV["HOMEBREW_ERROR_PIPE"] = server.path
+          server.close
+          read.close
+          write.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
+          yield
+        rescue Exception => e # rubocop:disable Lint/RescueException
+          error_hash = JSON.parse e.to_json
 
-            # Special case: We need to recreate ErrorDuringExecutions
-            # for proper error messages and because other code expects
-            # to rescue them further down.
-            if e.is_a?(ErrorDuringExecution)
-              error_hash["cmd"] = e.cmd
-              error_hash["status"] = e.status.exitstatus
-              error_hash["output"] = e.output
-            end
-
-            write.puts error_hash.to_json
-            write.close
-
-            exit!
-          else
-            exit!(true)
+          # Special case: We need to recreate ErrorDuringExecutions
+          # for proper error messages and because other code expects
+          # to rescue them further down.
+          if e.is_a?(ErrorDuringExecution)
+            error_hash["cmd"] = e.cmd
+            error_hash["status"] = e.status.exitstatus
+            error_hash["output"] = e.output
           end
+
+          write.puts error_hash.to_json
+          write.close
+
+          exit!
+        else
+          exit!(true)
         end
 
         ignore_interrupts(:quietly) do # the child will receive the interrupt and marshal it back

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -53,8 +53,8 @@ module Utils
           write.close
 
           exit!
-              else
-                exit!(true)
+        else # rubocop:disable Lint/ElseAlignment
+          exit!(true)
         end
 
         ignore_interrupts(:quietly) do # the child will receive the interrupt and marshal it back

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -229,9 +229,9 @@ class Version
 
     stem = if spec.directory?
       spec.basename
-    elsif %r{((?:sourceforge\.net|sf\.net)/.*)/download$}.match?(spec_s)
+    elsif spec_s.match?(%r{((?:sourceforge\.net|sf\.net)/.*)/download$})
       Pathname.new(spec.dirname).stem
-    elsif /\.[^a-zA-Z]+$/.match?(spec_s)
+    elsif spec_s.match?(/\.[^a-zA-Z]+$/)
       Pathname.new(spec_s).basename
     else
       spec.stem

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -229,9 +229,9 @@ class Version
 
     stem = if spec.directory?
       spec.basename
-    elsif %r{((?:sourceforge\.net|sf\.net)/.*)/download$} =~ spec_s
+    elsif %r{((?:sourceforge\.net|sf\.net)/.*)/download$}.match?(spec_s)
       Pathname.new(spec.dirname).stem
-    elsif /\.[^a-zA-Z]+$/ =~ spec_s
+    elsif /\.[^a-zA-Z]+$/.match?(spec_s)
       Pathname.new(spec_s).basename
     else
       spec.stem


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was set to 2.3 because Homebrew was running Ruby 2.3.7. Since
  https://github.com/Homebrew/brew/pull/6556, we're running 2.6.3. With
  this change, Rubocop will check against modern Ruby syntax.
- You probably want to review this either commit by commit (with the
  first commit and last two commits being the most important IMO), or with
  `?w=1` as a query string on the diff URL.