### PR TITLE
audit: Supress pre-release audits for known pre-release formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -597,6 +597,8 @@ module Homebrew
       "libepoxy"            => "1.5",
     }.freeze
 
+    GITHUB_PRERELEASE_ALLOWLIST = %w[cake].freeze
+
     # version_prefix = stable_version_string.sub(/\d+$/, "")
     # version_prefix = stable_version_string.split(".")[0..1].join(".")
 
@@ -705,8 +707,11 @@ module Homebrew
 
         begin
           if @online && (release = GitHub.open_api("#{GitHub::API_URL}/repos/#{owner}/#{repo}/releases/tags/#{tag}"))
-            problem "#{tag} is a GitHub prerelease" if release["prerelease"]
-            problem "#{tag} is a GitHub draft" if release["draft"]
+            if release["prerelease"] && !GITHUB_PRERELEASE_ALLOWLIST.include?(formula.name)
+              problem "#{tag} is a GitHub prerelease"
+            elsif release["draft"]
+              problem "#{tag} is a GitHub draft"
+            end
           end
         rescue GitHub::HTTPNotFoundError
           # No-op if we can't find the release.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This safelists one formula that has only ever shipped pre-releases, from before we had the GitHub pre-release audit. So it won't fail CI and cause maintainers more work to determine if it's always been that way, or if it's new. Then, we don't have to keep comments at the top of files to say so for the next contributors.
- We should check this list from time to time to make sure that the formulae here have graduated to actual releases and we can remove them.
