### PR TITLE
software_spec: add uses_from_macos since bound

### DIFF
--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -3,8 +3,19 @@
 class SoftwareSpec
   undef uses_from_macos
 
-  def uses_from_macos(deps)
+  def uses_from_macos(deps, bounds = {})
     @uses_from_macos_elements ||= []
-    @uses_from_macos_elements << deps
+
+    if deps.is_a?(Hash)
+      bounds = deps.dup
+      deps = Hash[*bounds.shift]
+    end
+
+    bounds.transform_values! { |v| MacOS::Version.from_symbol(v) }
+    if MacOS.version >= bounds[:since]
+      @uses_from_macos_elements << deps
+    else
+      depends_on deps
+    end
   end
 end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2431,8 +2431,8 @@ class Formula
     # Indicates use of dependencies provided by macOS.
     # On macOS this is a no-op (as we use the system libraries there).
     # On Linux this will act as `depends_on`.
-    def uses_from_macos(dep)
-      specs.each { |spec| spec.uses_from_macos(dep) }
+    def uses_from_macos(dep, bounds = {})
+      specs.each { |spec| spec.uses_from_macos(dep, bounds) }
     end
 
     # Block executed only executed on macOS. No-op on Linux.

--- a/Library/Homebrew/rubocops/dependency_order.rb
+++ b/Library/Homebrew/rubocops/dependency_order.rb
@@ -126,7 +126,7 @@ module RuboCop
 
         # Node pattern method to extract `name` in `depends_on :name` or `uses_from_macos :name`
         def_node_search :dependency_name_node, <<~EOS
-          {(send nil? {:depends_on :uses_from_macos} {(hash (pair $_ _)) $({str sym} _) $(const nil? _)})
+          {(send nil? {:depends_on :uses_from_macos} {(hash (pair $_ _) ...) $({str sym} _) $(const nil? _)} ...)
            (if _ (send nil? :depends_on {(hash (pair $_ _)) $({str sym} _) $(const nil? _)}) nil?)}
         EOS
 

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -171,7 +171,8 @@ class SoftwareSpec
     add_dep_option(dep) if dep
   end
 
-  def uses_from_macos(spec)
+  def uses_from_macos(spec, _bounds = {})
+    spec = Hash[*spec.first] if spec.is_a?(Hash)
     depends_on(spec)
   end
 

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -19,6 +19,18 @@ describe Formula do
       expect(f.class.devel.deps.first.name).to eq("foo")
       expect(f.class.head.deps.first.name).to eq("foo")
     end
+
+    it "ignores OS version specifications" do
+      f = formula "foo" do
+        url "foo-1.0"
+
+        uses_from_macos "foo", since: :mojave
+      end
+
+      expect(f.class.stable.deps.first.name).to eq("foo")
+      expect(f.class.devel.deps.first.name).to eq("foo")
+      expect(f.class.head.deps.first.name).to eq("foo")
+    end
   end
 
   describe "#on_linux" do

--- a/Library/Homebrew/test/os/mac/software_spec_spec.rb
+++ b/Library/Homebrew/test/os/mac/software_spec_spec.rb
@@ -13,11 +13,40 @@ describe SoftwareSpec do
       allow(OS::Mac).to receive(:version).and_return(OS::Mac::Version.new(sierra_os_version))
     end
 
-    it "doesn't add a dependency" do
+    it "adds a macOS dependency if the OS version meets requirements" do
+      spec.uses_from_macos("foo", since: :el_capitan)
+
+      expect(spec.deps).to be_empty
+      expect(spec.uses_from_macos_elements.first).to eq("foo")
+    end
+
+    it "doesn't add a macOS dependency if the OS version doesn't meet requirements" do
+      spec.uses_from_macos("foo", since: :high_sierra)
+
+      expect(spec.deps.first.name).to eq("foo")
+      expect(spec.uses_from_macos_elements).to be_empty
+    end
+
+    it "works with tags" do
+      spec.uses_from_macos("foo" => :build, :since => :high_sierra)
+
+      dep = spec.deps.first
+
+      expect(dep.name).to eq("foo")
+      expect(dep.tags).to include(:build)
+    end
+
+    it "doesn't add a dependency if no OS version is specified" do
       spec.uses_from_macos("foo")
       spec.uses_from_macos("bar" => :build)
 
       expect(spec.deps).to be_empty
+    end
+
+    it "raises an error if passing invalid OS versions" do
+      expect {
+        spec.uses_from_macos("foo", since: :bar)
+      }.to raise_error(ArgumentError, "unknown version :bar")
     end
   end
 end

--- a/Library/Homebrew/test/software_spec_spec.rb
+++ b/Library/Homebrew/test/software_spec_spec.rb
@@ -147,8 +147,8 @@ describe SoftwareSpec do
     end
 
     it "ignores OS version specifications", :needs_linux do
-      subject.uses_from_macos("foo")
-      subject.uses_from_macos("bar" => :build)
+      subject.uses_from_macos("foo", since: :mojave)
+      subject.uses_from_macos("bar" => :build, :since => :mojave)
 
       expect(subject.deps.first.name).to eq("foo")
       expect(subject.deps.last.name).to eq("bar")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Now with less bugs (hopefully). It passes `brew readall` unlike before.

I had hoped to have had a consistent syntax like:

```rb
uses_from_macos "foo", since: :mojave
uses_from_macos "foo" => :build, since: :mojave
```

or

```rb
uses_from_macos "foo", :since => :mojave
uses_from_macos "foo" => :build, :since => :mojave
```

but Rubocop strongly disagrees, so it's:

```rb
uses_from_macos "foo", since: :mojave
uses_from_macos "foo" => :build, :since => :mojave
```

I don't think `before` is particularly useful, and can cause problems when a user upgrades their version of macOS but doesn't reinstall the formula, so I have not brought that back.

I found the previous `after` name a little ambiguous. Is `after` `>=` or `>`? I went for `since` as a result.