### PR TITLE
Bottle extract and fetch fixes

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -191,7 +191,10 @@ module Homebrew
     # Remove any existing version suffixes, as a new one will be added later
     name.sub!(/\b@(.*)\z\b/i, "")
     versioned_name = Formulary.class_s("#{name}@#{version}")
-    result.gsub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
+    result.sub!("class #{class_name} < Formula", "class #{versioned_name} < Formula")
+
+    # Remove bottle blocks, they won't work.
+    result.sub!(/  bottle do.+?end\n\n/m, "") if destination_tap != source_tap
 
     path = destination_tap.path/"Formula/#{name}@#{version}.rb"
     if path.exist?
@@ -205,7 +208,8 @@ module Homebrew
       odebug "Overwriting existing formula at #{path}"
       path.delete
     end
-    ohai "Writing formula for #{name} from revision #{rev} to #{path}"
+    ohai "Writing formula for #{name} from revision #{rev} to:"
+    puts path
     path.write result
   end
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -292,7 +292,7 @@ class FormulaInstaller
 
     self.class.attempted << formula
 
-    if pour_bottle?(warn: true)
+    if pour_bottle?
       begin
         pour
       rescue Exception => e # rubocop:disable Lint/RescueException
@@ -983,11 +983,24 @@ class FormulaInstaller
 
     return if only_deps?
 
-    unless pour_bottle?
-      formula.fetch_patches
-      formula.resources.each(&:fetch)
-    end
+    if pour_bottle?(warn: true)
+      begin
+        downloader.fetch
+      rescue Exception => e # rubocop:disable Lint/RescueException
+        raise if Homebrew::EnvConfig.developer? ||
+                 Homebrew::EnvConfig.no_bottle_source_fallback? ||
+                 e.is_a?(Interrupt)
 
+        @pour_failed = true
+        onoe e.message
+        opoo "Bottle installation failed: building from source."
+        fetch_dependencies
+      end
+    end
+    return if pour_bottle?
+
+    formula.fetch_patches
+    formula.resources.each(&:fetch)
     downloader.fetch
   end
 


### PR DESCRIPTION
- Make `brew extract` strip out bottle blocks
- Make `brew extract` output the path in a readable fashion
- Warn about building from source before fetching (not installing)
- If fetching a bottle fails, refetch and build from source.

Addresses https://github.com/Homebrew/brew/issues/7732#issuecomment-646342144

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----