### PR TITLE
API: supply additional data for requirements

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1690,10 +1690,13 @@ class Formula
     end
 
     hsh["requirements"] = requirements.map do |req|
+      req.name.prepend("maximum_") if req.try(:comparator) == "<="
       {
         "name"     => req.name,
         "cask"     => req.cask,
         "download" => req.download,
+        "version"  => req.try(:version),
+        "contexts" => req.tags,
       }
     end
 

--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -3,9 +3,9 @@
 require "language/java"
 
 class JavaRequirement < Requirement
-  attr_reader :java_home
-
   fatal true
+
+  attr_reader :java_home, :version
 
   # A strict Java 8 requirement (1.8) should prompt the user to install
   # an OpenJDK 1.8 distribution. Versions newer than Java 8 are not

--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -5,6 +5,8 @@ require "requirement"
 class MacOSRequirement < Requirement
   fatal true
 
+  attr_reader :comparator, :version
+
   def initialize(tags = [], comparator: ">=")
     if comparator == "==" && tags.first.respond_to?(:map)
       @version = tags.shift.map { |s| MacOS::Version.from_symbol(s) }
@@ -52,6 +54,10 @@ class MacOSRequirement < Requirement
 
       "macOS #{@version.pretty_name} is required."
     end
+  end
+
+  def inspect
+    "#<#{self.class.name}: #{tags.inspect} version#{@comparator}#{@version}>"
   end
 
   def display_s

--- a/Library/Homebrew/requirements/xcode_requirement.rb
+++ b/Library/Homebrew/requirements/xcode_requirement.rb
@@ -5,6 +5,8 @@ require "requirement"
 class XcodeRequirement < Requirement
   fatal true
 
+  attr_reader :version
+
   satisfy(build_env: false) { xcode_installed_version }
 
   def initialize(tags = [])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Adds additional fields to the "requirements" section of the formula JSON API; specifically: 

- for `:maximum_macos`, changes _name_ to "maximum_macos"
- adds _version_ which can have a value for "macos", "maximum_macos", "java", and "xcode" requirements, and is _null_ for others
- adds _contexts_ which is a list of one or both "build" and "test" and an empty list otherwise
- also adds an inspect method to macos_requirement.rb so it includes the comparator and version

Merging this will allow fixing the display of e.g. macOS requirements for pages like https://formulae.brew.sh/formula/valgrind which don't include any version information.

<details>
  <summary>Example output</summary>
  <pre>

	# macos run version
	$ brew info --json go | jq ".[0].requirements"
	[
	  {
		"name": "macos",
		"cask": null,
		"download": null,
		"version": "10.11",
		"contexts": []
	  }
	]

	# maximum_macos run version
	$ brew info --json valgrind | jq ".[0].requirements"
	[
	  {
		"name": "maximum_macos",
		"cask": null,
		"download": null,
		"version": "10.13",
		"contexts": []
	  }
	]

	# maximum_macos build version
	$ brew info --json gcc@5 | jq ".[0].requirements"
	[
	  {
		"name": "maximum_macos",
		"cask": null,
		"download": null,
		"version": "10.13",
		"contexts": [
		  "build"
		]
	  }
	]

	# xcode build
	$ brew info --json llvm | jq ".[0].requirements"
	[
	  {
		"name": "xcode",
		"cask": null,
		"download": null,
		"version": null,
		"contexts": [
		  "build"
		]
	  }
	]

	# xcode version
	$ brew info --json rswift | jq ".[0].requirements"
	[
	  {
		"name": "xcode",
		"cask": null,
		"download": null,
		"version": "10.0",
		"contexts": []
	  }
	]

	# xcode version build
	$ brew info --json plank | jq ".[0].requirements"
	[
	  {
		"name": "xcode",
		"cask": null,
		"download": null,
		"version": "11.3",
		"contexts": [
		  "build"
		]
	  }
	]

	# xcode versions for run & build
	$ brew info --json needle | jq ".[0].requirements"
	[
	  {
		"name": "xcode",
		"cask": null,
		"download": null,
		"version": "10.0",
		"contexts": [
		  "build"
		]
	  },
	  {
		"name": "xcode",
		"cask": null,
		"download": null,
		"version": "6.0",
		"contexts": []
	  }
	]

	# xcode version for build & test
	$ brew info --json sourcedocs | jq ".[0].requirements"
	[
	  {
		"name": "xcode",
		"cask": null,
		"download": null,
		"version": "10.3",
		"contexts": [
		  "build",
		  "test"
		]
	  }
	]

	# java version
	$ brew info --json blazegraph | jq ".[0].requirements"
	[
	  {
		"name": "java",
		"cask": "adoptopenjdk",
		"download": null,
		"version": "1.7+",
		"contexts": []
	  }
	]

	# java version for build & test
	$ brew info --json infer | jq ".[0].requirements"
	[
	  {
		"name": "java",
		"cask": "homebrew/cask-versions/adoptopenjdk8",
		"download": null,
		"version": "1.8",
		"contexts": [
		  "build",
		  "test"
		]
	  }
	]

  </pre>
</details>
