### PR TITLE
ENV/std: restore original make_jobs return type

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -188,7 +188,7 @@ module Stdenv
   end
 
   def make_jobs
-    Homebrew::EnvConfig.make_jobs
+    Homebrew::EnvConfig.make_jobs.to_i
   end
 
   # This method does nothing in stdenv since there's no arg refurbishment


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This previously returned an integer and there is [code](https://github.com/Homebrew/brew/blob/6b2dbbc96f7d8aa12f9b8c9c60107c9cc58befc4/Library/Homebrew/language/haskell.rb#L47) which relies on this. (https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/60693/version=mojave/console)

The superenv version of `make_jobs` worked differently and still returns an integer.

The superenv-specific `determine_make_jobs` is probably not a concern. It could potentially even be removed entirely and its implementation inlined.