### PR TITLE
audit: Fix Regexp for stripping `.git` from repo URLs

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -597,7 +597,7 @@ module Homebrew
       _, user, repo = *regex.match(formula.homepage) unless user
       return if !user || !repo
 
-      repo.gsub!(/.git$/, "")
+      repo.delete_suffix!(".git")
 
       [user, repo]
     end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -144,10 +144,7 @@ module Homebrew
     errors_summary = "#{problem_plural} in #{formula_plural} detected"
     errors_summary += ", #{corrected_problem_plural} corrected" if corrected_problem_count.positive?
 
-    if problem_count.positive? ||
-       (new_formula_problem_count.positive? && !created_pr_comment)
-      ofail errors_summary
-    end
+    ofail errors_summary if problem_count.positive? || new_formula_problem_count.positive?
   end
 
   def format_problem_lines(problems)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- [For a formula named turbogit](https://github.com/Homebrew/homebrew-core/pull/55208), we didn't see any of the notability checks fail CI.
- The repo name was getting truncated to `turb`, which didn't exist, so the audit didn't return anything for this check.
- The Regexp to strip `.git` from the end of a repo URL was not escaping the `.`, so it would match anything ending in `git`, not a literal `.git`.
