### PR TITLE
Harden brew: unset (assumed) builtins

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -1,6 +1,8 @@
 #!/bin/bash
 set +o posix
 
+unset cd echo exec exit export return source
+
 # Fail fast with concise message when cwd does not exist
 if ! [[ -d "$PWD" ]]; then
   echo "Error: The current working directory doesn't exist, cannot proceed." >&2


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I was playing around with redefining some Bash builtins as functions when I stumbled upon an issue with Homebrew -- some of the commands were not working. I realized that Homebrew relies on them being builtins. Instead of assuming that, we can easily unset them. This way, users may continue to enjoy their fancy definitions and Homebrew.