### PR TITLE
cmd/uninstall: fix Array comparison

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -92,7 +92,8 @@ module Homebrew
             end
 
             unversioned_name = f.name.gsub(/@.+$/, "")
-            maybe_paths = Dir.glob("#{f.etc}/*#{unversioned_name}*") - paths.to_a
+            maybe_paths = Dir.glob("#{f.etc}/*#{unversioned_name}*")
+            maybe_paths -= paths if paths.present?
             if maybe_paths.present?
               puts
               opoo <<~EOS

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -92,7 +92,7 @@ module Homebrew
             end
 
             unversioned_name = f.name.gsub(/@.+$/, "")
-            maybe_paths = Dir.glob("#{f.etc}/*#{unversioned_name}*") - paths
+            maybe_paths = Dir.glob("#{f.etc}/*#{unversioned_name}*") - paths.to_a
             if maybe_paths.present?
               puts
               opoo <<~EOS


### PR DESCRIPTION
In #7526 a comparison for `paths` was introduced, but if `paths` is ever
`nil`, this triggers an error.

Coercing the variable to an Array should alleviate this problem, as
`nil.to_a` produces an empty and comparable Array.

Fixes #7540

Signed-off-by: Mike Fiedler <miketheman@gmail.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
  The added code didn't appear to be tested, so I was uncertain how/where to inject this kind of test.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
