### PR TITLE
Fix bug with printing pinned dependencies.

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -239,9 +239,9 @@ module Homebrew
     if pinned_dependents.present?
       plural = "dependent".pluralize(pinned_dependents.count)
       ohai "Not upgrading #{pinned_dependents.count} pinned #{plural}:"
-      puts pinned_dependents.map do |f|
+      puts(pinned_dependents.map do |f|
         "#{f.full_specified_name} #{f.pkg_version}"
-      end.join(", ")
+      end.join(", "))
     end
 
     # Print the upgradable dependents.
@@ -292,9 +292,9 @@ module Homebrew
       count = pinned_broken_dependents.count
       plural = "dependent".pluralize(pinned_broken_dependents.count)
       onoe "Not reinstalling #{count} broken and outdated, but pinned #{plural}:"
-      $stderr.puts pinned_broken_dependents.map do |f|
+      $stderr.puts(pinned_broken_dependents.map do |f|
         "#{f.full_specified_name} #{f.pkg_version}"
-      end.join(", ")
+      end.join(", "))
     end
 
     # Print the broken dependents.


### PR DESCRIPTION
Brew prints this error:
```
==> Not upgrading 5 pinned dependents:
#<Enumerator:0x00007fc2649dd630>
Error: undefined method `join' for nil:NilClass
```

when there are pinned dependencies because, in this code:

```ruby
puts pinned_dependents.map do |f|
  "#{f.full_specified_name} #{f.pkg_version}"
end.join(", ")
```
Ruby passes the block to `puts` and not to `map`. So `.join(",")` is called on the output of `puts`, which is always `nil`.

(I think the regression was introduced in this commit: e12a7b0808353ea81d63774be1edaff81710d7a6)
