### PR TITLE
pr-pull: eliminate another curl call

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -42,17 +42,22 @@ describe GitHub do
     end
   end
 
-  describe "::fetch_artifact", :needs_network do
+  describe "::get_artifact_url", :needs_network do
     it "fails to find a nonexistant workflow" do
       expect {
-        subject.fetch_artifact("Homebrew", "homebrew-core", 1, ".")
+        subject.get_artifact_url("Homebrew", "homebrew-core", 1)
       }.to raise_error(/No matching workflow run found/)
     end
 
     it "fails to find artifacts that don't exist" do
       expect {
-        subject.fetch_artifact("Homebrew", "homebrew-core", 51971, ".", artifact_name: "false_bottles")
+        subject.get_artifact_url("Homebrew", "homebrew-core", 51971, artifact_name: "false_bottles")
       }.to raise_error(/No artifact .+ was found/)
+    end
+
+    it "gets an artifact link" do
+      url = subject.get_artifact_url("Homebrew", "homebrew-core", 51971, artifact_name: "bottles")
+      expect(url).to eq("https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/3557392/zip")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This pull request eliminates another `curl` call that determines what the basename of the downloaded file should be. This should speed up bottle pulls even more, and make the case where the artifact zip is already downloaded into a no-op, rather than requiring that `curl` call.

Also, fixes a bug in the previous code (https://github.com/Homebrew/brew/pull/7343) that didn't properly mask secrets when running with `--verbose`.

`CurlNoResumeDownloadStrategy` is now `GitHubArtifactDownloadStrategy` as it is now quite specific to GitHub Artifacts.