### PR TITLE
docs: Update tap-pin and tap-unpin disable explanations

### DIFF
--- a/Library/Homebrew/cmd/tap-pin.rb
+++ b/Library/Homebrew/cmd/tap-pin.rb
@@ -12,7 +12,7 @@ module Homebrew
   end
 
   def tap_pin
-    odisabled "brew tap-pin user/tap",
-              "fully-scoped user/tap/formula naming"
+    odisabled "the brew tap-pin command",
+              "fully-scoped user/tap/formula naming when installing and in dependency references"
   end
 end

--- a/Library/Homebrew/cmd/tap-unpin.rb
+++ b/Library/Homebrew/cmd/tap-unpin.rb
@@ -12,7 +12,7 @@ module Homebrew
   end
 
   def tap_unpin
-    odisabled "brew tap-pin user/tap",
-              "fully-scoped user/tap/formula naming"
+    odisabled "the brew tap-unpin command",
+              "fully-scoped user/tap/formula naming when installing and in dependency references"
   end
 end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -491,8 +491,8 @@ module Formulary
     if possible_pinned_tap_formulae.size == 1
       selected_formula = factory(possible_pinned_tap_formulae.first, spec)
       if core_path(ref).file?
-        odisabled "brew tap-pin user/tap",
-                  "fully-scoped user/tap/formula naming"
+        odisabled "the brew tap-pin command",
+                  "fully-scoped user/tap/formula naming when installing and in dependency references"
       end
       selected_formula
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). **Did not feel it was necessary in this case as these commands are disabled anyways**
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
I interpreted the existing message as meaning "you don't pin a tap any more, rather you pin a specific formula from that tap". I.e. the command still worked, but it had to be done on a per-formula basis (eg. `brew tap-pin linuxbrew/xorg/mesa` instead of just `brew tap-pin linuxbrew/xorg`)
 IMO, this makes it clearer that the command itself is no longer supported.

Linking to https://github.com/Homebrew/brew/pull/5925 as that is where some of the previous discussion of tap-pinning deprecation was done.