### PR TITLE
Accept space separated and assigned values for --days, --category flags of  brew info.

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -29,11 +29,11 @@ module Homebrew
              description: "List global Homebrew analytics data or, if specified, installation and "\
                           "build error data for <formula> (provided neither `HOMEBREW_NO_ANALYTICS` "\
                           "nor `HOMEBREW_NO_GITHUB_API` are set)."
-      flag   "--days",
+      flag   "--days=",
              depends_on:  "--analytics",
              description: "How many days of analytics data to retrieve. "\
                           "The value for <days> must be `30`, `90` or `365`. The default is `30`."
-      flag   "--category",
+      flag   "--category=",
              depends_on:  "--analytics",
              description: "Which type of analytics data to retrieve. "\
                           "The value for <category> must be `install`, `install-on-request` or `build-error`; "\


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

## Problem
`brew info --analytics --days 30 hello`
fails with 
> Usage: brew info [options] [formula]
> ...
> Error: Invalid usage: --days must be one of 30, 90, 365

however,
`brew info --analytics --days=30 hello` is good.

## Expectation
 show proper use case,  and be consistent with other commands.

few examples of other commands that accept both:
`brew --env --shell fish formula`
`brew create --set-name "doremifaso" https://example.com`



## After change the following commands are all valid
`brew info --analytics --days=90  hello` 
`brew info --analytics --days  90  hello`
`brew info --analytics --category=install-on-request hello`
`brew info --analytics --category install-on-request hello`

for brevity not all combinations of this command are shown.

