### PR TITLE
cmd/info: fix --json argument handling.

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -78,7 +78,9 @@ module Homebrew
 
     if args.json
       raise UsageError, "Invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
-      raise UsageError, "This command's option requires a formula argument" if ARGV.named.empty?
+      if !(args.all? || args.installed?) && ARGV.named.blank?
+        raise UsageError, "This command's option requires a formula argument"
+      end
 
       print_json
     elsif args.github?


### PR DESCRIPTION
`--all` and `--installed` do not require formulae arguments.

Fixes https://github.com/Homebrew/brew/issues/6842

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----