### PR TITLE
create: cargo install --locked

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -167,7 +167,7 @@ module Homebrew
         <% elsif mode == :python %>
             virtualenv_install_with_resources
         <% elsif mode == :rust %>
-            system "cargo", "install", "--root", prefix, "--path", "."
+            system "cargo", "install", "--locked", "--root", prefix, "--path", "."
         <% else %>
             # Remove unrecognized options if warned by configure
             system "./configure", "--disable-debug",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I see in `homebrew-core` recently a trend where maintainers suggest PR authors to append `--locked` flag to `cargo install` and it's reasonable.
I thought it might be a good idea to include this in template.