### PR TITLE
update-reset: Use the default branch origin/HEAD

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -42,7 +42,9 @@ homebrew-update-reset() {
     echo
 
     ohai "Resetting $DIR..."
-    git checkout --force -B master origin/master
+    head="$(git symbolic-ref refs/remotes/origin/HEAD)"
+    head="${head#refs/remotes/origin/}"
+    git checkout --force -B "$head" origin/HEAD
     echo
   done
 }


### PR DESCRIPTION
Use the default branch of the repo, `origin/HEAD`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?