### PR TITLE
fix undefined variable interpolation in tcsh

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -20,8 +20,8 @@ homebrew-shellenv() {
       echo "setenv HOMEBREW_CELLAR $HOMEBREW_CELLAR;"
       echo "setenv HOMEBREW_REPOSITORY $HOMEBREW_REPOSITORY;"
       echo "setenv PATH $HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:\$PATH;"
-      echo "setenv MANPATH $HOMEBREW_PREFIX/share/man:\$MANPATH;"
-      echo "setenv INFOPATH $HOMEBREW_PREFIX/share/info:\$INFOPATH;"
+      echo "setenv MANPATH $HOMEBREW_PREFIX/share/man\`[ \${?MANPATH} == 1 ] && echo \":\${MANPATH}\"\`:;"
+      echo "setenv INFOPATH $HOMEBREW_PREFIX/share/info\`[ \${?INFOPATH} == 1 ] && echo \":\${INFOPATH}\"\`;"
       ;;
     *)
       echo "export HOMEBREW_PREFIX=\"$HOMEBREW_PREFIX\";"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`(t)csh` emits an error and aborts evaluation of `.tcshrc` when interpolating an undefined variable. `$MANPATH` and `$INFOPATH` are undefined on macOS by default, so this happens when calling `brew shellenv` in `.tcshrc`. c.f. https://github.com/Homebrew/brew/issues/7645

This PR introduces a short-circuiting construct to gracefully handle the case of undefined `$MANPATH` and `$INFOPATH` env vars, taking care to duplicate the special handling of `$MANPATH` introduced in https://github.com/Homebrew/brew/pull/6666.