### PR TITLE
tap: fix arguments.

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -56,7 +56,6 @@ module Homebrew
       begin
         tap.install clone_target:      ARGV.named.second,
                     force_auto_update: force_auto_update?,
-                    full_clone:        full_clone?,
                     quiet:             Homebrew.args.quiet?
       rescue TapRemoteMismatchError => e
         odie e
@@ -64,10 +63,6 @@ module Homebrew
         nil
       end
     end
-  end
-
-  def full_clone?
-    args.full? || ARGV.homebrew_developer?
   end
 
   def force_auto_update?

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -210,7 +210,7 @@ describe Tap do
       expect(already_tapped_tap).to be_installed
       wrong_remote = "#{subject.remote}-oops"
       expect {
-        already_tapped_tap.install clone_target: wrong_remote, full_clone: true
+        already_tapped_tap.install clone_target: wrong_remote
       }.to raise_error(TapRemoteMismatchError)
     end
 


### PR DESCRIPTION
- Use Ruby attribute arguments.
- Fix use of `full_clone` in `cmd/tap` to be on by default.
- Remove unnecessary argument in test.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----