### PR TITLE
Backfill missing Xcode/clang version maps

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -204,7 +204,11 @@ module OS
       "10.1"   => { clang: "10.0", clang_build: 1000 },
       "10.2"   => { clang: "10.0", clang_build: 1001 },
       "10.2.1" => { clang: "10.0", clang_build: 1001 },
+      "10.3"   => { clang: "10.0", clang_build: 1001 },
       "11.0"   => { clang: "11.0", clang_build: 1100 },
+      "11.1"   => { clang: "11.0", clang_build: 1100 },
+      "11.2"   => { clang: "11.0", clang_build: 1100 },
+      "11.2.1" => { clang: "11.0", clang_build: 1100 },
     }.freeze
 
     def compilers_standard?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In #6702 we did not update this list. Let's also backfill as it seems to have been missed the last few Xcode releases.