### PR TITLE
style: separate shell command arguments

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -844,15 +844,6 @@ module Homebrew
       # TODO: check could be in RuboCop
       problem "`env :userpaths` in formulae is deprecated" if line.include?("env :userpaths")
 
-      if line =~ /system ((["'])[^"' ]*(?:\s[^"' ]*)+\2)/
-        bad_system = Regexp.last_match(1)
-        unless %w[| < > & ; *].any? { |c| bad_system.include? c }
-          good_system = bad_system.gsub(" ", "\", \"")
-          # TODO: check could be in RuboCop
-          problem "Use `system #{good_system}` instead of `system #{bad_system}` "
-        end
-      end
-
       # TODO: check could be in RuboCop
       problem "`#{Regexp.last_match(1)}` is now unnecessary" if line =~ /(require ["']formula["'])/
 

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -252,55 +252,6 @@ module RuboCop
         end
       end
 
-      class ShellCommands < FormulaCop
-        def audit_formula(_node, _class_node, _parent_class_node, body_node)
-          # Match shell commands separated by spaces in the same string
-          shell_cmd_with_spaces_regex = /[^"' ]*(?:\s[^"' ]*)+/
-
-          popen_commands = [
-            :popen_read,
-            :safe_popen_read,
-            :popen_write,
-            :safe_popen_write,
-          ]
-
-          shell_metacharacters = %w[> < < | ; : & * $ ? : ~ + @ !` ( ) [ ]]
-
-          find_every_method_call_by_name(body_node, :system).each do |method|
-            # Only separate when no shell metacharacters are present
-            next if shell_metacharacters.any? { |meta| string_content(parameters(method).first).include?(meta) }
-
-            next unless match = regex_match_group(parameters(method).first, shell_cmd_with_spaces_regex)
-
-            good_args = match[0].gsub(" ", "\", \"")
-            offending_node(parameters(method).first)
-            problem "Separate `system` commands into `\"#{good_args}\"`"
-          end
-
-          popen_commands.each do |command|
-            find_instance_method_call(body_node, "Utils", command) do |method|
-              index = parameters(method).first.hash_type? ? 1 : 0
-
-              # Only separate when no shell metacharacters are present
-              next if shell_metacharacters.any? { |meta| string_content(parameters(method)[index]).include?(meta) }
-
-              next unless match = regex_match_group(parameters(method)[index], shell_cmd_with_spaces_regex)
-
-              good_args = match[0].gsub(" ", "\", \"")
-              offending_node(parameters(method)[index])
-              problem "Separate `Utils.#{command}` commands into `\"#{good_args}\"`"
-            end
-          end
-        end
-
-        def autocorrect(node)
-          lambda do |corrector|
-            good_args = node.source.gsub(" ", "\", \"")
-            corrector.replace(node.source_range, good_args)
-          end
-        end
-      end
-
       class Miscellaneous < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           # FileUtils is included in Formula
@@ -601,6 +552,55 @@ module RuboCop
               problem "Formulae in homebrew/core (except e.g. cryptography, libraries) " \
                       "should not run build-time checks"
             end
+          end
+        end
+      end
+
+      class ShellCommands < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          # Match shell commands separated by spaces in the same string
+          shell_cmd_with_spaces_regex = /[^"' ]*(?:\s[^"' ]*)+/
+
+          popen_commands = [
+            :popen_read,
+            :safe_popen_read,
+            :popen_write,
+            :safe_popen_write,
+          ]
+
+          shell_metacharacters = %w[> < < | ; : & * $ ? : ~ + @ !` ( ) [ ]]
+
+          find_every_method_call_by_name(body_node, :system).each do |method|
+            # Only separate when no shell metacharacters are present
+            next if shell_metacharacters.any? { |meta| string_content(parameters(method).first).include?(meta) }
+
+            next unless match = regex_match_group(parameters(method).first, shell_cmd_with_spaces_regex)
+
+            good_args = match[0].gsub(" ", "\", \"")
+            offending_node(parameters(method).first)
+            problem "Separate `system` commands into `\"#{good_args}\"`"
+          end
+
+          popen_commands.each do |command|
+            find_instance_method_call(body_node, "Utils", command) do |method|
+              index = parameters(method).first.hash_type? ? 1 : 0
+
+              # Only separate when no shell metacharacters are present
+              next if shell_metacharacters.any? { |meta| string_content(parameters(method)[index]).include?(meta) }
+
+              next unless match = regex_match_group(parameters(method)[index], shell_cmd_with_spaces_regex)
+
+              good_args = match[0].gsub(" ", "\", \"")
+              offending_node(parameters(method)[index])
+              problem "Separate `Utils.#{command}` commands into `\"#{good_args}\"`"
+            end
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            good_args = node.source.gsub(" ", "\", \"")
+            corrector.replace(node.source_range, good_args)
           end
         end
       end

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -264,7 +264,7 @@ module RuboCop
             :safe_popen_write,
           ]
 
-          shell_metacharacters = %w[> >> < << | ; & && || *]
+          shell_metacharacters = %w[> < < | ; : & * $ ? : ~ + @ !` ( ) [ ]]
 
           find_every_method_call_by_name(body_node, :system).each do |method|
             # Continue if a shell metacharacter is present

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -252,6 +252,55 @@ module RuboCop
         end
       end
 
+      class ShellCommands < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          # Match shell commands separated by spaces in the same string
+          shell_cmd_with_spaces_regex = /[^"' ]*(?:\s[^"' ]*)+/
+
+          popen_commands = [
+            :popen_read,
+            :safe_popen_read,
+            :popen_write,
+            :safe_popen_write,
+          ]
+
+          shell_metacharacters = %w[> >> < << | ; & && || *]
+
+          find_every_method_call_by_name(body_node, :system).each do |method|
+            # Continue if a shell metacharacter is present
+            next if shell_metacharacters.any? { |meta| string_content(parameters(method).first).include?(meta) }
+
+            next unless match = regex_match_group(parameters(method).first, shell_cmd_with_spaces_regex)
+
+            good_args = match[0].gsub(" ", "\", \"")
+            offending_node(parameters(method).first)
+            problem "Separate `system` commands into `\"#{good_args}\"`"
+          end
+
+          popen_commands.each do |command|
+            find_instance_method_call(body_node, "Utils", command) do |method|
+              index = parameters(method).first.hash_type? ? 1 : 0
+
+              # Continue if a shell metacharacter is present
+              next if shell_metacharacters.any? { |meta| string_content(parameters(method)[index]).include?(meta) }
+
+              next unless match = regex_match_group(parameters(method)[index], shell_cmd_with_spaces_regex)
+
+              good_args = match[0].gsub(" ", "\", \"")
+              offending_node(parameters(method)[index])
+              problem "Separate `Utils.#{command}` commands into `\"#{good_args}\"`"
+            end
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            good_args = node.source.gsub(" ", "\", \"")
+            corrector.replace(node.source_range, good_args)
+          end
+        end
+      end
+
       class Miscellaneous < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           # FileUtils is included in Formula

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -267,7 +267,7 @@ module RuboCop
           shell_metacharacters = %w[> < < | ; : & * $ ? : ~ + @ !` ( ) [ ]]
 
           find_every_method_call_by_name(body_node, :system).each do |method|
-            # Continue if a shell metacharacter is present
+            # Only separate when no shell metacharacters are present
             next if shell_metacharacters.any? { |meta| string_content(parameters(method).first).include?(meta) }
 
             next unless match = regex_match_group(parameters(method).first, shell_cmd_with_spaces_regex)
@@ -281,7 +281,7 @@ module RuboCop
             find_instance_method_call(body_node, "Utils", command) do |method|
               index = parameters(method).first.hash_type? ? 1 : 0
 
-              # Continue if a shell metacharacter is present
+              # Only separate when no shell metacharacters are present
               next if shell_metacharacters.any? { |meta| string_content(parameters(method)[index]).include?(meta) }
 
               next unless match = regex_match_group(parameters(method)[index], shell_cmd_with_spaces_regex)

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -715,6 +715,111 @@ describe RuboCop::Cop::FormulaAudit::ShellCommands do
         end
       RUBY
     end
+
+    it "separates shell commands in system" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "foo bar"
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "foo", "bar"
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands with string interpolation in system" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "\#{foo}/bar baz"
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "\#{foo}/bar", "baz"
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands in Utils.popen_read" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo bar")
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo", "bar")
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands with string interpolation in Utils.popen_read" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("\#{foo}/bar baz")
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("\#{foo}/bar", "baz")
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands following a shell variable in Utils.popen_read" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read({ "SHELL" => "bash" }, "foo bar")
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read({ "SHELL" => "bash" }, "foo", "bar")
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
   end
 end
 

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -574,255 +574,6 @@ describe RuboCop::Cop::FormulaAudit::ShellVariables do
   end
 end
 
-describe RuboCop::Cop::FormulaAudit::ShellCommands do
-  subject(:cop) { described_class.new }
-
-  context "When auditing shell commands" do
-    it "system arguments should be separated" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            system "foo bar"
-                   ^^^^^^^^^ Separate `system` commands into `\"foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "system arguments with string interpolation should be separated" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            system "\#{bin}/foo bar"
-                   ^^^^^^^^^^^^^^^^ Separate `system` commands into `\"\#{bin}/foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "system arguments with metacharacters should not be separated" do
-      expect_no_offenses(<<~RUBY)
-        class Foo < Formula
-          def install
-            system "foo bar > baz"
-          end
-        end
-      RUBY
-    end
-
-    it "only the first system argument should be separated" do
-      expect_no_offenses(<<~RUBY)
-        class Foo < Formula
-          def install
-            system "foo", "bar baz"
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.popen arguments should not be separated" do
-      expect_no_offenses(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.popen("foo bar")
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.popen_read arguments should be separated" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.popen_read("foo bar")
-                             ^^^^^^^^^ Separate `Utils.popen_read` commands into `\"foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.safe_popen_read arguments should be separated" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.safe_popen_read("foo bar")
-                                  ^^^^^^^^^ Separate `Utils.safe_popen_read` commands into `\"foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.popen_write arguments should be separated" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.popen_write("foo bar")
-                              ^^^^^^^^^ Separate `Utils.popen_write` commands into `\"foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.safe_popen_write arguments should be separated" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.safe_popen_write("foo bar")
-                                   ^^^^^^^^^ Separate `Utils.safe_popen_write` commands into `\"foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.popen_read arguments with string interpolation should be separated" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.popen_read("\#{bin}/foo bar")
-                             ^^^^^^^^^^^^^^^^ Separate `Utils.popen_read` commands into `\"\#{bin}/foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.popen_read arguments with metacharacters should not be separated" do
-      expect_no_offenses(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.popen_read("foo bar > baz")
-          end
-        end
-      RUBY
-    end
-
-    it "only the first Utils.popen_read argument should be separated" do
-      expect_no_offenses(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.popen_read("foo", "bar baz")
-          end
-        end
-      RUBY
-    end
-
-    it "Utils.popen_read arguments should be separated following a shell variable" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          def install
-            Utils.popen_read({ "SHELL" => "bash"}, "foo bar")
-                                                   ^^^^^^^^^ Separate `Utils.popen_read` commands into `\"foo\", \"bar\"`
-          end
-        end
-      RUBY
-    end
-
-    it "separates shell commands in system" do
-      source = <<~RUBY
-        class Foo < Formula
-          def install
-            system "foo bar"
-          end
-        end
-      RUBY
-
-      corrected_source = <<~RUBY
-        class Foo < Formula
-          def install
-            system "foo", "bar"
-          end
-        end
-      RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected_source)
-    end
-
-    it "separates shell commands with string interpolation in system" do
-      source = <<~RUBY
-        class Foo < Formula
-          def install
-            system "\#{foo}/bar baz"
-          end
-        end
-      RUBY
-
-      corrected_source = <<~RUBY
-        class Foo < Formula
-          def install
-            system "\#{foo}/bar", "baz"
-          end
-        end
-      RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected_source)
-    end
-
-    it "separates shell commands in Utils.popen_read" do
-      source = <<~RUBY
-        class Foo < Formula
-          def install
-            Utils.popen_read("foo bar")
-          end
-        end
-      RUBY
-
-      corrected_source = <<~RUBY
-        class Foo < Formula
-          def install
-            Utils.popen_read("foo", "bar")
-          end
-        end
-      RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected_source)
-    end
-
-    it "separates shell commands with string interpolation in Utils.popen_read" do
-      source = <<~RUBY
-        class Foo < Formula
-          def install
-            Utils.popen_read("\#{foo}/bar baz")
-          end
-        end
-      RUBY
-
-      corrected_source = <<~RUBY
-        class Foo < Formula
-          def install
-            Utils.popen_read("\#{foo}/bar", "baz")
-          end
-        end
-      RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected_source)
-    end
-
-    it "separates shell commands following a shell variable in Utils.popen_read" do
-      source = <<~RUBY
-        class Foo < Formula
-          def install
-            Utils.popen_read({ "SHELL" => "bash" }, "foo bar")
-          end
-        end
-      RUBY
-
-      corrected_source = <<~RUBY
-        class Foo < Formula
-          def install
-            Utils.popen_read({ "SHELL" => "bash" }, "foo", "bar")
-          end
-        end
-      RUBY
-
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected_source)
-    end
-  end
-end
-
 describe RuboCop::Cop::FormulaAudit::Miscellaneous do
   subject(:cop) { described_class.new }
 
@@ -1344,4 +1095,253 @@ describe RuboCop::Cop::FormulaAuditStrict::MakeCheck do
   end
 
   include_examples "formulae exist", described_class::MAKE_CHECK_ALLOWLIST
+end
+
+describe RuboCop::Cop::FormulaAuditStrict::ShellCommands do
+  subject(:cop) { described_class.new }
+
+  context "When auditing shell commands" do
+    it "system arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "foo bar"
+                   ^^^^^^^^^ Separate `system` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "system arguments with string interpolation should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "\#{bin}/foo bar"
+                   ^^^^^^^^^^^^^^^^ Separate `system` commands into `\"\#{bin}/foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "system arguments with metacharacters should not be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "foo bar > baz"
+          end
+        end
+      RUBY
+    end
+
+    it "only the first system argument should be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "foo", "bar baz"
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen arguments should not be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen("foo bar")
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo bar")
+                             ^^^^^^^^^ Separate `Utils.popen_read` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.safe_popen_read arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.safe_popen_read("foo bar")
+                                  ^^^^^^^^^ Separate `Utils.safe_popen_read` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_write arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_write("foo bar")
+                              ^^^^^^^^^ Separate `Utils.popen_write` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.safe_popen_write arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.safe_popen_write("foo bar")
+                                   ^^^^^^^^^ Separate `Utils.safe_popen_write` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments with string interpolation should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("\#{bin}/foo bar")
+                             ^^^^^^^^^^^^^^^^ Separate `Utils.popen_read` commands into `\"\#{bin}/foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments with metacharacters should not be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo bar > baz")
+          end
+        end
+      RUBY
+    end
+
+    it "only the first Utils.popen_read argument should be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo", "bar baz")
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments should be separated following a shell variable" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read({ "SHELL" => "bash"}, "foo bar")
+                                                   ^^^^^^^^^ Separate `Utils.popen_read` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "separates shell commands in system" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "foo bar"
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "foo", "bar"
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands with string interpolation in system" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "\#{foo}/bar baz"
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            system "\#{foo}/bar", "baz"
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands in Utils.popen_read" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo bar")
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo", "bar")
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands with string interpolation in Utils.popen_read" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("\#{foo}/bar baz")
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read("\#{foo}/bar", "baz")
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "separates shell commands following a shell variable in Utils.popen_read" do
+      source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read({ "SHELL" => "bash" }, "foo bar")
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          def install
+            Utils.popen_read({ "SHELL" => "bash" }, "foo", "bar")
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+  end
 end

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -574,6 +574,150 @@ describe RuboCop::Cop::FormulaAudit::ShellVariables do
   end
 end
 
+describe RuboCop::Cop::FormulaAudit::ShellCommands do
+  subject(:cop) { described_class.new }
+
+  context "When auditing shell commands" do
+    it "system arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "foo bar"
+                   ^^^^^^^^^ Separate `system` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "system arguments with string interpolation should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "\#{bin}/foo bar"
+                   ^^^^^^^^^^^^^^^^ Separate `system` commands into `\"\#{bin}/foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "system arguments with metacharacters should not be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "foo bar > baz"
+          end
+        end
+      RUBY
+    end
+
+    it "only the first system argument should be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            system "foo", "bar baz"
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen arguments should not be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen("foo bar")
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo bar")
+                             ^^^^^^^^^ Separate `Utils.popen_read` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.safe_popen_read arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.safe_popen_read("foo bar")
+                                  ^^^^^^^^^ Separate `Utils.safe_popen_read` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_write arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_write("foo bar")
+                              ^^^^^^^^^ Separate `Utils.popen_write` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.safe_popen_write arguments should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.safe_popen_write("foo bar")
+                                   ^^^^^^^^^ Separate `Utils.safe_popen_write` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments with string interpolation should be separated" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("\#{bin}/foo bar")
+                             ^^^^^^^^^^^^^^^^ Separate `Utils.popen_read` commands into `\"\#{bin}/foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments with metacharacters should not be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo bar > baz")
+          end
+        end
+      RUBY
+    end
+
+    it "only the first Utils.popen_read argument should be separated" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read("foo", "bar baz")
+          end
+        end
+      RUBY
+    end
+
+    it "Utils.popen_read arguments should be separated following a shell variable" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          def install
+            Utils.popen_read({ "SHELL" => "bash"}, "foo bar")
+                                                   ^^^^^^^^^ Separate `Utils.popen_read` commands into `\"foo\", \"bar\"`
+          end
+        end
+      RUBY
+    end
+  end
+end
+
 describe RuboCop::Cop::FormulaAudit::Miscellaneous do
   subject(:cop) { described_class.new }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This pr makes changes to audit to detect issues revolving around `Utils.popen_read`. These changes were discussed in more detail in https://github.com/Homebrew/homebrew-core/pull/55682 (mostly after the pr was closed).

Change:
- Use `Utils.popen_read "foo", "bar"` instead of `Utils.popen_read "foo bar"
    - This already exists for `system`. All that needs to be done is to extend this to `Utils.popen_read` and `Utils.safe_popen_read`. This ensures that the command is executed directly and a subshell isn't spawned (see [this comment](https://github.com/Homebrew/homebrew-core/pull/55682#issuecomment-638688164))

Question:
- For number 2 above, audit only catches `system "foo bar"` not `system("foo bar")`. Should this apply for `system("foo bar")` as well? As far as I can tell the parenthesis are optional so I would think that audit should catch this as well.