### PR TITLE
test: ensure pkill is run even without exception.

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -37,6 +37,7 @@ begin
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.puts e.to_json
   error_pipe.close
+ensure
   pid = Process.pid.to_s
   if which("pgrep") && which("pkill") && system("pgrep", "-P", pid, out: :close)
     $stderr.puts "Killing child processes..."
@@ -44,5 +45,5 @@ rescue Exception => e # rubocop:disable Lint/RescueException
     sleep 1
     system "pkill", "-9", "-P", pid
   end
-  exit! 1
+  exit! 1 if e
 end


### PR DESCRIPTION
This should make it easier to cleanup after test failures or successes.

It may also allow simplification of `test do` blocks if they can assume that all subprocesses will be killed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----