### PR TITLE
system_command_spec: Make part of bash error regex optional

### DIFF
--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -37,7 +37,7 @@ describe SystemCommand do
       it "unsets them" do
         expect {
           command.run!
-        }.to raise_error(/C: parameter null or not set/)
+        }.to raise_error(/C: parameter (null or )?not set/)
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **Not applicable**
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew tests` fails on my system without this. Bash has two very similar error messages that can come up when running the command specified by this test. Here's the relevant code from subst.c in a recent version of Bash:

```c
  else if (check_null == 0)
    report_error (_("%s: parameter not set"), name);
  else
    report_error (_("%s: parameter null or not set"), name);
```