### PR TITLE
tap: permit creating shallow taps

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -27,6 +27,8 @@ module Homebrew
       switch "--full",
              description: "Convert a shallow clone to a full clone without untapping. By default, taps are no "\
                           "longer cloned as shallow clones."
+      switch "--shallow",
+             description: "Fetch tap as a shallow clone rather than a full clone. Useful for continuous integration."
       switch "--force-auto-update",
              description: "Auto-update tap even if it is not hosted on GitHub. By default, only taps "\
                           "hosted on GitHub are auto-updated (for performance reasons)."
@@ -55,7 +57,8 @@ module Homebrew
       begin
         tap.install clone_target:      args.named.second,
                     force_auto_update: force_auto_update?,
-                    quiet:             args.quiet?
+                    quiet:             args.quiet?,
+                    full_clone:        !args.shallow?
       rescue TapRemoteMismatchError => e
         odie e
       rescue TapAlreadyTappedError

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -25,8 +25,8 @@ module Homebrew
         using protocols other than HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
       EOS
       switch "--full",
-             description: "Convert a shallow clone to a full clone without untapping. By default, taps are no "\
-                          "longer cloned as shallow clones."
+             description: "Convert a shallow clone to a full clone without untapping. Taps are only cloned as "\
+                          "shallow clones on continuous integration, or if `--shallow` was originally passed."
       switch "--shallow",
              description: "Fetch tap as a shallow clone rather than a full clone. Useful for continuous integration."
       switch "--force-auto-update",
@@ -53,12 +53,20 @@ module Homebrew
     elsif args.no_named?
       puts Tap.names
     else
+      full_clone = if args.full?
+        true
+      elsif args.shallow?.nil?
+        !ENV["CI"]
+      else
+        !args.shallow?
+      end
+      odebug "Tapping as #{full_clone ? "full" : "shallow"} clone"
       tap = Tap.fetch(args.named.first)
       begin
         tap.install clone_target:      args.named.second,
                     force_auto_update: force_auto_update?,
                     quiet:             args.quiet?,
-                    full_clone:        !args.shallow?
+                    full_clone:        full_clone
       rescue TapRemoteMismatchError => e
         odie e
       rescue TapAlreadyTappedError

--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -55,8 +55,8 @@ module Homebrew
     else
       full_clone = if args.full?
         true
-      elsif args.shallow?.nil?
-        !ENV["CI"]
+      elsif !args.shallow?
+        ENV["CI"].blank?
       else
         !args.shallow?
       end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -243,7 +243,7 @@ class Tap
 
     if installed?
       raise TapRemoteMismatchError.new(name, @remote, requested_remote) if clone_target && requested_remote != remote
-      raise TapAlreadyTappedError, name if force_auto_update.nil?
+      raise TapAlreadyTappedError, name if force_auto_update.nil? && !shallow?
     end
 
     # ensure git is installed

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -502,6 +502,8 @@ HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
 
 * `--full`:
   Convert a shallow clone to a full clone without untapping. By default, taps are no longer cloned as shallow clones.
+* `--shallow`:
+  Fetch tap as a shallow clone rather than a full clone. Useful for continuous integration.
 * `--force-auto-update`:
   Auto-update tap even if it is not hosted on GitHub. By default, only taps hosted on GitHub are auto-updated (for performance reasons).
 * `--repair`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -501,7 +501,7 @@ taps can be cloned from places other than GitHub and using protocols other than
 HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
 
 * `--full`:
-  Convert a shallow clone to a full clone without untapping. By default, taps are no longer cloned as shallow clones.
+  Convert a shallow clone to a full clone without untapping. Taps are only cloned as shallow clones on continuous integration, or if `--shallow` was originally passed.
 * `--shallow`:
   Fetch tap as a shallow clone rather than a full clone. Useful for continuous integration.
 * `--force-auto-update`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -638,6 +638,10 @@ With \fIURL\fR specified, tap a formula repository from anywhere, using any tran
 Convert a shallow clone to a full clone without untapping\. By default, taps are no longer cloned as shallow clones\.
 .
 .TP
+\fB\-\-shallow\fR
+Fetch tap as a shallow clone rather than a full clone\. Useful for continuous integration\.
+.
+.TP
 \fB\-\-force\-auto\-update\fR
 Auto\-update tap even if it is not hosted on GitHub\. By default, only taps hosted on GitHub are auto\-updated (for performance reasons)\.
 .

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -635,7 +635,7 @@ With \fIURL\fR specified, tap a formula repository from anywhere, using any tran
 .
 .TP
 \fB\-\-full\fR
-Convert a shallow clone to a full clone without untapping\. By default, taps are no longer cloned as shallow clones\.
+Convert a shallow clone to a full clone without untapping\. Taps are only cloned as shallow clones on continuous integration, or if \fB\-\-shallow\fR was originally passed\.
 .
 .TP
 \fB\-\-shallow\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This will help speed up continuous integration runs when we really don't need a full clone but want to use the `brew tap` logic instead of e.g., `actions/checkout@v2`. This will also slightly speed up our self-hosted runner upgrades when installing casks.

See:

* https://discourse.brew.sh/t/force-shallow-tap/7367
* https://github.com/Homebrew/brew/pull/6991
* https://github.com/Homebrew/brew/pull/7004