### PR TITLE
utils/fork: check for inner exception command.

### DIFF
--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -5,11 +5,13 @@ require "socket"
 
 module Utils
   def self.rewrite_child_error(child_error)
-    error = if child_error.inner_class == ErrorDuringExecution
+    error = if child_error.inner["cmd"] &&
+               child_error.inner_class == ErrorDuringExecution
       ErrorDuringExecution.new(child_error.inner["cmd"],
                                status: child_error.inner["status"],
                                output: child_error.inner["output"])
-    elsif child_error.inner_class == BuildError
+    elsif child_error.inner["cmd"] &&
+          child_error.inner_class == BuildError
       # We fill `BuildError#formula` and `BuildError#options` in later,
       # when we rescue this in `FormulaInstaller#build`.
       BuildError.new(nil, child_error.inner["cmd"],


### PR DESCRIPTION
If it's not present then `ErrorDuringExecution` and `BuildError` don't work correctly so better to fall back to a default `RuntimeError`.

Found working on https://github.com/Homebrew/brew/pull/7552.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----