### PR TITLE
dependency_collector: make resource dep available at test-time too

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -142,7 +142,7 @@ class DependencyCollector
   end
 
   def resource_dep(spec, tags)
-    tags << :build
+    tags << :build << :test
     strategy = spec.download_strategy
 
     if strategy <= CurlDownloadStrategy

--- a/Library/Homebrew/test/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/dependency_collector_spec.rb
@@ -62,13 +62,13 @@ describe DependencyCollector do
     it "creates a resource dependency from a CVS URL" do
       resource = Resource.new
       resource.url(":pserver:anonymous:@brew.sh:/cvsroot/foo/bar", using: :cvs)
-      expect(subject.add(resource)).to eq(Dependency.new("cvs", [:build]))
+      expect(subject.add(resource)).to eq(Dependency.new("cvs", [:build, :test]))
     end
 
     it "creates a resource dependency from a '.7z' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.7z")
-      expect(subject.add(resource)).to eq(Dependency.new("p7zip", [:build]))
+      expect(subject.add(resource)).to eq(Dependency.new("p7zip", [:build, :test]))
     end
 
     it "creates a resource dependency from a '.gz' URL" do
@@ -80,25 +80,25 @@ describe DependencyCollector do
     it "creates a resource dependency from a '.lz' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.lz")
-      expect(subject.add(resource)).to eq(Dependency.new("lzip", [:build]))
+      expect(subject.add(resource)).to eq(Dependency.new("lzip", [:build, :test]))
     end
 
     it "creates a resource dependency from a '.lha' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.lha")
-      expect(subject.add(resource)).to eq(Dependency.new("lha", [:build]))
+      expect(subject.add(resource)).to eq(Dependency.new("lha", [:build, :test]))
     end
 
     it "creates a resource dependency from a '.lzh' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.lzh")
-      expect(subject.add(resource)).to eq(Dependency.new("lha", [:build]))
+      expect(subject.add(resource)).to eq(Dependency.new("lha", [:build, :test]))
     end
 
     it "creates a resource dependency from a '.rar' URL" do
       resource = Resource.new
       resource.url("https://brew.sh/foo.rar")
-      expect(subject.add(resource)).to eq(Dependency.new("unrar", [:build]))
+      expect(subject.add(resource)).to eq(Dependency.new("unrar", [:build, :test]))
     end
 
     it "raises a TypeError for unknown classes" do

--- a/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/linux/dependency_collector_spec.rb
@@ -12,19 +12,19 @@ describe DependencyCollector do
       it "creates a resource dependency from a '.xz' URL" do
         resource.url("https://brew.sh/foo.xz")
         allow_any_instance_of(Object).to receive(:which).with("xz")
-        expect(subject.add(resource)).to eq(Dependency.new("xz", [:build]))
+        expect(subject.add(resource)).to eq(Dependency.new("xz", [:build, :test]))
       end
 
       it "creates a resource dependency from a '.zip' URL" do
         resource.url("https://brew.sh/foo.zip")
         allow_any_instance_of(Object).to receive(:which).with("unzip")
-        expect(subject.add(resource)).to eq(Dependency.new("unzip", [:build]))
+        expect(subject.add(resource)).to eq(Dependency.new("unzip", [:build, :test]))
       end
 
       it "creates a resource dependency from a '.bz2' URL" do
         resource.url("https://brew.sh/foo.tar.bz2")
         allow_any_instance_of(Object).to receive(:which).with("bzip2")
-        expect(subject.add(resource)).to eq(Dependency.new("bzip2", [:build]))
+        expect(subject.add(resource)).to eq(Dependency.new("bzip2", [:build, :test]))
       end
     end
 


### PR DESCRIPTION
There are formulae that use resource blocks for stuff that is needed in
test blocks. If a resource is a `.zip` archive, one needs `unzip`
utility in `PATH` to extract it, but its only available at build-time,
so one observes an error like that for example:

```
==> brew test psftools --verbose
Testing psftools
==> Downloading https://www.zone38.net/font/pc8x8.zip
Already downloaded: /github/home/.cache/Homebrew/downloads/ea5f6a485687368ff5bc99e4cc43a49b06e081baa51a97ee6ddcd8d1b82d7963--pc8x8.zip
==> Verifying ea5f6a485687368ff5bc99e4cc43a49b06e081baa51a97ee6ddcd8d1b82d7963--pc8x8.zip checksum
unzip -o /github/home/.cache/Homebrew/downloads/ea5f6a485687368ff5bc99e4cc43a49b06e081baa51a97ee6ddcd8d1b82d7963--pc8x8.zip -d /tmp/d20200304-21389-ui0wr0
Error: psftools: failed
undefined method `shelljoin' for nil:NilClass
```

Of course this issue affects Linux the most, because of higher
probability that the system lacks `unzip` for example.

With this commit, all resource guessed dependencies should be available
at build and test time.

cc @jonchang (we used to debug this issue someday)

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----