### PR TITLE
bump-formula-pr: fix forking error when formula is guessed from url

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -118,12 +118,6 @@ module Homebrew
 
     formula = args.formulae.first
 
-    if formula
-      tap_full_name, origin_branch, previous_branch = use_correct_linux_tap(formula)
-      check_for_duplicate_pull_requests(formula, tap_full_name)
-      checked_for_duplicates = true
-    end
-
     new_url = args.url
     if new_url && !formula
       # Split the new URL on / and find any formulae that have the same URL
@@ -152,7 +146,8 @@ module Homebrew
     end
     raise FormulaUnspecifiedError unless formula
 
-    check_for_duplicate_pull_requests(formula, tap_full_name) unless checked_for_duplicates
+    tap_full_name, origin_branch, previous_branch = use_correct_linux_tap(formula)
+    check_for_duplicate_pull_requests(formula, tap_full_name)
 
     requested_spec, formula_spec = if args.devel?
       devel_message = " (devel)"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb). (N/A)
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Regression introduced in f90612ccf0db03681dc6cbf6585cca5bc27b84b1 (#6718).

`tap_full_name` returned from `use_correct_linux_tap` has been required (`GitHub.create_fork(tap_full_name)`), but it was never set when the formula is guessed from args.url, resulting in an API request to https://api.github.com/repos//forks which 404s (note the missing :owner/:repo), and subsequently

    Error: Unable to fork: Not Found!