### PR TITLE
Add headers option to URLs in forumlas

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -421,7 +421,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
-    args += [meta[:header], meta[:headers]].compact.flatten.flat_map { |h| ["--header", h.strip] }
+    args += [meta[:header], meta[:headers]].compact.flatten.flat_map { |h| ["--header", h.strip] } 
 
     args
   end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -421,7 +421,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
-    args += [meta[:header], meta[:headers]].compact.flatten.flat_map { |h| ["--header", h.strip] } 
+    args += [meta[:header], meta[:headers]].compact.flatten.flat_map { |h| ["--header", h.strip] }
 
     args
   end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -423,6 +423,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--header", meta.fetch(:header)] if meta.key?(:header)
 
+    meta.fetch(:headers).each { |h| args += ["--header", h.strip] } if meta.key?(:headers)
+
     args
   end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -421,8 +421,6 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
-    args += ["--header", meta.fetch(:header)] if meta.key?(:header)
-
     args += [meta[:header], meta[:headers]].compact.flatten.flat_map { |h| ["--header", h.strip] }
 
     args

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -423,7 +423,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--header", meta.fetch(:header)] if meta.key?(:header)
 
-    meta.fetch(:headers).each { |h| args += ["--header", h.strip] } if meta.key?(:headers)
+    args += [meta.fetch(:header), *meta.fetch(:headers)].compact.flat_map { |h| ["--header", h.strip] }
 
     args
   end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -421,7 +421,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
-    args += [meta[:header], meta[:headers]].compact.flatten.flat_map { |h| ["--header", h.strip] }
+    args += [meta[:header], meta[:headers]].flatten.compact.flat_map { |h| ["--header", h.strip] }
 
     args
   end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -423,7 +423,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--header", meta.fetch(:header)] if meta.key?(:header)
 
-    args += [meta.fetch(:header), *meta.fetch(:headers)].compact.flat_map { |h| ["--header", h.strip] }
+    args += [meta[:header], meta[:headers]].compact.flatten.flat_map { |h| ["--header", h.strip] }
 
     args
   end

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -245,7 +245,7 @@ describe CurlDownloadStrategy do
     context "with headers set" do
       alias_matcher :a_string_matching, :match
 
-      let(:specs) { { headers: ["foo", "bar"]} }
+      let(:specs) { { headers: ["foo", "bar"] } }
 
       it "adds the appropriate curl args" do
         expect(subject).to receive(:system_command!) { |*, args:, **|

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -241,6 +241,21 @@ describe CurlDownloadStrategy do
         subject.fetch
       end
     end
+
+    context "with headers set" do
+      alias_matcher :a_string_matching, :match
+
+      let(:specs) { { headers: ["foo", "bar"]} }
+
+      it "adds the appropriate curl args" do
+        expect(subject).to receive(:system_command!) { |*, args:, **|
+          expect(args.each_cons(2).to_a).to include(["--header", "foo"])
+          expect(args.each_cons(2).to_a).to include(["--header", "bar"])
+        }
+
+        subject.fetch
+      end
+    end
   end
 
   describe "#cached_location" do


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
As raised in  https://github.com/Homebrew/brew/issues/7138 this adds the ability to use two headers when writing formula in case you need both an access key header and an accept header (plus many other fun uses).