### PR TITLE
.github/workflows/tests.yml: Deploy Docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: master
   pull_request: []
+  release:
+    types:
+      - published
 jobs:
   tests:
     if: github.repository == 'Homebrew/brew'
@@ -140,6 +143,22 @@ jobs:
       run: |
         if [ "$RUNNER_OS" = "Linux" ]; then
           docker-compose -f Dockerfile.yml run --rm -v $GITHUB_WORKSPACE:/tmp/test-bot sut
+          docker tag homebrew_sut brew
         else
           brew test-bot
         fi
+
+    - name: Deploy the latest Docker image
+      if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master'
+      run: |
+        docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
+        docker tag brew docker.pkg.github.com/homebrew/brew/brew
+        docker push docker.pkg.github.com/homebrew/brew/brew
+
+    - name: Deploy the tagged Docker image
+      if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/')
+      run: |
+        docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
+        v=${GITHUB_REF:10}
+        docker tag brew "docker.pkg.github.com/homebrew/brew/brew:$v"
+        docker push "docker.pkg.github.com/homebrew/brew/brew:$v"


### PR DESCRIPTION
Deploy the `latest` Docker image on a push to `master`.
Deploy a tagged Docker image upon publication of a release.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?