### PR TITLE
workflows/tests: ensure taps are up-to-date

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,10 +90,16 @@ jobs:
       run: |
         # Install taps needed for 'brew tests' and 'brew man'
         export HOMEBREW_NO_AUTO_UPDATE=1
+        cd "$(brew --repo)"
         brew tap homebrew/bundle
+        brew update-reset Library/Taps/homebrew/homebrew-bundle
         brew tap homebrew/services
+        brew update-reset Library/Taps/homebrew/homebrew-services
+        brew tap homebrew/test-bot
+        brew update-reset Library/Taps/homebrew/homebrew-test-bot
         if [ "$RUNNER_OS" = "macOS" ]; then
           brew tap homebrew/cask
+          brew update-reset Library/Taps/homebrew/homebrew-cask
         fi
 
     - name: Run brew style


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I suspect `brew man` has been failing because homebrew/services is now included in the macOS image and is outdated.