### PR TITLE
cmd/gist-logs: Fix bug with parsing of command-line arguments

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -33,8 +33,6 @@ module Homebrew
   end
 
   def gistify_logs(f)
-    gist_logs_args.parse
-
     files = load_logs(f.logs)
     build_time = f.logs.ctime
     timestamp = build_time.strftime("%Y-%m-%d_%H-%M-%S")
@@ -142,6 +140,8 @@ module Homebrew
   end
 
   def gist_logs
+    gist_logs_args.parse
+
     raise FormulaUnspecifiedError if Homebrew.args.resolved_formulae.length != 1
 
     Install.perform_preinstall_checks(all_fatal: true)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- A user reported the following error when running `brew gist-logs`, reproducible with any formula:

```
$ brew gist-logs rustup-init
Error: undefined method `length' for nil:NilClass
Please report this bug:
  https://docs.brew.sh/Troubleshooting
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/gist-logs.rb:145:in `gist_logs'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:102:in
```

- From what I can tell, `gist_logs_args.parse` had ended up in the wrong method. The `gistify_logs` method already has `formula` (ie the formula name) passed into it. But it's the `gist_logs` method that needs to do the argument parsing. This was discovered by looking at some other recently changed ARGV => Homebrew.args code like cmd/info for inspiration.

- Fixes #6933.