### PR TITLE
create: add --ruby option

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -31,6 +31,8 @@ module Homebrew
              description: "Create a basic template for a Perl build."
       switch "--python",
              description: "Create a basic template for a Python build."
+      switch "--ruby",
+             description: "Create a basic template for a Ruby build."
       switch "--rust",
              description: "Create a basic template for a Rust build."
       switch "--no-fetch",
@@ -86,6 +88,8 @@ module Homebrew
       :perl
     elsif args.python?
       :python
+    elsif args.ruby?
+      :ruby
     elsif args.rust?
       :rust
     end

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -112,6 +112,8 @@ module Homebrew
           uses_from_macos "perl"
         <% elsif mode == :python %>
           depends_on "python"
+        <% elsif mode == :ruby %>
+          uses_from_macos "ruby"
         <% elsif mode == :rust %>
           depends_on "rust" => :build
         <% elsif mode.nil? %>
@@ -166,6 +168,12 @@ module Homebrew
             bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
         <% elsif mode == :python %>
             virtualenv_install_with_resources
+        <% elsif mode == :ruby %>
+            ENV["GEM_HOME"] = libexec
+            system "gem", "build", "\#{name}.gemspec"
+            system "gem", "install", "\#{name}-\#{version}.gem"
+            bin.install libexec/"bin/\#{name}"
+            bin.env_script_all_files(libexec/"bin", :GEM_HOME => ENV["GEM_HOME"])
         <% elsif mode == :rust %>
             system "cargo", "install", "--locked", "--root", prefix, "--path", "."
         <% else %>

--- a/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
@@ -71,31 +71,6 @@ describe Cask::Cmd::Upgrade, :cask do
         expect(local_transmission_path).to be_a_directory
         expect(local_transmission.versions).to include("2.60")
       end
-
-      it 'updates "auto_updates" and "latest" Casks when their tokens are provided in the command line' do
-        local_caffeine = Cask::CaskLoader.load("local-caffeine")
-        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
-        auto_updates = Cask::CaskLoader.load("auto-updates")
-        auto_updates_path = Cask::Config.global.appdir.join("MyFancyApp.app")
-
-        expect(local_caffeine).to be_installed
-        expect(local_caffeine_path).to be_a_directory
-        expect(local_caffeine.versions).to include("1.2.2")
-
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.57")
-
-        described_class.run("local-caffeine", "auto-updates")
-
-        expect(local_caffeine).to be_installed
-        expect(local_caffeine_path).to be_a_directory
-        expect(local_caffeine.versions).to include("1.2.3")
-
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.61")
-      end
     end
 
     describe "with --greedy it checks additional Casks" do

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -813,6 +813,8 @@ a simple example. For the complete API, see:
   Create a basic template for a Perl build.
 * `--python`:
   Create a basic template for a Python build.
+* `--ruby`:
+  Create a basic template for a Ruby build.
 * `--rust`:
   Create a basic template for a Rust build.
 * `--no-fetch`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1044,6 +1044,10 @@ Create a basic template for a Perl build\.
 Create a basic template for a Python build\.
 .
 .TP
+\fB\-\-ruby\fR
+Create a basic template for a Ruby build\.
+.
+.TP
 \fB\-\-rust\fR
 Create a basic template for a Rust build\.
 .


### PR DESCRIPTION
Make possible executing `brew create --ruby` to create basic template for building Ruby gems.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----