### PR TITLE
cmd/leaves: handle missing formula.

### DIFF
--- a/Library/Homebrew/cmd/leaves.rb
+++ b/Library/Homebrew/cmd/leaves.rb
@@ -22,16 +22,8 @@ module Homebrew
     leaves_args.parse
 
     installed = Formula.installed.sort
-
-    deps_of_installed = installed.flat_map do |f|
-      f.runtime_dependencies.map do |dep|
-        dep.to_formula.full_name
-      rescue FormulaUnavailableError
-        dep.name
-      end
-    end
-
-    leaves = installed.map(&:full_name) - deps_of_installed
+    deps_of_installed = installed.flat_map(&:runtime_formula_dependencies)
+    leaves = installed.map(&:full_name) - deps_of_installed.map(&:full_name)
     leaves.each(&method(:puts))
   end
 end


### PR DESCRIPTION
Use `runtime_formula_dependencies` which does this for us.

Fixes #6827.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----