### PR TITLE
software_spec: do not add empty resources

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -115,6 +115,8 @@ class SoftwareSpec
       raise DuplicateResourceError, name if resource_defined?(name)
 
       res = klass.new(name, &block)
+      return unless res.url
+
       resources[name] = res
       dependency_collector.add(res)
     else


### PR DESCRIPTION
Empty resources are allowed to exist under the following form:

```
resource "filelock" do
  on_linux do
      url "https://files.pythonhosted.org/packages/14/ec/6ee2168387ce0154632f856d5cc5592328e9cf93127c5c9aeca92c8c16cb/filelock-3.0.12.tar.gz"
      sha256 "18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"
  end
end
```

In this case (or for the on_macos only resource case), just ignore the resource block.

Fixes:
```
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:148:in `resource_dep'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:99:in `parse_spec'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:53:in `build'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:40:in `block in fetch'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:40:in `fetch'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:40:in `fetch'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:30:in `add'
/usr/local/Homebrew/Library/Homebrew/software_spec.rb:120:in `resource'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2439:in `block in resource'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2438:in `each'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2438:in `resource'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/aws-google-auth.rb:149:in `<class:AwsGoogleAuth>'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/aws-google-auth.rb:1:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:38:in `rescue in load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:35:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:56:in `load_formula_from_path'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:138:in `load_file'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:128:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:124:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:333:in `factory'
/usr/local/Homebrew/Library/Homebrew/cli/args.rb:87:in `block in formulae'
/usr/local/Homebrew/Library/Homebrew/cli/args.rb:86:in `map'
/usr/local/Homebrew/Library/Homebrew/cli/args.rb:86:in `formulae'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:133:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:111:in `<main>'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
