### PR TITLE
OS::Mac::CPU: add Apple Silicon

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -11,12 +11,16 @@ module Hardware
         case sysctl_int("hw.cputype")
         when 7
           :intel
+        when MachO::Headers::CPU_TYPE_ARM64
+          :arm
         else
           :dunno
         end
       end
 
       def family
+        return :dunno if arm?
+
         case sysctl_int("hw.cpufamily")
         when 0x73d67300 # Yonah: Core Solo/Duo
           :core


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Apple's existing `CPU_TYPE_ARM64` define, used on iOS, also represents ARM64 on Mac.