### PR TITLE
dev-cmd/bottle: fix positioning of bottle block in some cases

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -531,25 +531,21 @@ module Homebrew
             odie "--keep-old was passed but there was no existing bottle block!" if args.keep_old?
             puts output
             update_or_add = "add"
-            if s.include? "stable do"
-              indent = s.slice(/^( +)stable do/, 1).length
-              string = s.sub!(/^ {#{indent}}stable do(.|\n)+?^ {#{indent}}end\n/m, '\0' + output + "\n")
-            else
-              pattern = /(
-                  (\ {2}\#[^\n]*\n)*                                             # comments
-                  \ {2}(                                                         # two spaces at the beginning
-                    (url|head)\ ['"][\S\ ]+['"]                                  # url or head with a string
-                    (
-                      ,[\S\ ]*$                                                  # url may have options
-                      (\n^\ {3}[\S\ ]+$)*                                        # options can be in multiple lines
-                    )?|
-                    (homepage|desc|sha1|sha256|version|mirror)\ ['"][\S\ ]+['"]| # specs with a string
-                    (revision|version_scheme)\ \d+                               # revision with a number
-                  )\n+                                                           # multiple empty lines
-                 )+
-               /mx
-              string = s.sub!(pattern, '\0' + output + "\n")
-            end
+            pattern = /(
+                (\ {2}\#[^\n]*\n)*                                                # comments
+                \ {2}(                                                            # two spaces at the beginning
+                  (url|head)\ ['"][\S\ ]+['"]                                     # url or head with a string
+                  (
+                    ,[\S\ ]*$                                                     # url may have options
+                    (\n^\ {3}[\S\ ]+$)*                                           # options can be in multiple lines
+                  )?|
+                  (homepage|desc|sha256|version|mirror|license)\ ['"][\S\ ]+['"]| # specs with a string
+                  (revision|version_scheme)\ \d+|                                 # revision with a number
+                  (stable|livecheck)\ do(\n+^\ {4}[\S\ ]+$)*\n+^\ {2}end          # components with blocks
+                )\n+                                                              # multiple empty lines
+               )+
+             /mx
+            string = s.sub!(pattern, '\0' + output + "\n")
             odie "Bottle block addition failed!" unless string
           end
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes the bottle commit breaking `brew style` when the license line or livecheck block is included.