### PR TITLE
Add python@3.8 handling to virtualenv_install_with_resources

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -153,7 +153,8 @@ module Language
       def virtualenv_install_with_resources(options = {})
         python = options[:using]
         if python.nil?
-          wanted = %w[python python@2 python2 python3 python@3 pypy pypy3].select { |py| needs_python?(py) }
+          pythons = %w[python python@2 python2 python3 python@3 python@3.8 pypy pypy3]
+          wanted = pythons.select { |py| needs_python?(py) }
           raise FormulaAmbiguousPythonError, self if wanted.size > 1
 
           python = wanted.first || "python2.7"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Since we have `python@3.8` formula, we need `virtualenv_install_with_resources` to handle it correctly.
Currently for `python@3.8` it uses `python2.7` which is not what we want.

Another possible solution is explicitly specifying `python3.8` in all formulae during the migration:
```diff
-    virtualenv_install_with_resources
+    virtualenv_install_with_resources using: "python3.8"
```

But I still prefer to change formulae as less as possible.

Ref: https://github.com/Homebrew/homebrew-core/pull/47326