### PR TITLE
log: use user path

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -29,6 +29,10 @@ module Homebrew
   def log
     log_args.parse
 
+    # As this command is simplifying user run commands then let's just use a
+    # user path, too.
+    ENV["PATH"] = ENV["HOMEBREW_PATH"]
+
     if ARGV.named.empty?
       git_log HOMEBREW_REPOSITORY
     else


### PR DESCRIPTION
Without this, one can't use a custom pager, if it's present in
non-standard PATH, like for example Homebrew on Linux prefix.

Fixes situations like this:

```
➜  .linuxbrew/Homebrew master ✓  brew log git --max-count=3
diff-so-fancy | less --tabs=4 -RFX: 1: diff-so-fancy | less --tabs=4 -RFX: diff-so-fancy: not found
```

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----