### PR TITLE
bintray: fix package creation for verbose output 

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -66,7 +66,7 @@ class Bintray
   def package_exists?(repo:, package:)
     url = "#{API_URL}/packages/#{@bintray_org}/#{repo}/#{package}"
     begin
-      open_api url, "--silent", "--output", "/dev/null", auth: false
+      open_api url, "--fail", "--silent", "--output", "/dev/null", auth: false
     rescue ErrorDuringExecution => e
       stderr = e.output
                 .select { |type,| type == :stderr }
@@ -83,7 +83,7 @@ class Bintray
   def file_published?(repo:, remote_file:)
     url = "https://dl.bintray.com/#{@bintray_org}/#{repo}/#{remote_file}"
     begin
-      curl "--silent", "--head", "--output", "/dev/null", url
+      curl "--fail", "--silent", "--head", "--output", "/dev/null", url
     rescue ErrorDuringExecution => e
       stderr = e.output
                 .select { |type,| type == :stderr }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Ref: https://github.com/Homebrew/brew/pull/7415#issuecomment-619453118

I believe we should consider  removing appending `--fail` flag from the expression
https://github.com/Homebrew/brew/blob/bbe300ab2aa5c6cb097cdee2bc2b2c7aeda8af2a/Library/Homebrew/utils/curl.rb#L35-L40