### PR TITLE
dev-cmd/audit: don't error out if no license is detected by GitHub

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -341,7 +341,7 @@ module Homebrew
           return if user.blank?
 
           github_license = GitHub.get_repo_license(user, repo)
-          return if github_license && (github_license == formula.license)
+          return if github_license && [formula.license, "NOASSERTION"].include?(github_license)
 
           problem "License mismatch - GitHub license is: #{github_license}, "\
                   "but Formulae license states: #{formula.license}."


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Should `fix` https://github.com/Homebrew/homebrew-core/pull/57432#issuecomment-653751828 and any other cases where License is not recognized by GitHub.