### PR TITLE
livecheck: reference Formula URLs

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2670,7 +2670,7 @@ class Formula
     #   regex /foo-(\d+(?:\.\d+)+)\.tar/
     # end</pre>
     def livecheck(&block)
-      @livecheck ||= Livecheck.new
+      @livecheck ||= Livecheck.new(self)
       return @livecheck unless block_given?
 
       @livecheckable = true

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -10,7 +10,8 @@ class Livecheck
   # e.g. `Not maintained`
   attr_reader :skip_msg
 
-  def initialize
+  def initialize(formula)
+    @formula = formula
     @regex = nil
     @skip = false
     @skip_msg = nil
@@ -44,7 +45,14 @@ class Livecheck
   def url(val = nil)
     return @url if val.nil?
 
-    @url = val
+    @url = case val
+    when :head, :stable, :devel
+      @formula.send(val).url
+    when :homepage
+      @formula.homepage
+    else
+      val
+    end
   end
 
   # Returns a Hash of all instance variable values.

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -697,6 +697,20 @@ describe Formula do
 
       expect(f.livecheckable?).to be true
     end
+
+    specify "livecheck references Formula URL" do
+      f = formula do
+        homepage "https://brew.sh/test"
+
+        url "https://brew.sh/test-1.0.tbz"
+        livecheck do
+          url :homepage
+          regex(/test-(\d+(?:.\d+)+).tbz/)
+        end
+      end
+
+      expect(f.livecheck.url).to eq("https://brew.sh/test")
+    end
   end
 
   specify "dependencies" do

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -1,9 +1,15 @@
 # frozen_string_literal: true
 
+require "formula"
 require "livecheck"
 
 describe Livecheck do
-  subject(:livecheckable) { described_class.new }
+  let(:f) do
+    formula do
+      url "https://brew.sh/test-0.1.tbz"
+    end
+  end
+  let(:livecheckable) { described_class.new(f) }
 
   describe "#regex" do
     it "returns nil if unset" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds the ability to reference Formula URLs in the `livecheck` block.

For example,
```ruby
livecheck do
  url :homepage
end
```

This would allow for referencing URLs from the Formula, rather than typing out the URL again (`livecheck` automatically uses URLs in the order `head` > `stable` > `homepage`, but sometimes we want to specify the URL).