### PR TITLE
Catalina upgrades causes Homebrew to break when you run brew cleanup.…

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -362,10 +362,9 @@ module Homebrew
 
       bundler_path = vendor_path/"bundle/ruby"
       if dry_run?
-        puts "Would remove: #{bundler_path} (#{bundler_path.abv})"
-        puts "Would remove: #{portable_ruby_path} (#{portable_ruby_path.abv})"
+        puts "Would remove:\n#{Utils.popen_read("git", "clean", "-xnf", bundler_path)}"
       else
-        FileUtils.rm_rf [bundler_path, portable_ruby_path]
+        safe_system "git", "clean", "-xf", bundler_path
       end
     end
 


### PR DESCRIPTION
Catalina has Ruby 2.6 installed, so the portable Ruby version is not needed.

If you have `/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby` (which exists for older OS X versions), then the cleanup tool will nuke everything in `/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby`. 

```
Traceback (most recent call last):
	4: from /usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `<main>'
	3: from /usr/local/Homebrew/Library/Homebrew/brew.rb:23:in `require_relative'
	2: from /usr/local/Homebrew/Library/Homebrew/global.rb:13:in `<top (required)>'
	1: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- active_support/core_ext/object/blank (LoadError)
```

You will need to brew update-reset to get back the old packages.

Trying to get feedback on why we're nuking vendor_path code.  Can we get rid of it?

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
