### PR TITLE
workflows/doctor: add macOS `brew doctor` CI.

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -1,0 +1,50 @@
+name: brew doctor
+on:
+  pull_request:
+    paths:
+      - .github/workflows/doctor.yml
+      - Library/Homebrew/cmd/doctor.rb
+      - Library/Homebrew/diagnostic.rb
+      - Library/Homebrew/extend/os/diagnostic.rb
+      - Library/Homebrew/extend/os/mac/diagnostic.rb
+      - Library/Homebrew/os/mac/xcode.rb
+jobs:
+  tests:
+    strategy:
+      matrix:
+        version: [10.15, 10.14, 10.13]
+      fail-fast: false
+    runs-on: ${{ matrix.version }}
+    env:
+      PATH: '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+      HOMEBREW_DEVELOPER: 1
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - name: Update Homebrew
+        run: brew update-reset
+
+      - name: Set up Git repository
+        run: |
+          cd $(brew --repo)
+          git clean -ffdx
+          git fetch --prune --force origin master
+          git fetch --prune --force origin ${{github.sha}}
+          git checkout --force ${{github.sha}}
+          git log -1
+
+      - name: Run brew test-bot --only-cleanup-before
+        run: brew test-bot --only-cleanup-before
+
+      - name: Run brew test-bot --only-setup
+        run: brew test-bot --only-setup
+
+      - name: Run brew test-bot --only-cleanup-after
+        if: always()
+        run: brew test-bot --only-cleanup-after
+
+      - name: Cleanup
+        if: always()
+        run: |
+          find .
+          rm -rf *


### PR DESCRIPTION
When we change any of the files related to `brew doctor` or Xcode versions ensure that we test them on the macOS self-hosted workers so we don't merge changes here that break `brew doctor` there.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----