### PR TITLE
dev-cmd: add pr-automerge

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require "utils/github"
+
+module Homebrew
+  module_function
+
+  def pr_automerge_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `pr-automerge` [<options>]
+
+        Finds pull requests that can be automatically merged using `brew pr-publish`.
+      EOS
+      flag "--tap=",
+           description: "Target repository tap (default: `homebrew/core`)"
+      flag "--with-label=",
+           description: "Pull requests must have this label (default: `ready to merge`)"
+      flag "--without-label=",
+           description: "Pull requests must not have this label (default: `do not merge`)"
+      switch "--publish",
+             description: "Run `brew pr-publish` on matching pull requests."
+      switch "--ignore-failures",
+             description: "Include pull requests that have failing status checks."
+      switch :debug
+      switch :verbose
+    end
+  end
+
+  def pr_automerge
+    pr_automerge_args.parse
+
+    ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" unless OS.mac?
+    with_label = Homebrew.args.with_label || "ready to merge"
+    without_label = Homebrew.args.without_label || "do not merge"
+    tap = Tap.fetch(Homebrew.args.tap || CoreTap.instance.name)
+
+    query = "is:pr is:open repo:#{tap.full_name} label:\"#{with_label}\" -label:\"#{without_label}\""
+    query += args.ignore_failures? ? " -status:pending" : " status:success"
+    odebug "Searching: #{query}"
+
+    prs = GitHub.search_issues query
+    if prs.blank?
+      ohai "No matching pull requests!"
+      return
+    end
+
+    ohai "#{prs.size} matching pull requests:"
+    pr_urls = []
+    prs.each do |pr|
+      puts "#{tap.full_name unless tap.core_tap?}##{pr["number"]}: #{pr["title"]}"
+      pr_urls << pr["html_url"]
+    end
+
+    if args.publish?
+      safe_system "#{HOMEBREW_PREFIX}/bin/brew", "pr-publish", *pr_urls
+    else
+      ohai "Now run:"
+      puts "  brew pr-publish \\\n    #{pr_urls.join " \\\n    "}"
+    end
+  end
+end

--- a/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-automerge_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.pr_automerge_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -884,6 +884,21 @@ Generate Homebrew's manpages.
 * `--link`:
   This is now done automatically by `brew update`.
 
+### `pr-automerge` [*`options`*]
+
+Finds pull requests that can be automatically merged using `brew pr-publish`.
+
+* `--tap`:
+  Target repository tap (default: `homebrew/core`)
+* `--with-label`:
+  Pull requests must have this label (default: `ready to merge`)
+* `--without-label`:
+  Pull requests must not have this label (default: `do not merge`)
+* `--publish`:
+  Run `brew pr-publish` on matching pull requests.
+* `--ignore-failures`:
+  Include pull requests that have failing status checks.
+
 ### `pr-publish` [*`options`*] *`pull_request`* [*`pull_request`* ...]
 
 Publishes bottles for a pull request with GitHub Actions. Requires write access

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1128,6 +1128,29 @@ Return a failing status code if changes are detected in the manpage outputs\. Th
 \fB\-\-link\fR
 This is now done automatically by \fBbrew update\fR\.
 .
+.SS "\fBpr\-automerge\fR [\fIoptions\fR]"
+Finds pull requests that can be automatically merged using \fBbrew pr\-publish\fR\.
+.
+.TP
+\fB\-\-tap\fR
+Target repository tap (default: \fBhomebrew/core\fR)
+.
+.TP
+\fB\-\-with\-label\fR
+Pull requests must have this label (default: \fBready to merge\fR)
+.
+.TP
+\fB\-\-without\-label\fR
+Pull requests must not have this label (default: \fBdo not merge\fR)
+.
+.TP
+\fB\-\-publish\fR
+Run \fBbrew pr\-publish\fR on matching pull requests\.
+.
+.TP
+\fB\-\-ignore\-failures\fR
+Include pull requests that have failing status checks\.
+.
 .SS "\fBpr\-publish\fR [\fIoptions\fR] \fIpull_request\fR [\fIpull_request\fR \.\.\.]"
 Publishes bottles for a pull request with GitHub Actions\. Requires write access to the repository\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is the last developer command needed in our master plan in https://github.com/Homebrew/brew/issues/6255#issuecomment-589916227. `brew pr-automerge` checks homebrew/core for pull requests with passing tests and the "ready to merge" label. Optionally add `--publish` to run `brew pr-publish` on those as well.

After this is merged, we can add this as a `scheduled` task in `homebrew/core`.

Example output:

```console
% brew pr-automerge --publish --verbose --debug
==> Searching: is:pr is:open repo:Homebrew/homebrew-core label:"ready to merge" -label:"do not merge" status:success
/usr/bin/curl --disable --globoff --show-error --user-agent Homebrew/2.2.12-58-g9e4dfaf\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.15.4\)\ curl/7.64.1 --retry 3 --location https://api.github.com/search/issues\?q=is\%3Apr\+is\%3Aopen\+repo\%3AHomebrew\%2Fhomebrew-core\+label\%3A\%22ready\+to\+merge\%22\+-label\%3A\%22do\+not\+merge\%22\+status\%3Asuccess\&per_page=100 --header Accept:\ application/vnd.github.v3\+json --write-out '
'\%\{http_code\} --header Accept:\ application/vnd.github.antiope-preview\+json --user jonchang:****** --dump-header /private/tmp/github_api_headers20200413-68197-sa8ds8
==> 4 matching pull requests:
#52984: xerces-c 3.2.3
#52890: emscripten 1.39.12
#52817: gtk+3 3.24.18
#52797: qpdf 10.0.1
==> Running:
  brew pr-publish \
    https://github.com/Homebrew/homebrew-core/pull/52984 \
    https://github.com/Homebrew/homebrew-core/pull/52890 \
    https://github.com/Homebrew/homebrew-core/pull/52817 \
    https://github.com/Homebrew/homebrew-core/pull/52797
/usr/local/bin/brew pr-publish https://github.com/Homebrew/homebrew-core/pull/52984 https://github.com/Homebrew/homebrew-core/pull/52890 https://github.com/Homebrew/homebrew-core/pull/52817 https://github.com/Homebrew/homebrew-core/pull/52797
==> Dispatching homebrew/core pull request #52984
==> Dispatching homebrew/core pull request #52890
==> Dispatching homebrew/core pull request #52817
==> Dispatching homebrew/core pull request #52797
```