### PR TITLE
throttle gatsby-cli to every 10 rel on multiple of 10

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -580,6 +580,7 @@ module Homebrew
       "aws-sdk-cpp" => "10",
       "awscli@1"    => "10",
       "balena-cli"  => "10",
+      "gatsby-cli"  => "10",
       "quicktype"   => "10",
       "vim"         => "50",
     }.freeze


### PR DESCRIPTION
gastby-cli release is pretty often and the changelog did not reflect what is really being changed, throttle the release on multiple of 10

commit history, https://github.com/gatsbyjs/gatsby/commits/master/packages/gatsby-cli
cli changelog, https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/CHANGELOG.md

PRs in the homebrew-core history, https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+gatsby-cli+