### PR TITLE
os/mac/diagnostic: check for deprecated cask taps.

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -345,6 +345,17 @@ module Homebrew
           directory on the same volume as your Cellar.
         EOS
       end
+
+      def check_deprecated_caskroom_taps
+        tapped_caskroom_taps = Tap.select { |t| t.user == "caskroom" }.map(&:repo)
+        return if tapped_caskroom_taps.empty?
+
+        <<~EOS
+          You have the following deprecated, cask taps tapped:
+            Caskroom/homebrew-#{tapped_caskroom_taps.join("\n  Caskroom/homebrew-")}
+          Untap them with `brew untap`.
+        EOS
+      end
     end
   end
 end


### PR DESCRIPTION
We keep seeing users popping up with these (#7449) so advise an untap.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----