### PR TITLE
rubocops/patches: Make more GitHub patch locations enforce revisions

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -39,6 +39,7 @@ module RuboCop
           end
 
           gh_patch_patterns = Regexp.union([%r{/raw\.github\.com/},
+                                            %r{/raw\.githubusercontent\.com/},
                                             %r{gist\.github\.com/raw},
                                             %r{gist\.github\.com/.+/raw},
                                             %r{gist\.githubusercontent\.com/.+/raw}])


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- We recently deleted a load of old Homebrew/formula-patches patches for non-existent core formulae (https://github.com/Homebrew/formula-patches/pull/283). This is a good action to take. Users should always be able to retrieve the patch once it's been deleted from the repo, if the formula they continue to use specifies a git revision to pull from, not just `master`.
- The code to detect `master` formulae was already here, so this adds another GitHub host to the detection: `raw.githubusercontent.com` as that's what the current patches that use `master` (https://github.com/Homebrew/homebrew-core/pull/51329) link to.
- Fixes https://github.com/Homebrew/homebrew-core/issues/51313.

Example `brew audit` output:

```
dbxml:
  * C: 23: col 17: GitHub/Gist patches should specify a revision:
      https://raw.githubusercontent.com/Homebrew/formula-patches/master/dbxml/c%2B%2B11.patch
Error: 1 problem in 1 formula detected
```