### PR TITLE
FormulaInstaller: rescue already attempted install

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -598,6 +598,10 @@ class FormulaInstaller
     oh1 "Installing #{formula.full_name} dependency: #{Formatter.identifier(dep.name)}"
     fi.install
     fi.finish
+  rescue FormulaInstallationAlreadyAttemptedError
+    # We already attempted to install f as part of the dependency tree of
+    # another formula. In that case, don't generate an error, just move on.
+    nil
   rescue Exception # rubocop:disable Lint/RescueException
     ignore_interrupts do
       tmp_keg.rename(installed_keg) if tmp_keg && !installed_keg.directory?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
We use `brew install --only-dependencies` in our CI jobs before building a package from source. Recently I noticed that some jobs were [failing to install the needed dependencies](https://build.osrfoundation.org/job/ignition_gazebo-ci-pr_any-homebrew-amd64/2174/console), with brew silently stopping before all the dependencies were installed. I had to add some print statements, but I tracked it down to a `rescue Exception` in FormulaInstaller that was catching a `FormulaInstallationAlreadyAttemptedError` and raising. There are several other places where we catch this error and allow it to continue:

* https://github.com/Homebrew/brew/blob/ae08b15cbe40a2022f6618e66863baafc2532e79/Library/Homebrew/reinstall.rb#L42-L43
* https://github.com/Homebrew/brew/blob/b80defdd3323b52836e7e7ef3ed88b9f60eac2a5/Library/Homebrew/cmd/upgrade.rb#L191-L194
* https://github.com/Homebrew/brew/blob/84c5f4079347fb7bc7844d594f5735347abf5607/Library/Homebrew/cmd/install.rb#L331-L334

So I've added the same rescue to `FormulaInstaller`.