### PR TITLE
rubocop/lines: add protobuf to whitelist

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -439,6 +439,7 @@ module RuboCop
               open-mpi
               openssl@1.1
               pcre
+              protobuf
               wolfssl
               xz
             ].include?(@formula_name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As seen in Homebrew/homebrew-core#50295, the protobuf formula fails `brew audit --strict` due to having a `make check` step. [It was suggested](https://github.com/Homebrew/homebrew-core/pull/50295#issuecomment-586670406) that I add protobuf to the whitelist since it's a library, so here we are.