### PR TITLE
audit: throttle awscli@1 instead of awscli

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -722,7 +722,7 @@ module Homebrew
 
       throttled = %w[
         aws-sdk-cpp 10
-        awscli 10
+        awscli@1 10
         quicktype 10
         vim 50
       ]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`awscli` is throttled in `audit.rb` to only update every ten versions, due to the near-daily release cycle of the v1 series. Version 2 of `awscli` was released on 2020-02-10 and version 1 was moved to `awscli@1`. Right now, `awscli@1` isn't being throttled even though it needs to be, so this updates the referenced formula in `audit.rb` accordingly.

`awscli` version 2 has had a slower release cadence (15 days for 2.0.1, six days for 2.0.2, seven days for 2.0.3). If the release cadence for v2 continues in the same fashion, I don't imagine we'll need to throttle it. If that's agreeable, we should probably remove the comment in the `awscli` formula about only updating on every tenth version.

For what it's worth, `brew test` gives failures on both master and this PR branch, varying between 4-6 failures per run, so I'm not sure what to think about that.