### PR TITLE
Resolve errors reported by Sorbet

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -27,7 +27,7 @@ module OS
 
     # rubocop:disable Naming/ConstantName
     # rubocop:disable Style/MutableConstant
-    ::MacOS = self
+    ::MacOS = OS::Mac
     # rubocop:enable Naming/ConstantName
     # rubocop:enable Style/MutableConstant
 

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -12,7 +12,7 @@ module OS
 
     # rubocop:disable Naming/ConstantName
     # rubocop:disable Style/MutableConstant
-    ::MacOS = self
+    ::MacOS = OS::Mac
     # rubocop:enable Naming/ConstantName
     # rubocop:enable Style/MutableConstant
 

--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -2,9 +2,7 @@
 
 module OS
   module Mac
-    X11 = XQuartz = Module.new # rubocop:disable Style/MutableConstant
-
-    module XQuartz
+    X11 = XQuartz = Module.new do # rubocop:disable Style/MutableConstant
       module_function
 
       DEFAULT_BUNDLE_PATH = Pathname.new("Applications/Utilities/XQuartz.app").freeze

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -13388,6 +13388,7 @@ class Object
   HOMEBREW_DEFAULT_TEMP = ::T.let(nil, ::T.untyped)
   HOMEBREW_HELP = ::T.let(nil, ::T.untyped)
   HOMEBREW_LIBRARY_PATH = ::T.let(nil, ::T.untyped)
+  HOMEBREW_PATCHELF_RB = ::T.let(nil, ::T.untyped)
   HOMEBREW_TAP_CASK_REGEX = ::T.let(nil, ::T.untyped)
   HOMEBREW_TAP_FORMULA_REGEX = ::T.let(nil, ::T.untyped)
   OFFICIAL_CASK_TAPS = ::T.let(nil, ::T.untyped)
@@ -13556,6 +13557,26 @@ module ParallelTests
 end
 
 ParseError = Racc::ParseError
+
+class Parser::AST::Processor
+  def on_find_pattern(node); end
+
+  def on_forward_arg(node); end
+end
+
+class Parser::Builders::Default
+  def find_pattern(lbrack_t, elements, rbrack_t); end
+
+  def forward_arg(dots_t); end
+
+  def forward_only_args(begin_t, dots_t, end_t); end
+end
+
+class Parser::Builders::Default
+  def self.emit_forward_arg(); end
+
+  def self.emit_forward_arg=(emit_forward_arg); end
+end
 
 Parser::CurrentRuby = Parser::Ruby26
 
@@ -13872,15 +13893,15 @@ class Parser::Ruby24
 
   def _reduce_332(val, _values, result); end
 
-  def _reduce_336(val, _values, result); end
+  def _reduce_333(val, _values, result); end
+
+  def _reduce_337(val, _values, result); end
 
   def _reduce_34(val, _values, result); end
 
-  def _reduce_340(val, _values, result); end
+  def _reduce_341(val, _values, result); end
 
-  def _reduce_342(val, _values, result); end
-
-  def _reduce_345(val, _values, result); end
+  def _reduce_343(val, _values, result); end
 
   def _reduce_346(val, _values, result); end
 
@@ -13888,9 +13909,9 @@ class Parser::Ruby24
 
   def _reduce_348(val, _values, result); end
 
-  def _reduce_35(val, _values, result); end
+  def _reduce_349(val, _values, result); end
 
-  def _reduce_350(val, _values, result); end
+  def _reduce_35(val, _values, result); end
 
   def _reduce_351(val, _values, result); end
 
@@ -13930,9 +13951,9 @@ class Parser::Ruby24
 
   def _reduce_368(val, _values, result); end
 
-  def _reduce_37(val, _values, result); end
+  def _reduce_369(val, _values, result); end
 
-  def _reduce_370(val, _values, result); end
+  def _reduce_37(val, _values, result); end
 
   def _reduce_371(val, _values, result); end
 
@@ -13948,7 +13969,7 @@ class Parser::Ruby24
 
   def _reduce_377(val, _values, result); end
 
-  def _reduce_379(val, _values, result); end
+  def _reduce_378(val, _values, result); end
 
   def _reduce_38(val, _values, result); end
 
@@ -13970,9 +13991,9 @@ class Parser::Ruby24
 
   def _reduce_388(val, _values, result); end
 
-  def _reduce_39(val, _values, result); end
+  def _reduce_389(val, _values, result); end
 
-  def _reduce_390(val, _values, result); end
+  def _reduce_39(val, _values, result); end
 
   def _reduce_391(val, _values, result); end
 
@@ -14048,19 +14069,19 @@ class Parser::Ruby24
 
   def _reduce_424(val, _values, result); end
 
-  def _reduce_426(val, _values, result); end
+  def _reduce_425(val, _values, result); end
 
   def _reduce_427(val, _values, result); end
 
   def _reduce_428(val, _values, result); end
 
+  def _reduce_429(val, _values, result); end
+
   def _reduce_43(val, _values, result); end
 
-  def _reduce_431(val, _values, result); end
+  def _reduce_432(val, _values, result); end
 
-  def _reduce_433(val, _values, result); end
-
-  def _reduce_438(val, _values, result); end
+  def _reduce_434(val, _values, result); end
 
   def _reduce_439(val, _values, result); end
 
@@ -14134,7 +14155,7 @@ class Parser::Ruby24
 
   def _reduce_472(val, _values, result); end
 
-  def _reduce_474(val, _values, result); end
+  def _reduce_473(val, _values, result); end
 
   def _reduce_475(val, _values, result); end
 
@@ -14254,7 +14275,7 @@ class Parser::Ruby24
 
   def _reduce_530(val, _values, result); end
 
-  def _reduce_532(val, _values, result); end
+  def _reduce_531(val, _values, result); end
 
   def _reduce_533(val, _values, result); end
 
@@ -14284,7 +14305,7 @@ class Parser::Ruby24
 
   def _reduce_546(val, _values, result); end
 
-  def _reduce_549(val, _values, result); end
+  def _reduce_547(val, _values, result); end
 
   def _reduce_55(val, _values, result); end
 
@@ -14302,25 +14323,25 @@ class Parser::Ruby24
 
   def _reduce_556(val, _values, result); end
 
-  def _reduce_559(val, _values, result); end
+  def _reduce_557(val, _values, result); end
 
   def _reduce_56(val, _values, result); end
 
   def _reduce_560(val, _values, result); end
 
-  def _reduce_563(val, _values, result); end
+  def _reduce_561(val, _values, result); end
 
   def _reduce_564(val, _values, result); end
 
   def _reduce_565(val, _values, result); end
 
-  def _reduce_567(val, _values, result); end
+  def _reduce_566(val, _values, result); end
 
   def _reduce_568(val, _values, result); end
 
-  def _reduce_57(val, _values, result); end
+  def _reduce_569(val, _values, result); end
 
-  def _reduce_570(val, _values, result); end
+  def _reduce_57(val, _values, result); end
 
   def _reduce_571(val, _values, result); end
 
@@ -14332,23 +14353,25 @@ class Parser::Ruby24
 
   def _reduce_575(val, _values, result); end
 
-  def _reduce_588(val, _values, result); end
+  def _reduce_576(val, _values, result); end
 
   def _reduce_589(val, _values, result); end
 
   def _reduce_59(val, _values, result); end
 
-  def _reduce_594(val, _values, result); end
+  def _reduce_590(val, _values, result); end
 
   def _reduce_595(val, _values, result); end
 
-  def _reduce_599(val, _values, result); end
+  def _reduce_596(val, _values, result); end
 
   def _reduce_6(val, _values, result); end
 
   def _reduce_60(val, _values, result); end
 
-  def _reduce_603(val, _values, result); end
+  def _reduce_600(val, _values, result); end
+
+  def _reduce_604(val, _values, result); end
 
   def _reduce_61(val, _values, result); end
 
@@ -14750,15 +14773,15 @@ class Parser::Ruby26
 
   def _reduce_334(val, _values, result); end
 
-  def _reduce_336(val, _values, result); end
+  def _reduce_335(val, _values, result); end
 
-  def _reduce_339(val, _values, result); end
+  def _reduce_337(val, _values, result); end
 
-  def _reduce_343(val, _values, result); end
+  def _reduce_340(val, _values, result); end
 
-  def _reduce_345(val, _values, result); end
+  def _reduce_344(val, _values, result); end
 
-  def _reduce_348(val, _values, result); end
+  def _reduce_346(val, _values, result); end
 
   def _reduce_349(val, _values, result); end
 
@@ -14768,7 +14791,7 @@ class Parser::Ruby26
 
   def _reduce_351(val, _values, result); end
 
-  def _reduce_353(val, _values, result); end
+  def _reduce_352(val, _values, result); end
 
   def _reduce_354(val, _values, result); end
 
@@ -14810,7 +14833,7 @@ class Parser::Ruby26
 
   def _reduce_371(val, _values, result); end
 
-  def _reduce_373(val, _values, result); end
+  def _reduce_372(val, _values, result); end
 
   def _reduce_374(val, _values, result); end
 
@@ -14828,7 +14851,7 @@ class Parser::Ruby26
 
   def _reduce_380(val, _values, result); end
 
-  def _reduce_382(val, _values, result); end
+  def _reduce_381(val, _values, result); end
 
   def _reduce_383(val, _values, result); end
 
@@ -14850,7 +14873,7 @@ class Parser::Ruby26
 
   def _reduce_391(val, _values, result); end
 
-  def _reduce_393(val, _values, result); end
+  def _reduce_392(val, _values, result); end
 
   def _reduce_394(val, _values, result); end
 
@@ -14928,19 +14951,19 @@ class Parser::Ruby26
 
   def _reduce_427(val, _values, result); end
 
-  def _reduce_429(val, _values, result); end
+  def _reduce_428(val, _values, result); end
 
   def _reduce_430(val, _values, result); end
 
   def _reduce_431(val, _values, result); end
 
-  def _reduce_434(val, _values, result); end
+  def _reduce_432(val, _values, result); end
 
-  def _reduce_436(val, _values, result); end
+  def _reduce_435(val, _values, result); end
+
+  def _reduce_437(val, _values, result); end
 
   def _reduce_44(val, _values, result); end
-
-  def _reduce_441(val, _values, result); end
 
   def _reduce_442(val, _values, result); end
 
@@ -15012,7 +15035,7 @@ class Parser::Ruby26
 
   def _reduce_475(val, _values, result); end
 
-  def _reduce_477(val, _values, result); end
+  def _reduce_476(val, _values, result); end
 
   def _reduce_478(val, _values, result); end
 
@@ -15136,7 +15159,7 @@ class Parser::Ruby26
 
   def _reduce_533(val, _values, result); end
 
-  def _reduce_535(val, _values, result); end
+  def _reduce_534(val, _values, result); end
 
   def _reduce_536(val, _values, result); end
 
@@ -15168,7 +15191,7 @@ class Parser::Ruby26
 
   def _reduce_549(val, _values, result); end
 
-  def _reduce_552(val, _values, result); end
+  def _reduce_550(val, _values, result); end
 
   def _reduce_553(val, _values, result); end
 
@@ -15184,21 +15207,21 @@ class Parser::Ruby26
 
   def _reduce_559(val, _values, result); end
 
-  def _reduce_562(val, _values, result); end
+  def _reduce_560(val, _values, result); end
 
   def _reduce_563(val, _values, result); end
 
-  def _reduce_566(val, _values, result); end
+  def _reduce_564(val, _values, result); end
 
   def _reduce_567(val, _values, result); end
 
   def _reduce_568(val, _values, result); end
 
-  def _reduce_570(val, _values, result); end
+  def _reduce_569(val, _values, result); end
 
   def _reduce_571(val, _values, result); end
 
-  def _reduce_573(val, _values, result); end
+  def _reduce_572(val, _values, result); end
 
   def _reduce_574(val, _values, result); end
 
@@ -15210,25 +15233,27 @@ class Parser::Ruby26
 
   def _reduce_578(val, _values, result); end
 
+  def _reduce_579(val, _values, result); end
+
   def _reduce_58(val, _values, result); end
 
   def _reduce_59(val, _values, result); end
 
-  def _reduce_591(val, _values, result); end
-
   def _reduce_592(val, _values, result); end
 
-  def _reduce_597(val, _values, result); end
+  def _reduce_593(val, _values, result); end
 
   def _reduce_598(val, _values, result); end
+
+  def _reduce_599(val, _values, result); end
 
   def _reduce_6(val, _values, result); end
 
   def _reduce_60(val, _values, result); end
 
-  def _reduce_602(val, _values, result); end
+  def _reduce_603(val, _values, result); end
 
-  def _reduce_606(val, _values, result); end
+  def _reduce_607(val, _values, result); end
 
   def _reduce_62(val, _values, result); end
 
@@ -15317,6 +15342,22 @@ class Parser::Ruby26
 end
 
 class Parser::Ruby26
+end
+
+class Parser::Source::TreeRewriter
+  def as_nested_actions(); end
+
+  def as_replacements(); end
+
+  def import!(foreign_rewriter, offset: T.unsafe(nil)); end
+end
+
+class Parser::Source::TreeRewriter::Action
+  def contract(); end
+
+  def moved(source_buffer, offset); end
+
+  def nested_actions(); end
 end
 
 class Pathname
@@ -19423,6 +19464,10 @@ class RuboCop::AST::Node
   def block_body(node=T.unsafe(nil)); end
 
   def cask_block?(node=T.unsafe(nil)); end
+
+  def find_pattern_type?(); end
+
+  def forward_arg_type?(); end
 
   def key_node(node=T.unsafe(nil)); end
 

--- a/Library/Homebrew/sorbet/rbi/todo.rbi
+++ b/Library/Homebrew/sorbet/rbi/todo.rbi
@@ -7,13 +7,6 @@ module ELFShim::Metadata::PatchELF::PatchError; end
 module ELFShim::PatchELF::PatchError; end
 module ELFShim::PatchELF::Patcher; end
 module Homebrew::Error; end
-module MacOS::CLT; end
-module MacOS::CLT::PKG_PATH; end
-module MacOS::Version; end
-module MacOS::Version::SYMBOLS; end
-module MacOS::X11; end
-module MacOS::XQuartz; end
-module MacOS::Xcode; end
 module OS::Mac::Version::NULL; end
 module T::CompatibilityPatches::RSpecCompatibility::MethodDoubleExtensions; end
 module T::CompatibilityPatches::RSpecCompatibility::RecorderExtensions; end

--- a/Library/Homebrew/sorbet/rbi/todo.rbi
+++ b/Library/Homebrew/sorbet/rbi/todo.rbi
@@ -3,6 +3,9 @@
 
 # typed: strong
 module DependencyCollector::Compat; end
+module ELFShim::Metadata::PatchELF::PatchError; end
+module ELFShim::PatchELF::PatchError; end
+module ELFShim::PatchELF::Patcher; end
 module Homebrew::Error; end
 module MacOS::CLT; end
 module MacOS::CLT::PKG_PATH; end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Error 4015, was caused because Sorbet could not identify `MacOS` as a class/module. This was because `MacOS` was dynamically defined in both `os/linux.rb:30` and `os/mac.rb:15`. 

I tried to replicate the module nesting in `os/linux.rb` file as per my understanding on sorbet.run :
- [Example](https://sorbet.run/#%23%20typed%3A%20false%0Amodule%20OS%0A%20%20module%20Mac%0A%20%20%20%20%3A%3AMacOS%20%3D%20self%0A%20%20%20%20def%20self.func1%0A%20%20%20%20%20%20%22hello%22%0A%20%20%20%20end%0A%0A%20%20%20%20module%20Xcode%0A%20%20%20%20%20%20def%20self.func2%0A%20%20%20%20%20%20%20%20%22ok%22%0A%20%20%20%20%20%20end%0A%20%20%20%20end%0A%20%20end%0Aend%0A%0Aputs%20MacOS.func1%20%23%20output%3A%20%22hello%22%0Aputs%20MacOS%3A%3AXcode.func2%20%23%20output%3A%20%22ok%22%0A) that fails
- Fixed [example](https://sorbet.run/#%23%20typed%3A%20false%0Amodule%20OS%0A%20%20module%20Mac%0A%20%20%20%20%3A%3AMacOS%20%3D%20OS%3A%3AMac%20%23%20Modified%20line%0A%20%20%20%20def%20self.func1%0A%20%20%20%20%20%20%22hello%22%0A%20%20%20%20end%0A%0A%20%20%20%20module%20Xcode%0A%20%20%20%20%20%20def%20self.func2%0A%20%20%20%20%20%20%20%20%22ok%22%0A%20%20%20%20%20%20end%0A%20%20%20%20end%0A%20%20end%0Aend%0A%0Aputs%20MacOS.func1%20%23%20output%3A%20%22hello%22%0Aputs%20MacOS%3A%3AXcode.func2%20%23%20output%3A%20%22ok%22%0A)
 