### PR TITLE
mac/hardware: cpu: Use ruby-macho's Intel constant

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -9,7 +9,7 @@ module Hardware
       # Look in <mach/machine.h> for decoding info.
       def type
         case sysctl_int("hw.cputype")
-        when 7
+        when MachO::Headers::CPU_TYPE_I386
           :intel
         when MachO::Headers::CPU_TYPE_ARM64
           :arm


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Replaces the `7` constant with its equivalent in `ruby-macho`. This is more explicit, and is visually consistent with the addition of ARM support in #7793.