### PR TITLE
manpages: Run `brew man` after `brew bundle` Whalebrew inclusion

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1015,8 +1015,8 @@ Install macOS applications distributed as binaries. See `brew-cask`(1).
 
 ### `bundle` *`subcommand`*
 
-Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask and the Mac App
-Store.
+Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store
+and Whalebrew.
 
 `brew bundle` [`install`]
 
@@ -1024,7 +1024,7 @@ Install or upgrade all dependencies in a `Brewfile`.
 
 `brew bundle dump`
 
-Write all installed casks/formulae/taps into a `Brewfile`.
+Write all installed casks/formulae/images/taps into a `Brewfile`.
 
 `brew bundle cleanup`
 
@@ -1065,6 +1065,8 @@ dependencies are listed.
   `list` tap dependencies.
 * `--mas`:
   `list` Mac App Store dependencies.
+* `--whalebrew`:
+  `list` Whalebrew dependencies.
 * `--describe`:
   `dump` a description comment above each line, unless the dependency does not have a description.
 * `--no-restart`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1290,7 +1290,7 @@ Install macOS applications distributed as binaries\. See \fBbrew\-cask\fR(1)\.
     \fIhttps://github\.com/Homebrew/homebrew\-cask\fR
 .
 .SS "\fBbundle\fR \fIsubcommand\fR"
-Bundler for non\-Ruby dependencies from Homebrew, Homebrew Cask and the Mac App Store\.
+Bundler for non\-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store and Whalebrew\.
 .
 .P
 \fBbrew bundle\fR [\fBinstall\fR]
@@ -1302,7 +1302,7 @@ Install or upgrade all dependencies in a \fBBrewfile\fR\.
 \fBbrew bundle dump\fR
 .
 .P
-Write all installed casks/formulae/taps into a \fBBrewfile\fR\.
+Write all installed casks/formulae/images/taps into a \fBBrewfile\fR\.
 .
 .P
 \fBbrew bundle cleanup\fR
@@ -1371,6 +1371,10 @@ Read the \fBBrewfile\fR from \fB~/\.Brewfile\fR\.
 .TP
 \fB\-\-mas\fR
 \fBlist\fR Mac App Store dependencies\.
+.
+.TP
+\fB\-\-whalebrew\fR
+\fBlist\fR Whalebrew dependencies\.
 .
 .TP
 \fB\-\-describe\fR


### PR DESCRIPTION
- This was added in https://github.com/Homebrew/homebrew-bundle/pull/656 but the subcommand docs were never updated here, causing failures on other, unrelated `brew` PRs.

(I tried to push this straight to master, but - sensibly - branch protection is enabled. ;-))