### PR TITLE
formula JSON: include URLs for non-bottled formulae

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1716,6 +1716,13 @@ class Formula
 
     %w[stable devel].each do |spec_sym|
       next unless spec = send(spec_sym)
+
+      hsh["urls"][spec_sym] = {
+        "url"      => spec.url,
+        "tag"      => spec.specs[:tag],
+        "revision" => spec.specs[:revision],
+      }
+
       next unless spec.bottle_defined?
 
       bottle_spec = spec.bottle_specification
@@ -1735,11 +1742,6 @@ class Formula
         }
       end
       hsh["bottle"][spec_sym] = bottle_info
-      hsh["urls"][spec_sym] = {
-        "url"      => spec.url,
-        "tag"      => spec.specs[:tag],
-        "revision" => spec.specs[:revision],
-      }
     end
 
     hsh["options"] = options.map do |opt|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Quick fix for `urls` in JSON output being blank for non-bottled formulae.