### PR TITLE
audit: add new homebrew/core audits

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -64,6 +64,15 @@ module RuboCop
 
             problem "Commented-out dependency #{Regexp.last_match(1)}"
           end
+
+          return if formula_tap != "homebrew-core"
+
+          # Citation and tag comments from third-party taps
+          audit_comments do |comment|
+            next if comment !~ /#\s*(cite(?=\s*\w+:)|doi(?=\s*['"])|tag(?=\s*['"]))/
+
+            problem "Formulae in homebrew/core should not use `#{Regexp.last_match(1)}` comments"
+          end
         end
       end
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -148,6 +148,16 @@ module RuboCop
 
             problem "Reference '#{match[1]}' without dashes"
           end
+
+          return if formula_tap != "homebrew-core"
+
+          # Use of build.with? implies options, which are forbidden in homebrew/core
+          find_instance_method_call(body_node, :build, :without?) do
+            problem "Formulae in homebrew/core should not use `build.without?`."
+          end
+          find_instance_method_call(body_node, :build, :with?) do
+            problem "Formulae in homebrew/core should not use `build.with?`."
+          end
         end
 
         def unless_modifier?(node)

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -419,6 +419,21 @@ module RuboCop
 
             problem "Use the `#{match}` Ruby method instead of `#{method.source}`"
           end
+
+          return if formula_tap != "homebrew-core"
+
+          # Avoid build-time checks in homebrew/core
+          find_every_method_call_by_name(body_node, :system).each do |method|
+            params = parameters(method)
+            next unless node_equals?(params[0], "make")
+
+            params[1..].each do |arg|
+              next unless regex_match_group(arg, /^(checks?|tests?)$/)
+
+              offending_node(method)
+              problem "Formulae in homebrew/core should not run build-time checks"
+            end
+          end
         end
 
         def modifier?(node)

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -349,6 +349,17 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
   subject(:cop) { described_class.new }
 
   context "When auditing formula" do
+    it "build-time checks in homebrew/core" do
+      expect_offense(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+          system "make", "-j1", "test"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not run build-time checks
+        end
+      RUBY
+    end
+
     it "FileUtils usage" do
       expect_offense(<<~RUBY)
         class Foo < Formula

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -160,6 +160,32 @@ end
 describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
   subject(:cop) { described_class.new }
 
+  it "build.without? in homebrew/core" do
+    expect_offense(<<~RUBY, "/homebrew-core/")
+      class Foo < Formula
+        desc "foo"
+        url 'https://brew.sh/foo-1.0.tgz'
+        def install
+          build.without? "bar"
+          ^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not use `build.without?`.
+        end
+      end
+    RUBY
+  end
+
+  it "build.with? in homebrew/core" do
+    expect_offense(<<~RUBY, "/homebrew-core/")
+      class Foo < Formula
+        desc "foo"
+        url 'https://brew.sh/foo-1.0.tgz'
+        def install
+          build.with? "bar"
+          ^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not use `build.with?`.
+        end
+      end
+    RUBY
+  end
+
   it "unless build.without? conditional" do
     expect_offense(<<~RUBY)
       class Foo < Formula

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -106,6 +106,21 @@ describe RuboCop::Cop::FormulaAudit::Comments do
         end
       RUBY
     end
+
+    it "citation tags" do
+      expect_offense(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+          # cite Howell_2009:
+          ^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not use `cite` comments
+          # doi "10.111/222.x"
+          ^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not use `doi` comments
+          # tag "software"
+          ^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not use `tag` comments
+        end
+      RUBY
+    end
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

These homebrew/core audits check for:

* `make check`
* `# tag "xxx"` comments from external taps
* `build.with?` implying the presence of options