### PR TITLE
ARGV: Deprecate ARGV.flags_only and replace with Homebrew.args.flags_only

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module HomebrewArgvExtension
-  def flags_only
-    select { |arg| arg.start_with?("--") }
-  end
-
   def value(name)
     arg_prefix = "--#{name}="
     flag_with_value = find { |arg| arg.start_with?(arg_prefix) }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -11,6 +11,7 @@ require "patch"
 require "compilers"
 require "global"
 require "os/mac/version"
+require "cli/parser"
 
 class SoftwareSpec
   extend Forwardable
@@ -41,7 +42,7 @@ class SoftwareSpec
     @bottle_specification = BottleSpecification.new
     @patches = []
     @options = Options.new
-    @flags = ARGV.flags_only
+    @flags = Homebrew.args.flags_only
     @deprecated_flags = []
     @deprecated_options = []
     @build = BuildOptions.new(Options.create(@flags), options)

--- a/Library/Homebrew/test/ARGV_spec.rb
+++ b/Library/Homebrew/test/ARGV_spec.rb
@@ -31,14 +31,6 @@ describe HomebrewArgvExtension do
     end
   end
 
-  describe "#flags_only" do
-    let(:argv) { ["--foo", "-vds", "a", "b", "cdefg"] }
-
-    it "returns an array of flags" do
-      expect(subject.flags_only).to eq ["--foo"]
-    end
-  end
-
   describe "#empty?" do
     let(:argv) { [] }
 

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -76,7 +76,8 @@ describe Messages do
     # rubocop:disable RSpec/VerifiedDoubles
     context "when the --display-times argument is present" do
       before do
-        allow(Homebrew).to receive(:args).and_return(double(display_times?: true))
+        allow(Homebrew).to receive(:args)
+          .and_return(double(display_times?: true, flags_only: ["--display-times"]))
       end
 
       context "when install_times is empty" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
#5730 