### PR TITLE
ENV/std: fix error when using older/no clang

### DIFF
--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -112,7 +112,7 @@ module Stdenv
   def clang
     super
     replace_in_cflags(/-Xarch_#{Hardware::CPU.arch_32_bit} (-march=\S*)/, '\1')
-    map = Hardware::CPU.optimization_flags
+    map = Hardware::CPU.optimization_flags.dup
     if DevelopmentTools.clang_build_version < 700
       # Clang mistakenly enables AES-NI on plain Nehalem
       map[:nehalem] = "-march=nehalem -Xclang -target-feature -Xclang -aes"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Not a very common execution path evidently, but is picked up by `brew tests`.

Fixes #7482.