### PR TITLE
Use long --disable instead of short -q in curl

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -160,7 +160,7 @@ Note that environment variables must have a value set to be detected. For exampl
     `git`(1) remote. If set, instructs Homebrew to instead use the specified URL.
 
   * `HOMEBREW_CURLRC`:
-    If set, Homebrew will not pass `-q` when invoking `curl`(1), which disables
+    If set, Homebrew will not pass `--disable` when invoking `curl`(1), which disables
     the use of `curlrc`.
 
   * `HOMEBREW_CURL_VERBOSE`:

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -4,14 +4,14 @@ require "utils/curl"
 
 describe "curl" do
   describe "curl_args" do
-    it "returns -q as the first argument when HOMEBREW_CURLRC is not set" do
-      # -q must be the first argument according to "man curl"
-      expect(curl_args("foo").first).to eq("-q")
+    it "returns --disable as the first argument when HOMEBREW_CURLRC is not set" do
+      # --disable must be the first argument according to "man curl"
+      expect(curl_args("foo").first).to eq("--disable")
     end
 
-    it "doesn't return -q as the first argument when HOMEBREW_CURLRC is set" do
+    it "doesn't return --disable as the first argument when HOMEBREW_CURLRC is set" do
       ENV["HOMEBREW_CURLRC"] = "1"
-      expect(curl_args("foo").first).not_to eq("-q")
+      expect(curl_args("foo").first).not_to eq("--disable")
     end
 
     it "uses `--retry 3` when HOMEBREW_CURL_RETRIES is unset" do

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -12,7 +12,7 @@ module Utils
         args = []
 
         # do not load .curlrc unless requested (must be the first argument)
-        args << "-q" unless ENV["HOMEBREW_CURLRC"]
+        args << "--disable" unless ENV["HOMEBREW_CURLRC"]
 
         args += %W[
           --max-time 3

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -17,7 +17,7 @@ def curl_args(*extra_args, show_output: false, user_agent: :default)
   args = []
 
   # do not load .curlrc unless requested (must be the first argument)
-  args << "-q" unless ENV["HOMEBREW_CURLRC"]
+  args << "--disable" unless ENV["HOMEBREW_CURLRC"]
 
   args << "--globoff"
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1199,7 +1199,7 @@ Note that environment variables must have a value set to be detected. For exampl
     `git`(1) remote. If set, instructs Homebrew to instead use the specified URL.
 
   * `HOMEBREW_CURLRC`:
-    If set, Homebrew will not pass `-q` when invoking `curl`(1), which disables
+    If set, Homebrew will not pass `--disable` when invoking `curl`(1), which disables
     the use of `curlrc`.
 
   * `HOMEBREW_CURL_VERBOSE`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1495,7 +1495,7 @@ By default, Homebrew uses \fBhttps://github\.com/Homebrew/homebrew\-core\fR (or 
 .
 .TP
 \fBHOMEBREW_CURLRC\fR
-If set, Homebrew will not pass \fB\-q\fR when invoking \fBcurl\fR(1), which disables the use of \fBcurlrc\fR\.
+If set, Homebrew will not pass \fB\-\-disable\fR when invoking \fBcurl\fR(1), which disables the use of \fBcurlrc\fR\.
 .
 .TP
 \fBHOMEBREW_CURL_VERBOSE\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Commands should use long flags instead of short flags when available. It makes it quicker to understand and detect errors.