### PR TITLE
ENV: don't help include libxml2 on macOS SDK 10.15.4 and later

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -97,12 +97,14 @@ module Stdenv
   end
 
   # Some configure scripts won't find libxml2 without help
+  # This is a no-op with macOS SDK 10.15.4 and later
   def libxml2
-    if !MacOS.sdk_path_if_needed
+    sdk = MacOS.sdk_path_if_needed
+    if !sdk
       append "CPPFLAGS", "-I/usr/include/libxml2"
-    else
+    elsif !(sdk/"usr/include/libxml").directory?
       # Use the includes form the sdk
-      append "CPPFLAGS", "-I#{MacOS.sdk_path}/usr/include/libxml2"
+      append "CPPFLAGS", "-I#{sdk}/usr/include/libxml2"
     end
   end
 

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -42,9 +42,17 @@ module Superenv
     paths
   end
 
+  # @private
+  def libxml2_include_needed?
+    return false if deps.any? { |d| d.name == "libxml2" }
+    return false if Pathname("#{self["HOMEBREW_SDKROOT"]}/usr/include/libxml").directory?
+
+    true
+  end
+
   def homebrew_extra_isystem_paths
     paths = []
-    paths << "#{self["HOMEBREW_SDKROOT"]}/usr/include/libxml2" unless deps.any? { |d| d.name == "libxml2" }
+    paths << "#{self["HOMEBREW_SDKROOT"]}/usr/include/libxml2" if libxml2_include_needed?
     paths << "#{self["HOMEBREW_SDKROOT"]}/usr/include/apache2" if MacOS::Xcode.without_clt?
     paths << MacOS::X11.include.to_s << "#{MacOS::X11.include}/freetype2" if x11?
     paths << "#{self["HOMEBREW_SDKROOT"]}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers"
@@ -64,7 +72,7 @@ module Superenv
 
   def homebrew_extra_cmake_include_paths
     paths = []
-    paths << "#{self["HOMEBREW_SDKROOT"]}/usr/include/libxml2" unless deps.any? { |d| d.name == "libxml2" }
+    paths << "#{self["HOMEBREW_SDKROOT"]}/usr/include/libxml2" if libxml2_include_needed?
     paths << "#{self["HOMEBREW_SDKROOT"]}/usr/include/apache2" if MacOS::Xcode.without_clt?
     paths << MacOS::X11.include.to_s << "#{MacOS::X11.include}/freetype2" if x11?
     paths << "#{self["HOMEBREW_SDKROOT"]}/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Xcode 11.4 includes some changes to the macOS SDK. So much so that Apple felt they needed to add a patch version to the SDK:

```
% xcrun --show-sdk-version
10.15.4
```

This is the first time I think they've done this - as evidenced by Qt no longer compiling due to the presence of the third number. The latest 10.14 SDK for example still returns "10.14".

One of the changes was moving `$(SDKROOT)/usr/include/libxml2/libxml` to `$(SDKROOT)/usr/include/libxml`. Apple did leave a symlink but they botched the upgrade process again and left the old modulemap so that there is now two, causing build errors:

```
cargo:warning=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/libxml2/libxml/module.modulemap:1:8: error: redefinition of module 'libxml2'
cargo:warning=module libxml2 [system] [extern_c] {
cargo:warning=       ^
cargo:warning=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/libxml2/module.modulemap:1:8: note: previously defined here
cargo:warning=module libxml2 [system] [extern_c] {
cargo:warning=       ^
```

As of the 10.15.4 SDK, we can drop the libxml2 include dir as the general one on `$(SDKROOT)/usr/include` will now cover it. I've implemented this by checking the presence of `$(SDKROOT)/usr/include/libxml`. Hopefully that won't pick up anything weird that people on old systems might have installed in `/usr/include`. Alternatively, we could compare against the SDK version (parsed from the plist).

I have not updated the pkg-config files. We can either:

* Ignore it and hope nobody is using libxml2 via pkg-config while using modulemaps (read by Objective-C and Swift compilers) at the same time.
* Create a 10.15.4 directory and select the correct pkg-config directory based on SDK version rather than OS version.

In general, I think it would be nice in the long term to not insert include paths unless explicitly requested by `uses_from_macos`, but that is a breaking change.