### PR TITLE
Fix GCC 10 support

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -106,7 +106,7 @@ class CompilerSelector
 
   def gnu_gcc_versions
     # prioritize gcc version provided by gcc formula.
-    v = Formulary.factory("gcc").version.to_s.slice(/\d/)
+    v = Formulary.factory("gcc").version.to_s.slice(/\d+/)
     GNU_GCC_VERSIONS - [v] + [v] # move the version to the end of the list
   rescue FormulaUnavailableError
     GNU_GCC_VERSIONS


### PR DESCRIPTION
Partial GCC 10 support was introduced in #7468
But the version number is not well detected is GCC 10 is the main GCC formula