### PR TITLE
dev-cmd/audit: check resource name does not match formula name

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -667,6 +667,8 @@ module Homebrew
         problems.concat ra.problems.map { |problem| "#{name}: #{problem}" }
 
         spec.resources.each_value do |resource|
+          problem "Resource name should be different from the formula name" if resource.name == formula.name
+
           ra = ResourceAuditor.new(resource, spec_name, online: @online, strict: @strict).audit
           problems.concat ra.problems.map { |problem|
             "#{name} resource #{resource.name.inspect}: #{problem}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When resource name matches formula name quite often it is made by mistake, for example
- https://github.com/Homebrew/homebrew-core/blob/4f0ff49/Formula/vsts-cli.rb#L129
- https://github.com/Homebrew/homebrew-core/pull/47054#discussion_r349594383

This PR adds a check for such kind of cases.

I didn't add a test for the current implementation:
- there are no tests for `#audit_specs` itself which I modified (or I just missed it)
- this check could be moved to `ResourceAuditor` but this will require to pass a formula name to it. Not sure that will be an idiomatic way, but anyway I'm open for suggestions.

Currently, homebrew has 2 formulae with resource name matching formula name: `vsts-cli` (real bug) and `smali` (just a coincidence) which I sort out in https://github.com/Homebrew/homebrew-core/pull/47181