### PR TITLE
os/mac: remove MacOS.cat.

### DIFF
--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -6,7 +6,7 @@ module Utils
       undef tag
 
       def tag
-        MacOS.cat
+        MacOS.version.to_sym
       end
     end
 

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -58,10 +58,6 @@ module OS
       version > latest_stable_version
     end
 
-    def cat
-      version.to_sym
-    end
-
     def languages
       @languages ||= [
         *ARGV.value("language")&.split(","),


### PR DESCRIPTION
None of the supported versions are "cats" any more.