### PR TITLE
Handle 2.2.0 deprecations/disableds

### DIFF
--- a/Library/Homebrew/cmd/tap-pin.rb
+++ b/Library/Homebrew/cmd/tap-pin.rb
@@ -7,29 +7,12 @@ module Homebrew
 
   def tap_pin_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `tap-pin` <tap>
-
-        Pin <tap>, prioritising its formulae over core when formula names are supplied
-        by the user. See also `tap-unpin`.
-      EOS
-      switch :debug
       hide_from_man_page!
     end
   end
 
   def tap_pin
-    odeprecated "brew tap-pin user/tap",
-                "fully-scoped user/tap/formula naming"
-
-    tap_pin_args.parse
-
-    ARGV.named.each do |name|
-      tap = Tap.fetch(name)
-      raise "pinning #{tap} is not allowed" if tap.core_tap?
-
-      tap.pin
-      ohai "Pinned #{tap}"
-    end
+    odisabled "brew tap-pin user/tap",
+              "fully-scoped user/tap/formula naming"
   end
 end

--- a/Library/Homebrew/cmd/tap-unpin.rb
+++ b/Library/Homebrew/cmd/tap-unpin.rb
@@ -7,28 +7,12 @@ module Homebrew
 
   def tap_unpin_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `tap-unpin` <tap>
-
-        Unpin <tap> so its formulae are no longer prioritised. See also `tap-pin`.
-      EOS
-      switch :debug
       hide_from_man_page!
     end
   end
 
   def tap_unpin
-    odeprecated "brew tap-pin user/tap",
-                "fully-scoped user/tap/formula naming"
-
-    tap_unpin_args.parse
-
-    ARGV.named.each do |name|
-      tap = Tap.fetch(name)
-      raise "unpinning #{tap} is not allowed" if tap.core_tap?
-
-      tap.unpin
-      ohai "Unpinned #{tap}"
-    end
+    odisabled "brew tap-pin user/tap",
+              "fully-scoped user/tap/formula naming"
   end
 end

--- a/Library/Homebrew/compat/cask/dsl/version.rb
+++ b/Library/Homebrew/compat/cask/dsl/version.rb
@@ -5,18 +5,15 @@ module Cask
     class Version < ::String
       module Compat
         def dots_to_slashes
-          odeprecated "#dots_to_slashes"
-          version { tr(".", "/") }
+          odisabled "#dots_to_slashes"
         end
 
         def hyphens_to_slashes
-          odeprecated "#hyphens_to_slashes"
-          version { tr("-", "/") }
+          odisabled "#hyphens_to_slashes"
         end
 
         def underscores_to_slashes
-          odeprecated "#underscores_to_slashes"
-          version { tr("_", "/") }
+          odisabled "#underscores_to_slashes"
         end
       end
 

--- a/Library/Homebrew/compat/requirements/macos_requirement.rb
+++ b/Library/Homebrew/compat/requirements/macos_requirement.rb
@@ -11,9 +11,8 @@ class MacOSRequirement < Requirement
 
           sym = MacOS::Version.new(v).to_sym
 
-          odeprecated "depends_on macos: #{v.inspect}", "depends_on macos: #{sym.inspect}",
-                      disable_on: Time.parse("2019-10-15")
-
+          odisabled "depends_on macos: #{v.inspect}",
+                    "depends_on macos: #{sym.inspect}"
           sym
         end
 
@@ -22,8 +21,8 @@ class MacOSRequirement < Requirement
         v, *rest = tags
         sym = MacOS::Version.new(v).to_sym
 
-        odeprecated "depends_on macos: #{v.inspect}", "depends_on macos: #{sym.inspect}",
-                    disable_on: Time.parse("2019-10-15")
+        odisabled "depends_on macos: #{v.inspect}",
+                  "depends_on macos: #{sym.inspect}"
 
         tags = [sym, *rest]
       end

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -28,7 +28,7 @@ BOTTLE_ERB = <<-EOS
     <% checksums.each do |checksum_type, checksum_values| %>
     <% checksum_values.each do |checksum_value| %>
     <% checksum, macos = checksum_value.shift %>
-    <%= checksum_type %> "<%= checksum %>" => :<%= macos %><%= "_or_later" if Homebrew.args.or_later? %>
+    <%= checksum_type %> "<%= checksum %>" => :<%= macos %>
     <% end %>
     <% end %>
   end
@@ -52,8 +52,6 @@ module Homebrew
       EOS
       switch "--skip-relocation",
              description: "Do not check if the bottle can be marked as relocatable."
-      switch "--or-later",
-             description: "Append `_or_later` to the bottle tag."
       switch "--force-core-tap",
              description: "Build a bottle even if <formula> is not in `homebrew/core` or any installed taps."
       switch "--no-rebuild",
@@ -396,8 +394,6 @@ module Homebrew
 
     return unless args.json?
 
-    tag = Utils::Bottles.tag.to_s
-    tag += "_or_later" if args.or_later?
     json = {
       f.full_name => {
         "formula" => {
@@ -410,7 +406,7 @@ module Homebrew
           "cellar"   => bottle.cellar.to_s,
           "rebuild"  => bottle.rebuild,
           "tags"     => {
-            tag => {
+            Utils::Bottles.tag.to_s => {
               "filename"       => filename.bintray,
               "local_filename" => filename.to_s,
               "sha256"         => sha256,

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -25,25 +25,18 @@ module Utils
         end
       end
 
-      def tag_without_or_later(tag)
-        tag
-      end
-
       # Find a bottle built for a previous version of macOS.
       def find_older_compatible_tag(tag)
-        begin
-          tag_version = MacOS::Version.from_symbol(tag)
+        tag_version = begin
+          MacOS::Version.from_symbol(tag)
         rescue ArgumentError
           return
         end
 
         keys.find do |key|
-          key_tag_version = tag_without_or_later(key)
-          begin
-            MacOS::Version.from_symbol(key_tag_version) <= tag_version
-          rescue ArgumentError
-            false
-          end
+          MacOS::Version.from_symbol(key) <= tag_version
+        rescue ArgumentError
+          false
         end
       end
     end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -490,14 +490,8 @@ module Formulary
     if possible_pinned_tap_formulae.size == 1
       selected_formula = factory(possible_pinned_tap_formulae.first, spec)
       if core_path(ref).file?
-        odeprecated "brew tap-pin user/tap",
-                    "fully-scoped user/tap/formula naming"
-        opoo <<~EOS
-          #{ref} is provided by core, but is now shadowed by #{selected_formula.full_name}.
-          This behaviour is deprecated and will be removed in Homebrew 2.2.0.
-          To refer to the core formula, use Homebrew/core/#{ref} instead.
-          To refer to the tap formula, use #{selected_formula.full_name} instead.
-        EOS
+        odisabled "brew tap-pin user/tap",
+                  "fully-scoped user/tap/formula naming"
       end
       selected_formula
     else

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -261,7 +261,7 @@ class Bottle
     def initialize(name, version, tag, rebuild)
       @name = File.basename name
       @version = version
-      @tag = tag.to_s.gsub(/_or_later$/, "")
+      @tag = tag.to_s
       @rebuild = rebuild
     end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -717,8 +717,6 @@ at its original value, while `--no-rebuild` will remove it.
 
 * `--skip-relocation`:
   Do not check if the bottle can be marked as relocatable.
-* `--or-later`:
-  Append `_or_later` to the bottle tag.
 * `--force-core-tap`:
   Build a bottle even if *`formula`* is not in `homebrew/core` or any installed taps.
 * `--no-rebuild`:

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "October 2019" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "November 2019" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "October 2019" "Homebrew" "brew"
+.TH "BREW" "1" "November 2019" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The missing package manager for macOS
@@ -896,10 +896,6 @@ Generate a bottle (binary package) from a formula that was installed with \fB\-\
 .TP
 \fB\-\-skip\-relocation\fR
 Do not check if the bottle can be marked as relocatable\.
-.
-.TP
-\fB\-\-or\-later\fR
-Append \fB_or_later\fR to the bottle tag\.
 .
 .TP
 \fB\-\-force\-core\-tap\fR


### PR DESCRIPTION
- Make all `odeprecated` from 2.1.0 `odisabled` instead
- Remove dead code that won't be run now
- Remove (unused) `or_later` handling for bottles

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----