### PR TITLE
Remove `--local` from `git config` commands as it's the default

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -40,11 +40,11 @@ module Homebrew
 
     HOMEBREW_REPOSITORY.cd do
       analytics_message_displayed =
-        Utils.popen_read("git", "config", "--local", "--get", "homebrew.analyticsmessage").chomp == "true"
+        Utils.popen_read("git", "config", "--get", "homebrew.analyticsmessage").chomp == "true"
       cask_analytics_message_displayed =
-        Utils.popen_read("git", "config", "--local", "--get", "homebrew.caskanalyticsmessage").chomp == "true"
+        Utils.popen_read("git", "config", "--get", "homebrew.caskanalyticsmessage").chomp == "true"
       analytics_disabled =
-        Utils.popen_read("git", "config", "--local", "--get", "homebrew.analyticsdisabled").chomp == "true"
+        Utils.popen_read("git", "config", "--get", "homebrew.analyticsdisabled").chomp == "true"
       if !analytics_message_displayed &&
          !cask_analytics_message_displayed &&
          !analytics_disabled &&
@@ -65,19 +65,19 @@ module Homebrew
 
         # Consider the message possibly missed if not a TTY.
         if $stdout.tty?
-          safe_system "git", "config", "--local", "--replace-all", "homebrew.analyticsmessage", "true"
-          safe_system "git", "config", "--local", "--replace-all", "homebrew.caskanalyticsmessage", "true"
+          safe_system "git", "config", "--replace-all", "homebrew.analyticsmessage", "true"
+          safe_system "git", "config", "--replace-all", "homebrew.caskanalyticsmessage", "true"
         end
       end
 
       donation_message_displayed =
-        Utils.popen_read("git", "config", "--local", "--get", "homebrew.donationmessage").chomp == "true"
+        Utils.popen_read("git", "config", "--get", "homebrew.donationmessage").chomp == "true"
       unless donation_message_displayed
         ohai "Homebrew is run entirely by unpaid volunteers. Please consider donating:"
         puts "  #{Formatter.url("https://github.com/Homebrew/brew#donations")}\n"
 
         # Consider the message possibly missed if not a TTY.
-        safe_system "git", "config", "--local", "--replace-all", "homebrew.donationmessage", "true" if $stdout.tty?
+        safe_system "git", "config", "--replace-all", "homebrew.donationmessage", "true" if $stdout.tty?
       end
     end
 

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -340,7 +340,7 @@ module Homebrew
           # GitHub API responds immediately but fork takes a few seconds to be ready.
           sleep 3
 
-          if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
+          if system("git", "config", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
             remote_url = response.fetch("ssh_url")
           else
             remote_url = response.fetch("clone_url")

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -91,11 +91,11 @@ module Homebrew
       oh1 "Setup test environment..."
       # copy Homebrew installation
       safe_system "git", "clone", "#{HOMEBREW_REPOSITORY}/.git", ".",
-                  "--local", "--branch", "master", "--single-branch"
+                  "--branch", "master", "--single-branch"
 
       # set git origin to another copy
       safe_system "git", "clone", "#{HOMEBREW_REPOSITORY}/.git", "remote.git",
-                  "--local", "--bare", "--branch", "master", "--single-branch"
+                  "--bare", "--branch", "master", "--single-branch"
       safe_system "git", "config", "remote.origin.url", "#{curdir}/remote.git"
 
       # force push origin to end_commit

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -729,7 +729,7 @@ class TapConfig
     return unless Utils.git_available?
 
     tap.path.cd do
-      Utils.popen_read("git", "config", "--local", "--get", "homebrew.#{key}").chomp.presence
+      Utils.popen_read("git", "config", "--get", "homebrew.#{key}").chomp.presence
     end
   end
 
@@ -738,7 +738,7 @@ class TapConfig
     return unless Utils.git_available?
 
     tap.path.cd do
-      safe_system "git", "config", "--local", "--replace-all", "homebrew.#{key}", value.to_s
+      safe_system "git", "config", "--replace-all", "homebrew.#{key}", value.to_s
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The `--local` option doesn't exist in early versions of git (~1.7), but its behaviour is the default (saving in the current repo's .git directory).
- As it's the default across versions, we don't need to specify it everywhere.
- Reported in https://github.com/Linuxbrew/install/issues/78.