### PR TITLE
rubocop: remove BINARY_URLS_WHITELIST and rust nightly

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -24,12 +24,6 @@ module RuboCop
           rust
         ].freeze
 
-        # specific rust-nightly temporarily acceptable until a newer version is released.
-        # DO NOT RE-ADD A NEWER RUST-NIGHTLY IN FUTURE.
-        BINARY_URLS_WHITELIST = %w[
-          https://static.rust-lang.org/dist/2019-08-24/rust-nightly-x86_64-apple-darwin.tar.xz
-        ].freeze
-
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           urls = find_every_func_call_by_name(body_node, :url)
           mirrors = find_every_func_call_by_name(body_node, :mirror)
@@ -232,7 +226,6 @@ module RuboCop
           audit_urls(urls, /(darwin|macos|osx)/i) do |_, url|
             next if url !~ /x86_64/i && url !~ /amd64/i
             next if BINARY_FORMULA_URLS_WHITELIST.include?(@formula_name)
-            next if BINARY_URLS_WHITELIST.include?(url)
 
             problem "#{url} looks like a binary package, not a source archive; " \
                     "homebrew/core is source-only."


### PR DESCRIPTION
This url is not used anymore, we replaced it with a new stable version
of rust.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
