### PR TITLE
Use commands cache in bash/fish completions

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -96,8 +96,12 @@ __brew_complete_tapped() {
 
 __brew_complete_commands() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
+  HOMEBREW_CACHE=$(brew --cache)
+  HOMEBREW_REPOSITORY=$(brew --repo)
   # Do not auto-complete "*instal" or "*uninstal" aliases for "*install" commands.
-  local cmds="$(brew commands --quiet --include-aliases | \grep -v instal$)"
+  [[ -f "$HOMEBREW_CACHE/all_commands_list.txt" ]] &&
+    local cmds="$(cat "$HOMEBREW_CACHE/all_commands_list.txt" | \grep -v instal$)" ||
+    local cmds="$(cat "$HOMEBREW_REPOSITORY/completions/internal_commands_list.txt" | \grep -v instal$)"
   COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
 }
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -181,7 +181,11 @@ function __fish_brew_suggest_taps_pinned -d "List only pinned taps"
 end
 
 function __fish_brew_suggest_commands -d "Lists all commands names, including aliases"
-    brew commands --quiet --include-aliases
+    if test -f (brew --cache)/all_commands_list.txt
+        cat (brew --cache)/all_commands_list.txt | \grep -v instal\$
+    else
+        cat (brew --repo)/completions/internal_commands_list.txt | \grep -v instal\$
+    end
 end
 
 # TODO: any better way to list available services?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Builds on #7767 by porting usage of the commands cache to `bash` and `fish`.