### PR TITLE
append colon (:) to end of INFOPATH for brew shellenv

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -29,7 +29,7 @@ homebrew-shellenv() {
       echo "export HOMEBREW_REPOSITORY=\"$HOMEBREW_REPOSITORY\";"
       echo "export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin\${PATH+:\$PATH}\";"
       echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man\${MANPATH+:\$MANPATH}:\";"
-      echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info\${INFOPATH+:\$INFOPATH}\";"
+      echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info:\${INFOPATH}\";"
       ;;
   esac
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The behavior of some programs (e.g., emacs) differs depending on
whether INFOPATH is terminated in a colon or not. For example, the
info viewer built into emacs has a default list of places from which
it will draw info files, and it will only check this if either (a)
INFOPATH is unset, or (b) INFOPATH ends in a colon.

Currently brew shellenv sets INFOPATH but does not terminate it with a
colon. As a result, installation of `hombrew` causes info pages to "disappear" from the info viewer in emacs, but they can be restored by either unsetting INFOPATH or appending a colon to the variable.

This commit only changes behavior for "other" shells (i.e., not fish,
csh, or tcsh) since I don't know how to append a colon to variables in
these shells.