### PR TITLE
pull: use `homebrew` remote if HOMEBREW_FORCE_HOMEBREW_ON_LINUX

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -289,6 +289,7 @@ module Homebrew
 
     # Use `homebrew` remote if HOMEBREW_FORCE_HOMEBREW_ON_LINUX env variable is set.
     # The `homebrew` remote points to homebrew-core tap and is used by Linux maintainers.
+    # See https://docs.brew.sh/Homebrew-linuxbrew-core-Maintainer-Guide#preparation
     remote = ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] ? "homebrew" : "origin"
     safe_system "git", "fetch", "--quiet", remote, "pull/#{pr_number}/head"
     Utils.popen_read("git", "rev-list", "--parents", "-n1", "FETCH_HEAD").count(" ") > 1

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -287,7 +287,10 @@ module Homebrew
     pr_number = url[%r{/pull\/([0-9]+)}, 1]
     return false unless pr_number
 
-    safe_system "git", "fetch", "--quiet", "origin", "pull/#{pr_number}/head"
+    # Use `homebrew` remote if HOMEBREW_FORCE_HOMEBREW_ON_LINUX env variable is set.
+    # The `homebrew` remote points to homebrew-core tap and is used by Linux maintainers.
+    remote = ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] ? "homebrew" : "origin"
+    safe_system "git", "fetch", "--quiet", remote, "pull/#{pr_number}/head"
     Utils.popen_read("git", "rev-list", "--parents", "-n1", "FETCH_HEAD").count(" ") > 1
   end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

With this change, linux maintainers are able to perform `brew pull --bottle` after exporting `HOMEBREW_FORCE_HOMEBREW_ON_LINUX` environment variable and checking out the `master` branch of `homebrew` remote.

Successful commit example: https://github.com/Homebrew/homebrew-core/commit/76bbb1d75815aca4f049c6c5e825290d70ea1448

Bottle works (thanks to @issyl0 for this):
```
╭─issyl0@chi /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core ‹master*› 
╰─ $ brew install findomain 
==> Downloading https://homebrew.bintray.com/bottles/findomain-1.4.1.catalina.bottle.tar.gz
==> Downloading from https://akamai.bintray.com/6f/6fb58677ebe4f07259ecb13fd99fd33f0615e299b33bd795cc1265c9e8b87a3b?__gda__=exp=1582402268~hmac=e1456e4284f4033f93611c72076d2be705ce12990172f67f51397b654765bd4
######################################################################## 100.0%
==> Pouring findomain-1.4.1.catalina.bottle.tar.gz
:beer:  /usr/local/Cellar/findomain/1.4.1: 6 files, 4.4MB
╭─issyl0@chi /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core ‹master*› 
╰─ $ brew test findomain                                                                                                                                                                                   1 ↵
Testing findomain
==> /usr/local/Cellar/findomain/1.4.1/bin/findomain -t brew.sh
```