### PR TITLE
Use Gem to install gems instead of invoking system

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -66,12 +66,10 @@ module Homebrew
     setup_gem_environment! if setup_gem_environment
     return unless Gem::Specification.find_all_by_name(name, version).empty?
 
-    # Shell out to `gem` to avoid RubyGems requires for e.g. loading JSON.
     ohai_if_defined "Installing '#{name}' gem"
-    install_args = %W[--no-document #{name}]
-    install_args << "--version" << version if version
-    return if system "#{ruby_bindir}/gem", "install", *install_args
-
+    # document: [] , is equivalent to --no-document
+    Gem.install name, version, document: []
+  rescue Gem::UnsatisfiableDependencyError
     odie_if_defined "failed to install the '#{name}' gem."
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Performing a gem install using `system`  when a ruby program is running, 
for unknown reasons( i couldn't figure out) fails to require the newly installed gem.
However by performing `Gem.install` the newly installed gem can be required.

## Example for previously failing case
`Homebrew.install_gem! "hola"`
`require 'hola'` fails with LoadError


## Other Notes / Doubts
> # Shell out to `gem` to avoid RubyGems requires for e.g. loading JSON.
deleted comment, i would like to know what this meant. 