### PR TITLE
dev-cmd/pr-pull: fix strategy error

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -187,7 +187,9 @@ module Homebrew
             next
           end
 
-          GitHub.fetch_artifact(user, repo, pr, dir, workflow_id: workflow, artifact_name: artifact)
+          GitHub.fetch_artifact(user, repo, pr, dir, workflow_id:   workflow,
+                                                     artifact_name: artifact,
+                                                     strategy:      CurlNoResumeDownloadStrategy)
 
           if Homebrew.args.dry_run?
             puts "brew bottle --merge --write #{Dir["*.json"].join " "}"
@@ -200,9 +202,7 @@ module Homebrew
           if Homebrew.args.dry_run?
             puts "Upload bottles described by these JSON files to Bintray:\n  #{Dir["*.json"].join("\n  ")}"
           else
-            bintray.upload_bottle_json Dir["*.json"],
-                                       publish_package: !args.no_publish?,
-                                       strategy:        CurlNoResumeDownloadStrategy
+            bintray.upload_bottle_json Dir["*.json"], publish_package: !args.no_publish?
           end
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

```
Error: unknown keyword: strategy
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:87:in `upload_bottle_json'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:203:in `block (3 levels) in pr_pull'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/fileutils.rb:128:in `chdir'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/fileutils.rb:128:in `cd'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:180:in `block (2 levels) in pr_pull'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.3/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:179:in `block in pr_pull'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:170:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:170:in `pr_pull'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```