### PR TITLE
Retry `curl` requests 3 times by default.

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -168,6 +168,7 @@ Note that environment variables must have a value set to be detected. For exampl
 
   * `HOMEBREW_CURL_RETRIES`:
     If set, Homebrew will pass the given retry count to `--retry` when invoking `curl`(1).
+    By default, `curl`(1) is invoked with `--retry 3`.
 
   * `HOMEBREW_DEBUG`:
     If set, any commands that can emit debugging information will do so.

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -14,9 +14,13 @@ describe "curl" do
       expect(curl_args("foo").first).not_to eq("-q")
     end
 
-    it "returns --retry when HOMEBREW_CURL_RETRIES is set" do
-      ENV["HOMEBREW_CURL_RETRIES"] = "3"
+    it "uses `--retry 3` when HOMEBREW_CURL_RETRIES is unset" do
       expect(curl_args("foo").join(" ")).to include("--retry 3")
+    end
+
+    it "uses the given value for `--retry` when HOMEBREW_CURL_RETRIES is set" do
+      ENV["HOMEBREW_CURL_RETRIES"] = "10"
+      expect(curl_args("foo").join(" ")).to include("--retry 10")
     end
   end
 end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -39,7 +39,8 @@ def curl_args(*extra_args, show_output: false, user_agent: :default)
     args << "--silent" unless $stdout.tty?
   end
 
-  args << "--retry" << ENV["HOMEBREW_CURL_RETRIES"] if ENV["HOMEBREW_CURL_RETRIES"]
+  # When changing the default value, the manpage has to be updated.
+  args << "--retry" << (ENV["HOMEBREW_CURL_RETRIES"] || "3")
 
   args + extra_args
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1200,6 +1200,7 @@ Note that environment variables must have a value set to be detected. For exampl
 
   * `HOMEBREW_CURL_RETRIES`:
     If set, Homebrew will pass the given retry count to `--retry` when invoking `curl`(1).
+    By default, `curl`(1) is invoked with `--retry 3`.
 
   * `HOMEBREW_DEBUG`:
     If set, any commands that can emit debugging information will do so.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1496,7 +1496,7 @@ If set, Homebrew will pass \fB\-\-verbose\fR when invoking \fBcurl\fR(1)\.
 .
 .TP
 \fBHOMEBREW_CURL_RETRIES\fR
-If set, Homebrew will pass the given retry count to \fB\-\-retry\fR when invoking \fBcurl\fR(1)\.
+If set, Homebrew will pass the given retry count to \fB\-\-retry\fR when invoking \fBcurl\fR(1)\. By default, \fBcurl\fR(1) is invoked with \fB\-\-retry 3\fR\.
 .
 .TP
 \fBHOMEBREW_DEBUG\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Make this the default instead of only using it in `test-bot` (https://github.com/Homebrew/homebrew-test-bot/pull/327). 