### PR TITLE
Fetch formula resources before unlinking during upgrade.

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -369,6 +369,7 @@ module Cask
             fi.show_header = true
             fi.verbose = verbose?
             fi.prelude
+            fi.fetch
             fi.install
             fi.finish
           end

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -368,8 +368,8 @@ module Cask
             fi.installed_on_request = false
             fi.show_header = true
             fi.verbose = verbose?
-            fi.prelude
             fi.fetch
+            fi.prelude
             fi.install
             fi.finish
           end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -326,6 +326,7 @@ module Homebrew
     fi.interactive          = args.interactive?
     fi.git                  = args.git?
     fi.prelude
+    fi.fetch
     fi.install
     fi.finish
   rescue FormulaInstallationAlreadyAttemptedError

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -325,8 +325,8 @@ module Homebrew
     fi.build_bottle         = args.build_bottle?
     fi.interactive          = args.interactive?
     fi.git                  = args.git?
-    fi.prelude
     fi.fetch
+    fi.prelude
     fi.install
     fi.finish
   rescue FormulaInstallationAlreadyAttemptedError

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -192,6 +192,8 @@ module Homebrew
     end
     oh1 "Upgrading #{Formatter.identifier(f.full_specified_name)} #{upgrade_version} #{fi.options.to_a.join(" ")}"
 
+    fi.fetch
+
     # first we unlink the currently active keg for this formula otherwise it is
     # possible for the existing build to interfere with the build we are about to
     # do! Seriously, it happens!

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -183,7 +183,6 @@ module Homebrew
       fi.installed_as_dependency = tab.installed_as_dependency
       fi.installed_on_request  ||= tab.installed_on_request
     end
-    fi.prelude
 
     upgrade_version = if f.optlinked?
       "#{Keg.new(f.opt_prefix).version} -> #{f.pkg_version}"
@@ -193,6 +192,7 @@ module Homebrew
     oh1 "Upgrading #{Formatter.identifier(f.full_specified_name)} #{upgrade_version} #{fi.options.to_a.join(" ")}"
 
     fi.fetch
+    fi.prelude
 
     # first we unlink the currently active keg for this formula otherwise it is
     # possible for the existing build to interfere with the build we are about to

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1160,6 +1160,7 @@ class Formula
   # @private
   def brew
     @prefix_returns_versioned_prefix = true
+    active_spec.fetch
     stage do |staging|
       staging.retain! if Homebrew.args.keep_tmp?
       prepare_patches

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -561,6 +561,18 @@ class FormulaInstaller
     @show_header = true unless deps.empty?
   end
 
+  def fetch_dependency(dep)
+    df = dep.to_formula
+    fi = FormulaInstaller.new(df)
+
+    fi.build_from_source       = Homebrew.args.build_formula_from_source?(df)
+    fi.force_bottle            = false
+    fi.verbose                 = verbose?
+    fi.quiet                   = quiet?
+    fi.debug                   = debug?
+    fi.fetch
+  end
+
   def install_dependency(dep, inherited_options)
     df = dep.to_formula
     tab = Tab.for_formula(df)
@@ -600,7 +612,6 @@ class FormulaInstaller
     fi.installed_as_dependency = true
     fi.installed_on_request    = df.any_version_installed? && tab.installed_on_request
     fi.prelude
-    fi.fetch
     oh1 "Installing #{formula.full_name} dependency: #{Formatter.identifier(dep.name)}"
     fi.install
     fi.finish
@@ -952,9 +963,7 @@ class FormulaInstaller
 
     return if deps.empty? || ignore_deps?
 
-    deps.each do |dep, _|
-      dep.to_formula.resources.each(&:fetch)
-    end
+    deps.each { |dep, _options| fetch_dependency(dep) }
   end
 
   def fetch

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -36,6 +36,7 @@ module Homebrew
       fi.installed_on_request    = tab.installed_on_request
     end
     fi.prelude
+    fi.fetch
 
     oh1 "Reinstalling #{Formatter.identifier(f.full_name)} #{options.to_a.join " "}"
 

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -35,8 +35,8 @@ module Homebrew
       fi.installed_as_dependency = tab.installed_as_dependency
       fi.installed_on_request    = tab.installed_on_request
     end
-    fi.prelude
     fi.fetch
+    fi.prelude
 
     oh1 "Reinstalling #{Formatter.identifier(f.full_name)} #{options.to_a.join " "}"
 

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -70,8 +70,8 @@ class Resource
   def stage(target = nil, &block)
     raise ArgumentError, "target directory or block is required" unless target || block
 
-    fetch
     prepare_patches
+
     unpack(target, &block)
   end
 

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -23,7 +23,10 @@ describe FormulaInstaller do
     stub_formula_loader formula("gcc") { url "gcc-1.0" }
     stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
     allow(Formula["patchelf"]).to receive(:latest_version_installed?).and_return(true)
-    described_class.new(formula).install
+
+    fi = FormulaInstaller.new(formula)
+    fi.fetch
+    fi.install
 
     keg = Keg.new(formula.prefix)
 

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -21,6 +21,7 @@ describe FormulaInstaller do
 
     installer = described_class.new(formula)
 
+    installer.fetch
     installer.install
 
     keg = Keg.new(formula.prefix)
@@ -158,6 +159,7 @@ describe FormulaInstaller do
 
     it "shows audit problems if HOMEBREW_DEVELOPER is set" do
       ENV["HOMEBREW_DEVELOPER"] = "1"
+      formula_installer.fetch
       formula_installer.install
       expect(formula_installer).to receive(:audit_installed).and_call_original
       formula_installer.caveats

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -149,6 +149,7 @@ describe Formulary do
       let(:installer) { FormulaInstaller.new(installed_formula) }
 
       it "returns a Formula when given a rack" do
+        installer.fetch
         installer.install
 
         f = described_class.from_rack(installed_formula.rack)
@@ -156,6 +157,7 @@ describe Formulary do
       end
 
       it "returns a Formula when given a Keg" do
+        installer.fetch
         installer.install
 
         keg = Keg.new(installed_formula.prefix)

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -177,6 +177,7 @@ RSpec.shared_context "integration test" do
     fi = FormulaInstaller.new(Formula[name])
     fi.build_bottle = build_bottle
     fi.prelude
+    fi.fetch
     fi.install
     fi.finish
   end

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -176,8 +176,8 @@ RSpec.shared_context "integration test" do
     setup_test_formula(name, content)
     fi = FormulaInstaller.new(Formula[name])
     fi.build_bottle = build_bottle
-    fi.prelude
     fi.fetch
+    fi.prelude
     fi.install
     fi.finish
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This updates the `brew upgrade` command. Upgrading default behavior will now fetch remote resources before unlinking, and then install the new version as requested in #6339 

Fixes #6374.
