### PR TITLE
os/mac/pkgconfig: delete most cflags on 10.14+

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libcurl.pc
@@ -37,4 +37,4 @@ Description: Library to transfer files with ftp, http, etc.
 Version: 7.54.0
 Libs: -L${libdir} -lcurl
 Libs.private: -lldap -lz
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libexslt.pc
@@ -10,4 +10,4 @@ Version: 0.8.17
 Description: EXSLT Extension library
 Requires: libxml-2.0
 Libs: -L${libdir} -lexslt -lxslt  -lxml2 -lz -lpthread -licucore -lm
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libxml-2.0.pc
@@ -2,7 +2,7 @@ homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib
-includedir=${prefix}/include
+includedir=${prefix}/include/libxml2
 modules=1
 
 Name: libXML
@@ -11,4 +11,4 @@ Description: libXML library version2.
 Requires:
 Libs: -L${libdir} -lxml2
 Libs.private: -lz -lpthread -licucore -lm
-Cflags: -I${includedir}/libxml2
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libxslt.pc
@@ -10,4 +10,4 @@ Version: 1.1.29
 Description: XSLT library version 2.
 Requires: libxml-2.0
 Libs: -L${libdir} -lxslt  -lxml2 -lz -lpthread -licucore -lm
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/sqlite3.pc
@@ -9,4 +9,4 @@ Description: SQL database engine
 Version: 3.24.0
 Libs: -L${libdir} -lsqlite3
 Libs.private:
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/uuid.pc
@@ -3,7 +3,7 @@ prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib
 sharedlibdir=${libdir}
-includedir=${prefix}/include
+includedir=${prefix}/include/uuid
 
 Name: uuid
 Description: Universally unique id library
@@ -11,4 +11,4 @@ Version: 1.0
 
 Requires:
 Libs:
-Cflags: -I${includedir}/uuid
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.14/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/zlib.pc
@@ -11,4 +11,4 @@ Version: 1.2.11
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libcurl.pc
@@ -37,4 +37,4 @@ Description: Library to transfer files with ftp, http, etc.
 Version: 7.64.1
 Libs: -L${libdir} -lcurl
 Libs.private: -lldap -lz
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libexslt.pc
@@ -10,4 +10,4 @@ Version: 0.8.17
 Description: EXSLT Extension library
 Requires: libxml-2.0
 Libs: -L${libdir} -lexslt -lxslt  -lxml2 -lz -lpthread -licucore -lm
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libxml-2.0.pc
@@ -11,4 +11,4 @@ Description: libXML library version2.
 Requires:
 Libs: -L${libdir} -lxml2
 Libs.private: -lz -lpthread -licucore -lm
-Cflags: -I${includedir}/libxml2
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libxslt.pc
@@ -10,4 +10,4 @@ Version: 1.1.29
 Description: XSLT library version 2.
 Requires: libxml-2.0
 Libs: -L${libdir} -lxslt  -lxml2 -lz -lpthread -licucore -lm
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/sqlite3.pc
@@ -9,4 +9,4 @@ Description: SQL database engine
 Version: 3.28.0
 Libs: -L${libdir} -lsqlite3
 Libs.private:
-Cflags: -I${includedir}
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/uuid.pc
@@ -3,7 +3,7 @@ prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib
 sharedlibdir=${libdir}
-includedir=${prefix}/include
+includedir=${prefix}/include/uuid
 
 Name: uuid
 Description: Universally unique id library
@@ -11,4 +11,4 @@ Version: 1.0
 
 Requires:
 Libs:
-Cflags: -I${includedir}/uuid
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/zlib.pc
@@ -11,4 +11,4 @@ Version: 1.2.11
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz
-Cflags: -I${includedir}
+Cflags:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If the cflags are going to cause problems, let's not provide them at all. Apple's compiler is able to find `<SDK>/usr/include` without extra help anyway - it was mainly libxml2 and uuid that benefitted from this as well as just the general presence of these files to satisfy pkg-config only build systems.

Apart from SwiftPM, there should be no visible change here to anyone, unless someone had set `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS` (which is a bad idea anyway on macOS and provides no real benefit unless you are using a non-Apple, non-brewed, misconfigured compiler - which wouldn't have worked previously anyway because we only introduced the SDK part recently).

Due to them not being at standard include paths, I have not deleted cflags on:
* libxml-2.0 on Mojave (Catalina pc file will assume 10.15.4 SDK is installed - if it isn't then the user will need to specify the include path manually though they would have to have done so before all these changes anyway)
* uuid