### PR TITLE
formula_assertions: print output on assertion failed.

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -11,6 +11,9 @@ module Homebrew
       output = `#{cmd}`
       assert_equal result, $CHILD_STATUS.exitstatus
       output
+    rescue Test::Unit::AssertionFailedError
+      puts output if Homebrew.args.verbose?
+      raise
     end
 
     # Returns the output of running the cmd with the optional input, and
@@ -24,6 +27,9 @@ module Homebrew
       end
       assert_equal result, $CHILD_STATUS.exitstatus unless result.nil?
       output
+    rescue Test::Unit::AssertionFailedError
+      puts output if Homebrew.args.verbose?
+      raise
     end
   end
 end


### PR DESCRIPTION
When doing `brew test --verbose` (as `brew test-bot` does) ensure that the output is printed when an assertion fails to more easily debug the test failure.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----