### PR TITLE
cleanup: tweak missing clean file behaviour.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -142,14 +142,18 @@ module Homebrew
       cleanup = Cleanup.new
       if cleanup.periodic_clean_due?
         cleanup.periodic_clean!
-      elsif f.installed?
+      elsif f.latest_version_installed?
         cleanup.cleanup_formula(f)
       end
     end
 
     def periodic_clean_due?
       return false if Homebrew::EnvConfig.no_install_cleanup?
-      return true unless PERIODIC_CLEAN_FILE.exist?
+
+      unless PERIODIC_CLEAN_FILE.exist?
+        FileUtils.touch PERIODIC_CLEAN_FILE
+        return false
+      end
 
       PERIODIC_CLEAN_FILE.mtime < CLEANUP_DEFAULT_DAYS.days.ago
     end


### PR DESCRIPTION
Instead of cleaning every time if the file is missing: don't clean this time, touch the file and clean when it's next needed.

Now that this feature has been around for longer this makes more sense for existing installations and stops the first `brew install` run on a new/test installation without this file always running a `brew cleanup`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----