### PR TITLE
cat: Allow 'bat' to find existing configuration

### DIFF
--- a/Library/Homebrew/cask/cmd/cat.rb
+++ b/Library/Homebrew/cask/cmd/cat.rb
@@ -10,7 +10,12 @@ module Cask
 
       def run
         casks.each do |cask|
-          puts File.open(cask.sourcefile_path, &:read)
+          if Homebrew::EnvConfig.bat?
+            ENV["BAT_CONFIG_PATH"] = Homebrew::EnvConfig.bat_config_path
+            safe_system "#{HOMEBREW_PREFIX}/bin/bat", cask.sourcefile_path
+          else
+            puts File.open(cask.sourcefile_path, &:read)
+          end
         end
       end
 

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -21,6 +21,7 @@ module Homebrew
 
     cd HOMEBREW_REPOSITORY
     pager = if Homebrew::EnvConfig.bat?
+      ENV["BAT_CONFIG_PATH"] = Homebrew::EnvConfig.bat_config_path
       "#{HOMEBREW_PREFIX}/bin/bat"
     else
       "cat"

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -23,6 +23,10 @@ module Homebrew
         description: "If set, use `bat` for the `brew cat` command.",
         boolean:     true,
       },
+      HOMEBREW_BAT_CONFIG_PATH:           {
+        description:  "Use the `bat` configuration file. For example, `HOMEBREW_BAT=$HOME/.bat/config`.",
+        default_text: "$HOME/.bat/config",
+      },
       HOMEBREW_BINTRAY_KEY:               {
         description: "Use this API key when accessing the Bintray API (where bottles are stored).",
       },

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -49,16 +49,6 @@ describe Homebrew::EnvConfig do
       ENV["HOMEBREW_BAT"] = nil
       expect(env_config.bat?).to be(false)
     end
-
-    it "returns value if set" do
-      ENV["HOMEBREW_BAT_CONFIG_PATH"] = "~/.config/bat/config"
-      expect(env_config.bat_config_path).to eql("~/.config/bat/config")
-    end
-
-    it "returns nil if unset" do
-      ENV["HOMEBREW_BAT_CONFIG_PATH"] = nil
-      expect(env_config.bat_config_path).to be_nil
-    end
   end
 
   describe ".make_jobs" do

--- a/Library/Homebrew/test/env_config_spec.rb
+++ b/Library/Homebrew/test/env_config_spec.rb
@@ -49,6 +49,16 @@ describe Homebrew::EnvConfig do
       ENV["HOMEBREW_BAT"] = nil
       expect(env_config.bat?).to be(false)
     end
+
+    it "returns value if set" do
+      ENV["HOMEBREW_BAT_CONFIG_PATH"] = "~/.config/bat/config"
+      expect(env_config.bat_config_path).to eql("~/.config/bat/config")
+    end
+
+    it "returns nil if unset" do
+      ENV["HOMEBREW_BAT_CONFIG_PATH"] = nil
+      expect(env_config.bat_config_path).to be_nil
+    end
   end
 
   describe ".make_jobs" do

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1210,6 +1210,11 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_BAT`:
     If set, use `bat` for the `brew cat` command.
 
+  * `HOMEBREW_BAT_CONFIG_PATH`:
+    Use the `bat` configuration file. For example, `HOMEBREW_BAT=$HOME/.bat/config`.
+
+    *Default:* $HOME/.bat/config
+
   * `HOMEBREW_BINTRAY_KEY`:
     Use this API key when accessing the Bintray API (where bottles are stored).
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1543,6 +1543,13 @@ Automatically check for updates once per this seconds interval\.
 If set, use \fBbat\fR for the \fBbrew cat\fR command\.
 .
 .TP
+\fBHOMEBREW_BAT_CONFIG_PATH\fR
+Use the \fBbat\fR configuration file\. For example, \fBHOMEBREW_BAT=$HOME/\.bat/config\fR\.
+.
+.IP
+\fIDefault:\fR $HOME/\.bat/config
+.
+.TP
 \fBHOMEBREW_BINTRAY_KEY\fR
 Use this API key when accessing the Bintray API (where bottles are stored)\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Following #6504, setting `HOMEBREW_BAT` to anything enables the use of `bat` in place of `cat`. But because of the environment variable filtering, it is unable to recognise user configuration either `export`ed as `BAT_*` environment variables, or a [configuration file](https://github.com/sharkdp/bat#configuration-file) at [`$XDG_CONFIG_HOME/bat/config`](https://github.com/sharkdp/bat/blob/70480ee9d4e4169c5436f3ab3a7fa1c18ff1849e/src/bin/bat/directories.rs#L6-L8).

The simplest solution, as currently implemented in this PR, is to just set `HOMEBREW_BAT` to the path of the configuration file. For example `export HOMEBREW_BAT=$XDG_CONFIG_HOME/bat/config`. Although, if Homebrew didn't filter `XDG_*_HOME` variables from the environment, `bat` would work as is, as well as being be a more general solution.

Alternatively, Homebrew could avoid filtering `BAT_*` environment variables.