### PR TITLE
formula_installer: copy hidden files into bottles.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -18,6 +18,7 @@ require "linkage_checker"
 require "install"
 require "messages"
 require "cask/cask_loader"
+require "find"
 
 class FormulaInstaller
   include FormulaCellarChecks
@@ -201,12 +202,12 @@ class FormulaInstaller
   end
 
   def build_bottle_preinstall
-    @etc_var_glob ||= "#{HOMEBREW_PREFIX}/{etc,var}/**/*"
-    @etc_var_preinstall = Dir[@etc_var_glob]
+    @etc_var_dirs ||= [HOMEBREW_PREFIX/"etc", HOMEBREW_PREFIX/"var"]
+    @etc_var_preinstall = Find.find(*@etc_var_dirs.select(&:directory?)).to_a
   end
 
   def build_bottle_postinstall
-    @etc_var_postinstall = Dir[@etc_var_glob]
+    @etc_var_postinstall = Find.find(*@etc_var_dirs.select(&:directory?)).to_a
     (@etc_var_postinstall - @etc_var_preinstall).each do |file|
       Pathname.new(file).cp_path_sub(HOMEBREW_PREFIX, formula.bottle_prefix)
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). - **I'm getting a Ruby segfault when I run `brew tests` - sorry!**
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? - **I'm getting a Ruby segfault when I run `brew tests` - sorry!**

-----

Ref: Homebrew/homebrew-core#46252, #5783, Homebrew/homebrew-core#36801, #2792, Homebrew/homebrew-core#14662, Homebrew/legacy-homebrew#31760

When copying etc and var files into a bottle, hidden files and directories are ignored. In particular, this has caused [this line](https://github.com/Homebrew/homebrew-core/blob/8dda235fb52f93324b7899da40ebfabfb00a1d4f/Formula/mariadb.rb#L62) of the MariaDB formulae to not have any affect on bottles.

If merged, a rebuild should be performed on all of the MariaDB formulae to fully fix  Homebrew/homebrew-core#46252.