### PR TITLE
rubocop_rspec: disable RSpec/FilePath.

### DIFF
--- a/Library/.rubocop_rspec.yml
+++ b/Library/.rubocop_rspec.yml
@@ -15,12 +15,14 @@ Style/DisableCopsWithinSourceCodeDirective:
 # Intentionally disabled as it doesn't fit with our code style.
 RSpec/AnyInstance:
   Enabled: false
+RSpec/FilePath:
+  Enabled: false
 RSpec/ImplicitBlockExpectation:
   Enabled: false
 RSpec/SubjectStub:
   Enabled: false
 
-# TODO: try to enable these (also requires fixing Homebrew/bundle)
+# TODO: try to enable these
 RSpec/ContextWording:
   Enabled: false
 RSpec/DescribeClass:
@@ -34,7 +36,7 @@ RSpec/RepeatedDescription:
 RSpec/RepeatedExampleGroupDescription:
   Enabled: false
 
-# TODO: try to reduce these (also requires fixing Homebrew/bundle)
+# TODO: try to reduce these
 RSpec/ExampleLength:
   Max: 75
 RSpec/MultipleExpectations:

--- a/Library/Homebrew/test/.rubocop_todo.yml
+++ b/Library/Homebrew/test/.rubocop_todo.yml
@@ -12,54 +12,6 @@ RSpec/ExampleLength:
   Exclude:
     - 'rubocops/patches_spec.rb'
 
-# Offense count: 41
-# Configuration parameters: CustomTransform, IgnoreMethods.
-RSpec/FilePath:
-  Exclude:
-    - 'ARGV_spec.rb'
-    - 'PATH_spec.rb'
-    - 'bottle_filename_spec.rb'
-    - 'cache_store_spec.rb'
-    - 'cask/artifact/alt_target_spec.rb'
-    - 'cask/artifact/generic_artifact_spec.rb'
-    - 'cask/artifact/two_apps_correct_spec.rb'
-    - 'cask/artifact/uninstall_no_zap_spec.rb'
-    - 'cask/cask_loader/from__path_loader_spec.rb'
-    - 'cask/macos_spec.rb'
-    - 'cli/parser_spec.rb'
-    - 'checksum_verification_spec.rb'
-    - 'cxxstdlib_spec.rb'
-    - 'diagnostic_checks_spec.rb'
-    - 'env_config_spec.rb'
-    - 'missing_formula_spec.rb'
-    - 'os/linux/diagnostic_spec.rb'
-    - 'os/mac/diagnostic_spec.rb'
-    - 'requirements/macos_requirement_spec.rb'
-    - 'rubocops/cask/homepage_matches_url_spec.rb'
-    - 'rubocops/cask/homepage_url_trailing_slash_spec.rb'
-    - 'rubocops/cask/no_dsl_version_spec.rb'
-    - 'rubocops/cask/stanza_grouping_spec.rb'
-    - 'rubocops/cask/stanza_order_spec.rb'
-    - 'rubocops/caveats_spec.rb'
-    - 'rubocops/components_order_spec.rb'
-    - 'rubocops/components_redundancy_spec.rb'
-    - 'rubocops/conflicts_spec.rb'
-    - 'rubocops/dependency_order_spec.rb'
-    - 'rubocops/files_spec.rb'
-    - 'rubocops/keg_only_spec.rb'
-    - 'rubocops/homepage_spec.rb'
-    - 'rubocops/options_spec.rb'
-    - 'rubocops/patches_spec.rb'
-    - 'rubocops/text_spec.rb'
-    - 'rubocops/uses_from_macos_spec.rb'
-    - 'rubocops/formula_desc_spec.rb'
-    - 'search_spec.rb'
-    - 'string_spec.rb'
-    - 'style_spec.rb'
-    - 'system_command_result_spec.rb'
-    - 'unpack_strategy/p7zip_spec.rb'
-    - 'utils/github_spec.rb'
-
 # Offense count: 6
 # Configuration parameters: AssignmentOnly.
 RSpec/InstanceVariable:


### PR DESCRIPTION
We keep adding to the list of exceptions and this fails if it isn't run in the right directory.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----