### PR TITLE
Fix Audit check for `env :std`

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -948,15 +948,13 @@ module Homebrew
         problem "`Use :optional` or `:recommended` instead of `#{Regexp.last_match(0)}`"
       end
 
-      return unless line =~ %r{share(\s*[/+]\s*)(['"])#{Regexp.escape(formula.name)}(?:\2|/)}
-
-      problem "Use pkgshare instead of (share#{Regexp.last_match(1)}\"#{formula.name}\")"
+      if line =~ %r{share(\s*[/+]\s*)(['"])#{Regexp.escape(formula.name)}(?:\2|/)}
+        problem "Use pkgshare instead of (share#{Regexp.last_match(1)}\"#{formula.name}\")"
+      end
 
       return unless @core_tap
 
-      return unless line.include?("env :std")
-
-      problem "`env :std` in `core` formulae is deprecated"
+      problem "`env :std` in `core` formulae is deprecated" if line.include?("env :std")
     end
 
     def audit_reverse_migration


### PR DESCRIPTION
When performing a strict audit of a formula in the core tap, it was
possible that the check for `env :std` would not happen.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This fixes the strict audit, making sure that if the formula is part of core, `brew audit --strict` checks to see if `env :std` is used.

This references #6737.