### PR TITLE
uses_from_macos: remove before/after.

### DIFF
--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -3,30 +3,8 @@
 class SoftwareSpec
   undef uses_from_macos
 
-  def uses_from_macos(deps, **args)
+  def uses_from_macos(deps)
     @uses_from_macos_elements ||= []
-
-    if deps.is_a?(Hash)
-      args = deps
-      deps = Hash[*args.shift]
-    end
-
-    if add_mac_dependency?(args)
-      depends_on(deps)
-    else
-      @uses_from_macos_elements << deps
-    end
-  end
-
-  private
-
-  def add_mac_dependency?(args)
-    args.each { |key, version| args[key] = OS::Mac::Version.from_symbol(version) }
-
-    return false if args[:after] && OS::Mac.version >= args[:after]
-
-    return false if args[:before] && OS::Mac.version < args[:before]
-
-    args.present?
+    @uses_from_macos_elements << deps
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2375,8 +2375,8 @@ class Formula
       specs.each { |spec| spec.depends_on(dep) }
     end
 
-    def uses_from_macos(dep, **args)
-      specs.each { |spec| spec.uses_from_macos(dep, args) }
+    def uses_from_macos(dep)
+      specs.each { |spec| spec.uses_from_macos(dep) }
     end
 
     # @!attribute [w] option

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -171,10 +171,8 @@ class SoftwareSpec
     add_dep_option(dep) if dep
   end
 
-  def uses_from_macos(deps, **_args)
-    deps = Hash[*deps.shift] if deps.is_a?(Hash)
-
-    depends_on(deps)
+  def uses_from_macos(spec)
+    depends_on(spec)
   end
 
   def deps

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -19,17 +19,5 @@ describe Formula do
       expect(f.class.devel.deps.first.name).to eq("foo")
       expect(f.class.head.deps.first.name).to eq("foo")
     end
-
-    it "ignores OS version specifications" do
-      f = formula "foo" do
-        url "foo-1.0"
-
-        uses_from_macos("foo", after: :mojave)
-      end
-
-      expect(f.class.stable.deps.first.name).to eq("foo")
-      expect(f.class.devel.deps.first.name).to eq("foo")
-      expect(f.class.head.deps.first.name).to eq("foo")
-    end
   end
 end

--- a/Library/Homebrew/test/os/mac/software_spec_spec.rb
+++ b/Library/Homebrew/test/os/mac/software_spec_spec.rb
@@ -13,54 +13,11 @@ describe SoftwareSpec do
       allow(OS::Mac).to receive(:version).and_return(OS::Mac::Version.new(sierra_os_version))
     end
 
-    it "allows specifying macOS dependencies before a certain version" do
-      spec.uses_from_macos("foo", before: :high_sierra)
-
-      expect(spec.deps).to be_empty
-      expect(spec.uses_from_macos_elements.first).to eq("foo")
-    end
-
-    it "allows specifying macOS dependencies after a certain version" do
-      spec.uses_from_macos("foo", after: :el_capitan)
-
-      expect(spec.deps).to be_empty
-      expect(spec.uses_from_macos_elements.first).to eq("foo")
-    end
-
-    it "doesn't add a macOS dependency if the OS version doesn't meet requirements" do
-      spec.uses_from_macos("foo", after: :high_sierra)
-      spec.uses_from_macos("bar", before: :el_capitan)
-
-      expect(spec.deps.first.name).to eq("foo")
-      expect(spec.uses_from_macos_elements).to be_empty
-    end
-
-    it "works with tags" do
-      spec.uses_from_macos("foo" => :head, :after => :high_sierra)
-
-      dep = spec.deps.first
-
-      expect(dep.name).to eq("foo")
-      expect(dep.tags).to include(:head)
-    end
-
-    it "doesn't add a dependency if no OS version is specified" do
+    it "doesn't add a dependency" do
       spec.uses_from_macos("foo")
-      spec.uses_from_macos("bar" => :head)
+      spec.uses_from_macos("bar" => :build)
 
       expect(spec.deps).to be_empty
-    end
-
-    it "respects OS version requirements with tags" do
-      spec.uses_from_macos("foo" => :head, :before => :mojave)
-
-      expect(spec.deps).to be_empty
-    end
-
-    it "raises an error if passing invalid OS versions" do
-      expect {
-        spec.uses_from_macos("foo", after: "bar", before: :mojave)
-      }.to raise_error(ArgumentError, 'unknown version "bar"')
     end
   end
 end

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -140,19 +140,19 @@ describe SoftwareSpec do
     end
 
     it "works with tags", :needs_linux do
-      subject.uses_from_macos("foo" => :head, :after => :mojave)
+      subject.uses_from_macos("foo" => :build)
 
       expect(subject.deps.first.name).to eq("foo")
-      expect(subject.deps.first.tags).to include(:head)
+      expect(subject.deps.first.tags).to include(:build)
     end
 
     it "ignores OS version specifications", :needs_linux do
-      subject.uses_from_macos("foo", after: :mojave)
-      subject.uses_from_macos("bar" => :head, :after => :mojave)
+      subject.uses_from_macos("foo")
+      subject.uses_from_macos("bar" => :build)
 
       expect(subject.deps.first.name).to eq("foo")
       expect(subject.deps.last.name).to eq("bar")
-      expect(subject.deps.last.tags).to include(:head)
+      expect(subject.deps.last.tags).to include(:build)
     end
   end
 


### PR DESCRIPTION
We're not actually using this anywhere and it makes the code more complicated.

Relatedly, this PR fixes the issue where `uses_from_macos "python@2" => :build` was valid on macOS but not on Linux.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----