### PR TITLE
Fix detecting version from URL

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -261,7 +261,7 @@ class Version
     # e.g. foobar-4.5.1-1
     # e.g. unrtf_0.20.4-1
     # e.g. ruby-1.9.1-p243
-    m = /[-_]((?:\d+\.)*\d\.\d+-(?:p|rc|RC)?\d+)(?:[-._](?:bin|dist|stable|src|sources))?$/.match(stem)
+    m = /[-_]((?:\d+\.)*\d+\.\d+-(?:p|rc|RC)?\d+)(?:[-._](?:bin|dist|stable|src|sources))?$/.match(stem)
     return m.captures.first unless m.nil?
 
     # URL with no extension
@@ -271,7 +271,7 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. lame-398-1
-    m = /-((?:\d)+-\d+)/.match(stem)
+    m = /-(\d+-\d+)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. foobar-4.5.1
@@ -350,7 +350,7 @@ class Version
     # e.g. https://wwwlehre.dhbw-stuttgart.de/~sschulz/WORK/E_DOWNLOAD/V_1.9/E.tgz
     # e.g. https://github.com/JustArchi/ArchiSteamFarm/releases/download/2.3.2.0/ASF.zip
     # e.g. https://people.gnome.org/~newren/eg/download/1.7.5.2/eg
-    m = %r{/([rvV]_?)?(\d\.\d+(\.\d+){,2})}.match(spec_s)
+    m = %r{/([rvV]_?)?(\d+\.\d+(\.\d+){,2})}.match(spec_s)
     return m.captures.second unless m.nil?
 
     # e.g. https://www.ijg.org/files/jpegsrc.v8d.tar.gz


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently, line 264 does not work for one of the given examples `unrtf_0.20.4-1`

```rb
m = /[-_]((?:\d+\.)*\d\.\d+-(?:p|rc|RC)?\d+)(?:[-._](?:bin|dist|stable|src|sources))?$/.match(stem)
```

Looking closer, `\d\.\d+` should be `\d+\.\d+` where another `+` is added to indicate that there can be more than one digit `\d`.

(A similar change is made to line 353.)

---

And as for line 274 `m = /-((?:\d)+-\d+)/.match(stem)`, some redundancy can be removed by replacing `(?:\d)` with `\d`. Usually, the syntax `(?:)` is used either for (1) matching a group of characters without creating a capture such as `(?:\d+\.)*` or (2) "or" expressions such as `(?:p|rc|RC)`. However, since it's just `\d` by itself, it can be simplified.