### PR TITLE
Update brew.sh: hide printf's stderr in numeric()

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -61,7 +61,7 @@ git() {
 numeric() {
   # Condense the exploded argument into a single return value.
   # shellcheck disable=SC2086,SC2183
-  printf "%01d%02d%02d%03d" ${1//[.rc]/ }
+  printf "%01d%02d%02d%03d" ${1//[.rc]/ } 2>/dev/null
 }
 
 HOMEBREW_VERSION="$(git -C "$HOMEBREW_REPOSITORY" describe --tags --dirty --abbrev=7 2>/dev/null)"


### PR DESCRIPTION
Avoid #6721 and similar confusing messages during version comparison by hiding printf's stderr (printf woks anyway).

- [+] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [+] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [+] Have you added an explanation of what your changes do and why you'd like us to include them?
- [-] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [+] Have you successfully run `brew style` with your changes locally?
- [+] Have you successfully run `brew tests` with your changes locally?

-----
