### PR TITLE
keg_only tweaks

### DIFF
--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -68,10 +68,10 @@ module Homebrew
       if keg_only
         if Homebrew.default_prefix?
           f = keg.to_formula
-          if f.keg_only_reason.reason == :provided_by_macos
+          if f.keg_only_reason.reason.by_macos?
             caveats = Caveats.new(f)
             opoo <<~EOS
-              Refusing to link macOS-provided software: #{keg.name}
+              Refusing to link macOS provided/shadowed software: #{keg.name}
               #{caveats.keg_only_text(skip_reason: true).strip}
             EOS
             next

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -396,8 +396,8 @@ module Homebrew
           end
 
           if @new_formula &&
-             dep_f.keg_only_reason&.reason == :provided_by_macos &&
-             dep_f.keg_only_reason.valid? &&
+             dep_f.keg_only_reason.provided_by_macos? &&
+             dep_f.keg_only_reason.applicable? &&
              !%w[apr apr-util openblas openssl openssl@1.1].include?(dep.name)
             new_formula_problem(
               "Dependency '#{dep.name}' is provided by macOS; " \
@@ -507,13 +507,14 @@ module Homebrew
       return unless @core_tap
 
       if formula.keg_only?
-        return if formula.keg_only_reason.reason == :versioned_formula
+        return if formula.keg_only_reason.versioned_formula?
         if formula.name.start_with?("openssl", "libressl") &&
-           formula.keg_only_reason.reason == :provided_by_macos
+           formula.keg_only_reason.provided_by_macos?
           return
         end
       end
 
+      # TODO: verify formulae still exist
       keg_only_whitelist = %w[
         autoconf@2.13
         bash-completion@2

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -364,6 +364,13 @@ module Homebrew
       problem "Formula name conflicts with existing core formula."
     end
 
+    USES_FROM_MACOS_WHITELIST = %w[
+      apr
+      apr-util
+      openblas
+      openssl@1.1
+    ].freeze
+
     def audit_deps
       @specs.each do |spec|
         # Check for things we don't like to depend on.
@@ -398,7 +405,7 @@ module Homebrew
           if @new_formula &&
              dep_f.keg_only_reason.provided_by_macos? &&
              dep_f.keg_only_reason.applicable? &&
-             !%w[apr apr-util openblas openssl openssl@1.1].include?(dep.name)
+             !USES_FROM_MACOS_WHITELIST.include?(dep.name)
             new_formula_problem(
               "Dependency '#{dep.name}' is provided by macOS; " \
               "please replace 'depends_on' with 'uses_from_macos'.",
@@ -502,6 +509,15 @@ module Homebrew
       end
     end
 
+    VERSIONED_KEG_ONLY_WHITELIST = %w[
+      autoconf@2.13
+      bash-completion@2
+      gnupg@1.4
+      lua@5.1
+      numpy@1.16
+      libsigc++@2
+    ].freeze
+
     def audit_versioned_keg_only
       return unless @versioned_formula
       return unless @core_tap
@@ -514,17 +530,7 @@ module Homebrew
         end
       end
 
-      # TODO: verify formulae still exist
-      keg_only_whitelist = %w[
-        autoconf@2.13
-        bash-completion@2
-        gnupg@1.4
-        lua@5.1
-        numpy@1.16
-        libsigc++@2
-      ].freeze
-
-      return if keg_only_whitelist.include?(formula.name) || formula.name.start_with?("gcc@")
+      return if VERSIONED_KEG_ONLY_WHITELIST.include?(formula.name) || formula.name.start_with?("gcc@")
 
       problem "Versioned formulae in homebrew/core should use `keg_only :versioned_formula`"
     end
@@ -662,6 +668,47 @@ module Homebrew
       [user, repo]
     end
 
+    VERSIONED_HEAD_SPEC_WHITELIST = %w[
+      bash-completion@2
+      imagemagick@6
+    ].freeze
+
+    THROTTLED_BLACKLIST = {
+      "aws-sdk-cpp" => "10",
+      "awscli@1"    => "10",
+      "quicktype"   => "10",
+      "vim"         => "50",
+    }.freeze
+
+    UNSTABLE_WHITELIST = {
+      "aalib"           => "1.4rc",
+      "automysqlbackup" => "3.0-rc",
+      "aview"           => "1.3.0rc",
+      "elm-format"      => "0.6.0-alpha",
+      "ftgl"            => "2.1.3-rc",
+      "hidapi"          => "0.8.0-rc",
+      "libcaca"         => "0.99b",
+      "premake"         => "4.4-beta",
+      "pwnat"           => "0.3-beta",
+      "recode"          => "3.7-beta",
+      "speexdsp"        => "1.2rc",
+      "sqoop"           => "1.4.",
+      "tcptraceroute"   => "1.5beta",
+      "tiny-fugue"      => "5.0b",
+      "vbindiff"        => "3.0_beta",
+    }.freeze
+
+    GNOME_DEVEL_WHITELIST = {
+      "libart"              => "2.3",
+      "gtk-mac-integration" => "2.1",
+      "gtk-doc"             => "1.31",
+      "gcab"                => "1.3",
+      "libepoxy"            => "1.5",
+    }.freeze
+
+    # version_prefix = stable_version_string.sub(/\d+$/, "")
+    # version_prefix = stable_version_string.split(".")[0..1].join(".")
+
     def audit_specs
       problem "Head-only (no stable download)" if head_only?(formula)
       problem "Devel-only (no stable download)" if devel_only?(formula)
@@ -715,58 +762,16 @@ module Homebrew
 
       if formula.head && @versioned_formula
         head_spec_message = "Formulae should not have a `HEAD` spec"
-        versioned_head_spec = %w[
-          bash-completion@2
-          imagemagick@6
-        ]
-        problem head_spec_message unless versioned_head_spec.include?(formula.name)
+        problem head_spec_message unless VERSIONED_HEAD_SPEC_WHITELIST.include?(formula.name)
       end
 
-      throttled = %w[
-        aws-sdk-cpp 10
-        awscli@1 10
-        quicktype 10
-        vim 50
-      ]
-
-      throttled.each_slice(2).to_a.map do |a, b|
+      THROTTLED_BLACKLIST.each do |f, v|
         next if formula.stable.nil?
 
         version = formula.stable.version.to_s.split(".").last.to_i
-        if a == formula.name && version.modulo(b.to_i).nonzero?
-          problem "should only be updated every #{b} releases on multiples of #{b}"
+        if f == formula.name && version.modulo(v.to_i).nonzero?
+          problem "should only be updated every #{v} releases on multiples of #{v}"
         end
-      end
-
-      unstable_whitelist = %w[
-        aalib 1.4rc5
-        automysqlbackup 3.0-rc6
-        aview 1.3.0rc1
-        elm-format 0.6.0-alpha
-        ftgl 2.1.3-rc5
-        hidapi 0.8.0-rc1
-        libcaca 0.99b19
-        premake 4.4-beta5
-        pwnat 0.3-beta
-        recode 3.7-beta2
-        speexdsp 1.2rc3
-        sqoop 1.4.6
-        tcptraceroute 1.5beta7
-        tiny-fugue 5.0b8
-        vbindiff 3.0_beta4
-      ].each_slice(2).to_a.map do |formula, version|
-        [formula, version.sub(/\d+$/, "")]
-      end
-
-      gnome_devel_whitelist = %w[
-        libart 2.3.21
-        pygtkglext 1.1.0
-        gtk-mac-integration 2.1.3
-        gtk-doc 1.31
-        gcab 1.3
-        libepoxy 1.5.4
-      ].each_slice(2).to_a.map do |formula, version|
-        [formula, version.split(".")[0..1].join(".")]
       end
 
       stable = formula.stable
@@ -783,12 +788,12 @@ module Homebrew
       when /[\d\._-](alpha|beta|rc\d)/
         matched = Regexp.last_match(1)
         version_prefix = stable_version_string.sub(/\d+$/, "")
-        return if unstable_whitelist.include?([formula.name, version_prefix])
+        return if UNSTABLE_WHITELIST[formula.name] == version_prefix
 
         problem "Stable version URLs should not contain #{matched}"
       when %r{download\.gnome\.org/sources}, %r{ftp\.gnome\.org/pub/GNOME/sources}i
         version_prefix = stable_version_string.split(".")[0..1].join(".")
-        return if gnome_devel_whitelist.include?([formula.name, version_prefix])
+        return if GNOME_DEVEL_WHITELIST[formula.name] == version_prefix
         return if stable_url_version < Version.create("1.0")
         return if stable_url_minor_version.even?
 

--- a/Library/Homebrew/extend/os/mac/formula_support.rb
+++ b/Library/Homebrew/extend/os/mac/formula_support.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class KegOnlyReason
-  def valid?
+  def applicable?
     true
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1045,7 +1045,7 @@ class Formula
   def keg_only?
     return false unless keg_only_reason
 
-    keg_only_reason.valid?
+    keg_only_reason.applicable?
   end
 
   # @private

--- a/Library/Homebrew/formula_support.rb
+++ b/Library/Homebrew/formula_support.rb
@@ -13,24 +13,41 @@ class KegOnlyReason
     @explanation = explanation
   end
 
-  def valid?
-    ![:provided_by_macos, :provided_by_osx, :shadowed_by_macos].include?(@reason)
+  def versioned_formula?
+    @reason == :versioned_formula
+  end
+
+  def provided_by_macos?
+    @reason == :provided_by_macos
+  end
+
+  def shadowed_by_macos?
+    @reason == :shadowed_by_macos
+  end
+
+  def by_macos?
+    provided_by_macos? || shadowed_by_macos?
+  end
+
+  def applicable?
+    # macOS reasons aren't applicable on other OSs
+    # (see extend/os/mac/formula_support for override on macOS)
+    !by_macos?
   end
 
   def to_s
     return @explanation unless @explanation.empty?
 
-    case @reason
-    when :versioned_formula
+    if versioned_formula?
       <<~EOS
         this is an alternate version of another formula
       EOS
-    when :provided_by_macos
+    elsif provided_by_macos?
       <<~EOS
         macOS already provides this software and installing another version in
         parallel can cause all kinds of trouble
       EOS
-    when :shadowed_by_macos
+    elsif shadowed_by_macos?
       <<~EOS
         macOS provides similar software and installing this software in
         parallel can cause all kinds of trouble

--- a/Library/Homebrew/rubocops/class.rb
+++ b/Library/Homebrew/rubocops/class.rb
@@ -86,8 +86,8 @@ module RuboCop
             return
           end
 
-          return unless test.body.single_line? &&
-                        test.body.source.to_s == "true"
+          return unless test.body.single_line?
+          return if test.body.source.to_s != "true"
 
           problem "`test do` should contain a real test"
         end

--- a/Library/Homebrew/rubocops/class.rb
+++ b/Library/Homebrew/rubocops/class.rb
@@ -70,7 +70,7 @@ module RuboCop
       end
     end
 
-    module FormulaAuditStrict
+    module FormulaAudit
       # - `test do ..end` should be meaningfully defined in the formula.
       class Test < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)

--- a/Library/Homebrew/rubocops/conflicts.rb
+++ b/Library/Homebrew/rubocops/conflicts.rb
@@ -12,13 +12,13 @@ module RuboCop
               "Use `keg_only :versioned_formula` instead."
 
         WHITELIST = %w[
-          bash-completion@
+          bash-completion@2
         ].freeze
 
         def audit_formula(_node, _class_node, _parent_class_node, body)
           return unless versioned_formula?
 
-          problem MSG if !@formula_name.start_with?(*WHITELIST) &&
+          problem MSG if !WHITELIST.include?(@formula_name) &&
                          method_called_ever?(body, :conflicts_with)
         end
       end

--- a/Library/Homebrew/rubocops/formula_desc.rb
+++ b/Library/Homebrew/rubocops/formula_desc.rb
@@ -38,7 +38,7 @@ module RuboCop
       end
     end
 
-    module FormulaAuditStrict
+    module FormulaAudit
       # This cop audits `desc` in Formulae.
       #
       # - Checks for leading/trailing whitespace in `desc`

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -196,6 +196,26 @@ module RuboCop
       end
 
       class Miscellaneous < FormulaCop
+        MAKE_CHECK_WHITELIST = %w[
+          beecrypt
+          ccrypt
+          git
+          gmp
+          gnupg
+          gnupg@1.4
+          google-sparsehash
+          jemalloc
+          jpeg-turbo
+          mpfr
+          nettle
+          open-mpi
+          openssl@1.1
+          pcre
+          protobuf
+          wolfssl
+          xz
+        ].freeze
+
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           # FileUtils is included in Formula
           # encfs modifies a file with this name, so check for some leading characters
@@ -425,25 +445,7 @@ module RuboCop
           # Avoid build-time checks in homebrew/core
           find_every_method_call_by_name(body_node, :system).each do |method|
             next if @formula_name.start_with?("lib")
-            next if %w[
-              beecrypt
-              ccrypt
-              git
-              gmp
-              gnupg
-              gnupg@1.4
-              google-sparsehash
-              jemalloc
-              jpeg-turbo
-              mpfr
-              nettle
-              open-mpi
-              openssl@1.1
-              pcre
-              protobuf
-              wolfssl
-              xz
-            ].include?(@formula_name)
+            next if MAKE_CHECK_WHITELIST.include?(@formula_name)
 
             params = parameters(method)
             next unless node_equals?(params[0], "make")

--- a/Library/Homebrew/rubocops/options.rb
+++ b/Library/Homebrew/rubocops/options.rb
@@ -39,7 +39,7 @@ module RuboCop
                     " Migrate '--#{option}' with `deprecated_option`."
           end
 
-          return unless formula_tap == "homebrew-core"
+          return if formula_tap != "homebrew-core"
 
           problem DEP_OPTION if method_called_ever?(body_node, :deprecated_option)
           problem OPTION if method_called_ever?(body_node, :option)

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -61,16 +61,18 @@ module RuboCop
           find_method_with_args(body_node, :system, "cargo", "build") do
             problem "use \"cargo\", \"install\", \"--root\", prefix, \"--path\", \".\""
           end
-        end
-      end
-    end
-    module FormulaAuditStrict
-      class Text < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+
           find_method_with_args(body_node, :go_resource) do
             problem "`go_resource`s are deprecated. Please ask upstream to implement Go vendoring"
           end
         end
+      end
+    end
+
+    # Keep this (empty) module and class around in case we need it later to
+    # avoid deleting all the FormulaAuditStrict referencing logic.
+    module FormulaAuditStrict
+      class Text < FormulaCop
       end
     end
   end

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -12,7 +12,7 @@ module RuboCop
             problem "Please set plist_options when using a formula-defined plist."
           end
 
-          if depends_on?("openssl") && depends_on?("libressl")
+          if (depends_on?("openssl") || depends_on?("openssl@1.1")) && depends_on?("libressl")
             problem "Formulae should not depend on both OpenSSL and LibreSSL (even optionally)."
           end
 

--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -26,7 +26,7 @@ module RuboCop
           m4
           ncurses
           openldap
-          openssl
+          openssl@1.1
           perl
           php
           ruby

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -633,5 +633,12 @@ module Homebrew
         expect(fa.problems).to eq([])
       end
     end
+
+    include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_WHITELIST
+    include_examples "formulae exist", described_class::VERSIONED_HEAD_SPEC_WHITELIST
+    include_examples "formulae exist", described_class::USES_FROM_MACOS_WHITELIST
+    include_examples "formulae exist", described_class::THROTTLED_BLACKLIST.keys
+    include_examples "formulae exist", described_class::UNSTABLE_WHITELIST.keys
+    include_examples "formulae exist", described_class::GNOME_DEVEL_WHITELIST.keys
   end
 end

--- a/Library/Homebrew/test/rubocops/class_spec.rb
+++ b/Library/Homebrew/test/rubocops/class_spec.rb
@@ -105,7 +105,7 @@ describe RuboCop::Cop::FormulaAudit::TestCalls do
   end
 end
 
-describe RuboCop::Cop::FormulaAuditStrict::Test do
+describe RuboCop::Cop::FormulaAudit::Test do
   subject(:cop) { described_class.new }
 
   it "reports an offense when there is no test block" do

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -26,4 +26,6 @@ describe RuboCop::Cop::FormulaAudit::Conflicts do
       RUBY
     end
   end
+
+  include_examples "formulae exist", described_class::WHITELIST
 end

--- a/Library/Homebrew/test/rubocops/formula_desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_spec.rb
@@ -48,7 +48,7 @@ describe RuboCop::Cop::FormulaAudit::DescLength do
   end
 end
 
-describe RuboCop::Cop::FormulaAuditStrict::Desc do
+describe RuboCop::Cop::FormulaAudit::Desc do
   subject(:cop) { described_class.new }
 
   context "When auditing formula desc" do

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -860,4 +860,6 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
       RUBY
     end
   end
+
+  include_examples "formulae exist", described_class::MAKE_CHECK_WHITELIST
 end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -218,6 +218,8 @@ describe RuboCop::Cop::FormulaAudit::Urls do
       RUBY
     end
   end
+
+  include_examples "formulae exist", described_class::BINARY_BOOTSTRAP_FORMULA_URLS_WHITELIST
 end
 
 describe RuboCop::Cop::FormulaAudit::PyPiUrls do

--- a/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/uses_from_macos_spec.rb
@@ -16,4 +16,6 @@ describe RuboCop::Cop::FormulaAudit::UsesFromMacos do
       end
     RUBY
   end
+
+  include_examples "formulae exist", described_class::ALLOWED_USES_FROM_MACOS_DEPS
 end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -52,6 +52,7 @@ require "test/support/helper/output_as_tty"
 
 require "test/support/helper/spec/shared_context/homebrew_cask" if OS.mac?
 require "test/support/helper/spec/shared_context/integration_test"
+require "test/support/helper/spec/shared_examples/formulae_exist"
 
 TEST_DIRECTORIES = [
   CoreTap.instance.path/"Formula",

--- a/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_examples/formulae_exist.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+shared_examples "formulae exist" do |array|
+  array.each do |f|
+    it "#{f} formula exists" do
+      formula_path = Pathname("#{HOMEBREW_LIBRARY_PATH}/../Taps/homebrew/homebrew-core/Formula/#{f}.rb")
+      expect(formula_path.exist?).to be true
+    end
+  end
+end

--- a/Library/Homebrew/test/support/lib/config.rb
+++ b/Library/Homebrew/test/support/lib/config.rb
@@ -17,7 +17,7 @@ TEST_TMPDIR = ENV.fetch("HOMEBREW_TEST_TMPDIR") do |k|
 end.freeze
 
 # Paths pointing into the Homebrew code base that persist across test runs
-HOMEBREW_SHIMS_PATH = (HOMEBREW_LIBRARY_PATH.parent/"Homebrew/shims").freeze
+HOMEBREW_SHIMS_PATH = (HOMEBREW_LIBRARY_PATH/"shims").freeze
 
 require "extend/git_repository"
 


### PR DESCRIPTION
- don't allow linking macOS shadowed software (now we've updated them in homebrew-core to be consistent and there's more shadowed)
- move lists of formulae in rubocops and audit to (tested) arrays/hashes
- fix issues noticed due to the above
- add some more keg only reason helpers
- refactor some rubocops

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----