### PR TITLE
bin/brew: unset functions that override builtins

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -19,8 +19,7 @@ symlink_target_directory() {
   quiet_cd "$directory" && quiet_cd "$target_dirname" && pwd -P
 }
 
-# Unset functions that override Bash builtins
-# Enable all Bash builtins
+# Enable and use default Bash builtins rather than user-defined functions
 for cmd in $(compgen -A builtin)
 do
   unset -f $cmd

--- a/bin/brew
+++ b/bin/brew
@@ -19,6 +19,13 @@ symlink_target_directory() {
   quiet_cd "$directory" && quiet_cd "$target_dirname" && pwd -P
 }
 
+for cmd in $(compgen -A builtin)
+do
+  unset -f $cmd  # Unset functions that override Bash builtins
+  enable $cmd # Enable all Bash builtins
+done
+unset cmd
+
 BREW_FILE_DIRECTORY="$(quiet_cd "${0%/*}/" && pwd -P)"
 HOMEBREW_BREW_FILE="${BREW_FILE_DIRECTORY%/}/${0##*/}"
 HOMEBREW_PREFIX="${HOMEBREW_BREW_FILE%/*/*}"

--- a/bin/brew
+++ b/bin/brew
@@ -19,10 +19,12 @@ symlink_target_directory() {
   quiet_cd "$directory" && quiet_cd "$target_dirname" && pwd -P
 }
 
+# Unset functions that override Bash builtins
+# Enable all Bash builtins
 for cmd in $(compgen -A builtin)
 do
-  unset -f $cmd  # Unset functions that override Bash builtins
-  enable $cmd # Enable all Bash builtins
+  unset -f $cmd
+  enable $cmd
 done
 unset cmd
 

--- a/bin/brew
+++ b/bin/brew
@@ -20,10 +20,11 @@ symlink_target_directory() {
 }
 
 # Enable and use default Bash builtins rather than user-defined functions
-for cmd in $(compgen -A builtin)
+builtin enable compgen unset
+for cmd in $(builtin compgen -A builtin)
 do
-  unset -f $cmd
-  enable $cmd
+  builtin unset -f $cmd
+  builtin enable $cmd
 done
 unset cmd
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

1. Unset functions that override builtins (for those who override Bash builtins).
2. Enable all Bash builtins (for those who disable Bash builtins).