### PR TITLE
tap: update docs to note non-shallow default.

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -22,12 +22,11 @@ module Homebrew
         any transport protocol that `git`(1) handles. The one-argument form of `tap`
         simplifies but also limits. This two-argument command makes no
         assumptions, so taps can be cloned from places other than GitHub and
-        using protocols other than HTTPS, e.g. SSH, GIT, HTTP, FTP(S), RSYNC.
+        using protocols other than HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
       EOS
       switch "--full",
-             description: "Use a full clone when tapping a repository. By default, the repository is "\
-                          "cloned as a shallow copy (`--depth=1`). To convert a shallow copy to a "\
-                          "full copy, you can retap by passing `--full` without first untapping."
+             description: "Convert a shallow clone to a full clone without untapping. By default, taps are no "\
+                          "longer cloned as shallow clones."
       switch "--force-auto-update",
              description: "Auto-update tap even if it is not hosted on GitHub. By default, only taps "\
                           "hosted on GitHub are auto-updated (for performance reasons)."

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -496,10 +496,10 @@ With *`URL`* specified, tap a formula repository from anywhere, using any
 transport protocol that `git`(1) handles. The one-argument form of `tap`
 simplifies but also limits. This two-argument command makes no assumptions, so
 taps can be cloned from places other than GitHub and using protocols other than
-HTTPS, e.g. SSH, GIT, HTTP, FTP(S), RSYNC.
+HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
 
 * `--full`:
-  Use a full clone when tapping a repository. By default, the repository is cloned as a shallow copy (`--depth=1`). To convert a shallow copy to a full copy, you can retap by passing `--full` without first untapping.
+  Convert a shallow clone to a full clone without untapping. By default, taps are no longer cloned as shallow clones.
 * `--force-auto-update`:
   Auto-update tap even if it is not hosted on GitHub. By default, only taps hosted on GitHub are auto-updated (for performance reasons).
 * `--repair`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -627,11 +627,11 @@ If no arguments are provided, list all installed taps\.
 With \fIURL\fR unspecified, tap a formula repository from GitHub using HTTPS\. Since so many taps are hosted on GitHub, this command is a shortcut for \fBbrew tap\fR \fIuser\fR\fB/\fR\fIrepo\fR \fBhttps://github\.com/\fR\fIuser\fR\fB/homebrew\-\fR\fIrepo\fR\.
 .
 .P
-With \fIURL\fR specified, tap a formula repository from anywhere, using any transport protocol that \fBgit\fR(1) handles\. The one\-argument form of \fBtap\fR simplifies but also limits\. This two\-argument command makes no assumptions, so taps can be cloned from places other than GitHub and using protocols other than HTTPS, e\.g\. SSH, GIT, HTTP, FTP(S), RSYNC\.
+With \fIURL\fR specified, tap a formula repository from anywhere, using any transport protocol that \fBgit\fR(1) handles\. The one\-argument form of \fBtap\fR simplifies but also limits\. This two\-argument command makes no assumptions, so taps can be cloned from places other than GitHub and using protocols other than HTTPS, e\.g\. SSH, git, HTTP, FTP(S), rsync\.
 .
 .TP
 \fB\-\-full\fR
-Use a full clone when tapping a repository\. By default, the repository is cloned as a shallow copy (\fB\-\-depth=1\fR)\. To convert a shallow copy to a full copy, you can retap by passing \fB\-\-full\fR without first untapping\.
+Convert a shallow clone to a full clone without untapping\. By default, taps are no longer cloned as shallow clones\.
 .
 .TP
 \fB\-\-force\-auto\-update\fR


### PR DESCRIPTION
Also, while we're here, `rsync` and `git` are not acronyms.

Fixes #7050

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----