### PR TITLE
Initialize Homebrew.args with CLI::Args instance

### DIFF
--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -28,6 +28,7 @@ end
 require "config"
 require "os"
 require "extend/ARGV"
+require "cli/args"
 require "messages"
 require "system_command"
 
@@ -83,7 +84,7 @@ module Homebrew
     end
 
     def args
-      @args ||= OpenStruct.new
+      @args ||= CLI::Args.new(argv: ARGV)
     end
 
     def messages


### PR DESCRIPTION
If we initialize it with OpenStruct, then methods defined in CLI::Args
cannot be called from `Homebrew.args` and they would always return nil leading to bugs

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
