### PR TITLE
style: improve keg_only style checks

### DIFF
--- a/Library/Homebrew/rubocops/keg_only.rb
+++ b/Library/Homebrew/rubocops/keg_only.rb
@@ -22,18 +22,28 @@ module RuboCop
             Firefox
           ].freeze
 
-          reason = string_content(parameters(keg_only_node).first)
+          reason = parameters(keg_only_node).first
+          offending_node(reason)
           name = Regexp.new(@formula_name, Regexp::IGNORECASE)
-          reason = reason.sub(name, "")
+          reason = string_content(reason).sub(name, "")
           first_word = reason.split.first
 
           if reason =~ /\A[A-Z]/ && !reason.start_with?(*allowlist)
-            problem "'#{first_word}' from the keg_only reason should be '#{first_word.downcase}'."
+            problem "'#{first_word}' from the `keg_only` reason should be '#{first_word.downcase}'."
           end
 
           return unless reason.end_with?(".")
 
-          problem "keg_only reason should not end with a period."
+          problem "`keg_only` reason should not end with a period."
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            reason = string_content(node)
+            reason[0] = reason[0].downcase
+            reason = reason.delete_suffix(".")
+            corrector.replace(node.source_range, "\"#{reason}\"")
+          end
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/keg_only_spec.rb
+++ b/Library/Homebrew/test/rubocops/keg_only_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::FormulaAudit::KegOnly do
         homepage "https://brew.sh"
 
         keg_only "Because why not"
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Because' from the keg_only reason should be 'because'.
+                 ^^^^^^^^^^^^^^^^^ 'Because' from the `keg_only` reason should be 'because'.
       end
     RUBY
   end
@@ -25,9 +25,51 @@ describe RuboCop::Cop::FormulaAudit::KegOnly do
         homepage "https://brew.sh"
 
         keg_only "ending with a period."
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ keg_only reason should not end with a period.
+                 ^^^^^^^^^^^^^^^^^^^^^^^ `keg_only` reason should not end with a period.
       end
     RUBY
+  end
+
+  specify "keg_only_autocorrects_downcasing" do
+    source = <<~RUBY
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+        homepage "https://brew.sh"
+        keg_only "Because why not"
+      end
+    RUBY
+
+    corrected_source = <<~RUBY
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+        homepage "https://brew.sh"
+        keg_only "because why not"
+      end
+    RUBY
+
+    new_source = autocorrect_source(source)
+    expect(new_source).to eq(corrected_source)
+  end
+
+  specify "keg_only_autocorrects_redundant_period" do
+    source = <<~RUBY
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+        homepage "https://brew.sh"
+        keg_only "ending with a period."
+      end
+    RUBY
+
+    corrected_source = <<~RUBY
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
+        homepage "https://brew.sh"
+        keg_only "ending with a period"
+      end
+    RUBY
+
+    new_source = autocorrect_source(source)
+    expect(new_source).to eq(corrected_source)
   end
 
   specify "keg_only_handles_block_correctly" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Improve the style checks for the `keg_only` cop

Changes:

1. Add backticks around `keg_only` to problem message easier to read
1. Isolate the offending node to just the string that follows the `keg_only` line.

    Example:
    ```
    keg_only "Because why not"
             ^^^^^^^^^^^^^^^^^ 'Because' from the keg_only reason should be 'because'.
    ```
    instead of
    ```
    keg_only "Because why not"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^ 'Because' from the keg_only reason should be 'because'.
    ```
1. Add autocorrect ability