### PR TITLE
formula: add std_cabal_v2_args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1343,6 +1343,17 @@ class Formula
     ["-trimpath", "-o", bin/name]
   end
 
+  # Standard parameters for cabal-v2 builds.
+  def std_cabal_v2_args
+    # cabal-install's dependency-resolution backtracking strategy can
+    # easily need more than the default 2,000 maximum number of
+    # "backjumps," since Hackage is a fast-moving, rolling-release
+    # target. The highest known needed value by a formula was 43,478
+    # for git-annex, so 100,000 should be enough to avoid most
+    # gratuitous backjumps build failures.
+    ["--jobs=#{ENV.make_jobs}", "--max-backjumps=100000", "--install-method=copy", "--installdir=#{bin}"]
+  end
+
   # an array of all core {Formula} names
   # @private
   def self.core_names


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

**The below is obsolete information; follow the discussion to the end to see what actually happened.**

This pull request is a partial implementation of #6957, with the ultimate goal of fixing https://github.com/Homebrew/homebrew-core/issues/48604

In an interim period, v2-builds and v1-builds can coexist.  So far I have locally updated a little more than 20 formulae to use v2-builds.  Most of the updates are pretty trivial.  I have a list of the ones that I could not convert successfully:

* arx.rb: violates v2-install rule on autogenerated files

* cedille.rb: only uses cabal to bootstrap its own bespoke build
  system.  Could possibly be fixed.

* cless.rb: not a maintained package (no updates since 2015);
  doesn't compile with any GHC in Homebrew

* darcs.rb: violates v2-install rule on autogenerated files

* elm.rb: suspect this also violates a v2-install restriction, but
  it manifests differently.  The tarball it generates contains '..'
  filenames for some reason (cabal bug?)

* futhark.rb: uses too restrictive freeze file instead of
  index-state (fixed in HEAD)

* git-annex.rb: fails due to actual code bug (missing extensions);
  but the cabal stuff seems like it works.

* hopenpgp-tools: the cabal stuff works, but the wrong library
  versions are used (this is what we want to eventually fix)

* idris.rb: violates v2-install rule on autogenerated files

* shellcheck.rb: explicitly wants an old version of Cabal (<2.5) for
  some reason.  Looks like this is fixed in upstream.

I still have another 20 formula or so to look at.  It's quite a slog.  But again, we don't have to convert all of them at once.

The issues with autogenerated files is because of upstream packages generating things like modules that contain version numbers, but without telling `cabal` that they exist.  This used to work, but no more.

This PR does not on its own solve the Haskell reproducibility issue, but it is a foundation.  v2-style builds read the `cabal.project` file, which can contain an `index-state` field that freezes their view of Hackage (the Haskell library repository).  I don't think many upstreams use this yet, but they could probably be convinced as it's pretty easy ([this is what it looks like](https://github.com/diku-dk/futhark/blob/master/cabal.project)).  We can also try autogenerating index-state timestamps based on the time the package was released, but I'm not yet sure how to detect that in a formula (is the tarball timestamp reliable?).  I hope upstream will be willing to help out a little, since that is clearly the sanest approach.