### PR TITLE
pr-*: only unique named args

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -9,7 +9,7 @@ module Homebrew
   def pr_publish_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `pr-publish` <pull_request>
+        `pr-publish` [<options>] <pull_request> [<pull_request> ...]
 
         Publishes bottles for a pull request with GitHub Actions.
         Requires write access to the repository.
@@ -25,7 +25,7 @@ module Homebrew
 
     odie "You need to specify at least one pull request number!" if Homebrew.args.named.empty?
 
-    args.named.each do |arg|
+    args.named.uniq.each do |arg|
       arg = "#{CoreTap.instance.default_remote}/pull/#{arg}" if arg.to_i.positive?
       url_match = arg.match HOMEBREW_PULL_OR_COMMIT_URL_REGEX
       _, user, repo, issue = *url_match

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -11,7 +11,7 @@ module Homebrew
   def pr_pull_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `pr-pull` <pull_request>
+        `pr-pull` [<options>] <pull_request> [<pull_request> ...]
 
         Download and publish bottles, and apply the bottle commit from a
         pull request with artifacts generated from GitHub Actions.
@@ -159,7 +159,7 @@ module Homebrew
 
     setup_git_environment!
 
-    args.named.each do |arg|
+    args.named.uniq.each do |arg|
       arg = "#{tap.default_remote}/pull/#{arg}" if arg.to_i.positive?
       url_match = arg.match HOMEBREW_PULL_OR_COMMIT_URL_REGEX
       _, user, repo, pr = *url_match

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -884,12 +884,12 @@ Generate Homebrew's manpages.
 * `--link`:
   This is now done automatically by `brew update`.
 
-### `pr-publish` *`pull_request`*
+### `pr-publish` [*`options`*] *`pull_request`* [*`pull_request`* ...]
 
 Publishes bottles for a pull request with GitHub Actions. Requires write access
 to the repository.
 
-### `pr-pull` *`pull_request`*
+### `pr-pull` [*`options`*] *`pull_request`* [*`pull_request`* ...]
 
 Download and publish bottles, and apply the bottle commit from a pull request
 with artifacts generated from GitHub Actions. Requires write access to the

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1128,10 +1128,10 @@ Return a failing status code if changes are detected in the manpage outputs\. Th
 \fB\-\-link\fR
 This is now done automatically by \fBbrew update\fR\.
 .
-.SS "\fBpr\-publish\fR \fIpull_request\fR"
+.SS "\fBpr\-publish\fR [\fIoptions\fR] \fIpull_request\fR [\fIpull_request\fR \.\.\.]"
 Publishes bottles for a pull request with GitHub Actions\. Requires write access to the repository\.
 .
-.SS "\fBpr\-pull\fR \fIpull_request\fR"
+.SS "\fBpr\-pull\fR [\fIoptions\fR] \fIpull_request\fR [\fIpull_request\fR \.\.\.]"
 Download and publish bottles, and apply the bottle commit from a pull request with artifacts generated from GitHub Actions\. Requires write access to the repository\.
 .
 .TP


### PR DESCRIPTION
Motivation for this change: maintainer can by mistake fire duplicate workflows for one PR.

Also tweak usage to show that the commands accept multiple arguments.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----