### PR TITLE
upgrade: fix error checking dependents

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -161,8 +161,8 @@ module Homebrew
     # Assess the dependents tree again now we've upgraded.
     oh1 "Checking for dependents of upgraded formulae..." unless args.dry_run?
     broken_dependents = CacheStoreDatabase.use(:linkage) do |db|
-      formulae_to_install.flat_map(&:runtime_installed_formula_dependents)
-                         .select do |f|
+      installed_formulae.flat_map(&:runtime_installed_formula_dependents)
+                        .select do |f|
         keg = f.opt_or_installed_prefix_keg
         next unless keg
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

```
Error: undefined local variable or method `formulae_to_install' for Homebrew:Module
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:164:in `block in check_installed_dependents'
/usr/local/Homebrew/Library/Homebrew/cache_store.rb:17:in `use'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:163:in `check_installed_dependents'
/usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:114:in `upgrade'
/usr/local/Homebrew/Library/Homebrew/brew.rb:111:in `<main>'
```
