### PR TITLE
workflows/tests: fix gem caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     steps:
     - name: Set up Homebrew
+      id: set-up-homebrew
       run: |
         if which brew &>/dev/null; then
           HOMEBREW_REPOSITORY="$(brew --repo)"
@@ -76,10 +77,10 @@ jobs:
       id: cache
       uses: actions/cache@v1
       with:
-        path: Library/Homebrew/vendor/bundle/
-        key: ${{ runner.os }}-gems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+        path: Library/Homebrew/vendor/bundle/ruby/
+        key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
         restore-keys: |
-          ${{ runner.os }}-gems-
+          ${{ runner.os }}-rubygems-
 
     - name: Install Bundler RubyGems
       if: steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

* `steps.set-up-homebrew.outputs.gems-hash` was empty. Add the missing `id`.
* Don't cache `bundler/setup.rb`
  - Change the key to invalidate previous caches due to the path change