### PR TITLE
ruby.sh: allow running on older Ruby versions

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -42,7 +42,7 @@ setup-ruby-path() {
         usable_ruby_version="true"
       elif [[ -n "$HOMEBREW_RUBY_PATH" && -z "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
       then
-        usable_ruby_version="$("$HOMEBREW_RUBY_PATH" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e "puts Gem::Version.new(RUBY_VERSION.to_s.dup).canonical_segments.first(2) == Gem::Version.new('$required_ruby_version').canonical_segments.first(2)")"
+        usable_ruby_version="$("$HOMEBREW_RUBY_PATH" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)")"
       fi
 
       if [[ -z "$HOMEBREW_RUBY_PATH" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" || "$usable_ruby_version" != "true" ]]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
When installing on a fresh pre-10.15 system, the installer throws an error because `/usr/bin/ruby` is 2.3.7, but `Version.canonical_segments` didn't arrive until [2.5.0](https://docs.ruby-lang.org/en/2.5.0/Gem/Version.html).

```
...
 * [new tag]             2.2.7      -> 2.2.7
 * [new tag]             2.2.8      -> 2.2.8
 * [new tag]             2.2.9      -> 2.2.9
HEAD is now at 8e984d621 Merge pull request #7419 from Bo98/audit
-e:1:in `<main>': undefined method `canonical_segments' for #<Gem::Version "2.3.7"> (NoMethodError)
==> Downloading https://homebrew.bintray.com/bottles-portable-ruby/portable-ruby-2.6.3.mavericks.bottle.tar.gz
...
