### PR TITLE
formula: disable! deprecates before disable date.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2637,7 +2637,9 @@ class Formula
       @pour_bottle_check.instance_eval(&block)
     end
 
-    # Deprecates a {Formula} so a warning is shown on each installation.
+    # Deprecates a {Formula} (on a given date, if provided) so a warning is
+    # shown on each installation. If the date has not yet passed the formula
+    # will not be deprecated.
     def deprecate!(date: nil)
       return if date.present? && Date.parse(date) > Date.today
 
@@ -2651,9 +2653,14 @@ class Formula
       @deprecated == true
     end
 
-    # Disables a {Formula} so it cannot be installed.
+    # Disables a {Formula}  (on a given date, if provided) so it cannot be
+    # installed. If the date has not yet passed the formula
+    # will be deprecated instead of disabled.
     def disable!(date: nil)
-      return if date.present? && Date.parse(date) > Date.today
+      if date.present? && Date.parse(date) > Date.today
+        @deprecated = true
+        return
+      end
 
       @disabled = true
     end


### PR DESCRIPTION
This makes more sense to me; if we expect a formula will be disabled at a given point in the future then we should deprecate it immediately.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----