### PR TITLE
Library/Homebrew: add free_port test helper

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -36,6 +36,7 @@ module Homebrew
     test_args.parse
 
     require "formula_assertions"
+    require "formula_free_port"
 
     args.resolved_formulae.each do |f|
       # Cannot test uninstalled formulae

--- a/Library/Homebrew/formula_free_port.rb
+++ b/Library/Homebrew/formula_free_port.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Homebrew
+  module FreePort
+    require "socket"
+
+    def free_port
+      server = TCPServer.new 0
+      _, port, = server.addr
+      server.close
+
+      port
+    end
+  end
+end

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -7,6 +7,7 @@ require "extend/ENV"
 require "timeout"
 require "debrew"
 require "formula_assertions"
+require "formula_free_port"
 require "fcntl"
 require "socket"
 require "cli/parser"
@@ -26,6 +27,7 @@ begin
 
   formula = Homebrew.args.resolved_formulae.first
   formula.extend(Homebrew::Assertions)
+  formula.extend(Homebrew::FreePort)
   formula.extend(Debrew::Formula) if Homebrew.args.debug?
 
   # tests can also return false to indicate failure

--- a/Library/Homebrew/test/formula_free_port_spec.rb
+++ b/Library/Homebrew/test/formula_free_port_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "socket"
+require "formula_free_port"
+
+module Homebrew
+  describe FreePort do
+    include described_class
+
+    describe "#free_port" do
+      # IANA suggests user port from 1024 to 49151
+      # and dynamic port for 49152 to 65535
+      # http://www.iana.org/assignments/port-numbers
+      MIN_PORT = 1024
+      MAX_PORT = 65535
+
+      it "returns a free TCP/IP port" do
+        port = free_port
+
+        expect(port).to be_between(MIN_PORT, MAX_PORT)
+        expect { TCPServer.new(port).close }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR adds a naive implementation of `free_port` helper for getting an unused port. 

Currently we already several usages of it in tests:
```bash
$ git grep -l 'TCPServer.new(0)' | wc -l
26
```
And sometimes we use popular ports (like 8080): 
```
$ git grep -l ':8080' | wc -l
23
```

So I suggest having a unified approach.

Here is a couple of examples of refactoring using `free_port`:
```diff
diff --git a/Formula/anycable-go.rb b/Formula/anycable-go.rb
index ae207f9dee..f6a8c02a16 100644
--- a/Formula/anycable-go.rb
+++ b/Formula/anycable-go.rb
@@ -22,11 +22,13 @@ class AnycableGo < Formula
   end
 
   test do
+    port = free_port
+
     pid = fork do
-      exec "#{bin}/anycable-go"
+      exec "#{bin}/anycable-go --port=#{port}"
     end
     sleep 1
-    output = shell_output("curl -sI http://localhost:8080/health")
+    output = shell_output("curl -sI http://localhost:#{port}/health")
     assert_match(/200 OK/m, output)
   ensure
     Process.kill("HUP", pid)
```
```diff
diff --git a/Formula/traefik.rb b/Formula/traefik.rb
index 43b49fb7aa..7b824221e2 100644
--- a/Formula/traefik.rb
+++ b/Formula/traefik.rb
@@ -60,12 +60,8 @@ class Traefik < Formula
   test do
     require "socket"
 
-    ui_server = TCPServer.new(0)
-    http_server = TCPServer.new(0)
-    ui_port = ui_server.addr[1]
-    http_port = http_server.addr[1]
-    ui_server.close
-    http_server.close
+    ui_port = free_port
+    http_port = free_port
 
     (testpath/"traefik.toml").write <<~EOS
       [entryPoints]
```