### PR TITLE
Allow missing libraries

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -7,11 +7,37 @@ class Formula
     "#{name}.so#{"." unless version.nil?}#{version}"
   end
 
+  undef allowed_missing_lib?
+  def allowed_missing_lib?(lib)
+    # lib:   Full path to the missing library
+    #        Ex.: /home/linuxbrew/.linuxbrew/lib/libsomething.so.1
+    # x -    Name of or a pattern for a library, linkage to which is allowed to be missing.
+    #        Ex. 1: "libONE.so.1"
+    #        Ex. 2: %r{(libONE|libTWO)\.so}
+    self.class.allowed_missing_libraries.any? do |x|
+      if x.is_a? Regexp
+        x.match? lib
+      elsif x.is_a? String
+        lib.include? x
+      end
+    end
+  end
+
   class << self
     undef on_linux
 
     def on_linux(&_block)
       yield
+    end
+
+    def ignore_missing_libraries(*libs)
+      libs.flatten!
+      allowed_missing_libraries.merge(libs)
+    end
+
+    # @private
+    def allowed_missing_libraries
+      @allowed_missing_libraries ||= Set.new
     end
   end
 end

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -15,9 +15,10 @@ class Formula
     #        Ex. 1: "libONE.so.1"
     #        Ex. 2: %r{(libONE|libTWO)\.so}
     self.class.allowed_missing_libraries.any? do |x|
-      if x.is_a? Regexp
+      case x
+      when Regexp
         x.match? lib
-      elsif x.is_a? String
+      when String
         lib.include? x
       end
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1131,6 +1131,13 @@ class Formula
     end
   end
 
+  # Whether this {Formula} is allowed to have broken linkage.
+  # Defaults to false.
+  # @return [Boolean]
+  def allow_missing_libs?
+    false
+  end
+
   # Whether this {Formula} is deprecated (i.e. warns on installation).
   # Defaults to false.
   # @method deprecated?
@@ -2594,6 +2601,10 @@ class Formula
     # @private
     def skip_clean_paths
       @skip_clean_paths ||= Set.new
+    end
+
+    def allow_missing_libs
+      define_method(:allow_missing_libs?) { true }
     end
 
     # Software that will not be symlinked into the `brew --prefix` will only

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1131,10 +1131,10 @@ class Formula
     end
   end
 
-  # Whether this {Formula} is allowed to have broken linkage.
+  # Whether this {Formula} is allowed to have a broken linkage to specified library.
   # Defaults to false.
   # @return [Boolean]
-  def allow_missing_libs?
+  def allowed_missing_lib?(*)
     false
   end
 
@@ -2601,10 +2601,6 @@ class Formula
     # @private
     def skip_clean_paths
       @skip_clean_paths ||= Set.new
-    end
-
-    def allow_missing_libs
-      define_method(:allow_missing_libs?) { true }
     end
 
     # Software that will not be symlinked into the `brew --prefix` will only

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -59,14 +59,20 @@ class LinkageChecker
     display_items "Broken dependencies", @broken_deps, puts_output: puts_output
     display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
     display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
-    puts "No broken library linkage" unless broken_library_linkage?
+    if got_library_issues?
+      puts "Broken library linkage ignored" if @formula.allow_missing_libs?
+    else
+      puts "No broken library linkage"
+    end
   end
 
   def broken_library_linkage?
-    !@broken_dylibs.empty? ||
-      !@broken_deps.empty? ||
-      !@unwanted_system_dylibs.empty? ||
-      !@version_conflict_deps.empty?
+    !@formula.allow_missing_libs? && got_library_issues?
+  end
+
+  def got_library_issues?
+    issues = [@broken_dylibs, @broken_deps, @unwanted_system_dylibs, @version_conflict_deps]
+    issues.any?(&:present?)
   end
 
   private

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -55,24 +55,35 @@ class LinkageChecker
   end
 
   def display_test_output(puts_output: true)
-    display_items "Missing libraries", @broken_dylibs, puts_output: puts_output
+    display_items "Missing libraries", broken_dylibs_with_expectations, puts_output: puts_output
     display_items "Broken dependencies", @broken_deps, puts_output: puts_output
     display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
     display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
-    if got_library_issues?
-      puts "Broken library linkage ignored" if @formula.allow_missing_libs?
+
+    if @broken_dylibs.empty?
+      puts "No broken library linkage detected"
+    elsif unexpected_broken_libs.empty?
+      puts "No unexpected broken library linkage detected."
     else
-      puts "No broken library linkage"
+      puts "Broken library linkage detected"
     end
   end
 
   def broken_library_linkage?
-    !@formula.allow_missing_libs? && got_library_issues?
+    issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps]
+    [issues, unexpected_broken_libs].flatten.any?(&:present?)
   end
 
-  def got_library_issues?
-    issues = [@broken_dylibs, @broken_deps, @unwanted_system_dylibs, @version_conflict_deps]
-    issues.any?(&:present?)
+  def unexpected_broken_libs
+    @broken_dylibs.reject { |lib| @formula.allowed_missing_lib? lib }
+  end
+
+  def broken_dylibs_with_expectations
+    output = {}
+    @broken_dylibs.each do |lib|
+      output[lib] = (unexpected_broken_libs.include? lib) ? ["unexpected"] : ["expected"]
+    end
+    output
   end
 
   private


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This enables formula creators/editors to say that the formula can have broken linkage by adding `allow_missing_libs` to the formula definition.
Things to consider:
1. Shall this be a bit more precise and affect `broken_dylibs` only?
2. Shall this be always `false` on a Mac and define `allow_missing_libs` on Linux only (under `extend/os/linux/linkage_checker`)?

CC @sjackman @iMichka 