### PR TITLE
cmd/install: don't fetch for disabled formulae

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -325,8 +325,8 @@ module Homebrew
     fi.build_bottle         = args.build_bottle?
     fi.interactive          = args.interactive?
     fi.git                  = args.git?
-    fi.fetch
     fi.prelude
+    fi.fetch
     fi.install
     fi.finish
   rescue FormulaInstallationAlreadyAttemptedError


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Before:

```console
% brew install protobuf-swift
==> Downloading https://homebrew.bintray.com/bottles/protobuf%403.7-3.7.1_1.moja
Already downloaded: /Users/jonchang/Library/Caches/Homebrew/downloads/bbfbc0fbb17678f0fc967597d845f82dd2ff260efdd88ee8dd5741e9927342de--protobuf@3.7-3.7.1_1.mojave.bottle.tar.gz
==> Downloading https://homebrew.bintray.com/bottles/protobuf-swift-4.0.6_2.moja
Already downloaded: /Users/jonchang/Library/Caches/Homebrew/downloads/86d656c4c6af1a1a47191bef2d8df0717d07e84e5a24d9fa97f3f70c6ada2c15--protobuf-swift-4.0.6_2.mojave.bottle.tar.gz
Error: protobuf-swift has been disabled!
```

After:

```console
% brew install protobuf-swift
Error: protobuf-swift has been disabled!
```