### PR TITLE
Ensure TMPDIR is set for Xcode’s `make`

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -44,6 +44,10 @@ module Homebrew
     ENV["GEM_HOME"] = gem_home
     ENV["GEM_PATH"] = ENV["GEM_HOME"]
 
+    # Set TMPDIR so Xcode's `make` doesn't fall back to `/var/tmp/`,
+    # which may be not user-writable.
+    ENV["TMPDIR"] = ENV["HOMEBREW_TEMP"]
+
     # Make RubyGems notice environment changes.
     require "rubygems"
     Gem.clear_paths


### PR DESCRIPTION
**Edit:** changed title and final paragraph to reflect new modifications. Also changed embarrassing grammar in thank-you notice.

**Edit 2:** changed final paragraph to reflect that the code has been moved to `gems.rb`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **No tests** because `/var/tmp` may or may not be writable on a machine that runs the tests.
- [x] Have you successfully run `brew style` with your changes locally? **Yes, and it worked for the first time in ages**
- [x] Have you successfully run `brew tests` with your changes locally? ~**Not applicable**~ **Edit:** yes but `--only=utils`.

-----

This fixes an issue where at least in Xcode 11.0, `make` uses
`/var/tmp` as a fallback for temporary files unless `TMPDIR` is set:

```bash
$ strings "$(xcrun -f make)" | grep -B 3 fopen
TMPDIR
/var/tmp/
GmXXXXXX
fopen (temporary file)
```

Given that Homebrew filtered `TMPDIR`, and the `/var/tmp` directory may not be writable for non-`root` users, this would cause Homebrew’s build environment to error out:

```bash
$ brew ruby -e 'puts ENV["TMPDIR"]; puts `: | make -f -`'
```

```
Ignoring bigdecimal-2.0.0 because its extensions are not built. Try: gem pristine bigdecimal --version 2.0.0
[…]
Ignoring zlib-1.1.0 because its extensions are not built. Try: gem pristine zlib --version 1.1.0

make: *** fopen (temporary file): Permission denied.  Stop.
```

In practice, this would break `brew audit`, `brew style`, and other
commands, which would run `make` to build native gem extensions.

~This commit adds `TMPDIR` to Homebrew’s list of allowed environment
variables. It also adds unconditionally sets `TMPDIR` to `${HOMEBREW_TEMP}`, which
is user-controlled but also guaranteed to be set with a fallback of `/tmp`, which takes precedence
over `/var/tmp` in case `TMPDIR` is not set in the user’s environment.~

This commit sets `TMPDIR` to `${HOMEBREW_TEMP}` in the gem environment, which mirrors the behaviour we already have in other places.  
We choose `HOMEBREW_TEMP` because that’s user-controlled but also falls back to `/tmp` in case `TMPDIR` is not set in the user’s environment.

Thanks to Bo Anderson for helping find the bug.