### PR TITLE
ENV/super: always set HOMEBREW_SDKROOT for Xcode builds

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -108,7 +108,7 @@ module Superenv
   # @private
   def setup_build_environment(formula = nil)
     sdk = formula ? MacOS.sdk_for_formula(formula) : MacOS.sdk
-    if MacOS.sdk_root_needed?
+    if MacOS.sdk_root_needed? || sdk.source == :xcode
       self["HOMEBREW_SDKROOT"] = sdk.path
       self["HOMEBREW_DEVELOPER_DIR"] = if sdk.source == :xcode
         MacOS::Xcode.prefix


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The superenv changes have been working well. One last tweak I think needs making, which I've done here, is to always set `HOMEBREW_SDKROOT` when the Xcode SDK is requested. Without it, it can mean defaulting to the CLT. This only affects 10.13 and earlier.