### PR TITLE
ARGV: Deprecate ARGV.build_bottle? and replace with Homebrew.args.build_bottle

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -179,6 +179,12 @@ module Homebrew
         cmdline_args.include?("--build-from-source") || cmdline_args.include?("-s")
       end
 
+      def build_bottle
+        return true if args_parsed && build_bottle?
+
+        cmdline_args.include?("--build-bottle")
+      end
+
       def force_bottle
         return true if args_parsed && force_bottle?
 
@@ -219,12 +225,6 @@ module Homebrew
         return true if args_parsed && universal?
 
         cmdline_args.include?("--universal")
-      end
-
-      def build_bottle
-        return true if args_parsed && build_bottle?
-
-        cmdline_args.include?("--build-bottle")
       end
 
       def spec(default = :stable)

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -31,10 +31,6 @@ module HomebrewArgvExtension
     flag?("--debug") || !ENV["HOMEBREW_DEBUG"].nil?
   end
 
-  def build_bottle?
-    include?("--build-bottle")
-  end
-
   def bottle_arch
     arch = value "bottle-arch"
     arch&.to_sym

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -268,7 +268,7 @@ module SharedEnvExtension
 
   # @private
   def effective_arch
-    if ARGV.build_bottle? && ARGV.bottle_arch
+    if Homebrew.args.build_bottle && ARGV.bottle_arch
       ARGV.bottle_arch
     else
       Hardware.oldest_cpu

--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -3,7 +3,7 @@
 module SharedEnvExtension
   # @private
   def effective_arch
-    if ARGV.build_bottle?
+    if Homebrew.args.build_bottle?
       ARGV.bottle_arch || Hardware.oldest_cpu
     else
       :native

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -25,7 +25,7 @@ module Homebrew
 
     fi = FormulaInstaller.new(f)
     fi.options              = options
-    fi.build_bottle         = ARGV.build_bottle?
+    fi.build_bottle         = Homebrew.args.build_bottle
     fi.interactive          = Homebrew.args.interactive?
     fi.git                  = Homebrew.args.git?
     fi.link_keg           ||= keg_was_linked if keg_had_linked_opt


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#5730 