### PR TITLE
pr-automerge: allow multiple comma separated without labels

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -854,8 +854,8 @@ Finds pull requests that can be automatically merged using `brew pr-publish`.
   Target repository tap (default: `homebrew/core`)
 * `--with-label`:
   Pull requests must have this label (default: `ready to merge`)
-* `--without-label`:
-  Pull requests must not have this label (default: `do not merge`)
+* `--without-labels`:
+  Pull requests must not have these labels (default: `do not merge`, `new formula`)
 * `--publish`:
   Run `brew pr-publish` on matching pull requests.
 * `--ignore-failures`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1100,8 +1100,8 @@ Target repository tap (default: \fBhomebrew/core\fR)
 Pull requests must have this label (default: \fBready to merge\fR)
 .
 .TP
-\fB\-\-without\-label\fR
-Pull requests must not have this label (default: \fBdo not merge\fR)
+\fB\-\-without\-labels\fR
+Pull requests must not have these labels (default: \fBdo not merge\fR, \fBnew formula\fR)
 .
 .TP
 \fB\-\-publish\fR


### PR DESCRIPTION
This PR adds an ability to specify multiple labels for `pr-automerge` command.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----