### PR TITLE
audit: Port some version checks to RuboCop

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1042,9 +1042,6 @@ module Homebrew
     def audit_version
       if version.nil?
         problem "missing version"
-      elsif version.blank?
-        # TODO: check could be in RuboCop
-        problem "version is set to an empty string"
       elsif !version.detected_from_url?
         version_text = version
         version_url = Version.detect(url, specs)
@@ -1052,14 +1049,6 @@ module Homebrew
           problem "version #{version_text} is redundant with version scanned from URL"
         end
       end
-
-      # TODO: check could be in RuboCop
-      problem "version #{version} should not have a leading 'v'" if version.to_s.start_with?("v")
-
-      return unless version.to_s.match?(/_\d+$/)
-
-      # TODO: check could be in RuboCop
-      problem "version #{version} should not end with an underline and a number"
     end
 
     def audit_download_strategy

--- a/Library/Homebrew/rubocops.rb
+++ b/Library/Homebrew/rubocops.rb
@@ -21,5 +21,6 @@ require "rubocops/class"
 require "rubocops/uses_from_macos"
 require "rubocops/files"
 require "rubocops/keg_only"
+require "rubocops/version"
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/rubocops/version.rb
+++ b/Library/Homebrew/rubocops/version.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rubocops/extend/formula"
+
+module RuboCop
+  module Cop
+    module FormulaAudit
+      class Version < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          version_node = find_node_method_by_name(body_node, :version)
+          return unless version_node
+
+          version = string_content(parameters(version_node).first)
+
+          problem "version is set to an empty string" if version.empty?
+
+          problem "version #{version} should not have a leading 'v'" if version.start_with?("v")
+
+          return unless version.match?(/_\d+$/)
+
+          problem "version #{version} should not end with an underline and a number"
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rubocops/version"
+
+describe RuboCop::Cop::FormulaAudit::Version do
+  subject(:cop) { described_class.new }
+
+  context "When auditing version" do
+    it "version should not be an empty string" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          version ""
+          ^^^^^^^^^^ version is set to an empty string
+        end
+      RUBY
+    end
+
+    it "version should not have a leading 'v'" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          version "v1.0"
+          ^^^^^^^^^^^^^^ version v1.0 should not have a leading 'v'
+        end
+      RUBY
+    end
+
+    it "version should not end with underline and number" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          version "1_0"
+          ^^^^^^^^^^^^^ version 1_0 should not end with an underline and a number
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Port some version checks to that do not rely on `Formula` state to `RuboCop` and add tests.

Motivated by https://github.com/Homebrew/brew/issues/7392

----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

Some (unrelated) tests fail locally with the following message, although I do have the newest Xcode (`11.4.1` at the time of writing) + the newest command line tools 🤷‍♂️ 

```
       expected block to not output to stderr, but output "Warning: A newer Command Line Tools release is available.\nUpdate them from Software Update in System Preferences or run:\n  softwareupdate --all --install --force\n\nIf that doesn't show you an update run:\n  sudo rm -rf /Library/Developer/CommandLineTools\n  sudo xcode-select --install\n\nAlternatively, manually download them from:\n  https://developer.apple.com/download/more/.\n\n"
```
