### PR TITLE
Base homebrew/brew Docker image on ubuntu:20.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["18.04", "20.04"]
+        version: ["16.04", "18.04", "20.04"]
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -33,9 +33,20 @@ jobs:
           docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
           docker tag brew "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:$brew_version"
           docker push "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:$brew_version"
+          docker tag brew "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:latest"
+          docker push "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:latest"
       - name: Deploy the tagged Docker image to Docker Hub
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           docker login -u brewtestbot -p ${{secrets.DOCKER_TOKEN}}
           docker tag brew "homebrew/ubuntu${{matrix.version}}:$brew_version"
           docker push "homebrew/ubuntu${{matrix.version}}:$brew_version"
+          docker tag brew "homebrew/ubuntu${{matrix.version}}:latest"
+          docker push "homebrew/ubuntu${{matrix.version}}:latest"
+      - name: Deploy the homebrew/brew Docker image to GitHub and Docker Hub
+        if: startsWith(github.ref, 'refs/tags/') && matrix.version == '20.04'
+        run: |
+            docker tag brew "docker.pkg.github.com/homebrew/brew/brew:latest"
+            docker push "docker.pkg.github.com/homebrew/brew/brew:latest"
+            docker tag brew "homebrew/brew:latest"
+            docker push "homebrew/brew:latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches: master
   pull_request: []
-  release:
-    types:
-      - published
 env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
@@ -176,7 +173,7 @@ jobs:
 
     - name: Build Docker image
       if: matrix.os == 'ubuntu-latest'
-      run: docker build -t brew .
+      run: docker build -t brew --build-arg=version=16.04 .
 
     - name: Run brew test-bot
       run: |
@@ -187,16 +184,11 @@ jobs:
         fi
 
     - name: Deploy the Docker image to GitHub and Docker Hub
-      if: matrix.os == 'ubuntu-latest' && (github.ref == 'refs/heads/master' || github.event_name == 'release')
+      if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master'
       run: |
-        case $GITHUB_REF in
-          refs/heads/master) v=latest ;;
-          refs/tags/*) v=${GITHUB_REF:10} ;;
-          *) echo Error: unexpected GITHUB_REF: $GITHUB_REF; exit 1 ;;
-        esac
         docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
-        docker tag brew "docker.pkg.github.com/homebrew/brew/brew:$v"
-        docker push "docker.pkg.github.com/homebrew/brew/brew:$v"
+        docker tag brew "docker.pkg.github.com/homebrew/brew/ubuntu16.04:master"
+        docker push "docker.pkg.github.com/homebrew/brew/ubuntu16.04:master"
         docker login -u brewtestbot -p ${{secrets.DOCKER_TOKEN}}
-        docker tag brew "homebrew/brew:$v"
-        docker push "homebrew/brew:$v"
+        docker tag brew "homebrew/ubuntu16.04:master"
+        docker push "homebrew/ubuntu16.04:master"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG version=16.04
+ARG version=20.04
 FROM ubuntu:$version
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Add a new image `homebrew/ubuntu16.04` for building Linux bottles.
Tag the most recent stable release of each image as `latest`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`homebrew/ubuntu16.04` has two symbolic tags. `latest` is the most recent stable release of `Homebrew/brew`. `master` is the `master` branch of `Homebrew/brew`.