### PR TITLE
pr-pull: add commit message trailers for pull requests with approved reviews

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -42,6 +42,13 @@ describe GitHub do
     end
   end
 
+  describe "::approved_reviews", :needs_network do
+    it "can get reviews for a pull request" do
+      reviews = subject.approved_reviews("Homebrew", "homebrew-core", 1, commit: "deadbeef")
+      expect(reviews).to eq([])
+    end
+  end
+
   describe "::get_artifact_url", :needs_network do
     it "fails to find a nonexistant workflow" do
       expect {

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -394,6 +394,52 @@ module GitHub
     open_api(uri) { |json| json.fetch("items", []) }
   end
 
+  def approved_reviews(user, repo, pr, commit: nil)
+    url = "https://api.github.com/graphql"
+    data = {
+      query: <<~EOS,
+        { repository(name: "#{repo}", owner: "#{user}") {
+            pullRequest(number: #{pr}) {
+              reviews(states: APPROVED, first: 100) {
+                nodes {
+                  author {
+                    ... on User { email login name databaseId }
+                    ... on Organization { email login name databaseId }
+                  }
+                  authorAssociation
+                  commit { oid }
+                }
+              }
+            }
+          }
+        }
+      EOS
+    }
+    result = open_api(url, data: data, request_method: "POST")
+    raise Error, result["errors"] if result["errors"].present?
+
+    reviews = result["data"]["repository"]["pullRequest"]["reviews"]["nodes"]
+
+    reviews.map do |r|
+      next if commit.present? && commit != r["commit"]["oid"]
+      next unless %w[MEMBER OWNER].include? r["authorAssociation"]
+
+      email = if r["author"]["email"].empty?
+        "#{r["author"]["databaseId"]}+#{r["author"]["login"]}@users.noreply.github.com"
+      else
+        r["author"]["email"]
+      end
+
+      name = r["author"]["name"] || r["author"]["login"]
+
+      {
+        "email" => email,
+        "name"  => name,
+        "login" => r["author"]["login"],
+      }
+    end.compact
+  end
+
   def dispatch_event(user, repo, event, **payload)
     url = "#{API_URL}/repos/#{user}/#{repo}/dispatches"
     open_api(url, data:           { event_type: event, client_payload: payload },

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -424,13 +424,13 @@ module GitHub
       next if commit.present? && commit != r["commit"]["oid"]
       next unless %w[MEMBER OWNER].include? r["authorAssociation"]
 
-      email = if r["author"]["email"].empty?
+      email = if r["author"]["email"].blank?
         "#{r["author"]["databaseId"]}+#{r["author"]["login"]}@users.noreply.github.com"
       else
         r["author"]["email"]
       end
 
-      name = r["author"]["name"] || r["author"]["login"]
+      name = r["author"]["name"].presence || r["author"]["login"]
 
       {
         "email" => email,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Prior to the suite of new `pr-*` commands, a core maintainer who merged a pull request via the `brew pull` command would have their information added to a commit via a `Signed-off-by` trailer. (This still happens if a maintainer runs `brew pr-pull` on their own machine and the `git push`es the result, e.g. https://github.com/Homebrew/homebrew-core/commit/1143c8a2e88b9cd595fd27fe78417874d6778ff1)

Currently, however, if you let BrewTestBot automerge a pull request by writing an approving review, that approval is lost during the merge process. This is undesireable from both a "provenance" and a "crediting contributors" perspective.

This pull request addresses the situation by adding a new `Approved-by` trailer when running `brew pr-pull`, which uses the GitHub API to get a list of approving reviews for the pull request in question. For example, [this pull request](https://github.com/Homebrew/homebrew-core/pull/56952) and [subsequent commit message](https://github.com/Homebrew/homebrew-core/commit/7a33609c2bfeca9870d57f75e9358667cf12e766) would have instead been merged as:

```
mame 0.222

Closes #56952.

Approved-by: Sean Molenaar <1484494+SMillerDev@users.noreply.github.com>
Signed-off-by: BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>
```

Pinging @Homebrew/core for thoughts, especially on two issues:

1. This pull request restricts the list of who will be added to the trailers to members of the Homebrew organization. Should this be expanded to anyone who has contributed to Homebrew, or everyone? ([Currently this is restricted to `MEMBER` and `OWNER` associations](https://developer.github.com/v4/enum/commentauthorassociation/))

2. Do we want `Approved-by` or something else, like `Signed-off-by`? The [Linux kernel uses `Reviewed-by`](https://github.com/torvalds/linux/blob/1590a2e1c681b0991bd42c992cabfd380e0338f2/Documentation/process/submitting-patches.rst#13-using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes) for something similar, though I note we don't use `Signed-off-by` in the same way as the kernel either.

It would also be great if a few maintainers tested this with `brew pr-pull` on a pull request, just in case I missed something when testing it myself.