### PR TITLE
Lint the homebrew/brew Dockerfile with `hadolint`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,12 @@ jobs:
         brew install vale
         vale docs/
 
+    - name: Lint Dockerfile
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        brew install hadolint
+        hadolint Dockerfile
+
     - name: Build Docker image
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:xenial
 LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
+# hadolint ignore=DL3008
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends software-properties-common \
 	&& add-apt-repository -y ppa:git-core/ppa \
@@ -27,10 +28,12 @@ RUN apt-get update \
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
 	&& useradd -m -s /bin/bash linuxbrew \
 	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
-ADD . /home/linuxbrew/.linuxbrew/Homebrew
+COPY . /home/linuxbrew/.linuxbrew/Homebrew
 ARG FORCE_REBUILD
+
+# hadolint ignore=DL3003
 RUN cd /home/linuxbrew/.linuxbrew \
-	&& mkdir -p bin etc include lib opt sbin share var/homebrew/linked Cellar \
+  && mkdir -p bin etc include lib opt sbin share var/homebrew/linked Cellar \
 	&& ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/ \
 	&& cd /home/linuxbrew/.linuxbrew/Homebrew \
 	&& git remote set-url origin https://github.com/Homebrew/brew

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,49 +3,49 @@ LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
 
 # hadolint ignore=DL3008
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends software-properties-common \
-	&& add-apt-repository -y ppa:git-core/ppa \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		bzip2 \
-		ca-certificates \
-		curl \
-		file \
-		fonts-dejavu-core \
-		g++ \
-		git \
-		libz-dev \
-		locales \
-		make \
-		netbase \
-		openssh-client \
-		patch \
-		sudo \
-		uuid-runtime \
-		tzdata \
-	&& rm -rf /var/lib/apt/lists/*
+  && apt-get install -y --no-install-recommends software-properties-common \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bzip2 \
+    ca-certificates \
+    curl \
+    file \
+    fonts-dejavu-core \
+    g++ \
+    git \
+    libz-dev \
+    locales \
+    make \
+    netbase \
+    openssh-client \
+    patch \
+    sudo \
+    uuid-runtime \
+    tzdata \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
-	&& useradd -m -s /bin/bash linuxbrew \
-	&& echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+  && useradd -m -s /bin/bash linuxbrew \
+  && echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 COPY . /home/linuxbrew/.linuxbrew/Homebrew
 ARG FORCE_REBUILD
 
 # hadolint ignore=DL3003
 RUN cd /home/linuxbrew/.linuxbrew \
   && mkdir -p bin etc include lib opt sbin share var/homebrew/linked Cellar \
-	&& ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/ \
-	&& cd /home/linuxbrew/.linuxbrew/Homebrew \
-	&& git remote set-url origin https://github.com/Homebrew/brew
+  && ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/ \
+  && cd /home/linuxbrew/.linuxbrew/Homebrew \
+  && git remote set-url origin https://github.com/Homebrew/brew
 
 WORKDIR /home/linuxbrew
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
-	SHELL=/bin/bash
+  SHELL=/bin/bash
 
 # Install portable-ruby, tap homebrew/core, install audit gems, and cleanup
 RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
-	&& chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
-	&& chmod -R g+w,o-w /home/linuxbrew/.linuxbrew \
-	&& rm -rf ~/.cache \
-	&& brew install-bundler-gems \
-	&& brew cleanup
+  && chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
+  && chmod -R g+w,o-w /home/linuxbrew/.linuxbrew \
+  && rm -rf ~/.cache \
+  && brew install-bundler-gems \
+  && brew cleanup


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- I suggested this for the contents of [Linuxbrew/docker](https://github.com/Linuxbrew/docker) in https://github.com/Linuxbrew/docker/issues/75. People agreed, and Shaun asked me to do the same here.
- This adds a step to CI to lint the Dockerfile, via [hadolint](https://github.com/hadolint/hadolint), on Ubuntu.
- The linting errors it surfaced on this Dockerfile were:

```
Dockerfile:4 DL3008 Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
Dockerfile:30 DL3020 Use COPY instead of ADD for files and folders
Dockerfile:32 DL3003 Use WORKDIR to switch to a directory
```

- [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) - pinning versions in `apt-get install` - is at odds with what we recommend in the normal Homebrew on Linux dependency install instructions. We don't want the dependency management of having to check each of these Dockerfiles periodically for the latest version numbers of packages and have to update them. So I've disabled this lint.