### PR TITLE
perl: set perl shebang to /usr/bin/perl only on mac

### DIFF
--- a/Library/Homebrew/language/perl.rb
+++ b/Library/Homebrew/language/perl.rb
@@ -6,7 +6,7 @@ module Language
       module_function
 
       def detected_perl_shebang(formula = self)
-        perl_path = if formula.uses_from_macos_elements&.include? "perl"
+        perl_path = if formula.uses_from_macos_elements&.include? "perl" && OS.mac?
           "/usr/bin/perl"
         elsif formula.deps.map(&:name).include? "perl"
           Formula["perl"].opt_bin/"perl"


### PR DESCRIPTION
This should be only done on macOS.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----