### PR TITLE
rubocop/lines: add perl to whitelist

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -439,6 +439,7 @@ module RuboCop
               open-mpi
               openssl@1.1
               pcre
+              perl
               protobuf
               wolfssl
               xz


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

As seen in https://github.com/Homebrew/homebrew-core/pull/52407, the `perl` formula fails `brew audit` with:
`* C: 40: col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks`

I'm following the lead of https://github.com/Homebrew/brew/pull/7040 and adding it to the libraries whitelist.