### PR TITLE
audit: add "homebrew/core" for relevant checks

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -219,7 +219,7 @@ module Homebrew
       @except = options[:except]
       # Accept precomputed style offense results, for efficiency
       @style_offenses = options[:style_offenses]
-      # Allow the formula tap to be set as `core`, for testing purposes
+      # Allow the formula tap to be set as homebrew/core, for testing purposes
       @core_tap = formula.tap&.core_tap? || options[:core_tap]
       @problems = []
       @new_formula_problems = []
@@ -335,15 +335,15 @@ module Homebrew
 
       name = formula.name
 
-      problem "'#{name}' is blacklisted." if MissingFormula.blacklisted_reason(name)
+      problem "'#{name}' is blacklisted from homebrew/core." if MissingFormula.blacklisted_reason(name)
 
       if Formula.aliases.include? name
-        problem "Formula name conflicts with existing aliases."
+        problem "Formula name conflicts with existing aliases in homebrew/core."
         return
       end
 
       if oldname = CoreTap.instance.formula_renames[name]
-        problem "'#{name}' is reserved as the old name of #{oldname}"
+        problem "'#{name}' is reserved as the old name of #{oldname} in homebrew/core."
         return
       end
 
@@ -380,7 +380,8 @@ module Homebrew
 
           if self.class.aliases.include?(dep.name) &&
              (dep_f.core_formula? || !dep_f.versioned_formula?)
-            problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
+            problem "Dependency '#{dep.name}' from homebrew/core is an alias; " \
+            "use the canonical name '#{dep.to_formula.full_name}'."
           end
 
           if @new_formula &&
@@ -414,14 +415,14 @@ module Homebrew
           next unless @core_tap
 
           if dep.tags.include?(:recommended) || dep.tags.include?(:optional)
-            problem "Formulae should not have optional or recommended dependencies"
+            problem "Formulae in homebrew/core should not have optional or recommended dependencies"
           end
         end
 
         next unless @core_tap
 
         if spec.requirements.map(&:recommended?).any? || spec.requirements.map(&:optional?).any?
-          problem "Formulae should not have optional or recommended requirements"
+          problem "Formulae in homebrew/core should not have optional or recommended requirements"
         end
       end
     end
@@ -485,7 +486,7 @@ module Homebrew
       begin
         Formula[previous_formula_name]
       rescue FormulaUnavailableError
-        problem "Versioned #{previous_formula_name} must be created for " \
+        problem "Versioned #{previous_formula_name} in homebrew/core must be created for " \
                 "`brew-postgresql-upgrade-database` and `pg_upgrade` to work."
       end
     end
@@ -513,7 +514,7 @@ module Homebrew
 
       return if keg_only_whitelist.include?(formula.name) || formula.name.start_with?("gcc@")
 
-      problem "Versioned formulae should use `keg_only :versioned_formula`"
+      problem "Versioned formulae in homebrew/core should use `keg_only :versioned_formula`"
     end
 
     def audit_homepage
@@ -542,7 +543,7 @@ module Homebrew
 
       return unless formula.bottle_defined?
 
-      new_formula_problem "New formulae should not have a `bottle do` block"
+      new_formula_problem "New formulae in homebrew/core should not have a `bottle do` block"
     end
 
     def audit_bottle_disabled
@@ -553,7 +554,7 @@ module Homebrew
 
       return unless @core_tap
 
-      problem "Formulae should not use `bottle :disabled`"
+      problem "Formulae in homebrew/core should not use `bottle :disabled`"
     end
 
     def audit_github_repository
@@ -698,7 +699,7 @@ module Homebrew
 
       return unless @core_tap
 
-      problem "Formulae should not have a `devel` spec" if formula.devel
+      problem "Formulae in homebrew/core should not have a `devel` spec" if formula.devel
 
       if formula.head && @versioned_formula
         head_spec_message = "Formulae should not have a `HEAD` spec"
@@ -951,7 +952,7 @@ module Homebrew
 
       return unless @core_tap
 
-      problem "`env :std` in `core` formulae is deprecated" if line.include?("env :std")
+      problem "`env :std` in homebrew/core formulae is deprecated" if line.include?("env :std")
     end
 
     def audit_reverse_migration

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -163,7 +163,8 @@ module RuboCop
           return unless formula_tap == "homebrew-core"
 
           find_method_with_args(body_node, :depends_on, "mpich") do
-            problem "Use 'depends_on \"open-mpi\"' instead of '#{@offensive_node.source}'."
+            problem "Formulae in homebrew/core should use 'depends_on \"open-mpi\"' " \
+            "instead of '#{@offensive_node.source}'."
           end
         end
 
@@ -201,7 +202,7 @@ module RuboCop
             next if formula_tap != "homebrew-core" || file_path&.include?("linuxbrew")
 
             find_instance_method_call(body_node, "OS", method_name) do |check|
-              problem "Don't use #{check.source}; Homebrew/core only supports macOS"
+              problem "Don't use #{check.source}; homebrew/core only supports macOS"
             end
           end
 

--- a/Library/Homebrew/rubocops/options.rb
+++ b/Library/Homebrew/rubocops/options.rb
@@ -10,8 +10,8 @@ module RuboCop
         DEPRECATION_MSG = "macOS has been 64-bit only since 10.6 so 32-bit options are deprecated."
         UNI_DEPRECATION_MSG = "macOS has been 64-bit only since 10.6 so universal options are deprecated."
 
-        DEP_OPTION = "Formulae should not use `deprecated_option`"
-        OPTION = "Formulae should not have an `option`"
+        DEP_OPTION = "Formulae in homebrew/core should not use `deprecated_option`."
+        OPTION = "Formulae in homebrew/core should not use `option`."
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           option_call_nodes = find_every_method_call_by_name(body_node, :option)

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -17,7 +17,7 @@ module RuboCop
           end
 
           if formula_tap == "homebrew-core" && (depends_on?("veclibfort") || depends_on?("lapack"))
-            problem "Formulae should use OpenBLAS as the default serial linear algebra library."
+            problem "Formulae in homebrew/core should use OpenBLAS as the default serial linear algebra library."
           end
 
           if method_called_ever?(body_node, :virtualenv_create) ||

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -234,8 +234,8 @@ module RuboCop
             next if BINARY_FORMULA_URLS_WHITELIST.include?(@formula_name)
             next if BINARY_URLS_WHITELIST.include?(url)
 
-            problem "#{url} looks like a binary package, not a source archive. " \
-                    "Homebrew/homebrew-core is source-only."
+            problem "#{url} looks like a binary package, not a source archive; " \
+                    "homebrew/core is source-only."
           end
         end
       end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -569,7 +569,7 @@ module Homebrew
         fa.audit_versioned_keg_only
 
         expect(fa.problems.first)
-          .to match("Versioned formulae should use `keg_only :versioned_formula`")
+          .to match("Versioned formulae in homebrew/core should use `keg_only :versioned_formula`")
       end
 
       specify "it warns when a versioned formula has an incorrect `keg_only` reason" do
@@ -584,7 +584,7 @@ module Homebrew
         fa.audit_versioned_keg_only
 
         expect(fa.problems.first)
-          .to match("Versioned formulae should use `keg_only :versioned_formula`")
+          .to match("Versioned formulae in homebrew/core should use `keg_only :versioned_formula`")
       end
 
       specify "it does not warn when a versioned formula has `keg_only :versioned_formula`" do

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -289,7 +289,7 @@ describe RuboCop::Cop::FormulaAudit::MpiCheck do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on "mpich"
-          ^^^^^^^^^^^^^^^^^^ Use 'depends_on "open-mpi"' instead of 'depends_on "mpich"'.
+          ^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should use 'depends_on "open-mpi"' instead of 'depends_on "mpich"'.
         end
       RUBY
 
@@ -353,7 +353,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           url 'https://brew.sh/foo-1.0.tgz'
           bottle do
             if OS.linux?
-               ^^^^^^^^^ Don\'t use OS.linux?; Homebrew/core only supports macOS
+               ^^^^^^^^^ Don\'t use OS.linux?; homebrew/core only supports macOS
               nil
             end
             sha256 "fe0679b932dd43a87fd415b609a7fbac7a069d117642ae8ebaac46ae1fb9f0b3" => :sierra

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -52,7 +52,7 @@ describe RuboCop::Cop::FormulaAudit::Options do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           deprecated_option "examples" => "with-examples"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae should not use `deprecated_option`
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not use `deprecated_option`.
         end
       RUBY
     end
@@ -62,7 +62,7 @@ describe RuboCop::Cop::FormulaAudit::Options do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           option "with-examples"
-          ^^^^^^^^^^^^^^^^^^^^^^ Formulae should not have an `option`
+          ^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not use `option`.
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
           url "https://brew.sh/foo-1.0.tgz"
           homepage "https://brew.sh"
           depends_on "veclibfort"
-          ^^^^^^^^^^^^^^^^^^^^^^^ Formulae should use OpenBLAS as the default serial linear algebra library.
+          ^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should use OpenBLAS as the default serial linear algebra library.
         end
       RUBY
     end
@@ -49,7 +49,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
           url "https://brew.sh/foo-1.0.tgz"
           homepage "https://brew.sh"
           depends_on "lapack"
-          ^^^^^^^^^^^^^^^^^^^ Formulae should use OpenBLAS as the default serial linear algebra library.
+          ^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should use OpenBLAS as the default serial linear algebra library.
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -145,13 +145,13 @@ describe RuboCop::Cop::FormulaAudit::Urls do
     }, {
       "url"         => "https://brew.sh/example-darwin.x86_64.tar.gz",
       "msg"         => "https://brew.sh/example-darwin.x86_64.tar.gz looks like a binary package, " \
-                       "not a source archive. Homebrew/homebrew-core is source-only.",
+                       "not a source archive; homebrew/core is source-only.",
       "col"         => 2,
       "formula_tap" => "homebrew-core",
     }, {
       "url"         => "https://brew.sh/example-darwin.amd64.tar.gz",
       "msg"         => "https://brew.sh/example-darwin.amd64.tar.gz looks like a binary package, " \
-                       "not a source archive. Homebrew/homebrew-core is source-only.",
+                       "not a source archive; homebrew/core is source-only.",
       "col"         => 2,
       "formula_tap" => "homebrew-core",
     }]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This should help contributors and maintainers of third-party taps to more clearly see which audits are specific to Homebrew-core. This will also be a prelude to including more core checks by default.