### PR TITLE
diagnostic: whitelist /bin and /sbin for *-config files

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -444,6 +444,7 @@ module Homebrew
         scripts = []
 
         whitelist = %W[
+          /bin /sbin
           /usr/bin /usr/sbin
           /usr/X11/bin /usr/X11R6/bin /opt/X11/bin
           #{HOMEBREW_PREFIX}/bin #{HOMEBREW_PREFIX}/sbin


### PR DESCRIPTION
Keep getting these lines in `brew doctor`'s output:

```
Having additional scripts in your path can confuse software installed via
Homebrew if the config script overrides a system or Homebrew-provided
script of the same name. We found the following "config" scripts:
  /sbin/update-texmf-config
  /bin/apt-config
  /bin/ncurses5-config
  /bin/xdelta-config
  /bin/ncurses6-config
  /bin/ncursesw6-config
  /bin/im-config
  /bin/ncursesw5-config
```

I think it might be reasonable to also whitelist `/bin` and `/sbin`.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----