### PR TITLE
Prevent overriding default MANPATH while MANPATH is empty.

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -28,7 +28,7 @@ homebrew-shellenv() {
       echo "export HOMEBREW_CELLAR=\"$HOMEBREW_CELLAR\";"
       echo "export HOMEBREW_REPOSITORY=\"$HOMEBREW_REPOSITORY\";"
       echo "export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin\${PATH+:\$PATH}\";"
-      echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man\${MANPATH+:\$MANPATH}\";"
+      echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man\${MANPATH+:\$MANPATH}:\";"
       echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info\${INFOPATH+:\$INFOPATH}\";"
       ;;
   esac


### PR DESCRIPTION
      modified:   Library/Homebrew/cmd/shellenv.sh

Prevent overriding default MANPATH while MANPATH is empty.

I notice if I install Homebrew on Linux machines without su (install in ~/.linuxbrew), and add evirenment variables with shellenv by following the documents, then the "man" command couldn't get default man documents. I check "man manpath", and it says the default MATNPATH will be overrided if users set MANPATH unless appended with ':'. 

- [y] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [y] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [y] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [n] Have you successfully run `brew style` with your changes locally?
- [n] Have you successfully run `brew tests` with your changes locally?

-----
