### PR TITLE
Cask: use regex in appcast adjusted_version_stanza

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -314,7 +314,7 @@ module Cask
                                       "--globoff", "--max-time", "5", appcast_stanza)
       version_stanza = cask.version.to_s
       adjusted_version_stanza = if cask.appcast.configuration.blank?
-        version_stanza.split(",")[0].split("-")[0].split("_")[0]
+        version_stanza.match(/^[[:alnum:].]+/)[0]
       else
         cask.appcast.configuration
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

@core-code I’m guessing this is close to your original point for the exclusions, to match from the start of the `version` string until the first character that isn’t either alphanumeric or a `.`.

Making this change because the intent (if I understood your original point) is clearer, thus easier to document (which is what I was doing that prompted this change). As a bonus, this will fail if `version` doesn’t conform to our expected structure.

Pairs with https://github.com/Homebrew/homebrew-cask/pull/83548.

Haven’t run the tests because nothing has changed since https://github.com/Homebrew/brew/pull/7606.