### PR TITLE
search: add separate flag for formulae

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -37,11 +37,11 @@ module Homebrew
         No online search is performed.
       EOS
       switch "--formulae",
-             description: "List all locally available formulae. "\
-                          "No online search is performed."
+             description: "Without <text>, list all locally available formulae (no online search is performed). " \
+                          "With <text>, search online and locally for formulae."
       switch "--casks",
-             description: "List all locally available casks (including tapped ones). "\
-                          "No online search is performed."
+             description: "Without <text>, list all locally available casks (including tapped ones, no online " \
+                          "search is performed). With <text>, search online and locally for casks."
       switch "--desc",
              description: "Search for formulae with a description matching <text> and casks with "\
                           "a name matching <text>."
@@ -68,7 +68,7 @@ module Homebrew
 
     if args.remaining.empty?
       if args.casks?
-        raise UsageError, "Cannot specify --formulae and --casks without an argument!" if args.formulae?
+        raise UsageError, "specifying both --formulae and --casks requires an argument!" if args.formulae?
 
         puts Formatter.columns(Cask::Cask.to_a.map(&:full_name).sort)
       else

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -36,6 +36,9 @@ module Homebrew
         If no <text> is provided, list all locally available formulae (including tapped ones).
         No online search is performed.
       EOS
+      switch "--formulae",
+             description: "List all locally available formulae. "\
+                          "No online search is performed."
       switch "--casks",
              description: "List all locally available casks (including tapped ones). "\
                           "No online search is performed."
@@ -65,6 +68,8 @@ module Homebrew
 
     if args.remaining.empty?
       if args.casks?
+        raise UsageError, "Cannot specify --formulae and --casks without an argument!" if args.formulae?
+
         puts Formatter.columns(Cask::Cask.to_a.map(&:full_name).sort)
       else
         puts Formatter.columns(Formula.full_names.sort)
@@ -88,14 +93,17 @@ module Homebrew
       local_casks = search_casks(string_or_regex)
       remote_casks = remote_results[:casks]
       all_casks = local_casks + remote_casks
+      print_formulae = args.formulae?
+      print_casks = args.casks?
+      print_formulae = print_casks = true if !print_formulae && !print_casks
 
-      if all_formulae.any?
+      if print_formulae && all_formulae.any?
         ohai "Formulae"
         puts Formatter.columns(all_formulae)
       end
 
-      if all_casks.any?
-        puts if all_formulae.any?
+      if print_casks && all_casks.any?
+        puts if args.formulae? && all_formulae.any?
         ohai "Casks"
         puts Formatter.columns(all_casks)
       end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -425,6 +425,8 @@ search for *`text`* is extended online to `homebrew/core` and `homebrew/cask`.
 If no *`text`* is provided, list all locally available formulae (including tapped
 ones). No online search is performed.
 
+* `--formulae`:
+  List all locally available formulae. No online search is performed.
 * `--casks`:
   List all locally available casks (including tapped ones). No online search is performed.
 * `--desc`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -426,9 +426,9 @@ If no *`text`* is provided, list all locally available formulae (including tappe
 ones). No online search is performed.
 
 * `--formulae`:
-  List all locally available formulae. No online search is performed.
+  Without *`text`*, list all locally available formulae (no online search is performed). With *`text`*, search online and locally for formulae.
 * `--casks`:
-  List all locally available casks (including tapped ones). No online search is performed.
+  Without *`text`*, list all locally available casks (including tapped ones, no online search is performed). With *`text`*, search online and locally for casks.
 * `--desc`:
   Search for formulae with a description matching *`text`* and casks with a name matching *`text`*.
 * `--macports`:

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "February 2020" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "March 2020" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "February 2020" "Homebrew" "brew"
+.TH "BREW" "1" "March 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -546,6 +546,10 @@ Perform a substring search of cask tokens and formula names for \fItext\fR\. If 
 .
 .P
 If no \fItext\fR is provided, list all locally available formulae (including tapped ones)\. No online search is performed\.
+.
+.TP
+\fB\-\-formulae\fR
+List all locally available formulae\. No online search is performed\.
 .
 .TP
 \fB\-\-casks\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -549,11 +549,11 @@ If no \fItext\fR is provided, list all locally available formulae (including tap
 .
 .TP
 \fB\-\-formulae\fR
-List all locally available formulae\. No online search is performed\.
+Without \fItext\fR, list all locally available formulae (no online search is performed)\. With \fItext\fR, search online and locally for formulae\.
 .
 .TP
 \fB\-\-casks\fR
-List all locally available casks (including tapped ones)\. No online search is performed\.
+Without \fItext\fR, list all locally available casks (including tapped ones, no online search is performed)\. With \fItext\fR, search online and locally for casks\.
 .
 .TP
 \fB\-\-desc\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR attempts to solve issue #6975. 

Right now, this PR has a lot of scope for improvement, but I am determined to get this done right and merged. As discussed in the above issue I have added a separate `--formulae` flag in brew search and this is what brew search looks like now:

```
brew search					#lists both formulae and casks
brew search --formulae		#lists only formulae
brew search --casks 		#lists only casks
```

I have tested these changes locally, and they seem to work so far.

In this version of implementation, `brew search` first lists all cask names(sorted) followed by sorted formula names. Is this correct, or should I mix all cask and formula names in a list and then print this list in a sorted manner (this would mix all cask and formula names).

Thank you, @issyl0 for telling me such a convenient way to test out my changes locally -- it saved me a lot of time! Please take a look and let me know. 😃

Thanks! 🚀 