### PR TITLE
Build Docker images for Ubuntu 18.04 and 20.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Library/Homebrew/vendor/portable-ruby
+Library/Taps

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,31 @@
+name: Docker
+on:
+  pull_request:
+    paths:
+      - .github/workflows/docker.yml
+      - Dockerfile
+  release:
+    types:
+      - published
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ["18.04", "20.04"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Build Docker image
+        run: docker build -t brew --build-arg=version=${{matrix.version}} .
+      - name: Run brew test-bot
+        run: docker run --rm brew brew test-bot
+      - name: Deploy the tagged Docker image to GitHub
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
+          v=${GITHUB_REF:10}
+          docker tag brew "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:$v"
+          docker push "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:$v"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,14 +187,14 @@ jobs:
           brew test-bot
         fi
 
-    - name: Deploy the latest Docker image
+    - name: Deploy the latest Docker image to GitHub
       if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master'
       run: |
         docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
         docker tag brew docker.pkg.github.com/homebrew/brew/brew
         docker push docker.pkg.github.com/homebrew/brew/brew
 
-    - name: Deploy the tagged Docker image
+    - name: Deploy the tagged Docker image to GitHub
       if: matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/tags/')
       run: |
         docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@
 /docs/vendor
 
 # Unignore our root-level metadata files.
+!/.dockerignore
 !/.editorconfig
 !/.gitignore
 !/.yardopts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM ubuntu:xenial
-LABEL maintainer="Shaun Jackman <sjackman@gmail.com>"
+ARG version=16.04
+FROM ubuntu:$version
+ARG DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3008
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends software-properties-common \
-  && add-apt-repository -y ppa:git-core/ppa \
-  && apt-get update \
   && apt-get install -y --no-install-recommends \
     bzip2 \
     ca-certificates \
@@ -14,6 +12,7 @@ RUN apt-get update \
     fonts-dejavu-core \
     g++ \
     git \
+    less \
     libz-dev \
     locales \
     make \
@@ -23,29 +22,23 @@ RUN apt-get update \
     sudo \
     uuid-runtime \
     tzdata \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN localedef -i en_US -f UTF-8 en_US.UTF-8 \
+  && rm -rf /var/lib/apt/lists/* \
+  && localedef -i en_US -f UTF-8 en_US.UTF-8 \
   && useradd -m -s /bin/bash linuxbrew \
   && echo 'linuxbrew ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
+
 COPY . /home/linuxbrew/.linuxbrew/Homebrew
-ARG FORCE_REBUILD
+ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH
+WORKDIR /home/linuxbrew
 
 # hadolint ignore=DL3003
 RUN cd /home/linuxbrew/.linuxbrew \
   && mkdir -p bin etc include lib opt sbin share var/homebrew/linked Cellar \
   && ln -s ../Homebrew/bin/brew /home/linuxbrew/.linuxbrew/bin/ \
-  && cd /home/linuxbrew/.linuxbrew/Homebrew \
-  && git remote set-url origin https://github.com/Homebrew/brew
-
-WORKDIR /home/linuxbrew
-ENV PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:$PATH \
-  SHELL=/bin/bash
-
-# Install portable-ruby, tap homebrew/core, install audit gems, and cleanup
-RUN HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
-  && chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
-  && chmod -R g+w,o-w /home/linuxbrew/.linuxbrew \
-  && rm -rf ~/.cache \
+  && git -C /home/linuxbrew/.linuxbrew/Homebrew remote set-url origin https://github.com/Homebrew/brew \
+  && HOMEBREW_NO_ANALYTICS=1 HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/core \
   && brew install-bundler-gems \
-  && brew cleanup
+  && brew cleanup \
+  && rm -rf ~/.cache \
+  && chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
+  && chmod -R g+w,o-w /home/linuxbrew/.linuxbrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Ubuntu 20.04 is now released. Homebrew currently provides the Docker image homebrew/brew based on Ubuntu 16.04, which is used to build bottles on Linux. Users may prefer to run Homebrew on a more up-to-date base distribution, such as Ubuntu 18.04 or Ubuntu 20.04.