### PR TITLE
formula_installer: fix pruning of test deps also marked as build

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -456,7 +456,7 @@ class FormulaInstaller
         keep_build_test = false
         keep_build_test ||= runtime_requirements.include?(req)
         keep_build_test ||= req.test? && include_test? && dependent == f
-        keep_build_test ||= req.build? && !install_bottle_for_dependent
+        keep_build_test ||= req.build? && !install_bottle_for_dependent && !dependent.latest_version_installed?
 
         if req.prune_from_option?(build)
           Requirement.prune
@@ -491,13 +491,11 @@ class FormulaInstaller
 
       keep_build_test = false
       keep_build_test ||= dep.test? && include_test? && Homebrew.args.include_formula_test_deps?(dependent)
-      keep_build_test ||= dep.build? && !install_bottle_for?(dependent, build)
+      keep_build_test ||= dep.build? && !install_bottle_for?(dependent, build) && !dependent.latest_version_installed?
 
       if dep.prune_from_option?(build)
         Dependency.prune
       elsif (dep.build? || dep.test?) && !keep_build_test
-        Dependency.prune
-      elsif dep.prune_if_build_and_not_dependent?(dependent)
         Dependency.prune
       elsif dep.satisfied?(inherited_options[dep.name])
         Dependency.skip


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`dep.prune_if_build_and_not_dependent?` should be a part of the `keep_build_test` logic.

I also found the name incredibly confusing - I couldn't figure out from the name alone what "not dependent" meant. Turns out what it actually does (in this case) was `dep.build? && !dependent.installed?`, so I made it a direct `latest_version_installed?` check instead.

I've also added the check to the requirements part since I think it should have been there.