### PR TITLE
tap: default to full clones.

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -60,7 +60,8 @@ module Homebrew
                     quiet:             args.quieter?
       rescue TapRemoteMismatchError => e
         odie e
-      rescue TapAlreadyTappedError, TapAlreadyUnshallowError # rubocop:disable Lint/SuppressedException
+      rescue TapAlreadyTappedError
+        nil
       end
     end
   end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -258,18 +258,6 @@ class TapAlreadyTappedError < RuntimeError
   end
 end
 
-class TapAlreadyUnshallowError < RuntimeError
-  attr_reader :name
-
-  def initialize(name)
-    @name = name
-
-    super <<~EOS
-      Tap #{name} already a full clone.
-    EOS
-  end
-end
-
 class TapPinStatusError < RuntimeError
   attr_reader :name, :pinned
 

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -207,18 +207,11 @@ describe Tap do
     it "raises an error when the remote doesn't match" do
       setup_git_repo
       already_tapped_tap = described_class.new("Homebrew", "foo")
-      touch subject.path/".git/shallow"
       expect(already_tapped_tap).to be_installed
       wrong_remote = "#{subject.remote}-oops"
       expect {
         already_tapped_tap.install clone_target: wrong_remote, full_clone: true
       }.to raise_error(TapRemoteMismatchError)
-    end
-
-    it "raises an error when the Tap is already unshallow" do
-      setup_git_repo
-      already_tapped_tap = described_class.new("Homebrew", "foo")
-      expect { already_tapped_tap.install full_clone: true }.to raise_error(TapAlreadyUnshallowError)
     end
 
     describe "force_auto_update" do


### PR DESCRIPTION
This makes `Tap` consistent with what the installer is doing.

Generally shallow clones get slower and slower (and more and more pointless) the more they are fetched so don't make sense for our use-case.

Keep the option around anyway because it's useful for integration tests.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----