### PR TITLE
rubocop/lines: add whitelist.

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -424,6 +424,25 @@ module RuboCop
 
           # Avoid build-time checks in homebrew/core
           find_every_method_call_by_name(body_node, :system).each do |method|
+            next if @formula_name.start_with?("lib")
+            next if %w[
+              beecrypt
+              ccrypt
+              git
+              gmp
+              gnupg
+              gnupg@1.4
+              google-sparsehash
+              jemalloc
+              jpeg-turbo
+              mpfr
+              open-mpi
+              openssl@1.1
+              pcre
+              wolfssl
+              xz
+            ].include?(@formula_name)
+
             params = parameters(method)
             next unless node_equals?(params[0], "make")
 
@@ -431,7 +450,8 @@ module RuboCop
               next unless regex_match_group(arg, /^(checks?|tests?)$/)
 
               offending_node(method)
-              problem "Formulae in homebrew/core should not run build-time checks"
+              problem "Formulae in homebrew/core (except e.g. cryptography, libraries) " \
+                      "should not run build-time checks"
             end
           end
         end

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -355,7 +355,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           system "make", "-j1", "test"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should not run build-time checks
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
         end
       RUBY
     end


### PR DESCRIPTION
Follow-up from https://github.com/Homebrew/brew/pull/6916 CC @jonchang @fxcoudert for what should/shouldn't be in the whitelist.

Let's only allow cryto or libraries.

Current failures (before this change):

```
Formula/aqbanking.rb:39:    system "make", "check"
Formula/arabica.rb:30:    system "make", "check"
Formula/argon2.rb:19:    system "make", "test"
Formula/bdw-gc.rb:33:    system "make", "check"
Formula/beecrypt.rb:32:    system "make", "check"
Formula/bgpdump.rb:24:    system "make", "check"
Formula/caf.rb:24:    system "make", "--directory=build", "test"
Formula/ccrypt.rb:23:    system "make", "check"
Formula/chapel.rb:42:      system "make", "check"
Formula/clisp.rb:51:      system "make", "check"
Formula/cln.rb:20:    system "make", "check"
Formula/cmark-gfm.rb:25:      system "make", "test"
Formula/cmark.rb:22:      system "make", "test"
Formula/confuse.rb:21:    system "make", "check"
Formula/cppi.rb:24:    system "make", "check"
Formula/dcadec.rb:27:    system "make", "check"
Formula/deja-gnu.rb:30:    system "make", "check"
Formula/dfix.rb:21:    system "make", "test"
Formula/direvent.rb:21:    system "make", "check"
Formula/djbdns.rb:36:    system "make", "setup", "check"
Formula/epic5.rb:27:    system "make", "test"
Formula/freexl.rb:24:    system "make", "check"
Formula/gauche.rb:17:    system "make", "check"
Formula/gawk.rb:27:    system "make", "check"
Formula/geoip.rb:27:    system "make", "check"
Formula/ghc@8.2.rb:55:      system "make", "check"
Formula/ghc@8.6.rb:50:      system "make", "check"
Formula/git-number.rb:17:    system "make", "test"
Formula/git.rb:112:      system "make", "test"
Formula/gmp.rb:28:    system "make", "check"
Formula/gnupg-pkcs11-scd.rb:33:    system "make", "check"
Formula/gnupg.rb:36:    system "make", "check"
Formula/gnupg@1.4.rb:31:    system "make", "check"
Formula/google-sparsehash.rb:21:    system "make", "check"
Formula/gpp.rb:21:    system "make", "check"
Formula/hunspell.rb:31:    system "make", "check"
Formula/ipmitool.rb:47:    system "make", "check"
Formula/isl.rb:38:    system "make", "check"
Formula/iso-codes.rb:21:    system "make", "check"
Formula/ivykis.rb:24:    system "make", "check"
Formula/jasper.rb:25:      system "make", "test"
Formula/jemalloc.rb:38:    system "make", "check"
Formula/jose.rb:25:    system "make", "check"
Formula/jpeg-turbo.rb:22:    system "make", "test"
Formula/knot.rb:45:    system "make", "check"
Formula/lastpass-cli.rb:32:      system "make", "all", "lpass-test", "test", "install", "install-doc"
Formula/libatomic_ops.rb:18:    system "make", "check"
Formula/libcello.rb:18:    system "make", "check"
Formula/libdap.rb:39:    system "make", "check"
Formula/libdsk.rb:23:    system "make", "check"
Formula/libgcrypt.rb:43:    system "make", "check"
Formula/libkate.rb:30:    system "make", "check"
Formula/liblcf.rb:28:    system "make", "check"
Formula/liblouis.rb:38:    system "make", "check"
Formula/libmaxminddb.rb:29:    system "make", "check"
Formula/libmill.rb:24:    system "make", "all", "check", "install"
Formula/libmpc.rb:29:    system "make", "check"
Formula/libpng.rb:29:    system "make", "test"
Formula/libressl.rb:38:    system "make", "check"
Formula/libscrypt.rb:20:    system "make", "check", "LDFLAGS=", "CFLAGS_EXTRA="
Formula/libsigc++.rb:20:    system "make", "check"
Formula/libsigc++@2.rb:19:    system "make", "check"
Formula/libsigsegv.rb:22:    system "make", "check"
Formula/libsodium.rb:27:    system "make", "check"
Formula/libtomcrypt.rb:16:    system "make", "test"
Formula/libtorrent-rasterbar.rb:56:                    libexec/"examples/make_torrent.cpp", "-o", "test"
Formula/libunistring.rb:22:    system "make", "check"
Formula/lightning.rb:20:    system "make", "check", "-j1"
Formula/lmdb.rb:20:      system "make", "test", "SOEXT=.dylib"
Formula/loudmouth.rb:35:    system "make", "check"
Formula/lutok.rb:26:    system "make", "check"
Formula/lzip.rb:19:    system "make", "check"
Formula/lzlib.rb:20:    system "make", "check"
Formula/lzo.rb:22:    system "make", "check"
Formula/makefile2graph.rb:23:    system "make", "test"
Formula/mbelib.rb:25:      system "make", "test"
Formula/midicsv.rb:20:    system "make", "check"
Formula/moreutils.rb:51:    system "make", "check"
Formula/mosh.rb:43:    system "make", "check"
Formula/mpfi.rb:22:    system "make", "check"
Formula/mpfr.rb:26:    system "make", "check"
Formula/mpich.rb:41:    system "make", "check"
Formula/mysql-sandbox.rb:22:    system "make", "test", "install"
Formula/mytop.rb:72:    system "make", "test", "install"
Formula/nettle.rb:36:    system "make", "check"
Formula/newlisp.rb:21:    system "make", "check"
Formula/nghttp2.rb:48:    system "make", "check"
Formula/odo.rb:22:    system "make", "test"
Formula/open-mpi.rb:45:    system "make", "check"
Formula/openssl@1.1.rb:49:    system "make", "test"
Formula/paperkey.rb:23:    system "make", "check"
Formula/pcre.rb:42:    system "make", "test"
Formula/percona-toolkit.rb:47:    system "make", "test", "install"
Formula/perl.rb:38:    system "make", "test"
Formula/pit.rb:45:    system "make", "test"
Formula/pk.rb:25:    system "make", "test"
Formula/pkg-config.rb:31:    system "make", "check"
Formula/plzip.rb:27:    system "make", "check"
Formula/protobuf.rb:37:    system "make", "check"
Formula/protobuf@3.7.rb:39:    system "make", "check"
Formula/ptex.rb:21:    system "make", "test"
Formula/pth.rb:26:    system "make", "test"
Formula/pushpin.rb:27:    system "make", "check"
Formula/riemann-client.rb:28:    system "make", "check"
Formula/sdl_sound.rb:42:    system "make", "check"
Formula/sflowtool.rb:23:    system "make", "check"
Formula/signify-osx.rb:18:    system "make", "test"
Formula/snappystream.rb:21:    system "make", "all", "test", "install"
Formula/spim.rb:20:      system "make", "test"
Formula/srtp.rb:21:    system "make", "test"
Formula/sslsplit.rb:24:    system "make", "test"
Formula/stoken.rb:29:    system "make", "check"
Formula/strongswan.rb:68:    system "make", "check"
Formula/terraform@0.11.rb:34:      system "make", "tools", "test", "bin"
Formula/tokyo-dystopia.rb:23:    system "make", "check"
Formula/tpl.rb:29:    system "make", "-C", "tests"
Formula/ucspi-tcp.rb:32:    system "make", "check"
Formula/uhd.rb:41:      system "make", "test"
Formula/unbound.rb:33:    system "make", "test"
Formula/vifm.rb:20:    system "make", "check"
Formula/wiggle.rb:15:    system "make", "OptDbg=#{ENV.cflags}", "wiggle", "wiggle.man", "test"
Formula/wolfssl.rb:88:    system "make", "check"
Formula/wslay.rb:33:    system "make", "check"
Formula/xz.rb:24:    system "make", "check"
Formula/ykclient.rb:30:    system "make", "check"
Formula/ykneomgr.rb:34:    system "make", "check"
Formula/ykpers.rb:26:    system "make", "check"
Formula/zdelta.rb:20:    system "make", "test", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
Formula/zpaq.rb:26:    system "make", "check"
Formula/zxcc.rb:20:    system "make", "check"

```

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----