### PR TITLE
Skip needed_libraries check when patchelf is the bottle being installed.

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -132,6 +132,8 @@ module ELFShim
       elsif DevelopmentTools.locate "patchelf"
         needed_libraries_using_patchelf path
       else
+        return [nil, []] if path.basename.to_s == "patchelf"
+
         raise "patchelf must be installed: brew install patchelf"
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When `brew install patchelf` is run on a system which doesn't have `patchelf` or `readelf` installed.  brew fails with "patchelf not found".  patchelf is not required to install itself.

Discussion of this issue https://github.com/Homebrew/brew/issues/7454

