### PR TITLE
actions/tests: Run `brew style` and `brew man` before `brew tests`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,12 @@ jobs:
           sudo chmod -R g-w,o-w /home/linuxbrew /home/runner /opt
         fi
 
+    - name: Run brew style
+      run: brew style --display-cop-names
+
+    - name: Run brew man
+      run: brew man --fail-if-changed
+
     - name: Run brew tests
       run: |
         # brew tests doesn't like world writable directories
@@ -106,12 +112,6 @@ jobs:
 
         # These cannot be queried at the macOS level on GitHub Actions.
         HOMEBREW_LANGUAGES: en-GB
-
-    - name: Run brew style
-      run: brew style --display-cop-names
-
-    - name: Run brew man
-      run: brew man --fail-if-changed
 
     - name: Run brew update-tests
       run: |


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- The style and man page checks are quicker than `brew tests`, which can take forever.
- If people make mistakes with style or forget to run `brew man`, they will notice quicker, thus fixing issues quicker.
- This also wastes less compute time (and therefore energy) by only running `brew tests` when all the other less-involved checks work.

I'll leave this up for comments. :-)