### PR TITLE
shims/mac/super/xcrun: use Homebrew's chosen SDK and DEVELOPER_DIR

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -109,6 +109,11 @@ module Superenv
   def setup_build_environment(formula = nil)
     generic_setup_build_environment(formula)
     self["HOMEBREW_SDKROOT"] = effective_sysroot
+    self["HOMEBREW_DEVELOPER_DIR"] = if MacOS::CLT.installed? && MacOS::CLT.provides_sdk?
+      MacOS::CLT::PKG_PATH
+    else
+      MacOS::Xcode.prefix
+    end
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/shims/mac/super/xcrun
+++ b/Library/Homebrew/shims/mac/super/xcrun
@@ -1,10 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 # Historically, xcrun has had various bugs, and in some cases it didn't
 # work at all (e.g. CLT-only in the Xcode 4.3 era). This script emulates
 # it and attempts to avoid these issues.
 
-# Some build tools set DEVELOPER_DIR, so discard it
-unset DEVELOPER_DIR
+# SDKROOT is not used if `--sdk` is supplied.
+# We however don't want to interrupt other uses like `xcrun --find clang`.
+if [[ "$*" =~ (^| )-?-sdk ]]; then
+  export DEVELOPER_DIR=$HOMEBREW_DEVELOPER_DIR
+else
+  # Some build tools set DEVELOPER_DIR, so discard it
+  unset DEVELOPER_DIR
+fi
+
+if [ -z "$SDKROOT" ]; then
+  export SDKROOT=$HOMEBREW_SDKROOT
+fi
 
 if [ $# -eq 0 ]; then
   exec /usr/bin/xcrun "$@"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #7250.

Turns out `xcrun` is really awkward as it has so many uses. You don't want to set `DEVELOPER_DIR` all the time because, for example, we have an older compiler in the CLT on Mojave CI nodes - and that compiler might be found via `xcrun --find clang`.