### PR TITLE
dev-cmd/bump-formula-pr: improve --version handling

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -195,8 +195,8 @@ module Homebrew
       resource.download_strategy = DownloadStrategyDetector.detect_from_url(new_url)
       resource.owner = Resource.new(formula.name)
       if forced_version
-        if forced_version == resource.version
-          forced_version = nil
+        if forced_version == resource.version.to_s
+          forced_version = "0"
         else
           resource.version = forced_version
         end
@@ -281,7 +281,7 @@ module Homebrew
 
     if forced_version && forced_version != "0"
       if requested_spec == :stable
-        replacement_pairs << if File.read(formula.path).include?("version \"#{old_formula_version}\"")
+        replacement_pairs << if formula_contents.include?("version \"#{old_formula_version}\"")
           [
             old_formula_version.to_s,
             forced_version,
@@ -303,7 +303,7 @@ module Homebrew
           "\\1#{forced_version}\\2",
         ]
       end
-    elsif forced_version && forced_version == "0"
+    elsif forced_version && forced_version == "0" && formula_contents.include?("version \"#{old_formula_version}\"")
       if requested_spec == :stable
         replacement_pairs << [
           /^  version \"[\w\.\-\+]+\"\n/m,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

* Don't clear `--version` unless it is an exact string match with the parsed version rather than semantically equal.
* If the version strings do match, act like `--version=0` was passed and clear existing an `version` line.
  - Current behaviour is to not touch the existing `version` line, which is likely never what the user was intending.
  - To cover cases where there is no `version` line, logic was added to not fail if `--version=0` was passed and there was no version line to remove.