### PR TITLE
tap-info: include cask tokens and all commands in JSON output

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "commands"
 require "extend/cachable"
 require "readall"
 require "description_cache_store"
@@ -474,17 +475,10 @@ class Tap
     @command_dir ||= path/"cmd"
   end
 
-  def command_file?(file)
-    file = Pathname.new(file) unless file.is_a? Pathname
-    file = file.expand_path(path)
-    file.parent == command_dir && file.basename.to_s.match?(/^brew(cask)?-/) &&
-      (file.executable? || file.extname == ".rb")
-  end
-
   # An array of all commands files of this {Tap}.
   def command_files
     @command_files ||= if command_dir.directory?
-      command_dir.children.select(&method(:command_file?))
+      Commands.find_commands(command_dir)
     else
       []
     end
@@ -533,9 +527,9 @@ class Tap
       "official"      => official?,
       "formula_names" => formula_names,
       "formula_files" => formula_files.map(&:to_s),
-      "command_files" => command_files.map(&:to_s),
       "cask_tokens"   => cask_tokens,
       "cask_files"    => cask_files.map(&:to_s),
+      "command_files" => command_files.map(&:to_s),
       "pinned"        => pinned?,
     }
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -419,7 +419,12 @@ class Tap
 
   # An array of all {Formula} names of this {Tap}.
   def formula_names
-    @formula_names ||= formula_files.map { |f| formula_file_to_name(f) }
+    @formula_names ||= formula_files.map(&method(:formula_file_to_name))
+  end
+
+  # An array of all {Cask} tokens of this {Tap}.
+  def cask_tokens
+    @cask_tokens ||= cask_files.map(&method(:formula_file_to_name))
   end
 
   # path to the directory of all alias files for this {Tap}.
@@ -529,6 +534,7 @@ class Tap
       "formula_names" => formula_names,
       "formula_files" => formula_files.map(&:to_s),
       "command_files" => command_files.map(&:to_s),
+      "cask_tokens"   => cask_tokens,
       "cask_files"    => cask_files.map(&:to_s),
       "pinned"        => pinned?,
     }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Follow-up to #7043: 

- also list cask tokens in JSON output (e.g. `brew tap-info homebrew/homebrew-cask --json|jq -r '.[] ' `
- fix logic for detecting command files in taps