### PR TITLE
dev-cmd/extract: allow maintainers to extract to core.

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -111,8 +111,10 @@ module Homebrew
     end
 
     destination_tap = Tap.fetch(args.remaining.second)
-    odie "Cannot extract formula to homebrew/core!" if destination_tap.core_tap?
-    odie "Cannot extract formula to the same tap!" if destination_tap == source_tap
+    unless ARGV.homebrew_developer?
+      odie "Cannot extract formula to homebrew/core!" if destination_tap.core_tap?
+      odie "Cannot extract formula to the same tap!" if destination_tap == source_tap
+    end
     destination_tap.install unless destination_tap.installed?
 
     repo = source_tap.path


### PR DESCRIPTION
I was wanting to do this today to add `ruby@2.6` and it's a social rather than technical requirement (i.e. we don't want users to mess with their homebrew/core unless they know what they are doing) so allow overriding with `HOMEBREW_DEVELOPER` set.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----