### PR TITLE
uses_from_macos: Add gzip rsync to the white list

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -62,12 +62,14 @@ module RuboCop
           bash
           expect
           groff
+          gzip
           openssl
           openssl@1.1
           perl
           php
           python
           python@3
+          rsync
           vim
           xz
           zsh


### PR DESCRIPTION
`/usr/bin/gzip` and `/usr/bin/rsync` are provided by macOS.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?