### PR TITLE
Further test dep fixes

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -175,6 +175,12 @@ module Homebrew
         formulae.any? { |args_f| args_f.full_name == f.full_name }
       end
 
+      def include_formula_test_deps?(f)
+        return false unless include_test?
+
+        formulae.any? { |args_f| args_f.full_name == f.full_name }
+      end
+
       private
 
       def option_to_name(option)

--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -100,16 +100,11 @@ module Homebrew
         klass.prune if ignores.include?("recommended?") || dependent.build.without?(dep)
       elsif dep.optional?
         klass.prune if !includes.include?("optional?") && !dependent.build.with?(dep)
-      elsif dep.test?
-        if includes.include?("test?")
-          Dependency.keep_but_prune_recursive_deps if type == :dependencies
-        elsif dep.build?
-          klass.prune unless includes.include?("build?")
-        else
-          klass.prune
-        end
-      elsif dep.build?
-        klass.prune unless includes.include?("build?")
+      elsif dep.build? || dep.test?
+        keep = false
+        keep ||= dep.test? && includes.include?("test?") && dependent == formula
+        keep ||= dep.build? && includes.include?("build?")
+        klass.prune unless keep
       end
 
       # If a tap isn't installed, we can't find the dependencies of one of

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -89,9 +89,6 @@ class Dependency
       deps.each do |dep|
         next if dependent.name == dep.name
 
-        # we only care about one level of test dependencies.
-        next if dep.test? && @expand_stack.length > 1
-
         case action(dependent, dep, &block)
         when :prune
           next

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -490,7 +490,7 @@ class FormulaInstaller
         Dependency.prune
       elsif dep.test? || (dep.build? && install_bottle_for?(dependent, build))
         keep = false
-        keep ||= dep.test? && include_test? && dependent == formula
+        keep ||= dep.test? && include_test? && Homebrew.args.include_formula_test_deps?(dependent)
         keep ||= dep.build? && !install_bottle_for?(dependent, build)
         Dependency.prune unless keep
       elsif dep.prune_if_build_and_not_dependent?(dependent)
@@ -569,6 +569,7 @@ class FormulaInstaller
 
     fi.build_from_source       = Homebrew.args.build_formula_from_source?(df)
     fi.force_bottle            = false
+    fi.include_test            = Homebrew.args.include_formula_test_deps?(df)
     fi.verbose                 = verbose?
     fi.quiet                   = quiet?
     fi.debug                   = debug?
@@ -611,6 +612,7 @@ class FormulaInstaller
     fi.options                &= df.options
     fi.build_from_source       = Homebrew.args.build_formula_from_source?(df)
     fi.force_bottle            = false
+    fi.include_test            = Homebrew.args.include_formula_test_deps?(df)
     fi.verbose                 = verbose?
     fi.quiet                   = quiet?
     fi.debug                   = debug?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

* `--include-test` was being propagated to dependents in the formula installer. This leads to dependencies being requested in install that haven't been fetched. The fix is to use a system similar to `--build-from-source`.
* `brew deps` was incorrectly not returning runtime dependencies of test dependencies. The fix is similar to that made in the formula installer
* `Dependency.expand` was stripping test dependencies not on the first level. In some cases we actually _want_ this (e.g. multiple formulae passed with `--include-test`) so remove this and handle it in the places that use the function. The code was originally for `brew deps` (1dfeff72742fb69193d3796626ac21f368fbe64a) and that has been handled in the fixes done there.