### PR TITLE
deps: use `runtime_dependencies` more readily.

### DIFF
--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -80,12 +80,13 @@ module Homebrew
       return
     end
 
-    @only_installed_arg = args.installed? &&
-                          recursive &&
-                          !args.include_build? &&
-                          !args.include_test? &&
-                          !args.include_optional? &&
-                          !args.skip_recommended?
+    installed = args.installed? || ARGV.formulae.all?(&:opt_or_installed_prefix_keg)
+
+    @use_runtime_dependencies = installed && recursive &&
+                                !args.include_build? &&
+                                !args.include_test? &&
+                                !args.include_optional? &&
+                                !args.skip_recommended?
 
     if args.remaining.empty?
       raise FormulaUnspecifiedError unless args.installed?
@@ -137,7 +138,7 @@ module Homebrew
   def deps_for_formula(f, recursive = false)
     includes, ignores = argv_includes_ignores(ARGV)
 
-    deps = f.runtime_dependencies if @only_installed_arg
+    deps = f.runtime_dependencies if @use_runtime_dependencies
 
     if recursive
       deps ||= recursive_includes(Dependency,  f, includes, ignores)

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -58,15 +58,16 @@ module Homebrew
       ARGV.named.map { |name| OpenStruct.new name: name, full_name: name }
     end
 
-    only_installed_arg = args.installed? &&
-                         !args.include_build? &&
-                         !args.include_test? &&
-                         !args.include_optional? &&
-                         !args.skip_recommended?
+    use_runtime_dependents = args.installed? &&
+                             !args.include_build? &&
+                             !args.include_test? &&
+                             !args.include_optional? &&
+                             !args.skip_recommended?
 
-    uses = if only_installed_arg && !used_formulae_missing
+    uses = if use_runtime_dependents && !used_formulae_missing
       used_formulae.map(&:runtime_installed_formula_dependents)
                    .reduce(&:&)
+                   .select(&:any_version_installed?)
     else
       formulae = args.installed? ? Formula.installed : Formula
       recursive = args.recursive?


### PR DESCRIPTION
If all the passed packages are currently installed then use `runtime_dependencies` to get dependency data more quickly and accurately.

While we're here, also make `brew uses --installed` behave consistently with `brew deps` and what the documentation claims it should do.

As discussed in https://github.com/Homebrew/brew/issues/6769 FYI @Bo98.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----