### PR TITLE
Fixes uninstall if formula is unavailable

### DIFF
--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -81,6 +81,8 @@ module Homebrew
               puts "Run `brew uninstall --force #{keg.name}` to remove all versions."
             end
 
+            next unless f
+
             paths = f.pkgetc.find.map(&:to_s) if f.pkgetc.exist?
             if paths.present?
               puts


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Encountered an issue where a brewed binary does not have an associated formula.

```
Error: undefined method `pkgetc' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:84:in `block (3 levels) in uninstall'
/usr/local/Homebrew/Library/Homebrew/keg.rb:363:in `block in lock'
/usr/local/Homebrew/Library/Homebrew/lock_file.rb:31:in `with_lock'
/usr/local/Homebrew/Library/Homebrew/keg.rb:359:in `lock'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:71:in `block (2 levels) in uninstall'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:60:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:60:in `block in uninstall'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:46:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:46:in `uninstall'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```

#7526 seems to have introduced an issue where uninstall will error if the formula is unavailable (exception raised via FormulaUnavailableError). This fix simply ignores the new code in #7526 unless `f` is defined.
