### PR TITLE
language/python: fix virtualenv symlinks for versioned Python

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -220,14 +220,21 @@ module Language
             next unless f.symlink?
             next unless (rp = f.realpath.to_s).start_with? HOMEBREW_CELLAR
 
-            new_target = rp.sub %r{#{HOMEBREW_CELLAR}/python/[^/]+}, Formula["python"].opt_prefix
+            version = rp.match %r{^#{HOMEBREW_CELLAR}/python@(.*?)/}
+            version = "@#{version.captures.first}" unless version.nil?
+
+            new_target = rp.sub %r{#{HOMEBREW_CELLAR}/python#{version}/[^/]+}, Formula["python#{version}"].opt_prefix
             f.unlink
             f.make_symlink new_target
           end
 
           Pathname.glob(@venv_root/"lib/python*/orig-prefix.txt").each do |prefix_file|
             prefix_path = prefix_file.read
-            prefix_path.sub! %r{^#{HOMEBREW_CELLAR}/python/[^/]+}, Formula["python"].opt_prefix
+
+            version = prefix_path.match %r{^#{HOMEBREW_CELLAR}/python@(.*?)/}
+            version = "@#{version.captures.first}" unless version.nil?
+
+            prefix_path.sub! %r{^#{HOMEBREW_CELLAR}/python#{version}/[^/]+}, Formula["python#{version}"].opt_prefix
             prefix_file.atomic_write prefix_path
           end
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Previously for `ls -l /usr/local/opt/ansible/libexec/lib/python3.8/`:

```
__future__.py -> ../../../../../python@3.8/3.8.1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/__future__.py
```

Now:

```
__future__.py -> ../../../../../../opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/__future__.py
```