### PR TITLE
pr-upload: Add argument root-url

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -19,6 +19,8 @@ module Homebrew
              description: "Print what would be done rather than doing it."
       flag "--bintray-org=",
            description: "Upload to the specified Bintray organisation (default: homebrew)."
+      flag "--root-url=",
+           description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
     end
   end
 
@@ -28,10 +30,15 @@ module Homebrew
     bintray_org = args.bintray_org || "homebrew"
     bintray = Bintray.new(org: bintray_org)
 
+    bottle_args = ["bottle", "--merge", "--write"]
+    bottle_args << "--root-url=#{args.root_url}" if args.root_url
+    odie "No JSON files found in the current working directory" if Dir["*.json"].empty?
+    bottle_args += Dir["*.json"]
+
     if args.dry_run?
-      puts "brew bottle --merge --write #{Dir["*.json"].join " "}"
+      puts "brew #{bottle_args.join " "}"
     else
-      system HOMEBREW_BREW_FILE, "bottle", "--merge", "--write", *Dir["*.json"]
+      system HOMEBREW_BREW_FILE, "bottle", *bottle_args
     end
 
     if args.dry_run?

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -908,6 +908,8 @@ Apply the bottle commit and publish bottles to Bintray.
   Print what would be done rather than doing it.
 * `--bintray-org`:
   Upload to the specified Bintray organisation (default: homebrew).
+* `--root-url`:
+  Use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
 
 ### `prof` *`command`*
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1178,6 +1178,10 @@ Print what would be done rather than doing it\.
 \fB\-\-bintray\-org\fR
 Upload to the specified Bintray organisation (default: homebrew)\.
 .
+.TP
+\fB\-\-root\-url\fR
+Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
+.
 .SS "\fBprof\fR \fIcommand\fR"
 Run Homebrew with the Ruby profiler, e\.g\. \fBbrew prof readall\fR\.
 .


### PR DESCRIPTION
The argument root-url is needed for third-party taps.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?