### PR TITLE
show help for aliased commands

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -58,6 +58,7 @@ begin
       help_flag = true
     elsif !cmd && !help_flag_list.include?(arg)
       cmd = ARGV.delete_at(i)
+      cmd = Commands::HOMEBREW_INTERNAL_COMMAND_ALIASES.fetch(cmd, cmd)
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew help ` followed by an alias shows help text for the aliased command.

# before 
$ `brew help dr`

```
 Warning: No help text in: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/cmd/doctor.rb
Example usage:
  brew search [TEXT|/REGEX/]
  brew info [FORMULA...]
   ...
```
The same applies for other aliased commands

# expected behaviour(of implementation)
`brew help dr` must be the same help text as  `brew help doctor`


# Other notes
This is quick In place fix, 
modifying  `Commands.valid_internal_command?`, `Commands.valid_internal_dev_command?`
maybe a better fix. 
Any case, suggestions wholeheartedly welcome.

