### PR TITLE
bump-formula-pr: Only delete Linux bottle line if it exists

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -256,10 +256,11 @@ module Homebrew
       ]
     end
 
-    # When bumping a linux-only formula,
-    # one needs to also delete the sha256 linux bottle line.
-    # That's because of running test-bot with --keep-old option in linuxbrew-core.
-    if formula.path.read.include?("depends_on :linux")
+    # When bumping a linux-only formula, one needs to also delete the
+    # sha256 linux bottle line if it exists. That's because of running
+    # test-bot with --keep-old option in linuxbrew-core.
+    formula_contents = formula.path.read
+    if formula_contents.include?("depends_on :linux") && formula_contents.include?("=> :x86_64_linux")
       replacement_pairs << [
         /^    sha256 ".+" => :x86_64_linux\n/m,
         "\\2",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- We have some Linux-only formulae that don't have bottles.
- Previously, bumping a Linux-only formula that didn't have a bottle
  line - eg, `adoptopenjdk` which is `bottle :unneeded` - would fail:

```
Error: inreplace failed
/app/linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/adoptopenjdk.rb:

expected replacement of /^    sha256 ".+" => :x86_64_linux\n/m with "\2"
```

Fixes https://github.com/Homebrew/linuxbrew-core/issues/19633