### PR TITLE
Dockerfile: changes to speed CI runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
 	&& chmod -R g+w,o-w /home/linuxbrew/.linuxbrew \
 	&& rm -rf ~/.cache \
 	&& brew install-bundler-gems \
-	&& brew cleanup -s
+	&& brew cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,10 @@ WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
 	SHELL=/bin/bash
 
-# Install portable-ruby and tap homebrew/core.
+# Install portable-ruby, tap homebrew/core, install audit gems, and cleanup
 RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
 	&& chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
 	&& chmod -R g+w,o-w /home/linuxbrew/.linuxbrew \
-	&& rm -rf ~/.cache
+	&& rm -rf ~/.cache \
+	&& brew install-bundler-gems \
+	&& brew cleanup -s


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This pull request modifies the Docker image to pre-install needed gems for `brew audit` and the like, and to run `brew cleanup`. These changes are intended to speed up continuous integration runs that use the Docker image.

An alternative to these changes would be to more aggressively cache Homebrew's gems using CI features, and to set `HOMEBREW_NO_INSTALL_CLEANUP`.