### PR TITLE
dev-cmd/tap-new: Set up GitHub Actions CI instead of Azure

### DIFF
--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -7,12 +7,13 @@ describe "Homebrew.tap_new_args" do
 end
 
 describe "brew tap-new", :integration_test do
-  it "initializes a new Tap with a ReadMe file" do
+  it "initializes a new Tap with a ReadMe file and GitHub Actions CI" do
     expect { brew "tap-new", "homebrew/foo", "--verbose" }
       .to be_a_success
       .and output(%r{homebrew/foo}).to_stdout
       .and not_to_output.to_stderr
 
     expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/README.md").to exist
+    expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/main.yml").to exist
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- We recently removed Azure as a supported CI provider (Homebrew/homebrew-test-bot PR 325), so `brew test-bot` won't run on Azure any more.
- Homebrew CI is moving towards GitHub Actions as the standard.

Fixes #7031