### PR TITLE
bump-formula-pr: Remove Linux bottle line on Linux-only formulae bumps

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -311,6 +311,12 @@ module Homebrew
       EOS
     end
 
+    formula_file = File.read(formula.path)
+    if formula_file.match?("# tag \"linux\"") && formula_file.match?(/:x86_64_linux/)
+      ohai "Removing Linux bottle line..." if args.dry_run?
+      safe_system "sed -i '/\:x86_64_linux$/d' #{formula.path}"
+    end
+
     alias_rename = alias_update_pair(formula, new_formula_version)
     if alias_rename.present?
       ohai "renaming alias #{alias_rename.first} to #{alias_rename.last}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Over in Homebrew/linuxbrew-core, whenever we bump Linux-only formulae, we have to manually delete the Linux bottle line otherwise CI fails. This is a [documented limitation](https://docs.brew.sh/Homebrew-linuxbrew-core-Maintainer-Guide#linux-only-formulae).
- This makes `brew bump-formula-pr` handle deleting the Linux bottle line for Linux-only formulae, if one exists.
- This assumes that to bump a Linux-only formula you have to be running Linux, as it uses GNU sed syntax as `sed` not `gsed`.