### PR TITLE
Set HOMEBREW_GITHUB_API_TOKEN from GITHUB_TOKEN.

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -126,11 +126,12 @@ module Homebrew
                      "such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.",
       },
       HOMEBREW_GITHUB_API_TOKEN:          {
-        description: "A personal access token for the GitHub API, used by Homebrew for features such as " \
+        description:  "A personal access token for the GitHub API, used by Homebrew for features such as " \
                      "`brew search`. You can create one at <https://github.com/settings/tokens>. If set, " \
                      "GitHub will allow you a greater number of API requests. For more information, see: " \
                      "<https://developer.github.com/v3/#rate-limiting>\n\n    *Note:* Homebrew doesn't " \
                      "require permissions for any of the scopes.",
+        default_text: "`$GITHUB_TOKEN`.",
       },
       HOMEBREW_GITHUB_API_USERNAME:       {
         description: "GitHub username for authentication with the GitHub API, used by Homebrew for features " \

--- a/bin/brew
+++ b/bin/brew
@@ -79,6 +79,12 @@ then
   export HOMEBREW_EDITOR="$VISUAL"
 fi
 
+# Use GITHUB_TOKEN if HOMEBREW_GITHUB_API_TOKEN is unset.
+if [[ -z "$HOMEBREW_GITHUB_API_TOKEN" && -n "$GITHUB_TOKEN" ]]
+then
+  export HOMEBREW_GITHUB_API_TOKEN="$GITHUB_TOKEN"
+fi
+
 # Set CI variable for GitHub Actions, Azure Pipelines, Jenkins
 # (Set by default on Circle and Travis CI)
 if [[ -n "$GITHUB_ACTIONS" || -n "$TF_BUILD" || -n "$JENKINS_HOME" ]]

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1282,6 +1282,8 @@ Note that environment variables must have a value set to be detected. For exampl
 
     *Note:* Homebrew doesn't require permissions for any of the scopes.
 
+    *Default:* `$GITHUB_TOKEN`.
+
   * `HOMEBREW_GITHUB_API_USERNAME`:
     GitHub username for authentication with the GitHub API, used by Homebrew for features such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1637,6 +1637,9 @@ A personal access token for the GitHub API, used by Homebrew for features such a
 .IP
 \fINote:\fR Homebrew doesn\'t require permissions for any of the scopes\.
 .
+.IP
+\fIDefault:\fR \fB$GITHUB_TOKEN\fR\.
+.
 .TP
 \fBHOMEBREW_GITHUB_API_USERNAME\fR
 GitHub username for authentication with the GitHub API, used by Homebrew for features such as \fBbrew search\fR\. We strongly recommend using \fBHOMEBREW_GITHUB_API_TOKEN\fR instead\.


### PR DESCRIPTION
If `HOMEBREW_GITHUB_API_TOKEN` is not set and `GITHUB_TOKEN` is: let's use it. `GITHUB_TOKEN` is a somewhat standard env var to set for GitHub authentication tokens (e.g. used by `hub`).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----