### PR TITLE
missing_formula: TexLive is only blacklisted on macOS

### DIFF
--- a/Library/Homebrew/extend/os/mac/missing_formula.rb
+++ b/Library/Homebrew/extend/os/mac/missing_formula.rb
@@ -14,6 +14,19 @@ module Homebrew
           <<~EOS
             Xcode can be installed from the App Store.
           EOS
+        when "tex", "tex-live", "texlive", "mactex", "latex"
+          <<~EOS
+            There are three versions of MacTeX.
+
+            Full installation:
+              brew cask install mactex
+
+            Full installation without bundled applications:
+              brew cask install mactex-no-gui
+
+            Minimal installation:
+              brew cask install basictex
+          EOS
         else
           generic_blacklisted_reason(name)
         end

--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -16,18 +16,6 @@ module Homebrew
           macOS provides gem as part of Ruby. To install a newer version:
             brew install ruby
         EOS
-        when "tex", "tex-live", "texlive", "mactex", "latex" then <<~EOS
-          There are three versions of MacTeX.
-
-          Full installation:
-            brew cask install mactex
-
-          Full installation without bundled applications:
-            brew cask install mactex-no-gui
-
-          Minimal installation:
-            brew cask install basictex
-        EOS
         when "pip" then <<~EOS
           pip is part of the python formula:
             brew install python

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -17,7 +17,7 @@ describe Homebrew::MissingFormula do
     end
 
     it { is_expected.to blacklist("gem") }
-    it { is_expected.to blacklist("latex") }
+    it("blacklists LaTeX", :needs_macos) { is_expected.to blacklist("latex") }
     it { is_expected.to blacklist("pip") }
     it { is_expected.to blacklist("pil") }
     it { is_expected.to blacklist("macruby") }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- In Homebrew/linuxbrew-core, [we have a Linux-only formula for
  `texlive`](https://github.com/Homebrew/linuxbrew-core/tree/master/Formula/texlive.rb).
- When running `brew audit --strict texlive` on Linux, we got the
  following messaging:

  ```
  $ brew audit --strict texlive
  texlive:
    * 'texlive' is blacklisted from homebrew/core.
    Error: 1 problem in 1 formula detected
  ```

- Looking at where this comes from leads to the missing formula
  messaging to install `mactex` via Homebrew Cask. The 'blacklisted in
  homebrew/core' messaging only applies to macOS where Casks are an option
  for users, so let's not surface the audit for `texlive` on Linux.

Tested this on Linux and macOS.