### PR TITLE
on_os resources: allow linux-only or mac-only resources

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -103,6 +103,27 @@ module RuboCop
             @offensive_node = resource_block
             @offense_source_range = resource_block.source_range
 
+            next if on_macos_blocks.length.zero? && on_linux_blocks.length.zero?
+
+            if on_macos_blocks.length == 1
+              on_macos_block = on_macos_blocks.first
+              child_nodes = on_macos_block.body.child_nodes
+              if child_nodes[0].method_name.to_s != "url" && child_nodes[1].method_name.to_s != "sha256"
+                problem "only an url and a sha256 (in the right order) are allowed in a `on_macos` " \
+                        "block within a resource block."
+                next
+              end
+            end
+
+            if on_linux_blocks.length == 1
+              on_linux_block = on_linux_blocks.first
+              child_nodes = on_linux_block.body.child_nodes
+              if child_nodes[0].method_name.to_s != "url" && child_nodes[1].method_name.to_s != "sha256"
+                problem "only an url and a sha256 (in the right order) are allowed in a `on_linux` " \
+                        "block within a resource block."
+              end
+            end
+
             if on_macos_blocks.length > 1
               problem "there can only be one `on_macos` block in a resource block."
               next
@@ -111,32 +132,6 @@ module RuboCop
             if on_linux_blocks.length > 1
               problem "there can only be one `on_linux` block in a resource block."
               next
-            end
-
-            if on_macos_blocks.length == 1 && on_linux_blocks.length.zero?
-              problem "you need to define an `on_linux` block within your resource block."
-              next
-            end
-
-            if on_macos_blocks.length.zero? && on_linux_blocks.length == 1
-              problem "you need to define an `on_macos` block within your resource block."
-              next
-            end
-
-            on_macos_block = on_macos_blocks.first
-            on_linux_block = on_linux_blocks.first
-
-            child_nodes = on_macos_block.body.child_nodes
-            if child_nodes[0].method_name.to_s != "url" && child_nodes[1].method_name.to_s != "sha256"
-              problem "only an url and a sha256 (in the right order) are allowed in a `on_macos` " \
-                      "block within a resource block."
-              next
-            end
-
-            child_nodes = on_linux_block.body.child_nodes
-            if child_nodes[0].method_name.to_s != "url" && child_nodes[1].method_name.to_s != "sha256"
-              problem "only an url and a sha256 (in the right order) are allowed in a `on_linux` " \
-                      "block within a resource block."
             end
           end
         end

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -435,12 +435,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     end
 
     it "there is a on_macos block but no on_linux block" do
-      expect_offense(<<~RUBY)
+      expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
-
           resource do
-          ^^^^^^^^^^^ you need to define an `on_linux` block within your resource block.
             on_macos do
               url "https://brew.sh/resource1.tar.gz"
               sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -451,12 +449,10 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     end
 
     it "there is a on_linux block but no on_macos block" do
-      expect_offense(<<~RUBY)
+      expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
-
           resource do
-          ^^^^^^^^^^^ you need to define an `on_macos` block within your resource block.
             on_linux do
               url "https://brew.sh/resource1.tar.gz"
               sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"


### PR DESCRIPTION
This is now allowed since #7833 has been fixed.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
