### PR TITLE
extend/string: match multiline make variables

### DIFF
--- a/Library/Homebrew/extend/string.rb
+++ b/Library/Homebrew/extend/string.rb
@@ -41,7 +41,7 @@ module StringInreplaceExtension
   # Looks for Makefile style variable definitions and replaces the
   # value with "new_value", or removes the definition entirely.
   def change_make_var!(flag, new_value)
-    return if gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=[ \t]*(.*)$/, "#{flag}=#{new_value}", false)
+    return if gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=[ \t]*((?:.*\\\n)*.*)$/, "#{flag}=#{new_value}", false)
 
     errors << "expected to change #{flag.inspect} to #{new_value.inspect}"
   end
@@ -50,7 +50,7 @@ module StringInreplaceExtension
   def remove_make_var!(flags)
     Array(flags).each do |flag|
       # Also remove trailing \n, if present.
-      unless gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=.*$\n?/, "", false)
+      unless gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=(?:.*\\\n)*.*$\n?/, "", false)
         errors << "expected to remove #{flag.inspect}"
       end
     end
@@ -58,6 +58,6 @@ module StringInreplaceExtension
 
   # Finds the specified variable
   def get_make_var(flag)
-    self[/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=[ \t]*(.*)$/, 1]
+    self[/^#{Regexp.escape(flag)}[ \t]*[\\?\+\:\!]?=[ \t]*((?:.*\\\n)*.*)$/, 1]
   end
 end

--- a/Library/Homebrew/test/inreplace_spec.rb
+++ b/Library/Homebrew/test/inreplace_spec.rb
@@ -53,6 +53,24 @@ describe StringInreplaceExtension do
           EOS
         end
       end
+
+      context "with newlines" do
+        let(:string) do
+          <<~'EOS'
+            CFLAGS = -Wall -O2 \
+                     -DSOME_VAR=1
+            LDFLAGS = -lcrypto -lssl
+          EOS
+        end
+
+        it "is successfully replaced" do
+          subject.change_make_var! "CFLAGS", "-O3"
+          expect(subject).to eq <<~EOS
+            CFLAGS=-O3
+            LDFLAGS = -lcrypto -lssl
+          EOS
+        end
+      end
     end
 
     context "empty flag between other flags" do
@@ -146,6 +164,23 @@ describe StringInreplaceExtension do
           EOS
         end
       end
+
+      context "with newlines" do
+        let(:string) do
+          <<~'EOS'
+            CFLAGS = -Wall -O2 \
+                     -DSOME_VAR=1
+            LDFLAGS = -lcrypto -lssl
+          EOS
+        end
+
+        it "is successfully removed" do
+          subject.remove_make_var! "CFLAGS"
+          expect(subject).to eq <<~EOS
+            LDFLAGS = -lcrypto -lssl
+          EOS
+        end
+      end
     end
 
     context "multiple flags" do
@@ -192,6 +227,20 @@ describe StringInreplaceExtension do
 
       it "extracts the value for a given variable" do
         expect(subject.get_make_var("CFLAGS")).to eq("-Wall -O2")
+      end
+    end
+
+    context "with newlines" do
+      let(:string) do
+        <<~'EOS'
+          CFLAGS = -Wall -O2 \
+                   -DSOME_VAR=1
+          LDFLAGS = -lcrypto -lssl
+        EOS
+      end
+
+      it "extracts the value for a given variable" do
+        expect(subject.get_make_var("CFLAGS")).to match(/^-Wall -O2 \\\n +-DSOME_VAR=1$/)
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Take a Makefile like this:

```
CFLAGS = -Wall -O2 \
         -DSOME_VAR=1
```

Previously, `get_make_var("CFLAGS")` would return `-Wall -O2 \` while `remove_make_var!("CFLAGS")` would result in:

```
         -DSOME_VAR=1
```

This pull request adds checks for the backslash to escape newlines, so that the above scenarios are handled properly.