### PR TITLE
Revert "ARGV: Deprecate ARGV.flags_only and replace with Homebrew.args.flags_only"

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module HomebrewArgvExtension
+  def flags_only
+    select { |arg| arg.start_with?("--") }
+  end
+
   def value(name)
     arg_prefix = "--#{name}="
     flag_with_value = find { |arg| arg.start_with?(arg_prefix) }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -11,7 +11,6 @@ require "patch"
 require "compilers"
 require "global"
 require "os/mac/version"
-require "cli/parser"
 
 class SoftwareSpec
   extend Forwardable
@@ -42,7 +41,7 @@ class SoftwareSpec
     @bottle_specification = BottleSpecification.new
     @patches = []
     @options = Options.new
-    @flags = Homebrew.args.flags_only
+    @flags = ARGV.flags_only
     @deprecated_flags = []
     @deprecated_options = []
     @build = BuildOptions.new(Options.create(@flags), options)

--- a/Library/Homebrew/test/ARGV_spec.rb
+++ b/Library/Homebrew/test/ARGV_spec.rb
@@ -31,6 +31,14 @@ describe HomebrewArgvExtension do
     end
   end
 
+  describe "#flags_only" do
+    let(:argv) { ["--foo", "-vds", "a", "b", "cdefg"] }
+
+    it "returns an array of flags" do
+      expect(subject.flags_only).to eq ["--foo"]
+    end
+  end
+
   describe "#empty?" do
     let(:argv) { [] }
 

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -76,8 +76,7 @@ describe Messages do
     # rubocop:disable RSpec/VerifiedDoubles
     context "when the --display-times argument is present" do
       before do
-        allow(Homebrew).to receive(:args)
-          .and_return(double(display_times?: true, flags_only: ["--display-times"]))
+        allow(Homebrew).to receive(:args).and_return(double(display_times?: true))
       end
 
       context "when install_times is empty" do


### PR DESCRIPTION
Fixes https://github.com/Homebrew/brew/issues/7498
Reverts Homebrew/brew#7490

CC @GauthamGoli FYI