### PR TITLE
sh: fix custom shell prompt for zsh

### DIFF
--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -40,10 +40,10 @@ module Homebrew
       # superenv stopped adding brew's bin but generally users will want it
       ENV["PATH"] = PATH.new(ENV["PATH"]).insert(1, HOMEBREW_PREFIX/"bin")
     end
-    ENV["PS1"] = if ENV["SHELL"].include?("zsh")
-      "brew %B%F{green}~%f%b$ "
+    subshell = if ENV["SHELL"].include?("zsh")
+      "PS1='brew %B%F{green}%~%f%b$ ' #{ENV["SHELL"]} -d"
     else
-      'brew \[\033[1;32m\]\w\[\033[0m\]$ '
+      "PS1=\"brew \\[\\033[1;32m\\]\\w\\[\\033[0m\\]$ \" #{ENV["SHELL"]}"
     end
     ENV["VERBOSE"] = "1"
     puts <<~EOS
@@ -55,6 +55,6 @@ module Homebrew
       When done, type `exit`.
     EOS
     $stdout.flush
-    safe_system ENV["SHELL"]
+    safe_system subshell
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The custom shell prompt for `brew sh` is only set for zsh if the -d flag is passed. (Note that this still won't overwrite a custom prompt set in dotfiles.) Also adds a missing % to make the prompt show the current working directory.