### PR TITLE
rubocops/urls: check for bitbucket hg URLs

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -112,7 +112,7 @@ module RuboCop
             next if user.nil?
 
             api_url = "https://api.bitbucket.org/2.0/repositories/#{user}/#{repo}"
-            out = %x{/usr/bin/curl --request GET #{api_url}}
+            out = %x{/usr/bin/curl --show-error --silent --request GET #{api_url}}
             next unless $?.exitstatus == 0
 
             metadata = JSON.parse(out)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

[Bitbucket is deleting all mercurial repositories on June 1](https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket), and the date is coming soon. Thanks to @SMillerDev's work in #6425, we have a an audit check to complain if new formulae are added to homebrew-core that have a bitbucket link in the `homepage` or stable `url`. This is a good start, but there are many formulae in core that have links to bitbucket hg repositories in `homepage`, `head` or `url` fields that will soon be unavailable, so I think more urgent action is needed (not to mention the formula in 3rd-party taps). The code in this draft PR is a bit of a hack, as it makes a system call to `curl` from within the `rubocop` code, but it identifies quite a few homebrew-core formulae with issues (see https://gist.github.com/scpeters/b3e42182dc5b56ee0cefa001c641770d).

This doesn't catch all the problems though. There are some repositories that have already been migrated to another location and the hg repository replaced with a placeholder git repository. For example, [bgpdump's stable url](https://github.com/Homebrew/homebrew-core/blob/master/Formula/bgpdump.rb#L4) points to bitbucket, but that link gives a 404 because it's been moved to github (see the [bitbucket README](https://bitbucket.org/ripencc/bgpdump/src/master/README.md)). Using `brew audit --strict --new-formula --online bgpdump` shows the 404.

I'll start using this script to identify problematic formulae in homebrew-core, though we may not want to merge it, since it's a bit of a hack.