### PR TITLE
bump-formula-pr: delete linux sha256 line if required

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -256,6 +256,16 @@ module Homebrew
       ]
     end
 
+    # When bumping a linux-only formula,
+    # one needs to also delete the sha256 linux bottle line.
+    # That's because of running test-bot with --keep-old option in linuxbrew-core.
+    if formula.path.read.include?('# tag "linux"')
+      replacement_pairs << [
+        /^    sha256 ".+" => :x86_64_linux\n/m,
+        "\\2",
+      ]
+    end
+
     if forced_version && forced_version != "0"
       if requested_spec == :stable
         if File.read(formula.path).include?("version \"#{old_formula_version}\"")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

At `linuxbrew-core`, we are using `--keep-old` option passed to `brew test-bot`. When `brew bump-formula-pr`ing a linux-only formula, we need to also delete the `:x86_64_linux` sha256 line in the formula file manually. With this PR, we don't have to do this by hand anymore.

Tested [here](https://github.com/Homebrew/linuxbrew-core/pull/19048) and [here](https://github.com/Homebrew/linuxbrew-core/pull/19049) for example.

cc @issyl0 @iMichka 