### PR TITLE
workflows/apidoc: try to rebase before pushing.

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -34,8 +34,10 @@ jobs:
 
           # commit and push generated files
           git add docs
-          
+
           if ! git diff --exit-code HEAD -- docs; then
             git commit -m 'docs: update from Homebrew/brew push' docs
+            git fetch
+            git rebase origin/master
             git push
           fi


### PR DESCRIPTION
This avoids failures when you have two `master` builds running at once.