### PR TITLE
Remove ARGV_WITHOUT_MONKEY_PATCHING

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -13,7 +13,7 @@ module Homebrew
         super
 
         self[:remaining] = []
-        self[:cmdline_args] = ARGV_WITHOUT_MONKEY_PATCHING.dup
+        self[:cmdline_args] = ARGV.dup.freeze
 
         @args_parsed = false
         @processed_options = []

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -40,7 +40,6 @@ require "cli/args"
 require "messages"
 require "system_command"
 
-ARGV_WITHOUT_MONKEY_PATCHING = ARGV.dup.freeze
 ARGV.extend(HomebrewArgvExtension)
 
 HOMEBREW_PRODUCT = ENV["HOMEBREW_PRODUCT"]


### PR DESCRIPTION
Our usage of `ARGV` will go away soon enough and maintaining state between `ARGV` and `ARGV_WITHOUT_MONKEY_PATCHING` is futile.

Fixes #7397

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----