### PR TITLE
Improve Homebrew Portable Ruby messaging

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -144,7 +144,7 @@ EOS
 EOSCRIPT
 )"
   else
-    odie "Cannot verify the checksum ('shasum' or 'sha256sum' not found)!"
+    odie "Cannot verify checksum ('shasum' or 'sha256sum' not found)!"
   fi
 
   if [[ "$sha" != "$VENDOR_SHA" ]]
@@ -197,7 +197,7 @@ install() {
     then
       mv "$VENDOR_VERSION.reinstall" "$VENDOR_VERSION"
     fi
-    odie "Failed to vendor $VENDOR_NAME $VENDOR_VERSION."
+    odie "Failed to install $VENDOR_NAME $VENDOR_VERSION!"
   fi
 
   trap - SIGINT
@@ -222,13 +222,13 @@ homebrew-vendor-install() {
         [[ "$option" = *d* ]] && HOMEBREW_DEBUG=1
         ;;
       *)
-        [[ -n "$VENDOR_NAME" ]] && odie "This command does not take multiple vendor targets"
+        [[ -n "$VENDOR_NAME" ]] && odie "This command does not take multiple vendor targets!"
         VENDOR_NAME="$option"
         ;;
     esac
   done
 
-  [[ -z "$VENDOR_NAME" ]] && odie "This command requires one vendor target."
+  [[ -z "$VENDOR_NAME" ]] && odie "This command requires a vendor target!"
   [[ -n "$HOMEBREW_DEBUG" ]] && set -x
 
   url_var="${VENDOR_NAME}_URL"
@@ -237,16 +237,13 @@ homebrew-vendor-install() {
   VENDOR_URL="${!url_var}"
   VENDOR_URL2="${!url2_var}"
   VENDOR_SHA="${!sha_var}"
+  VENDOR_VERSION="$(<"$VENDOR_DIR/portable-$VENDOR_NAME-version")"
 
   if [[ -z "$VENDOR_URL" || -z "$VENDOR_SHA" ]]
   then
-    odie <<-EOS
-Cannot find a vendored version of $VENDOR_NAME for your $HOMEBREW_PROCESSOR
-processor on $HOMEBREW_PRODUCT!
-EOS
+    odie "No Homebrew $VENDOR_NAME $VENDOR_VERSION available for $HOMEBREW_PROCESSOR processors!"
   fi
 
-  VENDOR_VERSION="$(<"$VENDOR_DIR/portable-$VENDOR_NAME-version")"
   CACHED_LOCATION="$HOMEBREW_CACHE/$(basename "$VENDOR_URL")"
 
   lock "vendor-install-$VENDOR_NAME"

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -26,7 +26,18 @@ setup-ruby-path() {
       then
         if ! brew vendor-install ruby
         then
-          onoe "Failed to upgrade vendor Ruby."
+          if [[ -n "$HOMEBREW_MACOS" ]]
+          then
+            odie "Failed to upgrade Homebrew Portable Ruby!"
+          else
+            odie <<-EOS
+Failed to upgrade Homebrew Portable Ruby!
+If there's no Homebrew Portable Ruby available for your processor:
+- install Ruby $required_ruby_version with your system package manager (or rbenv/ruby-build)
+- make it first in your PATH
+- try again
+EOS
+          fi
         fi
       fi
     else
@@ -50,7 +61,18 @@ setup-ruby-path() {
         brew vendor-install ruby
         if [[ ! -x "$vendor_ruby_path" ]]
         then
-          odie "Failed to install vendor Ruby."
+          if [[ -n "$HOMEBREW_MACOS" ]]
+          then
+            odie "Failed to install Homebrew Portable Ruby (and your system version is too old)!"
+          else
+            odie <<-EOS
+Failed to install Homebrew Portable Ruby and cannot find another Ruby $required_ruby_version!
+If there's no Homebrew Portable Ruby available for your processor:
+- install $required_ruby_version with your system package manager (or rbenv/ruby-build)
+- make it first in your PATH
+- try again
+EOS
+          fi
         fi
         HOMEBREW_RUBY_PATH="$vendor_ruby_path"
       fi

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -68,6 +68,8 @@ sudo yum install libxcrypt-compat # needed by Fedora 30 and up
 
 Homebrew can run on 32-bit ARM (Raspberry Pi and others) and 64-bit ARM (AArch64), but no binary packages (bottles) are available. Support for ARM is on a best-effort basis. Pull requests are welcome to improve the experience on ARM platforms.
 
+You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as in the future we will no longer distribute a Homebrew Portable Ruby for ARM.
+
 ### 32-bit x86
 
 Homebrew does not currently support 32-bit x86 platforms. It would be possible for Homebrew to work on 32-bit x86 platforms with some effort. An interested and dedicated person could maintain a fork of Homebrew to develop support for 32-bit x86.


### PR DESCRIPTION
As-of https://github.com/Homebrew/homebrew-portable-ruby/pull/100 we've removed ARM builds for Portable Ruby due to months of breakage. Similarly, when we last bumped Portable Ruby the ARM build was much delayed but, despite Homebrew/brew being completely unusable to anyone using it on ARM in that case, no-one complained or filed issues.

Instead of attempting to maintain and update a Portable Ruby on niche (Homebrew) platforms like ARM (or, in past/future PPC) improve the messaging to provide users with a workaround.

Now we allow only a major/minor version match it should be pretty doable for those users to install e.g. a prebuilt Ruby binary from a PPA or built it from source if needed using `ruby-build` and `rbenv`.

The messaging could be improved further but we're somewhat limited by `ruby.sh` and `vendor-install.sh` being separate. I'm tempted to combine them (or at least have `vendor-install.sh` not be so generic as to not
be able to give Ruby-specific advice).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----