### PR TITLE
FormulaInstaller: link tmp kegs during rescue

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -598,16 +598,16 @@ class FormulaInstaller
     oh1 "Installing #{formula.full_name} dependency: #{Formatter.identifier(dep.name)}"
     fi.install
     fi.finish
-  rescue FormulaInstallationAlreadyAttemptedError
-    # We already attempted to install f as part of the dependency tree of
-    # another formula. In that case, don't generate an error, just move on.
-    nil
-  rescue Exception # rubocop:disable Lint/RescueException
+  rescue Exception => e # rubocop:disable Lint/RescueException
     ignore_interrupts do
       tmp_keg.rename(installed_keg) if tmp_keg && !installed_keg.directory?
       linked_keg.link if keg_was_linked
     end
-    raise
+    raise unless e.is_a? FormulaInstallationAlreadyAttemptedError
+
+    # We already attempted to install f as part of another formula's
+    # dependency tree. In that case, don't generate an error, just move on.
+    nil
   else
     ignore_interrupts { tmp_keg.rmtree if tmp_keg&.directory? }
   end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In #6807, the FormulaInstaller began to rescue from
FormulaInstallationAlreadyAttemptedError but there is the
potential for tmp kegs to remain unlinked in the cellar (noted in https://github.com/Homebrew/brew/pull/6807#issuecomment-561830681).
I've copied the code for linking tmp kegs from the
next rescue statement to execute here as well.

This issue has recently been manifesting in the following CI build of ours:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=1634)](https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/1634/) https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/1634/