### PR TITLE
utils/gems: prioritise Homebrew's chosen Ruby

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -52,8 +52,8 @@ module Homebrew
     # Add necessary Ruby and Gem binary directories to PATH.
     gem_bindir ||= Gem.bindir
     paths = ENV["PATH"].split(":")
-    paths.unshift(ruby_bindir) unless paths.include?(ruby_bindir)
     paths.unshift(gem_bindir) unless paths.include?(gem_bindir)
+    paths.unshift(ruby_bindir) unless paths.include?(ruby_bindir)
     ENV["PATH"] = paths.compact.join(":")
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

As seen in https://github.com/Homebrew/brew/issues/5561#issuecomment-606872007, Ruby in other locations like rbenv may be used when installing gems. At the very least, this can mean installing native extensions to a place that won't match what Homebrew's chosen Ruby actually uses. At worst, we get hard to debug errors.

The reason other Rubys were being picked was because `~/.gem/2.6.0/bin` was prioritised over Homebrew's chosen Ruby bin directory. This may mean that `~/.gem/2.6.0/bin/bundle` is run instead.

This is a separate issue to the `TMPDIR` one.