### PR TITLE
audit: Check if `uses_from_macos` usage is correct

### DIFF
--- a/Library/Homebrew/rubocops.rb
+++ b/Library/Homebrew/rubocops.rb
@@ -18,5 +18,6 @@ require "rubocops/options"
 require "rubocops/urls"
 require "rubocops/lines"
 require "rubocops/class"
+require "rubocops/uses_from_macos"
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -15,21 +15,29 @@ module RuboCop
           expect
           flex
           groff
+          icu4c
+          krb5
+          libedit
           libffi
+          libpcap
           libxml2
           libxslt
+          llvm
           ncurses
           m4
+          openldap
+          openssl
           perl
           php
-          python@2
           ruby
           sqlite
+          tcl-tk
           texinfo
           unzip
           vim
           xz
           zlib
+          zip
           zsh
         ].freeze
 

--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rubocops/extend/formula"
+
+module RuboCop
+  module Cop
+    module FormulaAudit
+      # This cop audits `uses_from_macos` dependencies in formulae
+      class UsesFromMacos < FormulaCop
+        ALLOWED_USES_FROM_MACOS_DEPS = %w[
+          bison
+          bzip2
+          curl
+          expat
+          expect
+          flex
+          groff
+          libffi
+          libxml2
+          libxslt
+          ncurses
+          m4
+          perl
+          php
+          python@2
+          ruby
+          sqlite
+          texinfo
+          unzip
+          vim
+          xz
+          zlib
+          zsh
+        ].freeze
+
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          find_method_with_args(body_node, :uses_from_macos, /^"(.+)"/).each do |method|
+            dep = if parameters(method).first.class == RuboCop::AST::StrNode
+              parameters(method).first
+            elsif parameters(method).first.class == RuboCop::AST::HashNode
+              parameters(method).first.keys.first
+            end
+
+            next if ALLOWED_USES_FROM_MACOS_DEPS.include?(string_content(dep))
+
+            problem "`uses_from_macos` should only be used for macOS dependencies, not #{string_content(dep)}."
+          end
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/.rubocop_todo.yml
+++ b/Library/Homebrew/test/.rubocop_todo.yml
@@ -48,6 +48,7 @@ RSpec/FilePath:
     - 'rubocops/options_spec.rb'
     - 'rubocops/patches_spec.rb'
     - 'rubocops/text_spec.rb'
+    - 'rubocops/uses_from_macos_spec.rb'
     - 'search_spec.rb'
     - 'string_spec.rb'
     - 'system_command_result_spec.rb'

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rubocops/uses_from_macos"
+
+describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
+  subject(:cop) { described_class.new }
+
+  it "when auditing uses_from_macos dependencies" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+        homepage "https://brew.sh"
+
+        uses_from_macos "postgresql"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `uses_from_macos` should only be used for macOS dependencies, not postgresql.
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This resurrects #6265 by @jonchang and brings it up to date.
- We need to know whether all the `uses_from_macos` usage is legit, so we check against a safelist of dependencies that we know to ship with macOS.