### PR TITLE
sorbet/files.yaml: set utils files to true

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -445,7 +445,6 @@ false:
   - ./unpack_strategy/zip.rb
   - ./utils.rb
   - ./utils/analytics.rb
-  - ./utils/bottles.rb
   - ./utils/curl.rb
   - ./utils/fork.rb
   - ./utils/formatter.rb
@@ -847,8 +846,6 @@ false:
   - ./utils/inreplace.rb
   - ./utils/link.rb
   - ./utils/shebang.rb
-  - ./utils/shell.rb
-  - ./utils/svn.rb
   - ./version.rb
 
 true:
@@ -888,6 +885,9 @@ true:
   - ./tap_constants.rb
   - ./test/support/helper/fixtures.rb
   - ./test/support/lib/config.rb
+  - ./utils/bottles.rb
+  - ./utils/shell.rb
+  - ./utils/svn.rb
   - ./utils/tty.rb
   - ./version/null.rb
 

--- a/Library/Homebrew/sorbet/rbi/utils/shell.rbi
+++ b/Library/Homebrew/sorbet/rbi/utils/shell.rbi
@@ -1,0 +1,38 @@
+# typed: strict
+
+module Utils::Shell
+  include Kernel
+
+  sig{ params(path: String).returns(T.nilable(Symbol)) }
+  def from_path(path)
+  end
+
+  sig{ returns(T.nilable(Symbol)) }
+  def preferred
+  end
+
+  def parent
+  end
+
+  def export_value(key, value, shell = preferred)
+  end
+
+  sig{ returns(String) }
+  def profile
+  end
+
+  def set_variable_in_profile(variable, value)
+  end
+
+  sig{ params(path: String).returns(T.nilable(String)) }
+  def prepend_path_in_profile(path)
+  end
+
+  sig{ params(str: String).returns(T.nilable(String)) }
+  def csh_quote(str)
+  end
+
+  sig{ params(str: String).returns(T.nilable(String)) }
+  def sh_quote(str)
+  end
+end

--- a/Library/Homebrew/sorbet/rbi/utils/utils.rbi
+++ b/Library/Homebrew/sorbet/rbi/utils/utils.rbi
@@ -1,0 +1,8 @@
+# typed: strict
+
+module Utils
+  include Kernel
+
+  class Bottles
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This PR sets `utils/bottles.rb`, `utils/shell.rb` and `utils/svn.rb` to true so that type errors in these files may be reported by Sorbet.
