### PR TITLE
bump-formula-pr: improve mirror handling

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -172,6 +172,10 @@ module Homebrew
     new_mirror ||= case new_url
     when requested_spec != :devel && %r{.*ftp.gnu.org/gnu.*}
       new_url.sub "ftp.gnu.org/gnu", "ftpmirror.gnu.org"
+    when %r{.*download.savannah.gnu.org/*}
+      new_url.sub "download.savannah.gnu.org", "download-mirror.savannah.gnu.org"
+    when %r{.*www.apache.org/dyn/closer.lua\?path=.*}
+      new_url.sub "www.apache.org/dyn/closer.lua?path=", "archive.apache.org/dist/"
     when %r{.*mirrors.ocf.berkeley.edu/debian.*}
       new_url.sub "mirrors.ocf.berkeley.edu/debian", "mirrorservice.org/sites/ftp.debian.org/debian"
     end

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -312,6 +312,17 @@ module Homebrew
 
     new_formula_version = formula_version(formula, requested_spec, new_contents)
 
+    if !new_mirror && !formula_spec.mirrors.empty?
+      if Homebrew.args.force?
+        opoo "#{formula}: Removing all mirrors because a --mirror= argument was not specified."
+      else
+        odie <<~EOS
+          #{formula}: a --mirror= argument for updating the mirror URL was not specified.
+          Use --force to remove all mirrors.
+        EOS
+      end
+    end
+
     if new_formula_version < old_formula_version
       formula.path.atomic_write(backup_file) unless args.dry_run?
       odie <<~EOS

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -146,7 +146,7 @@ module Homebrew
       if guesses.count == 1
         formula = guesses.shift
       elsif guesses.count > 1
-        odie "Couldn't guess formula for sure; could be one of these:\n#{guesses}"
+        odie "Couldn't guess formula for sure; could be one of these:\n#{guesses.map(&:name).join(", ")}"
       end
     end
     raise FormulaUnspecifiedError unless formula

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -168,7 +168,13 @@ module Homebrew
     new_hash = args[hash_type] if hash_type
     new_tag = args.tag
     new_revision = args.revision
-    new_mirror = args.mirror
+    new_mirror ||= args.mirror
+    new_mirror ||= case new_url
+    when requested_spec != :devel && %r{.*ftp.gnu.org/gnu.*}
+      new_url.sub "ftp.gnu.org/gnu", "ftpmirror.gnu.org"
+    when %r{.*mirrors.ocf.berkeley.edu/debian.*}
+      new_url.sub "mirrors.ocf.berkeley.edu/debian", "mirrorservice.org/sites/ftp.debian.org/debian"
+    end
     forced_version = args.version
     new_url_hash = if new_url && new_hash
       true
@@ -179,12 +185,6 @@ module Homebrew
     elsif !new_url
       odie "#{formula}: no --url= argument specified!"
     else
-      new_mirror ||= case new_url
-      when requested_spec != :devel && %r{.*ftp.gnu.org/gnu.*}
-        new_url.sub "ftp.gnu.org/gnu", "ftpmirror.gnu.org"
-      when %r{.*mirrors.ocf.berkeley.edu/debian.*}
-        new_url.sub "mirrors.ocf.berkeley.edu/debian", "mirrorservice.org/sites/ftp.debian.org/debian"
-      end
       resource = Resource.new { @url = new_url }
       resource.download_strategy = DownloadStrategyDetector.detect_from_url(new_url)
       resource.owner = Resource.new(formula.name)

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -41,6 +41,11 @@ module RuboCop
             problem "Please don't use fossies.org in the url (using as a mirror is fine)"
           end
 
+          apache_pattern = %r{^https?://(?:[^/]*\.)?apache\.org/(?:dyn/closer\.cgi\?path=/?|dist/)(.*)}i
+          audit_urls(urls, apache_pattern) do |match, url|
+            problem "#{url} should be `https://www.apache.org/dyn/closer.lua?path=#{match[1]}`"
+          end
+
           audit_urls(mirrors, /.*/) do |_, mirror|
             urls.each do |url|
               url_string = string_content(parameters(url).first)
@@ -58,7 +63,7 @@ module RuboCop
                                                  %r{^http://ftpmirror\.gnu\.org/},
                                                  %r{^http://download\.savannah\.gnu\.org/},
                                                  %r{^http://download-mirror\.savannah\.gnu\.org/},
-                                                 %r{^http://[^/]*\.apache\.org/},
+                                                 %r{^http://(?:[^/]*\.)?apache\.org/},
                                                  %r{^http://code\.google\.com/},
                                                  %r{^http://fossies\.org/},
                                                  %r{^http://mirrors\.kernel\.org/},
@@ -76,6 +81,11 @@ module RuboCop
                                                  %r{^http://(?:[^/]*\.)?mirrorservice\.org/}])
           audit_urls(urls, http_to_https_patterns) do |_, url|
             problem "Please use https:// for #{url}"
+          end
+
+          apache_mirror_pattern = %r{^https?://(?:[^/]*\.)?apache\.org/dyn/closer\.(?:cgi|lua)\?path=/?(.*)}i
+          audit_urls(mirrors, apache_mirror_pattern) do |match, mirror|
+            problem "Please use `https://archive.apache.org/dist/#{match[1]}` as a mirror instead of #{mirror}."
           end
 
           cpan_pattern = %r{^http://search\.mcpan\.org/CPAN/(.*)}i

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -19,6 +19,11 @@ describe RuboCop::Cop::FormulaAudit::Urls do
       "msg" => "Please use https:// for http://tools.ietf.org/tools/rfcmarkup/rfcmarkup-1.119.tgz",
       "col" => 2,
     }, {
+      "url" => "https://apache.org/dyn/closer.cgi?path=/apr/apr-1.7.0.tar.bz2",
+      "msg" => "https://apache.org/dyn/closer.cgi?path=/apr/apr-1.7.0.tar.bz2 should be " \
+               "`https://www.apache.org/dyn/closer.lua?path=apr/apr-1.7.0.tar.bz2`",
+      "col" => 2,
+    }, {
       "url" => "http://search.mcpan.org/CPAN/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz",
       "msg" => "http://search.mcpan.org/CPAN/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz should be " \
                "`https://cpan.metacpan.org/authors/id/Z/ZE/ZEFRAM/Perl4-CoreLibs-0.003.tar.gz`",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -767,7 +767,7 @@ uses.
 * `--no-fork`:
   Don't try to fork the repository.
 * `--mirror`:
-  Use the specified *`URL`* as a mirror URL.
+  Use the specified *`URL`* as a mirror URL. If *`URL`* is a comma-separated list of URLs, multiple mirrors will be added.
 * `--version`:
   Use the specified *`version`* to override the value parsed from the URL or tag. Note that `--version=0` can be used to delete an existing version override from a formula if it has become redundant.
 * `--message`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -975,7 +975,7 @@ Don\'t try to fork the repository\.
 .
 .TP
 \fB\-\-mirror\fR
-Use the specified \fIURL\fR as a mirror URL\.
+Use the specified \fIURL\fR as a mirror URL\. If \fIURL\fR is a comma\-separated list of URLs, multiple mirrors will be added\.
 .
 .TP
 \fB\-\-version\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Relocates the automatic mirroring logic to also run when a checksum is specified, and protects against mirrors from being too easily removed. (xref Homebrew/homebrew-core#50396, Homebrew/homebrew-core#50404)

Also modified `--mirror` to support a comma-separated list of URLs so more than one can be specified at once.