### PR TITLE
os/mac/keg_relocate: handle libexec/lib.

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -106,10 +106,12 @@ class Keg
       bad_name.sub(PREFIX_PLACEHOLDER, HOMEBREW_PREFIX)
     elsif bad_name.start_with? CELLAR_PLACEHOLDER
       bad_name.sub(CELLAR_PLACEHOLDER, HOMEBREW_CELLAR)
-    elsif (file.dylib? || file.mach_o_bundle?) && (file.parent + bad_name).exist?
+    elsif (file.dylib? || file.mach_o_bundle?) && (file.dirname/bad_name).exist?
       "@loader_path/#{bad_name}"
-    elsif file.mach_o_executable? && (lib + bad_name).exist?
+    elsif file.mach_o_executable? && (lib/bad_name).exist?
       "#{lib}/#{bad_name}"
+    elsif file.mach_o_executable? && (libexec/"lib"/bad_name).exist?
+      "#{libexec}/lib/#{bad_name}"
     elsif bad_name.start_with?("@rpath") && ENV["HOMEBREW_RELOCATE_METAVARS"]
       expand_rpath file, bad_name
     elsif (abs_name = find_dylib(bad_name)) && abs_name.exist?


### PR DESCRIPTION
We can fix up libraries in `lib` not `libexec/lib` so add an extra check for that case.

Inspired by https://github.com/Homebrew/homebrew-core/pull/53790#issuecomment-637622329

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----