### PR TITLE
Fix SDK issues on Mojave and High Sierra

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -111,7 +111,7 @@ module OS
 
       # If there's no CLT SDK, return early
       return if MacOS::CLT.installed? && !MacOS::CLT.provides_sdk?
-      # If the CLT is installed and provides headers, return early
+      # If the CLT is installed and headers are provided by the system, return early
       return if MacOS::CLT.installed? && !MacOS::CLT.separate_header_package?
 
       sdk_path(v)

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -85,10 +85,10 @@ module OS
     # if available. Otherwise, the latest SDK is returned.
 
     def sdk(v = nil)
-      @locator ||= if Xcode.installed?
-        XcodeSDKLocator.new
-      else
+      @locator ||= if CLT.installed? && CLT.provides_sdk?
         CLTSDKLocator.new
+      else
+        XcodeSDKLocator.new
       end
 
       @locator.sdk_if_applicable(v)
@@ -101,7 +101,7 @@ module OS
     end
 
     def sdk_path_if_needed(v = nil)
-      # Prefer Xcode SDK when both Xcode and the CLT are installed.
+      # Prefer CLT SDK when both Xcode and the CLT are installed.
       # Expected results:
       # 1. On Xcode-only systems, return the Xcode SDK.
       # 2. On Xcode-and-CLT systems where headers are provided by the system, return nil.

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -81,17 +81,8 @@ module OS
     #      are available) is returned.
     #   3. If no SDKs are available, nil is returned.
     #
-    # If no specific SDK is requested:
-    #
-    #   1. For Xcode >= 7, the latest SDK is returned even if the latest SDK is
-    #      named after a newer OS version than the running OS. The
-    #      `MACOSX_DEPLOYMENT_TARGET` must be set to the OS for which you're
-    #      actually building (usually the running OS version).
-    #      - https://github.com/Homebrew/legacy-homebrew/pull/50355
-    #      - https://developer.apple.com/library/ios/documentation/DeveloperTools/Conceptual/WhatsNewXcode/Articles/Introduction.html#//apple_ref/doc/uid/TP40004626
-    #      Section "About SDKs and Simulator"
-    #   2. For Xcode < 7, proceed as if the SDK for the running OS version had
-    #      specifically been requested according to the rules above.
+    # If no specific SDK is requested, the SDK matching the OS version is returned,
+    # if available. Otherwise, the latest SDK is returned.
 
     def sdk(v = nil)
       @locator ||= if Xcode.installed?

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -33,7 +33,7 @@ module OS
       def sdk_if_applicable(v = nil)
         sdk = begin
           if v.nil?
-            (source_version.to_i >= 7) ? latest_sdk : sdk_for(OS::Mac.version)
+            sdk_for OS::Mac.version
           else
             sdk_for v
           end

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -200,7 +200,7 @@ module OS
       end
 
       def separate_header_package?
-        version >= "10"
+        version >= "10" && MacOS.version >= "10.14"
       end
 
       def provides_sdk?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The amount of workarounds is [getting ridiculous](https://github.com/Homebrew/homebrew-core/search?q=HOMEBREW_SDKROOT&unscoped_q=HOMEBREW_SDKROOT). Time to tackle the core of the problem.

### Mojave (and likely Catalina come Xcode 12)

After the removal of `/usr/include`, Apple directed people to use the SDK. However by default, Homebrew uses the latest SDK. This is wrong when dealing with system headers.

For example, Git compiled against the system curl headers. On Mojave under Xcode 11, Homebrew would pick the 10.15 SDK. These curl headers are newer so the `LIBCURL_VERSION_NUM` was higher. This triggered Git to enable some features only available on newer curl. This compiled fine, but would fail at runtime because Mojave's curl library doesn't support the features Git was trying to use.

Instead I changed it so to always prioritise matching the SDK with the OS version. In the event this is not found (which is the case for 10.10-10.13), then the `rescue BaseSDKLocator::NoSDKError` covers that already and returns the latest SDK.

However, this doesn't quite solve the problem under all setups.

Xcode 11 on Mojave does NOT ship with the 10.14 SDK - only the CLT does. Because we prioritise Xcode SDK searching over the CLT, it will never find the 10.14 SDK. I've changed it now to search the CLT first. This is a notable change, but I can't see any reason why it would be problematic on older systems.

These changes also fixes significant GCC issues. GCC is compiled with various patches to the SDK. This does not work if the SDK used does not match what it was compiled with. We currently compile with the SDK matching the OS as it causes the least issues for those using GCC outside of the Homebrew environment, and actually matches the behaviour of Clang.

There is one outstanding issue: Ruby. This is arguably an Apple bug. `gem` does not work unless `SDKROOT` is set to the correct SDK matching the OS. We no longer set SDKROT in the superenv as of mid-2018. That was an area that I wanted to avoid touching as it certainly seems like something that could potentially trigger issues with a few formulae. I'm not sure of a nice way to solve this unless we made a `gem` shim or something.

### High Sierra

Additionally, there were a few issues on High Sierra, albeit less frequent. This was caused by the logic of `MacOS::CLT.separate_header_package?`. The naming is somewhat legacy as the "separate header package" was just some compatibilty crossover period and is no longer supplied. What this really was being used for was to see whether `/usr/include` existed - and thus affect whether the `-isysroot` would be set to the SDK or not. If it was false and the CLT was installed, no SDK would be inserted.

This check was erroneous on High Sierra with CLT 10 installed. The check compared whether the CLT was version >= 10, but did not consider the fact that the system header situation only applies to Mojave and not High Sierra. This meant that both `/usr/include` and the equivalent in the 10.14 SDK was in the search path. Usually, `/usr/include` takes priority but there was some cases where the SDK was used.

The fix was to correct `MacOS::CLT.separate_header_package?` to also consider the OS version.