### PR TITLE
extract: handle versioned formulae names

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -180,6 +180,9 @@ module Homebrew
     # The class name has to be renamed to match the new filename,
     # e.g. Foo version 1.2.3 becomes FooAT123 and resides in Foo@1.2.3.rb.
     class_name = Formulary.class_s(name)
+
+    # Remove any existing version suffixes, as a new one will be added later
+    name.sub!(/\b@(.*)\z\b/i, "")
     versioned_name = Formulary.class_s("#{name}@#{version}")
     result.gsub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
 


### PR DESCRIPTION
Turn the output versioned formula from the form "name@version" to
"name-version", then following by appending the specific version
after it.

This solution ensures that separate extracted versions of a formulae
can exist alongside each other (e.g. 'python-2@2.7.17' and
'python-2@2.7.16').

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This addresses #7057, although it's probably not the only solution to the issue. I'm open to feedback on other better ways to handle this.