### PR TITLE
Use `git tag -l` instead of `git tag --list`

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -183,7 +183,7 @@ merge_or_rebase() {
 
   if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -n "$HOMEBREW_UPDATE_TO_TAG" ]]
   then
-    UPSTREAM_TAG="$(git tag --list |
+    UPSTREAM_TAG="$(git tag -l |
                     sort --field-separator=. --key=1,1nr -k 2,2nr -k 3,3nr |
                     grep --max-count=1 '^[0-9]*\.[0-9]*\.[0-9]*$')"
   else
@@ -435,7 +435,7 @@ EOS
     declare PREFETCH_REVISION"$TAP_VAR"="$(git rev-parse -q --verify refs/remotes/origin/"$UPSTREAM_BRANCH_DIR")"
 
     # Force a full update if we don't have any tags.
-    if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -z "$(git tag --list)" ]]
+    if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -z "$(git tag -l)" ]]
     then
       HOMEBREW_UPDATE_FORCE=1
     fi

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -45,13 +45,13 @@ module Homebrew
       elsif date = args.before
         Utils.popen_read("git", "rev-list", "-n1", "--before=#{date}", "origin/master").chomp
       elsif args.to_tag?
-        tags = Utils.popen_read("git", "tag", "--list", "--sort=-version:refname")
+        tags = Utils.popen_read("git", "tag", "-l", "--sort=-version:refname")
         if tags.blank?
           tags = if (HOMEBREW_REPOSITORY/".git/shallow").exist?
             safe_system "git", "fetch", "--tags", "--depth=1"
-            Utils.popen_read("git", "tag", "--list", "--sort=-version:refname")
+            Utils.popen_read("git", "tag", "-l", "--sort=-version:refname")
           elsif OS.linux?
-            Utils.popen_read("git tag --list | sort -rV")
+            Utils.popen_read("git tag -l | sort -rV")
           end
         end
         current_tag, previous_tag, = tags.lines


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

----

- In early versions of git (~1.7), the `list` flag doesn't exist and causes the brew update on install to error:

```
Error: Failure while executing; `git config --local --replace-all homebrew.private false` exited with 129.
error: unknown option `list'
```

- The shortened `-l` flag exists in all versions, though, so switch to that.
- This was reported in https://github.com/Linuxbrew/install/issues/78.
- Thanks to @dawidd6 for reading the git docs better than I could at midnight! ;-)