### PR TITLE
version: add support for aleth version style

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -651,7 +651,9 @@ describe Version do
       expect(described_class.create("4.0.18"))
         .to be_detected_from("https://ftpmirror.gnu.org/mtools/mtools_4.0.18_i386.deb")
       expect(described_class.create("1.8.0"))
-        .to be_detected_from("https://github.com/ethereum/aleth/releases/download/v1.8.0/aleth-1.8.0-darwin-x86_64.tar.gz")
+        .to be_detected_from(
+          "https://github.com/ethereum/aleth/releases/download/v1.8.0/aleth-1.8.0-darwin-x86_64.tar.gz",
+        )
     end
 
     specify "opam version" do

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -650,6 +650,8 @@ describe Version do
         .to be_detected_from("https://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x64.zip")
       expect(described_class.create("4.0.18"))
         .to be_detected_from("https://ftpmirror.gnu.org/mtools/mtools_4.0.18_i386.deb")
+      expect(described_class.create("1.8.0"))
+        .to be_detected_from("https://github.com/ethereum/aleth/releases/download/v1.8.0/aleth-1.8.0-darwin-x86_64.tar.gz")
     end
 
     specify "opam version" do

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -254,8 +254,9 @@ class Version
     m = /[-_]([Rr]\d+[AaBb]\d*(?:-\d+)?)/.match(spec_s)
     return m.captures.first unless m.nil?
 
+    # e.g. foobar-4_5_1
     # e.g. boost_1_39_0
-    m = /((?:\d+_)+\d+)$/.match(stem)
+    m = /([-_](?:\d+_)+\d+)$/.match(stem)
     return m.captures.first.tr("_", ".") unless m.nil?
 
     # e.g. foobar-4.5.1-1
@@ -303,7 +304,8 @@ class Version
     # e.g. https://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x86.zip
     # e.g. https://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x64.zip
     # e.g. https://ftpmirror.gnu.org/mtools/mtools_4.0.18_i386.deb
-    m = /[-_](\d+\.\d+(?:\.\d+)?(?:-\d+)?)[-_.](?:i[36]86|x86|x64(?:[-_](?:32|64))?)$/.match(stem)
+    # e.g. https://github.com/ethereum/aleth/releases/download/v1.8.0/aleth-1.8.0-darwin-x86_64.tar.gz
+    m = /[-_](\d+\.\d+(?:\.\d+)?(?:-\d+)?)(?:[-_.](?:darwin|linux))?[-_.](?:i[36]86|(?:x86|x64)(?:[-_](?:32|64))?)$/.match(stem)
     return m.captures.first unless m.nil?
 
     # devel spec

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -305,7 +305,9 @@ class Version
     # e.g. https://ftpmirror.gnu.org/libtasn1/libtasn1-2.8-x64.zip
     # e.g. https://ftpmirror.gnu.org/mtools/mtools_4.0.18_i386.deb
     # e.g. https://github.com/ethereum/aleth/releases/download/v1.8.0/aleth-1.8.0-darwin-x86_64.tar.gz
+    # rubocop:disable Layout/LineLength
     m = /[-_](\d+\.\d+(?:\.\d+)?(?:-\d+)?)(?:[-_.](?:darwin|linux))?[-_.](?:i[36]86|(?:x86|x64)(?:[-_](?:32|64))?)$/.match(stem)
+    # rubocop:enable Layout/LineLength
     return m.captures.first unless m.nil?
 
     # devel spec


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Adds support for `x86_64` arch 
  - The old pattern `x86|x64(?:[-_](?:32|64))?` excludes `x86` in checking for the suffix `_32` or `_64` (i.e. `x64_64` matches, but `x86_64` does not)
  - The new pattern `(?:x86|x64)(?:[-_](?:32|64))?` fixes this
- Adds support for aleth version style `aleth-1.8.0-darwin-x86_64`
  - The addition of `(?:[-_.](?:darwin|linux))?` allows for an optional operating-system specifier
- Added `[-_]` prefix to boost version style so that `x86_64` is not interpreted as version `86_64`

-----

~`brew style` fails due to line 308 being too long. I'm not sure how to fix this~