### PR TITLE
Linux Maintainer Guide: Reflect recent changes to tap commands

### DIFF
--- a/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
@@ -219,7 +219,7 @@ running `git push your-fork master`
 After merging changes, we must rebuild bottles for all the PRs that
 had conflicts.
 
-To do this, tap `Linuxbrew/homebrew-developer` and run the following
+To do this, tap `Homebrew/homebrew-linux-dev` and run the following
 command where the merge commit is `HEAD`:
 
 ```sh
@@ -235,7 +235,6 @@ against the formulae:
 And it skips formulae if any of the following are true:
 - it doesn't need a bottle
 - it already has a bottle
-- the formula depends on macOS to build
 - the formula's tap is Homebrew/homebrew-core (the upstream macOS repo)
 - there is already an open PR for the formula's bottle
 - the current branch is not master
@@ -246,7 +245,7 @@ run `brew find-formulae-to-bottle --verbose` separate to the `for`
 loop above.
 
 The `build-bottle-pr` script creates a branch called `bottle-<FORMULA>`, adds `# Build a bottle
-for Linuxbrew` to the top of the formula, pushes the branch to GitHub
+for Linux` to the top of the formula, pushes the branch to GitHub
 at the specified remote (default: `origin`), and opens a pull request using `hub
 pull-request`.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- We recently changed the name of the Linux commands tap from
  Linuxbrew/homebrew-developer to Homebrew/homebrew-linux-dev in our
  continual efforts to move away from the Linuxbrew name. Related to
  this, we changed the comment produced by `brew build-bottle-pr` to
  simply "Linux".
- We also [changed `brew
  find-formulae-to-bottle`](https://github.com/Homebrew/homebrew-linux-dev/pull/130)
  so that it will build a bottle for a formula even if it has a macOS
  requirement. There were cases like `go` that build perfectly fine on
  Linux.