### PR TITLE
Improve zsh completion performance

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -45,20 +45,19 @@ __brew_completion_caching_policy() {
   tmp=( $1(mw-2N) )
   (( $#tmp )) || return 0
 
-  # otherwise, invalidate if latest tap index file is missing or newer than
-  # cache file
+  # otherwise, invalidate if latest tap index file is missing or newer than cache file
   tmp=( ${HOMEBREW_REPOSITORY:-/usr/local/Homebrew}/Library/Taps/*/*/.git/index(om[1]N) )
   [[ -z $tmp || $tmp -nt $1 ]]
 }
 
 __brew_formulae() {
-  local -a formulae
+  local -a list
   local comp_cachename=brew_formulae
-  if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then
-    formulae=($(brew search))
-    _store_cache $comp_cachename formulae
+  if ! _retrieve_cache $comp_cachename; then
+    list=( $(brew search) )
+    _store_cache $comp_cachename list
   fi
-  _describe -t formulae 'all formulae' formulae
+  _describe -t formulae 'all formulae' list
 }
 
 __brew_installed_formulae() {
@@ -145,18 +144,17 @@ __brew_common_commands() {
 }
 
 __brew_all_commands() {
-  local -a commands
+  local -a list
   local comp_cachename=brew_all_commands
-  if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then
-    HOMEBREW_CACHE=$(brew --cache)
-    HOMEBREW_REPOSITORY=$(brew --repo)
-    [[ -f "$HOMEBREW_CACHE/all_commands_list.txt" ]] &&
-      commands=($(cat "$HOMEBREW_CACHE/all_commands_list.txt")) ||
-      commands=($(cat "$HOMEBREW_REPOSITORY/completions/internal_commands_list.txt"))
-    commands=(${commands:#*instal}) # Exclude instal, uninstal, etc.
-    _store_cache $comp_cachename commands
+  if ! _retrieve_cache $comp_cachename; then
+    local cache_dir=$(brew --cache)
+    [[ -f $cache_dir/all_commands_list.txt ]] &&
+      list=( $(<$cache_dir/all_commands_list.txt) ) ||
+      list=( $(<$(brew --repo)/completions/internal_commands_list.txt) )
+    list=( ${list:#*instal} ) # Exclude instal, uninstal, etc.
+    _store_cache $comp_cachename list
   fi
-  _describe -t all-commands 'all commands' commands
+  _describe -t all-commands 'all commands' list
 }
 
 __brew_commands() {
@@ -857,10 +855,10 @@ _brew() {
   case "$state" in
     command)
       # set default cache policy
-      zstyle -s ":completion:${curcontext%:*}:*" cache-policy tmp
-      [[ -n $tmp ]] ||
-      zstyle ":completion:${curcontext%:*}:*" cache-policy \
-        __brew_completion_caching_policy
+      zstyle -s ":completion:${curcontext%:*}:*" cache-policy tmp ||
+         zstyle ":completion:${curcontext%:*}:*" cache-policy __brew_completion_caching_policy
+      zstyle -s ":completion:${curcontext%:*}:*" use-cache tmp ||
+         zstyle ":completion:${curcontext%:*}:*" use-cache true
 
       __brew_commands && return 0
       ;;
@@ -878,10 +876,10 @@ _brew() {
 
       # set default cache policy (we repeat this dance because the context
       # service differs from above)
-      zstyle -s ":completion:${curcontext%:*}:*" cache-policy tmp
-      [[ -n $tmp ]] ||
-      zstyle ":completion:${curcontext%:*}:*" cache-policy \
-        __brew_completion_caching_policy
+      zstyle -s ":completion:${curcontext%:*}:*" cache-policy tmp ||
+         zstyle ":completion:${curcontext%:*}:*" cache-policy __brew_completion_caching_policy
+      zstyle -s ":completion:${curcontext%:*}:*" use-cache tmp ||
+         zstyle ":completion:${curcontext%:*}:*" use-cache true
 
       # call completion for named command e.g. _brew_list
       local completion_func="_brew_${command//-/_}"

--- a/completions/zsh/_brew_cask
+++ b/completions/zsh/_brew_cask
@@ -21,7 +21,7 @@ __brew_all_casks() {
   local expl
   local comp_cachename=brew_casks
 
-  if _cache_invalid $comp_cachename || ! _retrieve_cache $comp_cachename; then
+  if ! _retrieve_cache $comp_cachename; then
     list=( $(brew search --casks) )
     _store_cache $comp_cachename list
   fi


### PR DESCRIPTION
* Move main completion cache handling to `brew update`.
* Enable completion caching by default.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Improve perceived zsh completion performance by 
* delegating most of the cache handling to when `brew update` is being run, instead of doing it when the user tries to get a completion, since the user is expecting to wait during `brew update` anyway, and by 
* enabling caching of brew completions by default, since many users don't know how to enable this feature and since it's not enabled by default for new Zsh users.

I have not written tests for this, because I have no idea how to test this. I looked at other PRs for Zsh completions, but they don't seem to have included tests either. I guess no one really know how to test them.