### PR TITLE
Fix that `reason` is coerced to a boolean

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -103,7 +103,7 @@ module Homebrew
       if $stdout.tty?
         count = all_formulae.count + all_casks.count
 
-        if reason = MissingFormula.reason(query, silent: true) && !local_casks.include?(query)
+        if (reason = MissingFormula.reason(query, silent: true)) && !local_casks.include?(query)
           if count.positive?
             puts
             puts "If you meant #{query.inspect} specifically:"


### PR DESCRIPTION
https://github.com/Homebrew/brew/commit/f762033a57be271b778be6e39fe7d5b9d068ec64 introduced a bug such that `reason` is coerced to a boolean, so when displayed it loses information about the actual return value from `MissingFormula.reason`. This patch re-scopes the assignment of `reason` such that the actual reason is retained, while also retaining the sense of the new boolean check.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
