### PR TITLE
cmd/uninstall: note etc files that stay around.

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -80,6 +80,27 @@ module Homebrew
               puts "#{keg.name} #{versions.to_sentence} #{"is".pluralize(versions.count)} still installed."
               puts "Run `brew uninstall --force #{keg.name}` to remove all versions."
             end
+
+            paths = f.pkgetc.find.map(&:to_s) if f.pkgetc.exist?
+            if paths.present?
+              puts
+              opoo <<~EOS
+                The following #{f.name} configuration files have not been removed!
+                If desired, remove them manually with `rm -rf`:
+                  #{paths.sort.uniq.join("\n  ")}
+              EOS
+            end
+
+            unversioned_name = f.name.gsub(/@.+$/, "")
+            maybe_paths = Dir.glob("#{f.etc}/*#{unversioned_name}*") - paths
+            if maybe_paths.present?
+              puts
+              opoo <<~EOS
+                The following may be #{f.name} configuration files and have not been removed!
+                If desired, remove them manually with `rm -rf`:
+                  #{maybe_paths.sort.uniq.join("\n  ")}
+              EOS
+            end
           end
         end
       end


### PR DESCRIPTION
We don't remove `etc` files on uninstall. Now we have `pkgetc`, though, we have a pretty decent guess at what files in `etc` may belong to a given package and can warn about them being left around on uninstall.

Thoughts: should we do the same thing for `var`? I don't see it being used nearly as consistently.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----