### PR TITLE
formula: ensure CMake uses the desired SDK

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1335,6 +1335,10 @@ class Formula
     # CMake cache entries for other weak symbols may be added here as needed.
     args << "-DHAVE_CLOCK_GETTIME:INTERNAL=0" if MacOS.version == "10.11" && MacOS::Xcode.version >= "8.0"
 
+    # Ensure CMake is using the same SDK we are using.
+    sdk = MacOS.sdk_path_if_needed
+    args << "-DCMAKE_OSX_SYSROOT=#{sdk}" if sdk
+
     args
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Because we don't set the `SDKROOT` environment variable, CMake doesn't actually know which SDK we are using. Homebrew's SDK control is purely on a compiler level (shims). This results in Homebrew and CMake independently making their own decisions on which SDK to use (unlike other build systems, CMake uses the SDK for package searching so that's why Homebrew's compiler shim control won't cover it). In some cases, this could lead to mismatching SDK versions being used, which is problematic.

Instead, we can tell CMake which SDK we are using by setting the `CMAKE_OSX_SYSROOT` CMake variable. CMake will use that SDK for things like `find_package` and point to the correct place for system headers etc.