### PR TITLE
python: Use literal "python" for virtualenv path

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -227,7 +227,7 @@ module Language
 
           Pathname.glob(@venv_root/"lib/python*/orig-prefix.txt").each do |prefix_file|
             prefix_path = prefix_file.read
-            prefix_path.sub! %r{^#{HOMEBREW_CELLAR}/#{python}/[^/]+}, Formula["python"].opt_prefix
+            prefix_path.sub! %r{^#{HOMEBREW_CELLAR}/python/[^/]+}, Formula["python"].opt_prefix
             prefix_file.atomic_write prefix_path
           end
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is part 2 of #7116 ; it looks like https://github.com/Bo98/brew/commit/c46a30b5757f901d111dafc585e53df35a46e407#diff-86d78c9fcb1fe847e0ef982ea0b5adfdL221 removed the local variable without removing the interpolation, so this raises an exception now. Since this was the change that was made on L213-214 I think this is probably what the intent was here.

Tested locally, but did not add new tests for this.

Thank you!
