### PR TITLE
Separate formula name from tap name in need_python?

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -167,7 +167,7 @@ module Language
       def needs_python?(python)
         return true if build.with?(python)
 
-        (requirements.to_a | deps).any? { |r| r.name == python && r.required? }
+        (requirements.to_a | deps).any? { |r| r.name.split("/").last == python && r.required? }
       end
 
       # Helper method for the common case of installing a Python application.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #7896

When comparing python dependencies to python executables, `need_python?` didn't separate the tap name from the formula name. This caused an issue where a formula depended on `homebrew/core/python@3.8` but `need_python?` didn't recognize that as a valid `python` dependency. This PR will trim the `homebrew/core` prefix and interpret the dependency as just `python@3.8`.

CC: @Bo98 