### PR TITLE
Make vendor-install.sh script more robust

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -236,6 +236,12 @@ processor on $HOMEBREW_PRODUCT!
 EOS
   fi
 
+  if [[ ! -f "$VENDOR_DIR/portable-$VENDOR_NAME-version" ]]
+  then
+    git fetch "https://github.com/Homebrew/brew" master
+    git checkout FETCH_HEAD -- "$VENDOR_DIR"
+  fi
+
   VENDOR_VERSION="$(<"$VENDOR_DIR/portable-$VENDOR_NAME-version")"
   CACHED_LOCATION="$HOMEBREW_CACHE/$(basename "$VENDOR_URL")"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`vendor-install.sh` script relies on the presence of the `$VENDOR_DIR/portable-$VENDOR_NAME-version` file. In situations when user (accidentally) deletes this file or the directory containing it, executing the `brew` command will fail with:

    /usr/local/Homebrew/Library/Homebrew/cmd/vendor-install.sh: line 239: /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby-version: No such file or directory
    ==> Downloading https://homebrew.bintray.com/bottles-portable-ruby/portable-ruby--2.6.3.mavericks.bottle.tar.gz
    Already downloaded: /Users/mbelkin/Library/Caches/Homebrew/portable-ruby--2.6.3.mavericks.bottle.tar.gz
    ==> Pouring portable-ruby--2.6.3.mavericks.bottle.tar.gz
    Error: Failed to vendor ruby .
    Error: Failed to install vendor Ruby.

This PR fixes situations like these by fetching the official Homebrew/brew tap and completely restoring the directory containing this file.
