### PR TITLE
Add new `pr-publish` command

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require "utils/github"
+
+module Homebrew
+  module_function
+
+  def pr_publish_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `pr-publish` <pull_request>
+
+        Publishes bottles for a pull request with GitHub Actions.
+        Requires write access to the repository.
+      EOS
+      switch :verbose
+    end
+  end
+
+  def pr_publish
+    pr_publish_args.parse
+
+    odie "You need to specify a pull request number!" if Homebrew.args.named.empty?
+
+    args.named.each do |arg|
+      arg = "#{CoreTap.instance.default_remote}/pull/#{arg}" if arg.to_i.positive?
+      url_match = arg.match HOMEBREW_PULL_OR_COMMIT_URL_REGEX
+      _, user, repo, issue = *url_match
+      tap = Tap.fetch(user, repo) if repo.match?(HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX)
+      odie "Not a GitHub pull request: #{arg}" unless issue
+      ohai "Dispatching #{tap} pull request ##{issue}"
+      GitHub.dispatch(user, repo, "Publish ##{issue}", pull_request: issue)
+    end
+  end
+end

--- a/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-publish_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.pr_publish_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -431,6 +431,13 @@ module GitHub
     comments.any? { |comment| comment["body"].eql?(body) }
   end
 
+  def dispatch(user, repo, event, **payload)
+    url = "#{API_URL}/repos/#{user}/#{repo}/dispatches"
+    open_api(url, data:           { event_type: event, client_payload: payload },
+                  request_method: :POST,
+                  scopes:         CREATE_ISSUE_FORK_OR_PR_SCOPES)
+  end
+
   def api_errors
     [GitHub::AuthenticationFailedError, GitHub::HTTPNotFoundError,
      GitHub::RateLimitExceededError, GitHub::Error, JSON::ParserError].freeze

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -880,6 +880,11 @@ Generate Homebrew's manpages.
 * `--link`:
   This is now done automatically by `brew update`.
 
+### `pr-publish` *`pull_request`*
+
+Publishes bottles for a pull request with GitHub Actions. Requires write access
+to the repository.
+
 ### `prof` *`command`*
 
 Run Homebrew with the Ruby profiler, e.g. `brew prof readall`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1120,6 +1120,9 @@ Return a failing status code if changes are detected in the manpage outputs\. Th
 \fB\-\-link\fR
 This is now done automatically by \fBbrew update\fR\.
 .
+.SS "\fBpr\-publish\fR \fIpull_request\fR"
+Publishes bottles for a pull request with GitHub Actions\. Requires write access to the repository\.
+.
 .SS "\fBprof\fR \fIcommand\fR"
 Run Homebrew with the Ruby profiler, e\.g\. \fBbrew prof readall\fR\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is the maintainer-facing command we need before switching over to GitHub Actions with self-hosted runners.

This new command issues a single GitHub API call to fire the `repository_dispatch` event, which starts this workflow in Homebrew/core: https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/publish-commit-bottles.yml

The workflow:

1. Gets the details of the user who fired the dispatch event (name and email address)
2. Authenticates against GitHub using the BrewTestBot personal access token and checks out Homebrew/core
3. Downloads artifacts (bottles) associated with the pull request specified in `brew pr-publish`
4. Uploads those bottles to Bintray using `brew test-bot --ci-upload --publish` (c.f. https://github.com/Homebrew/homebrew-test-bot/pull/344)
5. Modifies all new commits to set the committer to the user who fired the dispatch event and signs off the last commit (similar to `brew pull --bottle`)
6. Pushes the new commits to `master`

Maintainers who want to opt-in to the new workflow should simply run `brew pr-publish <pr> [<pr> ...]`. This will use the GitHub Actions bottles rather than the Jenkins bottles. The Jenkins workflow can still be used with `brew pull --bottle <pr>`.

Example of a successful run:

* Pull request: https://github.com/Homebrew/homebrew-core/pull/52012/
* Actions run: https://github.com/Homebrew/homebrew-core/runs/525213544?check_suite_focus=true
* Bottling commit: https://github.com/Homebrew/homebrew-core/commit/d5917cf421d959451cb6c4fb1882e7f9a7f6f7c3