### PR TITLE
Add `brew sponsors` command

### DIFF
--- a/Library/Homebrew/dev-cmd/sponsors.rb
+++ b/Library/Homebrew/dev-cmd/sponsors.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require "utils/github"
+
+module Homebrew
+  module_function
+
+  def sponsors_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `sponsors`
+
+        Print a Markdown summary of Homebrew's GitHub Sponsors, suitable for pasting into a README.
+      EOS
+    end
+  end
+
+  def sponsors
+    sponsors_args.parse
+
+    sponsors = {
+      "named" => [],
+      "users" => 0,
+      "orgs"  => 0,
+    }
+
+    GitHub.sponsors_by_tier("Homebrew").each do |tier|
+      sponsors["named"] += tier["sponsors"] if tier["tier"] >= 100
+      sponsors["users"] += tier["count"]
+      sponsors["orgs"] += tier["sponsors"].count { |s| s["type"] == "organization" }
+    end
+
+    items = []
+    items += sponsors["named"].map { |s| "[#{s["name"]}](https://github.com/#{s["login"]})" }
+
+    anon_users = sponsors["users"] - sponsors["named"].length - sponsors["orgs"]
+
+    items << if items.length > 1
+      "#{anon_users} other users"
+    else
+      "#{anon_users} users"
+    end
+
+    if sponsors["orgs"] == 1
+      items << "#{sponsors["orgs"]} organization"
+    elsif sponsors["orgs"] > 1
+      items << "#{sponsors["orgs"]} organizations"
+    end
+
+    sponsor_text = if items.length > 2
+      items[0..-2].join(", ") + " and #{items.last}"
+    else
+      items.join(" and ")
+    end
+
+    puts "Homebrew is generously supported by #{sponsor_text} via [GitHub Sponsors](https://github.com/sponsors/Homebrew)."
+  end
+end

--- a/Library/Homebrew/test/dev-cmd/sponsors_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/sponsors_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.sponsors_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -49,6 +49,14 @@ describe GitHub do
     end
   end
 
+  describe "::sponsors_by_tier", :needs_network do
+    it "errors on an unauthenticated token" do
+      expect {
+        subject.sponsors_by_tier("Homebrew")
+      }.to raise_error(/INSUFFICIENT_SCOPES|FORBIDDEN/)
+    end
+  end
+
   describe "::get_artifact_url", :needs_network do
     it "fails to find a nonexistant workflow" do
       expect {

--- a/README.md
+++ b/README.md
@@ -88,3 +88,5 @@ Secure password storage and syncing is provided by [1Password for Teams](https:/
 Homebrew is a member of the [Software Freedom Conservancy](https://sfconservancy.org).
 
 [![Software Freedom Conservancy](https://sfconservancy.org/img/conservancy_64x64.png)](https://sfconservancy.org)
+
+Homebrew is generously supported by [Zeno R.R. Davatz](https://github.com/zdavatz), [Randy Reddig](https://github.com/ydnar) and 262 other users via [GitHub Sponsors](https://github.com/sponsors/Homebrew).

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -71,6 +71,7 @@ ruby
 search
 sh
 shellenv
+sponsors
 style
 switch
 tap

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -967,6 +967,11 @@ build systems would not find otherwise.
 * `--env`:
   Use the standard `PATH` instead of superenv's when `std` is passed.
 
+### `sponsors`
+
+Print a Markdown summary of Homebrew's GitHub Sponsors, suitable for pasting
+into a README.
+
 ### `style` [*`options`*] [*`file`*|*`tap`*|*`formula`*]
 
 Check formulae or files for conformance to Homebrew style guidelines.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1254,6 +1254,9 @@ Start a Homebrew build environment shell\. Uses our years\-battle\-hardened Home
 \fB\-\-env\fR
 Use the standard \fBPATH\fR instead of superenv\'s when \fBstd\fR is passed\.
 .
+.SS "\fBsponsors\fR"
+Print a Markdown summary of Homebrew\'s GitHub Sponsors, suitable for pasting into a README\.
+.
 .SS "\fBstyle\fR [\fIoptions\fR] [\fIfile\fR|\fItap\fR|\fIformula\fR]"
 Check formulae or files for conformance to Homebrew style guidelines\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Adds a new hidden developer command, `brew sponsors`, that queries the GitHub API to get a list of our supporters on GitHub Sponsors. 

Ideally this would be automatically updated via continuous integration, but this API requires a personal access token with scopes `admin:org` and `user`, which are some pretty big scopes and makes me a bit worried about security. Instead, someone with Owner permissions on the Homebrew org should run this every so often and update the README with its output. Suggestions for automation are welcome.