### PR TITLE
os/mac/xcode: support Xcode 11.4.1

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -13,9 +13,9 @@ module OS
       # CI systems have been updated.
       # This may be a beta version for a beta macOS.
       def latest_version
-        latest = "11.4"
+        latest = "11.4.1"
         case MacOS.version
-        when "10.15" then "11.4"
+        when "10.15" then "11.4.1"
         when "10.14" then "11.3.1"
         when "10.13" then "10.1"
         when "10.12" then "9.2"
@@ -173,7 +173,7 @@ module OS
         # installed CLT version. This is useful as they are packaged
         # simultaneously so workarounds need to apply to both based on their
         # comparable version.
-        latest = "11.4"
+        latest = "11.4.1"
         case (DevelopmentTools.clang_version.to_f * 10).to_i
         when 110     then latest
         when 100     then "10.3"
@@ -250,7 +250,7 @@ module OS
       # and our CI systems have been updated.
       def latest_clang_version
         case MacOS.version
-        when "10.15" then "1100.0.33.16"
+        when "10.15" then "1103.0.32.59"
         when "10.14" then "1001.0.46.4"
         when "10.13" then "1000.10.44.2"
         when "10.12" then "900.0.39.2"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Note: There is a CLT 11.4.1 available, and it was offered through `softwareupdate` on the CI VMs. ~~As per previous discussion, I have not touched `latest_clang_version` here however.~~

For future reference, the new Clang version is `1103.0.32.59`.