### PR TITLE
ARGV: Deprecate ARGV.formulae, replace with Homebrew.args.formulae

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -5,17 +5,6 @@ module HomebrewArgvExtension
     select { |arg| arg.start_with?("--") }
   end
 
-  def formulae
-    require "formula"
-    (downcased_unique_named - casks).map do |name|
-      if name.include?("/") || File.exist?(name)
-        Formulary.factory(name, spec)
-      else
-        Formulary.find_with_priority(name, spec)
-      end
-    end.uniq(&:name)
-  end
-
   def casks
     # TODO: use @instance variable to ||= cache when moving to CLI::Parser
     downcased_unique_named.grep HOMEBREW_CASK_TAP_CASK_REGEX

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -82,7 +82,7 @@ class FormulaInstaller
     build_flags = Homebrew.args.collect_build_args
     return if build_flags.empty?
 
-    all_bottled = ARGV.formulae.all?(&:bottled?)
+    all_bottled = Homebrew.args.formulae.all?(&:bottled?)
     raise BuildFlagsError.new(build_flags, bottled: all_bottled)
   end
 

--- a/Library/Homebrew/test/ARGV_spec.rb
+++ b/Library/Homebrew/test/ARGV_spec.rb
@@ -7,20 +7,6 @@ describe HomebrewArgvExtension do
 
   let(:argv) { ["mxcl"] }
 
-  describe "#formulae" do
-    it "raises an error when a Formula is unavailable" do
-      expect { subject.formulae }.to raise_error FormulaUnavailableError
-    end
-
-    context "when there are no Formulae" do
-      let(:argv) { [] }
-
-      it "returns an empty array" do
-        expect(subject.formulae).to be_empty
-      end
-    end
-  end
-
   describe "#casks" do
     it "returns an empty array if there is no match" do
       expect(subject.casks).to eq []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#5730 