### PR TITLE
Replace ARGV#flags_only with Homebrew.args.flags_only

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -5,6 +5,8 @@ require "ostruct"
 module Homebrew
   module CLI
     class Args < OpenStruct
+      attr_reader :options_only, :flags_only
+
       # undefine tap to allow --tap argument
       undef tap
 
@@ -12,6 +14,8 @@ module Homebrew
         super()
 
         @processed_options = []
+        @options_only = args_options_only(argv)
+        @flags_only = args_flags_only(argv)
 
         # Can set these because they will be overwritten by freeze_named_args!
         # (whereas other values below will only be overwritten if passed).
@@ -46,16 +50,9 @@ module Homebrew
 
         @processed_options += processed_options
         @processed_options.freeze
-      end
 
-      def options_only
-        @options_only ||= cli_args.select { |arg| arg.start_with?("-") }
-                                  .freeze
-      end
-
-      def flags_only
-        @flags_only ||= cli_args.select { |arg| arg.start_with?("--") }
-                                .freeze
+        @options_only = args_options_only(cli_args)
+        @flags_only = args_flags_only(cli_args)
       end
 
       def passthrough
@@ -202,6 +199,16 @@ module Homebrew
           end
         end
         @cli_args.freeze
+      end
+
+      def args_options_only(args)
+        args.select { |arg| arg.start_with?("-") }
+            .freeze
+      end
+
+      def args_flags_only(args)
+        args.select { |arg| arg.start_with?("--") }
+            .freeze
       end
 
       def downcased_unique_named

--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module HomebrewArgvExtension
-  def flags_only
-    select { |arg| arg.start_with?("--") }
-  end
-
   def value(name)
     arg_prefix = "--#{name}="
     flag_with_value = find { |arg| arg.start_with?(arg_prefix) }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -41,7 +41,7 @@ class SoftwareSpec
     @bottle_specification = BottleSpecification.new
     @patches = []
     @options = Options.new
-    @flags = ARGV.flags_only
+    @flags = Homebrew.args.flags_only
     @deprecated_flags = []
     @deprecated_options = []
     @build = BuildOptions.new(Options.create(@flags), options)

--- a/Library/Homebrew/test/ARGV_spec.rb
+++ b/Library/Homebrew/test/ARGV_spec.rb
@@ -31,14 +31,6 @@ describe HomebrewArgvExtension do
     end
   end
 
-  describe "#flags_only" do
-    let(:argv) { ["--foo", "-vds", "a", "b", "cdefg"] }
-
-    it "returns an array of flags" do
-      expect(subject.flags_only).to eq ["--foo"]
-    end
-  end
-
   describe "#empty?" do
     let(:argv) { [] }
 

--- a/Library/Homebrew/test/messages_spec.rb
+++ b/Library/Homebrew/test/messages_spec.rb
@@ -76,7 +76,8 @@ describe Messages do
     # rubocop:disable RSpec/VerifiedDoubles
     context "when the --display-times argument is present" do
       before do
-        allow(Homebrew).to receive(:args).and_return(double(display_times?: true))
+        allow(Homebrew).to receive(:args).and_return \
+          double(display_times?: true, flags_only: ["--display-times"])
       end
 
       context "when install_times is empty" do


### PR DESCRIPTION
Take two on https://github.com/Homebrew/brew/pull/7490

This works now by adding a `CLI::Parser#formulae` method which removes the coupling on `CLI::Args#formulae` before it has been parsed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----