### PR TITLE
shims/mac/super/xcrun: unset rather than emptying DEVELOPER_DIR

### DIFF
--- a/Library/Homebrew/shims/mac/super/xcrun
+++ b/Library/Homebrew/shims/mac/super/xcrun
@@ -4,14 +4,14 @@
 # it and attempts to avoid these issues.
 
 # These could be used in conjunction with `--sdk` which ignores SDKROOT.
-if [[ "$*" =~ (^| )-?-show-sdk-(path|version|build) ]]; then
+if [[ "$*" =~ (^| )-?-show-sdk-(path|version|build) && -n "$HOMEBREW_DEVELOPER_DIR" ]]; then
   export DEVELOPER_DIR=$HOMEBREW_DEVELOPER_DIR
 else
   # Some build tools set DEVELOPER_DIR, so discard it
   unset DEVELOPER_DIR
 fi
 
-if [ -z "$SDKROOT" ]; then
+if [[ -z "$SDKROOT" && -n "$HOMEBREW_SDKROOT" ]]; then
   export SDKROOT=$HOMEBREW_SDKROOT
 fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I still don't know how this is even a problem or how it doesn't affect every formula. Took several days for anything to break.