### PR TITLE
ENV/std: remove space in -isysroot

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -60,9 +60,9 @@ module Stdenv
     return unless (sdk = MacOS.sdk_path_if_needed(version))
 
     delete("SDKROOT")
-    remove_from_cflags "-isysroot #{sdk}"
-    remove "CPPFLAGS", "-isysroot #{sdk}"
-    remove "LDFLAGS", "-isysroot #{sdk}"
+    remove_from_cflags "-isysroot#{sdk}"
+    remove "CPPFLAGS", "-isysroot#{sdk}"
+    remove "LDFLAGS", "-isysroot#{sdk}"
     if HOMEBREW_PREFIX.to_s == "/usr/local"
       delete("CMAKE_PREFIX_PATH")
     else
@@ -87,10 +87,10 @@ module Stdenv
     # Tell clang/gcc where system include's are:
     append_path "CPATH", "#{sdk}/usr/include"
     # The -isysroot is needed, too, because of the Frameworks
-    append_to_cflags "-isysroot #{sdk}"
-    append "CPPFLAGS", "-isysroot #{sdk}"
+    append_to_cflags "-isysroot#{sdk}"
+    append "CPPFLAGS", "-isysroot#{sdk}"
     # And the linker needs to find sdk/usr/lib
-    append "LDFLAGS", "-isysroot #{sdk}"
+    append "LDFLAGS", "-isysroot#{sdk}"
     # Needed to build cmake itself and perhaps some cmake projects:
     append_path "CMAKE_PREFIX_PATH", "#{sdk}/usr"
     append_path "CMAKE_FRAMEWORK_PATH", "#{sdk}/System/Library/Frameworks"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is needed in order for the latest version of gpsd to build: Homebrew/homebrew-core#53013

We already did this in the superenv a few months ago, for different reasons: b4ff330ac1dc9d6ee60fdbcd1b3e0542c7416457