### PR TITLE
Revert "help: print cli/parser help message if used"

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -95,7 +95,7 @@ begin
   if (empty_argv || help_flag) && cmd != "cask"
     require "help"
     Homebrew::Help.help cmd, empty_argv: empty_argv
-    # `Homebrew.help` never returns, except for unknown commands.
+    # `Homebrew.help` never returns, except for external/unknown commands.
   end
 
   if internal_cmd

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -16,22 +16,6 @@ module Homebrew
         new(args, &block).parse(args)
       end
 
-      def self.from_cmd_path(cmd_path)
-        cmd_method_prefix = cmd_path.basename(cmd_path.extname)
-                                    .to_s
-                                    .sub(/^brew-/, "")
-                                    .tr("-", "_")
-        cmd_args_method_name = "#{cmd_method_prefix}_args".to_sym
-
-        begin
-          Homebrew.send(cmd_args_method_name) if require?(cmd_path)
-        rescue NoMethodError => e
-          raise if e.name != cmd_args_method_name
-
-          nil
-        end
-      end
-
       def self.global_options
         {
           quiet:   [["-q", "--quiet"], :quiet, "Suppress any warnings."],
@@ -171,8 +155,7 @@ module Homebrew
       end
 
       def generate_help_text
-        @parser.to_s
-               .sub(/^/, "#{Tty.bold}Usage: brew#{Tty.reset} ")
+        @parser.to_s.sub(/^/, "#{Tty.bold}Usage: brew#{Tty.reset} ")
                .gsub(/`(.*?)`/m, "#{Tty.bold}\\1#{Tty.reset}")
                .gsub(%r{<([^\s]+?://[^\s]+?)>}) { |url| Formatter.url(url) }
                .gsub(/<(.*?)>/m, "#{Tty.underline}\\1#{Tty.reset}")

--- a/Library/Homebrew/help.rb
+++ b/Library/Homebrew/help.rb
@@ -72,31 +72,37 @@ module Homebrew
       # Resume execution in `brew.rb` for unknown commands.
       return if path.nil?
 
-      # Display help for commands (or generic help if undocumented).
+      # Display help for internal command (or generic help if undocumented).
       puts command_help(path)
       exit 0
     end
 
     def command_help(path)
-      # Let OptionParser generate help text for commands which have a parser
-      if cmd_parser = CLI::Parser.from_cmd_path(path)
-        return cmd_parser.generate_help_text
+      # Let OptionParser generate help text for commands which have a parser defined
+      cmd = path.basename(path.extname)
+      cmd_args_method_name = "#{cmd.to_s.tr("-", "_")}_args".to_sym
+      begin
+        return Homebrew.send(cmd_args_method_name)
+                       .generate_help_text
+      rescue NoMethodError => e
+        raise if e.name != cmd_args_method_name
+
+        nil
       end
 
-      # Otherwise read #: lines from the file.
       help_lines = command_help_lines(path)
-      if help_lines.blank?
+      if help_lines.empty?
         opoo "No help text in: #{path}" if ARGV.homebrew_developer?
-        return HOMEBREW_HELP
+        HOMEBREW_HELP
+      else
+        Formatter.wrap(help_lines.join.gsub(/^  /, ""), COMMAND_DESC_WIDTH)
+                 .sub("@hide_from_man_page ", "")
+                 .sub(/^\* /, "#{Tty.bold}Usage: brew#{Tty.reset} ")
+                 .gsub(/`(.*?)`/m, "#{Tty.bold}\\1#{Tty.reset}")
+                 .gsub(%r{<([^\s]+?://[^\s]+?)>}) { |url| Formatter.url(url) }
+                 .gsub(/<(.*?)>/m, "#{Tty.underline}\\1#{Tty.reset}")
+                 .gsub(/\*(.*?)\*/m, "#{Tty.underline}\\1#{Tty.reset}")
       end
-
-      Formatter.wrap(help_lines.join.gsub(/^  /, ""), COMMAND_DESC_WIDTH)
-               .sub("@hide_from_man_page ", "")
-               .sub(/^\* /, "#{Tty.bold}Usage: brew#{Tty.reset} ")
-               .gsub(/`(.*?)`/m, "#{Tty.bold}\\1#{Tty.reset}")
-               .gsub(%r{<([^\s]+?://[^\s]+?)>}) { |url| Formatter.url(url) }
-               .gsub(/<(.*?)>/m, "#{Tty.underline}\\1#{Tty.reset}")
-               .gsub(/\*(.*?)\*/m, "#{Tty.underline}\\1#{Tty.reset}")
     end
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -498,10 +498,7 @@ module Kernel
   end
 
   def command_help_lines(path)
-    path.read
-        .lines
-        .grep(/^#:/)
-        .map { |line| line.slice(2..-1) }
+    path.read.lines.grep(/^#:/).map { |line| line.slice(2..-1) }
   end
 
   def redact_secrets(input, secrets)


### PR DESCRIPTION
Reverts Homebrew/brew#6965

Breaks e.g. `brew services --help` until things are ported over.