### PR TITLE
link_overwrite: allow to overwrite files from alias

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1118,9 +1118,8 @@ class Formula
       rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
         return false # this keg belongs to another formula
       else
-        # this keg belongs to another formula
-        # but it is not an alias
-        return false unless f.aliases.include? keg.name
+        # this keg belongs to another unrelated formula
+        return false unless (f.aliases + f.oldname).include?(keg.name)
       end
     end
     to_check = path.relative_path_from(HOMEBREW_PREFIX).to_s

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1112,13 +1112,15 @@ class Formula
       return false if tab_tap.nil?
 
       begin
-        Formulary.factory(keg.name)
+        f = Formulary.factory(keg.name)
       rescue FormulaUnavailableError
         # formula for this keg is deleted, so defer to allowlist
       rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
         return false # this keg belongs to another formula
       else
-        return false # this keg belongs to another formula
+        # this keg belongs to another formula
+        # but it is not an alias
+        return false unless f.aliases.include? keg.name
       end
     end
     to_check = path.relative_path_from(HOMEBREW_PREFIX).to_s


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/54912#issuecomment-653893645
Formulary.factory("python") points to python@3.8, which breaks link_overwrite
for that case.

This changes checks if the formula is an alias, so that we can still override
the files during installation.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
