### PR TITLE
audit: fix keg_only check

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -403,6 +403,7 @@ module Homebrew
           end
 
           if @new_formula &&
+             dep_f.keg_only? &&
              dep_f.keg_only_reason.provided_by_macos? &&
              dep_f.keg_only_reason.applicable? &&
              !USES_FROM_MACOS_WHITELIST.include?(dep.name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes https://github.com/Homebrew/brew/issues/7341

Before this patch:

```console
% brew audit --strict --new-formula xsimd   
Error: undefined method `provided_by_macos?' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:406:in `block (2 levels) in audit_deps'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/delegate.rb:349:in `each'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/delegate.rb:349:in `block in delegating_block'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:378:in `block in audit_deps'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:375:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:375:in `audit_deps'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1017:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1010:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:1010:in `audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:117:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:110:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:110:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

After this patch:

```console
% brew audit --strict --new-formula xsimd
xsimd:
  * New formulae in homebrew/core should not have a `bottle do` block
Error: 1 problem in 1 formula detected
```