### PR TITLE
Dockerfile: install 'netbase' apt package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
 		libz-dev \
 		locales \
 		make \
+		netbase \
 		openssh-client \
 		patch \
 		sudo \


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This package is providing files, that are needed by some formulae on Linux ([`haskell-stack`](https://github.com/Homebrew/linuxbrew-core/pull/19236) or [`elm`](https://github.com/Homebrew/linuxbrew-core/pull/9028) for example).

`build-essential` apt package has `netbase` in its dependency tree, as a recommended package.

See also: https://github.com/commercialhaskell/stack/issues/4124