### PR TITLE
dev-cmd/mirror: use Bintray wrapper

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -34,6 +34,7 @@ class Bintray
   def open_api(url, *extra_curl_args, auth: true)
     args = extra_curl_args
     args += ["--user", "#{@bintray_user}:#{@bintray_key}"] if auth
+    args += ["--output", "/dev/null"] unless Homebrew.args.verbose?
     curl(*args, url,
          show_output: Homebrew.args.verbose?,
          secrets:     @bintray_key)
@@ -66,7 +67,7 @@ class Bintray
   def package_exists?(repo:, package:)
     url = "#{API_URL}/packages/#{@bintray_org}/#{repo}/#{package}"
     begin
-      open_api url, "--fail", "--silent", "--output", "/dev/null", auth: false
+      open_api url, "--fail", "--silent", auth: false
     rescue ErrorDuringExecution => e
       stderr = e.output
                 .select { |type,| type == :stderr }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR switches `brew mirror` command to use our wrapper for Bintray API 
