### PR TITLE
Update .rubocop.yml

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -39,6 +39,14 @@ Lint/ParenthesesAsGroupedExpression:
 Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: true
 
+# Required configuration of cop for style check
+Lint/RaiseException:
+  Enabled: false
+
+# Required configuration of cop for style check
+Lint/StructNewOverride:
+  Enabled: false
+
 # TODO: try to bring down all metrics maximums
 Metrics/AbcSize:
   Enabled: true


### PR DESCRIPTION
Update to rubocop version 0.81 requires configuration of these two additional cops as either enabled/disabled. Without a configuration, then an error is thrown because they're initially configured as pending.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
