### PR TITLE
completions/zsh: add --greedy argument for `brew cask outdated`

### DIFF
--- a/completions/zsh/_brew_cask
+++ b/completions/zsh/_brew_cask
@@ -134,6 +134,12 @@ _brew_cask_ls() {
   _brew_cask_list
 }
 
+_brew_cask_outdated() {
+  _arguments : \
+    '--greedy:also list Casks with auto_updates or version \:latest' \
+    '*::token:__brew_installed_casks'
+}
+
 _brew_cask_remove() {
   _brew_cask_uninstall
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Just adding ZSH completion for `brew cask outdated --g<tab>` :)