### PR TITLE
resource: restore fetch in stage

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1160,7 +1160,6 @@ class Formula
   # @private
   def brew
     @prefix_returns_versioned_prefix = true
-    active_spec.fetch
     stage do |staging|
       staging.retain! if Homebrew.args.keep_tmp?
       prepare_patches

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -70,6 +70,7 @@ class Resource
   def stage(target = nil, &block)
     raise ArgumentError, "target directory or block is required" unless target || block
 
+    fetch
     prepare_patches
 
     unpack(target, &block)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Resource staging is used in many places, including in formulae themselves. Removing the fetch from the stage call is problematic as, unlike the formula installer which resides in Homebrew/brew, we can't be going around modifying existing formulae to add the explicit fetch call.

Added resources (beyond the base source & bottle resource) are not covered under the new prefetching strategy and the fix is not to go and make it do so. Resources cannot realistically be prefetched like the base resource as we have no way of knowing which resource is used at which stage - some are build-only, some are test-only.

There are still some more minor regressions, like fetching being done twice (caching prevents a full re-download however). But they are not introduced by this pull request, which is focussing on the more urgent problem.

Fixes #7546.