### PR TITLE
doctor: remove DYLD checks

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -474,28 +474,6 @@ module Homebrew
         EOS
       end
 
-      def check_ld_vars
-        ld_vars = ENV.keys.grep(/^(|DY)LD_/)
-        return if ld_vars.empty?
-
-        values = ld_vars.map { |var| "#{var}: #{ENV.fetch(var)}" }
-        message = inject_file_list values, <<~EOS
-          Setting DYLD_* or LD_* variables can break dynamic linking.
-          Set variables:
-        EOS
-
-        if ld_vars.include? "DYLD_INSERT_LIBRARIES"
-          message += <<~EOS
-
-            Setting DYLD_INSERT_LIBRARIES can cause Go builds to fail.
-            Having this set is common if you use this software:
-              #{Formatter.url("https://asepsis.binaryage.com/")}
-          EOS
-        end
-
-        message
-      end
-
       def check_for_symlinked_cellar
         return unless HOMEBREW_CELLAR.exist?
         return unless HOMEBREW_CELLAR.symlink?

--- a/Library/Homebrew/test/diagnostic_checks_spec.rb
+++ b/Library/Homebrew/test/diagnostic_checks_spec.rb
@@ -113,26 +113,6 @@ describe Homebrew::Diagnostic::Checks do
     HOMEBREW_CELLAR.mkpath
   end
 
-  specify "#check_ld_vars catches LD vars" do
-    ENV["LD_LIBRARY_PATH"] = "foo"
-    expect(subject.check_ld_vars).to match("Setting DYLD_\\* or LD_\\* variables")
-  end
-
-  specify "#check_ld_vars catches DYLD vars" do
-    ENV["DYLD_LIBRARY_PATH"] = "foo"
-    expect(subject.check_ld_vars).to match("Setting DYLD_\\* or LD_\\* variables")
-  end
-
-  specify "#check_ld_vars catches LD and DYLD vars" do
-    ENV["LD_LIBRARY_PATH"] = "foo"
-    ENV["DYLD_LIBRARY_PATH"] = "foo"
-    expect(subject.check_ld_vars).to match("Setting DYLD_\\* or LD_\\* variables")
-  end
-
-  specify "#check_ld_vars returns success when neither LD nor DYLD vars are set" do
-    expect(subject.check_ld_vars).to be nil
-  end
-
   specify "#check_tmpdir" do
     ENV["TMPDIR"] = "/i/don/t/exis/t"
     expect(subject.check_tmpdir).to match("doesn't exist")

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -28,9 +28,4 @@ describe Homebrew::Diagnostic::Checks do
     expect(subject.check_ruby_version)
       .to match "Ruby version 1.8.6 is unsupported on 10.12"
   end
-
-  specify "#check_dyld_insert" do
-    ENV["DYLD_INSERT_LIBRARIES"] = "foo"
-    expect(subject.check_ld_vars).to match("Setting DYLD_INSERT_LIBRARIES")
-  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Per #6961, `check_ld_vars` no longer works because of SIP and [intentional](https://github.com/Homebrew/brew/issues/6961#issuecomment-578437609) envvar whitelisting. Rather than keep this check around, it'd be better to remove it to prevent future confusion over its veracity.

Alternatively, we could pass in prefixed versions of the DYLD envvars for `brew doctor` to check against, though I'm not sure how to work around SIP stripping the envvars in the first place.