### PR TITLE
shell: Use .profile unless .bash_profile exists

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -3,7 +3,7 @@
 #:  Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 #:
 #:  The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-#:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.bash_profile` or `~/.zprofile`) with: `eval $(brew shellenv)`
+#:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 homebrew-shellenv() {
   case "$SHELL" in

--- a/Library/Homebrew/manpages/brew-cask.1.md
+++ b/Library/Homebrew/manpages/brew-cask.1.md
@@ -243,7 +243,8 @@ Environment variables specific to Homebrew Cask:
   * `HOMEBREW_CASK_OPTS`:
     This variable may contain any arguments normally used as options on
     the command-line. This is particularly useful to make options persistent.
-    For example, you might add to your .bash_profile or .zshenv something like:
+    For example, you might add to your ~/.profile, ~/.bash_profile, or ~/.zshenv
+    something like:
 
                export HOMEBREW_CASK_OPTS='--appdir=~/Applications --fontdir=/Library/Fonts'
 

--- a/Library/Homebrew/test/utils/shell_spec.rb
+++ b/Library/Homebrew/test/utils/shell_spec.rb
@@ -4,19 +4,19 @@ require "utils/shell"
 
 describe Utils::Shell do
   describe "::profile" do
-    it "returns ~/.bash_profile by default" do
+    it "returns ~/.profile by default" do
       ENV["SHELL"] = "/bin/another_shell"
-      expect(subject.profile).to eq("~/.bash_profile")
+      expect(subject.profile).to eq("~/.profile")
     end
 
-    it "returns ~/.bash_profile for sh" do
+    it "returns ~/.profile for sh" do
       ENV["SHELL"] = "/bin/sh"
-      expect(subject.profile).to eq("~/.bash_profile")
+      expect(subject.profile).to eq("~/.profile")
     end
 
-    it "returns ~/.bash_profile for Bash" do
+    it "returns ~/.profile for Bash" do
       ENV["SHELL"] = "/bin/bash"
-      expect(subject.profile).to eq("~/.bash_profile")
+      expect(subject.profile).to eq("~/.profile")
     end
 
     it "returns /tmp/.zshrc for Zsh if ZDOTDIR is /tmp" do

--- a/Library/Homebrew/utils/shell.rb
+++ b/Library/Homebrew/utils/shell.rb
@@ -39,9 +39,15 @@ module Utils
 
     # return the shell profile file based on user's preferred shell
     def profile
-      return "#{ENV["ZDOTDIR"]}/.zshrc" if preferred == :zsh && ENV["ZDOTDIR"].present?
+      case preferred
+      when :bash
+        bash_profile = "#{ENV["HOME"]}/.bash_profile"
+        return bash_profile if File.exist? bash_profile
+      when :zsh
+        return "#{ENV["ZDOTDIR"]}/.zshrc" if ENV["ZDOTDIR"].present?
+      end
 
-      SHELL_PROFILE_MAP.fetch(preferred, "~/.bash_profile")
+      SHELL_PROFILE_MAP.fetch(preferred, "~/.profile")
     end
 
     def set_variable_in_profile(variable, value)
@@ -67,12 +73,12 @@ module Utils
     end
 
     SHELL_PROFILE_MAP = {
-      bash: "~/.bash_profile",
+      bash: "~/.profile",
       csh:  "~/.cshrc",
       fish: "~/.config/fish/config.fish",
       ksh:  "~/.kshrc",
       mksh: "~/.kshrc",
-      sh:   "~/.bash_profile",
+      sh:   "~/.profile",
       tcsh: "~/.tcshrc",
       zsh:  "~/.zshrc",
     }.freeze

--- a/docs/Gems,-Eggs-and-Perl-Modules.md
+++ b/docs/Gems,-Eggs-and-Perl-Modules.md
@@ -114,7 +114,7 @@ sudo cpan local::lib
 
 Note that this will install some other dependencies like `Module::Install`.
 Then put the appropriate incantation in your shell’s startup, e.g. for
-`.bash_profile` you insert the below, for others see the
+`.profile` you insert the below, for others see the
 [`local::lib`](https://metacpan.org/pod/local::lib) docs.
 
 ```sh

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -435,7 +435,7 @@ ones). No online search is performed.
 Print export statements. When run in a shell, this installation of Homebrew will be added to your `PATH`, `MANPATH`, and `INFOPATH`.
 
 The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
-Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.bash_profile` or `~/.zprofile`) with: `eval $(brew shellenv)`
+Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 ### `switch` *`formula`* *`version`*
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -8,7 +8,7 @@ You must configure your shell to enable its completion support. This is because 
 
 ## Configuring Completions in `bash`
 
-To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.bash_profile` file:
+To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.profile` file:
 
 ```sh
 if type brew &>/dev/null; then

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -274,7 +274,7 @@ Environment variables specific to Homebrew Cask:
 .
 .TP
 \fBHOMEBREW_CASK_OPTS\fR
-This variable may contain any arguments normally used as options on the command\-line\. This is particularly useful to make options persistent\. For example, you might add to your \.bash_profile or \.zshenv something like:
+This variable may contain any arguments normally used as options on the command\-line\. This is particularly useful to make options persistent\. For example, you might add to your ~/\.profile, ~/\.bash_profile, or ~/\.zshenv something like:
 .
 .IP "" 4
 .

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -576,7 +576,7 @@ Search for \fItext\fR in the given package manager\'s list\.
 Print export statements\. When run in a shell, this installation of Homebrew will be added to your \fBPATH\fR, \fBMANPATH\fR, and \fBINFOPATH\fR\.
 .
 .P
-The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.bash_profile\fR or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
+The variables \fBHOMEBREW_PREFIX\fR, \fBHOMEBREW_CELLAR\fR and \fBHOMEBREW_REPOSITORY\fR are also exported to avoid querying them multiple times\. Consider adding evaluation of this command\'s output to your dotfiles (e\.g\. \fB~/\.profile\fR, \fB~/\.bash_profile\fR, or \fB~/\.zprofile\fR) with: \fBeval $(brew shellenv)\fR
 .
 .SS "\fBswitch\fR \fIformula\fR \fIversion\fR"
 Symlink all of the specified \fIversion\fR of \fIformula\fR\'s installation into Homebrew\'s prefix\.


### PR DESCRIPTION
See issue https://github.com/Homebrew/brew/issues/7516 and PR https://github.com/Homebrew/brew/pull/7518.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Ubuntu uses `~/.profile` by default, and not `~/.bash_profile`. Creating a `~/.bash_profile` from scratch disables any configuration that the user has in `~/.profile`, including the system defaults, which can lead to unexpected behaviour.