### PR TITLE
Cleanup ARGV.include? usage

### DIFF
--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -81,7 +81,7 @@ module Homebrew
       ignores << "optional?"
     end
 
-    ignores << "recommended?" if ARGV.include? "--skip-recommended"
+    ignores << "recommended?" if Homebrew.args.skip_recommended?
 
     [includes, ignores]
   end

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -235,20 +235,6 @@ module SharedEnvExtension
       ohai "Building with an alternative Fortran compiler"
       puts "This is unsupported."
       self["F77"] ||= fc
-
-      if ARGV.include? "--default-fortran-flags"
-        flags = FC_FLAG_VARS.reject { |key| self[key] }
-      elsif values_at(*FC_FLAG_VARS).compact.empty?
-        opoo <<~EOS
-          No Fortran optimization information was provided.  You may want to consider
-          setting FCFLAGS and FFLAGS or pass the `--default-fortran-flags` option to
-          `brew install` if your compiler is compatible with GCC.
-
-          If you like the default optimization level of your compiler, ignore this
-          warning.
-        EOS
-      end
-
     else
       if (gfortran = which("gfortran", (HOMEBREW_PREFIX/"bin").to_s))
         ohai "Using Homebrew-provided Fortran compiler."

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -52,7 +52,7 @@ class FormulaInstaller
     @build_from_source = Homebrew.args.build_from_source?
     @build_bottle = false
     @force_bottle = Homebrew.args.force_bottle?
-    @include_test = ARGV.include?("--include-test")
+    @include_test = Homebrew.args.include_test?
     @interactive = false
     @git = false
     @verbose = Homebrew.args.verbose?
@@ -707,7 +707,6 @@ class FormulaInstaller
     args << "--verbose" if verbose?
     args << "--debug" if debug?
     args << "--cc=#{ARGV.cc}" if ARGV.cc
-    args << "--default-fortran-flags" if ARGV.include? "--default-fortran-flags"
     args << "--keep-tmp" if Homebrew.args.keep_tmp?
 
     if ARGV.env

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -78,7 +78,7 @@ module Homebrew
       case output_type
       when :print
         args << "--debug" if ARGV.debug?
-        args << "--display-cop-names" if ARGV.include? "--display-cop-names"
+        args << "--display-cop-names" if Homebrew.args.display_cop_names?
         args << "--format" << "simple" if files
         system(cache_env, "rubocop", *args)
         rubocop_success = $CHILD_STATUS.success?


### PR DESCRIPTION
Remove usage where `Homebrew.args` could be used instead or, due to the `Homebrew.args` parsing, there was dead code that was never executed (and no-one complained about not working).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----