### PR TITLE
style: enforce ISO-8601 in deprecation date

### DIFF
--- a/Library/Homebrew/rubocops.rb
+++ b/Library/Homebrew/rubocops.rb
@@ -22,5 +22,6 @@ require "rubocops/uses_from_macos"
 require "rubocops/files"
 require "rubocops/keg_only"
 require "rubocops/version"
+require "rubocops/deprecate"
 
 require "rubocops/rubocop-cask"

--- a/Library/Homebrew/rubocops/deprecate.rb
+++ b/Library/Homebrew/rubocops/deprecate.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rubocops/extend/formula"
+
+module RuboCop
+  module Cop
+    module FormulaAudit
+      # This cop audits deprecate!
+      class Deprecate < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          deprecate_node = find_node_method_by_name(body_node, :deprecate!)
+
+          return if deprecate_node.nil? || deprecate_node.children.length < 3
+
+          date_node = find_strings(deprecate_node).first
+
+          begin
+            Date.iso8601(string_content(date_node))
+          rescue ArgumentError
+            fixed_date_string = Date.parse(string_content(date_node)).iso8601
+            offending_node(date_node)
+            problem "Use `#{fixed_date_string}` to comply with ISO 8601"
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            fixed_fixed_date_string = Date.parse(string_content(node)).iso8601
+            corrector.replace(node.source_range, "\"#{fixed_fixed_date_string}\"")
+          end
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/rubocops/deprecate_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rubocops/deprecate"
+
+describe RuboCop::Cop::FormulaAudit::Deprecate do
+  subject(:cop) { described_class.new }
+
+  context "When auditing formula for deprecate!" do
+    it "deprecation date is not ISO-8601 compliant" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! :date => "June 25, 2020"
+                              ^^^^^^^^^^^^^^^ Use `2020-06-25` to comply with ISO 8601
+        end
+      RUBY
+    end
+
+    it "deprecation date is ISO-8601 compliant" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! :date => "2020-06-25"
+        end
+      RUBY
+    end
+
+    it "no deprecation date" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate!
+        end
+      RUBY
+    end
+
+    it "auto corrects to ISO-8601 format" do
+      source = <<~RUBY
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! :date => "June 25, 2020"
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! :date => "2020-06-25"
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add RuboCop check to make sure `deprecate!` date is ISO-8601 compliant

Corresponding homebrew-core PR: https://github.com/Homebrew/homebrew-core/pull/56903