### PR TITLE
audit: Migrate scheme checks for `cvs`, `bzr`, `hg`, `fossil` and `svn+http` to `Rubocop` + add tests

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1052,11 +1052,6 @@ module Homebrew
     end
 
     def audit_download_strategy
-      if url =~ %r{^(cvs|bzr|hg|fossil)://} || url =~ %r{^(svn)\+http://}
-        # TODO: check could be in RuboCop
-        problem "Use of the #{$&} scheme is deprecated, pass `:using => :#{Regexp.last_match(1)}` instead"
-      end
-
       url_strategy = DownloadStrategyDetector.detect(url)
 
       if using == :git || url_strategy == GitDownloadStrategy

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -66,6 +66,16 @@ module RuboCop
             problem "#{url} should be `https://www.apache.org/dyn/closer.lua?path=#{match[1]}`"
           end
 
+          version_control_pattern = %r{^(cvs|bzr|hg|fossil)://}
+          audit_urls(urls, version_control_pattern) do |match, _|
+            problem "Use of the #{match[1]}:// scheme is deprecated, pass `:using => :#{match[1]}` instead"
+          end
+
+          svn_pattern = %r{^svn\+http://}
+          audit_urls(urls, svn_pattern) do |_, _|
+            problem "Use of the svn+http:// scheme is deprecated, pass `:using => :svn` instead"
+          end
+
           audit_urls(mirrors, /.*/) do |_, mirror|
             urls.each do |url|
               url_string = string_content(parameters(url).first)

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -159,6 +159,26 @@ describe RuboCop::Cop::FormulaAudit::Urls do
                        "not a source archive; homebrew/core is source-only.",
       "col"         => 2,
       "formula_tap" => "homebrew-core",
+    }, {
+      "url" => "cvs://brew.sh/foo/bar",
+      "msg" => "Use of the cvs:// scheme is deprecated, pass `:using => :cvs` instead",
+      "col" => 2,
+    }, {
+      "url" => "bzr://brew.sh/foo/bar",
+      "msg" => "Use of the bzr:// scheme is deprecated, pass `:using => :bzr` instead",
+      "col" => 2,
+    }, {
+      "url" => "hg://brew.sh/foo/bar",
+      "msg" => "Use of the hg:// scheme is deprecated, pass `:using => :hg` instead",
+      "col" => 2,
+    }, {
+      "url" => "fossil://brew.sh/foo/bar",
+      "msg" => "Use of the fossil:// scheme is deprecated, pass `:using => :fossil` instead",
+      "col" => 2,
+    }, {
+      "url" => "svn+http://brew.sh/foo/bar",
+      "msg" => "Use of the svn+http:// scheme is deprecated, pass `:using => :svn` instead",
+      "col" => 2,
     }]
   }
 


### PR DESCRIPTION
Migrate scheme checks for `cvs`, `bzr`, `hg`, `fossil` and `svn+http` to `Rubocop`.

Motivated by https://github.com/Homebrew/brew/issues/7392

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
