### PR TITLE
Fetch (all) resources when building from source

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -114,7 +114,9 @@ class Build
     with_env(new_env) do
       formula.extend(Debrew::Formula) if ARGV.debug?
 
-      formula.brew do |_formula, staging|
+      formula.update_head_version
+
+      formula.brew(fetch: false) do |_formula, staging|
         # For head builds, HOMEBREW_FORMULA_PREFIX should include the commit,
         # which is not known until after the formula has been staged.
         ENV["HOMEBREW_FORMULA_PREFIX"] = formula.prefix

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -973,6 +973,11 @@ class FormulaInstaller
 
     return if only_deps?
 
+    unless pour_bottle?
+      formula.fetch_patches
+      formula.resources.each(&:fetch)
+    end
+
     downloader.fetch
   end
 
@@ -982,7 +987,7 @@ class FormulaInstaller
     elsif pour_bottle?
       formula.bottle
     else
-      formula.downloader
+      formula
     end
   end
 

--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -117,8 +117,8 @@ class ExternalPatch
   attr_reader :resource, :strip
 
   def_delegators :resource,
-                 :url, :fetch, :patch_files, :verify_download_integrity, :cached_download,
-                 :clear_cache
+                 :url, :fetch, :patch_files, :verify_download_integrity,
+                 :cached_download, :downloaded?, :clear_cache
 
   def initialize(strip, &block)
     @strip    = strip

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -55,6 +55,10 @@ class Resource
     "#{owner.name}--#{escaped_name}"
   end
 
+  def downloaded?
+    cached_download.exist?
+  end
+
   def cached_download
     downloader.cached_location
   end
@@ -68,17 +72,19 @@ class Resource
   # directory. Subclasses that override stage should implement the tmp
   # dir using {Mktemp} so that works with all subtypes.
   def stage(target = nil, &block)
-    raise ArgumentError, "target directory or block is required" unless target || block
+    raise ArgumentError, "target directory or block is required" if target.blank? && block.blank?
 
-    fetch
-    prepare_patches
+    fetch_patches(skip_downloaded: true)
+    fetch unless downloaded?
 
     unpack(target, &block)
   end
 
-  def prepare_patches
+  def fetch_patches(skip_downloaded: false)
     patches.grep(DATAPatch) { |p| p.path = owner.owner.path }
-    patches.select(&:external?).each(&:fetch)
+    patches.select!(&:external?)
+    patches.reject!(&:downloaded?) if skip_downloaded
+    patches.each(&:fetch)
   end
 
   def apply_patches
@@ -114,6 +120,8 @@ class Resource
 
   def fetch(verify_download_integrity: true)
     HOMEBREW_CACHE.mkpath
+
+    fetch_patches
 
     begin
       downloader.fetch


### PR DESCRIPTION
Also:
- when `brew test` or `brew postinstall` is run allow `Resource#stage`
  to fetch the resource.
- make `Formula#fetch` and `Resource#fetch` fetch external patches too.

Follow-up from #7549 and #7546.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----