### PR TITLE
rubocop_rspec: fix includes.

### DIFF
--- a/Library/.rubocop_rspec.yml
+++ b/Library/.rubocop_rspec.yml
@@ -2,7 +2,9 @@ inherit_from: ./.rubocop.yml
 
 AllCops:
   Include:
-    - '**/*_spec.rb'
+    - '**/cmd/**/*.rb'
+    - '**/lib/**/*.rb'
+    - '**/spec/**/*.rb'
   Exclude:
     - '**/vendor/**/*'
 


### PR DESCRIPTION
Otherwise taps with specs don't get their style fixed.

CC @Bo98 as we talked about this.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----