### PR TITLE
bottle: don't keep old cellar

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -371,7 +371,7 @@ module Homebrew
          (old_spec.cellar == cellar &&
           [:any, :any_skip_relocation].include?(bottle.cellar))
         mismatches.delete(:cellar)
-        bottle.cellar :any
+        bottle.cellar old_spec.cellar
       end
       unless mismatches.empty?
         bottle_path.unlink if bottle_path.exist?

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -367,7 +367,9 @@ module Homebrew
       mismatches = [:root_url, :prefix, :cellar, :rebuild].reject do |key|
         old_spec.send(key) == bottle.send(key)
       end
-      if old_spec.cellar == :any && bottle.cellar == :any_skip_relocation
+      if (old_spec.cellar == :any && bottle.cellar == :any_skip_relocation) ||
+         (old_spec.cellar == cellar &&
+          [:any, :any_skip_relocation].include?(bottle.cellar))
         mismatches.delete(:cellar)
         bottle.cellar :any
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR is a proposal, to primarily make `linuxbrew-core` maintainers life easier.

There are cases when we merge `homebrew-core` to `linuxbrew-core` and attempt to build a bottle, but then it fails like this for example:
```
Error: --keep-old was passed but there are changes in:
cellar: old: "/home/linuxbrew/.linuxbrew/Cellar", new: :any_skip_relocation
```

If the above happens, we need to change the `cellar` manually accordingly as the error says.
This is of course doable, but why do it manually if we can have it done by `brew`?

Don't know if this change is really an ideal solution to the problem, I'm open for suggestions.