### PR TITLE
pr-automerge: match only approved PRs by default

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -858,9 +858,11 @@ Find pull requests that can be automatically merged using `brew pr-publish`.
 * `--tap`:
   Target tap repository (default: `homebrew/core`).
 * `--with-label`:
-  Pull requests must have this label (default: `ready to merge`).
+  Pull requests must have this label.
 * `--without-labels`:
   Pull requests must not have these labels (default: `do not merge`, `new formula`).
+* `--without-approval`:
+  Pull requests do not require approval to be merged.
 * `--publish`:
   Run `brew pr-publish` on matching pull requests.
 * `--ignore-failures`:

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "April 2020" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "May 2020" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "April 2020" "Homebrew" "brew"
+.TH "BREW" "1" "May 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -1103,11 +1103,15 @@ Target tap repository (default: \fBhomebrew/core\fR)\.
 .
 .TP
 \fB\-\-with\-label\fR
-Pull requests must have this label (default: \fBready to merge\fR)\.
+Pull requests must have this label\.
 .
 .TP
 \fB\-\-without\-labels\fR
 Pull requests must not have these labels (default: \fBdo not merge\fR, \fBnew formula\fR)\.
+.
+.TP
+\fB\-\-without\-approval\fR
+Pull requests do not require approval to be merged\.
 .
 .TP
 \fB\-\-publish\fR


### PR DESCRIPTION
> Also remove default `--with-label` value.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Tied with: https://github.com/Homebrew/homebrew-core/pull/54324