### PR TITLE
cask version MAJOR_MINOR_PATCH_REGEX: allow any word character instead of only digits

### DIFF
--- a/Library/Homebrew/cask/dsl/version.rb
+++ b/Library/Homebrew/cask/dsl/version.rb
@@ -11,7 +11,7 @@ module Cask
 
       DIVIDER_REGEX = /(#{DIVIDERS.keys.map { |v| Regexp.quote(v) }.join('|')})/.freeze
 
-      MAJOR_MINOR_PATCH_REGEX = /^(\d+)(?:\.(\d+)(?:\.(\d+))?)?/.freeze
+      MAJOR_MINOR_PATCH_REGEX = /^([^.,:]+)(?:\.([^.,:]+)(?:\.([^.,:]+))?)?/.freeze
 
       INVALID_CHARACTERS = /[^0-9a-zA-Z\.\,\:\-\_]/.freeze
 

--- a/Library/Homebrew/test/cask/dsl/version_spec.rb
+++ b/Library/Homebrew/test/cask/dsl/version_spec.rb
@@ -85,50 +85,50 @@ describe Cask::DSL::Version, :cask do
   describe "string manipulation helpers" do
     describe "#major" do
       include_examples "version expectations hash", :major,
-                       "1"         => "1",
-                       "1.2"       => "1",
-                       "1.2.3"     => "1",
-                       "1.2.3_4-5" => "1"
+                       "1"           => "1",
+                       "1.2"         => "1",
+                       "1.2.3"       => "1",
+                       "1.2.3-4,5:6" => "1"
     end
 
     describe "#minor" do
       include_examples "version expectations hash", :minor,
-                       "1"         => "",
-                       "1.2"       => "2",
-                       "1.2.3"     => "2",
-                       "1.2.3_4-5" => "2"
+                       "1"           => "",
+                       "1.2"         => "2",
+                       "1.2.3"       => "2",
+                       "1.2.3-4,5:6" => "2"
     end
 
     describe "#patch" do
       include_examples "version expectations hash", :patch,
-                       "1"         => "",
-                       "1.2"       => "",
-                       "1.2.3"     => "3",
-                       "1.2.3_4-5" => "3"
+                       "1"           => "",
+                       "1.2"         => "",
+                       "1.2.3"       => "3",
+                       "1.2.3-4,5:6" => "3-4"
     end
 
     describe "#major_minor" do
       include_examples "version expectations hash", :major_minor,
-                       "1"         => "1",
-                       "1.2"       => "1.2",
-                       "1.2.3"     => "1.2",
-                       "1.2.3_4-5" => "1.2"
+                       "1"           => "1",
+                       "1.2"         => "1.2",
+                       "1.2.3"       => "1.2",
+                       "1.2.3-4,5:6" => "1.2"
     end
 
     describe "#major_minor_patch" do
       include_examples "version expectations hash", :major_minor_patch,
-                       "1"         => "1",
-                       "1.2"       => "1.2",
-                       "1.2.3"     => "1.2.3",
-                       "1.2.3_4-5" => "1.2.3"
+                       "1"           => "1",
+                       "1.2"         => "1.2",
+                       "1.2.3"       => "1.2.3",
+                       "1.2.3-4,5:6" => "1.2.3-4"
     end
 
     describe "#minor_patch" do
       include_examples "version expectations hash", :minor_patch,
-                       "1"         => "",
-                       "1.2"       => "2",
-                       "1.2.3"     => "2.3",
-                       "1.2.3_4-5" => "2.3"
+                       "1"           => "",
+                       "1.2"         => "2",
+                       "1.2.3"       => "2.3",
+                       "1.2.3-4,5:6" => "2.3-4"
     end
 
     describe "#before_comma" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I don’t recall a single time where restricting this regex to digits has made things easier, but I do recall being annoyed by the current behaviour making things hard and having to contort to comply.

Developers are inconsistent and we should accept that. It’s intuitive to think of `major.minor.patch` as “whatever is between `.`”, not “whatever is between `.` except it there’s a non-numeric character, in which case break”, especially since we don’t care about non-numberic characters in versions in any other method.