### PR TITLE
os/mac/keg_relocate: add missing `libexec` method

### DIFF
--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -117,6 +117,10 @@ class Keg
     path/"lib"
   end
 
+  def libexec
+    path/"libexec"
+  end
+
   def text_files
     text_files = []
     return text_files unless which("file") && which("xargs")


### PR DESCRIPTION
Continuation of #7679 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?