### PR TITLE
.gitattributes: hide vendored files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Library/Homebrew/vendor/**/* linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@
 
 # Unignore our root-level metadata files.
 !/.editorconfig
+!/.gitattributes
 !/.gitignore
 !/.yardopts
 !/CHANGELOG.md


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR marks `Library/Homebrew/vendor/` as linguist-vendored to make all changes in this directory hidden in GitHub PRs

Ref: https://github.com/github/linguist#generated-code