### PR TITLE
Make Version.tokens public

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -446,13 +446,13 @@ class Version
   end
   alias to_str to_s
 
-  protected
-
-  attr_reader :version
-
   def tokens
     @tokens ||= tokenize
   end
+
+  protected
+
+  attr_reader :version
 
   private
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This change is required for the version filtering feature that I've implemented in Homebrew/homebrew-livecheck#536 to work. Basically, we have to be able to access a `Version`'s tokens to be able to compare the individual parts of the version (major, minor, patch, etc.) for filtering. For example, if we're working with a versioned formula where we only want to match major versions that are less than or equal to three, we would need to check the `Version`'s first token.

Currently, `Version.tokens` is protected and seemingly inaccessible from within `livecheck`'s heuristic. This aims to address this by making `tokens` public but let me know if this is inappropriate or I should go about this (or the aforementioned livecheck PR) in a different manner.

For what it's worth, `brew tests` is currently hanging for me at some point (and didn't complete even after letting it run for an hour) but this is also true on the latest `master`.