### PR TITLE
Split out prepare_patches and fetch_patches methods.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1165,6 +1165,8 @@ class Formula
     active_spec.fetch if fetch
     stage do |staging|
       staging.retain! if Homebrew.args.keep_tmp?
+
+      prepare_patches
       fetch_patches if fetch
 
       begin
@@ -2082,13 +2084,15 @@ class Formula
   end
 
   def fetch_patches
-    active_spec.add_legacy_patches(patches) if respond_to?(:patches)
-
-    patchlist.grep(DATAPatch) { |p| p.path = path }
     patchlist.select(&:external?).each(&:fetch)
   end
 
   private
+
+  def prepare_patches
+    active_spec.add_legacy_patches(patches) if respond_to?(:patches)
+    patchlist.grep(DATAPatch) { |p| p.path = path }
+  end
 
   # Returns the prefix for a given formula version number.
   # @private

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -74,14 +74,18 @@ class Resource
   def stage(target = nil, &block)
     raise ArgumentError, "target directory or block is required" if target.blank? && block.blank?
 
+    prepare_patches
     fetch_patches(skip_downloaded: true)
     fetch unless downloaded?
 
     unpack(target, &block)
   end
 
-  def fetch_patches(skip_downloaded: false)
+  def prepare_patches
     patches.grep(DATAPatch) { |p| p.path = owner.owner.path }
+  end
+
+  def fetch_patches(skip_downloaded: false)
     patches.select!(&:external?)
     patches.reject!(&:downloaded?) if skip_downloaded
     patches.each(&:fetch)


### PR DESCRIPTION
The new `fetch_patches` method wasn't exclusively fetching so shouldn't have been skipped when it was.

Fixes #7558.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----