### PR TITLE
Revert "pull: use `homebrew` remote if HOMEBREW_FORCE_HOMEBREW_ON_LINUX"

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -287,12 +287,7 @@ module Homebrew
     pr_number = url[%r{/pull\/([0-9]+)}, 1]
     return false unless pr_number
 
-    # Use `homebrew` remote if HOMEBREW_FORCE_HOMEBREW_ON_LINUX env variable is set.
-    # The `homebrew` remote points to homebrew-core tap and is used by Linux maintainers.
-    # See https://docs.brew.sh/Homebrew-linuxbrew-core-Maintainer-Guide#preparation
-    # Skip that on Jenkins, because upload job runs on Linux.
-    remote = (ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] && ENV["JENKINS_HOME"].nil?) ? "homebrew" : "origin"
-    safe_system "git", "fetch", "--quiet", remote, "pull/#{pr_number}/head"
+    safe_system "git", "fetch", "--quiet", "origin", "pull/#{pr_number}/head"
     Utils.popen_read("git", "rev-list", "--parents", "-n1", "FETCH_HEAD").count(" ") > 1
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This reverts commit 9fb1876101a1abac8e3bfcc9f4f6fadbf0921c7c and commit f8863c8a3bbef32dc65c9b95a57b54d7fc26c27e. See PR 7076 and https://github.com/Homebrew/brew/pull/7076#pullrequestreview-363749368 for context as to why the second commit.
- The `JENKINS_HOME` envvar appears to be unset on the Linux Jenkins master that holds the BinTray credentials.
- It's bed time, we're too tired to be fixing forward!