### PR TITLE
docs: `depends_on :linux` is now the identifier for Linux-only formulae

### DIFF
--- a/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
@@ -260,13 +260,14 @@ push a bottle commit to Homebrew/linuxbrew-core.
 
 Make a PR to `Homebrew/linuxbrew-core` containing one commit named
 like this: `name (new formula)`. Keep only one commit in this PR,
-squash and force push to your branch if needed. Include a comment: `#
-tag "linux"` in the formula after the `url` stanza, so maintainers can
-easily find Linux only formulae.
+squash and force push to your branch if needed. Include the line
+`depends_on :linux` in the dependencies section, so that maintainers
+can easily find Linux-only formulae.
 
 For the bottle commit to be successful when new formulae are added, we
 have to insert an empty bottle block into the formula code. This
-usually goes after the `linux` tag.
+usually goes after the `url` and `sha256` lines, with a blank line in
+between.
 
 ```ruby
 bottle do
@@ -351,7 +352,7 @@ correct repository:
 ### Linux-only formulae
 
 If the formula is a Linux-only formula, it either:
-- will contain the line `# tag "linux"`
+- will contain the line `depends_on :linux`
 - won't have macOS bottles
 
 If the user hasn't used `brew bump-formula-pr`, or is submitting


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This was changed in https://github.com/Homebrew/linuxbrew-core/commit/6578a4aa86b80816cf0553f1d45828c0072197a4.