### PR TITLE
Upped the timeout for curl to 15 seconds to match other code

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -437,7 +437,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
   end
 
   def curl(*args, **options)
-    args << "--connect-timeout" << "5" unless mirrors.empty?
+    args << "--connect-timeout" << "15" unless mirrors.empty?
     super(*_curl_args, *args, **_curl_opts, **options)
   end
 end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
The default `--connect-timeout=5` argument for curl is too small and is preventing many packages from properly installing.

```
nathan@UNICORNVOMIT:~$ /usr/bin/curl -q --globoff --show-error --user-agent Linuxbrew/2.1.16\ \(Linux\;\ x86_64\ Ubuntu\ 18.04.3\ LTS\)\ curl/7.58.0 --fail --location --remote-time --continue-at 0 --output /home/nathan/.cache/Homebrew/downloads/38643e81048ad5dcd6482ba07097ed3e62ae22dfdb272a8187d0745c1cde60b1--sbt-1.3.3.tgz.incomplete https://sbt-downloads.cdnedge.bluemix.net/releases/v1.3.3/sbt-1.3.3.tgz --connect-timeout 5
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
curl: (28) Resolving timed out after 5552 milliseconds
nathan@UNICORNVOMIT:~$ /usr/bin/curl -q --globoff --show-error --user-agent Linuxbrew/2.1.16\ \(Linux\;\ x86_64\ Ubuntu\ 18.04.3\ LTS\)\ curl/7.58.0 --fail --location --remote-time --continue-at 0 --output /home/nathan/.cache/Homebrew/downloads/38643e81048ad5dcd6482ba07097ed3e62ae22dfdb272a8187d0745c1cde60b1--sbt-1.3.3.tgz.incomplete https://sbt-downloads.cdnedge.bluemix.net/releases/v1.3.3/sbt-1.3.3.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 49.4M  100 49.4M    0     0  3221k      0  0:00:15  0:00:15 --:--:-- 11.9M
```
The default value also does not match the `--connect-timeout` value in other places show here.

```
nathan@UNICORNVOMIT:/home/linuxbrew/.linuxbrew$ pt connect-timeout
./Homebrew/Library/Homebrew/download_strategy.rb
440:    args << "--connect-timeout" << "5" unless mirrors.empty?

./Homebrew/Library/Homebrew/dev-cmd/pull.rb
464:    headers, = curl_output("--connect-timeout", "15", "--location", "--head", url)

./Homebrew/Library/Homebrew/utils/curl.rb
192:    "--connect-timeout", "15", "--max-time", max_time, url,
```
