### PR TITLE
Sorbet/files.yaml: Move cmd/home.rb to true

### DIFF
--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -8,14 +8,14 @@ module Homebrew
   module_function
 
   def home_args
-    Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
+    Homebrew::CLI::Parser.new do |p|
+      p.usage_banner <<~EOS
         `home` [<formula>]
 
         Open <formula>'s homepage in a browser, or open Homebrew's own homepage
         if no formula is provided.
       EOS
-      switch :debug
+      p.switch :debug
     end
   end
 

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -5,6 +5,8 @@ require "cask/cask_loader"
 require "cask/exceptions"
 
 module Homebrew
+  include Kernel
+
   module_function
 
   def home_args
@@ -22,10 +24,10 @@ module Homebrew
   def home
     home_args.parse
 
-    if args.no_named?
+    if Homebrew.args.no_named?
       exec_browser HOMEBREW_WWW
     else
-      homepages = args.named.map do |name|
+      homepages = Homebrew.args.named.map do |name|
         f = Formulary.factory(name)
         puts "Opening homepage for formula #{name}"
         f.homepage

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -8,24 +8,24 @@ module Homebrew
   module_function
 
   def home_args
-    Homebrew::CLI::Parser.new do |p|
-      p.usage_banner <<~EOS
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
         `home` [<formula>]
 
         Open <formula>'s homepage in a browser, or open Homebrew's own homepage
         if no formula is provided.
       EOS
-      p.switch :debug
+      switch :debug
     end
   end
 
   def home
     home_args.parse
 
-    if Homebrew.args.no_named?
+    if args.no_named?
       exec_browser HOMEBREW_WWW
     else
-      homepages = Homebrew.args.named.map do |name|
+      homepages = args.named.map do |name|
         f = Formulary.factory(name)
         puts "Opening homepage for formula #{name}"
         f.homepage

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -5,8 +5,6 @@ require "cask/cask_loader"
 require "cask/exceptions"
 
 module Homebrew
-  include Kernel
-
   module_function
 
   def home_args

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -63,6 +63,8 @@ require "os"
 require "os/global"
 
 module Homebrew
+  include Kernel
+
   extend FileUtils
 
   DEFAULT_PREFIX ||= HOMEBREW_DEFAULT_PREFIX

--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -101,7 +101,6 @@ false:
   - ./cmd/fetch.rb
   - ./cmd/gist-logs.rb
   - ./cmd/help.rb
-  - ./cmd/home.rb
   - ./cmd/info.rb
   - ./cmd/install.rb
   - ./cmd/leaves.rb
@@ -860,6 +859,7 @@ true:
   - ./cask/macos.rb
   - ./cask/url.rb
   - ./checksum.rb
+  - ./cmd/home.rb
   - ./config.rb
   - ./extend/cachable.rb
   - ./extend/os/linux/development_tools.rb

--- a/Library/Homebrew/sorbet/rbi/homebrew.rbi
+++ b/Library/Homebrew/sorbet/rbi/homebrew.rbi
@@ -1,30 +1,33 @@
 # typed: strict
 
 module Homebrew
-  sig { params(blk: T.untyped(T.proc.bind(Homebrew::CLI::Parser).void)).returns(Homebrew::CLI::Parser) }
-  def home_args(&blk)
+  def home_args()
   end
 
   sig { void }
   def home
   end
 
-  module CLI
-    class Parser
-      sig {override.params(names: T.untyped, description: T.untyped, env: T.untyped, required_for: T.untyped, depends_on: T.untyped).void}
-      def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil); end
-    end
+  def args
   end
-end
 
-module Homebrew
   module CLI
     class Parser
-      extend T::Helpers
-      abstract!
 
-      sig {abstract.params(names: T.untyped, description: T.untyped, env: T.untyped, required_for: T.untyped, depends_on: T.untyped).void}
+      sig do
+        params(
+          names: T::Array[String],
+          description: T.nilable(String),
+          env: T.nilable(String),
+          required_for: T.nilable(String),
+          depends_on: T.nilable(String),
+        )
+        .void
+      end
       def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil); end
+
+      sig {params(text: String).void}
+      def usage_banner(text); end
     end
   end
 end

--- a/Library/Homebrew/sorbet/rbi/homebrew.rbi
+++ b/Library/Homebrew/sorbet/rbi/homebrew.rbi
@@ -1,7 +1,7 @@
 # typed: strict
 
 module Homebrew
-  sig { params(blk: T.nilable(T.proc.bind(Homebrew::CLI::Parser).void)).returns(Homebrew::CLI::Parser) }
+  sig { params(blk: T.untyped(T.proc.bind(Homebrew::CLI::Parser).void)).returns(Homebrew::CLI::Parser) }
   def home_args(&blk)
   end
 
@@ -11,9 +11,20 @@ module Homebrew
 
   module CLI
     class Parser
+      sig {override.params(names: T.untyped, description: T.untyped, env: T.untyped, required_for: T.untyped, depends_on: T.untyped).void}
+      def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil); end
+    end
+  end
+end
 
-      def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil)
-      end
+module Homebrew
+  module CLI
+    class Parser
+      extend T::Helpers
+      abstract!
+
+      sig {abstract.params(names: T.untyped, description: T.untyped, env: T.untyped, required_for: T.untyped, depends_on: T.untyped).void}
+      def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil); end
     end
   end
 end

--- a/Library/Homebrew/sorbet/rbi/homebrew.rbi
+++ b/Library/Homebrew/sorbet/rbi/homebrew.rbi
@@ -1,0 +1,19 @@
+# typed: strict
+
+module Homebrew
+  sig { params(blk: T.nilable(T.proc.bind(Homebrew::CLI::Parser).void)).returns(Homebrew::CLI::Parser) }
+  def home_args(&blk)
+  end
+
+  sig { void }
+  def home
+  end
+
+  module CLI
+    class Parser
+
+      def switch(*names, description: nil, env: nil, required_for: nil, depends_on: nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
[WIP] Setting `typed` to `true` for `cmd/home.rb` has introduced 10 new type errors. Prior to this, only 13 syntax related errors were being reported by Sorbet. This PR aims to resolve all of the new type errors. For now I've used very redundant fixes for the type errors. The next few days, I will be discussing more feasible workarounds with my mentors and implementing them in this draft PR.