### PR TITLE
pull: Deprecate `--bottle` flag

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -927,8 +927,6 @@ Each *`patch`* may be the number of a pull request in `homebrew/core`, the URL o
 any pull request or commit on GitHub or a "https://jenkins.brew.sh/job/..."
 testing job URL.
 
-* `--bottle`:
-  Handle bottles, pulling the bottle-update commit and publishing files on Bintray.
 * `--bump`:
   For one-formula PRs, automatically reword commit message to our preferred format.
 * `--clean`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1180,10 +1180,6 @@ Get a patch from a GitHub commit or pull request and apply it to Homebrew\. Opti
 Each \fIpatch\fR may be the number of a pull request in \fBhomebrew/core\fR, the URL of any pull request or commit on GitHub or a "https://jenkins\.brew\.sh/job/\.\.\." testing job URL\.
 .
 .TP
-\fB\-\-bottle\fR
-Handle bottles, pulling the bottle\-update commit and publishing files on Bintray\.
-.
-.TP
 \fB\-\-bump\fR
 For one\-formula PRs, automatically reword commit message to our preferred format\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Muscle memory is a thing, as is relying heavily on one's shell
  history. Now that the Jenkins runners are gone, `brew pull --bottle`
  no longer works. So, this signposts maintainers to learn about the new
  way.
- This is quick and dirty. Please, suggest better, more comprehensive
  ways!

```
$ brew pull --bottle 1234
==> Fetching patch
Patch: https://github.com/Homebrew/linuxbrew-core/pull/1234.patch
==> Applying patch
Applying: jasper: Build a bottle for Linuxbrew
Error: DEPRECATED. Learn how to pull bottles the new way at https://docs.brew.sh/Brew-Test-Bot-For-Core-Contributors#bottling.
```