### PR TITLE
Fix exception when calling "brew cask" with --help and no subcommand

### DIFF
--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -243,6 +243,10 @@ module Cask
         $stderr.puts
         $stderr.puts Help.usage
       end
+
+      def help
+        run
+      end
     end
   end
 end


### PR DESCRIPTION
- [ x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x ] Have you successfully run `brew style` with your changes locally?
- [x ] Have you successfully run `brew tests` with your changes locally?

-----
Running `brew cask --help` results in an exception; It should probably just display the "No subcommand given." error message.

```
01:18:30|~/dev/brew (master)$ brew cask --help
Error: undefined method `help' for #<Cask::Cmd::NullCommand:0x00007fa00c932ae8>
Follow the instructions here:
  https://github.com/Homebrew/homebrew-cask#reporting-bugs
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:148:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd.rb:92:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:9:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```
