### PR TITLE
node: add --unsafe-perm to std_args

### DIFF
--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -50,7 +50,7 @@ module Language
         #{Dir.pwd}/#{pack}
       ]
 
-      args << "--unsafe-perm" if ENV["USER"] == "root"
+      args << "--unsafe-perm" if Process.uid.zero?
 
       args
     end

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -44,6 +44,7 @@ module Language
       %W[
         -ddd
         --global
+        --unsafe-perm
         --build-from-source
         --#{npm_cache_config}
         --prefix=#{libexec}

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -41,15 +41,18 @@ module Language
       pack = pack_for_installation
 
       # npm install args for global style module format installed into libexec
-      %W[
+      args = %W[
         -ddd
         --global
-        --unsafe-perm
         --build-from-source
         --#{npm_cache_config}
         --prefix=#{libexec}
         #{Dir.pwd}/#{pack}
       ]
+
+      args << "--unsafe-perm" if ENV["USER"] == "root"
+
+      args
     end
 
     def self.local_npm_install_args


### PR DESCRIPTION
Quoting the docs: https://docs.npmjs.com/misc/config#unsafe-perm

> Default: false if running as root, true otherwise

`npm` fails without this option if run as root (`linuxbrew-core` CI for example).

Closes: https://github.com/Homebrew/linuxbrew-core/issues/19517

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----