### PR TITLE
github: double check if issue is opened

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -302,7 +302,9 @@ module GitHub
   def issues_for_formula(name, options = {})
     tap = options[:tap] || CoreTap.instance
     tap_full_name = options[:tap_full_name] || tap.full_name
-    search_issues(name, state: "open", repo: tap_full_name, in: "title")
+    issues = search_issues(name, state: "open", repo: tap_full_name, in: "title")
+    issues.delete_if { |issue| issue["state"] != "open" }
+    issues
   end
 
   def user


### PR DESCRIPTION
The API could mysteriously sometimes return an issue that is actually
closed, regardless the `state:open` in the search query.

```
irb(main):047:0> GitHub.issues_for_formula("actions-updater", tap_full_name: "dawidd6/homebrew-tap").first["state"]
=> "closed"
```

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----