### PR TITLE
cask-caveats-kext: retry installation if it fails

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -49,9 +49,11 @@ module Cask
         next if MacOS.version < :high_sierra
 
         <<~EOS
-          To install and/or use #{@cask} you may need to enable its kernel extension in:
+          #{@cask} requires a kernel extension to work.
+          If the installation fails, retry after you enable it in:
             System Preferences → Security & Privacy → General
-          For more information refer to vendor documentation or this Apple Technical Note:
+
+          For more information, refer to vendor documentation or this Apple Technical Note:
             #{Formatter.url("https://developer.apple.com/library/content/technotes/tn2459/_index.html")}
         EOS
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some installations fail before the user has the chance to allow the kext. Seeing as those are being deprecated, it seems like a waste of resources to invest time on a workaround that likely will fail (there’s a reason we show a message instead).