### PR TITLE
shims/super/cc: remove isysroot space to fix cpp

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -114,7 +114,7 @@ class Cmd
       if tool == "ld"
         args << "-syslibroot" << sysroot
       else
-        args << "-isysroot" << sysroot << "--sysroot=#{sysroot}"
+        args << "-isysroot#{sysroot}" << "--sysroot=#{sysroot}"
       end
     end
 
@@ -213,7 +213,7 @@ class Cmd
       if mac?
         sdk = enum.next
         # We set the sysroot for macOS SDKs
-        args << "-isysroot" << sdk unless sdk.downcase.include? "osx"
+        args << "-isysroot#{sdk}" unless sdk.downcase.include? "osx"
       else
         args << arg << enum.next
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a fix to #5153, where the `cpp` shim was broken in Xcode 10 and later.

It turns out that Xcode's `cpp` is just a dumb script. Here's a snippet from it:

```sh
while [ $# -gt 0 ]
do
        A="$1"
        shift

        case "$A" in
        -nostdinc)
                NSI=yes
                ;;
        -traditional)
                ;;
        -I*)
                INCS=("${INCS[@]}" "$A")
                ;;
        -imacros|-include|-idirafter|-iprefix|-iwithprefix)
                INCS=("${INCS[@]}" "$A" "$1")
                shift
                ;;
        -*)
                OPTS=("${OPTS[@]}" "$A")
                ;;
        *)
                FOUNDFILES=yes
                # If we've found an input name and there's still an arg left,
                # that next arg will be the output file.
                if [ $# -eq 1 ]; then
                    OUTPUT="$1"
                    # and get rid of last arg
                    shift
                fi
                $CPP -traditional "${INCS[@]}" -x c "${OPTS[@]}" "$A" \
                     -o "$OUTPUT" || exit $?
                ;;
        esac
done
```

It splits arguments by spaces, and completely breaks down when we pass `-isysroot sdk`. The entire flow revolves around `$#`, `$1` and `shift` which work by splitting by spaces so sees `-isysroot` and `sdk` as separate arguments. Here is a demonstration of what happens:

```
$ cpp -isysroot/A -isysroot/B test.ext
xcrun cc -E -traditional  -x c  -isysroot/A -isysroot/B test.ext -o -

$ cpp -isysroot /A -isysroot /B test.ext
xcrun cc -E -traditional  -x c  -isysroot /A -o -
xcrun cc -E -traditional  -x c  -isysroot -isysroot /B test.ext -o -
```

The script does have special handling for `-imacros`, `-include`, `-idirafter`, `-iprefix` and `-iwithprefix` to work with spaces (or rather _require_ spaces), but not `-isysroot`.

When interacting with clang directly, `-isysroot` works both with and without spaces between `-isysroot` and the path. In fact, originally spaces weren't supported there either - that's a later innovation. MacPorts doesn't put a space after `-isysroot` for that reason, albeit that older toolchain support isn't a concern in Homebrew.

Considering `-isysroot` without spaces still works today, I propose removing the space as that fixes all the problems without having to do special `cpp` handling. Note that `-isystem` already behaves this way.