### PR TITLE
cli: readability improvements.

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -13,7 +13,7 @@ module Homebrew
         super
 
         self[:remaining] = []
-        self[:cmdline_args] = ARGV.dup.freeze
+        self[:argv] = ARGV.dup.freeze
 
         @args_parsed = false
         @processed_options = []
@@ -174,21 +174,21 @@ module Homebrew
       end
 
       def build_from_source
-        return true if args_parsed && (build_from_source? || s?)
+        return argv.include?("--build-from-source") || argv.include?("-s") unless args_parsed
 
-        cmdline_args.include?("--build-from-source") || cmdline_args.include?("-s")
+        build_from_source? || s?
       end
 
       def build_bottle
-        return true if args_parsed && build_bottle?
+        return argv.include?("--build-bottle") unless args_parsed
 
-        cmdline_args.include?("--build-bottle")
+        build_bottle?
       end
 
       def force_bottle
-        return true if args_parsed && force_bottle?
+        return argv.include?("--force-bottle") unless args_parsed
 
-        cmdline_args.include?("--force-bottle")
+        force_bottle?
       end
 
       private
@@ -198,7 +198,7 @@ module Homebrew
         arguments = if args_parsed
           named
         else
-          cmdline_args.reject { |arg| arg.start_with?("-") }
+          argv.reject { |arg| arg.start_with?("-") }
         end
         arguments.map do |arg|
           if arg.include?("/") || arg.end_with?(".tar.gz") || File.exist?(arg)
@@ -210,21 +210,21 @@ module Homebrew
       end
 
       def head
-        return true if args_parsed && HEAD?
+        return argv.include?("--HEAD") unless args_parsed
 
-        cmdline_args.include?("--HEAD")
+        HEAD?
       end
 
       def devel
-        return true if args_parsed && devel?
+        return argv.include?("--devel") unless args_parsed
 
-        cmdline_args.include?("--devel")
+        devel?
       end
 
       def build_universal
-        return true if args_parsed && universal?
+        return argv.include?("--universal") unless args_parsed
 
-        cmdline_args.include?("--universal")
+        universal?
       end
 
       def spec(default = :stable)

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -152,11 +152,11 @@ module Homebrew
         @parser.to_s
       end
 
-      def parse(cmdline_args = ARGV, allow_no_named_args: false)
+      def parse(argv = ARGV, allow_no_named_args: false)
         raise "Arguments were already parsed!" if @args_parsed
 
         begin
-          named_args = @parser.parse(cmdline_args)
+          named_args = @parser.parse(argv)
         rescue OptionParser::InvalidOption => e
           $stderr.puts generate_help_text
           raise e
@@ -166,7 +166,7 @@ module Homebrew
         @args[:remaining] = named_args
         @args.freeze_processed_options!(@processed_options)
         Homebrew.args = @args
-        cmdline_args.freeze
+        argv.freeze
         @args_parsed = true
         @parser
       end


### PR DESCRIPTION
- Rename `cmdline_args` to `argv` to make it more obvious where they come from.
- Make the `if args_parsed` early return into `unless args_parsed` to (hopefully) make it clearer that this is not the "normal" case and to not check `argv` unless arguments haven't been parsed.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----