### PR TITLE
python: add rewrite function for generic shebangs

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -88,6 +88,17 @@ module Language
       ]
     end
 
+    def self.rewrite_python_shebang(python_path)
+      Pathname(".").find do |f|
+        regex = %r{^#! ?/usr/bin/(env )?python([23](\.\d{1,2})?)$}
+        maximum_regex_length = "#! /usr/bin/env pythonx.yyy$".length
+        next unless f.file?
+        next unless regex.match?(f.read(maximum_regex_length))
+
+        Utils::Inreplace.inreplace f.to_s, regex, "#!#{python_path}"
+      end
+    end
+
     # Mixin module for {Formula} adding virtualenv support features.
     module Virtualenv
       def self.included(base)


### PR DESCRIPTION
From PEP 394
https://www.python.org/dev/peps/pep-0394/#for-python-script-publishers

In cases where the script is expected to be executed outside virtual environments,
developers will need to be aware of the following discrepancies across platforms and installation methods:

Older Linux distributions will provide a python command that refers to Python 2, and will likely not provide a python2 command.
Some newer Linux distributions will provide a python command that refers to Python 3.
Some Linux distributions will not provide a python command at all by default, but will provide a python3 command by default.

When potentially targeting these environments, developers may either use a Python package installation tool that rewrites shebang lines
for the installed environment, provide instructions on updating shebang lines interactively,
or else use more specific shebang lines that are tailored to the target environment.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
