### PR TITLE
Use patchelf.rb to set interpreter instead of patchelf. First step towards shelless elftools

### DIFF
--- a/Library/Homebrew/os/linux/global.rb
+++ b/Library/Homebrew/os/linux/global.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# enables experimental patchelf.rb write support.
+HOMEBREW_PATCHELF_RB_WRITE = ENV["HOMEBREW_PATCHELF_RB_WRITE"].present?.freeze
+
 module Homebrew
   DEFAULT_PREFIX ||= if Homebrew::EnvConfig.force_homebrew_on_linux?
     HOMEBREW_DEFAULT_PREFIX


### PR DESCRIPTION
Add a new gem requirement to [patchelf.rb](https://github.com/david942j/patchelf.rb),

`patchelf` command was used to update the name of interpreter and replace DT_RPATH.
Same features of [patchelf.rb](https://github.com/david942j/patchelf.rb), was used as a substitute.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
