### PR TITLE
Dockerfile: install newer AddTrust cert in 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,3 +47,7 @@ RUN cd /home/linuxbrew/.linuxbrew \
   && rm -rf ~/.cache \
   && chown -R linuxbrew: /home/linuxbrew/.linuxbrew \
   && chmod -R g+w,o-w /home/linuxbrew/.linuxbrew
+
+RUN test "$version" = "16.04" \
+  && curl -L https://git.io/JfKpe -o /usr/share/ca-certificates/mozilla/AddTrust_External_Root.crt \
+  && update-ca-certificates --fresh


### PR DESCRIPTION
Without this, pulling stuff from apache (and possibly other) sites via curl fails.

https://calnetweb.berkeley.edu/calnet-technologists/incommon-sectigo-certificate-service/addtrust-external-root-expiration-may-2020

Certificate taken from: https://spaces.at.internet2.edu/download/attachments/24576265/InCommonRSAServerCA_2.crt?api=v2
and mirrored to gist.github.com (cause downloading from the site above also fails) on my account.


- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----