### PR TITLE
bottle: author bottle commit as BrewTestBot

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -561,7 +561,8 @@ module Homebrew
           pkg_version = bottle_hash["formula"]["pkg_version"]
 
           path.parent.cd do
-            safe_system "git", "commit", "--no-edit", "--verbose",
+            author = "BrewTestBot <homebrew-test-bot@lists.sfconservancy.org>"
+            safe_system "git", "commit", "--no-edit", "--verbose", "--author=#{author}",
                         "--message=#{short_name}: #{update_or_add} #{pkg_version} bottle.",
                         "--", path
           end


### PR DESCRIPTION
As it is in `test-bot`:
https://github.com/Homebrew/homebrew-test-bot/blob/6b2a8182f9d515f80722fda1dadab43ef4334e01/lib/test_bot.rb#L348-L350

Don't know if it is the correct implementation here, but a move must be made, because currently bottle commits are authored by the committer, rather than @BrewTestBot as it should be:
https://github.com/Homebrew/homebrew-core/commit/242aab6b299fe7ecf7e6bc5b1858417a4d041d03

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----