### PR TITLE
Versions docs: Add note on unstable versions

### DIFF
--- a/docs/Versions.md
+++ b/docs/Versions.md
@@ -9,7 +9,7 @@ Versioned formulae we include in [homebrew/core](https://github.com/homebrew/hom
 
 * Versioned software should build on all Homebrew's supported versions of macOS.
 * Versioned formulae should differ in major/minor (not patch) versions from the current stable release. This is because patch versions indicate bug or security updates and we want to ensure you apply security updates.
-* Unstable versions (alpha, beta, development versions) are not acceptable, not even for versioned formulae.
+* Unstable versions (alpha, beta, development versions) are not acceptable for versioned (or unversioned) formulae.
 * Upstream should have a release branch for the versioned formulae version and still make security updates for that version, when necessary. For example, [PHP 5.5 was not a supported version but PHP 7.2 was](https://php.net/supported-versions.php) in January 2018.
 * Formulae that depend on versioned formulae must not depend on the same formulae at two different versions twice in their recursive dependencies. For example, if you depend on `openssl@1.0` and `foo`, and `foo` depends on `openssl` then you must instead use `openssl`.
 * Versioned formulae should only be linkable at the same time as their non-versioned counterpart if the upstream project provides support for it, e.g. using suffixed binaries. If this is not possible, use `keg_only :versioned_formula` to allow users to have multiple versions installed at once.

--- a/docs/Versions.md
+++ b/docs/Versions.md
@@ -9,6 +9,7 @@ Versioned formulae we include in [homebrew/core](https://github.com/homebrew/hom
 
 * Versioned software should build on all Homebrew's supported versions of macOS.
 * Versioned formulae should differ in major/minor (not patch) versions from the current stable release. This is because patch versions indicate bug or security updates and we want to ensure you apply security updates.
+* Unstable versions (alpha, beta, development versions) are not acceptable, not even for versioned formulae.
 * Upstream should have a release branch for the versioned formulae version and still make security updates for that version, when necessary. For example, [PHP 5.5 was not a supported version but PHP 7.2 was](https://php.net/supported-versions.php) in January 2018.
 * Formulae that depend on versioned formulae must not depend on the same formulae at two different versions twice in their recursive dependencies. For example, if you depend on `openssl@1.0` and `foo`, and `foo` depends on `openssl` then you must instead use `openssl`.
 * Versioned formulae should only be linkable at the same time as their non-versioned counterpart if the upstream project provides support for it, e.g. using suffixed binaries. If this is not possible, use `keg_only :versioned_formula` to allow users to have multiple versions installed at once.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

The explanation that unstable versions are not acceptable was already in https://docs.brew.sh/Acceptable-Formulae#niche-or-self-submitted-stuff, but not in the Versions docs, which made me believe that unstable versions are fine for versioned formulae (see https://github.com/Homebrew/homebrew-core/pull/50882).

I have added a note to the Versions docs for clarity.