### PR TITLE
cmd/uninstall: handle unparsed arguments.

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -130,7 +130,7 @@ module Homebrew
     protected
 
     def sample_command
-      "brew uninstall --ignore-dependencies #{Homebrew.args.named.join(" ")}"
+      "brew uninstall --ignore-dependencies #{Array(Homebrew.args.named).join(" ")}"
     end
 
     def are_required_by_deps


### PR DESCRIPTION
If `Homebrew.args` hasn't yet been populated then `named` will return `nil`. Instead, ensure it is an array before we try to `join` it.

This is pretty much only a test-time problem but has been causing flaky builds.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----