### PR TITLE
pr-pull: streamline mirroring and upload

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -72,7 +72,7 @@ class Bintray
     status_code.start_with?("2")
   end
 
-  def mirror_formula(formula, repo: "mirror")
+  def mirror_formula(formula, repo: "mirror", publish_package: false)
     package = Utils::Bottles::Bintray.package formula.name
 
     create_package(repo: repo, package: package) unless package_exists?(repo: repo, package: package)
@@ -93,7 +93,10 @@ class Bintray
       sha256:      formula.stable.checksum,
       remote_file: filename,
     )
-    publish(repo: repo, package: package, version: version)
+    return destination_url unless publish_package
+
+    odebug "Publishing #{@bintray_org}/#{repo}/#{package}/#{version}"
+    publish(repo: repo, package: package, version: version, file_count: 1)
 
     destination_url
   end

--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -15,6 +15,10 @@ module Homebrew
       EOS
       flag "--bintray-org=",
            description: "Upload to the specified Bintray organisation (default: homebrew)."
+      flag "--bintray-repo=",
+           description: "Upload to the specified Bintray repository (default: mirror)."
+      switch "--no-publish",
+             description: "Upload to Bintray, but don't publish."
       switch :verbose
       switch :debug
       hide_from_man_page!
@@ -26,11 +30,12 @@ module Homebrew
     mirror_args.parse
 
     bintray_org = args.bintray_org || "homebrew"
+    bintray_repo = args.bintray_repo || "mirror"
 
     bintray = Bintray.new(org: bintray_org)
 
     args.formulae.each do |formula|
-      mirror_url = bintray.mirror_formula(formula)
+      mirror_url = bintray.mirror_formula(formula, repo: bintray_repo, publish_package: !args.no_publish?)
       ohai "Mirrored #{formula.full_name} to #{mirror_url}!"
     end
   end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -41,6 +41,11 @@ module Homebrew
              description: "Upload to the specified Bintray organisation (default: homebrew)."
       flag   "--tap=",
              description: "Target tap repository (default: homebrew/core)."
+      flag   "--root-url=",
+             description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
+      flag   "--bintray-mirror=",
+             description: "Use the specified Bintray repository to automatically mirror stable URLs "\
+                          "defined in the formulae (default: mirror)"
       switch :verbose
       switch :debug
       min_named 1
@@ -128,6 +133,30 @@ module Homebrew
   def formulae_need_bottles?(tap, original_commit)
     return if Homebrew.args.dry_run?
 
+    changed_formulae(tap, original_commit).any? do |f|
+      !f.bottle_unneeded? && !f.bottle_disabled?
+    end
+  end
+
+  def mirror_formulae(tap, original_commit, publish: true, org:, repo:)
+    changed_formulae(tap, original_commit).select do |f|
+      stable_urls = [f.stable.url] + f.stable.mirrors
+      stable_urls.grep(%r{^https://dl.bintray.com/#{org}/#{repo}/}) do |mirror_url|
+        if Homebrew.args.dry_run?
+          puts "brew mirror #{f.full_name}"
+        else
+          odebug "Mirroring #{mirror_url}"
+          mirror_args = ["mirror", f.full_name]
+          mirror_args << "--bintray-org=#{org}" if org
+          mirror_args << "--bintray-repo=#{repo}" if repo
+          mirror_args << "--no-publish" unless publish
+          system HOMEBREW_BREW_FILE, *mirror_args
+        end
+      end
+    end
+  end
+
+  def changed_formulae(tap, original_commit)
     if Homebrew::EnvConfig.disable_load_formula?
       opoo "Can't check if updated bottles are necessary as formula loading is disabled!"
       return
@@ -136,19 +165,17 @@ module Homebrew
     Utils.popen_read("git", "-C", tap.path, "diff-tree",
                      "-r", "--name-only", "--diff-filter=AM",
                      original_commit, "HEAD", "--", tap.formula_dir)
-         .lines.each do |line|
+         .lines.map do |line|
       next unless line.end_with? ".rb\n"
 
       name = "#{tap.name}/#{File.basename(line.chomp, ".rb")}"
       begin
-        f = Formula[name]
+        Formula[name]
       rescue Exception # rubocop:disable Lint/RescueException
         # Make sure we catch syntax errors.
         next
       end
-      return true if !f.bottle_unneeded? && !f.bottle_disabled?
-    end
-    nil
+    end.compact
   end
 
   def download_artifact(url, dir, pr)
@@ -181,12 +208,11 @@ module Homebrew
 
     if bintray_user.blank? || bintray_key.blank?
       odie "Missing HOMEBREW_BINTRAY_USER or HOMEBREW_BINTRAY_KEY variables!" if !args.dry_run? && !args.no_upload?
-    else
-      bintray = Bintray.new(user: bintray_user, key: bintray_key, org: bintray_org)
     end
 
     workflow = args.workflow || "tests.yml"
     artifact = args.artifact || "bottles"
+    mirror_repo = args.bintray_mirror || "mirror"
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
 
     setup_git_environment!
@@ -206,6 +232,10 @@ module Homebrew
           cherry_pick_pr! pr, path: tap.path
           signoff! pr, path: tap.path unless args.clean?
 
+          unless args.no_upload?
+            mirror_formulae(tap, original_commit, org: bintray_org, repo: mirror_repo, publish: !args.no_publish?)
+          end
+
           unless formulae_need_bottles? tap, original_commit
             ohai "Skipping artifacts for ##{pr} as the formulae don't need bottles"
             next
@@ -214,41 +244,14 @@ module Homebrew
           url = GitHub.get_artifact_url(user, repo, pr, workflow_id: workflow, artifact_name: artifact)
           download_artifact(url, dir, pr)
 
-          json_files = Dir["*.json"]
-
-          if Homebrew.args.dry_run?
-            puts "brew bottle --merge --write #{json_files.join " "}"
-          else
-            quiet_system "#{HOMEBREW_PREFIX}/bin/brew", "bottle", "--merge", "--write", *json_files
-          end
-
           next if args.no_upload?
 
-          if Homebrew.args.dry_run?
-            puts "Upload bottles described by these JSON files to Bintray:\n  #{json_files.join("\n  ")}"
-          else
-            bintray.upload_bottle_json json_files, publish_package: !args.no_publish?
-          end
-
-          bottles_hash = json_files.reduce({}) do |hash, json_file|
-            hash.deep_merge(JSON.parse(IO.read(json_file)))
-          end
-
-          bottles_hash.each do |formula_name, _|
-            formula = Formula[formula_name]
-            stable_urls = [formula.stable.url] + formula.stable.mirrors
-            stable_urls.grep(%r{^https://dl.bintray.com/homebrew/mirror/}) do |mirror_url|
-              if Homebrew.args.dry_run?
-                puts "Mirror formulae sources described by these JSON files to Bintray:\n  #{json_files.join("\n  ")}"
-                next
-              end
-
-              next if bintray.stable_mirrored?(mirror_url)
-
-              mirror_url = bintray.mirror_formula(formula)
-              ohai "Mirrored #{formula.full_name} to #{mirror_url}!"
-            end
-          end
+          upload_args = ["pr-upload"]
+          upload_args << "--no-publish" if args.no_publish?
+          upload_args << "--dry-run" if args.dry_run?
+          upload_args << "--root_url=#{args.root_url}" if args.root_url
+          upload_args << "--bintray-org=#{bintray_org}"
+          system HOMEBREW_BREW_FILE, *upload_args
         end
       end
     end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -147,6 +147,8 @@ module Homebrew
         else
           odebug "Mirroring #{mirror_url}"
           mirror_args = ["mirror", f.full_name]
+          mirror_args << "--debug" if Homebrew.args.debug?
+          mirror_args << "--verbose" if Homebrew.args.verbose?
           mirror_args << "--bintray-org=#{org}" if org
           mirror_args << "--bintray-repo=#{repo}" if repo
           mirror_args << "--no-publish" unless publish
@@ -247,6 +249,8 @@ module Homebrew
           next if args.no_upload?
 
           upload_args = ["pr-upload"]
+          upload_args << "--debug" if Homebrew.args.debug?
+          upload_args << "--verbose" if Homebrew.args.verbose?
           upload_args << "--no-publish" if args.no_publish?
           upload_args << "--dry-run" if args.dry_run?
           upload_args << "--root_url=#{args.root_url}" if args.root_url

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -21,6 +21,8 @@ module Homebrew
            description: "Upload to the specified Bintray organisation (default: homebrew)."
       flag "--root-url=",
            description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
+      switch :verbose
+      switch :debug
     end
   end
 
@@ -31,6 +33,8 @@ module Homebrew
     bintray = Bintray.new(org: bintray_org)
 
     bottle_args = ["bottle", "--merge", "--write"]
+    bottle_args << "--verbose" if args.verbose?
+    bottle_args << "--debug" if args.debug?
     bottle_args << "--root-url=#{args.root_url}" if args.root_url
     odie "No JSON files found in the current working directory" if Dir["*.json"].empty?
     bottle_args += Dir["*.json"]

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -901,6 +901,10 @@ repository.
   Upload to the specified Bintray organisation (default: homebrew).
 * `--tap`:
   Target tap repository (default: homebrew/core).
+* `--root-url`:
+  Use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
+* `--bintray-mirror`:
+  Use the specified Bintray repository to automatically mirror stable URLs defined in the formulae (default: mirror)
 
 ### `pr-upload` [*`options`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1171,6 +1171,14 @@ Upload to the specified Bintray organisation (default: homebrew)\.
 \fB\-\-tap\fR
 Target tap repository (default: homebrew/core)\.
 .
+.TP
+\fB\-\-root\-url\fR
+Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
+.
+.TP
+\fB\-\-bintray\-mirror\fR
+Use the specified Bintray repository to automatically mirror stable URLs defined in the formulae (default: mirror)
+.
 .SS "\fBpr\-upload\fR [\fIoptions\fR]"
 Apply the bottle commit and publish bottles to Bintray\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

* Remove duplicated functionality in `brew pr-pull` and let `mirror` and `pr-upload` handle it instead.
* Fixes a bug where mirrored URLs were being uploaded but not published since `bintray.publish` needs the number of files published to confirm that everything was uploaded correctly. 
* Lets third-party taps use the same mirroring logic for their own Bintray repositories.
       