### PR TITLE
Fix stupid mistake in 6ff61909a91edf3f31adc608dcafd3f5f8e642d0

### DIFF
--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -50,7 +50,7 @@ module StringInreplaceExtension
   def remove_make_var!(flags)
     Array(flags).each do |flag|
       # Also remove trailing \n, if present.
-      if gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "", false)
+      if !gsub(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "")
         errors << "expected to remove #{flag.inspect}"
       end
     end

--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -50,7 +50,7 @@ module StringInreplaceExtension
   def remove_make_var!(flags)
     Array(flags).each do |flag|
       # Also remove trailing \n, if present.
-      if !gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "", false)
+      unless gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "", false)
         errors << "expected to remove #{flag.inspect}"
       end
     end

--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -50,7 +50,7 @@ module StringInreplaceExtension
   def remove_make_var!(flags)
     Array(flags).each do |flag|
       # Also remove trailing \n, if present.
-      if !gsub(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "")
+      if !gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "", false)
         errors << "expected to remove #{flag.inspect}"
       end
     end


### PR DESCRIPTION
I forgot to alter the call to gsub() when breaking up the unless clause to shorten the line..

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
mea culpa