### PR TITLE
Bottle: put Homebrew metafiles at the front of the tarball

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -292,7 +292,15 @@ module Homebrew
 
         cd cellar do
           sudo_purge
-          safe_system "tar", "cf", tar_path, "#{f.name}/#{f.pkg_version}"
+          keg_root = "#{f.name}/#{f.pkg_version}"
+          safe_system "tar", "cf", tar_path,
+                      # Put the two metafiles at the start of the tarball,
+                      # before listing the actual root of the keg.
+                      # This ensures that even a partial tarball download
+                      # should contain these two files.
+                      "#{keg_root}/INSTALL_RECEIPT.json",
+                      "#{keg_root}/#{keg.relative_formula_path}",
+                      keg_root
           sudo_purge
           tar_path.utime(tab.source_modified_time, tab.source_modified_time)
           relocatable_tar_path = "#{f}-bottle.tar"

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -549,6 +549,10 @@ class Keg
     find { |pn| FileUtils.rm_rf pn if pn.basename.to_s == "__pycache__" }
   end
 
+  def relative_formula_path
+    ".brew/#{name}.rb"
+  end
+
   private
 
   def resolve_any_conflicts(dst, mode)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -130,7 +130,7 @@ class Keg
         next true if pn.symlink?
         next true if pn.directory?
         next false if pn.basename.to_s == "orig-prefix.txt" # for python virtualenvs
-        next true if pn == self/".brew/#{name}.rb"
+        next true if pn == self/relative_formula_path
         next true if Metafiles::EXTENSIONS.include?(pn.extname)
 
         if pn.text_executable?

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -42,7 +42,7 @@ module Utils
 
       def resolve_formula_names(bottle_file)
         receipt_file_path = receipt_path bottle_file
-        receipt_file = Utils.popen_read("tar", "-xOzf", bottle_file, receipt_file_path)
+        receipt_file = Utils.popen_read("tar", "-xqOzf", bottle_file, receipt_file_path)
         name = receipt_file_path.split("/").first
         tap = Tab.from_file_content(receipt_file, "#{bottle_file}/#{receipt_file_path}").tap
 
@@ -63,7 +63,7 @@ module Utils
                            name: resolve_formula_names(bottle_file)[0])
         bottle_version = resolve_version bottle_file
         formula_path = "#{name}/#{bottle_version}/.brew/#{name}.rb"
-        contents = Utils.popen_read "tar", "-xOzf", bottle_file, formula_path
+        contents = Utils.popen_read "tar", "-xqOzf", bottle_file, formula_path
         raise BottleFormulaUnavailableError.new(bottle_file, formula_path) unless $CHILD_STATUS.success?
 
         contents


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This comes out of some work I've been doing to audit our bottles, as well as some conversations I've had with @sjackman.

It's very convenient to be able to download only part of a tarball in order to fetch its Homebrew metafiles but not the binary contents. By coincidence, our `INSTALL_RECEIPT.json` is usually at the front of the tarball but that's not guaranteed by the way we create them. Unfortunately, the formula file isn't usually near the front of the tarball and as a result can't be fetched without downloading the full contents.

This PR fixes this by explicitly listing these two files as the first two arguments to `tar`, ensuring they go at the start of the tarball before anything else.