### PR TITLE
tap-new: restrict new tap names.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -22,7 +22,10 @@ module Homebrew
   def tap_new
     tap_new_args.parse
 
+    tap_name = args.named.first
     tap = Tap.fetch(args.named.first)
+    raise "Invalid tap name '#{tap_name}'" unless tap.path.to_s.match?(HOMEBREW_TAP_PATH_REGEX)
+
     titleized_user = tap.user.dup
     titleized_repo = tap.repo.dup
     titleized_user[0] = titleized_user[0].upcase

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -34,10 +34,7 @@ class Tap
     return CoreTap.instance if ["Homebrew", "Linuxbrew"].include?(user) && ["core", "homebrew"].include?(repo)
 
     cache_key = "#{user}/#{repo}".downcase
-    tap = cache.fetch(cache_key) { |key| cache[key] = Tap.new(user, repo) }
-    raise "Invalid tap name '#{args.join("/")}'" unless tap.path.to_s.match?(HOMEBREW_TAP_PATH_REGEX)
-
-    tap
+    cache.fetch(cache_key) { |key| cache[key] = Tap.new(user, repo) }
   end
 
   def self.from_path(path)


### PR DESCRIPTION
Don't want to restrict this for all taps otherwise existing ones may explode.

Fixes #7734

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----