### PR TITLE
download_strategy: unlink the lock file after unlocking it

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -326,6 +326,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
     end
   ensure
     download_lock&.unlock
+    download_lock&.path&.unlink
   end
 
   def clear_cache


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR solves the issue, where `.incomplete.lock` files are added to the bottle (oddly only on Linux).

Test subject `brew install --build-bottle neofetch`:

- before patch

```
root@943ff26116de:/home/linuxbrew# brew ls -v neofetch
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/INSTALL_RECEIPT.json
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/LICENSE.md
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/bin/neofetch
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/.brew/neofetch.rb
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/README.md
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/.bottle/var/homebrew/locks/24736b4782b7372003a40fe3f994747e4c3a6fafbc4c5f7a8c5c5dbed58ebb0a--neofetch-7.0.0.tar.gz.incomplete.lock
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/share/man/man1/neofetch.1
```

- after patch

```
root@d81b4d2a97a0:/home/linuxbrew# brew ls -v neofetch
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/INSTALL_RECEIPT.json
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/LICENSE.md
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/bin/neofetch
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/.brew/neofetch.rb
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/README.md
/home/linuxbrew/.linuxbrew/Cellar/neofetch/7.0.0/share/man/man1/neofetch.1
```