### PR TITLE
cpu_spec: add :icelake

### DIFF
--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -29,6 +29,7 @@ describe Hardware::CPU do
         :core2,
         :dothan,
         :haswell,
+        :icelake,
         :ivybridge,
         :kabylake,
         :merom,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I noticed that the `:icelake` family was missing from here while running `brew tests`.

Note that for my machine, from `brew config`:
```
CPU: octa-core 64-bit icelake
```

Note also that `:icelake` is already located in [cpu.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/os/mac/hardware/cpu.rb) (and also in the [Linux one](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/os/linux/hardware/cpu.rb)).