### PR TITLE
shellenv: use PATH variable, fish_user_paths should remain universal

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -11,7 +11,7 @@ homebrew-shellenv() {
       echo "set -gx HOMEBREW_PREFIX \"$HOMEBREW_PREFIX\";"
       echo "set -gx HOMEBREW_CELLAR \"$HOMEBREW_CELLAR\";"
       echo "set -gx HOMEBREW_REPOSITORY \"$HOMEBREW_REPOSITORY\";"
-      echo "set -g fish_user_paths \"$HOMEBREW_PREFIX/bin\" \"$HOMEBREW_PREFIX/sbin\" \$fish_user_paths;"
+      echo "set -q PATH; or set PATH ''; set -gx PATH \"$HOMEBREW_PREFIX/bin\" \"$HOMEBREW_PREFIX/sbin\" \$PATH;"
       echo "set -q MANPATH; or set MANPATH ''; set -gx MANPATH \"$HOMEBREW_PREFIX/share/man\" \$MANPATH;"
       echo "set -q INFOPATH; or set INFOPATH ''; set -gx INFOPATH \"$HOMEBREW_PREFIX/share/info\" \$INFOPATH;"
       ;;


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There are two ways to manipulate PATH in fish shell.
- set the `PATH` variable directly
- set the `fish_user_paths` variable, whose contents are automatically prepended to `PATH`

`fish_user_paths` is supposed to be a [universal variable](https://fishshell.com/docs/current/tutorial.html#tut-universal).

```
> set --show fish_user_paths
$fish_user_paths: not set in local scope
$fish_user_paths: not set in global scope
$fish_user_paths: set in universal scope, unexported, with 1 elements
$fish_user_paths[1]: length=20 value=|/home/charego/fzf/bin|
```

When you evaluate the output of shellenv, `fish_user_paths` is set as a global variable which shadows the universal variable. This is technically legal, but it goes against best practice and causes issues when the user wants to update `fish_user_paths` in the future.

```
> eval (/home/linuxbrew/.linuxbrew/bin/brew shellenv)

> set --show fish_user_paths
$fish_user_paths: not set in local scope
$fish_user_paths: set in global scope, unexported, with 3 elements
$fish_user_paths[1]: length=30 value=|/home/linuxbrew/.linuxbrew/bin|
$fish_user_paths[2]: length=31 value=|/home/linuxbrew/.linuxbrew/sbin|
$fish_user_paths[3]: length=20 value=|/home/charego/fzf/bin|
$fish_user_paths: set in universal scope, unexported, with 1 elements
$fish_user_paths[1]: length=20 value=|/home/charego/fzf/bin|

> echo $fish_user_paths
/home/linuxbrew/.linuxbrew/bin /home/linuxbrew/.linuxbrew/sbin /home/charego/fzf/bin
```
```
> set -U fish_user_paths ~/bin $fish_user_paths
set: Universal variable 'fish_user_paths' is shadowed by the global variable of the same name.

> set --show fish_user_paths
$fish_user_paths: not set in local scope
$fish_user_paths: set in global scope, unexported, with 3 elements
$fish_user_paths[1]: length=30 value=|/home/linuxbrew/.linuxbrew/bin|
$fish_user_paths[2]: length=31 value=|/home/linuxbrew/.linuxbrew/sbin|
$fish_user_paths[3]: length=20 value=|/home/charego/fzf/bin|
$fish_user_paths: set in universal scope, unexported, with 4 elements
$fish_user_paths[1]: length=16 value=|/home/charego/bin|
$fish_user_paths[2]: length=30 value=|/home/linuxbrew/.linuxbrew/bin|
$fish_user_paths[3]: length=31 value=|/home/linuxbrew/.linuxbrew/sbin|
$fish_user_paths[4]: length=20 value=|/home/charego/fzf/bin|

> echo $fish_user_paths
/home/linuxbrew/.linuxbrew/bin /home/linuxbrew/.linuxbrew/sbin /home/charego/fzf/bin
```

For this reason it makes sense that shellenv should output instructions to update the `PATH` variable directly instead of fiddling with `fish_user_paths`.

Reference: fish shell tutorial, [$PATH](https://fishshell.com/docs/current/tutorial.html#path) section