### PR TITLE
Fix for when version is nil

### DIFF
--- a/Library/Homebrew/pkg_version.rb
+++ b/Library/Homebrew/pkg_version.rb
@@ -36,7 +36,10 @@ class PkgVersion
   def <=>(other)
     return unless other.is_a?(PkgVersion)
 
-    (version <=> other.version).nonzero? || revision <=> other.revision
+    comp_ver = (version <=> other.version)
+    return if comp_ver.nil?
+
+    comp_ver.nonzero? || revision <=> other.revision
   end
   alias eql? ==
 

--- a/Library/Homebrew/pkg_version.rb
+++ b/Library/Homebrew/pkg_version.rb
@@ -36,10 +36,10 @@ class PkgVersion
   def <=>(other)
     return unless other.is_a?(PkgVersion)
 
-    comp_ver = (version <=> other.version)
-    return if comp_ver.nil?
+    version_comparison = (version <=> other.version)
+    return if version_comparison.nil?
 
-    comp_ver.nonzero? || revision <=> other.revision
+    version_comparison.nonzero? || revision <=> other.revision
   end
   alias eql? ==
 

--- a/Library/Homebrew/test/pkg_version_spec.rb
+++ b/Library/Homebrew/test/pkg_version_spec.rb
@@ -54,6 +54,11 @@ describe PkgVersion do
   describe "#<=>" do
     it "returns nil if the comparison fails" do
       expect(described_class.new(Version.create("1.0"), 0) <=> Object.new).to be nil
+      expect(Object.new <=> described_class.new(Version.create("1.0"), 0)).to be nil
+      expect(Object.new <=> described_class.new(Version.create("1.0"), 0)).to be nil
+      expect(described_class.new(Version.create("1.0"), 0) <=> nil).to be nil
+      # This one used to fail due to dereferencing a null `self`
+      expect(described_class.new(nil, 0) <=> described_class.new(Version.create("1.0"), 0)).to be nil
     end
   end
 


### PR DESCRIPTION
When version is nil, (version <==> other.version) also returns nil and then the nill object doesn't have a nonzero? method.

Fixes https://github.com/Homebrew/brew/issues/7110 

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
