### PR TITLE
resource: fix incorrect argument error for empty/non-existent target

### DIFF
--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -72,7 +72,7 @@ class Resource
   # directory. Subclasses that override stage should implement the tmp
   # dir using {Mktemp} so that works with all subtypes.
   def stage(target = nil, &block)
-    raise ArgumentError, "target directory or block is required" if target.blank? && block.blank?
+    raise ArgumentError, "target directory or block is required" if !target && block.blank?
 
     prepare_patches
     fetch_patches(skip_downloaded: true)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`blank?` returns true if the passed target is a `Pathname` and the directory it points to is empty (or doesn't exist at all).