### PR TITLE
bottle_publisher: add needed `require`

### DIFF
--- a/Library/Homebrew/bottle_publisher.rb
+++ b/Library/Homebrew/bottle_publisher.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-require "utils"
+require "net/http"
+require "net/https"
+
+require "checksum"
 require "formula_info"
+require "utils"
 
 class BottlePublisher
   def initialize(tap, changed_formulae_names, bintray_org, no_publish, warn_on_publish_failure)


### PR DESCRIPTION
These went unnoticed as they were loaded in `dev-cmd/pull`, currently the only consumer of `bottle_publisher`.

Needed for https://github.com/Homebrew/homebrew-test-bot/pull/344 to work properly.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?