### PR TITLE
livecheck: modified urls cop

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -13,11 +13,12 @@ module RuboCop
           https://downloads.sourceforge.net/project/bittwist/
           https://downloads.sourceforge.net/project/launch4j/
           https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/archive/
-          https://github.com/obihann/archey-osx/archive/
+          https://github.com/obihann/archey-osx
           https://github.com/sindresorhus/macos-wallpaper/archive/
           https://raw.githubusercontent.com/liyanage/macosx-shell-scripts/
           https://osxbook.com/book/bonus/chapter8/core/download/gcore
           https://naif.jpl.nasa.gov/pub/naif/toolkit/C/MacIntel_OSX_AppleC_64bit/packages/
+          https://artifacts.videolan.org/x264/release-macos/
         ].freeze
 
         # These are formulae that, sadly, require an upstream binary to bootstrap.
@@ -48,6 +49,12 @@ module RuboCop
           urls = find_every_func_call_by_name(body_node, :url)
           mirrors = find_every_func_call_by_name(body_node, :mirror)
 
+          # Identify livecheck urls, to skip some checks for them
+          livecheck_url = if (livecheck = find_every_func_call_by_name(body_node, :livecheck).first) &&
+                             (livecheck_url = find_every_func_call_by_name(livecheck.parent, :url).first)
+            string_content(parameters(livecheck_url).first)
+          end
+
           # GNU urls; doesn't apply to mirrors
           gnu_pattern = %r{^(?:https?|ftp)://ftpmirror.gnu.org/(.*)}
           audit_urls(urls, gnu_pattern) do |match, url|
@@ -63,6 +70,8 @@ module RuboCop
 
           apache_pattern = %r{^https?://(?:[^/]*\.)?apache\.org/(?:dyn/closer\.cgi\?path=/?|dist/)(.*)}i
           audit_urls(urls, apache_pattern) do |match, url|
+            next if url == livecheck_url
+
             problem "#{url} should be `https://www.apache.org/dyn/closer.lua?path=#{match[1]}`"
           end
 
@@ -158,7 +167,7 @@ module RuboCop
 
             problem "Don't use /download in SourceForge urls (url is #{url})." if url.end_with?("/download")
 
-            if url.match?(%r{^https?://sourceforge\.})
+            if url.match?(%r{^https?://sourceforge\.}) && url != livecheck_url
               problem "Use https://downloads.sourceforge.net to get geolocation (url is #{url})."
             end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Changes to the urls cop, related to the migration of Livecheckables to `livecheck` blocks in Homebrew/homebrew-core Formulae.

Summary:
* `archey-osx`: Shortened the whitelist prefix
* `apache` urls - skipped livecheck urls. Modifying the url to the suggested alternative did not work with livecheck, which currently uses `archive.apache.org` urls for the version heuristic.
* `sourceforge` urls - skipped livecheck urls. **Question:** The alternative suggested is `download.sourceforge.net/...`, however that redirects to just `sourceforge.net/...`; and while I've just disabled the check specifically for livecheck urls, should it be removed as there's a redirection anyway?

Other related changes: PRs Homebrew/homebrew-livecheck#748, Homebrew/homebrew-livecheck#749, Homebrew/homebrew-livecheck#750, Homebrew/homebrew-livecheck#751, Homebrew/homebrew-livecheck#752