### PR TITLE
rubocop.yml: reduce Max LineLength.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -80,7 +80,7 @@ Metrics/PerceivedComplexity:
 
 # GitHub diff UI wraps beyond 118 characters (so that's the goal)
 Layout/LineLength:
-  Max: 170
+  Max: 167
   # ignore manpage comments and long single-line strings
   IgnoredPatterns: ['#: ', ' url "', ' mirror "', ' plist_options :']
 


### PR DESCRIPTION
Fixed the formulae in homebrew/core. Slowly but surely...

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----