### PR TITLE
rubocop: enable Style/TrailingBodyOnMethodDefinition.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -111,10 +111,6 @@ Style/StringLiteralsInInterpolation:
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
 
-# messes with existing plist/caveats style
-Style/TrailingBodyOnMethodDefinition:
-  Enabled: false
-
 # a bit confusing to non-Rubyists but useful for longer arrays
 Style/WordArray:
   MinSize: 4

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -139,7 +139,3 @@ Style/MutableConstant:
 # LineLength is low enough here to re-enable it.
 Style/IfUnlessModifier:
   Enabled: true
-
-# so many of these in formulae but none in here
-Style/TrailingBodyOnMethodDefinition:
-  Enabled: true


### PR DESCRIPTION
This is default, more consistent with Ruby style and autocorrectable.

I have updated the usage in Homebrew/core to be consistent.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----