### PR TITLE
Improve upgrade dependents check performance, reliability and readability

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -58,6 +58,9 @@ module Homebrew
 
   def deps
     deps_args.parse
+
+    Formulary.enable_factory_cache!
+
     mode = OpenStruct.new(
       installed?:  args.installed?,
       tree?:       args.tree?,

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -263,6 +263,7 @@ module Homebrew
 
         changed_files = keg.replace_locations_with_placeholders unless args.skip_relocation?
 
+        Formula.clear_cache
         Keg.clear_cache
         Tab.clear_cache
         tab = Tab.for_keg(keg)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -263,6 +263,7 @@ module Homebrew
 
         changed_files = keg.replace_locations_with_placeholders unless args.skip_relocation?
 
+        Keg.clear_cache
         Tab.clear_cache
         tab = Tab.for_keg(keg)
         original_tab = tab.dup

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1570,6 +1570,23 @@ class Formula
     end.compact
   end
 
+  def runtime_installed_formula_dependents
+    # `opt_or_installed_prefix_keg` and `runtime_dependencies` `select`s ensure
+    # that we don't end up with something `Formula#runtime_dependencies` can't
+    # read from a `Tab`.
+    Formula.cache[:runtime_installed_formula_dependents] = {}
+    Formula.cache[:runtime_installed_formula_dependents][name] ||= Formula.installed
+                                                                          .select(&:opt_or_installed_prefix_keg)
+                                                                          .select(&:runtime_dependencies)
+                                                                          .select do |f|
+      f.runtime_formula_dependencies.any? do |dep|
+        full_name == dep.full_name
+      rescue
+        name == dep.name
+      end
+    end
+  end
+
   # Returns a list of formulae depended on by this formula that aren't
   # installed
   def missing_dependencies(hide: nil)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -52,6 +52,7 @@ class Formula
   include Utils::Shell
   extend Enumerable
   extend Forwardable
+  extend Cachable
 
   # @!method inreplace(paths, before = nil, after = nil)
   # Actually implemented in {Utils::Inreplace.inreplace}.
@@ -1528,7 +1529,8 @@ class Formula
   # If not, return nil.
   # @private
   def opt_or_installed_prefix_keg
-    if optlinked? && opt_prefix.exist?
+    Formula.cache[:opt_or_installed_prefix_keg] ||= {}
+    Formula.cache[:opt_or_installed_prefix_keg][name] ||= if optlinked? && opt_prefix.exist?
       Keg.new(opt_prefix)
     elsif installed_prefix.directory?
       Keg.new(installed_prefix)
@@ -1538,27 +1540,27 @@ class Formula
   # Returns a list of Dependency objects that are required at runtime.
   # @private
   def runtime_dependencies(read_from_tab: true, undeclared: true)
-    if read_from_tab &&
-       undeclared &&
-       (keg = opt_or_installed_prefix_keg) &&
-       (tab_deps = keg.runtime_dependencies)
-      return tab_deps.map do |d|
+    deps = if read_from_tab && undeclared &&
+              (tab_deps = opt_or_installed_prefix_keg&.runtime_dependencies)
+      tab_deps.map do |d|
         full_name = d["full_name"]
         next unless full_name
 
         Dependency.new full_name
       end.compact
     end
-
-    return declared_runtime_dependencies unless undeclared
-
-    declared_runtime_dependencies | undeclared_runtime_dependencies
+    deps ||= declared_runtime_dependencies unless undeclared
+    deps ||= (declared_runtime_dependencies | undeclared_runtime_dependencies)
+    deps
   end
 
   # Returns a list of Formula objects that are required at runtime.
   # @private
   def runtime_formula_dependencies(read_from_tab: true, undeclared: true)
-    runtime_dependencies(
+    cache_key = "#{name}-#{read_from_tab}-#{undeclared}"
+
+    Formula.cache[:runtime_formula_dependencies] ||= {}
+    Formula.cache[:runtime_formula_dependencies][cache_key] ||= runtime_dependencies(
       read_from_tab: read_from_tab,
       undeclared:    undeclared,
     ).map do |d|

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -649,6 +649,7 @@ class FormulaInstaller
 
     # Update tab with actual runtime dependencies
     tab = Tab.for_keg(keg)
+    Keg.clear_cache
     Tab.clear_cache
     f_runtime_deps = formula.runtime_dependencies(read_from_tab: false)
     tab.runtime_dependencies = Tab.runtime_deps_hash(f_runtime_deps)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -649,7 +649,6 @@ class FormulaInstaller
 
     # Update tab with actual runtime dependencies
     tab = Tab.for_keg(keg)
-    Keg.clear_cache
     Tab.clear_cache
     f_runtime_deps = formula.runtime_dependencies(read_from_tab: false)
     tab.runtime_dependencies = Tab.runtime_deps_hash(f_runtime_deps)
@@ -783,6 +782,7 @@ class FormulaInstaller
     unless link_keg
       begin
         keg.optlink
+        Formula.clear_cache
       rescue Keg::LinkError => e
         onoe "Failed to create #{formula.opt_prefix}"
         puts "Things that depend on #{formula.full_name} will probably not build."

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -6,6 +6,8 @@ require "lock_file"
 require "ostruct"
 
 class Keg
+  extend Cachable
+
   class AlreadyLinkedError < RuntimeError
     def initialize(keg)
       super <<~EOS
@@ -519,7 +521,8 @@ class Keg
   end
 
   def runtime_dependencies
-    tab.runtime_dependencies
+    Keg.cache[:runtime_dependencies] ||= {}
+    Keg.cache[:runtime_dependencies][path] ||= tab.runtime_dependencies
   end
 
   def aliases

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -13,10 +13,6 @@ describe DependencyCollector do
     subject.requirements.find { |req| req.is_a? klass }
   end
 
-  after do
-    described_class.clear_cache
-  end
-
   describe "#add" do
     specify "dependency creation" do
       subject.add "foo" => :build

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -38,7 +38,6 @@ describe Homebrew::MissingFormula do
     subject { described_class.tap_migration_reason(formula) }
 
     before do
-      Tap.clear_cache
       tap_path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
       tap_path.mkpath
       (tap_path/"tap_migrations.json").write <<~JSON
@@ -63,7 +62,6 @@ describe Homebrew::MissingFormula do
     subject { described_class.deleted_reason(formula, silent: true) }
 
     before do
-      Tap.clear_cache
       tap_path = Tap::TAP_DIRECTORY/"homebrew/homebrew-foo"
       tap_path.mkpath
       (tap_path/"deleted-formula.rb").write "placeholder"

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -5,10 +5,6 @@ require "dependency_collector"
 describe DependencyCollector do
   alias_matcher :be_a_build_requirement, :be_build
 
-  after do
-    described_class.clear_cache
-  end
-
   describe "#add" do
     resource = Resource.new
 

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -5,10 +5,6 @@ require "dependency_collector"
 describe DependencyCollector do
   alias_matcher :need_tar_xz_dependency, :be_tar_needs_xz_dependency
 
-  after do
-    described_class.clear_cache
-  end
-
   specify "Resource dependency from a '.xz' URL" do
     resource = Resource.new
     resource.url("https://brew.sh/foo.tar.xz")

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -145,6 +145,7 @@ RSpec.configure do |config|
 
     begin
       Homebrew.raise_deprecation_exceptions = true
+      Formula.clear_cache
       Keg.clear_cache
       Tap.clear_cache
       FormulaInstaller.clear_attempted
@@ -178,6 +179,7 @@ RSpec.configure do |config|
       end
 
       Tab.clear_cache
+      Formula.clear_cache
       Keg.clear_cache
 
       FileUtils.rm_rf [

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -145,6 +145,7 @@ RSpec.configure do |config|
 
     begin
       Homebrew.raise_deprecation_exceptions = true
+      Keg.clear_cache
       Tap.clear_cache
       FormulaInstaller.clear_attempted
 
@@ -177,6 +178,7 @@ RSpec.configure do |config|
       end
 
       Tab.clear_cache
+      Keg.clear_cache
 
       FileUtils.rm_rf [
         TEST_DIRECTORIES.map(&:children),

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -145,9 +145,13 @@ RSpec.configure do |config|
 
     begin
       Homebrew.raise_deprecation_exceptions = true
+
+      Formulary.clear_cache
+      Tap.clear_cache
+      DependencyCollector.clear_cache
       Formula.clear_cache
       Keg.clear_cache
-      Tap.clear_cache
+      Tab.clear_cache
       FormulaInstaller.clear_attempted
 
       TEST_DIRECTORIES.each(&:mkpath)
@@ -178,9 +182,12 @@ RSpec.configure do |config|
         @__stderr.close
       end
 
-      Tab.clear_cache
+      Formulary.clear_cache
+      Tap.clear_cache
+      DependencyCollector.clear_cache
       Formula.clear_cache
       Keg.clear_cache
+      Tab.clear_cache
 
       FileUtils.rm_rf [
         TEST_DIRECTORIES.map(&:children),

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -78,8 +78,6 @@ describe Tap do
     expect {
       described_class.fetch("homebrew", "homebrew/baz")
     }.to raise_error(/Invalid tap name/)
-  ensure
-    described_class.clear_cache
   end
 
   describe "::from_path" do


### PR DESCRIPTION
Still need to do more testing but this PR removes the possibility for infinite loops and stack overflows by removing all `until` loops and recursion in favour of some shared-with-`cmd/uses.rb`, heavily cached (based on profiling and `brew prof`) logic in `formula.rb` to generate runtime dependents.

Closes #6695
Fixes #6671

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----