### PR TITLE
sandbox: do not assume home is inside `/Users`

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -47,12 +47,12 @@ class Sandbox
   end
 
   def allow_cvs
-    allow_write_path "/Users/#{ENV["USER"]}/.cvspass"
+    allow_write_path "#{ENV["HOME"]}/.cvspass"
   end
 
   def allow_fossil
-    allow_write_path "/Users/#{ENV["USER"]}/.fossil"
-    allow_write_path "/Users/#{ENV["USER"]}/.fossil-journal"
+    allow_write_path "#{ENV["HOME"]}/.fossil"
+    allow_write_path "#{ENV["HOME"]}/.fossil-journal"
   end
 
   def allow_write_cellar(formula)
@@ -63,7 +63,7 @@ class Sandbox
 
   # Xcode projects expect access to certain cache/archive dirs.
   def allow_write_xcode
-    allow_write_path "/Users/#{ENV["USER"]}/Library/Developer"
+    allow_write_path "#{ENV["HOME"]}/Library/Developer"
   end
 
   def allow_write_log(formula)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **A couple of tests fail** on my local machine but all of them are unrelated, and can be traced to flaky test code. See #7417.

-----

It’s not uncommon to use `/var/${USER}` as a home directory, especially for shared or CLI-only users.

This fixes an issue where a formula that requires `xcodebuild` is `brew install`ed from such a shared or CLI-only user account. In that case, `xcodebuild` would fail because it is denied write access to `/var/${USER}/Library/Developer/Xcode`.

For details, see: https://gist.github.com/claui/17cd89f8f6b4094ac704f142ea811fd8
