### PR TITLE
Fix cask loading after adding an artifact type

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -69,7 +69,7 @@ module Cask
     attr_accessor :explicit
 
     def initialize(default: nil, env: nil, explicit: {})
-      @default = self.class.canonicalize(default) if default
+      @default = DEFAULT_DIRS.merge(self.class.canonicalize(default)) if default
       @env = self.class.canonicalize(env) if env
       @explicit = self.class.canonicalize(explicit)
 

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -50,4 +50,20 @@ describe Cask::Config, :cask do
       expect(config.explicit[:appdir]).to eq(Pathname("/explicit/path/to/apps"))
     end
   end
+
+  context "when installing a cask and then adding a global default dir" do
+    let(:config) { described_class.new(default: { appdir: "/default/path/before/adding/fontdir" }) }
+
+    describe "#appdir" do
+      it "honors metadata of the installed cask" do
+        expect(config.appdir).to eq(Pathname("/default/path/before/adding/fontdir"))
+      end
+    end
+
+    describe "#fontdir" do
+      it "falls back to global default on incomplete metadata" do
+        expect(config.default).to include(fontdir: Pathname(TEST_TMPDIR).join("cask-fontdir"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **A couple of tests fail** on my local machine but all of them seem to be unrelated. For example:

> expected block to not output to stderr, but output "Warning: Your Xcode (11.0) is outdated.\nPlease update to Xcode 11.3.1 (or delete it).\nXcode can be updated from the App Store.\n\n"

-----

## Summary

This PR fixes an issue where [we added a new global artifact](https://github.com/Homebrew/brew/pull/7286#issuecomment-613376568) and then updated a cask to make use of that new artifact. This caused [a number of `brew cask` commands to fail](https://discourse.brew.sh/t/cask-definition-is-invalid-invalid-mdimporter-stanza-key-not-found-mdimporterdir) for users who had the cask installed before the artifact was added.

## Root cause

When loading the definition of an installed cask, we configure it using a snapshot from install time, e. g. `/usr/local/Caskroom/markdownmdimporter/.metadata/config.json`.

The snapshot looks like this:

```
{
  "default": {
    "appdir": "/Applications",
    "prefpanedir": "/Users/claudia/Library/PreferencePanes",
    "qlplugindir": "/Users/claudia/Library/QuickLook",
    "dictionarydir": "/Users/claudia/Library/Dictionaries",
    "fontdir": "/Users/claudia/Library/Fonts",
    "colorpickerdir": "/Users/claudia/Library/ColorPickers",
    "servicedir": "/Users/claudia/Library/Services",
    "input_methoddir": "/Users/claudia/Library/Input Methods",
    "internet_plugindir": "/Users/claudia/Library/Internet Plug-Ins",
    "audio_unit_plugindir": "/Users/claudia/Library/Audio/Plug-Ins/Components",
    "vst_plugindir": "/Users/claudia/Library/Audio/Plug-Ins/VST",
    "vst3_plugindir": "/Users/claudia/Library/Audio/Plug-Ins/VST3",
    "screen_saverdir": "/Users/claudia/Library/Screen Savers"
  },
  "env": {},
  "explicit": {}
}
```

Note that there is no `mdimporterdir` because the cask was installed before the artifact was added.

The root cause is that the cask loading code still expects the snapshot to contain directory configuration for all artifact types.  
Since the snapshot never learned about the new artifact type, cask loading would fail.

## Proposed fix

The fix is to fall back to the global default whenever the `default` directory map of a configuration snapshot is incomplete.
