### PR TITLE
shims/super/cc: relax restrictions with -Xclang

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -185,7 +185,7 @@ class Cmd
       "-fuse-linker-plugin", "-frounding-math"
       # clang doesn't support these flags
       args << arg unless tool =~ /^clang/
-    when "-Xpreprocessor"
+    when "-Xpreprocessor", "-Xclang"
       # used for -Xpreprocessor -fopenmp
       args << arg << enum.next
     when /-mmacosx-version-min=10\.(\d+)/


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

For a lot of cases, `-Xpreprocessor` and `-Xclang` do similar things. We already have relaxed restrictions for `-Xpreprocessor` so we should give equal treatment to `-Xclang`.

Notably, the comment explicitly mentions `-Xpreprocessor -fopenmp` but `-Xclang -fopenmp` is equally valid and is used within CMake.

Fixes https://github.com/Homebrew/homebrew-core/pull/53598#discussion_r414187523. With this change, all the added `args` in that pull request can be removed again.