### PR TITLE
feat: expose casks in tap.to_hash for tap-info --json

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -529,6 +529,7 @@ class Tap
       "formula_names" => formula_names,
       "formula_files" => formula_files.map(&:to_s),
       "command_files" => command_files.map(&:to_s),
+      "cask_files"    => cask_files.map(&:to_s),
       "pinned"        => pinned?,
     }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Hey yall. I wanted to install [meme] all the fonts [/meme] from homebrew-cask-fonts (well, i _really_ want to generate specimens for all of them so i can find a font that looks like the ✨ aesthetic ✨ i'm looking for, but that's a larger change and my ruby experience is minimal), and so i wanted to see all of the casks it provides, and adding it to the hash seems like the correct place, as `formula_files` and `command_files` are there.

With this, I was able to complete my task with `brew tap-info homebrew/homebrew-cask-fonts --json|jq -r '.[] | .cask_files[]' | sed -e 's|.*/||' -e 's/\.rb$//' | xargs brew cask install`.