### PR TITLE
GitHub Actions: get username if we don't have it

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -341,7 +341,7 @@ module Homebrew
           remote_url = Utils.popen_read("git remote get-url --push origin").chomp
           username = formula.tap.user
         else
-          remote_url, username = forked_repo_info(formula, tap_full_name, backup_file)
+          remote_url, username = forked_repo_info(tap_full_name)
         end
 
         safe_system "git", "fetch", "--unshallow", "origin" if shallow
@@ -380,16 +380,15 @@ module Homebrew
     end
   end
 
-  def forked_repo_info(formula, tap_full_name, backup_file)
-    begin
-      response = GitHub.create_fork(tap_full_name)
-      # GitHub API responds immediately but fork takes a few seconds to be ready.
-      sleep 3
-    rescue GitHub::AuthenticationFailedError, *GitHub.api_errors => e
-      formula.path.atomic_write(backup_file)
-      odie "Unable to fork: #{e.message}!"
-    end
-    remote_url = if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
+  def forked_repo_info(tap_full_name)
+    response = GitHub.create_fork(tap_full_name)
+  rescue GitHub::AuthenticationFailedError, *GitHub.api_errors => e
+    formula.path.atomic_write(backup_file)
+    odie "Unable to fork: #{e.message}!"
+  else
+    # GitHub API responds immediately but fork takes a few seconds to be ready.
+    sleep 1 until GitHub.check_fork_exists(tap_full_name)
+    remote_url =  if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
       response.fetch("ssh_url")
     else
       response.fetch("clone_url")

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -341,9 +341,16 @@ module GitHub
   end
 
   def check_fork_exists(repo)
-    _, username = api_credentials
     _, reponame = repo.split("/")
+
+    case api_credentials_type
+    when :keychain
+      _, username = api_credentials
+    when :environment
+      username = open_api(url_to("user")) { |json| json["login"] }
+    end
     json = open_api(url_to("repos", username, reponame))
+
     return false if json["message"] == "Not Found"
 
     true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a fix for my previous submission #6723 for cases when `api_credentials` has a token only without a username

@dawidd6 and @chenrui333, could you please set this PR with your workflow(s)?