### PR TITLE
respect DO_NOT_TRACK env var per consoledonottrack.com

### DIFF
--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -25,7 +25,7 @@ module Utils
       end
 
       def report(type, metadata = {})
-        return if ENV["HOMEBREW_NO_ANALYTICS"] || ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"]
+        return if ENV["HOMEBREW_NO_ANALYTICS"] || ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] || ENV["DO_NOT_TRACK"]
 
         args = []
 


### PR DESCRIPTION
https://consoledonottrack.com

This adds a check for the environment variable `DO_NOT_TRACK`, a new proposed standard for user opt out of tracking and telemetry in command-line tools.