### PR TITLE
Use CodeCov for coverage reporting.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,8 +139,7 @@ jobs:
         HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         # set variables for coverage reporting
-        HOMEBREW_CI_NAME: github-actions
-        HOMEBREW_COVERALLS_REPO_TOKEN: 3F6U6ZqctoNJwKyREremsqMgpU3qYgxFk
+        HOMEBREW_CODECOV_TOKEN: 3ea0364c-80ce-47a3-9fba-93a940d4b5d7
 
         # These cannot be queried at the macOS level on GitHub Actions.
         HOMEBREW_LANGUAGES: en-GB

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@
 **/vendor/bundle/ruby/*/gems/byebug-*/
 **/vendor/bundle/ruby/*/gems/coderay-*/
 **/vendor/bundle/ruby/*/gems/connection_pool-*/
-**/vendor/bundle/ruby/*/gems/coveralls-*/
+**/vendor/bundle/ruby/*/gems/codecov-*/
 **/vendor/bundle/ruby/*/gems/diff-lcs-*/
 **/vendor/bundle/ruby/*/gems/docile-*/
 **/vendor/bundle/ruby/*/gems/domain_name-*/
@@ -127,11 +127,8 @@
 **/vendor/bundle/ruby/*/gems/ruby-prof-*/
 **/vendor/bundle/ruby/*/gems/ruby-progressbar-*/
 **/vendor/bundle/ruby/*/gems/simplecov-*/
-**/vendor/bundle/ruby/*/gems/simplecov-cobertura-*/
 **/vendor/bundle/ruby/*/gems/simplecov-html-*/
-**/vendor/bundle/ruby/*/gems/term-ansicolor-*/
-**/vendor/bundle/ruby/*/gems/thor-*/
-**/vendor/bundle/ruby/*/gems/tins-*/
+**/vendor/bundle/ruby/*/gems/url-*/
 **/vendor/bundle/ruby/*/gems/unf_ext-*/
 **/vendor/bundle/ruby/*/gems/unf-*/
 **/vendor/bundle/ruby/*/gems/unicode-display_width-*/

--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "English"
 
@@ -20,7 +21,8 @@ SimpleCov.start do
 
       # Just save result, but don't write formatted output.
       coverage_result = Coverage.result
-      SimpleCov.add_not_loaded_files(coverage_result)
+      # TODO: this method is private, find a better way.
+      SimpleCov.send(:add_not_loaded_files, coverage_result)
       simplecov_result = SimpleCov::Result.new(coverage_result)
       SimpleCov::ResultMerger.store_result(simplecov_result)
 
@@ -50,8 +52,8 @@ SimpleCov.start do
 
   require "rbconfig"
   host_os = RbConfig::CONFIG["host_os"]
-  add_filter %r{/os/mac} if host_os !~ /darwin/
-  add_filter %r{/os/linux} if host_os !~ /linux/
+  add_filter %r{/os/mac} unless /darwin/.match?(host_os)
+  add_filter %r{/os/linux} unless /linux/.match?(host_os)
 
   # Add groups and the proper project name to the output.
   project_name "Homebrew"

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 # installed gems
 gem "byebug"
-gem "coveralls", "~> 0.8", require: false
+gem "codecov", require: false
 gem "parallel_tests"
 gem "ronn", require: false
 gem "rspec"

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -9,14 +9,12 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
     byebug (11.1.3)
+    codecov (0.1.17)
+      json
+      simplecov
+      url
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     diff-lcs (1.4.4)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -99,24 +97,18 @@ GEM
       rubocop (>= 0.68.1)
     ruby-macho (2.2.0)
     ruby-progressbar (1.10.1)
-    simplecov (0.16.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
-    sync (0.5.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
-    thor (1.0.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     thread_safe (0.3.6)
-    tins (1.25.0)
-      sync
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    url (0.3.2)
     webrobots (0.1.2)
     zeitwerk (2.3.1)
 
@@ -126,8 +118,8 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   byebug
+  codecov
   concurrent-ruby
-  coveralls (~> 0.8)
   mechanize
   parallel_tests
   plist
@@ -143,4 +135,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -4,12 +4,10 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
   require "simplecov"
 
   formatters = [SimpleCov::Formatter::HTMLFormatter]
-  if ENV["HOMEBREW_COVERALLS_REPO_TOKEN"] && RUBY_PLATFORM[/darwin/]
-    require "coveralls"
+  if ENV["HOMEBREW_CODECOV_TOKEN"] && RUBY_PLATFORM[/darwin/]
+    require "codecov"
 
-    Coveralls::Output.no_color if !ENV["HOMEBREW_COLOR"] && (ENV["HOMEBREW_NO_COLOR"] || !$stdout.tty?)
-
-    formatters << Coveralls::SimpleCov::Formatter
+    formatters << SimpleCov::Formatter::Codecov
 
     if ENV["TEST_ENV_NUMBER"]
       SimpleCov.at_exit do
@@ -18,16 +16,7 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
       end
     end
 
-    ENV["CI_NAME"] = ENV["HOMEBREW_CI_NAME"]
-    ENV["COVERALLS_REPO_TOKEN"] = ENV["HOMEBREW_COVERALLS_REPO_TOKEN"]
-
-    ENV["CI_BUILD_NUMBER"] = ENV["HOMEBREW_CI_BUILD_NUMBER"]
-    ENV["CI_BRANCH"] = ENV["HOMEBREW_CI_BRANCH"]
-    %r{refs/pull/(?<pr>\d+)/merge} =~ ENV["HOMEBREW_CI_BUILD_NUMBER"]
-    ENV["CI_PULL_REQUEST"] = pr
-    ENV["CI_BUILD_URL"] = "https://github.com/#{ENV["HOMEBREW_GITHUB_REPOSITORY"]}/pull/#{pr}/checks"
-
-    ENV["CI_JOB_ID"] = ENV["TEST_ENV_NUMBER"] || "1"
+    ENV["CODECOV_TOKEN"] = ENV["HOMEBREW_CODECOV_TOKEN"]
   end
 
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)


### PR DESCRIPTION
An alternate solution to https://github.com/Homebrew/brew/pull/7827. We used to use them and then bailed due to lack of Azure Pipelines support. Looks like they support both Azure and GitHub Actions now and their gem seems significantly better maintained than Coveralls at this point.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----