### PR TITLE
cli/parser: chomp '=' from comma_array flag name

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -95,6 +95,7 @@ module Homebrew
       end
 
       def comma_array(name, description: nil)
+        name = name.chomp "="
         description = option_to_description(name) if description.nil?
         process_option(name, description)
         @parser.on(name, OptionParser::REQUIRED_ARGUMENT, Array, *wrap_option_desc(description)) do |list|

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -40,7 +40,7 @@ module Homebrew
              description: "Print the pull request URL instead of opening in a browser."
       switch "--no-fork",
              description: "Don't try to fork the repository."
-      comma_array "--mirror=",
+      comma_array "--mirror",
                   description: "Use the specified <URL> as a mirror URL. If <URL> is a comma-separated list "\
                                "of URLs, multiple mirrors will be added."
       flag   "--version=",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1015,8 +1015,8 @@ Install macOS applications distributed as binaries. See `brew-cask`(1).
 
 ### `bundle` *`subcommand`*
 
-Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask and the Mac App
-Store.
+Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store
+and Whalebrew.
 
 `brew bundle` [`install`]
 
@@ -1024,7 +1024,7 @@ Install or upgrade all dependencies in a `Brewfile`.
 
 `brew bundle dump`
 
-Write all installed casks/formulae/taps into a `Brewfile`.
+Write all installed casks/formulae/images/taps into a `Brewfile`.
 
 `brew bundle cleanup`
 
@@ -1065,6 +1065,8 @@ dependencies are listed.
   `list` tap dependencies.
 * `--mas`:
   `list` Mac App Store dependencies.
+* `--whalebrew`:
+  `list` Whalebrew dependencies.
 * `--describe`:
   `dump` a description comment above each line, unless the dependency does not have a description.
 * `--no-restart`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1290,7 +1290,7 @@ Install macOS applications distributed as binaries\. See \fBbrew\-cask\fR(1)\.
     \fIhttps://github\.com/Homebrew/homebrew\-cask\fR
 .
 .SS "\fBbundle\fR \fIsubcommand\fR"
-Bundler for non\-Ruby dependencies from Homebrew, Homebrew Cask and the Mac App Store\.
+Bundler for non\-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store and Whalebrew\.
 .
 .P
 \fBbrew bundle\fR [\fBinstall\fR]
@@ -1302,7 +1302,7 @@ Install or upgrade all dependencies in a \fBBrewfile\fR\.
 \fBbrew bundle dump\fR
 .
 .P
-Write all installed casks/formulae/taps into a \fBBrewfile\fR\.
+Write all installed casks/formulae/images/taps into a \fBBrewfile\fR\.
 .
 .P
 \fBbrew bundle cleanup\fR
@@ -1371,6 +1371,10 @@ Read the \fBBrewfile\fR from \fB~/\.Brewfile\fR\.
 .TP
 \fB\-\-mas\fR
 \fBlist\fR Mac App Store dependencies\.
+.
+.TP
+\fB\-\-whalebrew\fR
+\fBlist\fR Whalebrew dependencies\.
 .
 .TP
 \fB\-\-describe\fR


### PR DESCRIPTION
`brew bump-formula-pr` help message:

Before:

```
        --mirror=                    Use the specified URL as a mirror URL. If
                                     URL is a comma-separated list of URLs,
                                     multiple mirrors will be added.
```

After:

```
        --mirror                     Use the specified URL as a mirror URL. If
                                     URL is a comma-separated list of URLs,
                                     multiple mirrors will be added.
```

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----