### PR TITLE
load_path: trim entries where possible to fix Ruby crashes

### DIFF
--- a/Library/Homebrew/load_path.rb
+++ b/Library/Homebrew/load_path.rb
@@ -4,6 +4,9 @@ require "pathname"
 
 HOMEBREW_LIBRARY_PATH = Pathname(__dir__).realpath.freeze
 
-$LOAD_PATH.push(HOMEBREW_LIBRARY_PATH.to_s) unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
+$LOAD_PATH.push HOMEBREW_LIBRARY_PATH.to_s
 
 require "vendor/bundle/bundler/setup"
+
+$LOAD_PATH.select! { |d| Pathname(d).directory? }
+$LOAD_PATH.uniq!

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -9,11 +9,6 @@ RSpec::Matchers.define_negated_matcher :be_a_failure, :be_a_success
 RSpec.shared_context "integration test" do
   extend RSpec::Matchers::DSL
 
-  if OS.mac? &&
-     !RUBY_BIN.to_s.match?(%r{^/(System/Library/Frameworks/Ruby\.framework/Versions/(Current|\d+\.\d+)/)usr/bin$})
-    skip "integration test requires system Ruby"
-  end
-
   matcher :be_a_success do
     match do |actual|
       status = actual.is_a?(Proc) ? actual.call : actual


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] :-) Have you successfully run `brew tests` with your changes locally?

-----
