### PR TITLE
✨ Add handling for existing fork

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -347,6 +347,14 @@ module GitHub
   end
 
   def check_fork_exists(repo)
+    json = fork_for_repo(repo)
+
+    return false if json["message"] == "Not Found"
+
+    true
+  end
+
+  def fork_for_repo(repo)
     _, reponame = repo.split("/")
 
     case api_credentials_type
@@ -355,11 +363,7 @@ module GitHub
     when :env_token
       username = open_api(url_to("user")) { |json| json["login"] }
     end
-    json = open_api(url_to("repos", username, reponame))
-
-    return false if json["message"] == "Not Found"
-
-    true
+    open_api(url_to("repos", username, reponame))
   end
 
   def create_pull_request(repo, title, head, base, body)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This change fixes a frustration I have with this command - it throws an `AuthenticationFailedError` if the user already has a homebrew-core fork. The `--no-fork` option appears to only be available to core contributors, using it tells the command to try to push to and create a PR on the main repo.

I maintain [mas](https://github.com/mas-cli/mas) and publish primarily to homebrew-core, but also to a [custom tap](https://github.com/mas-cli/homebrew-tap) to support older OS versions. This capability will help simplify this publishing process.

I know a bit about ruby, but welcome any style and factoring suggestions as this is a much more complicated project than I'm familiar with.