### PR TITLE
When a HEAD build fails, output an instruction to raise PRs not issues

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -35,6 +35,13 @@ rescue MissingEnvironmentVariables => e
   exec ENV["HOMEBREW_BREW_FILE"], *ARGV
 end
 
+def head_unsupported_error
+  $stderr.puts <<~EOS
+    Please create pull requests instead of asking for help on Homebrew's GitHub,
+    Discourse, Twitter or IRC.
+  EOS
+end
+
 begin
   trap("INT", std_trap) # restore default CTRL-C handler
 
@@ -141,12 +148,18 @@ rescue Interrupt
 rescue BuildError => e
   Utils::Analytics.report_build_error(e)
   e.dump
+
+  head_unsupported_error if Homebrew.args.HEAD?
+
   exit 1
 rescue RuntimeError, SystemCallError => e
   raise if e.message.empty?
 
   onoe e
   $stderr.puts e.backtrace if ARGV.debug?
+
+  head_unsupported_error if Homebrew.args.HEAD?
+
   exit 1
 rescue MethodDeprecatedError => e
   onoe e


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

~- I didn't originally intend to go into too much detail here about raising PRs rather than issues, as it doesn't feel like something people will read, but I couldn't think of a better place to put that extra detail, so here we are.~

~- If there are better places for this then I'll gladly hear them!~

- This has to be in multiple places, hence a new method. A patch failing
  to apply, which is a common occurrence with HEAD builds because the
  patch is already upstream, raises a different exception to another,
  "normal" build failure.

Tested with:

```
╭─issyl0@rigel /home/linuxbrew/.linuxbrew/Homebrew ‹head-builds-arent-officially-supported*›
╰─ $ brew install --HEAD mtr
==> Cloning https://github.com/traviscross/mtr.git
Updating /home/issyl0/.cache/Homebrew/mtr--git
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
HEAD is now at 155f76a Merge pull request #340 from Sea-n/master
==> Downloading traviscross/mtr#315
Already downloaded: /home/issyl0/.cache/Homebrew/downloads/82d9d939303d8fceb7a3ae071ecd49a5f075e0fb451b308653b555ffbae74336--315.patch
==> Patching
==> Applying 315.patch
patching file packet/probe.c
Hunk #1 FAILED at 323.
Hunk #2 FAILED at 364.
2 out of 2 hunks FAILED -- saving rejects to file packet/probe.c.rej
Error: Failure while executing; `patch -g 0 -f -p1 -i /tmp/mtr--patch-20200330-10734-avjmyy/315.patch` exited with 1.
HEAD builds are unsupported by maintainers - please file pull requests instead of issues.
```

and

```
╭─issyl0@rigel /home/linuxbrew/.linuxbrew/Homebrew ‹head-builds-arent-officially-supported*›
╰─ $ brew install --HEAD zookeeper
==> Cloning https://gitbox.apache.org/repos/asf/zookeeper.git
Updating /home/issyl0/.cache/Homebrew/zookeeper--git
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
HEAD is now at 1ff1b779 ZOOKEEPER-3755: Use maven to create fatjar
==> ant compile_jute
Last 15 lines from /home/issyl0/.cache/Homebrew/Logs/zookeeper/01.ant:
2020-03-30 21:45:10 +0100

ant
compile_jute

Picked up _JAVA_OPTIONS: -Duser.home=/home/issyl0/.cache/Homebrew/java_cache
Buildfile: build.xml does not exist!
Build failed

READ THIS: https://docs.brew.sh/Troubleshooting

HEAD builds are unsupported by maintainers - please file pull requests instead of issues.
```

- This came about because I feel like I've done a lot of telling people that HEAD builds are unsupported when they raise issues about patches that don't apply, or broken builds.