### PR TITLE
Remove hyphen in ISO 8601 in rubocops/deprecate_spec.rb

### DIFF
--- a/Library/Homebrew/test/rubocops/deprecate_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::FormulaAudit::Deprecate do
   subject(:cop) { described_class.new }
 
   context "When auditing formula for deprecate!" do
-    it "deprecation date is not ISO-8601 compliant" do
+    it "deprecation date is not ISO 8601 compliant" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -16,7 +16,7 @@ describe RuboCop::Cop::FormulaAudit::Deprecate do
       RUBY
     end
 
-    it "deprecation date is ISO-8601 compliant" do
+    it "deprecation date is ISO 8601 compliant" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -34,7 +34,7 @@ describe RuboCop::Cop::FormulaAudit::Deprecate do
       RUBY
     end
 
-    it "auto corrects to ISO-8601 format" do
+    it "auto corrects to ISO 8601 format" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Correct `ISO-8601` to `ISO 8601` in the `rubocops/deprecate` test.

CC: @reitermarkus 