### PR TITLE
rubocops: add go@1.12 to BINARY_FORMULA_URLS_WHITELIST

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -17,6 +17,7 @@ module RuboCop
           go@1.9
           go@1.10
           go@1.11
+          go@1.12
           haskell-stack
           ldc
           mlton


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Should prevent this audit message:
```
  * C: 27: col 7: FormulaAudit/Urls: https://storage.googleapis.com/golang/go1.7.darwin-amd64.tar.gz looks like a binary package, not a source archive. Homebrew/homebrew-core is source-only.
```