### PR TITLE
version: parse tag if detecting version

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -684,9 +684,14 @@ describe Version do
         .to be_detected_from("https://php.net/get/php-7.1.10.tar.gz/from/this/mirror")
     end
 
-    specify "from URL" do
+    specify "from tag" do
       expect(described_class.create("1.2.3"))
         .to be_detected_from("https://github.com/foo/bar.git", tag: "v1.2.3")
+    end
+
+    specify "beta from tag" do
+      expect(described_class.create("1.2.3-beta1"))
+        .to be_detected_from("https://github.com/foo/bar.git", tag: "v1.2.3-beta1")
     end
   end
 end

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -201,7 +201,7 @@ class Version
 
   def self.detect(url, specs)
     if specs.key?(:tag)
-      FromURL.new(specs[:tag][/((?:\d+\.)*\d+)/, 1])
+      FromURL.parse(specs[:tag])
     else
       FromURL.parse(url)
     end


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes detecting the version from a tag such as `v1.2.3-beta1` as `1.2.3` when it should be `1.2.3-beta1`