### PR TITLE
formulae: add generic shared_library_extension

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Formula
+  undef shared_library
+
+  def shared_library(name, version = nil)
+    "#{name}.so#{"." unless version.nil?}#{version}"
+  end
+
   class << self
     undef on_linux
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1402,6 +1402,10 @@ class Formula
     ["--prefix=#{prefix}", "--libdir=#{lib}"]
   end
 
+  def shared_library(name, version = nil)
+    "#{name}.#{version}#{"." unless version.nil?}dylib"
+  end
+
   # an array of all core {Formula} names
   # @private
   def self.core_names

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "test/support/fixtures/testball"
 require "formula"
 
 describe Formula do
@@ -99,6 +100,14 @@ describe Formula do
       end
       expect(f.resources.length).to eq(1)
       expect(f.resources.first.url).to eq("on_linux")
+    end
+  end
+
+  describe "#shared_library" do
+    it "generates a shared library string" do
+      f = Testball.new
+      expect(f.shared_library("foobar")).to eq("foobar.so")
+      expect(f.shared_library("foobar", 2)).to eq("foobar.so.2")
     end
   end
 end

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "test/support/fixtures/testball"
 require "formula"
 
 describe Formula do
@@ -106,6 +107,14 @@ describe Formula do
       end
       expect(f.resources.length).to eq(1)
       expect(f.resources.first.url).to eq("resource_macos")
+    end
+  end
+
+  describe "#shared_library" do
+    it "generates a shared library string" do
+      f = Testball.new
+      expect(f.shared_library("foobar")).to eq("foobar.dylib")
+      expect(f.shared_library("foobar", 2)).to eq("foobar.2.dylib")
     end
   end
 end


### PR DESCRIPTION
We have strings containing hardcoded ".dylib" extensions in homebrew-core.
To be able to bring linuxbrew-core and homebrew-core closer together,
I am introducing a new generic attribute that can be used in formulae.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
