### PR TITLE
don't warn "no interpreter found" for Shared ELF objects.

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -78,7 +78,7 @@ module ELFShim
         begin
           patchelf_patcher.interpreter.present?
         rescue PatchELF::PatchError => e
-          opoo e
+          opoo e unless e.to_s.start_with? "No interpreter found"
           false
         end
       elsif which "readelf"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We don't wish to print "no interpreter found" when the object is a shared library

@sjackman 
