### PR TITLE
Rename Formula#installed? to Formula#latest_version_installed?

### DIFF
--- a/Library/Homebrew/compat.rb
+++ b/Library/Homebrew/compat.rb
@@ -2,3 +2,4 @@
 
 require "compat/cask/dsl/version"
 require "compat/requirements/macos_requirement"
+require "compat/formula"

--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Formula
+  module Compat
+    def installed?
+      # odeprecated "Formula#installed?",
+      #             "Formula#latest_version_installed? (or Formula#any_version_installed? )"
+      latest_version_installed?
+    end
+  end
+
+  prepend Compat
+end

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -39,7 +39,9 @@ class Dependency
     formula
   end
 
-  delegate installed?: :to_formula
+  def installed?
+    to_formula.latest_version_installed?
+  end
 
   def satisfied?(inherited_options)
     installed? && missing_options(inherited_options).empty?

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -95,7 +95,7 @@ module Homebrew
 
   def ensure_relocation_formulae_installed!
     Keg.relocation_formulae.each do |f|
-      next if Formula[f].installed?
+      next if Formula[f].latest_version_installed?
 
       ohai "Installing #{f}..."
       safe_system HOMEBREW_BREW_FILE, "install", f
@@ -205,7 +205,7 @@ module Homebrew
   end
 
   def bottle_formula(f)
-    return ofail "Formula not installed or up-to-date: #{f.full_name}" unless f.installed?
+    return ofail "Formula not installed or up-to-date: #{f.full_name}" unless f.latest_version_installed?
 
     unless tap = f.tap
       return ofail "Formula not from core or any installed taps: #{f.full_name}" unless args.force_core_tap?

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -40,7 +40,7 @@ module Homebrew
 
     ARGV.resolved_formulae.each do |f|
       # Cannot test uninstalled formulae
-      unless f.installed?
+      unless f.latest_version_installed?
         ofail "Testing requires the latest version of #{f.full_name}"
         next
       end

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -33,7 +33,7 @@ module Homebrew
       ohai "git add vendor/bundle"
       system "git", "add", "vendor/bundle"
 
-      if Formula["gpg"].installed?
+      if Formula["gpg"].optlinked?
         ENV["PATH"] = PATH.new(ENV["PATH"])
                           .prepend(Formula["gpg"].opt_bin)
       end

--- a/Library/Homebrew/extend/os/linux/requirements/osxfuse_requirement.rb
+++ b/Library/Homebrew/extend/os/linux/requirements/osxfuse_requirement.rb
@@ -6,7 +6,7 @@ class OsxfuseRequirement < Requirement
   download "https://github.com/libfuse/libfuse"
 
   satisfy(build_env: false) do
-    next true if libfuse_formula_exists? && Formula["libfuse"].installed?
+    next true if libfuse_formula_exists? && Formula["libfuse"].latest_version_installed?
 
     includedirs = %w[
       /usr/include

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -463,7 +463,7 @@ class Formula
   # This is actually just a check for if the {#installed_prefix} directory
   # exists and is not empty.
   # @private
-  def installed?
+  def latest_version_installed?
     (dir = installed_prefix).directory? && !dir.children.empty?
   end
 
@@ -1211,7 +1211,7 @@ class Formula
   end
 
   def new_formula_available?
-    installed_alias_target_changed? && !latest_formula.installed?
+    installed_alias_target_changed? && !latest_formula.latest_version_installed?
   end
 
   def current_installed_alias_target
@@ -1932,7 +1932,7 @@ class Formula
   # @private
   def eligible_kegs_for_cleanup(quiet: false)
     eligible_for_cleanup = []
-    if installed?
+    if latest_version_installed?
       eligible_kegs = if head? && (head_prefix = latest_head_prefix)
         installed_kegs - [Keg.new(head_prefix)]
       else

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -343,7 +343,7 @@ class FormulaInstaller
 
     build_bottle_postinstall if build_bottle?
 
-    opoo "Nothing was installed to #{formula.prefix}" unless formula.installed?
+    opoo "Nothing was installed to #{formula.prefix}" unless formula.latest_version_installed?
     end_time = Time.now
     Homebrew.messages.formula_installed(formula, end_time - start_time)
   end

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -124,17 +124,17 @@ describe Homebrew::Cleanup do
       Tab.create(f, DevelopmentTools.default_compiler, :libcxx).write
     end
 
-    expect(f1).to be_installed
-    expect(f2).to be_installed
-    expect(f3).to be_installed
-    expect(f4).to be_installed
+    expect(f1).to be_latest_version_installed
+    expect(f2).to be_latest_version_installed
+    expect(f3).to be_latest_version_installed
+    expect(f4).to be_latest_version_installed
 
     subject.cleanup_formula f3
 
-    expect(f1).not_to be_installed
-    expect(f2).not_to be_installed
-    expect(f3).to be_installed
-    expect(f4).to be_installed
+    expect(f1).not_to be_latest_version_installed
+    expect(f2).not_to be_latest_version_installed
+    expect(f3).to be_latest_version_installed
+    expect(f4).to be_latest_version_installed
   end
 
   describe "#cleanup_cask", :cask do

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -15,19 +15,19 @@ describe FormulaInstaller do
   end
 
   def temporarily_install_bottle(formula)
-    expect(formula).not_to be_installed
+    expect(formula).not_to be_latest_version_installed
     expect(formula).to be_bottled
     expect(formula).to pour_bottle
 
     stub_formula_loader formula
     stub_formula_loader formula("gcc") { url "gcc-1.0" }
     stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
-    allow(Formula["patchelf"]).to receive(:installed?).and_return(true)
+    allow(Formula["patchelf"]).to receive(:latest_version_installed?).and_return(true)
     described_class.new(formula).install
 
     keg = Keg.new(formula.prefix)
 
-    expect(formula).to be_installed
+    expect(formula).to be_latest_version_installed
 
     begin
       expect(Tab.for_keg(keg)).to be_poured_from_bottle
@@ -41,7 +41,7 @@ describe FormulaInstaller do
     end
 
     expect(keg).not_to exist
-    expect(formula).not_to be_installed
+    expect(formula).not_to be_latest_version_installed
   end
 
   specify "basic bottle install" do
@@ -73,13 +73,13 @@ describe FormulaInstaller do
     # Testball doesn't have a bottle block, so use it to test this behavior
     formula = Testball.new
 
-    expect(formula).not_to be_installed
+    expect(formula).not_to be_latest_version_installed
     expect(formula).not_to be_bottled
 
     expect {
       described_class.new(formula).install
     }.to raise_error(BuildToolsError)
 
-    expect(formula).not_to be_installed
+    expect(formula).not_to be_latest_version_installed
   end
 end

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -17,7 +17,7 @@ describe FormulaInstaller do
   end
 
   def temporary_install(formula)
-    expect(formula).not_to be_installed
+    expect(formula).not_to be_latest_version_installed
 
     installer = described_class.new(formula)
 
@@ -25,7 +25,7 @@ describe FormulaInstaller do
 
     keg = Keg.new(formula.prefix)
 
-    expect(formula).to be_installed
+    expect(formula).to be_latest_version_installed
 
     begin
       Tab.clear_cache
@@ -42,7 +42,7 @@ describe FormulaInstaller do
     end
 
     expect(keg).not_to exist
-    expect(formula).not_to be_installed
+    expect(formula).not_to be_latest_version_installed
   end
 
   specify "basic installation" do
@@ -84,7 +84,7 @@ describe FormulaInstaller do
     expect(formula).to have_disabled_bottle
 
     temporary_install(formula) do |f|
-      expect(f).to be_installed
+      expect(f).to be_latest_version_installed
     end
   end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -279,22 +279,22 @@ describe Formula do
     expect(f).not_to need_migration
   end
 
-  describe "#installed?" do
+  describe "#latest_version_installed?" do
     let(:f) { Testball.new }
 
     it "returns false if the #installed_prefix is not a directory" do
       allow(f).to receive(:installed_prefix).and_return(double(directory?: false))
-      expect(f).not_to be_installed
+      expect(f).not_to be_latest_version_installed
     end
 
     it "returns false if the #installed_prefix does not have children" do
       allow(f).to receive(:installed_prefix).and_return(double(directory?: true, children: []))
-      expect(f).not_to be_installed
+      expect(f).not_to be_latest_version_installed
     end
 
     it "returns true if the #installed_prefix has children" do
       allow(f).to receive(:installed_prefix).and_return(double(directory?: true, children: [double]))
-      expect(f).to be_installed
+      expect(f).to be_latest_version_installed
     end
   end
 
@@ -871,10 +871,10 @@ describe Formula do
         Tab.create(f, DevelopmentTools.default_compiler, :libcxx).write
       end
 
-      expect(f1).to be_installed
-      expect(f2).to be_installed
-      expect(f3).to be_installed
-      expect(f4).to be_installed
+      expect(f1).to be_latest_version_installed
+      expect(f2).to be_latest_version_installed
+      expect(f3).to be_latest_version_installed
+      expect(f4).to be_latest_version_installed
       expect(f3.eligible_kegs_for_cleanup.sort_by(&:version))
         .to eq([f2, f1].map { |f| Keg.new(f.prefix) })
     end
@@ -890,9 +890,9 @@ describe Formula do
       f3.brew { f3.install }
 
       expect(f1.prefix).to eq((HOMEBREW_PINNED_KEGS/f1.name).resolved_path)
-      expect(f1).to be_installed
-      expect(f2).to be_installed
-      expect(f3).to be_installed
+      expect(f1).to be_latest_version_installed
+      expect(f2).to be_latest_version_installed
+      expect(f3).to be_latest_version_installed
       expect(f3.eligible_kegs_for_cleanup).to eq([Keg.new(f2.prefix)])
     end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -142,7 +142,7 @@ describe Formulary do
         allow(described_class).to receive(:loader_for).and_call_original
         stub_formula_loader formula("gcc") { url "gcc-1.0" }
         stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
-        allow(Formula["patchelf"]).to receive(:installed?).and_return(true)
+        allow(Formula["patchelf"]).to receive(:latest_version_installed?).and_return(true)
       end
 
       let(:installed_formula) { described_class.factory(formula_path) }

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -11,7 +11,7 @@ module Utils
       end
 
       def built_as?(f)
-        return false unless f.installed?
+        return false unless f.latest_version_installed?
 
         tab = Tab.for_keg(f.installed_prefix)
         tab.built_as_bottle


### PR DESCRIPTION
This naming has always been a bit weird and confusing so let's change it. ~~It doesn't need a minor release for the deprecation because it's a private internal method and not used in Homebrew/core.~~ It's used in Homebrew/linuxbrew-core so not making it `odeprecated` yet.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----