### PR TITLE
docs: restore h1 headings for pages with front matter

### DIFF
--- a/docs/Brew-Test-Bot.md
+++ b/docs/Brew-Test-Bot.md
@@ -1,8 +1,10 @@
 ---
-title: Brew Test Bot
 logo: https://brew.sh/assets/img/brewtestbot.png
 image: https://brew.sh/assets/img/brewtestbot.png
 ---
+
+# Brew Test Bot
+
 `brew test-bot` is the name for the automated review and testing system funded
 by [our Kickstarter in 2013](https://www.kickstarter.com/projects/homebrew/brew-test-bot).
 

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -1,5 +1,4 @@
 ---
-title: Homebrew on Linux
 logo: https://brew.sh/assets/img/linuxbrew.png
 image: https://brew.sh/assets/img/linuxbrew.png
 redirect_from:
@@ -7,9 +6,12 @@ redirect_from:
   - /Linux
   - /Linuxbrew
 ---
+
+# Homebrew on Linux
+
 The Homebrew package manager may be used on Linux and [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/about). Homebrew was formerly referred to as Linuxbrew when running on Linux or WSL. It can be installed in your home directory, in which case it does not use *sudo*. Homebrew does not use any libraries provided by your host system, except *glibc* and *gcc* if they are new enough. Homebrew can install its own current versions of *glibc* and *gcc* for older distributions of Linux.
 
-[Features](#features), [dependencies](#dependencies) and [installation instructions](#install) are described below. Terminology (e.g. the difference between a Cellar, Tap, Cask and so forth) is [explained in the documentation](Formula-Cookbook.md#homebrew-terminology).
+[Features](#features), [installation instructions](#install) and [requirements](#requirements) are described below. Terminology (e.g. the difference between a Cellar, Tap, Cask and so forth) is [explained in the documentation](Formula-Cookbook.md#homebrew-terminology).
 
 ## Features
 
@@ -39,7 +41,7 @@ You're done! Try installing a package:
 brew install hello
 ```
 
-If you're using an older distribution of Linux, installing your first package will also install a recent version of `glibc` and `gcc`. Use `brew doctor` to troubleshoot common issues.
+If you're using an older distribution of Linux, installing your first package will also install a recent version of *glibc* and *gcc*. Use `brew doctor` to troubleshoot common issues.
 
 ## Requirements
 
@@ -68,7 +70,7 @@ sudo yum install libxcrypt-compat # needed by Fedora 30 and up
 
 Homebrew can run on 32-bit ARM (Raspberry Pi and others) and 64-bit ARM (AArch64), but no binary packages (bottles) are available. Support for ARM is on a best-effort basis. Pull requests are welcome to improve the experience on ARM platforms.
 
-You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as in the future we will no longer distribute a Homebrew Portable Ruby for ARM.
+You may need to install your own Ruby using your system package manager, a PPA, or `rbenv/ruby-build` as we no longer distribute a Homebrew Portable Ruby for ARM.
 
 ### 32-bit x86
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [n/a] Have you successfully run `brew style` with your changes locally?
- [n/a] Have you successfully run `brew tests` with your changes locally?

-----

Plus other fixes for Homebrew-on-Linux.md.
GitHub Pages' jekyll-titles-from-headings sets a page's title to its first Markdown heading.
