### PR TITLE
formula_installer: prelude before fetch.

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -368,8 +368,8 @@ module Cask
             fi.installed_on_request = false
             fi.show_header = true
             fi.verbose = verbose?
-            fi.fetch
             fi.prelude
+            fi.fetch
             fi.install
             fi.finish
           end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -325,8 +325,8 @@ module Homebrew
     fi.build_bottle         = args.build_bottle?
     fi.interactive          = args.interactive?
     fi.git                  = args.git?
-    fi.fetch
     fi.prelude
+    fi.fetch
     fi.install
     fi.finish
   rescue FormulaInstallationAlreadyAttemptedError

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -191,8 +191,8 @@ module Homebrew
     end
     oh1 "Upgrading #{Formatter.identifier(f.full_specified_name)} #{upgrade_version} #{fi.options.to_a.join(" ")}"
 
-    fi.fetch
     fi.prelude
+    fi.fetch
 
     # first we unlink the currently active keg for this formula otherwise it is
     # possible for the existing build to interfere with the build we are about to

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -141,7 +141,6 @@ class FormulaInstaller
   def prelude
     Tab.clear_cache
     verify_deps_exist unless ignore_deps?
-    lock
     check_install_sanity
   end
 
@@ -221,6 +220,8 @@ class FormulaInstaller
   end
 
   def install
+    lock
+
     start_time = Time.now
     if !formula.bottle_unneeded? && !pour_bottle? && DevelopmentTools.installed?
       Homebrew::Install.perform_build_from_source_checks
@@ -969,9 +970,10 @@ class FormulaInstaller
   end
 
   def fetch_dependencies
-    deps = compute_dependencies
+    return if ignore_deps?
 
-    return if deps.empty? || ignore_deps?
+    deps = compute_dependencies
+    return if deps.empty?
 
     deps.each { |dep, _options| fetch_dependency(dep) }
   end

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -35,8 +35,8 @@ module Homebrew
       fi.installed_as_dependency = tab.installed_as_dependency
       fi.installed_on_request    = tab.installed_on_request
     end
-    fi.fetch
     fi.prelude
+    fi.fetch
 
     oh1 "Reinstalling #{Formatter.identifier(f.full_name)} #{options.to_a.join " "}"
 

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -176,8 +176,8 @@ RSpec.shared_context "integration test" do
     setup_test_formula(name, content)
     fi = FormulaInstaller.new(Formula[name])
     fi.build_bottle = build_bottle
-    fi.fetch
     fi.prelude
+    fi.fetch
     fi.install
     fi.finish
   end


### PR DESCRIPTION
This ensures that dependencies are verified and tapped before they are fetched. `FormulaInstaller#lock` has been moved into `FormulaInstaller#install` to avoid locking until necessary.

While we're here, don't compute dependencies before fetching if we're not going to use them.

Fixes #7626
Closes #7572

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----