### PR TITLE
analytics: tweak behaviour.

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -51,6 +51,7 @@ module Homebrew
       puts <<~EOS
         #{Tty.bold}Read the analytics documentation (and how to opt-out) here:
           #{Formatter.url("https://docs.brew.sh/Analytics")}#{Tty.reset}
+        No analytics have been recorded yet (or will be during this `brew` run).
 
       EOS
 

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -6,6 +6,7 @@ module Utils
   module Analytics
     class << self
       def report(type, metadata = {})
+        return if not_this_run?
         return if disabled?
 
         args = []
@@ -77,9 +78,13 @@ module Utils
       end
 
       def disabled?
-        return true if ENV["HOMEBREW_NO_ANALYTICS"] || ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"]
+        return true if ENV["HOMEBREW_NO_ANALYTICS"]
 
         config_true?(:analyticsdisabled)
+      end
+
+      def not_this_run?
+        ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"].present?
       end
 
       def no_message_output?


### PR DESCRIPTION
- Use separate method for `not_this_run?` so we can still set the analytics message as seen when set.
- Clarify when analytics message is printed that we haven't sent any analytics yet.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----