### PR TITLE
formula_cellar_checks: skip unless Python libs

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -180,6 +180,8 @@ module FormulaCellarChecks
       match.captures.first
     end.compact
 
+    return if pythons.blank?
+
     python_deps = deps.map(&:name)
                       .grep(/^python(@.*)?$/)
                       .map { |d| Formula[d].version.to_s[/^\d+\.\d+/] }


### PR DESCRIPTION
This avoids an unusual error message when Python is needed for building (e.g., code generation) and files are installed to `lib` but Python is not used at runtime.

Needed for https://github.com/Homebrew/linuxbrew-core/pull/19996

```
==> brew audit recode --online
Error: 1 problem in 1 formula detected
recode:
  * Packages have been installed for:

    but this formula depends on:
      Python 3.7
```

Because build-time dependencies are uninstalled on test-bot, this audit shouldn't be triggered as no Python libraries are actually installed to `lib`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----