### PR TITLE
formula_installer: ignore dependencies when fetching.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -572,6 +572,10 @@ class FormulaInstaller
     fi.verbose                 = verbose?
     fi.quiet                   = quiet?
     fi.debug                   = debug?
+    # When fetching we don't need to recurse the dependency tree as it's already
+    # been done for us in `compute_dependencies` and there's no requirement to
+    # fetch in a particular order.
+    fi.ignore_deps             = true
     fi.fetch
   end
 


### PR DESCRIPTION
Whenever you are fetching a dependency you only care about fetching that specific dependency and not all the dependencies of that dependency.

Unlike installing, dependencies can be fetched in any order and have no "chains" between them.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----