### PR TITLE
rubocop: set LineLength to 118.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -78,9 +78,9 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-# GitHub diff UI wraps beyond 118 characters (so that's the goal)
+# GitHub diff UI wraps beyond 118 characters
 Layout/LineLength:
-  Max: 167
+  Max: 118
   # ignore manpage comments and long single-line strings
   IgnoredPatterns: ['#: ', ' url "', ' mirror "', ' plist_options :']
 

--- a/Library/.rubocop_shared.yml
+++ b/Library/.rubocop_shared.yml
@@ -58,9 +58,9 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: true
 
-# This shouldn't be enabled until LineLength is lower.
+# Enabled now LineLength is lowish.
 Style/IfUnlessModifier:
-  Enabled: false
+  Enabled: true
 
 # Only use this for numbers >= `1_000_000`.
 Style/NumericLiterals:

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -61,12 +61,6 @@ Metrics/PerceivedComplexity:
   Enabled: true
   Max: 100
 
-# GitHub diff UI wraps beyond 118 characters
-Layout/LineLength:
-  Max: 118
-  # ignore manpage comments
-  IgnoredPatterns: ['#: ']
-
 # we won't change backward compatible predicate names
 Naming/PredicateName:
   Exclude:


### PR DESCRIPTION
GitHub diff UI wraps beyond 118 characters. This also allows enabling `Style/IfUnlessModifier` (which autocorrects).

I've fixed all violations in Homebrew/homebrew-core.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----