### PR TITLE
catworkflows/tests: skip update-test unless on a PR.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,7 @@ jobs:
         brew update-test
         brew update-test --to-tag
         brew update-test --commit=HEAD
+      if: github.event_name == 'pull_request'
 
     - name: Run brew readall
       run: |


### PR DESCRIPTION
If this is a `master` build and it was merged: this is a flaky test we
can't do anything about.