### PR TITLE
Use Xcode_10.2.1

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -58,7 +58,7 @@ module Homebrew
         steps:
           - bash: |
               set -e
-              sudo xcode-select --switch /Applications/Xcode_10.2.app/Contents/Developer
+              sudo xcode-select --switch /Applications/Xcode_10.2.1.app/Contents/Developer
               brew update
               HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/#{tap.full_name}"
               mkdir -p "$HOMEBREW_TAP_DIR"


### PR DESCRIPTION
`brew doctor` will return exit code 1 if using Xcode_10.2

```
==> brew doctor
Please note that these warnings are just used to help the Homebrew maintainers
with debugging if you file an issue. If everything you use Homebrew for is
working fine: please don't worry or file an issue; just ignore this. Thanks!

Warning: Your Xcode (10.2) is outdated.
Please update to Xcode 10.2.1 (or delete it).
Xcode can be updated from the App Store.

==> FAILED
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
