### PR TITLE
formula: copy hidden files _from_ bottles.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -20,6 +20,7 @@ require "extend/ENV"
 require "language/python"
 require "tab"
 require "mktemp"
+require "find"
 
 # A formula provides instructions and metadata for Homebrew to install a piece
 # of software. Every Homebrew formula is a {Formula}.
@@ -998,7 +999,9 @@ class Formula
     with_env(new_env) do
       ENV.clear_sensitive_environment!
 
-      Pathname.glob("#{bottle_prefix}/{etc,var}/**/*") do |path|
+      etc_var_dirs = [bottle_prefix/"etc", bottle_prefix/"var"]
+      Find.find(*etc_var_dirs.select(&:directory?)) do |path|
+        path = Pathname.new(path)
         path.extend(InstallRenamed)
         path.cp_path_sub(bottle_prefix, HOMEBREW_PREFIX)
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In #6708 I fixed a situation where hidden files in etc or var were not copied into bottles. And that has worked. I can confirm the MariaDB bottles all now have `.homebrew_dont_prune_me`. I thought it already was working copying _from_ bottles as well - and I wasn't alone in that (see Homebrew/homebrew-core#46252 in which another user confirmed installing the new bottles worked).

I've discovered a case however, on clean installs, that those files might not be copied from the bottle, which I hope to fix here.

The situation is very similar to the other pull request: `glob` doesn't return dotfiles while `find` does.