### PR TITLE
Remove ARGV.env

### DIFF
--- a/Library/Homebrew/extend/ARGV.rb
+++ b/Library/Homebrew/extend/ARGV.rb
@@ -15,10 +15,6 @@ module HomebrewArgvExtension
     value "cc"
   end
 
-  def env
-    value "env"
-  end
-
   private
 
   def options_only

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -6,7 +6,7 @@ require "extend/ENV/std"
 require "extend/ENV/super"
 
 def superenv?
-  ARGV.env != "std" && Superenv.bin
+  Homebrew.args.env != "std" && Superenv.bin
 end
 
 module EnvActivation

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -731,8 +731,8 @@ class FormulaInstaller
     args << "--cc=#{ARGV.cc}" if ARGV.cc
     args << "--keep-tmp" if Homebrew.args.keep_tmp?
 
-    if ARGV.env
-      args << "--env=#{ARGV.env}"
+    if Homebrew.args.env.present?
+      args << "--env=#{Homebrew.args.env}"
     elsif formula.env.std? || formula.deps.select(&:build?).any? { |d| d.name == "scons" }
       args << "--env=std"
     end


### PR DESCRIPTION
Replace with `Homebrew.args.env`.

Part of #5730.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----