### PR TITLE
ENV/std: conditionally apply AES-NI workaround

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -112,9 +112,11 @@ module Stdenv
   def clang
     super
     replace_in_cflags(/-Xarch_#{Hardware::CPU.arch_32_bit} (-march=\S*)/, '\1')
-    # Clang mistakenly enables AES-NI on plain Nehalem
     map = Hardware::CPU.optimization_flags
-                       .merge(nehalem: "-march=nehalem -Xclang -target-feature -Xclang -aes")
+    if DevelopmentTools.clang_build_version < 700
+      # Clang mistakenly enables AES-NI on plain Nehalem
+      map[:nehalem] = "-march=nehalem -Xclang -target-feature -Xclang -aes"
+    end
     set_cpu_cflags map
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is needed in order for the latest version of gpsd to build: Homebrew/homebrew-core#53013

I believe this was fixed in LLVM 3.7.0. I don't have older systems/VMs/whatever to thoroughly confirm that. However, the majority of the time we are not running in Nehalem mode because we use `oldest_cpu`.

This workaround was also never applied to the superenv, probably because Nehalem mode was never activated there until Mojave.