### PR TITLE
integration_test: only run on system Ruby.

### DIFF
--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -9,6 +9,11 @@ RSpec::Matchers.define_negated_matcher :be_a_failure, :be_a_success
 RSpec.shared_context "integration test" do
   extend RSpec::Matchers::DSL
 
+  if OS.mac? &&
+     !RUBY_BIN.to_s.match?(%r{^/(System/Library/Frameworks/Ruby\.framework/Versions/(Current|\d+\.\d+)/)usr/bin$})
+    skip "integration test requires system Ruby"
+  end
+
   matcher :be_a_success do
     match do |actual|
       status = actual.is_a?(Proc) ? actual.call : actual


### PR DESCRIPTION
There appear to be random, seemingly impossible to debug issues with running integration tests on portable Ruby. Instead of confusing contributors when these will be run on CI anyway: let's just skip them by default (like we do with `--online` for online tests anyway).

Note to self: ensure that CI is definitely using system Ruby before this is merged...

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----