### PR TITLE
Deal with GMake Makefile conditional assignment operators.

### DIFF
--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -41,7 +41,7 @@ module StringInreplaceExtension
   # Looks for Makefile style variable definitions and replaces the
   # value with "new_value", or removes the definition entirely.
   def change_make_var!(flag, new_value)
-    return if gsub!(/^#{Regexp.escape(flag)}[ \t]*=[ \t]*(.*)$/, "#{flag}=#{new_value}", false)
+    return if gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=[ \t]*(.*)$/, "#{flag}=#{new_value}", false)
 
     errors << "expected to change #{flag.inspect} to #{new_value.inspect}"
   end
@@ -50,12 +50,14 @@ module StringInreplaceExtension
   def remove_make_var!(flags)
     Array(flags).each do |flag|
       # Also remove trailing \n, if present.
-      errors << "expected to remove #{flag.inspect}" unless gsub!(/^#{Regexp.escape(flag)}[ \t]*=.*$\n?/, "", false)
+      if gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "", false)
+        errors << "expected to remove #{flag.inspect}"
+      end
     end
   end
 
   # Finds the specified variable
   def get_make_var(flag)
-    self[/^#{Regexp.escape(flag)}[ \t]*=[ \t]*(.*)$/, 1]
+    self[/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=[ \t]*(.*)$/, 1]
   end
 end


### PR DESCRIPTION
Ordinarily variable assignments in Makefiles are done simply with an unconditional assignment: the equals sign.  There are variants of this:

```
FOO := $(BAR)   Avoid recursively expand variables.
FOO ?= bar      Assign only if $(FOO) is not already set.
FOO += bar      Add more to a variable.
FOO != bar      Execute a shell script and assign result to $(FOO).
```
    
See also:
- https://www.gnu.org/software/make/manual/html_node/Conditional-Example.html
- https://www.gnu.org/software/make/manual/html_node/Flavors.html

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Not sure what new tests would apply or be required for my changes. 
Running `brew tests` showed failures not caused by my changes.