### PR TITLE
Refactor CLI to remove `unless args_parsed`

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -12,8 +12,8 @@ module Homebrew
     class Parser
       attr_reader :processed_options, :hide_from_man_page
 
-      def self.parse(args = ARGV, allow_no_named_args: false, &block)
-        new(args, &block).parse(args, allow_no_named_args: allow_no_named_args)
+      def self.parse(argv = ARGV.dup.freeze, allow_no_named_args: false, &block)
+        new(argv, &block).parse(allow_no_named_args: allow_no_named_args)
       end
 
       def self.from_cmd_path(cmd_path)
@@ -37,9 +37,10 @@ module Homebrew
         }
       end
 
-      def initialize(&block)
+      def initialize(argv = ARGV.dup.freeze, &block)
         @parser = OptionParser.new
-        @args = Homebrew::CLI::Args.new
+        @argv = argv
+        @args = Homebrew::CLI::Args.new(@argv)
 
         @constraints = []
         @conflicts = []
@@ -152,7 +153,7 @@ module Homebrew
         @parser.to_s
       end
 
-      def parse(argv = ARGV, allow_no_named_args: false)
+      def parse(argv = @argv, allow_no_named_args: false)
         raise "Arguments were already parsed!" if @args_parsed
 
         begin
@@ -161,12 +162,14 @@ module Homebrew
           $stderr.puts generate_help_text
           raise e
         end
+
         check_constraint_violations
         check_named_args(named_args, allow_no_named_args: allow_no_named_args)
-        @args[:remaining] = named_args
+        @args.freeze_named_args!(named_args)
+        parse_formula_options
         @args.freeze_processed_options!(@processed_options)
         Homebrew.args = @args
-        argv.freeze
+
         @args_parsed = true
         @parser
       end
@@ -186,21 +189,7 @@ module Homebrew
       end
 
       def formula_options
-        @args.formulae.each do |f|
-          next if f.options.empty?
-
-          f.options.each do |o|
-            name = o.flag
-            description = "`#{f.name}`: #{o.description}"
-            if name.end_with? "="
-              flag   name, description: description
-            else
-              switch name, description: description
-            end
-          end
-        end
-      rescue FormulaUnavailableError
-        []
+        @parse_formula_options = true
       end
 
       def max_named(count)
@@ -238,6 +227,26 @@ module Homebrew
       end
 
       private
+
+      def parse_formula_options
+        return unless @parse_formula_options
+
+        @args.formulae.each do |f|
+          next if f.options.empty?
+
+          f.options.each do |o|
+            name = o.flag
+            description = "`#{f.name}`: #{o.description}"
+            if name.end_with? "="
+              flag   name, description: description
+            else
+              switch name, description: description
+            end
+          end
+        end
+      rescue FormulaUnavailableError
+        []
+      end
 
       def enable_switch(*names, from:)
         names.each do |name|

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -152,7 +152,7 @@ module Homebrew
       end
 
       # --HEAD, fail with no head defined
-      raise "No head is defined for #{f.full_name}" if args.head? && f.head.nil?
+      raise "No head is defined for #{f.full_name}" if args.HEAD? && f.head.nil?
 
       # --devel, fail with no devel defined
       raise "No devel block is defined for #{f.full_name}" if args.devel? && f.devel.nil?

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -18,7 +18,8 @@ module Homebrew
   module_function
 
   def irb_args
-    Homebrew::CLI::Parser.new do
+    # work around IRB modifying ARGV.
+    Homebrew::CLI::Parser.new(ARGV.dup) do
       usage_banner <<~EOS
         `irb` [<options>]
 
@@ -33,8 +34,7 @@ module Homebrew
   end
 
   def irb
-    # work around IRB modifying ARGV.
-    irb_args.parse(ARGV.dup)
+    irb_args.parse
 
     if args.examples?
       puts "'v8'.f # => instance of the v8 formula"

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -268,7 +268,7 @@ module SharedEnvExtension
 
   # @private
   def effective_arch
-    if Homebrew.args.build_bottle && ARGV.bottle_arch
+    if Homebrew.args.build_bottle? && ARGV.bottle_arch
       ARGV.bottle_arch
     else
       Hardware.oldest_cpu

--- a/Library/Homebrew/fetch.rb
+++ b/Library/Homebrew/fetch.rb
@@ -5,7 +5,7 @@ module Homebrew
     module_function
 
     def fetch_bottle?(f)
-      return true if Homebrew.args.force_bottle && f.bottle
+      return true if Homebrew.args.force_bottle? && f.bottle
       return false unless f.bottle && f.pour_bottle?
       return false if Homebrew.args.build_formula_from_source?(f)
       return false unless f.bottle.compatible_cellar?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -49,9 +49,9 @@ class FormulaInstaller
     @show_header = false
     @ignore_deps = false
     @only_deps = false
-    @build_from_source = Homebrew.args.build_from_source
+    @build_from_source = Homebrew.args.build_from_source?
     @build_bottle = false
-    @force_bottle = Homebrew.args.force_bottle
+    @force_bottle = Homebrew.args.force_bottle?
     @include_test = ARGV.include?("--include-test")
     @interactive = false
     @git = false

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -85,7 +85,7 @@ module Homebrew
     end
 
     def args
-      @args ||= CLI::Args.new
+      @args ||= CLI::Args.new(set_default_args: true)
     end
 
     def messages

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -25,7 +25,7 @@ module Homebrew
 
     fi = FormulaInstaller.new(f)
     fi.options              = options
-    fi.build_bottle         = Homebrew.args.build_bottle
+    fi.build_bottle         = Homebrew.args.build_bottle?
     fi.interactive          = Homebrew.args.interactive?
     fi.git                  = Homebrew.args.git?
     fi.link_keg           ||= keg_was_linked if keg_had_linked_opt

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -95,7 +95,7 @@ class SoftwareSpec
 
   def bottled?
     bottle_specification.tag?(Utils::Bottles.tag) && \
-      (bottle_specification.compatible_cellar? || Homebrew.args.force_bottle)
+      (bottle_specification.compatible_cellar? || Homebrew.args.force_bottle?)
   end
 
   def bottle(disable_type = nil, disable_reason = nil, &block)


### PR DESCRIPTION
Refactor the CLI::Args module so it doesn't have different paths to check arguments depending on whether the arguments have been parsed or not. Instead, set the values we need from the global ARGV at first, global initialisation time where they will be thrown away when the actual arguments parse

To do this some other general refactoring was needed:
- more methods made private when possible
- e.g. `HEAD?` used consistently instead of `head` before arguments are parsed
- formula options are only parsed after named arguments are extracted

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----