### PR TITLE
Allow writes to ~/Library/Caches and ~/.caches

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -53,6 +53,8 @@ class Sandbox
   def allow_write_temp_and_cache
     allow_write_path "/private/tmp"
     allow_write_path "/private/var/tmp"
+    allow_write_path "/Users/#{ENV["USER"]}/Library/Caches"
+    allow_write_path "/Users/#{ENV["USER"]}/.cache"
     allow_write "^/private/var/folders/[^/]+/[^/]+/[C,T]/", type: :regex
     allow_write_path HOMEBREW_TEMP
     allow_write_path HOMEBREW_CACHE


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
    * Got 8 tests failing with `Segmentation fault`, need assistance to resolve
-----

**The general case**

Allow writes to the the default macOS cache directory (`~/Library/Caches`) as well as the default cache directory according to the [XDG Base Directory Standard](https://wiki.archlinux.org/index.php/XDG_Base_Directory) (`~/.caches`). 

**My case**

I have a formula that uses [coursier bootstrap](https://get-coursier.io/docs/cli-bootstrap) during installation to build an artifact from a Java application published on Maven Central. For this to work, it's necessary for coursier to be able to work with the local cache which is is stored in `~/Library/Caches/Coursier`.

I don't need write access to `~/.caches`, but it seems sensible to allow this given that Homebrew grants write access to the default macOS cache directory in this PR.

Please let me know if you'd rather have this somewhere else (`language/java.rb` maybe?)