### PR TITLE
update: Fetch the symbolic reference origin/HEAD

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -38,6 +38,7 @@ homebrew-update-reset() {
     cd "$DIR" || continue
     ohai "Fetching $DIR..."
     git fetch --force --tags origin
+    git remote set-head origin --auto >/dev/null
     echo
 
     ohai "Resetting $DIR..."

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -38,6 +38,7 @@ git_init_if_necessary() {
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     latest_tag="$(git ls-remote --tags --refs -q origin | tail -n1 | cut -f2)"
     git fetch --force origin --shallow-since="$latest_tag"
+    git remote set-head origin --auto >/dev/null
     git reset --hard origin/master
     SKIP_FETCH_BREW_REPOSITORY=1
     set +e
@@ -59,6 +60,7 @@ git_init_if_necessary() {
     git config remote.origin.url "$HOMEBREW_CORE_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     git fetch --force --depth=1 origin refs/heads/master:refs/remotes/origin/master
+    git remote set-head origin --auto >/dev/null
     git reset --hard origin/master
     SKIP_FETCH_CORE_REPOSITORY=1
     set +e
@@ -84,6 +86,11 @@ upstream_branch() {
   local upstream_branch
 
   upstream_branch="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)"
+  if [[ -z "$upstream_branch" ]]
+  then
+    git remote set-head origin --auto >/dev/null
+    upstream_branch="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null)"
+  fi
   upstream_branch="${upstream_branch#refs/remotes/origin/}"
   [[ -z "$upstream_branch" ]] && upstream_branch="master"
   echo "$upstream_branch"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`origin/HEAD` is a symbolic reference to the default upstream branch. Use the command `git remote set-head origin --auto` to fetch this information from the upstream Git repository. The command `git symbolic-ref refs/remotes/origin/HEAD` queries the value of this symbolic reference.