### PR TITLE
bin/brew: Fix `brew edit` behaviour when using a graphical editor

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -88,7 +88,7 @@ then
 
   FILTERED_ENV=()
   # Filter all but the specific variables.
-  for VAR in HOME SHELL PATH TERM TERMINFO COLUMNS LOGNAME USER CI SSH_AUTH_SOCK SUDO_ASKPASS \
+  for VAR in HOME SHELL PATH TERM TERMINFO COLUMNS DISPLAY LOGNAME USER CI SSH_AUTH_SOCK SUDO_ASKPASS \
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              "${!HOMEBREW_@}" "${!TRAVIS_@}"
   do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Without `DISPLAY` as an envvar in `bin/brew`, running `brew edit`
  with $EDITOR set to a graphical editor (eg `gedit`), it errored on
  Linux:

```
$ EDITOR=gedit brew edit vim

Editing
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/vim.rb
Unable to init server: Could not connect: Connection refused

(org.gnome.gedit:15470): Gtk-WARNING **: 18:17:07.537: cannot open display:
Error: Failure while executing; `gedit
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/vim.rb`
exited with 1.
```

Fixes #6958.