### PR TITLE
Fix audit online release variable

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -697,7 +697,7 @@ module Homebrew
                    .second
 
         begin
-          if @online && (@release = GitHub.open_api("#{GitHub::API_URL}/repos/#{owner}/#{repo}/releases/tags/#{tag}"))
+          if @online && (release = GitHub.open_api("#{GitHub::API_URL}/repos/#{owner}/#{repo}/releases/tags/#{tag}"))
             problem "#{tag} is a GitHub prerelease" if release["prerelease"]
             problem "#{tag} is a GitHub draft" if release["draft"]
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

#7685 changed the release variable but not the following lines leading to this error currently when using `brew audit --online`:
```
Error: undefined local variable or method `release' for #<Homebrew::FormulaAuditor:0x00007fb5c7b89a28>
``` 