### PR TITLE
enable patchelf.rb when HOMEBREW_DEVELOPER is set

### DIFF
--- a/Library/Homebrew/os/linux/global.rb
+++ b/Library/Homebrew/os/linux/global.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # enables experimental readelf.rb, patchelf support.
-HOMEBREW_PATCHELF_RB = ENV["HOMEBREW_PATCHELF_RB"].present?.freeze
+HOMEBREW_PATCHELF_RB = (ENV["HOMEBREW_PATCHELF_RB"].present? ||
+                        (ENV["HOMEBREW_DEVELOPER"].present? && ENV["HOMEBREW_NO_PATCHELF_RB"].blank?)).freeze
 
 module Homebrew
   DEFAULT_PREFIX ||= if Homebrew::EnvConfig.force_homebrew_on_linux?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
~~Enable HOMEBREW_PATCHELF_RB by default when HOMEBREW_DEVELOPER is enabled unless HOMEBREW_PATCHELF_RB=0  - @sjackman~~

HOMEBREW_PATCHELF_RB is enabled on 2 cases. 

1) `HOMEBREW_PATCHELF_RB` is set
2) `HOMEBREW_DEVELOPER` is set , and `HOMEBREW_NO_PATCHELF_RB` is not set.


use `HOMEBREW_NO_PATCHELF_RB` to turn it off for devs.

**Note**: When `HOMEBREW_PATCHELF_RB` and `HOMEBREW_NO_PATCHELF_RB` both are
  present,  use of `patchelf.rb`  is enabled.


cc @woodruffw  @sjackman  @MikeMcQuaid 
