### PR TITLE
add stack as an alternate install method for haskell packages

### DIFF
--- a/Library/Homebrew/language/haskell.rb
+++ b/Library/Homebrew/language/haskell.rb
@@ -92,5 +92,27 @@ module Language
         end
       end
     end
+    module Stack
+      # run stack install, using the current latest LTS snapshot on stackage.org
+      def stack_install(*args)
+        system "stack", "install", "--resolver=lts", *args
+      end
+
+      # install tools, sequentially as some tools can depend on other tools
+      def stack_install_tools(*tools)
+        tools.each { |tool| stack_install tool }
+      end
+
+      def install_stack_package(*args, **options)
+        stack_install_tools(*options[:using]) if options[:using]
+
+        flags = "--flags=#{options[:flags].join(" ")}" if options[:flags]
+        args_and_flags = args
+        args_and_flags << flags unless flags.nil?
+        stack_install "--prefix=#{prefix}", *args_and_flags
+
+        yield if block_given?
+      end
+    end
   end
 end


### PR DESCRIPTION
cabal sometimes picks old, possibly incompatible versions of
dependencies. stack pulls dependencies from a known-compatible set of
recent packages when possible, giving more reliable builds.
Debian and other distro packagers use it for this reason.
Cf https://github.com/Homebrew/homebrew-core/pull/49010

This commit just adds Language::Haskell::Stack as an alternate
install method, which can be selected by individual packages.