### PR TITLE
Add Vale linting for our docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -130,6 +130,12 @@ jobs:
         export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin"
         brew readall --aliases
 
+    - name: Run vale for docs linting
+      run: |
+        export PATH="/home/linuxbrew/.linuxbrew/bin:/usr/local/bin:/usr/bin:/bin"
+        brew install vale
+        vale $(brew --repo)/docs/
+
     - name: Build Docker image
       run: |
         docker pull homebrew/brew

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@
 !/.editorconfig
 !/.gitignore
 !/.yardopts
+!/.vale.ini
 !/CHANGELOG.md
 !/CONTRIBUTING.md
 !/Dockerfile

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,4 @@
+StylesPath = ./docs/vale-styles
+
+[*.md]
+BasedOnStyles = Homebrew

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -9,7 +9,7 @@
 #
 # When done, regenerate the man page and its HTML version by running `brew man`.
 %>
-brew(1) -- The missing package manager for macOS
+brew(1) -- The Missing Package Manager for macOS
 ================================================
 
 ## SYNOPSIS

--- a/docs/Bottles.md
+++ b/docs/Bottles.md
@@ -1,4 +1,4 @@
-# Bottles (binary packages)
+# Bottles (Binary Packages)
 
 Bottles are produced by installing a formula with `brew install --build-bottle <formula>` and then bottling it with `brew bottle <formula>`. This outputs the bottle DSL which should be inserted into the formula file.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -204,9 +204,9 @@ our analytics identified it was not widely used.
 
 ## Homebrew is a poor name, it's too generic, why was it chosen?
 @mxcl was too concerned with the beer theme and didn’t consider that the
-project may actually prove popular. By the time he realised it was, it was too
-late. However, today, the first Google hit for “homebrew” is not beer
-related ;&#8209;)
+project may actually prove popular. By the time Max realised that it
+was popular, it was too late. However, today, the first Google hit for
+“homebrew” is not beer related ;&#8209;)
 
 ## What does "keg-only" mean?
 It means the formula is installed only into the Cellar; it is not linked

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -732,9 +732,9 @@ Homebrew provides two formula DSL methods for launchd plist files:
 
 Homebrew has multiple levels of environment variable filtering which affects variables available to formulae.
 
-Firstly, the overall environment in which Homebrew runs is filtered to avoid environment contamination breaking from-source builds (<https://github.com/Homebrew/brew/issues/932>).  In particular, this process filters all but the given whitelisted variables, but allows environment variables prefixed with `HOMEBREW_`. The specific implementation can be seen in [`bin/brew`](https://github.com/Homebrew/brew/blob/master/bin/brew).
+Firstly, the overall environment in which Homebrew runs is filtered to avoid environment contamination breaking from-source builds (<https://github.com/Homebrew/brew/issues/932>). In particular, this process filters all but the given whitelisted variables, but allows environment variables prefixed with `HOMEBREW_`. The specific implementation can be seen in [`bin/brew`](https://github.com/Homebrew/brew/blob/master/bin/brew).
 
-The second level of filtering removes sensitive environment variables (such as credentials like keys, passwords or tokens) to avoid malicious subprocesses obtaining them (<https://github.com/Homebrew/brew/pull/2524>).  This has the effect of preventing any such variables from reaching a formula's Ruby code as they are filtered before it is called.  The specific implementation can be seen in the [`ENV.clear_sensitive_environment!` method](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/ENV.rb).
+The second level of filtering removes sensitive environment variables (such as credentials like keys, passwords or tokens) to avoid malicious subprocesses obtaining them (<https://github.com/Homebrew/brew/pull/2524>). This has the effect of preventing any such variables from reaching a formula's Ruby code as they are filtered before it is called. The specific implementation can be seen in the [`ENV.clear_sensitive_environment!` method](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/ENV.rb).
 
 In summary, environment variables used by a formula need to conform to these filtering rules in order to be available.
 

--- a/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
@@ -23,7 +23,7 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 Once we've done that, we need to get access to the `merge-homebrew`
 command that will be used for the merge. To do that we have to tap the
 [`Homebrew/linux-dev`](https://github.com/Homebrew/homebrew-linux-dev)
-repo:
+repository:
 
 ```bash
 brew tap homebrew/linux-dev
@@ -235,7 +235,7 @@ against the formulae:
 And it skips formulae if any of the following are true:
 - it doesn't need a bottle
 - it already has a bottle
-- the formula's tap is Homebrew/homebrew-core (the upstream macOS repo)
+- the formula's tap is Homebrew/homebrew-core (the upstream macOS repository)
 - there is already an open PR for the formula's bottle
 - the current branch is not master
 

--- a/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
@@ -1,4 +1,4 @@
-# Homebrew linuxbrew-core Maintainer Guide
+# Homebrew/linuxbrew-core Maintainer Guide
 
 ## Merging formulae updates from Homebrew/homebrew-core
 

--- a/docs/How-To-Open-a-Homebrew-Pull-Request.md
+++ b/docs/How-To-Open-a-Homebrew-Pull-Request.md
@@ -1,4 +1,4 @@
-# How To Open a Homebrew Pull Request (and get it merged)
+# How To Open a Homebrew Pull Request
 
 The following commands are used by Homebrew contributors to set up a fork of Homebrew's Git repository on GitHub, create a new branch and create a GitHub pull request ("PR") of the changes in that branch.
 

--- a/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
+++ b/docs/How-to-Build-Software-Outside-Homebrew-with-Homebrew-keg-only-Dependencies.md
@@ -1,4 +1,4 @@
-# How to build software outside Homebrew with Homebrew `keg_only` dependencies
+# How to Build Software Outside Homebrew with Homebrew `keg_only` Dependencies
 
 ## What does "keg-only" mean?
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1,4 +1,4 @@
-brew(1) -- The missing package manager for macOS
+brew(1) -- The Missing Package Manager for macOS
 ================================================
 
 ## SYNOPSIS

--- a/docs/Prose-Style-Guidelines.md
+++ b/docs/Prose-Style-Guidelines.md
@@ -41,7 +41,7 @@ We prefer:
 
 ### Structure and markup
 
-* Sentence case in section headings, not Title Case
+* Title Case in `h1` headings; sentence case in all other headings
 * Periods at the ends of list items where most items in that list are complete sentences
 * More generally, parallel list item structure
 * Capitalise all list items if you want, even if they're not complete sentences; just be consistent within each list, and preferably, throughout the whole page

--- a/docs/Prose-Style-Guidelines.md
+++ b/docs/Prose-Style-Guidelines.md
@@ -1,3 +1,5 @@
+<!-- vale off -->
+<!-- Disable vale linting for the whole of the style guide, because it contains deliberately bad examples. -->
 # Prose Style Guidelines
 
 This is a set of style and usage guidelines for Homebrew's prose documentation aimed at users, contributors, and maintainers (as opposed to executable computer code). It applies to documents like those in `docs` in the `Homebrew/brew` repository, announcement emails, and other communications with the Homebrew community.
@@ -86,3 +88,5 @@ Refer to these guidelines to make decisions about style and usage in your own wr
 PRs that fix style and usage throughout a document or multiple documents are okay and encouraged. PRs for just one or two style changes are a bit much.
 
 Giving style and usage feedback on a PR or commit that involves documents is okay and encouraged. But keep in mind that these are just guidelines, and for any change, the author may have made a deliberate choice to break these rules in the interest of understandability or aesthetics.
+
+<!-- vale on -->

--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -16,12 +16,15 @@ mistydemeo/tigerbrew
 dunn/emacs
 ```
 
+<!-- vale Homebrew.Terms = OFF -->
+<!-- The `terms` lint suggests changing "repo" to "repository". But we need the abbreviation in the tap syntax and URL example. -->
 * `brew tap <user/repo>` makes a shallow clone of the repository at
   https://github.com/user/repo. After that, `brew` will be able to work on
   those formulae as if they were in Homebrew's canonical repository. You can
   install and uninstall them with `brew [un]install`, and the formulae are
   automatically updated when you run `brew update`. (See below for details
   about how `brew tap` handles the names of repositories.)
+<!-- vale Homebrew.Terms = ON -->
 
 * `brew tap <user/repo> <URL>` makes a shallow clone of the repository at URL.
   Unlike the one-argument version, URL is not assumed to be GitHub, and it

--- a/docs/Taps.md
+++ b/docs/Taps.md
@@ -1,4 +1,4 @@
-# Taps (third-party repositories)
+# Taps (Third-Party Repositories)
 
 `brew tap` adds more repositories to the list of formulae that `brew` tracks, updates,
 and installs from. By default, `tap` assumes that the repositories come from GitHub,

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,7 @@ exclude:
   - bin
   - CNAME
   - Gemfile*
+  - vale-styles
   - vendor
 
 plugins:

--- a/docs/vale-styles/Homebrew/Abbreviations.yml
+++ b/docs/vale-styles/Homebrew/Abbreviations.yml
@@ -1,0 +1,12 @@
+---
+extends: substitution
+message: Use '%s'
+ignorecase: false
+link: 'https://github.com/Homebrew/brew/blob/master/docs/Prose-Style-Guidelines.md#style-and-usage'
+level: error
+nonword: true
+swap:
+  '\beg\b': e.g.
+  '\bie\b': i.e.
+  'e\.g\.,': e.g.
+  'i\.e\.,': i.e.

--- a/docs/vale-styles/Homebrew/OxfordComma.yml
+++ b/docs/vale-styles/Homebrew/OxfordComma.yml
@@ -1,0 +1,8 @@
+---
+extends: existence
+message: 'No Oxford commas!'
+link: 'https://github.com/Homebrew/brew/blob/master/docs/Prose-Style-Guidelines.md#typographical-conventions'
+scope: sentence
+level: warning
+tokens:
+  - '(?:[^,]+,){1,}\s\w+,\sand'

--- a/docs/vale-styles/Homebrew/Pronouns.yml
+++ b/docs/vale-styles/Homebrew/Pronouns.yml
@@ -1,0 +1,15 @@
+---
+extends: existence
+message: Avoid gender-specific language when not necessary.
+link: 'https://github.com/Homebrew/brew/blob/master/docs/Prose-Style-Guidelines.md#personal-pronouns'
+level: warning
+ignorecase: true
+tokens:
+  - him
+  - her
+  - she
+  - he
+  - his
+  - hers
+  - himself
+  - herself

--- a/docs/vale-styles/Homebrew/README.md
+++ b/docs/vale-styles/Homebrew/README.md
@@ -1,0 +1,1 @@
+Based on Homebrew's [Prose Style Guidelines](http://docs.brew.sh/Prose-Style-Guidelines.html).

--- a/docs/vale-styles/Homebrew/Spacing.yml
+++ b/docs/vale-styles/Homebrew/Spacing.yml
@@ -1,0 +1,9 @@
+---
+extends: existence
+message: "'%s' should have one space."
+link: 'https://github.com/Homebrew/brew/blob/master/docs/Prose-Style-Guidelines.md#typographical-conventions'
+level: error
+nonword: true
+tokens:
+  - '[a-z][.?!][A-Z]'
+  - '[.?!] {2,}[A-Z]'

--- a/docs/vale-styles/Homebrew/Terms.yml
+++ b/docs/vale-styles/Homebrew/Terms.yml
@@ -3,6 +3,7 @@ extends: substitution
 message: Use '%s' instead of '%s'.
 link: 'https://github.com/Homebrew/brew/blob/master/docs/Prose-Style-Guidelines.md#terminology-words-and-word-styling'
 level: error
+scope: $paragraph
 swap:
   Pull Request: pull request
   repo: repository

--- a/docs/vale-styles/Homebrew/Terms.yml
+++ b/docs/vale-styles/Homebrew/Terms.yml
@@ -1,0 +1,9 @@
+---
+extends: substitution
+message: Use '%s' instead of '%s'.
+link: 'https://github.com/Homebrew/brew/blob/master/docs/Prose-Style-Guidelines.md#terminology-words-and-word-styling'
+level: error
+swap:
+  Pull Request: pull request
+  repo: repository
+  Rubocop: RuboCop

--- a/docs/vale-styles/Homebrew/Titles.yml
+++ b/docs/vale-styles/Homebrew/Titles.yml
@@ -1,0 +1,6 @@
+---
+extends: capitalization
+message: "'%s' should be in sentence case"
+level: warning
+scope: heading
+match: $sentence

--- a/docs/vale-styles/Homebrew/Titles.yml
+++ b/docs/vale-styles/Homebrew/Titles.yml
@@ -1,6 +1,10 @@
----
 extends: capitalization
-message: "'%s' should be in sentence case"
+message: "'%s' should be in title case"
 level: warning
-scope: heading
-match: $sentence
+scope: heading.h1
+match: $title
+style: AP
+exceptions:
+  - brew(1)
+  - Homebrew/homebrew-core
+  - Homebrew/linuxbrew-core

--- a/docs/vale-styles/Homebrew/Trademarks.yml
+++ b/docs/vale-styles/Homebrew/Trademarks.yml
@@ -1,0 +1,12 @@
+---
+extends: existence
+message: 'No "TM", ™, SM, ©, ®, or other explicit indicators of rights ownership or trademarks'
+link: 'https://github.com/Homebrew/brew/blob/master/docs/Prose-Style-Guidelines.md#typographical-conventions'
+level: error
+nonword: true
+tokens:
+  - \bTM\b
+  - ™
+  - \bSM\b
+  - ©
+  - ®

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -4,7 +4,7 @@
 .TH "BREW" "1" "December 2019" "Homebrew" "brew"
 .
 .SH "NAME"
-\fBbrew\fR \- The missing package manager for macOS
+\fBbrew\fR \- The Missing Package Manager for macOS
 .
 .SH "SYNOPSIS"
 \fBbrew\fR \fB\-\-version\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- I noticed that another open source project had taken the Homebrew style guide and made it into [Vale linting rules](https://github.com/testthedocs/vale-styles/tree/master/Homebrew). This copies them into here, so that we can make use of them. Thanks!
- What use is a style guide if our own docs don't at least try to adhere to it? This aims to make the rules more visible to all contributors.
- In order for these to do anything, you'll have to `brew install vale` and run `vale` in the root of this repo. It will look for Markdown files.
- A next step would be adding this as a pre-commit hook, or...
- The GitHub Action would have been really good, but [it doesn't support forks](https://github.com/errata-ai/vale-action#limitations).

-----

Current status with `vale .`:

```
✖ 226 errors, 851 warnings and 0 suggestions in 233 files.
```

Current status with `vale docs/`:

```
✖ 15 errors, 89 warnings and 0 suggestions in 45 files.
```

There are probably some false positives, and some legitimate exceptions, but it's worth looking at.