### PR TITLE
pr-pull, pr-upload: add --warn-on-upload-failure

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -41,7 +41,7 @@ class Bintray
 
   def upload(local_file, repo:, package:, version:, remote_file:, sha256: nil)
     url = "#{API_URL}/content/#{@bintray_org}/#{repo}/#{package}/#{version}/#{remote_file}"
-    args = ["--upload-file", local_file]
+    args = ["--fail", "--upload-file", local_file]
     args += ["--header", "X-Checksum-Sha2: #{sha256}"] unless sha256.blank?
     result = open_api url, *args
     json = JSON.parse(result.stdout)
@@ -52,7 +52,7 @@ class Bintray
 
   def publish(repo:, package:, version:, file_count:)
     url = "#{API_URL}/content/#{@bintray_org}/#{repo}/#{package}/#{version}/publish"
-    result = open_api url, "--request", "POST"
+    result = open_api url, "--request", "POST", "--fail"
     json = JSON.parse(result.stdout)
     if file_count.present? && json["files"] != file_count
       raise "Bottle publish failed: expected #{file_count} bottles, but published #{json["files"]} instead."

--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -50,12 +50,15 @@ class Bintray
     result
   end
 
-  def publish(repo:, package:, version:, file_count:)
+  def publish(repo:, package:, version:, file_count:, warn_on_error: false)
     url = "#{API_URL}/content/#{@bintray_org}/#{repo}/#{package}/#{version}/publish"
     result = open_api url, "--request", "POST", "--fail"
     json = JSON.parse(result.stdout)
     if file_count.present? && json["files"] != file_count
-      raise "Bottle publish failed: expected #{file_count} bottles, but published #{json["files"]} instead."
+      message = "Bottle publish failed: expected #{file_count} bottles, but published #{json["files"]} instead."
+      raise message unless warn_on_error
+
+      opoo message
     end
 
     odebug "Published #{json["files"]} bottles"
@@ -143,7 +146,7 @@ class Bintray
     end
   end
 
-  def upload_bottle_json(json_files, publish_package: false)
+  def upload_bottle_json(json_files, publish_package: false, warn_on_error: false)
     bottles_hash = json_files.reduce({}) do |hash, json_file|
       hash.deep_merge(JSON.parse(IO.read(json_file)))
     end
@@ -161,14 +164,19 @@ class Bintray
 
         odebug "Checking remote file #{@bintray_org}/#{bintray_repo}/#{filename}"
         if file_published? repo: bintray_repo, remote_file: filename
-          raise Error, <<~EOS
-            #{filename} is already published.
+          already_published = "#{filename} is already published."
+          failed_message = <<~EOS
+            #{already_published}
             Please remove it manually from:
               https://bintray.com/#{@bintray_org}/#{bintray_repo}/#{bintray_package}/view#files
             Or run:
               curl -X DELETE -u $HOMEBREW_BINTRAY_USER:$HOMEBREW_BINTRAY_KEY \\
               https://api.bintray.com/content/#{@bintray_org}/#{bintray_repo}/#{filename}
           EOS
+          raise Error, failed_message unless warn_on_error
+
+          opoo already_published
+          next
         end
 
         if !formula_packaged[formula_name] && !package_exists?(repo: bintray_repo, package: bintray_package)
@@ -189,7 +197,11 @@ class Bintray
 
       bottle_count = bottle_hash["bottle"]["tags"].length
       odebug "Publishing #{@bintray_org}/#{bintray_repo}/#{bintray_package}/#{version}"
-      publish repo: bintray_repo, package: bintray_package, version: version, file_count: bottle_count
+      publish(repo:          bintray_repo,
+              package:       bintray_package,
+              version:       version,
+              file_count:    bottle_count,
+              warn_on_error: warn_on_error)
     end
   end
 end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -260,7 +260,7 @@ module Homebrew
           upload_args << "--dry-run" if args.dry_run?
           upload_args << "--root_url=#{args.root_url}" if args.root_url
           upload_args << "--bintray-org=#{bintray_org}"
-          system HOMEBREW_BREW_FILE, *upload_args
+          safe_system HOMEBREW_BREW_FILE, *upload_args
         end
       end
     end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -33,6 +33,9 @@ module Homebrew
       switch "--resolve",
              description: "When a patch fails to apply, leave in progress and allow user to resolve, "\
                           "instead of aborting."
+      switch "--warn-on-upload-failure",
+             description: "Warn instead of raising an error if the bottle upload fails. "\
+                          "Useful for repairing bottle uploads that previously failed."
       flag   "--workflow=",
              description: "Retrieve artifacts from the specified workflow (default: `tests.yml`)."
       flag   "--artifact=",
@@ -258,6 +261,7 @@ module Homebrew
           upload_args << "--verbose" if Homebrew.args.verbose?
           upload_args << "--no-publish" if args.no_publish?
           upload_args << "--dry-run" if args.dry_run?
+          upload_args << "--warn-on-upload-failure" if args.warn_on_upload_failure?
           upload_args << "--root_url=#{args.root_url}" if args.root_url
           upload_args << "--bintray-org=#{bintray_org}"
           safe_system HOMEBREW_BREW_FILE, *upload_args

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -17,6 +17,9 @@ module Homebrew
              description: "Apply the bottle commit and upload the bottles, but don't publish them."
       switch "-n", "--dry-run",
              description: "Print what would be done rather than doing it."
+      switch "--warn-on-upload-failure",
+             description: "Warn instead of raising an error if the bottle upload fails. "\
+                          "Useful for repairing bottle uploads that previously failed."
       flag   "--bintray-org=",
              description: "Upload to the specified Bintray organisation (default: `homebrew`)."
       flag   "--root-url=",
@@ -48,7 +51,9 @@ module Homebrew
     if args.dry_run?
       puts "Upload bottles described by these JSON files to Bintray:\n  #{Dir["*.json"].join("\n  ")}"
     else
-      bintray.upload_bottle_json Dir["*.json"], publish_package: !args.no_publish?
+      bintray.upload_bottle_json(Dir["*.json"],
+                                 publish_package: !args.no_publish?,
+                                 warn_on_error:   args.warn_on_upload_failure?)
     end
   end
 end

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -42,7 +42,7 @@ module Homebrew
     if args.dry_run?
       puts "brew #{bottle_args.join " "}"
     else
-      system HOMEBREW_BREW_FILE, *bottle_args
+      safe_system HOMEBREW_BREW_FILE, *bottle_args
     end
 
     if args.dry_run?

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -903,6 +903,8 @@ repository.
   Do not warn if pulling to a branch besides master (useful for testing).
 * `--resolve`:
   When a patch fails to apply, leave in progress and allow user to resolve, instead of aborting.
+* `--warn-on-upload-failure`:
+  Warn instead of raising an error if the bottle upload fails. Useful for repairing bottle uploads that previously failed.
 * `--workflow`:
   Retrieve artifacts from the specified workflow (default: `tests.yml`).
 * `--artifact`:
@@ -924,6 +926,8 @@ Apply the bottle commit and publish bottles to Bintray.
   Apply the bottle commit and upload the bottles, but don't publish them.
 * `-n`, `--dry-run`:
   Print what would be done rather than doing it.
+* `--warn-on-upload-failure`:
+  Warn instead of raising an error if the bottle upload fails. Useful for repairing bottle uploads that previously failed.
 * `--bintray-org`:
   Upload to the specified Bintray organisation (default: `homebrew`).
 * `--root-url`:

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "June 2020" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "July 2020" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "June 2020" "Homebrew" "brew"
+.TH "BREW" "1" "July 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -1176,6 +1176,10 @@ Do not warn if pulling to a branch besides master (useful for testing)\.
 When a patch fails to apply, leave in progress and allow user to resolve, instead of aborting\.
 .
 .TP
+\fB\-\-warn\-on\-upload\-failure\fR
+Warn instead of raising an error if the bottle upload fails\. Useful for repairing bottle uploads that previously failed\.
+.
+.TP
 \fB\-\-workflow\fR
 Retrieve artifacts from the specified workflow (default: \fBtests\.yml\fR)\.
 .
@@ -1209,6 +1213,10 @@ Apply the bottle commit and upload the bottles, but don\'t publish them\.
 .TP
 \fB\-n\fR, \fB\-\-dry\-run\fR
 Print what would be done rather than doing it\.
+.
+.TP
+\fB\-\-warn\-on\-upload\-failure\fR
+Warn instead of raising an error if the bottle upload fails\. Useful for repairing bottle uploads that previously failed\.
 .
 .TP
 \fB\-\-bintray\-org\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It is occasionally useful for maintainers to be able to upload bottles while ignoring all failed upload/publish steps. This pull request adds a new `--warn-on-upload-failure` option to `brew pr-pull` and `brew pr-upload` and the necessary machinery to `Bintray` to handle this.

While we're here, make bottle publishing more robust to failure by:

* using `safe_system` instead of `system` when shelling out to `brew`
* add the `--fail` switch when calling `curl` on operations that we definitely want to fail on e.g. weird openssl errors

