### PR TITLE
virtualenv: support mojave and high sierra system Python

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -93,8 +93,13 @@ module Language
       def self.included(base)
         base.class_eval do
           resource "homebrew-virtualenv" do
-            url PYTHON_VIRTUALENV_URL
-            sha256 PYTHON_VIRTUALENV_SHA256
+            if MacOS.version > :mojave
+              url PYTHON_VIRTUALENV_URL
+              sha256 PYTHON_VIRTUALENV_SHA256
+            else
+              url PYTHON_VIRTUALENV_URL_MOJAVE
+              sha256 PYTHON_VIRTUALENV_SHA256_MOJAVE
+            end
           end
         end
       end

--- a/Library/Homebrew/language/python_virtualenv_constants.rb
+++ b/Library/Homebrew/language/python_virtualenv_constants.rb
@@ -6,3 +6,10 @@ PYTHON_VIRTUALENV_URL =
   "/virtualenv-16.7.4.tar.gz"
 PYTHON_VIRTUALENV_SHA256 =
   "94a6898293d07f84a98add34c4df900f8ec64a570292279f6d91c781d37fd305"
+
+PYTHON_VIRTUALENV_URL_MOJAVE =
+  "https://files.pythonhosted.org/packages/b1/72" \
+  "/2d70c5a1de409ceb3a27ff2ec007ecdd5cc52239e7c74990e32af57affe9" \
+  "/virtualenv-15.2.0.tar.gz"
+PYTHON_VIRTUALENV_SHA256_MOJAVE =
+  "1d7e241b431e7afce47e77f8843a276f652699d1fa4f93b9d8ce0076fd7b0b54"


### PR DESCRIPTION
On High Sierra and Mojave, virtualenv 16.x does not build when used with
system Python
Fall back to an older virtualenv version, which is known to work.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
