### PR TITLE
rubocops/patches: suggest url with full_index=1

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -57,7 +57,7 @@ module RuboCop
           if match_obj = regex_match_group(patch, gh_patch_diff_pattern)
             problem <<~EOS
               use GitHub pull request URLs:
-                https://github.com/#{match_obj[1]}/#{match_obj[2]}/pull/#{match_obj[3]}.patch
+                https://github.com/#{match_obj[1]}/#{match_obj[2]}/pull/#{match_obj[3]}.patch?full_index=1
               Rather than patch-diff:
                 #{patch_url}
             EOS

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -94,7 +94,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
           [{ message:
                        <<~EOS,
                          use GitHub pull request URLs:
-                           https://github.com/foo/foo-bar/pull/100.patch
+                           https://github.com/foo/foo-bar/pull/100.patch?full_index=1
                          Rather than patch-diff:
                            https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch
                        EOS
@@ -231,7 +231,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
           [{ message:
                        <<~EOS,
                          use GitHub pull request URLs:
-                           https://github.com/foo/foo-bar/pull/100.patch
+                           https://github.com/foo/foo-bar/pull/100.patch?full_index=1
                          Rather than patch-diff:
                            https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch
                        EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds `full_index=1` for suggested GitHub PR URL, otherwise `brew audit` will complain next time on this URL due to lack of `full_index=1`