### PR TITLE
audit: add uses_from_macos dependency ordering

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -32,6 +32,7 @@ module RuboCop
             [{ name: :option,   type: :method_call }],
             [{ name: :deprecated_option, type: :method_call }],
             [{ name: :depends_on, type: :method_call }],
+            [{ name: :uses_from_macos, type: :method_call }],
             [{ name: :conflicts_with, type: :method_call }],
             [{ name: :skip_clean, type: :method_call }],
             [{ name: :cxxstdlib_check, type: :method_call }],

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -6,6 +6,19 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
   subject(:cop) { described_class.new }
 
   context "When auditing formula components order" do
+    it "When uses_from_macos precedes depends_on" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+
+          uses_from_macos "apple"
+          depends_on "foo"
+          ^^^^^^^^^^^^^^^^ `depends_on` (line 6) should be put before `uses_from_macos` (line 5)
+        end
+      RUBY
+    end
+
     it "When url precedes homepage" do
       expect_offense(<<~RUBY)
         class Foo < Formula

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -5,6 +5,75 @@ require "rubocops/dependency_order"
 describe RuboCop::Cop::FormulaAudit::DependencyOrder do
   subject(:cop) { described_class.new }
 
+  context "uses_from_macos" do
+    it "wrong conditional uses_from_macos order" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          uses_from_macos "apple" if build.with? "foo"
+          uses_from_macos "foo" => :optional
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency "foo" (line 5) should be put before dependency "apple" (line 4)
+        end
+      RUBY
+    end
+
+    it "wrong alphabetical uses_from_macos order" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          uses_from_macos "foo"
+          uses_from_macos "bar"
+          ^^^^^^^^^^^^^^^^^^^^^ dependency "bar" (line 5) should be put before dependency "foo" (line 4)
+        end
+      RUBY
+    end
+
+    it "supports requirement constants" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          uses_from_macos FooRequirement
+          uses_from_macos "bar"
+          ^^^^^^^^^^^^^^^^^^^^^ dependency "bar" (line 5) should be put before dependency "FooRequirement" (line 4)
+        end
+      RUBY
+    end
+
+    it "wrong conditional uses_from_macos order with block" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          head do
+            uses_from_macos "apple" if build.with? "foo"
+            uses_from_macos "bar"
+            ^^^^^^^^^^^^^^^^^^^^^ dependency "bar" (line 6) should be put before dependency "apple" (line 5)
+            uses_from_macos "foo" => :optional
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency "foo" (line 7) should be put before dependency "apple" (line 5)
+          end
+          uses_from_macos "apple" if build.with? "foo"
+          uses_from_macos "foo" => :optional
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency "foo" (line 10) should be put before dependency "apple" (line 9)
+        end
+      RUBY
+    end
+
+    it "correct uses_from_macos order for multiple tags" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          uses_from_macos "bar" => [:build, :test]
+          uses_from_macos "foo" => :build
+          uses_from_macos "apple"
+        end
+      RUBY
+    end
+  end
+
   context "depends_on" do
     it "wrong conditional depends_on order" do
       expect_offense(<<~RUBY)
@@ -75,6 +144,29 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
   end
 
   context "autocorrect" do
+    it "wrong conditional uses_from_macos order" do
+      source = <<~RUBY
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          uses_from_macos "apple" if build.with? "foo"
+          uses_from_macos "foo" => :optional
+        end
+      RUBY
+
+      correct_source = <<~RUBY
+        class Foo < Formula
+          homepage "https://brew.sh"
+          url "https://brew.sh/foo-1.0.tgz"
+          uses_from_macos "foo" => :optional
+          uses_from_macos "apple" if build.with? "foo"
+        end
+      RUBY
+
+      corrected_source = autocorrect_source(source)
+      expect(corrected_source).to eq(correct_source)
+    end
+
     it "wrong conditional depends_on order" do
       source = <<~RUBY
         class Foo < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Brings `uses_from_macos` into the `brew audit` fold by checking that it

1. comes after any `depends_on` statements
2. is ordered like `depends_on` statements