### PR TITLE
Raise deprecation exceptions in tests

### DIFF
--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -47,14 +47,6 @@ describe "Satisfy Dependencies and Requirements", :cask do
       end
     end
 
-    context "given a string", :needs_compat do
-      let(:cask) { Cask::CaskLoader.load(cask_path("compat/with-depends-on-macos-string")) }
-
-      it "does not raise an error" do
-        expect { install }.not_to raise_error
-      end
-    end
-
     context "given a symbol" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-symbol")) }
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -335,14 +335,6 @@ describe Cask::DSL, :cask do
   end
 
   describe "depends_on macos" do
-    context "string disabled", :needs_compat do
-      let(:token) { "compat/with-depends-on-macos-string" }
-
-      it "allows depends_on macos to be specified" do
-        expect { cask }.to raise_error(Cask::CaskInvalidError)
-      end
-    end
-
     context "invalid depends_on macos value" do
       let(:token) { "invalid/invalid-depends-on-macos-bad-release" }
 

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -335,11 +335,11 @@ describe Cask::DSL, :cask do
   end
 
   describe "depends_on macos" do
-    context "valid", :needs_compat do
+    context "string disabled", :needs_compat do
       let(:token) { "compat/with-depends-on-macos-string" }
 
       it "allows depends_on macos to be specified" do
-        expect(cask.depends_on.macos).not_to be nil
+        expect { cask }.to raise_error(Cask::CaskInvalidError)
       end
     end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -246,12 +246,6 @@ describe Formulary do
       formula = described_class.find_with_priority(formula_name)
       expect(formula.path).to eq(core_path)
     end
-
-    it "prioritizes Formulae from pinned Taps" do
-      tap.pin
-      formula = described_class.find_with_priority(formula_name)
-      expect(formula.path).to eq(tap_path.realpath)
-    end
   end
 
   describe "::core_path" do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -144,6 +144,7 @@ RSpec.configure do |config|
     end
 
     begin
+      Homebrew.raise_deprecation_exceptions = true
       Tap.clear_cache
       FormulaInstaller.clear_attempted
 


### PR DESCRIPTION
Previously tests which hit `odeprecated` would print warnings but not always raise exceptions or fail. Combine this with the ability to have `odeprecated` to turn into `odisabled` on certain dates and you have tests that may fail just on the clock changing (this is bad).

Instead, ensure that tests always raise deprecations as exceptions so that new deprecations will have their tests handled immediately.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----