### PR TITLE
[Linux] docs: Update sponsors to say GitHub Actions not CircleCI

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -95,8 +95,6 @@ eval $(~/.linuxbrew/bin/brew shellenv)
 
 ## Sponsors
 
-Our binary packages (bottles) are built on [CircleCI](https://circleci.com/) and hosted by [Bintray](https://bintray.com/linuxbrew).
-
-[<img alt="CircleCI logo" style="height:1in" src="https://assets.brandfolder.com/otz6k5-cj8pew-e4rk9u/original/circle-logo-horizontal-black.png">](https://circleci.com/)
+Our binary packages (bottles) are built on [GitHub Actions](https://github.com/features/actions) and hosted by [Bintray](https://bintray.com/linuxbrew).
 
 [![Downloads by Bintray](https://bintray.com/docs/images/downloads_by_bintray_96.png)](https://bintray.com/linuxbrew)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- We switched from Circle CI to Azure Pipelines, then to GitHub Actions.
- I can't find any directly linkable official GitHub logo assets on
  https://github.com/logos and I don't want to upload an image directly
  to this repo. So, remove the image. If that's acceptable.