### PR TITLE
dev-cmd/audit: add --skip-style option.

### DIFF
--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -353,7 +353,7 @@ module Homebrew
       end
     end
 
-    describe "#audit_keg_only_style" do
+    describe "#audit_keg_only" do
       specify "keg_only_needs_downcasing" do
         fa = formula_auditor "foo", <<~RUBY, strict: true
           class Foo < Formula
@@ -363,7 +363,7 @@ module Homebrew
           end
         RUBY
 
-        fa.audit_keg_only_style
+        fa.audit_keg_only
         expect(fa.problems)
           .to eq(["'Because' from the keg_only reason should be 'because'.\n"])
       end
@@ -377,7 +377,7 @@ module Homebrew
           end
         RUBY
 
-        fa.audit_keg_only_style
+        fa.audit_keg_only
         expect(fa.problems)
           .to eq(["keg_only reason should not end with a period."])
       end
@@ -396,7 +396,7 @@ module Homebrew
           end
         RUBY
 
-        fa.audit_keg_only_style
+        fa.audit_keg_only
         expect(fa.problems)
           .to eq([])
       end
@@ -410,7 +410,7 @@ module Homebrew
           end
         RUBY
 
-        fa.audit_keg_only_style
+        fa.audit_keg_only
         expect(fa.problems)
           .to eq([])
       end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -633,9 +633,9 @@ available formulae. Will exit with a non-zero status if any errors are found,
 which can be useful for implementing pre-commit hooks.
 
 * `--strict`:
-  Run additional style checks, including RuboCop style checks.
+  Run additional, stricter style checks.
 * `--online`:
-  Run additional slower style checks that require a network connection.
+  Run additional, slower style checks that require a network connection.
 * `--new-formula`:
   Run various additional style checks to determine if a new formula is eligible for Homebrew. This should be used when creating new formula and implies `--strict` and `--online`.
 * `--fix`:
@@ -644,6 +644,8 @@ which can be useful for implementing pre-commit hooks.
   Include the RuboCop cop name for each violation in the output.
 * `--display-filename`:
   Prefix every line of output with the file or formula name being audited, to make output easy to grep.
+* `--skip-style`:
+  Skip running non-RuboCop style checks. Useful if you plan on running `brew style` separately.
 * `-D`, `--audit-debug`:
   Enable debugging and profiling of audit methods.
 * `--only`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -799,11 +799,11 @@ Check \fIformula\fR for Homebrew coding style violations\. This should be run be
 .
 .TP
 \fB\-\-strict\fR
-Run additional style checks, including RuboCop style checks\.
+Run additional, stricter style checks\.
 .
 .TP
 \fB\-\-online\fR
-Run additional slower style checks that require a network connection\.
+Run additional, slower style checks that require a network connection\.
 .
 .TP
 \fB\-\-new\-formula\fR
@@ -820,6 +820,10 @@ Include the RuboCop cop name for each violation in the output\.
 .TP
 \fB\-\-display\-filename\fR
 Prefix every line of output with the file or formula name being audited, to make output easy to grep\.
+.
+.TP
+\fB\-\-skip\-style\fR
+Skip running non\-RuboCop style checks\. Useful if you plan on running \fBbrew style\fR separately\.
 .
 .TP
 \fB\-D\fR, \fB\-\-audit\-debug\fR


### PR DESCRIPTION
This will allow `brew style` and `brew audit` to be run separately without providing duplicates.

Additionally, run RuboCop style rules when `--strict` isn't provided and remove a confusing reference to `style`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----