### PR TITLE
bump-formula-pr: ignore --version argument if equal to detected version

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -194,7 +194,13 @@ module Homebrew
       resource = Resource.new { @url = new_url }
       resource.download_strategy = DownloadStrategyDetector.detect_from_url(new_url)
       resource.owner = Resource.new(formula.name)
-      resource.version = forced_version if forced_version
+      if forced_version
+        if forced_version == resource.version
+          forced_version = nil
+        else
+          resource.version = forced_version
+        end
+      end
       odie "No --version= argument specified!" unless resource.version
       resource_path = resource.fetch
       tar_file_extensions = %w[.tar .tb2 .tbz .tbz2 .tgz .tlz .txz .tZ]


### PR DESCRIPTION
If one specifies `--version` to the same value as the version detected from URL, `brew bump-formula-pr` will now not set explicit `version` Formula property.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----