### PR TITLE
shims/mac/super/pkg-config: pass and use HOMEBREW_SDKROOT

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -112,6 +112,8 @@ module Superenv
     end
     generic_setup_build_environment(formula)
 
+    self["PKG_CONFIG"] = Superenv.bin/"pkg-config"
+
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.
     if MacOS.version == "10.12" && MacOS::Xcode.version >= "9.0"

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libcurl.pc
@@ -23,8 +23,8 @@
 # This should most probably benefit from getting a "Requires:" field added
 # dynamically by configure.
 #
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 supported_protocols="DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libexslt.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libxml-2.0.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 modules=1

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libxslt.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/sqlite3.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/uuid.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 sharedlibdir=${libdir}
 includedir=${prefix}/include

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/zlib.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 sharedlibdir=${libdir}
 includedir=${prefix}/include

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libcurl.pc
@@ -23,8 +23,8 @@
 # This should most probably benefit from getting a "Requires:" field added
 # dynamically by configure.
 #
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 supported_protocols="DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libexslt.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libxml-2.0.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 modules=1

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libxslt.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/sqlite3.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/uuid.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 sharedlibdir=${libdir}
 includedir=${prefix}/include

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/zlib.pc
@@ -1,5 +1,5 @@
-prefix=/usr
-exec_prefix=${prefix}
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
 libdir=${exec_prefix}/lib
 sharedlibdir=${libdir}
 includedir=${prefix}/include

--- a/Library/Homebrew/shims/mac/super/pkg-config
+++ b/Library/Homebrew/shims/mac/super/pkg-config
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+exec "$HOMEBREW_OPT/pkg-config/bin/pkg-config" \
+  "--define-variable=homebrew_sdkroot=$HOMEBREW_SDKROOT" \
+  "$@"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #5068.

Homebrew/homebrew-core#52565 and #7276 must be merged first.

I'm not entirely sure how CMake behaves if pkg-config isn't installed. Usually it would give a clear error but it might falsely detect it is installed based on the shim and instead error later.