### PR TITLE
github: need read-only email scope to see emails

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -413,7 +413,7 @@ module GitHub
         }
       EOS
     }
-    result = open_api(url, data: data, request_method: "POST")
+    result = open_api(url, scopes: ["user:email"], data: data, request_method: "POST")
     raise Error, result["errors"] if result["errors"].present?
 
     reviews = result["data"]["repository"]["pullRequest"]["reviews"]["nodes"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Commits [like this one](https://github.com/Homebrew/homebrew-core/commit/a5188af7d7188acad2efb7dff7ac717ffa4a0fce) merged via BrewTestBot should sign off with the approving reviewer's email listed in the profile, if present, or the GitHub noreply email if not.

 The [GitHub API documentation](https://developer.github.com/v3/users/) suggests that all you need is authorization with a personal access token, and while that may be true for the v3 API endpoints, it doesn't seem to be the case for the v4 GraphQL endpoints. I've confirmed this by testing on my local machine, and the ([read-only](https://developer.github.com/v3/users/emails/)) `user:email` scope is needed on the access token.