### PR TITLE
add the new cask analytics info to `brew info <some cask>` as well

### DIFF
--- a/Library/Homebrew/cask/cmd/info.rb
+++ b/Library/Homebrew/cask/cmd/info.rb
@@ -41,12 +41,12 @@ module Cask
         output << artifact_info(cask) + "\n"
         caveats = Installer.caveats(cask)
         output << caveats if caveats
+        output << ::Utils::Analytics.get_cask_analytics(cask)
         output
       end
 
       def self.info(cask)
         puts get_info(cask)
-        ::Utils::Analytics.cask_output(cask)
       end
 
       def self.title_info(cask)

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -172,7 +172,7 @@ module Utils
             end
           end
 
-          puts "#{category}: #{analytics.join(", ")}" unless full_analytics
+          return "#{category}: #{analytics.join(", ")}" unless full_analytics
         end
       end
 
@@ -180,14 +180,15 @@ module Utils
         json = formulae_brew_sh_json("#{formula_path}/#{f}.json")
         return if json.blank? || json["analytics"].blank?
 
-        get_analytics(json)
+        puts get_analytics(json)
       end
 
-      def cask_output(cask)
+      def get_cask_analytics(cask)
+        # this returns the analytics string
         json = formulae_brew_sh_json("#{cask_path}/#{cask}.json")
-        return if json.blank? || json["analytics"].blank?
+        return "" if json.blank? || json["analytics"].blank?
 
-        get_analytics(json)
+        return get_analytics(json)
       end
 
       def custom_prefix_label

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -150,7 +150,7 @@ module Utils
       def get_analytics(json)
         full_analytics = Homebrew.args.analytics? || Homebrew.args.verbose?
 
-        ohai "Analytics"
+        analytics_categories = []
         json["analytics"].each do |category, value|
           category = category.tr("_", "-")
           analytics = []
@@ -172,8 +172,11 @@ module Utils
             end
           end
 
-          return "#{category}: #{analytics.join(", ")}" unless full_analytics
+          analytics_categories.append("#{category}: #{analytics.join(", ")}") unless full_analytics
         end
+        output = ohai_title("Analytics") + "\n"
+        output << analytics_categories.join("\n")
+        output
       end
 
       def formula_output(f)

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -188,7 +188,7 @@ module Utils
         json = formulae_brew_sh_json("#{cask_path}/#{cask}.json")
         return "" if json.blank? || json["analytics"].blank?
 
-        return get_analytics(json)
+        get_analytics(json)
       end
 
       def custom_prefix_label


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This addresses my comment on #7566 and adds the new `brew cask info ...` analytics stats added by @tharun208 in #7580 into `brew info <some cask>` as well.

Had to tweak a few things so that strings are returned at a lower level instead of direct `puts`.  Also changed some names to hopefully clarify which functions print a string and which return a string.


Here's the output of this working:
```
$ brew cask info dropbox
==> Analytics
dropbox: latest
https://www.dropbox.com/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/dropbox.rb
==> Name
Dropbox
==> Artifacts
Dropbox.app (App)
install: 2,095 (30 days), 6,517 (90 days), 29,650 (365 days)


$ brew info dropbox
Error: No available formula with the name "dropbox"
==> Analytics
Found a cask named "dropbox" instead.

dropbox: latest
https://www.dropbox.com/
Not installed
From: https://github.com/Homebrew/homebrew-cask/blob/master/Casks/dropbox.rb
==> Name
Dropbox
==> Artifacts
Dropbox.app (App)
install: 2,095 (30 days), 6,517 (90 days), 29,650 (365 days)
```