### PR TITLE
formula: add standard meson args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1373,6 +1373,11 @@ class Formula
     ["--jobs=#{ENV.make_jobs}", "--max-backjumps=100000", "--install-method=copy", "--installdir=#{bin}"]
   end
 
+  # Standard parameters for meson builds.
+  def std_meson_args
+    ["--prefix=#{prefix}", "--libdir=#{lib}"]
+  end
+
   # an array of all core {Formula} names
   # @private
   def self.core_names

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -142,7 +142,7 @@ module Homebrew
             system "go", "build", *std_go_args
         <% elsif mode == :meson %>
             mkdir "build" do
-              system "meson", "--prefix=\#{prefix}", ".."
+              system "meson", *std_meson_args, ".."
               system "ninja", "-v"
               system "ninja", "install", "-v"
             end


### PR DESCRIPTION
libdir is especially important on Fedora based distributions,
where it might default to "lib64", but everything else expects "lib",
so forcing the libdir is necessary there.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
