### PR TITLE
download_strategy: use (more consistent) TypeError.

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1122,7 +1122,7 @@ class DownloadStrategyDetector
     when :post                   then CurlPostDownloadStrategy
     when :fossil                 then FossilDownloadStrategy
     else
-      raise "Unknown download strategy #{symbol} was requested."
+      raise TypeError, "Unknown download strategy #{symbol} was requested."
     end
   end
 end


### PR DESCRIPTION
Rather than a base `RuntimeError`.

Fixes https://github.com/Homebrew/brew/issues/6839

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----