### PR TITLE
formula: sort versioned_formulae by version

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -392,7 +392,7 @@ class Formula
       Formula[path.basename(".rb").to_s]
     rescue FormulaUnavailableError
       nil
-    end.compact.sort
+    end.compact.sort_by(&:version).reverse
   end
 
   # A named Resource for the currently active {SoftwareSpec}.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

[Currently](https://formulae.brew.sh/formula/go), we sort alphabetically, so we get the following order for `go`:

* `go@1.10`
* `go@1.11`
* `go@1.12`
* `go@1.13`
* `go@1.9`

Instead, I've tweaked it to sort by the version field, with the latest version first. The output after the change is:

* `go@1.13`
* `go@1.12`
* `go@1.11`
* `go@1.10`
* `go@1.9`