### PR TITLE
github: add sponsors GraphQL API

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -480,6 +480,34 @@ module GitHub
     artifact.first["archive_download_url"]
   end
 
+  def sponsors_by_tier(user)
+    url = "https://api.github.com/graphql"
+    data = {
+      query: <<~EOS,
+          {
+            organization(login: "#{user}") {
+              sponsorsListing {
+                tiers(first: 100) {
+                  nodes {
+                    monthlyPriceInDollars
+                    adminInfo {
+                    sponsorships(first: 100) {
+                      totalCount
+                      nodes {
+                        sponsor { login }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      EOS
+    }
+    open_api(url, scopes: ["admin:org", "user"], data: data, request_method: "POST")
+  end
+
   def api_errors
     [GitHub::AuthenticationFailedError, GitHub::HTTPNotFoundError,
      GitHub::RateLimitExceededError, GitHub::Error, JSON::ParserError].freeze


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Add a GitHub API call to retrieve sponsors information. As this isn't available in the standard REST API, I've had to construct a GraphQL API call to get this to work.

The goal is to eventually automate adding sponsors at the applicable tier to the README automatically. I haven't decided what that will look like but this API call is the first step needed.