### PR TITLE
pr-pull: allow to specify tap

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -37,7 +37,9 @@ module Homebrew
       flag "--artifact=",
            description: "Download artifacts with the specified name (default: bottles)."
       flag "--bintray-org=",
-           description: "Upload to the specified Bintray organisation."
+           description: "Upload to the specified Bintray organisation (default: homebrew)."
+      flag "--tap=",
+           description: "Target repository tap (default: homebrew/core)."
       switch :verbose
       switch :debug
       min_named 1
@@ -106,12 +108,12 @@ module Homebrew
 
     workflow = args.workflow || "tests.yml"
     artifact = args.artifact || "bottles"
+    tap = Tap.fetch(args.tap || "homebrew/core")
 
     args.named.each do |arg|
-      arg = "#{CoreTap.instance.default_remote}/pull/#{arg}" if arg.to_i.positive?
+      arg = "#{tap.default_remote}/pull/#{arg}" if arg.to_i.positive?
       url_match = arg.match HOMEBREW_PULL_OR_COMMIT_URL_REGEX
       _, user, repo, pr = *url_match
-      tap = Tap.fetch(user, repo) if repo.match?(HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX)
       odie "Not a GitHub pull request: #{arg}" unless pr
 
       check_branch tap.path, "master"

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -910,7 +910,9 @@ repository.
 * `--artifact`:
   Download artifacts with the specified name (default: bottles).
 * `--bintray-org`:
-  Upload to the specified Bintray organisation.
+  Upload to the specified Bintray organisation (default: homebrew).
+* `--tap`:
+  Target repository tap (default: homebrew/core).
 
 ### `prof` *`command`*
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1164,7 +1164,11 @@ Download artifacts with the specified name (default: bottles)\.
 .
 .TP
 \fB\-\-bintray\-org\fR
-Upload to the specified Bintray organisation\.
+Upload to the specified Bintray organisation (default: homebrew)\.
+.
+.TP
+\fB\-\-tap\fR
+Target repository tap (default: homebrew/core)\.
 .
 .SS "\fBprof\fR \fIcommand\fR"
 Run Homebrew with the Ruby profiler, e\.g\. \fBbrew prof readall\fR\.


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR makes it possible to specify the tap, different than default `homebrew/core`.

cc @jonchang