### PR TITLE
formula_creator: update go build args

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -137,7 +137,7 @@ module Homebrew
                                   "--disable-silent-rules",
                                   "--prefix=\#{prefix}"
         <% elsif mode == :go %>
-            system "go", "build", "-o", "\#{bin}/\#{name}"
+            system "go", "build", *std_go_args
         <% elsif mode == :meson %>
             mkdir "build" do
               system "meson", "--prefix=\#{prefix}", ".."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We started using `"-ldflags", "-s -w", "-trimpath"` arguments passed to `go build` and it would be nice to have them added to new formulae too by `brew create --go`.