### PR TITLE
whitelist asymptote

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -28,10 +28,6 @@ module Homebrew
           Minimal installation:
             brew cask install basictex
         EOS
-        when "asymptote" then <<~EOS
-          Asymptote is part of MacTeX:
-            brew cask install mactex
-        EOS
         when "pip" then <<~EOS
           pip is part of the python formula:
             brew install python


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
   + not needed in this case, I think.

- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Revert blacklisting of asymptote (https://github.com/Homebrew/brew/pull/5816) so that new formula can be added (https://github.com/Homebrew/homebrew-core/pull/48871).

The reason a hombrew-core asymptote formula is useful is that the version that is installed via the MacTeX cask is updated only once per year.  However, asymptote is having around 10 releases per year.