### PR TITLE
[Linux] Remove `--skip-style` flag from `brew merge-homebrew` docs

### DIFF
--- a/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
@@ -85,12 +85,8 @@ including bottles). Once you're satisfied with the list of updated
 formulae, begin the merge:
 
 ```bash
-brew merge-homebrew --core --skip-style <sha>
+brew merge-homebrew --core <sha>
 ```
-
-The `--skip-style` argument skips running `brew style`, which saves
-time and in some cases avoids errors. The style errors can be fixed in
-bottle PRs later in the process when CI flags them.
 
 #### Simple Conflicts
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- This flag was removed (inverted to `--style`) in https://github.com/Homebrew/homebrew-linux-dev/pull/160.