### PR TITLE
Ruby 2.6 frozen string literals

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -6,8 +6,8 @@ std_trap = trap("INT") { exit! 130 } # no backtrace thanks
 
 # check ruby version before requiring any modules.
 RUBY_X, RUBY_Y, = RUBY_VERSION.split(".").map(&:to_i)
-if RUBY_X < 2 || (RUBY_X == 2 && RUBY_Y < 3)
-  raise "Homebrew must be run under Ruby 2.3! You're running #{RUBY_VERSION}."
+if RUBY_X < 2 || (RUBY_X == 2 && RUBY_Y < 6)
+  raise "Homebrew must be run under Ruby 2.6! You're running #{RUBY_VERSION}."
 end
 
 # Load Bundler first of all if it's needed to avoid Gem version conflicts.

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -1,6 +1,4 @@
-# Uses ERB so can't use Frozen String Literals until >=Ruby 2.4:
-# https://bugs.ruby-lang.org/issues/12031
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require "formula"
 require "utils/bottles"
@@ -11,7 +9,7 @@ require "cli/parser"
 require "utils/inreplace"
 require "erb"
 
-BOTTLE_ERB = <<-EOS.freeze
+BOTTLE_ERB = <<-EOS
   bottle do
     <% if !root_url.start_with?(HOMEBREW_BOTTLE_DEFAULT_DOMAIN) %>
     root_url "<%= root_url %>"
@@ -43,7 +41,7 @@ module Homebrew
 
   def bottle_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS.freeze
+      usage_banner <<~EOS
         `bottle` [<options>] <formula>
 
         Generate a bottle (binary package) from a formula that was installed with
@@ -382,7 +380,7 @@ module Homebrew
           "#{key}: old: #{old_value}, new: #{value}"
         end
 
-        odie <<~EOS.freeze
+        odie <<~EOS
           --keep-old was passed but there are changes in:
           #{mismatches.join("\n")}
         EOS
@@ -493,7 +491,7 @@ module Homebrew
               end
 
               unless mismatches.empty?
-                odie <<~EOS.freeze
+                odie <<~EOS
                   --keep-old was passed but there are changes in:
                   #{mismatches.join("\n")}
                 EOS

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -1,6 +1,4 @@
-# Uses ERB so can't use Frozen String Literals until >=Ruby 2.4:
-# https://bugs.ruby-lang.org/issues/12031
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 require "formula"
 require "erb"
@@ -18,7 +16,7 @@ module Homebrew
 
   def man_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS.freeze
+      usage_banner <<~EOS
         `man` [<options>]
 
         Generate Homebrew's manpages.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Updates the last two files to use `frozen_string_literal: true`. Also updates a Ruby version check in `brew.rb`.