### PR TITLE
bump-revision: insert after homepage if stable block is present

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -42,7 +42,12 @@ module Homebrew
         [checksum.hash_type, checksum.hexdigest]
       end
 
-      old = if hash_type
+      old = if formula.path.read.include?("stable do\n")
+        # insert replacement revision after homepage
+        <<~EOS
+          homepage "#{formula.homepage}"
+        EOS
+      elsif hash_type
         # insert replacement revision after hash
         <<~EOS
           #{hash_type} "#{old_hash}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
If a formula contains a stable block, insert the new revision after the homepage instead of the hash.

Before:
```
  homepage "https://crystal-lang.org/"

  stable do
    url "https://github.com/crystal-lang/crystal/archive/0.34.0.tar.gz"
    sha256 "973293ffbcfa4fb073f6a2f833b0ce5b82b72f7899427f39d7e5610ffc9029c8"
  revision 1
```

After:
```
  homepage "https://crystal-lang.org/"
  revision 1

  stable do
    url "https://github.com/crystal-lang/crystal/archive/0.34.0.tar.gz"
    sha256 "973293ffbcfa4fb073f6a2f833b0ce5b82b72f7899427f39d7e5610ffc9029c8"
```