### PR TITLE
Remove 'run' from generic binaries list

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -100,7 +100,7 @@ module FormulaCellarChecks
   def check_generic_executables(bin)
     return unless bin.directory?
 
-    generic_names = %w[run service start stop]
+    generic_names = %w[service start stop]
     generics = bin.children.select { |g| generic_names.include? g.basename.to_s }
     return if generics.empty?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There is a new project called [`run`](https://github.com/TekWizely/run) and there does not seem to be any commands with this name already taken.

https://github.com/Homebrew/homebrew-core/pull/48100