### PR TITLE
docs/Formula-Cookbook.md: mention the use of 'bottle :unneeded'

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -96,6 +96,8 @@ You’re now at a new prompt with the tarball extracted to a temporary sandbox.
 
 Check the package’s `README`. Does the package install with `./configure`, `cmake`, or something else? Delete the commented out `cmake` lines if the package uses `./configure`.
 
+If no compilation is involved, add the line `bottle :unneeded` since bottles are unnecessary in that case. Otherwise, a `bottle` block will be added by Homebrew's CI upon merging the formula pull-request.
+
 ### Check for dependencies
 
 The `README` probably tells you about dependencies and Homebrew or macOS probably already has them. You can check for Homebrew dependencies with `brew search`. Some common dependencies that macOS comes with:

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -96,7 +96,7 @@ You’re now at a new prompt with the tarball extracted to a temporary sandbox.
 
 Check the package’s `README`. Does the package install with `./configure`, `cmake`, or something else? Delete the commented out `cmake` lines if the package uses `./configure`.
 
-If no compilation is involved, add the line `bottle :unneeded` since bottles are unnecessary in that case. Otherwise, a `bottle` block will be added by Homebrew's CI upon merging the formula pull-request.
+If no compilation is involved and there are no `:build` dependencies, add the line `bottle :unneeded` since bottles are unnecessary in this case. Otherwise, a `bottle` block will be added by Homebrew's CI upon merging the formula's pull-request.
 
 ### Check for dependencies
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Based on @Bo98 [comments on a recent PR](https://github.com/Homebrew/homebrew-core/pull/52587#discussion_r403770399), I added a short mention of `bottle :unneeded` in the Formula-Cookbook since it wasn't present in the docs.