### PR TITLE
rubocops/urls: whitelist ghc@8.8

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -27,6 +27,7 @@ module RuboCop
           fpc
           ghc
           ghc@8.6
+          ghc@8.8
           go
           go@1.9
           go@1.10


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

In preparation for https://github.com/Homebrew/homebrew-core/pull/54005, a new ghc@8.8 version was added. 
ghc needs ghc to bootstrap itself so this adds the 8.8 version to the whitelist
