### PR TITLE
Dockerfile: make the prefix group writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,5 @@ ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 # Install portable-ruby and tap homebrew/core.
 RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
 	&& chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
-	&& chmod -R o-w /home/linuxbrew/.linuxbrew \
+	&& chmod -R g+w,o-w /home/linuxbrew/.linuxbrew \
 	&& rm -rf ~/.cache


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently members of `linuxbrew` group do not have permission to write in prefix, so they can't fully use `brew`.
This PR changes it. One can create a new user, add it to `linuxbrew` group and have full access to the existing files in prefix. It can be useful on CI (like Azure, where a new user is created in container).