### PR TITLE
dev-cmd/pull: deprecate.

### DIFF
--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -15,6 +15,7 @@ module Homebrew
 
   def pull_args
     Homebrew::CLI::Parser.new do
+      hide_from_man_page!
       usage_banner <<~EOS
         `pull` [<options>] <patch>
 
@@ -43,6 +44,8 @@ module Homebrew
   end
 
   def pull
+    odeprecated "brew pull", "hub checkout"
+
     odie "You meant `git pull --rebase`." if ARGV[0] == "--rebase"
 
     pull_args.parse

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -917,26 +917,6 @@ Apply the bottle commit and publish bottles to Bintray.
 
 Run Homebrew with the Ruby profiler, e.g. `brew prof readall`.
 
-### `pull` [*`options`*] *`patch`*
-
-Get a patch from a GitHub commit or pull request and apply it to Homebrew.
-
-Each *`patch`* may be the number of a pull request in `homebrew/core` or the URL
-of any pull request or commit on GitHub.
-
-* `--bump`:
-  For one-formula PRs, automatically reword commit message to our preferred format.
-* `--clean`:
-  Do not rewrite or otherwise modify the commits found in the pulled PR.
-* `--ignore-whitespace`:
-  Silently ignore whitespace discrepancies when applying diffs.
-* `--resolve`:
-  When a patch fails to apply, leave in progress and allow user to resolve, instead of aborting.
-* `--branch-okay`:
-  Do not warn if pulling to a branch besides master (useful for testing).
-* `--no-pbcopy`:
-  Do not copy anything to the system clipboard.
-
 ### `release-notes` [*`options`*] [*`previous_tag`*] [*`end_ref`*]
 
 Print the merged pull requests on Homebrew/brew between two Git refs. If no

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "May 2020" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "June 2020" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "May 2020" "Homebrew" "brew"
+.TH "BREW" "1" "June 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -1188,36 +1188,6 @@ Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew
 .
 .SS "\fBprof\fR \fIcommand\fR"
 Run Homebrew with the Ruby profiler, e\.g\. \fBbrew prof readall\fR\.
-.
-.SS "\fBpull\fR [\fIoptions\fR] \fIpatch\fR"
-Get a patch from a GitHub commit or pull request and apply it to Homebrew\.
-.
-.P
-Each \fIpatch\fR may be the number of a pull request in \fBhomebrew/core\fR or the URL of any pull request or commit on GitHub\.
-.
-.TP
-\fB\-\-bump\fR
-For one\-formula PRs, automatically reword commit message to our preferred format\.
-.
-.TP
-\fB\-\-clean\fR
-Do not rewrite or otherwise modify the commits found in the pulled PR\.
-.
-.TP
-\fB\-\-ignore\-whitespace\fR
-Silently ignore whitespace discrepancies when applying diffs\.
-.
-.TP
-\fB\-\-resolve\fR
-When a patch fails to apply, leave in progress and allow user to resolve, instead of aborting\.
-.
-.TP
-\fB\-\-branch\-okay\fR
-Do not warn if pulling to a branch besides master (useful for testing)\.
-.
-.TP
-\fB\-\-no\-pbcopy\fR
-Do not copy anything to the system clipboard\.
 .
 .SS "\fBrelease\-notes\fR [\fIoptions\fR] [\fIprevious_tag\fR] [\fIend_ref\fR]"
 Print the merged pull requests on Homebrew/brew between two Git refs\. If no \fIprevious_tag\fR is provided it defaults to the latest tag\. If no \fIend_ref\fR is provided it defaults to \fBorigin/master\fR\.


### PR DESCRIPTION
We no longer use this and `hub checkout` does what we want better.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----