### PR TITLE
os/mac/xcode: fallback to clang version for detecting CLT.

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -320,9 +320,10 @@ module OS
           next unless File.exist?("#{PKG_PATH}/usr/bin/clang")
 
           version = MacOS.pkgutil_info(id)[/version: (.+)$/, 1]
-          break if version
+          return version if version
         end
-        version
+
+        detect_clang_version
       end
     end
   end


### PR DESCRIPTION
For some reason `pkgutil --pkgs` no longer lists the CLT after the Catalina supplemental update.

Fixes https://github.com/Homebrew/brew/issues/6610

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----