### PR TITLE
utils/inreplace: do not allow to use empty list of files

### DIFF
--- a/Library/Homebrew/test/inreplace_spec.rb
+++ b/Library/Homebrew/test/inreplace_spec.rb
@@ -228,6 +228,12 @@ describe Utils::Inreplace do
 
   after { file.unlink }
 
+  it "raises error if there are no files given to replace" do
+    expect {
+      described_class.inreplace [], "d", "f"
+    }.to raise_error(Utils::InreplaceError)
+  end
+
   it "raises error if there is nothing to replace" do
     expect {
       described_class.inreplace file.path, "d", "f"

--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -22,6 +22,8 @@ module Utils
     def inreplace(paths, before = nil, after = nil, audit_result = true)
       errors = {}
 
+      errors["`paths` (first) parameter"] = ["`paths` was empty"] if paths.blank?
+
       Array(paths).each do |path|
         s = File.open(path, "rb", &:read).extend(StringInreplaceExtension)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Using `inreplace` with glob potentially could leed to calling `inreplace` for an empty list of files which in most cases are erroneous.

For example, I ran into it in https://github.com/Homebrew/homebrew-core/pull/45337#issuecomment-555810021 with the following example while doing formula update:

```ruby
    # Fix for https://github.com/Homebrew/homebrew-core/issues/21212
    inreplace Dir[lib_cellar/"**/_sysconfigdata_m_darwin_darwin.py"],
              %r{('LINKFORSHARED': .*?)'(Python.framework/Versions/3.\d+/Python)'}m,
              "\\1'#{opt_prefix}/Frameworks/\\2'"
```
