### PR TITLE
Adds mention about unshallowing for `brew extract`

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -201,6 +201,9 @@ module Formulary
         puts <<~EOS
           This will extract your desired #{formula_name} version to a stable tap instead of
           installing from an unstable URL!
+      
+          You need to unshallow the tap before `brew extract` will work if you are looking for an older version:
+          `git -C "$(brew --repo homebrew/core)" fetch --unshallow`
 
         EOS
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When I started extracting a formula, it took me a while to realize why it wasn't finding the older version I was looking for.
This change adds a hint to do the unshallowing of the tap first.

A better change would be for extract to just automatically unshallow if the version is not in history, but I didn't want to start off there.
