### PR TITLE
diagnostic: add doctor check for CPU arch on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -2,6 +2,7 @@
 
 require "tempfile"
 require "utils/shell"
+require "hardware"
 require "os/linux/diagnostic"
 require "os/linux/glibc"
 require "os/linux/kernel"
@@ -13,6 +14,7 @@ module Homebrew
         %w[
           check_glibc_minimum_version
           check_kernel_minimum_version
+          check_supported_architecture
         ].freeze
       end
 
@@ -68,6 +70,16 @@ module Homebrew
           be world-writable. This issue can be resolved by adding "umask 002" to
           your #{shell_profile}:
             echo 'umask 002' >> #{shell_profile}
+        EOS
+      end
+
+      def check_supported_architecture
+        return if Hardware::CPU.arch == :x86_64
+
+        <<~EOS
+          Your CPU architecture (#{Hardware::CPU.arch}) is not supported. We only support
+          x86_64 CPU architectures. You will be unable to use binary packages (bottles).
+          #{please_create_pull_requests}
         EOS
       end
 

--- a/Library/Homebrew/test/os/linux/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/linux/diagnostic_spec.rb
@@ -3,6 +3,13 @@
 require "diagnostic"
 
 describe Homebrew::Diagnostic::Checks do
+  specify "#check_supported_architecture" do
+    allow(Hardware::CPU).to receive(:type).and_return(:arm64)
+
+    expect(subject.check_supported_architecture)
+      .to match(/Your CPU architecture .+ is not supported/)
+  end
+
   specify "#check_glibc_minimum_version" do
     allow(OS::Linux::Glibc).to receive(:below_minimum_version?).and_return(true)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

c.f. https://github.com/Homebrew/linuxbrew-core/issues/19809

Adds a message to `brew doctor` that non-x86_64 CPU architectures are not supported on Linux, and to please file pull requests when encountering issues.