### PR TITLE
resource: fix patching when patch already fetched

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -86,12 +86,9 @@ class Resource
   end
 
   def fetch_patches(skip_downloaded: false)
-    patches.each do |p|
-      next unless p.external?
-      next if p.downloaded? && skip_downloaded
-
-      p.fetch
-    end
+    external_patches = patches.select(&:external?)
+    external_patches.reject!(&:downloaded?) if skip_downloaded
+    external_patches.each(&:fetch)
   end
 
   def apply_patches

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -86,9 +86,12 @@ class Resource
   end
 
   def fetch_patches(skip_downloaded: false)
-    patches.select!(&:external?)
-    patches.reject!(&:downloaded?) if skip_downloaded
-    patches.each(&:fetch)
+    patches.each do |p|
+      next unless p.external?
+      next if p.downloaded? && skip_downloaded
+
+      p.fetch
+    end
   end
 
   def apply_patches


### PR DESCRIPTION
This inappropriately modified the shared `patches` variable, meaning an already fetched patch would be removed and therefore not be applied when the resource was staged.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
