### PR TITLE
os/mac: move legacy functions to compat

### DIFF
--- a/Library/Homebrew/compat.rb
+++ b/Library/Homebrew/compat.rb
@@ -4,3 +4,4 @@ require "compat/cask/dsl/version"
 require "compat/language/python"
 require "compat/requirements/macos_requirement"
 require "compat/formula"
+require "compat/os/mac" if OS.mac?

--- a/Library/Homebrew/compat/os/mac.rb
+++ b/Library/Homebrew/compat/os/mac.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module OS
+  module Mac
+    class << self
+      module Compat
+        def preferred_arch
+          # odeprecated "MacOS.preferred_arch", "Hardware::CPU.arch (or ideally let the compiler handle it)"
+          if Hardware::CPU.is_64_bit?
+            Hardware::CPU.arch_64_bit
+          else
+            Hardware::CPU.arch_32_bit
+          end
+        end
+
+        def tcc_db
+          # odeprecated "MacOS.tcc_db"
+          @tcc_db ||= Pathname.new("/Library/Application Support/com.apple.TCC/TCC.db")
+        end
+
+        def pre_mavericks_accessibility_dotfile
+          # odeprecated "MacOS.pre_mavericks_accessibility_dotfile"
+          @pre_mavericks_accessibility_dotfile ||= Pathname.new("/private/var/db/.AccessibilityAPIEnabled")
+        end
+      end
+
+      prepend Compat
+    end
+  end
+end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -166,14 +166,6 @@ module OS
       paths.uniq
     end
 
-    def preferred_arch
-      if Hardware::CPU.is_64_bit?
-        Hardware::CPU.arch_64_bit
-      else
-        Hardware::CPU.arch_32_bit
-      end
-    end
-
     def app_with_bundle_id(*ids)
       path = mdfind(*ids)
              .reject { |p| p.include?("/Backups.backupdb/") }
@@ -195,14 +187,6 @@ module OS
 
     def mdfind_query(*ids)
       ids.map! { |id| "kMDItemCFBundleIdentifier == #{id}" }.join(" || ")
-    end
-
-    def tcc_db
-      @tcc_db ||= Pathname.new("/Library/Application Support/com.apple.TCC/TCC.db")
-    end
-
-    def pre_mavericks_accessibility_dotfile
-      @pre_mavericks_accessibility_dotfile ||= Pathname.new("/private/var/db/.AccessibilityAPIEnabled")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

* `pre_mavericks_accessibility_dotfile` is clearly for macOS versions we do not support.
* `tcc_db` is pretty much useless since it is SIP protected since Sierra.

Neither is used in Homebrew anymore.