### PR TITLE
bump-formula-pr: Determine Linux-only formulae with `depends_on :linux`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -259,7 +259,7 @@ module Homebrew
     # When bumping a linux-only formula,
     # one needs to also delete the sha256 linux bottle line.
     # That's because of running test-bot with --keep-old option in linuxbrew-core.
-    if formula.path.read.include?('# tag "linux"')
+    if formula.path.read.include?("depends_on :linux")
       replacement_pairs << [
         /^    sha256 ".+" => :x86_64_linux\n/m,
         "\\2",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- We used to use `# tag "linux"` in Homebrew/linuxbrew-core for the ~50 Linux-only formulae. As of https://github.com/Homebrew/linuxbrew-core/commit/6578a4aa86b80816cf0553f1d45828c0072197a4, we're using `depends_on :linux` to have a consistent syntax between Linux and macOS.
- Therefore, we have to change the search string for Linux-only formulae that determines whether or not `brew bump-formula-pr` deletes the bottle line.

Successfully tested with https://github.com/Homebrew/linuxbrew-core/pull/19623.