### PR TITLE
Integrate `--cache` and `home` with cask

### DIFF
--- a/Library/Homebrew/cask/cmd/--cache.rb
+++ b/Library/Homebrew/cask/cmd/--cache.rb
@@ -16,7 +16,7 @@ module Cask
 
       def run
         casks.each do |cask|
-          puts cached_location(cask)
+          puts self.class.cached_location(cask)
         end
       end
 

--- a/Library/Homebrew/cask/cmd/--cache.rb
+++ b/Library/Homebrew/cask/cmd/--cache.rb
@@ -16,8 +16,12 @@ module Cask
 
       def run
         casks.each do |cask|
-          puts Download.new(cask).downloader.cached_location
+          puts cached_location(cask)
         end
+      end
+
+      def self.cached_location(cask)
+        Download.new(cask).downloader.cached_location
       end
 
       def self.help

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -108,23 +108,6 @@ module Homebrew
                                          .freeze
       end
 
-      def formulae_and_casks
-        require "cask/cask_loader"
-        require "cask/exceptions"
-
-        @formulae_and_casks ||= downcased_unique_named.map do |name|
-          begin
-            Formulary.factory(name, spec)
-          rescue FormulaUnavailableError => e
-            begin
-              Cask::CaskLoader.load(name)
-            rescue Cask::CaskUnavailableError
-              raise e
-            end
-          end
-        end.uniq.freeze
-      end
-
       def kegs
         require "keg"
         require "formula"

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -38,7 +38,6 @@ module Homebrew
         @resolved_formulae = nil
         @formulae_paths = nil
         @casks = nil
-        @formulae_and_casks = nil
         @kegs = nil
 
         self[:named_args] = named_args

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -38,14 +38,16 @@ module Homebrew
         else
           puts formula.cached_download
         end
-      rescue FormulaUnavailableError => fe
+      rescue FormulaUnavailableError => e
+        formula_error_message = e.message
         begin
           cask = Cask::CaskLoader.load name
           puts "cask: #{Cask::Cmd::Cache.cached_location(cask)}"
-        rescue Cask::CaskUnavailableError => ce
+        rescue Cask::CaskUnavailableError => e
+          cask_error_message = e.message
           odie "No available formula or cask with the name \"#{name}\"\n" \
-               "#{fe.message}\n" \
-               "#{ce.message}\n"
+               "#{formula_error_message}\n" \
+               "#{cask_error_message}\n"
         end
       end
     end

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -32,23 +32,20 @@ module Homebrew
       puts HOMEBREW_CACHE
     else
       args.named.each do |name|
+        formula = Formulary.factory name
+        if Fetch.fetch_bottle?(formula)
+          puts formula.bottle.cached_download
+        else
+          puts formula.cached_download
+        end
+      rescue FormulaUnavailableError
         begin
-          formula = Formulary.factory name
-          if Fetch.fetch_bottle?(formula)
-            puts formula.bottle.cached_download
-          else
-            puts formula.cached_download
-          end
-        rescue FormulaUnavailableError => e
-          begin
-            cask = Cask::CaskLoader.load name
-            puts "cask: #{Cask::Cmd::Cache.cached_location(cask)}"
-          rescue Cask::CaskUnavailableError
-            ofail "No available formula or cask with the name \"#{name}\""
-          end
+          cask = Cask::CaskLoader.load name
+          puts "cask: #{Cask::Cmd::Cache.cached_location(cask)}"
+        rescue Cask::CaskUnavailableError
+          ofail "No available formula or cask with the name \"#{name}\""
         end
       end
     end
   end
-
 end

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -38,12 +38,14 @@ module Homebrew
         else
           puts formula.cached_download
         end
-      rescue FormulaUnavailableError
+      rescue FormulaUnavailableError => fe
         begin
           cask = Cask::CaskLoader.load name
           puts "cask: #{Cask::Cmd::Cache.cached_location(cask)}"
-        rescue Cask::CaskUnavailableError
-          ofail "No available formula or cask with the name \"#{name}\""
+        rescue Cask::CaskUnavailableError => ce
+          odie "No available formula or cask with the name \"#{name}\"\n" \
+               "#{fe.message}\n" \
+               "#{ce.message}\n"
         end
       end
     end

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -2,6 +2,7 @@
 
 require "fetch"
 require "cli/parser"
+require "cask/cmd"
 
 module Homebrew
   module_function
@@ -29,13 +30,21 @@ module Homebrew
     if args.no_named?
       puts HOMEBREW_CACHE
     else
-      args.formulae.each do |f|
-        if Fetch.fetch_bottle?(f)
-          puts f.bottle.cached_download
-        else
-          puts f.cached_download
+      args.formulae_and_casks.each do |formula_or_cask|
+        case formula_or_cask
+        when Formula
+          formula = formula_or_cask
+          if Fetch.fetch_bottle?(formula)
+            puts formula.bottle.cached_download
+          else
+            puts formula.cached_download
+          end
+        when Cask::Cask
+          cask = formula_or_cask
+          puts "cask: #{Cask::Cmd::Cache.cached_location(cask)}"
         end
       end
     end
   end
+
 end

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -46,10 +46,10 @@ module Homebrew
     else
       args.named.each do |name|
         print_formula_cache name
-      rescue FormulaUnavailableError => e
+      rescue FormulaUnavailableError
         begin
           print_cask_cache name
-        rescue Cask::CaskUnavailableError => e
+        rescue Cask::CaskUnavailableError
           odie "No available formula or cask with the name \"#{name}\""
         end
       end
@@ -66,8 +66,7 @@ module Homebrew
   end
 
   def print_cask_cache(name)
-      cask = Cask::CaskLoader.load name
-      puts Cask::Cmd::Cache.cached_location(cask)
+    cask = Cask::CaskLoader.load name
+    puts Cask::Cmd::Cache.cached_location(cask)
   end
-
 end

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -11,11 +11,11 @@ module Homebrew
   def __cache_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `--cache` [<options>] [<formula/cask>]
+        `--cache` [<options>] [<formula>]
 
         Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 
-        If <formula/cask> is provided, display the file or directory used to cache <formula/cask>.
+        If <formula> is provided, display the file or directory used to cache <formula>.
       EOS
       switch "-s", "--build-from-source",
              description: "Show the cache file used when building from source."

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -25,19 +25,17 @@ module Homebrew
     if args.no_named?
       exec_browser HOMEBREW_WWW
     else
-      homepages = args.named.map do |ref|
-        Formulary.factory(ref).homepage
-      rescue FormulaUnavailableError => e
-        formula_error_message = e.message
+      homepages = args.named.map do |name|
+        f = Formulary.factory(name)
+        puts "Opening homepage for formula #{name}"
+        f.homepage
+      rescue FormulaUnavailableError
         begin
-          cask = Cask::CaskLoader.load(ref)
-          puts "Formula \"#{ref}\" not found. Found a cask instead."
-          cask.homepage
+          c = Cask::CaskLoader.load(name)
+          puts "Opening homepage for cask #{name}"
+          c.homepage
         rescue Cask::CaskUnavailableError => e
-          cask_error_message = e.message
-          odie "No available formula or cask with the name \"#{name}\"\n" \
-               "#{formula_error_message}\n" \
-               "#{cask_error_message}\n"
+          odie "No available formula or cask with the name \"#{name}\""
         end
       end
       exec_browser(*homepages)

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -34,7 +34,7 @@ module Homebrew
           c = Cask::CaskLoader.load(name)
           puts "Opening homepage for cask #{name}"
           c.homepage
-        rescue Cask::CaskUnavailableError => e
+        rescue Cask::CaskUnavailableError
           odie "No available formula or cask with the name \"#{name}\""
         end
       end

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -25,20 +25,20 @@ module Homebrew
     if args.no_named?
       exec_browser HOMEBREW_WWW
     else
-      homepages = args.named.flat_map do |ref|
-        [Formulary.factory(ref).homepage]
-      rescue FormulaUnavailableError => e
-        puts e.message
+      homepages = args.named.map do |ref|
+        Formulary.factory(ref).homepage
+      rescue FormulaUnavailableError => fe
         begin
           cask = Cask::CaskLoader.load(ref)
-          puts "Found a cask with ref \"#{ref}\" instead."
-          [cask.homepage]
-        rescue Cask::CaskUnavailableError => e
-          puts e.message
-          []
+          puts "Formula \"#{ref}\" not found. Found a cask instead."
+          cask.homepage
+        rescue Cask::CaskUnavailableError => ce
+          odie "No available formula or cask with the name \"#{name}\"\n" \
+               "#{fe.message}\n" \
+               "#{ce.message}\n"
         end
       end
-      exec_browser(*homepages) unless homepages.empty?
+      exec_browser(*homepages)
     end
   end
 end

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -27,15 +27,17 @@ module Homebrew
     else
       homepages = args.named.map do |ref|
         Formulary.factory(ref).homepage
-      rescue FormulaUnavailableError => fe
+      rescue FormulaUnavailableError => e
+        formula_error_message = e.message
         begin
           cask = Cask::CaskLoader.load(ref)
           puts "Formula \"#{ref}\" not found. Found a cask instead."
           cask.homepage
-        rescue Cask::CaskUnavailableError => ce
+        rescue Cask::CaskUnavailableError => e
+          cask_error_message = e.message
           odie "No available formula or cask with the name \"#{name}\"\n" \
-               "#{fe.message}\n" \
-               "#{ce.message}\n"
+               "#{formula_error_message}\n" \
+               "#{cask_error_message}\n"
         end
       end
       exec_browser(*homepages)

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -25,21 +25,20 @@ module Homebrew
     if args.no_named?
       exec_browser HOMEBREW_WWW
     else
-      homepages = args.named.flat_map do |name|
+      homepages = args.named.flat_map do |ref|
+        [Formulary.factory(ref).homepage]
+      rescue FormulaUnavailableError => e
+        puts e.message
         begin
-          [Formulary.factory(name).homepage]
-        rescue FormulaUnavailableError => e
+          cask = Cask::CaskLoader.load(ref)
+          puts "Found a cask with ref \"#{ref}\" instead."
+          [cask.homepage]
+        rescue Cask::CaskUnavailableError => e
           puts e.message
-          begin
-            cask = Cask::CaskLoader.load(name)
-            puts "Found a cask named \"#{name}\" instead."
-            [cask.homepage]
-          rescue Cask::CaskUnavailableError
-            []
-          end
+          []
         end
       end
-      exec_browser *homepages
+      exec_browser(*homepages) unless homepages.empty?
     end
   end
 end

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -23,7 +23,7 @@ module Homebrew
     if args.no_named?
       exec_browser HOMEBREW_WWW
     else
-      exec_browser(*args.formulae.map(&:homepage))
+      exec_browser(*args.formulae_and_casks.map(&:homepage))
     end
   end
 end

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -23,7 +23,12 @@ describe "brew --cache", :integration_test do
 
   it "prints the cache files for a given Formula and Cask" do
     expect { brew "--cache", testball, cask_path("local-caffeine") }
-      .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--testball-.*\ncask: #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}).to_stdout
+      .to output(
+        %r{
+          #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--testball-.*\n
+          cask:\s#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip
+        }x,
+      ).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -16,7 +16,7 @@ describe "brew --cache", :integration_test do
 
   it "prints the cache files for a given Cask" do
     expect { brew "--cache", cask_path("local-caffeine") }
-      .to output(%r{cask: #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}).to_stdout
+      .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end
@@ -26,7 +26,7 @@ describe "brew --cache", :integration_test do
       .to output(
         %r{
           #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--testball-.*\n
-          cask:\s#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip
+          #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip
         }x,
       ).to_stdout
       .and not_to_output.to_stderr

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -13,4 +13,18 @@ describe "brew --cache", :integration_test do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  it "prints the cache files for a given Cask" do
+    expect { brew "--cache", cask_path("local-caffeine") }
+      .to output(%r{cask: #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "prints the cache files for a given Formula and Cask" do
+    expect { brew "--cache", testball, cask_path("local-caffeine") }
+      .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--testball-.*\ncask: #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
 end

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -1,17 +1,43 @@
 # frozen_string_literal: true
 
 require "cmd/shared_examples/args_parse"
+require "support/lib/config"
 
 describe "Homebrew.home_args" do
   it_behaves_like "parseable arguments"
 end
 
 describe "brew home", :integration_test do
+  let(:testballhome_homepage) {
+    Formula["testballhome"].homepage
+  }
+
+  let(:local_caffeine_homepage) {
+    Cask::CaskLoader.load(cask_path("local-caffeine")).homepage
+  }
+
   it "opens the homepage for a given Formula" do
     setup_test_formula "testballhome"
 
     expect { brew "home", "testballhome", "HOMEBREW_BROWSER" => "echo" }
-      .to output("#{Formula["testballhome"].homepage}\n").to_stdout
+      .to output("#{testballhome_homepage}\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "opens the homepage for a given Cask" do
+    expect { brew "home", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
+      .to output(/Found a cask with ref ".*" instead.\n#{local_caffeine_homepage}/m).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "opens the homepages for a given formula and Cask" do
+    setup_test_formula "testballhome"
+
+    expect { brew "home", "testballhome", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
+      .to output(/Found a cask with ref ".*" instead.\n#{testballhome_homepage} #{local_caffeine_homepage}/m)
+      .to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -24,7 +24,7 @@ describe "brew home", :integration_test do
     setup_test_formula "testballhome"
 
     expect { brew "home", "testballhome", "HOMEBREW_BROWSER" => "echo" }
-      .to output("#{testballhome_homepage}\n").to_stdout
+      .to output(/#{testballhome_homepage}/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -12,8 +12,12 @@ describe "brew home", :integration_test do
     Formula["testballhome"].homepage
   }
 
+  let(:local_caffeine_path) {
+    cask_path("local-caffeine")
+  }
+
   let(:local_caffeine_homepage) {
-    Cask::CaskLoader.load(cask_path("local-caffeine")).homepage
+    Cask::CaskLoader.load(local_caffeine_path).homepage
   }
 
   it "opens the homepage for a given Formula" do
@@ -27,7 +31,8 @@ describe "brew home", :integration_test do
 
   it "opens the homepage for a given Cask" do
     expect { brew "home", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
-      .to output(/Found a cask with ref ".*" instead.\n#{local_caffeine_homepage}/m).to_stdout
+      .to output(/Formula "#{local_caffeine_path}" not found. Found a cask instead.\n#{local_caffeine_homepage}/m)
+            .to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end
@@ -36,7 +41,7 @@ describe "brew home", :integration_test do
     setup_test_formula "testballhome"
 
     expect { brew "home", "testballhome", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
-      .to output(/Found a cask with ref ".*" instead.\n#{testballhome_homepage} #{local_caffeine_homepage}/m)
+      .to output(/Formula "#{local_caffeine_path}" not found. Found a cask instead.\n#{testballhome_homepage} #{local_caffeine_homepage}/m)
       .to_stdout
       .and not_to_output.to_stderr
       .and be_a_success

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -31,8 +31,7 @@ describe "brew home", :integration_test do
 
   it "opens the homepage for a given Cask" do
     expect { brew "home", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
-      .to output(/Formula "#{local_caffeine_path}" not found. Found a cask instead.\n#{local_caffeine_homepage}/m)
-            .to_stdout
+      .to output(/#{local_caffeine_homepage}/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end
@@ -41,8 +40,7 @@ describe "brew home", :integration_test do
     setup_test_formula "testballhome"
 
     expect { brew "home", "testballhome", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
-      .to output(/Formula "#{local_caffeine_path}" not found. Found a cask instead.\n#{testballhome_homepage} #{local_caffeine_homepage}/m)
-      .to_stdout
+      .to output(/#{testballhome_homepage} #{local_caffeine_homepage}/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -577,12 +577,11 @@ recommended dependency for their stable builds.
 * `--HEAD`:
   Show usage of *`formula`* by HEAD builds.
 
-### `--cache` [*`options`*] [<formula/cask>]
+### `--cache` [*`options`*] [*`formula`*]
 
 Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 
-If <formula/cask> is provided, display the file or directory used to cache
-<formula/cask>.
+If *`formula`* is provided, display the file or directory used to cache *`formula`*.
 
 * `-s`, `--build-from-source`:
   Show the cache file used when building from source.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -577,16 +577,21 @@ recommended dependency for their stable builds.
 * `--HEAD`:
   Show usage of *`formula`* by HEAD builds.
 
-### `--cache` [*`options`*] [*`formula`*]
+### `--cache` [*`options`*] [<formula/cask>]
 
 Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 
-If *`formula`* is provided, display the file or directory used to cache *`formula`*.
+If <formula/cask> is provided, display the file or directory used to cache
+<formula/cask>.
 
 * `-s`, `--build-from-source`:
   Show the cache file used when building from source.
 * `--force-bottle`:
   Show the cache file used when pouring a bottle.
+* `--formula`:
+  Show cache files for only formulae
+* `--cask`:
+  Show cache files for only casks
 
 ### `--cellar` [*`formula`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -749,11 +749,11 @@ Show usage of \fIformula\fR by development builds\.
 \fB\-\-HEAD\fR
 Show usage of \fIformula\fR by HEAD builds\.
 .
-.SS "\fB\-\-cache\fR [\fIoptions\fR] [<formula/cask>]"
+.SS "\fB\-\-cache\fR [\fIoptions\fR] [\fIformula\fR]"
 Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
 .
 .P
-If <formula/cask> is provided, display the file or directory used to cache <formula/cask>\.
+If \fIformula\fR is provided, display the file or directory used to cache \fIformula\fR\.
 .
 .TP
 \fB\-s\fR, \fB\-\-build\-from\-source\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -749,11 +749,11 @@ Show usage of \fIformula\fR by development builds\.
 \fB\-\-HEAD\fR
 Show usage of \fIformula\fR by HEAD builds\.
 .
-.SS "\fB\-\-cache\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fB\-\-cache\fR [\fIoptions\fR] [<formula/cask>]"
 Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
 .
 .P
-If \fIformula\fR is provided, display the file or directory used to cache \fIformula\fR\.
+If <formula/cask> is provided, display the file or directory used to cache <formula/cask>\.
 .
 .TP
 \fB\-s\fR, \fB\-\-build\-from\-source\fR
@@ -762,6 +762,14 @@ Show the cache file used when building from source\.
 .TP
 \fB\-\-force\-bottle\fR
 Show the cache file used when pouring a bottle\.
+.
+.TP
+\fB\-\-formula\fR
+Show cache files for only formulae
+.
+.TP
+\fB\-\-cask\fR
+Show cache files for only casks
 .
 .SS "\fB\-\-cellar\fR [\fIformula\fR]"
 Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add the ability to reference casks from `brew --cache` and `brew home`. 

`brew --cache <cask>` prints the cask's cached without any prefix.

`brew home <cask>` opens the homepage of the cask in the default browser.

With respect to the tests, I don't think I should reference a cask that exists as part of `homebrew-casks`, yet I cannot figure out how to add a cask such that it can be referenced by name from `Cask::CaskLoader.load`. I currently pass in the path to the `local-caffeine` cask. I'm relatively new to Ruby, so I'm not sure of all the factors in play here, but it appears `tests/cask/cask_spec.rb:32` is able to reference `local-caffeine` without trouble, and I'm interested to learn why.