### PR TITLE
formulary: install tap if needed.

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -279,6 +279,8 @@ module Formulary
     end
 
     def load_file
+      tap.install unless tap.installed?
+
       super
     rescue MethodDeprecatedError => e
       e.issues_url = tap.issues_url || tap.to_s

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -227,7 +227,8 @@ describe Formulary do
       end
     end
 
-    it "raises an error if the Formula is not available" do
+    it "raises an error if the Formula is not available after tapping" do
+      expect_any_instance_of(Tap).to receive(:install)
       expect {
         described_class.to_rack("a/b/#{formula_name}")
       }.to raise_error(TapFormulaUnavailableError)


### PR DESCRIPTION
This matches what `cask_loader` does and is low risk given we no longer allow tap pinning.

Fixes #7626

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----