### PR TITLE
version: handle -stable in tag

### DIFF
--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -6,7 +6,7 @@ describe Language::Node do
   describe "#setup_npm_environment" do
     it "calls prepend_path when node formula exists only during the first call" do
       node = formula "node" do
-        url "node-test"
+        url "node-test-v1.0"
       end
       stub_formula_loader(node)
       expect(ENV).to receive(:prepend_path)

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -686,7 +686,7 @@ describe Version do
 
     specify "from tag" do
       expect(described_class.create("1.2.3"))
-        .to be_detected_from("https://github.com/foo/bar.git", tag: "v1.2.3")
+        .to be_detected_from("https://github.com/foo/bar.git", tag: "v1.2.3-stable")
     end
 
     specify "beta from tag" do

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -336,11 +336,11 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. https://www.openssl.org/source/openssl-0.9.8s.tar.gz
-    m = /-v?([^-]+)/.match(stem)
+    m = /-v?(\d[^-]+)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. astyle_1.23_macosx.tar.gz
-    m = /_([^_]+)/.match(stem)
+    m = /_v?(\d[^_]+)/.match(stem)
     return m.captures.first unless m.nil?
 
     # e.g. http://mirrors.jenkins-ci.org/war/1.486/jenkins.war


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Account for `-stable` in a version tag by making two rules slightly more specific, allowing the version for [wolfSSL](https://formulae.brew.sh/formula/wolfssl) to be handled by a later rule. (xref #7088)