### PR TITLE
language/java: deprecate java_home_cmd

### DIFF
--- a/Library/Homebrew/compat.rb
+++ b/Library/Homebrew/compat.rb
@@ -3,5 +3,6 @@
 require "compat/extend/nil"
 require "compat/extend/string"
 require "compat/formula"
+require "compat/language/java"
 require "compat/language/python"
 require "compat/os/mac" if OS.mac?

--- a/Library/Homebrew/compat/language/java.rb
+++ b/Library/Homebrew/compat/language/java.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Language
+  module Java
+    class << self
+      module Compat
+        def java_home_cmd(version = nil)
+          odeprecated "Language::Java::java_home_cmd", "Language::Java::java_home"
+
+          # macOS provides /usr/libexec/java_home, but Linux does not.
+          return system_java_home_cmd(version) if OS.mac?
+
+          raise NotImplementedError
+        end
+      end
+
+      prepend Compat
+    end
+  end
+end

--- a/Library/Homebrew/extend/os/mac/language/java.rb
+++ b/Library/Homebrew/extend/os/mac/language/java.rb
@@ -2,19 +2,20 @@
 
 module Language
   module Java
-    def self.java_home_cmd(version = nil)
+    def self.system_java_home_cmd(version = nil)
       version_flag = " --version #{version}" if version
       "/usr/libexec/java_home#{version_flag}"
     end
+    private_class_method :system_java_home_cmd
 
     def self.java_home(version = nil)
-      cmd = Language::Java.java_home_cmd(version)
+      cmd = system_java_home_cmd(version)
       Pathname.new Utils.popen_read(cmd).chomp
     end
 
     # @private
     def self.java_home_shell(version = nil)
-      "$(#{java_home_cmd(version)})"
+      "$(#{system_java_home_cmd(version)})"
     end
   end
 end

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -2,11 +2,6 @@
 
 module Language
   module Java
-    def self.java_home_cmd(_ = nil)
-      # macOS provides /usr/libexec/java_home, but Linux does not.
-      raise NotImplementedError
-    end
-
     def self.java_home(version = nil)
       req = JavaRequirement.new [*version]
       raise UnsatisfiedRequirements, req.message unless req.satisfied?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This does not work on Linux and thus [any forumla which uses it](https://github.com/Homebrew/homebrew-core/search?q=java_home_cmd&unscoped_q=java_home_cmd) does not work on Linux by default.

I think it's best to make it an internal-only function.

To ease migration, I also plan to make `Pathname#write_java_env_script` so that the `export JAVA_HOME` script writing stuff can be simplified.