### PR TITLE
docs: clarify Formula location in Tap repositories

### DIFF
--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -16,10 +16,11 @@ See the [manpage](Manpage.md) for more information on repository naming.
 The `brew tap-new` command can be used to create a new tap along with some
 template files.
 
-Tap formulae follow the same format as the core’s ones, and can be added at the
-repository’s root, or under `Formula` or `HomebrewFormula` subdirectories. We
-recommend the latter options because it makes the repository organisation
-easier to grasp, and top-level files are not mixed with formulae.
+Tap formulae follow the same format as the core’s ones, and can be added under
+either the `Formula` subdirectory, the `HomebrewFormula` subdirectory or the
+repository’s root. The first available directory is used, other locations will
+be ignored. We recommend use of subdirectories because it makes the repository
+organisation easier to grasp, and top-level files are not mixed with formulae.
 
 See [homebrew/core](https://github.com/Homebrew/homebrew-core) for an example of
 a tap with a `Formula` subdirectory.


### PR DESCRIPTION
Make clear that Formula locations cannot be mixed, they are mutually
exclusive. This avoids the (false) implication that top-level Formula
can override those in the Formula subdirectory.

This makes no change in recommendations following the original
discussion in https://github.com/Homebrew/legacy-homebrew/pull/41858

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
