### PR TITLE
rewrite_python_shebang: move loop invariants out of loop

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -88,9 +88,9 @@ module Language
     end
 
     def self.rewrite_python_shebang(python_path)
+      regex = %r{^#! ?/usr/bin/(env )?python([23](\.\d{1,2})?)$}
+      maximum_regex_length = 28 # the length of "#! /usr/bin/env pythonx.yyy$"
       Pathname(".").find do |f|
-        regex = %r{^#! ?/usr/bin/(env )?python([23](\.\d{1,2})?)$}
-        maximum_regex_length = "#! /usr/bin/env pythonx.yyy$".length
         next unless f.file?
         next unless regex.match?(f.read(maximum_regex_length))
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`regex` and `maximum_regex_length` variables do not change inside `Pathname(".").find do |f|` loop, so move them out of the loop.

`brew style` complains:
```
Library/Homebrew/language/python.rb:92:30: C: Do not compute the size of statically sized objects.
      maximum_regex_length = "#! /usr/bin/env pythonx.yyy$".length
```

Do I need to fix it something like this
```diff
-      maximum_regex_length = "#! /usr/bin/env pythonx.yyy$".length
+      maximum_regex_length = 28 # the lenght of "#! /usr/bin/env pythonx.yyy$"
```
Or add `# rubocop:disable Performance/FixedSize`
Or something else?