### PR TITLE
.gitignore: ignore .vscode droppings from VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@
 
 # Unignore tests' bundle config
 !/Library/Homebrew/test/.bundle/config
+
+# Ignore droppings from editors
+.vscode


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

What do you think about adding the Visual Studio Code `.vscode` droppings to the `.gitignore`? These files are created when you open up the Homebrew repo in VS Code (maybe especially if you are using one of its Ruby extensions?) This would be a convenience for developers who are hacking on Homebrew using VS Code (who might not want to add `.vscode` to their user `~/.gitignore`, because in some projects you'd want to check them in).

I don't know what would be a test for this change, since it is not a behavior change in `brew` itself; just repo housekeeping.