### PR TITLE
bump-formula-pr: return remote url with token in it

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -420,7 +420,9 @@ module Homebrew
     remote_url = if system("git", "config", "--local", "--get-regexp", "remote\..*\.url", "git@github.com:.*")
       response.fetch("ssh_url")
     else
-      response.fetch("clone_url")
+      url = response.fetch("clone_url")
+      url.gsub!(%r{^https://github\.com/}, "https://#{GitHub.env_token}@github.com/") if GitHub.env_token
+      url
     end
     username = response.fetch("owner").fetch("login")
     [remote_url, username]


### PR DESCRIPTION
Might be useful to be able to push to remote using only the token.
For example on CI.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----