### PR TITLE
[Linux] docs: `brew bump-formula-pr` now removes the Linux bottle line

### DIFF
--- a/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
@@ -393,8 +393,8 @@ If the formula is a Linux-only formula, it either:
 - will contain the line `# tag "linux"`
 - won't have macOS bottles
 
-These formulae are fine for users to bump with `brew bump-formula-pr`,
-but you should request that they remove the existing `x86_64_linux`
+If the user hasn't used `brew bump-formula-pr`, or is submitting
+another change, you should request that they remove the `x86_64_linux`
 bottle SHA line so that CI will build a bottle for the new version
 correctly. If the bottle SHA isn't removed, CI will fail with the
 following error:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- This had been a continual source of pain, and was fixed by 359dc96.
- Now, `brew bump-formula-pr` should be seamless on Linux, which means
  less work for maintainers, which means fewer words are needed here.
