### PR TITLE
Add completion configuration for non-Homebrew fish

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -60,10 +60,10 @@ If your `fish` is from somewhere else, add the following to your `~/.config/fish
 
 ```sh
 if test -d (brew --prefix)"/share/fish/completions"
-    set -g -x fish_complete_path $fish_complete_path (brew --prefix)/share/fish/completions
+    set -gx fish_complete_path $fish_complete_path (brew --prefix)/share/fish/completions
 end
 
 if test -d (brew --prefix)"/share/fish/vendor_completions.d"
-    set -g -x fish_complete_path $fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+    set -gx fish_complete_path $fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
 end
 ```

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -54,4 +54,16 @@ Additionally, if you receive "zsh compinit: insecure directories" warnings when 
 
 ## Configuring Completions in `fish`
 
-No configuration is needed in `fish`. Friendly!
+No configuration is needed if you're using Homebrew's `fish`. Friendly!
+
+If your `fish` is from somewhere else, add the following to your `~/.config/fish/config.fish`:
+
+```sh
+if test -d (brew --prefix)"/share/fish/completions"
+    set -g -x fish_complete_path $fish_complete_path (brew --prefix)/share/fish/completions
+end
+
+if test -d (brew --prefix)"/share/fish/vendor_completions.d"
+    set -g -x fish_complete_path $fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+end
+```


### PR DESCRIPTION
Not everyone uses Homebrew fish, especially on Linux. Tested on Ubuntu 18.04 LTS.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
