### PR TITLE
workflows/tests: tweak behaviour by OS.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,10 +56,15 @@ jobs:
         export HOMEBREW_CI_BRANCH="$HEAD_GITHUB_REF"
         export HOMEBREW_GITHUB_REPOSITORY="$GITHUB_REPOSITORY"
 
-        export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin"
-        brew tests --no-compat --online
-        brew tests --generic --online
-        brew tests --online --coverage
+        # don't bother running all tests on both platforms (for speed)
+        if [ "$RUNNER_OS" = "Linux" ]; then
+          export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/bin:/bin"
+          brew tests --no-compat --online
+          brew tests --generic --online
+          brew tests --online
+        else
+          brew tests --online --coverage
+        fi
       env:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This should speed up Homebrew/brew testing by not running generic or
no-compat tests on macOS.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----