### PR TITLE
RuboCop string_content keep string interpolation

### DIFF
--- a/Library/Homebrew/rubocops/extend/formula.rb
+++ b/Library/Homebrew/rubocops/extend/formula.rb
@@ -495,7 +495,15 @@ module RuboCop
         when :str
           node.str_content
         when :dstr
-          node.each_child_node(:str).map(&:str_content).join
+          content = ""
+          node.each_child_node(:str, :begin) do |child|
+            content += if child.begin_type?
+              child.source
+            else
+              child.str_content
+            end
+          end
+          content
         when :const
           node.const_name
         when :sym


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Before, on a node like `"#{bin}/foo bar"`, `string_content` would return `"/foo bar"` and ignore the string interpolation.

An example of why this could be problematic:

```ruby
Utils.safe_popen_read("SHELL=bash #{bin}/foo bar")
```

`brew style output`:

```
Use Utils.safe_popen_read({ "SHELL" => "bash" }, "/foo bar") instead of Utils.safe_popen_read("SHELL=bash #{bin}/foo bar")
```

The `#{bin}` is cut off in the suggested text. This also means that running `brew style --fix` will change the line to `"/foo bar"` instead of `"#{bin}/foo/bar"`