### PR TITLE
utils/ruby.sh: search PATH for Ruby on Linux. update.sh: keep HOMEBREW_RUBY_PATH set.

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -599,7 +599,6 @@ EOS
         -d "$HOMEBREW_LIBRARY/LinkedKegs" ||
         (-n "$HOMEBREW_DEVELOPER" && -z "$HOMEBREW_UPDATE_PREINSTALL") ]]
   then
-    unset HOMEBREW_RUBY_PATH
     brew update-report "$@"
     return $?
   elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -599,13 +599,6 @@ EOS
         -d "$HOMEBREW_LIBRARY/LinkedKegs" ||
         (-n "$HOMEBREW_DEVELOPER" && -z "$HOMEBREW_UPDATE_PREINSTALL") ]]
   then
-    if [[ -n $HOMEBREW_FORCE_VENDOR_RUBY &&
-          -x $HOMEBREW_LIBRARY/Homebrew/vendor/portable-ruby/current/bin/ruby ]]
-    then
-      export HOMEBREW_RUBY_PATH="$HOMEBREW_LIBRARY/Homebrew/vendor/portable-ruby/current/bin/ruby"
-    elif [[ -z $HOMEBREW_DEVELOPER ]]; then
-      unset HOMEBREW_RUBY_PATH
-    fi
     brew update-report "$@"
     return $?
   elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -599,6 +599,13 @@ EOS
         -d "$HOMEBREW_LIBRARY/LinkedKegs" ||
         (-n "$HOMEBREW_DEVELOPER" && -z "$HOMEBREW_UPDATE_PREINSTALL") ]]
   then
+    if [[ -n $HOMEBREW_FORCE_VENDOR_RUBY &&
+          -x $HOMEBREW_LIBRARY/Homebrew/vendor/portable-ruby/current/bin/ruby ]]
+    then
+      export HOMEBREW_RUBY_PATH="$HOMEBREW_LIBRARY/Homebrew/vendor/portable-ruby/current/bin/ruby"
+    elif [[ -z $HOMEBREW_DEVELOPER ]]; then
+      unset HOMEBREW_RUBY_PATH
+    fi
     brew update-report "$@"
     return $?
   elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]]

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,5 +1,6 @@
 test-ruby () {
-  "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)"
+  "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e \
+    "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)"
 }
 
 setup-ruby-path() {

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -7,8 +7,9 @@ test-ruby () {
 
 setup-ruby-path() {
   local vendor_dir
-  local vendor_ruby_current_version
   local vendor_ruby_path
+  local vendor_ruby_latest_version
+  local vendor_ruby_current_version
   local usable_ruby_version
   # When bumping check if HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH (in brew.sh)
   # also needs to be changed.
@@ -22,8 +23,9 @@ If there's no Homebrew Portable Ruby available for your processor:
 "
 
   vendor_dir="$HOMEBREW_LIBRARY/Homebrew/vendor"
-  vendor_ruby_current_version="$vendor_dir/portable-ruby/current"
-  vendor_ruby_path="$vendor_ruby_current_version/bin/ruby"
+  vendor_ruby_path="$vendor_dir/portable-ruby/current/bin/ruby"
+  vendor_ruby_latest_version=$(<"$vendor_dir/portable-ruby-version")
+  vendor_ruby_current_version=$(readlink "$vendor_dir/portable-ruby/current")
 
   unset HOMEBREW_RUBY_PATH
 
@@ -35,8 +37,7 @@ If there's no Homebrew Portable Ruby available for your processor:
   if [[ -x "$vendor_ruby_path" ]]
   then
     HOMEBREW_RUBY_PATH="$vendor_ruby_path"
-
-    if [[ $(readlink "$vendor_ruby_current_version") != "$(<"$vendor_dir/portable-ruby-version")" ]]
+    if [[ $vendor_ruby_current_version != $vendor_ruby_latest_version ]]
     then
       if ! brew vendor-install ruby
       then

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -57,7 +57,7 @@ If there's no Homebrew Portable Ruby available for your processor:
         HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
       else
         HOMEBREW_RUBY_PATH=$(type -P ruby)
-        if [[ $(test-ruby $HOMEBREW_RUBY_PATH) != "true" ]]
+        if [[ $(test-ruby "$HOMEBREW_RUBY_PATH") != "true" ]]
         then
           HOMEBREW_RUBY_PATH=$(PATH="$HOMEBREW_PATH" type -P ruby)
           if [[ $(test-ruby "$HOMEBREW_RUBY_PATH") != "true" ]]

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -50,7 +50,7 @@ If there's no Homebrew Portable Ruby available for your processor:
       then
         HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
       else
-        IFS=$'\n'
+        IFS=$'\n' # Do word splitting on new lines only
         for ruby_exec in $(which -a ruby) $(PATH=$HOMEBREW_PATH which -a ruby)
         do
           if [[ $(test-ruby "$ruby_exec") == "true" ]]; then
@@ -58,7 +58,7 @@ If there's no Homebrew Portable Ruby available for your processor:
             break
           fi
         done
-        IFS=$' \t\n'
+        IFS=$' \t\n' # Restore IFS to its default value
         [[ -z $HOMEBREW_RUBY_PATH ]] && onoe "Failed to find usable Ruby $required_ruby_version!"
       fi
 

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -14,6 +14,12 @@ setup-ruby-path() {
   local required_ruby_version="2.6"
   local old_ruby_path
   local old_ruby_usable
+  local advice="
+If there's no Homebrew Portable Ruby available for your processor:
+- install Ruby $required_ruby_version with your system package manager (or rbenv/ruby-build)
+- make it first in your PATH
+- try again
+"
 
   vendor_dir="$HOMEBREW_LIBRARY/Homebrew/vendor"
   vendor_ruby_current_version="$vendor_dir/portable-ruby/current"
@@ -25,12 +31,9 @@ setup-ruby-path() {
     old_ruby_usable=$(test-ruby "$HOMEBREW_RUBY_PATH")
   fi
 
-  if [[ -z "$HOMEBREW_DEVELOPER" ]]
-  then
-    unset HOMEBREW_RUBY_PATH
-  fi
+  unset HOMEBREW_RUBY_PATH
 
-  if [[ -z "$HOMEBREW_RUBY_PATH" && "$HOMEBREW_COMMAND" != "vendor-install" ]]
+  if [[ "$HOMEBREW_COMMAND" != "vendor-install" ]]
   then
     if [[ -x "$vendor_ruby_path" ]]
     then
@@ -44,13 +47,7 @@ setup-ruby-path() {
           then
             odie "Failed to upgrade Homebrew Portable Ruby!"
           else
-            odie <<-EOS
-Failed to upgrade Homebrew Portable Ruby!
-If there's no Homebrew Portable Ruby available for your processor:
-- install Ruby $required_ruby_version with your system package manager (or rbenv/ruby-build)
-- make it first in your PATH
-- try again
-EOS
+            odie "Failed to upgrade Homebrew Portable Ruby!$advice"
           fi
         fi
       fi
@@ -67,13 +64,7 @@ EOS
           then
             if [[ $old_ruby_usable != true ]]
             then
-              odie <<-EOS
-Failed to find usable Ruby $required_ruby_version!
-If there's no Homebrew Portable Ruby available for your processor:
-- install $required_ruby_version with your system package manager (or rbenv/ruby-build)
-- make it first in your PATH
-- try again
-EOS
+              odie "Failed to find usable Ruby $required_ruby_version!$advice"
             else
               HOMEBREW_RUBY_PATH="$old_ruby_path"
             fi
@@ -98,13 +89,7 @@ EOS
           then
             odie "Failed to install Homebrew Portable Ruby (and your system version is too old)!"
           else
-            odie <<-EOS
-Failed to install Homebrew Portable Ruby and cannot find another Ruby $required_ruby_version!
-If there's no Homebrew Portable Ruby available for your processor:
-- install $required_ruby_version with your system package manager (or rbenv/ruby-build)
-- make it first in your PATH
-- try again
-EOS
+            odie "Failed to install Homebrew Portable Ruby and cannot find another Ruby $required_ruby_version!$advice"
           fi
         fi
         HOMEBREW_RUBY_PATH="$vendor_ruby_path"

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,6 +1,7 @@
 test-ruby () {
   "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e \
-    "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)"
+    "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == \
+          Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)"
 }
 
 setup-ruby-path() {

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,3 +1,7 @@
+test-ruby () {
+  "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)"
+}
+
 setup-ruby-path() {
   local vendor_dir
   local vendor_ruby_current_version
@@ -6,10 +10,18 @@ setup-ruby-path() {
   # When bumping check if HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH (in brew.sh)
   # also needs to be changed.
   local required_ruby_version="2.6"
+  local old_ruby_path
+  local old_ruby_usable
 
   vendor_dir="$HOMEBREW_LIBRARY/Homebrew/vendor"
   vendor_ruby_current_version="$vendor_dir/portable-ruby/current"
   vendor_ruby_path="$vendor_ruby_current_version/bin/ruby"
+
+  if [[ -n $HOMEBREW_RUBY_PATH ]]
+  then
+    old_ruby_path="$HOMEBREW_RUBY_PATH"
+    old_ruby_usable=$(test-ruby "$HOMEBREW_RUBY_PATH")
+  fi
 
   if [[ -z "$HOMEBREW_DEVELOPER" ]]
   then
@@ -45,7 +57,26 @@ EOS
       then
         HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
       else
-        HOMEBREW_RUBY_PATH="$(type -P ruby)"
+        HOMEBREW_RUBY_PATH=$(type -P ruby)
+        if [[ $(test-ruby $HOMEBREW_RUBY_PATH) != "true" ]]
+        then
+          HOMEBREW_RUBY_PATH=$(PATH="$HOMEBREW_PATH" type -P ruby)
+          if [[ $(test-ruby "$HOMEBREW_RUBY_PATH") != "true" ]]
+          then
+            if [[ $old_ruby_usable != true ]]
+            then
+              odie <<-EOS
+Failed to find usable Ruby $required_ruby_version!
+If there's no Homebrew Portable Ruby available for your processor:
+- install $required_ruby_version with your system package manager (or rbenv/ruby-build)
+- make it first in your PATH
+- try again
+EOS
+            else
+              HOMEBREW_RUBY_PATH="$old_ruby_path"
+            fi
+          fi
+        fi
       fi
 
       if [[ -n "$HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH" ]]
@@ -53,7 +84,7 @@ EOS
         usable_ruby_version="true"
       elif [[ -n "$HOMEBREW_RUBY_PATH" && -z "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
       then
-        usable_ruby_version="$("$HOMEBREW_RUBY_PATH" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)")"
+        usable_ruby_version=$(test-ruby "$HOMEBREW_RUBY_PATH")
       fi
 
       if [[ -z "$HOMEBREW_RUBY_PATH" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" || "$usable_ruby_version" != "true" ]]

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -64,7 +64,8 @@ If there's no Homebrew Portable Ruby available for your processor:
           then
             if [[ $old_ruby_usable != true ]]
             then
-              odie "Failed to find usable Ruby $required_ruby_version!$advice"
+              onoe "Failed to find usable Ruby $required_ruby_version!"
+              unset HOMEBREW_RUBY_PATH
             else
               HOMEBREW_RUBY_PATH="$old_ruby_path"
             fi

--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,7 +1,7 @@
 test-ruby () {
   "$1" --enable-frozen-string-literal --disable=gems,did_you_mean,rubyopt -rrubygems -e \
     "puts Gem::Version.new(RUBY_VERSION.to_s.dup).to_s.split('.').first(2) == \
-          Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)"
+          Gem::Version.new('$required_ruby_version').to_s.split('.').first(2)" 2>/dev/null
 }
 
 setup-ruby-path() {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Unsetting `HOMEBREW_RUBY_PATH` on platforms where system Ruby is too old breaks Homebrew.  I see that it was added on purpose (bcca2a7c6b) but I think the logic behind unsetting it has to be more complex.