### PR TITLE
Add CPU family ARMv8.3-A

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -21,8 +21,6 @@ module Hardware
       end
 
       def family
-        return :dunno if arm?
-
         case sysctl_int("hw.cpufamily")
         when 0x73d67300 # Yonah: Core Solo/Duo
           :core
@@ -48,6 +46,8 @@ module Hardware
           :kabylake
         when 0x38435547 # Ice Lake
           :icelake
+        when 0x07d34b9f # ARMv8.3-A (Vortex, Tempest)
+          :arm_vortex_tempest
         else
           :dunno
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Darwin 20 adds `CPUFAMILY_ARM_VORTEX_TEMPEST` (aka ARMv8.3-A), which is assigned the identifier of `0x07d34b9f`.

This is relevant for `SystemConfig` in Homebrew.

See also:
https://en.wikipedia.org/wiki/Comparison_of_ARMv8-A_cores
