### PR TITLE
Revert "Enable patchelf.rb for HOMEBREW_DEVELOPERs."

### DIFF
--- a/Library/Homebrew/os/linux/global.rb
+++ b/Library/Homebrew/os/linux/global.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 # enables experimental readelf.rb, patchelf support.
-HOMEBREW_PATCHELF_RB = (ENV["HOMEBREW_PATCHELF_RB"].present? ||
-                        (ENV["HOMEBREW_DEVELOPER"].present? && ENV["HOMEBREW_NO_PATCHELF_RB"].blank?)).freeze
+HOMEBREW_PATCHELF_RB = ENV["HOMEBREW_PATCHELF_RB"].present?.freeze
 
 module Homebrew
   DEFAULT_PREFIX ||= if Homebrew::EnvConfig.force_homebrew_on_linux?


### PR DESCRIPTION
This reverts commit 6106bfc4976dff2b03cf3fadbbf92dd1fd9e0f09.

Fix the error:
```console
$ brew install patchelf
==> Pouring patchelf-0.10.x86_64_linux.bottle.1.tar.gz
Error: cannot load such file -- patchelf
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----