### PR TITLE
upgrade: fix handling broken dependents.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -267,12 +267,13 @@ module Homebrew
     oh1 "Checking for dependents' broken linkage from upgraded formulae..."
     broken_dependents = CacheStoreDatabase.use(:linkage) do |db|
       formulae_to_install.flat_map(&:runtime_installed_formula_dependents)
-                         .map(&:opt_or_installed_prefix_keg)
-                         .compact
-                         .select do |keg|
+                         .select do |f|
+        keg = f.opt_or_installed_prefix_keg
+        next unless keg
+
         LinkageChecker.new(keg, cache_db: db)
                       .broken_library_linkage?
-      end
+      end.compact
     end
     if broken_dependents.blank?
       ohai "No broken dependents found!"


### PR DESCRIPTION
Ensure that we use the keg for checking linkage but that the dependents returned are still formulae.

Thanks to @scpeters for help in https://github.com/Homebrew/brew/pull/6698#pullrequestreview-314596027

Fixes #6715.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----