### PR TITLE
Add OpenPOWER platform detection

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -3,17 +3,12 @@
 module Hardware
   class CPU
     class << self
-      OPTIMIZATION_FLAGS_LINUX = {
-        native:  "-march=#{Homebrew::EnvConfig.arch}",
-        nehalem: "-march=nehalem",
-        core2:   "-march=core2",
-        core:    "-march=prescott",
-        armv6:   "-march=armv6",
-        armv8:   "-march=armv8-a",
-      }.freeze
-
       def optimization_flags
-        OPTIMIZATION_FLAGS_LINUX
+        @optimization_flags ||= begin
+          flags = generic_optimization_flags.dup
+          flags[:native] = arch_flag(Homebrew::EnvConfig.arch)
+          flags
+        end
       end
 
       def cpuinfo

--- a/Library/Homebrew/extend/os/linux/install.rb
+++ b/Library/Homebrew/extend/os/linux/install.rb
@@ -14,6 +14,19 @@ module Homebrew
       "/system/bin/linker",
     ].freeze
 
+    def check_cpu
+      return if (Hardware::CPU.intel? && Hardware::CPU.is_64_bit?) || Hardware::CPU.arm?
+
+      message = "Sorry, Homebrew does not support your computer's CPU architecture!"
+      if Hardware::CPU.ppc64le?
+        message += <<~EOS
+          For OpenPOWER Linux (PPC64LE) support, see:
+            #{Formatter.url("https://github.com/homebrew-ppc64le/brew")}
+        EOS
+      end
+      abort message
+    end
+
     def symlink_ld_so
       brew_ld_so = HOMEBREW_PREFIX/"lib/ld.so"
       return if brew_ld_so.readable?

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -10,14 +10,16 @@ module Homebrew
     module_function
 
     def check_cpu
-      case Hardware::CPU.type
-      when :ppc
-        abort <<~EOS
-          Sorry, Homebrew does not support your computer's CPU architecture.
-          For PPC support, see:
+      return if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+
+      message = "Sorry, Homebrew does not support your computer's CPU architecture!"
+      if Hardware::CPU.ppc?
+        message += <<~EOS
+          For PowerPC Mac (PPC32/PPC64BE) support, see:
             #{Formatter.url("https://github.com/mistydemeo/tigerbrew")}
         EOS
       end
+      abort message
     end
 
     def attempt_directory_creation


### PR DESCRIPTION
## Context

As suggested by Mike, I create this PR to add OpenPOWER CPU detection into `Hardware::CPU` class.

## Changes

* Add optimisation flag for PowerPC64
* Enhance the condition check for tigerbrew