### PR TITLE
Improve handling of *_GIT_REMOTE env vars

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -30,6 +30,10 @@ git_init_if_necessary() {
     trap '{ rm -rf .git; exit 1; }' EXIT
     git init
     git config --bool core.autocrlf false
+    if [[ "$HOMEBREW_DEFAULT_BREW_GIT_REMOTE" != "$HOMEBREW_BREW_GIT_REMOTE" ]]
+    then
+      echo "HOMEBREW_BREW_GIT_REMOTE set: using $HOMEBREW_BREW_GIT_REMOTE for Homebrew/brew Git remote URL."
+    fi
     git config remote.origin.url "$HOMEBREW_BREW_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     latest_tag="$(git ls-remote --tags --refs -q origin | tail -n1 | cut -f2)"
@@ -48,6 +52,10 @@ git_init_if_necessary() {
     trap '{ rm -rf .git; exit 1; }' EXIT
     git init
     git config --bool core.autocrlf false
+    if [[ "$HOMEBREW_DEFAULT_CORE_GIT_REMOTE" != "$HOMEBREW_CORE_GIT_REMOTE" ]]
+    then
+      echo "HOMEBREW_CORE_GIT_REMOTE set: using $HOMEBREW_CORE_GIT_REMOTE for Homebrew/core Git remote URL."
+    fi
     git config remote.origin.url "$HOMEBREW_CORE_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     git fetch --force --depth=1 origin refs/heads/master:refs/remotes/origin/master
@@ -397,6 +405,7 @@ EOS
   if [[ "$HOMEBREW_DEFAULT_BREW_GIT_REMOTE" != "$HOMEBREW_BREW_GIT_REMOTE" ]]
   then
     safe_cd "$HOMEBREW_REPOSITORY"
+    echo "HOMEBREW_BREW_GIT_REMOTE set: using $HOMEBREW_BREW_GIT_REMOTE for Homebrew/brew Git remote."
     git remote set-url origin "$HOMEBREW_BREW_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     latest_tag="$(git ls-remote --tags --refs -q origin | tail -n1 | cut -f2)"
@@ -407,6 +416,7 @@ EOS
      [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]]
   then
     safe_cd "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core"
+    echo "HOMEBREW_CORE_GIT_REMOTE set: using $HOMEBREW_CORE_GIT_REMOTE for Homebrew/brew Git remote."
     git remote set-url origin "$HOMEBREW_CORE_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     git fetch --force --depth=1 origin refs/heads/master:refs/remotes/origin/master

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -648,6 +648,15 @@ class CoreTap < Tap
     safe_system HOMEBREW_BREW_FILE, "tap", instance.name
   end
 
+  def install(options = {})
+    if HOMEBREW_CORE_GIT_REMOTE != default_remote
+      puts "HOMEBREW_CORE_GIT_REMOTE set: using #{HOMEBREW_CORE_GIT_REMOTE} " \
+           "for Homebrew/core Git remote URL."
+      options[:clone_target] ||= HOMEBREW_CORE_GIT_REMOTE
+    end
+    super(options)
+  end
+
   # @private
   def uninstall
     raise "Tap#uninstall is not available for CoreTap"


### PR DESCRIPTION
- Output a message whenever a non-default remote is set.
- Ensure that `CoreTap.instance.install` uses the right remote.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----