### PR TITLE
formula_installer: fix test dependencies.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -488,9 +488,9 @@ class FormulaInstaller
 
       if dep.prune_from_option?(build)
         Dependency.prune
-      elsif include_test? && dep.test? && !dep.installed?
-        Dependency.keep_but_prune_recursive_deps
-      elsif dep.build? && install_bottle_for?(dependent, build)
+      elsif dep.test? && !dep.build? && !include_test?
+        Dependency.prune
+      elsif dep.build? && !dep.test? && install_bottle_for?(dependent, build)
         Dependency.prune
       elsif dep.prune_if_build_and_not_dependent?(dependent)
         Dependency.prune


### PR DESCRIPTION
Only prune test dependencies from the tree when they aren't also build dependencies (and vice-versa with build dependencies) and the include test argument hasn't been passed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----