### PR TITLE
Add completion for livecheck

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -346,6 +346,17 @@ _brew_list() {
   fi
 }
 
+_brew_livecheck() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
+    -*)
+      __brewcomp "--verbose --quiet --debug --full-name --tap --installed --json --all --newer-only --help"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
+}
+
 _brew_log() {
   # if git-completion is loaded, then we complete git-log options
   declare -F _git_log >/dev/null || return
@@ -854,6 +865,7 @@ _brew() {
     irb)                        _brew_irb ;;
     link|ln)                    _brew_link ;;
     list|ls)                    _brew_list ;;
+    livecheck)                  _brew_livecheck ;;
     log)                        _brew_log ;;
     man)                        _brew_man ;;
     missing)                    __brew_complete_formulae ;;

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -504,6 +504,23 @@ _brew_list() {
     '*:: :__brew_installed_formulae'
 }
 
+# brew livecheck [--verbose] [--quiet] [--debug] [--full-name] [--tap user/repo]
+#                [--installed] [--json] [--all] [--newer-only] formulae
+_brew_livecheck() {
+  _arguments \
+    '(--verbose,-v)'{--verbose,-v}'[Make some output more verbose]' \
+    '(--quiet,-q)'{--quiet,-q}'[Suppress any warnings]' \
+    '(--debug,-d)'{--debug,-d}'[Display any debugging information]' \
+    '--full-name[Print formulae with fully-qualified name]' \
+    '--tap[Check the formulae within the given tap, specified as user/repo]' \
+    '--installed[Check formulae that are currently installed]' \
+    '--json[Output information in JSON format]' \
+    '--all[Check all available formulae]' \
+    '--newer-only[Show the latest version only if it is newer than the formula]' \
+    '(--help,-h)'{--help,-h}'[Show the help message]' \
+    '*:: :__brew_formulae'
+}
+
 # brew log [git-log-options] formula ...:
 _brew_log() {
   __brew_formulae


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR aims to add completions for `livecheck`. So far, I've added the completion for `zsh`, and will be adding those for `bash` and `fish` soon.

The timing for this might seem weird but I've been carrying out `livecheck` for many formulae, and having completions would make it quite a bit easier for me than having to type out whole Formulae names 😅.

CC: @samford @MikeMcQuaid  