### PR TITLE
caveats: add an unsigned_accessibility caveat message

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -58,6 +58,19 @@ module Cask
         EOS
       end
 
+      caveat :unsigned_accessibility do |access = "Accessibility"|
+        # access: the category in System Preferences -> Security & Privacy -> Privacy the app requires.
+
+        <<~EOS
+          #{@cask} is not signed and requires Accessibility access,
+          so you will need to re-grant Accessibility access every time the app is updated.
+
+          Enable or re-enable it in:
+            System Preferences → Security & Privacy → Privacy -> #{access}
+          To re-enable untick and retick #{@cask}.app.
+        EOS
+      end
+
       caveat :path_environment_variable do |path|
         <<~EOS
           To use #{@cask}, you may need to add the #{path} directory


### PR DESCRIPTION
This is useful for applications that are not signed by the developer and
require Accessibility access.

Because the app is not signed, macOS only authorizes the current binary,
and so when it is updated (and the binary changes) the new version is
unsigned, despite the app still showing as ticked in System Preferences.
The user has to manually untick and retick the app each time.

The ideal fix is for the developer to sign their app, but not all
developers are willing to pay for this, so the best we can do is to
advise users of the workaround/solution.

Refs: https://github.com/Homebrew/homebrew-cask/pull/83157

cc/ @vitorgalvao

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
  - No but none of the other caveats have tests.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----