### PR TITLE
cmd/upgrade: comment-out broken_dependents functionality.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -360,6 +360,10 @@ module Homebrew
 
     upgrade_formulae(upgradable)
 
+    # TODO: re-enable when this code actually works.
+    # https://github.com/Homebrew/brew/issues/6671
+    return unless ENV["HOMEBREW_BROKEN_DEPENDENTS"]
+
     # Assess the dependents tree again.
     kegs = formulae_with_runtime_dependencies
 


### PR DESCRIPTION
This is not a fix for https://github.com/Homebrew/brew/issues/6671 but will stop people hitting this bug for now.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----