### PR TITLE
Livecheck Formula DSL

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -46,6 +46,8 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: true
   Max: 1100
+  Exclude:
+    - 'test/formula_spec.rb'
 Metrics/BlockNesting:
   Enabled: true
   Max: 5

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Livecheck can be used to check for newer versions of the software.
+# The livecheck DSL specified in the formula is evaluated the methods
+# of this class, which set the instance variables accordingly. The
+# information is used by brew livecheck when checking for newer versions
+# of the software.
+class Livecheck
+  # The reason for skipping livecheck for the formula.
+  # e.g. `Not maintained`
+  attr_reader :skip_msg
+
+  def initialize
+    @regex = nil
+    @skip = false
+    @skip_msg = nil
+    @url = nil
+  end
+
+  # Sets the regex instance variable to the argument given, returns the
+  # regex instance variable when no argument is given.
+  def regex(pattern = nil)
+    return @regex if pattern.nil?
+
+    @regex = pattern
+  end
+
+  # Sets the skip instance variable to true, indicating that livecheck
+  # must be skipped for the formula. If an argument is given and present,
+  # its value is assigned to the skip_msg instance variable, else nil is
+  # assigned.
+  def skip(skip_msg = nil)
+    @skip = true
+    @skip_msg = skip_msg.presence
+  end
+
+  # Should livecheck be skipped for the formula?
+  def skip?
+    @skip
+  end
+
+  # Sets the url instance variable to the argument given, returns the url
+  # instance variable when no argument is given.
+  def url(val = nil)
+    return @url if val.nil?
+
+    @url = val
+  end
+
+  # Returns a Hash of all instance variable values.
+  def to_hash
+    {
+      "regex"    => @regex,
+      "skip"     => @skip,
+      "skip_msg" => @skip_msg,
+      "url"      => @url,
+    }
+  end
+end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -698,6 +698,43 @@ describe Formula do
     expect(f1.test_fixtures("foo")).to eq(Pathname.new("#{HOMEBREW_LIBRARY_PATH}/test/support/fixtures/foo"))
   end
 
+  specify "#livecheck" do
+    f = formula do
+      url "https://brew.sh/test-1.0.tbz"
+      livecheck do
+        skip "foo"
+        url "https://brew.sh/test/releases"
+        regex(/test-(\d+(?:\.\d+)+)\.tbz/)
+      end
+    end
+
+    expect(f.livecheck.skip?).to be true
+    expect(f.livecheck.skip_msg).to eq("foo")
+    expect(f.livecheck.url).to eq("https://brew.sh/test/releases")
+    expect(f.livecheck.regex).to eq(/test-(\d+(?:\.\d+)+)\.tbz/)
+  end
+
+  describe "#livecheckable?" do
+    specify "no livecheck block defined" do
+      f = formula do
+        url "https://brew.sh/test-1.0.tbz"
+      end
+
+      expect(f.livecheckable?).to be false
+    end
+
+    specify "livecheck block defined" do
+      f = formula do
+        url "https://brew.sh/test-1.0.tbz"
+        livecheck do
+          regex(/test-(\d+(?:.\d+)+).tbz/)
+        end
+      end
+
+      expect(f.livecheckable?).to be true
+    end
+  end
+
   specify "dependencies" do
     f1 = formula "f1" do
       url "f1-1.0"

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "livecheck"
+
+describe Livecheck do
+  subject(:livecheckable) { described_class.new }
+
+  describe "#regex" do
+    it "returns nil if unset" do
+      expect(livecheckable.regex).to be nil
+    end
+
+    it "returns the Regex if set" do
+      livecheckable.regex(/foo/)
+      expect(livecheckable.regex).to eq(/foo/)
+    end
+  end
+
+  describe "#skip" do
+    it "sets the instance variable skip to true and skip_msg to nil when the argument is not present" do
+      livecheckable.skip
+      expect(livecheckable.instance_variable_get(:@skip)).to be true
+      expect(livecheckable.instance_variable_get(:@skip_msg)).to be nil
+    end
+
+    it "sets the instance variable skip to true and skip_msg to the argument when present" do
+      livecheckable.skip("foo")
+      expect(livecheckable.instance_variable_get(:@skip)).to be true
+      expect(livecheckable.instance_variable_get(:@skip_msg)).to eq("foo")
+    end
+  end
+
+  describe "#skip?" do
+    it "returns the value of the instance variable skip" do
+      expect(livecheckable.skip?).to be false
+      livecheckable.skip
+      expect(livecheckable.skip?).to be true
+    end
+  end
+
+  describe "#url" do
+    it "returns nil if unset" do
+      expect(livecheckable.url).to be nil
+    end
+
+    it "returns the URL if set" do
+      livecheckable.url("foo")
+      expect(livecheckable.url).to eq("foo")
+    end
+  end
+
+  describe "#to_hash" do
+    it "returns a Hash of all instance variables" do
+      expect(livecheckable.to_hash).to eq({ "regex"=>nil, "skip"=>false, "skip_msg"=>nil, "url"=>nil })
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Addresses #7027, aims to add a Formula DSL for `livecheck`.

Just starting to implement this and I have a few doubts. Where would the functions for `skip`, `using`, etc. mentioned in the example be defined? Or would they be implemented in some other way?

So far (locally) I have tried this, below the definition of `livecheck(&block)`:
```ruby
def skip(reason)
  puts "Skipping: #{reason}"
end
```
However, I'm not sure if that's the way I should be doing it.