### PR TITLE
ARGV: Deprecate ARGV.casks and replace with Homebrew.args.casks

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -114,13 +114,13 @@ module Homebrew
 
     formulae = []
 
-    unless ARGV.casks.empty?
+    unless Homebrew.args.casks.empty?
       cask_args = []
       cask_args << "--force" if args.force?
       cask_args << "--debug" if args.debug?
       cask_args << "--verbose" if args.verbose?
 
-      ARGV.casks.each do |c|
+      Homebrew.args.casks.each do |c|
         ohai "brew cask install #{c} #{cask_args.join " "}"
         system("#{HOMEBREW_PREFIX}/bin/brew", "cask", "install", c, *cask_args)
       end

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -5,11 +5,6 @@ module HomebrewArgvExtension
     select { |arg| arg.start_with?("--") }
   end
 
-  def casks
-    # TODO: use @instance variable to ||= cache when moving to CLI::Parser
-    downcased_unique_named.grep HOMEBREW_CASK_TAP_CASK_REGEX
-  end
-
   def value(name)
     arg_prefix = "--#{name}="
     flag_with_value = find { |arg| arg.start_with?(arg_prefix) }

--- a/Library/Homebrew/test/ARGV_spec.rb
+++ b/Library/Homebrew/test/ARGV_spec.rb
@@ -7,12 +7,6 @@ describe HomebrewArgvExtension do
 
   let(:argv) { ["mxcl"] }
 
-  describe "#casks" do
-    it "returns an empty array if there is no match" do
-      expect(subject.casks).to eq []
-    end
-  end
-
   describe "#named" do
     let(:argv) { ["foo", "--debug", "-v"] }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
#5730 