### PR TITLE
workflows/tests: run brew style on Linux.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,6 @@ jobs:
       run: brew readall --aliases
 
     - name: Run brew style on homebrew-core
-      if: matrix.os == 'macOS-latest'
       run: brew style --display-cop-names homebrew/core
 
     - name: Run brew style on official taps


### PR DESCRIPTION
linuxbrew-core seems to be passing `brew style` now (and has CI checks to ensure it does in future, too).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----