### PR TITLE
cmd/options: add flag to list a command's options

### DIFF
--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -3,6 +3,7 @@
 require "formula"
 require "options"
 require "cli/parser"
+require "commands"
 
 module Homebrew
   module_function
@@ -20,8 +21,10 @@ module Homebrew
              description: "Show options for formulae that are currently installed."
       switch "--all",
              description: "Show options for all available formulae."
+      flag   "--command=",
+             description: "Show options for the specified <command>."
       switch :debug
-      conflicts "--installed", "--all"
+      conflicts "--installed", "--all", "--command"
     end
   end
 
@@ -32,11 +35,41 @@ module Homebrew
       puts_options Formula.to_a.sort
     elsif args.installed?
       puts_options Formula.installed.sort
+    elsif !args.command.nil?
+      path = Commands.path(args.command)
+      odie "Unknown command: #{args.command}" unless path
+      cmd_options = if cmd_parser = CLI::Parser.from_cmd_path(path)
+        cmd_parser.processed_options.map do |short, long, _, desc|
+          [long || short, desc]
+        end
+      else
+        cmd_comment_options(path)
+      end
+      if args.compact?
+        puts cmd_options.sort.map(&:first) * " "
+      else
+        cmd_options.sort.each { |option, desc| puts "#{option}\n\t#{desc}" }
+        puts
+      end
     elsif args.no_named?
       raise FormulaUnspecifiedError
     else
       puts_options args.formulae
     end
+  end
+
+  def cmd_comment_options(cmd_path)
+    options = []
+    comment_lines = cmd_path.read.lines.grep(/^#:/)
+    return options if comment_lines.empty?
+
+    # skip the comment's initial usage summary lines
+    comment_lines.slice(2..-1).each do |line|
+      if / (?<option>-[-\w]+) +(?<desc>.*)$/ =~ line
+        options << [option, desc]
+      end
+    end
+    options
   end
 
   def puts_options(formulae)

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -340,6 +340,8 @@ Show install options specific to *`formula`*.
   Show options for formulae that are currently installed.
 * `--all`:
   Show options for all available formulae.
+* `--command`:
+  Show options for the specified *`command`*.
 
 ### `outdated` [*`options`*] [*`formula`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -456,6 +456,10 @@ Show options for formulae that are currently installed\.
 \fB\-\-all\fR
 Show options for all available formulae\.
 .
+.TP
+\fB\-\-command\fR
+Show options for the specified \fIcommand\fR\.
+.
 .SS "\fBoutdated\fR [\fIoptions\fR] [\fIformula\fR]"
 List installed formulae that have an updated version available\. By default, version information is displayed in interactive shells, and suppressed otherwise\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Add a flag to `brew options` for listing a command's options and descriptions. This will be useful later for keeping shell completion files up to date.

Sample output:
```
$ brew options --command cleanup --compact
--debug --dry-run --prune --prune-prefix --verbose -s

$ brew options --command cleanup
--debug
	Display any debugging information.
--dry-run
	Show what would be removed, but do not actually remove anything.
--prune
	Remove all cache files older than specified <days>.
--prune-prefix
	Only prune the symlinks and directories from the prefix and remove no other files.
--verbose
	Make some output more verbose.
-s
	Scrub the cache, including downloads for even the latest versions. Note downloads for any installed formulae or casks will still not be deleted. If you want to delete those too: `rm -rf "$(brew --cache)"`

$ brew options --command update
--debug
	Display a trace of all shell commands as they are executed.
--force
	Always do a slower, full update check (even if unnecessary).
--help
	Show this message.
--merge
	Use `git merge` to apply updates (rather than `git rebase`).
--verbose
	Print the directories checked and `git` operations performed.
```