### PR TITLE
formula_installer: Fix `.installed?` method deprecation

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -418,7 +418,7 @@ class FormulaInstaller
 
     req_map.each_pair do |dependent, reqs|
       reqs.each do |req|
-        next if dependent.installed? && req.name == "maximummacos"
+        next if dependent.latest_version_installed? && req.name == "maximummacos"
 
         @requirement_messages << "#{dependent}: #{req.message}"
         fatals << req if req.fatal?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).~
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Trying to test out a user-submitted `brew bump-formula-pr` for `app-engine-java` gave an error locally that [hasn't shown up on CI](https://github.com/Homebrew/homebrew-core/pull/55798/checks?check_run_id=740165542), oddly.

```
➜ brew install app-engine-java -s && brew test app-engine-java
Error: Calling Formula#installed? is deprecated! Use Formula#latest_version_installed? (or Formula#any_version_installed? ) instead.

[--verbose --debug]
/usr/local/Homebrew/Library/Homebrew/compat/formula.rb:6:in `installed?'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:421:in `block (2 levels) in check_requirements'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:420:in `each'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:420:in `block in check_requirements'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:419:in `each_pair'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:419:in `check_requirements'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:392:in `compute_dependencies'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:149:in `verify_deps_exist'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:143:in `prelude'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:328:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:261:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:259:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:259:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```