### PR TITLE
livecheck: modify regex in tests

### DIFF
--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -668,14 +668,14 @@ describe Formula do
       livecheck do
         skip "foo"
         url "https://brew.sh/test/releases"
-        regex(/test-(\d+(?:\.\d+)+)\.tbz/)
+        regex(/test-v?(\d+(?:\.\d+)+)\.t/i)
       end
     end
 
     expect(f.livecheck.skip?).to be true
     expect(f.livecheck.skip_msg).to eq("foo")
     expect(f.livecheck.url).to eq("https://brew.sh/test/releases")
-    expect(f.livecheck.regex).to eq(/test-(\d+(?:\.\d+)+)\.tbz/)
+    expect(f.livecheck.regex).to eq(/test-v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   describe "#livecheckable?" do
@@ -691,7 +691,7 @@ describe Formula do
       f = formula do
         url "https://brew.sh/test-1.0.tbz"
         livecheck do
-          regex(/test-(\d+(?:.\d+)+).tbz/)
+          regex(/test-v?(\d+(?:\.\d+)+)\.t/i)
         end
       end
 
@@ -705,7 +705,7 @@ describe Formula do
         url "https://brew.sh/test-1.0.tbz"
         livecheck do
           url :homepage
-          regex(/test-(\d+(?:.\d+)+).tbz/)
+          regex(/test-v?(\d+(?:\.\d+)+)\.t/i)
         end
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR modifies the `regex` in the `livecheck`-specific tests in `formula_spec.rb` to be more representative of how `livecheck`'s regexes must be, as suggested by @samford in #7668 ([comment](https://github.com/Homebrew/brew/pull/7668#issuecomment-636480637)).