### PR TITLE
bump-formula-pr: enable same-repo (no-fork) Pull Requests

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -383,7 +383,7 @@ module Homebrew
   def forked_repo_info(tap_full_name)
     response = GitHub.create_fork(tap_full_name)
   rescue GitHub::AuthenticationFailedError, *GitHub.api_errors => e
-    formula.path.atomic_write(backup_file) unless args.dry_run?
+    formula.path.atomic_write(backup_file)
     odie "Unable to fork: #{e.message}!"
   else
     # GitHub API responds immediately but fork takes a few seconds to be ready.

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -388,10 +388,10 @@ module Homebrew
   else
     # GitHub API responds immediately but fork takes a few seconds to be ready.
     sleep 1 until GitHub.check_fork_exists(tap_full_name)
-    if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
-      remote_url = response.fetch("ssh_url")
+    remote_url =  if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
+      response.fetch("ssh_url")
     else
-      remote_url = response.fetch("clone_url")
+      response.fetch("clone_url")
     end
     username = response.fetch("owner").fetch("login")
     [remote_url, username]

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -340,6 +340,15 @@ module GitHub
     open_api(url, data: data, scopes: scopes)
   end
 
+  def check_fork_exists(repo)
+    username = api_credentials[1]
+    reponame = repo.split("/")[1]
+    json = open_api(url_to("repos", username, reponame))
+    return false if json["message"] == "Not Found"
+
+    true
+  end
+
   def create_pull_request(repo, title, head, base, body)
     url = "#{API_URL}/repos/#{repo}/pulls"
     data = { title: title, head: head, base: base, body: body }

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -341,8 +341,8 @@ module GitHub
   end
 
   def check_fork_exists(repo)
-    username = api_credentials[1]
-    reponame = repo.split("/")[1]
+    _, username = api_credentials
+    _, reponame = repo.split("/")
     json = open_api(url_to("repos", username, reponame))
     return false if json["message"] == "Not Found"
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -762,6 +762,8 @@ uses.
   Run `brew audit --strict` before opening the PR.
 * `--no-browse`:
   Print the pull request URL instead of opening in a browser.
+* `--no-fork`:
+  Don't try to fork the repository.
 * `--mirror`:
   Use the specified *`URL`* as a mirror URL.
 * `--version`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -966,6 +966,10 @@ Run \fBbrew audit \-\-strict\fR before opening the PR\.
 Print the pull request URL instead of opening in a browser\.
 .
 .TP
+\fB\-\-no\-fork\fR
+Don\'t try to fork the repository\.
+.
+.TP
 \fB\-\-mirror\fR
 Use the specified \fIURL\fR as a mirror URL\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

To build bottles with GitHub actions, we need to create PRs from branches that live in the same tap. Here I add `--no-fork` option that instructs `bump-formula-pr` to create branch in `origin` rather than in a forked repo.

Tested at https://github.com/Linuxbrew/homebrew-xorg/pull/581