### PR TITLE
workflows/tests: set global environment.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   release:
     types:
       - published
+env:
+  HOMEBREW_GITHUB_ACTIONS: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
 jobs:
   tests:
     if: github.repository == 'Homebrew/brew'
@@ -66,9 +69,6 @@ jobs:
           # Cleanup some Linux `brew doctor` failures
           sudo rm -rf /usr/local/include/node/
         else
-          # Allow Xcode to be outdated
-          export HOMEBREW_GITHUB_ACTIONS=1
-
           # Link old gettext (otherwise `brew doctor` is sad)
           brew link gettext
         fi
@@ -93,7 +93,6 @@ jobs:
     - name: Install taps
       run: |
         # Install taps needed for 'brew tests' and 'brew man'
-        export HOMEBREW_NO_AUTO_UPDATE=1
         cd "$(brew --repo)"
         brew tap homebrew/bundle
         brew update-reset Library/Taps/homebrew/homebrew-bundle
@@ -137,7 +136,6 @@ jobs:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         # set variables for coverage reporting
-        HOMEBREW_GITHUB_ACTIONS: 1
         HOMEBREW_CI_NAME: github-actions
         HOMEBREW_COVERALLS_REPO_TOKEN: 3F6U6ZqctoNJwKyREremsqMgpU3qYgxFk
 


### PR DESCRIPTION
We never want to auto-update and we want to globally set that we're in GitHub Actions.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----