### PR TITLE
version: add empty? method

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -173,6 +173,16 @@ describe Version do
     expect(versions.sort_by { |v| described_class.create(v) }).to eq(versions)
   end
 
+  describe "#empty?" do
+    it "returns true if version is empty" do
+      expect(described_class.create("").empty?).to eq(true)
+    end
+
+    it "returns false if version is not empty" do
+      expect(described_class.create("1.2.3").empty?).to eq(false)
+    end
+  end
+
   specify "hash equality" do
     v1 = described_class.create("0.1.0")
     v2 = described_class.create("0.1.0")

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -429,6 +429,10 @@ class Version
   end
   alias eql? ==
 
+  def empty?
+    version.empty?
+  end
+
   def hash
     version.hash
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In livecheck, we currently have some code that compares a given `Version` to an empty version like this:

```ruby
empty_version = Version.new("")
match_version_map.delete_if do |_match, version|
  next true if version == empty_version
```

It was suggested that we could refactor this to the following instead:

```ruby
match_version_map.delete_if do |_match, version|
  next true if version.to_s.empty?
```

The goal here is to check if a `Version` is empty, so I figured it would be ideal if we could just do `version.empty?`. If this isn't an appropriate addition, I'm fine with closing this but I thought there may be some value here (i.e., not having to allocate an extra string just to use `empty?`).

Otherwise, if there are more appropriate locations for the code additions in `version.rb` and `version_spec.rb`, please let me know and I'll update this.

Edit: I had originally added both `blank?` and `empty?` methods but I learned that if you add `empty?` you automatically get `blank?` for free, so I updated this accordingly.