### PR TITLE
pr-pull: fix to fetch extra-large bottles

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -5,6 +5,14 @@ require "utils/github"
 require "tmpdir"
 require "bintray"
 
+class CurlNoResumeDownloadStrategy < CurlDownloadStrategy
+  private
+
+  def _fetch(url:, resolved_url:)
+    curl("--location", "--remote-time", "--create-dirs", "--output", temporary_path, resolved_url)
+  end
+end
+
 module Homebrew
   module_function
 
@@ -192,7 +200,9 @@ module Homebrew
           if Homebrew.args.dry_run?
             puts "Upload bottles described by these JSON files to Bintray:\n  #{Dir["*.json"].join("\n  ")}"
           else
-            bintray.upload_bottle_json Dir["*.json"], publish_package: !args.no_publish?
+            bintray.upload_bottle_json Dir["*.json"],
+                                       publish_package: !args.no_publish?,
+                                       strategy:        CurlNoResumeDownloadStrategy
           end
         end
       end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -435,7 +435,8 @@ module GitHub
                   scopes:         CREATE_ISSUE_FORK_OR_PR_SCOPES)
   end
 
-  def fetch_artifact(user, repo, pr, dir, workflow_id: "tests.yml", artifact_name: "bottles")
+  def fetch_artifact(user, repo, pr, dir,
+                     workflow_id: "tests.yml", artifact_name: "bottles", strategy: CurlDownloadStrategy)
     scopes = CREATE_ISSUE_FORK_OR_PR_SCOPES
     base_url = "#{API_URL}/repos/#{user}/#{repo}"
     pr_payload = open_api("#{base_url}/pulls/#{pr}", scopes: scopes)
@@ -496,7 +497,7 @@ module GitHub
     FileUtils.chdir dir do
       curl_args[:cache] = Pathname.new(dir)
       curl_args[:secrets] = [token]
-      downloader = CurlDownloadStrategy.new(artifact_url, "artifact", pr, **curl_args)
+      downloader = strategy.new(artifact_url, "artifact", pr, **curl_args)
       downloader.fetch
       downloader.stage
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This pull request fixes the issue seen in https://github.com/Homebrew/homebrew-core/pull/52984 and other homebrew-core pull requests, where the bottle downloads are too large to be downloaded without timing out.

When retrieving artifacts from GitHub Actions, the artifact download requires an authorization token that is only valid for 1 minute, meaning the download must start within 60 seconds of retrieving that token.

However, the current two-step download strategy, which downloads a single byte to see if the server supports a range request, then resuming the download, means that large bottles often time out before the second request can occur.

This pull request adds a new download strategy, `CurlNoResumeDownloadStrategy`, which doesn't check if the server supports download continuations, and merely redownloads from scratch if needed. I've confirmed with local tests that if the entire file has been downloaded successfully, curl doesn't re-download the file.