### PR TITLE
bump-revision: fix handling formula with stable block

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -45,7 +45,14 @@ module Homebrew
         [checksum.hash_type, checksum.hexdigest]
       end
 
-      old = if hash_type
+      stable_block_given = formula.path.read.include? "  stable do"
+
+      old = if stable_block_given
+        # insert replacement revision before stable block
+        <<~EOS
+          stable do
+        EOS
+      elsif hash_type
         # insert replacement revision after hash
         <<~EOS
           #{hash_type} "#{old_hash}"
@@ -56,8 +63,12 @@ module Homebrew
           :revision => "#{formula_spec.specs[:revision]}"
         EOS
       end
-      replacement = old + "  revision 1\n"
 
+      replacement = if stable_block_given
+        "revision 1\n  " + old
+      else
+        old + "  revision 1\n"
+      end
     else
       old = "revision #{current_revision}"
       replacement = "revision #{current_revision+1}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Closes https://github.com/Homebrew/brew/pull/7431

`brew bump-revision` doesn't play nicely with formulae with a stable block.

Actual:
```diff
diff --git a/Formula/emscripten.rb b/Formula/emscripten.rb
index c5d2935cb6..00a7f1e0b5 100644
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -5,6 +5,7 @@ class Emscripten < Formula
   stable do
     url "https://github.com/emscripten-core/emscripten/archive/1.39.11.tar.gz"
     sha256 "4da8d99cbc73d71a69020888933245b2ff01b009909230290f7248de76e3881a"
+  revision 1
 
     resource "fastcomp" do
       url "https://github.com/emscripten-core/emscripten-fastcomp/archive/1.39.11.tar.gz"
```

Expected: `revision 1` should be put before `stable do`.

Is there a better way to find out if `stable do` is used than `formula.path.read.include? "  stable do"` ?