### PR TITLE
Add HOMEBREW_DISABLE_LOAD_FORMULA_MESSAGE

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -5,142 +5,142 @@ module Homebrew
     module_function
 
     ENVS = {
-      HOMEBREW_ARCH:                      {
+      HOMEBREW_ARCH:                         {
         description: "Linux only: Pass the set value to a type name representing the compiler's `-march` option.",
         default:     "native",
       },
-      HOMEBREW_ARTIFACT_DOMAIN:           {
+      HOMEBREW_ARTIFACT_DOMAIN:              {
         description: "Prefix all download URLs, including those for bottles, with this " \
                      "variable. For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a " \
                      "formula with the URL `https://example.com/foo.tar.gz` to instead download from " \
                      "`http://localhost:8080/example.com/foo.tar.gz`.",
       },
-      HOMEBREW_AUTO_UPDATE_SECS:          {
+      HOMEBREW_AUTO_UPDATE_SECS:             {
         description: "Automatically check for updates once per this seconds interval.",
         default:     300,
       },
-      HOMEBREW_BAT:                       {
+      HOMEBREW_BAT:                          {
         description: "If set, use `bat` for the `brew cat` command.",
         boolean:     true,
       },
-      HOMEBREW_BAT_CONFIG_PATH:           {
+      HOMEBREW_BAT_CONFIG_PATH:              {
         description:  "Use the `bat` configuration file. For example, `HOMEBREW_BAT=$HOME/.bat/config`.",
         default_text: "$HOME/.bat/config",
       },
-      HOMEBREW_BINTRAY_KEY:               {
+      HOMEBREW_BINTRAY_KEY:                  {
         description: "Use this API key when accessing the Bintray API (where bottles are stored).",
       },
-      HOMEBREW_BINTRAY_USER:              {
+      HOMEBREW_BINTRAY_USER:                 {
         description: "Use this username when accessing the Bintray API (where bottles are stored).",
       },
-      HOMEBREW_BOTTLE_DOMAIN:             {
+      HOMEBREW_BOTTLE_DOMAIN:                {
         description:  "Use the specified URL as the download mirror for bottles. " \
         "For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to " \
         "download from the prefix `http://localhost:8080/`.",
         default_text: "macOS: `https://homebrew.bintray.com/`, Linux: `https://linuxbrew.bintray.com/`.",
         default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,
       },
-      HOMEBREW_BREW_GIT_REMOTE:           {
+      HOMEBREW_BREW_GIT_REMOTE:              {
         description: "Use the specified URL as the Homebrew/brew `git`(1) remote.",
         default:     HOMEBREW_BREW_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_BROWSER:                   {
+      HOMEBREW_BROWSER:                      {
         description:  "Use this as the browser when opening project homepages.",
         default_text: "`$BROWSER` or the OS's default browser.",
       },
-      HOMEBREW_CACHE:                     {
+      HOMEBREW_CACHE:                        {
         description:  "Use the specified directory as the download cache.",
         default_text: "macOS: `$HOME/Library/Caches/Homebrew`, " \
                       "Linux: `$XDG_CACHE_HOME/Homebrew` or `$HOME/.cache/Homebrew`.",
         default:      HOMEBREW_DEFAULT_CACHE,
       },
-      HOMEBREW_CLEANUP_MAX_AGE_DAYS:      {
+      HOMEBREW_CLEANUP_MAX_AGE_DAYS:         {
         description: "Cleanup all cached files older than this many days.",
         default:     120,
       },
-      HOMEBREW_COLOR:                     {
+      HOMEBREW_COLOR:                        {
         description: "If set, force colour output on non-TTY outputs.",
         boolean:     true,
       },
-      HOMEBREW_CORE_GIT_REMOTE:           {
+      HOMEBREW_CORE_GIT_REMOTE:              {
         description:  "Use the specified URL as the Homebrew/homebrew-core `git`(1) remote.",
         default_text: "macOS: `https://github.com/Homebrew/homebrew-core`, " \
                       "Linux: `https://github.com/Homebrew/linuxbrew-core`.",
         default:      HOMEBREW_CORE_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_CURLRC:                    {
+      HOMEBREW_CURLRC:                       {
         description: "If set, do not pass `--disable` when invoking `curl`(1), which disables the " \
                      "use of `curlrc`.",
         boolean:     true,
       },
-      HOMEBREW_CURL_RETRIES:              {
+      HOMEBREW_CURL_RETRIES:                 {
         description: "Pass the given retry count to `--retry` when invoking `curl`(1).",
         default:     3,
       },
-      HOMEBREW_CURL_VERBOSE:              {
+      HOMEBREW_CURL_VERBOSE:                 {
         description: "If set, pass `--verbose` when invoking `curl`(1).",
         boolean:     true,
       },
-      HOMEBREW_DEVELOPER:                 {
+      HOMEBREW_DEVELOPER:                    {
         description: "If set, tweak behaviour to be more relevant for Homebrew developers (active or " \
                      "budding) by e.g. turning warnings into errors.",
         boolean:     true,
       },
-      HOMEBREW_DISABLE_LOAD_FORMULA:      {
+      HOMEBREW_DISABLE_LOAD_FORMULA:         {
         description: "If set, refuse to load formulae. This is useful when formulae are not trusted (such " \
                      "as in pull requests).",
         boolean:     true,
       },
-      HOMEBREW_DISABLE_LOAD_FORMULA_MESSAGE:      {
+      HOMEBREW_DISABLE_LOAD_FORMULA_MESSAGE: {
         description: "If set, Homebrew won't display messages when loading formulae. This is useful when debugging " \
                      "issues not related to loading formulae.",
         boolean:     true,
       },
-      HOMEBREW_DISPLAY:                   {
+      HOMEBREW_DISPLAY:                      {
         description:  "Use this X11 display when opening a page in a browser, for example with " \
                      "`brew home`. Primarily useful on Linux.",
         default_text: "`$DISPLAY`.",
       },
-      HOMEBREW_DISPLAY_INSTALL_TIMES:     {
+      HOMEBREW_DISPLAY_INSTALL_TIMES:        {
         description: "If set, print install times for each formula at the end of the run.",
         boolean:     true,
       },
-      HOMEBREW_EDITOR:                    {
+      HOMEBREW_EDITOR:                       {
         description:  "Use this editor when editing a single formula, or several formulae in the " \
                      "same directory.\n\n    *Note:* `brew edit` will open all of Homebrew as discontinuous files " \
                      "and directories. Visual Studio Code can handle this correctly in project mode, but many " \
                      "editors will do strange things in this case.",
         default_text: "`$EDITOR` or `$VISUAL`.",
       },
-      HOMEBREW_FAIL_LOG_LINES:            {
+      HOMEBREW_FAIL_LOG_LINES:               {
         description: "Output this many lines of output on formula `system` failures.",
         default:     15,
       },
-      HOMEBREW_FORCE_BREWED_CURL:         {
+      HOMEBREW_FORCE_BREWED_CURL:            {
         description: "If set, always use a Homebrew-installed `curl`(1) rather than the system version. " \
                      "Automatically set if the system version of `curl` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_BREWED_GIT:          {
+      HOMEBREW_FORCE_BREWED_GIT:             {
         description: "If set, always use a Homebrew-installed `git`(1) rather than the system version. " \
                      "Automatically set if the system version of `git` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_HOMEBREW_ON_LINUX:   {
+      HOMEBREW_FORCE_HOMEBREW_ON_LINUX:      {
         description: "If set, running Homebrew on Linux will use URLs for macOS. This is useful when merging " \
                      "pull requests for macOS while on Linux.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_VENDOR_RUBY:         {
+      HOMEBREW_FORCE_VENDOR_RUBY:            {
         description: "If set, always use Homebrew's vendored, relocatable Ruby version even if the system version " \
                      "of Ruby is new enough.",
         boolean:     true,
       },
-      HOMEBREW_GITHUB_API_PASSWORD:       {
+      HOMEBREW_GITHUB_API_PASSWORD:          {
         description: "Use this password for authentication with the GitHub API, for features " \
                      "such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.",
       },
-      HOMEBREW_GITHUB_API_TOKEN:          {
+      HOMEBREW_GITHUB_API_TOKEN:             {
         description: "Use this personal access token for the GitHub API, for features such as " \
                      "`brew search`. You can create one at <https://github.com/settings/tokens>. If set, " \
                      "GitHub will allow you a greater number of API requests. For more information, see: " \
@@ -148,28 +148,28 @@ module Homebrew
                      "require permissions for any of the scopes, but some developer commands may require " \
                      "additional permissions.",
       },
-      HOMEBREW_GITHUB_API_USERNAME:       {
+      HOMEBREW_GITHUB_API_USERNAME:          {
         description: "Use this username for authentication with the GitHub API, for features " \
                      "such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.",
       },
-      HOMEBREW_GIT_EMAIL:                 {
+      HOMEBREW_GIT_EMAIL:                    {
         description: "Set the Git author and committer name to this value.",
       },
-      HOMEBREW_GIT_NAME:                  {
+      HOMEBREW_GIT_NAME:                     {
         description: "Set the Git author and committer email to this value.",
       },
-      HOMEBREW_INSTALL_BADGE:             {
+      HOMEBREW_INSTALL_BADGE:                {
         description:  "Print this text before the installation summary of each successful build.",
         default_text: 'The "Beer Mug" emoji.',
-        default:      "🍺",
+        default:      "Ã°ÂÂÂº",
       },
-      HOMEBREW_LOGS:                      {
+      HOMEBREW_LOGS:                         {
         description:  "Use the specified directory to store log files.",
         default_text: "macOS: `$HOME/Library/Logs/Homebrew`, "\
                       "Linux: `$XDG_CACHE_HOME/Homebrew/Logs` or `$HOME/.cache/Homebrew/Logs`.",
         default:      HOMEBREW_DEFAULT_LOGS,
       },
-      HOMEBREW_MAKE_JOBS:                 {
+      HOMEBREW_MAKE_JOBS:                    {
         description:  "Use this value as the number of parallel jobs to run when building with `make`(1).",
         default_text: "The number of available CPU cores.",
         default:      lambda {
@@ -178,64 +178,64 @@ module Homebrew
           Hardware::CPU.cores
         },
       },
-      HOMEBREW_NO_ANALYTICS:              {
+      HOMEBREW_NO_ANALYTICS:                 {
         description: "If set, do not send analytics. See: <https://docs.brew.sh/Analytics>.",
         boolean:     true,
       },
-      HOMEBREW_NO_AUTO_UPDATE:            {
+      HOMEBREW_NO_AUTO_UPDATE:               {
         description: "If set, do not automatically update before running " \
                      "`brew install`, `brew upgrade` or `brew tap`.",
         boolean:     true,
       },
-      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: {
+      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK:    {
         description: "If set, fail on the failure of installation from a bottle rather than " \
                      "falling back to building from source.",
         boolean:     true,
       },
-      HOMEBREW_NO_COLOR:                  {
+      HOMEBREW_NO_COLOR:                     {
         description:  "If set, do not print text with colour added.",
         default_text: "`$NO_COLOR`.",
         boolean:      true,
       },
-      HOMEBREW_NO_COMPAT:                 {
+      HOMEBREW_NO_COMPAT:                    {
         description: "If set, disable all use of legacy compatibility code.",
         boolean:     true,
       },
-      HOMEBREW_NO_EMOJI:                  {
+      HOMEBREW_NO_EMOJI:                     {
         description: "If set, do not print `HOMEBREW_INSTALL_BADGE` on a successful build." \
                      "\n\n    *Note:* Only tries to print emoji on OS X Lion or newer.",
         boolean:     true,
       },
-      HOMEBREW_NO_GITHUB_API:             {
+      HOMEBREW_NO_GITHUB_API:                {
         description: "If set, do not use the GitHub API, e.g. for searches or fetching relevant issues " \
                      "on a failed install.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSECURE_REDIRECT:      {
+      HOMEBREW_NO_INSECURE_REDIRECT:         {
         description: "If set, forbid redirects from secure HTTPS to insecure HTTP." \
                      "\n\n    *Note:* While ensuring your downloads are fully secure, this is likely to cause " \
                      "from-source SourceForge, some GNU & GNOME based formulae to fail to download.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALL_CLEANUP:        {
+      HOMEBREW_NO_INSTALL_CLEANUP:           {
         description: "If set, `brew install`, `brew upgrade` and `brew reinstall` will never automatically " \
                      "cleanup installed/upgraded/reinstalled formulae or all formulae every 30 days.",
         boolean:     true,
       },
-      HOMEBREW_PRY:                       {
+      HOMEBREW_PRY:                          {
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
-      HOMEBREW_SKIP_OR_LATER_BOTTLES:     {
+      HOMEBREW_SKIP_OR_LATER_BOTTLES:        {
         description: "If set with `HOMEBREW_DEVELOPER`, do not use bottles from older versions " \
                      "of macOS. This is useful in development on new macOS versions.",
         boolean:     true,
       },
-      HOMEBREW_SVN:                       {
+      HOMEBREW_SVN:                          {
         description:  "Use this as the `svn`(1) binary.",
         default_text: "A Homebrew-built Subversion (if installed), or the system-provided binary.",
       },
-      HOMEBREW_TEMP:                      {
+      HOMEBREW_TEMP:                         {
         description:  "Use this path as the temporary directory for building packages. Changing " \
                       "this may be needed if your system temporary directory and Homebrew prefix are on " \
                       "different volumes, as macOS has trouble moving symlinks across volumes when the target " \
@@ -244,33 +244,33 @@ module Homebrew
         default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
-      HOMEBREW_UPDATE_TO_TAG:             {
+      HOMEBREW_UPDATE_TO_TAG:                {
         description: "If set, always use the latest stable tag (even if developer commands " \
                      "have been run).",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE:                   {
+      HOMEBREW_VERBOSE:                      {
         description: "If set, always assume `--verbose` when running commands.",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE_USING_DOTS:        {
+      HOMEBREW_VERBOSE_USING_DOTS:           {
         description: "If set, verbose output will print a `.` no more than once a minute. This can be " \
                      "useful to avoid long-running Homebrew commands being killed due to no output.",
         boolean:     true,
       },
-      all_proxy:                          {
+      all_proxy:                             {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      ftp_proxy:                          {
+      ftp_proxy:                             {
         description: "Use this FTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      http_proxy:                         {
+      http_proxy:                            {
         description: "Use this HTTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      https_proxy:                        {
+      https_proxy:                           {
         description: "Use this HTTPS proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      no_proxy:                           {
+      no_proxy:                              {
         description: "A comma-separated list of hostnames and domain names excluded " \
                      "from proxying by `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -91,6 +91,11 @@ module Homebrew
                      "as in pull requests).",
         boolean:     true,
       },
+      HOMEBREW_DISABLE_LOAD_FORMULA_MESSAGE:      {
+        description: "If set, Homebrew won't display messages when loading formulae. This is useful when debugging " \
+                     "issues not related to loading formulae.",
+        boolean:     true,
+      },
       HOMEBREW_DISPLAY:                   {
         description:  "Use this X11 display when opening a page in a browser, for example with " \
                      "`brew home`. Primarily useful on Linux.",

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -132,7 +132,9 @@ module Formulary
     private
 
     def load_file
-      $stderr.puts "#{$PROGRAM_NAME} (#{self.class.name}): loading #{path}" if Homebrew.args.debug?
+      if Homebrew.args.debug? && !Homebrew::EnvConfig.disable_load_formula_message?
+        $stderr.puts "#{$PROGRAM_NAME} (#{self.class.name}): loading #{path}"
+      end
       raise FormulaUnavailableError, name unless path.file?
 
       Formulary.load_formula_from_path(name, path)

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1342,6 +1342,9 @@ Note that environment variables must have a value set to be detected. For exampl
   * `HOMEBREW_DISABLE_LOAD_FORMULA`:
     If set, refuse to load formulae. This is useful when formulae are not trusted (such as in pull requests).
 
+  * `HOMEBREW_DISABLE_LOAD_FORMULA_MESSAGE`:
+    If set, Homebrew won't display messages when loading formulae. This is useful when debugging issues not related to loading formulae.
+
   * `HOMEBREW_DISPLAY`:
     Use this X11 display when opening a page in a browser, for example with `brew home`. Primarily useful on Linux.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1721,6 +1721,10 @@ If set, tweak behaviour to be more relevant for Homebrew developers (active or b
 If set, refuse to load formulae\. This is useful when formulae are not trusted (such as in pull requests)\.
 .
 .TP
+\fBHOMEBREW_DISABLE_LOAD_FORMULA_MESSAGE\fR
+If set, Homebrew won\'t display messages when loading formulae\. This is useful when debugging issues not related to loading formulae\.
+.
+.TP
 \fBHOMEBREW_DISPLAY\fR
 Use this X11 display when opening a page in a browser, for example with \fBbrew home\fR\. Primarily useful on Linux\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I suggest to add a new env. variable to turn off those `brew.rb loading <formula-name>` messages. This should be useful to Homebrew developers working on issues unrelated to the loading step, e.g. `brew livecheck --debug --tap homebrew/core`.