### PR TITLE
Add JSON support for brew cask outdated, fixes #7432

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -123,17 +123,18 @@ module Cask
     end
 
     def outdated_info(greedy, verbose, json)
+      return token unless verbose || json
+
+      installed_versions = outdated_versions(greedy).join(", ")
+
       if json
         {
           name:               token,
-          installed_versions: outdated_versions(greedy).join(", "),
+          installed_versions: installed_versions,
           current_version:    version,
         }
-      elsif verbose
-        outdated_info = token << " (#{outdated_versions(greedy).join(", ")})"
-        "#{outdated_info} != #{version}"
       else
-        token
+        "#{token} (#{installed_versions}) != #{version}"
       end
     end
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -122,6 +122,21 @@ module Cask
       installed.reject { |v| v == version }
     end
 
+    def outdated_info(greedy, verbose, json)
+      if json
+        {
+          name: token,
+          installed_versions: outdated_versions(greedy).join(", "),
+          current_version: version
+        }
+      elsif verbose
+        outdated_info = token << " (#{outdated_versions(greedy).join(", ")})"
+        "#{outdated_info} != #{version}"
+      else
+        token
+      end
+    end
+
     def to_s
       @token
     end

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -123,7 +123,7 @@ module Cask
     end
 
     def outdated_info(greedy, verbose, json)
-      return token unless verbose || json
+      return token if !verbose && !json
 
       installed_versions = outdated_versions(greedy).join(", ")
 

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -125,9 +125,9 @@ module Cask
     def outdated_info(greedy, verbose, json)
       if json
         {
-          name: token,
+          name:               token,
           installed_versions: outdated_versions(greedy).join(", "),
-          current_version: version
+          current_version:    version,
         }
       elsif verbose
         outdated_info = token << " (#{outdated_versions(greedy).join(", ")})"

--- a/Library/Homebrew/test/cask/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/outdated_spec.rb
@@ -88,4 +88,104 @@ describe Cask::Cmd::Outdated, :cask do
       EOS
     end
   end
+
+  describe "--json" do
+    it "lists outdated Casks in JSON format" do
+      result = [
+        {
+          name: "local-caffeine",
+          installed_versions: "1.2.2",
+          current_version: "1.2.3"
+        },
+        {
+          name: "local-transmission",
+          installed_versions: "2.60",
+          current_version: "2.61"
+        }
+      ].to_json
+
+      expect {
+        described_class.run("--json")
+      }.to output(result + "\n").to_stdout
+    end
+  end
+
+  describe "--json overrides --quiet" do
+    it "ignores --quiet and lists outdated Casks in JSON format" do
+      result = [
+        {
+          name: "local-caffeine",
+          installed_versions: "1.2.2",
+          current_version: "1.2.3"
+        },
+        {
+          name: "local-transmission",
+          installed_versions: "2.60",
+          current_version: "2.61"
+        }
+      ].to_json
+
+      expect {
+        described_class.run("--json", "--quiet")
+      }.to output(result + "\n").to_stdout
+    end
+  end
+
+  describe "--json and --greedy" do
+    it 'includes the Casks with "auto_updates true" or "version latest" in JSON format' do
+      result = [
+        {
+          name: "auto-updates",
+          installed_versions: "2.57",
+          current_version: "2.61"
+        },
+        {
+          name: "local-caffeine",
+          installed_versions: "1.2.2",
+          current_version: "1.2.3"
+        },
+        {
+          name: "local-transmission",
+          installed_versions: "2.60",
+          current_version: "2.61"
+        },
+        {
+          name: "version-latest-string",
+          installed_versions: "latest",
+          current_version: "latest"
+        }
+      ].to_json
+
+      expect {
+        described_class.run("--json", "--greedy")
+      }.to output(result + "\n").to_stdout
+    end
+
+    it 'does not include the Casks with "auto_updates true" with no version change in JSON format' do
+      cask = Cask::CaskLoader.load(cask_path("auto-updates"))
+      InstallHelper.install_with_caskfile(cask)
+
+      result = [
+        {
+          name: "local-caffeine",
+          installed_versions: "1.2.2",
+          current_version: "1.2.3"
+        },
+        {
+          name: "local-transmission",
+          installed_versions: "2.60",
+          current_version: "2.61"
+        },
+        {
+          name: "version-latest-string",
+          installed_versions: "latest",
+          current_version: "latest"
+        }
+      ].to_json
+
+      expect {
+        described_class.run("--json", "--greedy")
+      }.to output(result + "\n").to_stdout
+    end
+  end
 end

--- a/Library/Homebrew/test/cask/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/outdated_spec.rb
@@ -93,15 +93,15 @@ describe Cask::Cmd::Outdated, :cask do
     it "lists outdated Casks in JSON format" do
       result = [
         {
-          name: "local-caffeine",
+          name:               "local-caffeine",
           installed_versions: "1.2.2",
-          current_version: "1.2.3"
+          current_version:    "1.2.3",
         },
         {
-          name: "local-transmission",
+          name:               "local-transmission",
           installed_versions: "2.60",
-          current_version: "2.61"
-        }
+          current_version:    "2.61",
+        },
       ].to_json
 
       expect {
@@ -114,15 +114,15 @@ describe Cask::Cmd::Outdated, :cask do
     it "ignores --quiet and lists outdated Casks in JSON format" do
       result = [
         {
-          name: "local-caffeine",
+          name:               "local-caffeine",
           installed_versions: "1.2.2",
-          current_version: "1.2.3"
+          current_version:    "1.2.3",
         },
         {
-          name: "local-transmission",
+          name:               "local-transmission",
           installed_versions: "2.60",
-          current_version: "2.61"
-        }
+          current_version:    "2.61",
+        },
       ].to_json
 
       expect {
@@ -135,25 +135,25 @@ describe Cask::Cmd::Outdated, :cask do
     it 'includes the Casks with "auto_updates true" or "version latest" in JSON format' do
       result = [
         {
-          name: "auto-updates",
+          name:               "auto-updates",
           installed_versions: "2.57",
-          current_version: "2.61"
+          current_version:    "2.61",
         },
         {
-          name: "local-caffeine",
+          name:               "local-caffeine",
           installed_versions: "1.2.2",
-          current_version: "1.2.3"
+          current_version:    "1.2.3",
         },
         {
-          name: "local-transmission",
+          name:               "local-transmission",
           installed_versions: "2.60",
-          current_version: "2.61"
+          current_version:    "2.61",
         },
         {
-          name: "version-latest-string",
+          name:               "version-latest-string",
           installed_versions: "latest",
-          current_version: "latest"
-        }
+          current_version:    "latest",
+        },
       ].to_json
 
       expect {
@@ -167,20 +167,20 @@ describe Cask::Cmd::Outdated, :cask do
 
       result = [
         {
-          name: "local-caffeine",
+          name:               "local-caffeine",
           installed_versions: "1.2.2",
-          current_version: "1.2.3"
+          current_version:    "1.2.3",
         },
         {
-          name: "local-transmission",
+          name:               "local-transmission",
           installed_versions: "2.60",
-          current_version: "2.61"
+          current_version:    "2.61",
         },
         {
-          name: "version-latest-string",
+          name:               "version-latest-string",
           installed_versions: "latest",
-          current_version: "latest"
-        }
+          current_version:    "latest",
+        },
       ].to_json
 
       expect {


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds JSON support to `brew cask outdated`, including this change gives more feature parity with `brew outdated` (which already has JSON support). This PR addresses issue #7432 