### PR TITLE
Allow references to casks when running upgrade and outdated

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -30,11 +30,11 @@ module Homebrew
                           "formula is outdated. Otherwise, the repository's HEAD will only be checked for "\
                           "updates when a new stable or development version has been released."
       switch "--greedy",
-             description: "Print outdated casks with `auto_updates` or `version :latest`"
+             description: "Print outdated casks with `auto_updates` or `version :latest`."
       switch "--formula",
-             description: "Treat all arguments as formulae"
+             description: "Treat all arguments as formulae."
       switch "--cask",
-             description: "Treat all arguments as casks"
+             description: "Treat all arguments as casks."
       switch :debug
       conflicts "--quiet", "--verbose", "--json"
       conflicts "--formula", "--cask"
@@ -46,7 +46,7 @@ module Homebrew
 
     case json_version
     when :v1
-      opoo "JSON v1 has been deprecated. Please use --json=v2"
+      opoo "JSON v1 has been deprecated; please use --json=v2"
 
       outdated = if args.formula? || !args.cask?
         outdated_formulae

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -3,6 +3,8 @@
 require "formula"
 require "keg"
 require "cli/parser"
+require "cask/cmd"
+require "cask/caskroom"
 
 module Homebrew
   module_function
@@ -22,43 +24,67 @@ module Homebrew
       flag   "--json",
              description: "Print output in JSON format. Currently the default and only accepted "\
                           "value for <version> is `v1`. See the docs for examples of using the JSON "\
-                          "output: <https://docs.brew.sh/Querying-Brew>"
+                          "output: <https://docs.brew.sh/Querying-Brew>."\
+                          "By default, this option treats all arguments as formulae."\
+                          "To treat arguments as casks, use the --cask-only option."
       switch "--fetch-HEAD",
              description: "Fetch the upstream repository to detect if the HEAD installation of the "\
                           "formula is outdated. Otherwise, the repository's HEAD will only be checked for "\
                           "updates when a new stable or development version has been released."
+      switch "--greedy",
+             description: "Print outdated casks with `auto_updates` or `version :latest`"
+      switch "--formula-only",
+             description: "Treat all arguments as formulae"
+      switch "--cask-only",
+             description: "Treat all arguments as casks"
       switch :debug
       conflicts "--quiet", "--verbose", "--json"
+      conflicts "--formula-only", "--cask-only"
     end
   end
 
   def outdated
     outdated_args.parse
 
-    formulae = if args.resolved_formulae.blank?
-      Formula.installed
+    if args.formula_only? || !args.cask_only? && args.json
+      formulae = args.resolved_formulae.blank? ? Formula.installed : args.resolved_formulae
+      outdated = print_outdated_formulae(formulae)
+
+      Homebrew.failed = !formulae.blank? && !outdated.blank?
+    elsif args.cask_only?
+      casks = args.named.blank? ? Cask::Caskroom.casks : args.named
+      outdated = print_outdated_casks(casks)
+
+      Homebrew.failed = !casks.blank? && !outdated.blank?
     else
-      args.resolved_formulae
+      formulae, casks = args.resolved_formulae_casks
+
+      if formulae.blank? && casks.blank?
+        formulae = Formula.installed
+        casks = Cask::Caskroom.casks
+      end
+
+      outdated_formulae = print_outdated_formulae(formulae)
+      outdated_casks = print_outdated_casks(casks)
+
+      Homebrew.failed = !formulae.blank? && !outdated_formulae.blank? || !casks.blank? && !outdated_casks.blank?
     end
+  end
+
+  def print_outdated_formulae(formulae)
     if args.json
       raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
 
-      outdated = print_outdated_json(formulae)
-    else
-      outdated = print_outdated(formulae)
+      return print_outdated_formulae_json(formulae)
     end
-    Homebrew.failed = args.resolved_formulae.present? && !outdated.empty?
-  end
 
-  def print_outdated(formulae)
-    verbose = ($stdout.tty? || args.verbose?) && !args.quiet?
     fetch_head = args.fetch_HEAD?
 
     outdated_formulae = formulae.select { |f| f.outdated?(fetch_head: fetch_head) }
                                 .sort
 
     outdated_formulae.each do |f|
-      if verbose
+      if verbose?
         outdated_kegs = f.outdated_kegs(fetch_head: fetch_head)
 
         current_version = if f.alias_changed?
@@ -87,7 +113,7 @@ module Homebrew
     end
   end
 
-  def print_outdated_json(formulae)
+  def print_outdated_formulae_json(formulae)
     json = []
     fetch_head = args.fetch_HEAD?
     outdated_formulae = formulae.select { |f| f.outdated?(fetch_head: fetch_head) }
@@ -109,5 +135,21 @@ module Homebrew
     puts JSON.generate(json)
 
     outdated
+  end
+
+  def print_outdated_casks(casks)
+    outdated = casks.map { |cask| Cask::CaskLoader.load(cask) }.select do |cask|
+      odebug "Checking update info of Cask #{cask}"
+      cask.outdated?(args.greedy?)
+    end
+
+    output = outdated.map { |cask| cask.outdated_info(args.greedy?, verbose?, args.json?) }
+    puts args.json ? JSON.generate(output) : output
+
+    outdated
+  end
+
+  def verbose?
+    ($stdout.tty? || args.verbose?) && !args.quiet?
   end
 end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -22,11 +22,9 @@ module Homebrew
       switch :verbose,
              description: "Include detailed version information."
       flag   "--json",
-             description: "Print output in JSON format. Currently the default and only accepted "\
-                          "value for <version> is `v1`. See the docs for examples of using the JSON "\
-                          "output: <https://docs.brew.sh/Querying-Brew>. "\
-                          "By default, this option treats all arguments as formulae. "\
-                          "To treat arguments as casks, use the --cask option."
+             description: "Print output in JSON format. There are two versions: v1 and v2. " \
+                          "v1 is deprecated and is currently the default if no version is specified. " \
+                          "v2 prints outdated formulae and casks. "
       switch "--fetch-HEAD",
              description: "Fetch the upstream repository to detect if the HEAD installation of the "\
                           "formula is outdated. Otherwise, the repository's HEAD will only be checked for "\
@@ -48,6 +46,8 @@ module Homebrew
 
     case json_version
     when :v1
+      opoo "JSON v1 has been deprecated. Please use --json=v2"
+
       outdated = if args.formula? || !args.cask?
         outdated_formulae
       else

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -33,9 +33,9 @@ module Homebrew
                           "updates when a new stable or development version has been released."
       switch "--greedy",
              description: "Print outdated casks with `auto_updates` or `version :latest`"
-      switch "--formula-only",
+      switch "--formula",
              description: "Treat all arguments as formulae"
-      switch "--cask-only",
+      switch "--cask",
              description: "Treat all arguments as casks"
       switch :debug
       conflicts "--quiet", "--verbose", "--json"
@@ -46,19 +46,18 @@ module Homebrew
   def outdated
     outdated_args.parse
 
+    formula_only = args.formula?
     if args.json
       raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
 
       # When user asks for json, print json for formula only unless the user explicitly asks for casks
-      formula_only = !args.cask_only?
-    else
-      formula_only = args.formula_only?
+      formula_only = !args.cask?
     end
 
     if formula_only
       formulae = args.resolved_formulae.blank? ? Formula.installed : args.resolved_formulae
       outdated = print_outdated_formulae(formulae)
-    elsif args.cask_only?
+    elsif args.cask?
       casks = args.named.blank? ? Cask::Caskroom.casks : args.named
       outdated = print_outdated_casks(casks)
     else

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -48,9 +48,14 @@ module Homebrew
 
     if args.json
       raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
+
+      # When user asks for json, print json for formula only unless the user explicitly asks for casks
+      formula_only = !args.cask_only?
+    else
+      formula_only = args.formula_only?
     end
 
-    if args.formula_only? || !args.cask_only? && args.json
+    if formula_only
       formulae = args.resolved_formulae.blank? ? Formula.installed : args.resolved_formulae
       outdated = print_outdated_formulae(formulae)
     elsif args.cask_only?

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -46,6 +46,10 @@ module Homebrew
   def outdated
     outdated_args.parse
 
+    if args.json
+      raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
+    end
+
     if args.formula_only? || !args.cask_only? && args.json
       formulae = args.resolved_formulae.blank? ? Formula.installed : args.resolved_formulae
       outdated = print_outdated_formulae(formulae)
@@ -72,11 +76,7 @@ module Homebrew
   end
 
   def print_outdated_formulae(formulae)
-    if args.json
-      raise UsageError, "invalid JSON version: #{args.json}" unless ["v1", true].include? args.json
-
-      return print_outdated_formulae_json(formulae)
-    end
+    return print_outdated_formulae_json(formulae) if args.json
 
     fetch_head = args.fetch_HEAD?
 
@@ -143,7 +143,7 @@ module Homebrew
       cask.outdated?(args.greedy?)
     end
 
-    output = outdated.map { |cask| cask.outdated_info(args.greedy?, verbose?, args.json?) }
+    output = outdated.map { |cask| cask.outdated_info(args.greedy?, verbose?, args.json) }
     puts args.json ? JSON.generate(output) : output
 
     outdated

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -24,8 +24,8 @@ module Homebrew
       flag   "--json",
              description: "Print output in JSON format. Currently the default and only accepted "\
                           "value for <version> is `v1`. See the docs for examples of using the JSON "\
-                          "output: <https://docs.brew.sh/Querying-Brew>."\
-                          "By default, this option treats all arguments as formulae."\
+                          "output: <https://docs.brew.sh/Querying-Brew>. "\
+                          "By default, this option treats all arguments as formulae. "\
                           "To treat arguments as casks, use the --cask-only option."
       switch "--fetch-HEAD",
              description: "Fetch the upstream repository to detect if the HEAD installation of the "\
@@ -53,13 +53,9 @@ module Homebrew
     if args.formula_only? || !args.cask_only? && args.json
       formulae = args.resolved_formulae.blank? ? Formula.installed : args.resolved_formulae
       outdated = print_outdated_formulae(formulae)
-
-      Homebrew.failed = !formulae.blank? && !outdated.blank?
     elsif args.cask_only?
       casks = args.named.blank? ? Cask::Caskroom.casks : args.named
       outdated = print_outdated_casks(casks)
-
-      Homebrew.failed = !casks.blank? && !outdated.blank?
     else
       formulae, casks = args.resolved_formulae_casks
 
@@ -68,11 +64,10 @@ module Homebrew
         casks = Cask::Caskroom.casks
       end
 
-      outdated_formulae = print_outdated_formulae(formulae)
-      outdated_casks = print_outdated_casks(casks)
-
-      Homebrew.failed = !formulae.blank? && !outdated_formulae.blank? || !casks.blank? && !outdated_casks.blank?
+      outdated = print_outdated_formulae(formulae) + print_outdated_casks(casks)
     end
+
+    Homebrew.failed = args.named.present? && outdated.present?
   end
 
   def print_outdated_formulae(formulae)

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -46,7 +46,8 @@ module Homebrew
 
     case json_version
     when :v1
-      odeprecated "brew outdated --json=v1", "brew outdated --json=v2"
+      # TODO: enable for next major/minor release
+      # odeprecated "brew outdated --json=v1", "brew outdated --json=v2"
 
       outdated = if args.formula? || !args.cask?
         outdated_formulae

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -45,9 +45,9 @@ module Homebrew
     outdated_args.parse
 
     case json_version
-    when :v1
+    when :v1, :default
       # TODO: enable for next major/minor release
-      # odeprecated "brew outdated --json=v1", "brew outdated --json=v2"
+      # odeprecated "brew outdated --json#{json_version == :v1 ? "=v1" : ""}", "brew outdated --json=v2"
 
       outdated = if args.formula? || !args.cask?
         outdated_formulae
@@ -66,10 +66,11 @@ module Homebrew
         outdated_formulae_casks
       end
 
-      puts JSON.generate({
-                           "formulae" => json_info(formulae),
-                           "casks"    => json_info(casks),
-                         })
+      json = {
+        "formulae" => json_info(formulae),
+        "casks"    => json_info(casks),
+      }
+      puts JSON.generate(json)
 
       outdated = formulae + casks
 
@@ -106,10 +107,9 @@ module Homebrew
             f.pkg_version.to_s
           end
 
-          outdated_versions = outdated_kegs
-                              .group_by { |keg| Formulary.from_keg(keg).full_name }
-                              .sort_by { |full_name, _kegs| full_name }
-                              .map do |full_name, kegs|
+          outdated_versions = outdated_kegs.group_by { |keg| Formulary.from_keg(keg).full_name }
+                                           .sort_by { |full_name, _kegs| full_name }
+                                           .map do |full_name, kegs|
             "#{full_name} (#{kegs.map(&:version).join(", ")})"
           end.join(", ")
 
@@ -159,7 +159,7 @@ module Homebrew
   def json_version
     version_hash = {
       nil  => nil,
-      true => :v1,
+      true => :default,
       "v1" => :v1,
       "v2" => :v2,
     }

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -94,7 +94,7 @@ module Homebrew
       end
     end
 
-    return if outdated.empty?
+    return if outdated.blank?
 
     pinned = outdated.select(&:pinned?)
     outdated -= pinned

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -23,7 +23,6 @@ describe "brew outdated", :integration_test do
 
     expect { brew "outdated", "--json=v1" }
       .to output(expected_json + "\n").to_stdout
-      .and not_to_output.to_stderr
       .and be_a_success
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -360,11 +360,11 @@ otherwise.
 * `--fetch-HEAD`:
   Fetch the upstream repository to detect if the HEAD installation of the formula is outdated. Otherwise, the repository's HEAD will only be checked for updates when a new stable or development version has been released.
 * `--greedy`:
-  Print outdated casks with `auto_updates` or `version :latest`
+  Print outdated casks with `auto_updates` or `version :latest`.
 * `--formula`:
-  Treat all arguments as formulae
+  Treat all arguments as formulae.
 * `--cask`:
-  Treat all arguments as casks
+  Treat all arguments as casks.
 
 ### `pin` *`formula`*
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -356,7 +356,7 @@ otherwise.
 * `-v`, `--verbose`:
   Include detailed version information.
 * `--json`:
-  Print output in JSON format. Currently the default and only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>. By default, this option treats all arguments as formulae. To treat arguments as casks, use the --cask option.
+  Print output in JSON format. There are two versions: v1 and v2. v1 is deprecated and is currently the default if no version is specified. v2 prints outdated formulae and casks. 
 * `--fetch-HEAD`:
   Fetch the upstream repository to detect if the HEAD installation of the formula is outdated. Otherwise, the repository's HEAD will only be checked for updates when a new stable or development version has been released.
 * `--greedy`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -356,9 +356,15 @@ otherwise.
 * `-v`, `--verbose`:
   Include detailed version information.
 * `--json`:
-  Print output in JSON format. Currently the default and only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>
+  Print output in JSON format. Currently the default and only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>. By default, this option treats all arguments as formulae. To treat arguments as casks, use the --cask option.
 * `--fetch-HEAD`:
   Fetch the upstream repository to detect if the HEAD installation of the formula is outdated. Otherwise, the repository's HEAD will only be checked for updates when a new stable or development version has been released.
+* `--greedy`:
+  Print outdated casks with `auto_updates` or `version :latest`
+* `--formula`:
+  Treat all arguments as formulae
+* `--cask`:
+  Treat all arguments as casks
 
 ### `pin` *`formula`*
 
@@ -556,6 +562,8 @@ the upgraded formulae or, every 30 days, for all formulae.
   Print install times for each formula at the end of the run.
 * `-n`, `--dry-run`:
   Show what would be upgraded, but do not actually upgrade anything.
+* `--greedy`:
+  Upgrade casks with `auto_updates` or `version :latest`
 
 ### `uses` [*`options`*] *`formula`*
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -485,15 +485,15 @@ Fetch the upstream repository to detect if the HEAD installation of the formula 
 .
 .TP
 \fB\-\-greedy\fR
-Print outdated casks with \fBauto_updates\fR or \fBversion :latest\fR
+Print outdated casks with \fBauto_updates\fR or \fBversion :latest\fR\.
 .
 .TP
 \fB\-\-formula\fR
-Treat all arguments as formulae
+Treat all arguments as formulae\.
 .
 .TP
 \fB\-\-cask\fR
-Treat all arguments as casks
+Treat all arguments as casks\.
 .
 .SS "\fBpin\fR \fIformula\fR"
 Pin the specified \fIformula\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR \fIformula\fR command\. See also \fBunpin\fR\.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -477,11 +477,23 @@ Include detailed version information\.
 .
 .TP
 \fB\-\-json\fR
-Print output in JSON format\. Currently the default and only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
+Print output in JSON format\. Currently the default and only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR\. By default, this option treats all arguments as formulae\. To treat arguments as casks, use the \-\-cask option\.
 .
 .TP
 \fB\-\-fetch\-HEAD\fR
 Fetch the upstream repository to detect if the HEAD installation of the formula is outdated\. Otherwise, the repository\'s HEAD will only be checked for updates when a new stable or development version has been released\.
+.
+.TP
+\fB\-\-greedy\fR
+Print outdated casks with \fBauto_updates\fR or \fBversion :latest\fR
+.
+.TP
+\fB\-\-formula\fR
+Treat all arguments as formulae
+.
+.TP
+\fB\-\-cask\fR
+Treat all arguments as casks
 .
 .SS "\fBpin\fR \fIformula\fR"
 Pin the specified \fIformula\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR \fIformula\fR command\. See also \fBunpin\fR\.
@@ -721,6 +733,10 @@ Print install times for each formula at the end of the run\.
 .TP
 \fB\-n\fR, \fB\-\-dry\-run\fR
 Show what would be upgraded, but do not actually upgrade anything\.
+.
+.TP
+\fB\-\-greedy\fR
+Upgrade casks with \fBauto_updates\fR or \fBversion :latest\fR
 .
 .SS "\fBuses\fR [\fIoptions\fR] \fIformula\fR"
 Show formulae that specify \fIformula\fR as a dependency\. When given multiple formula arguments, show the intersection of formulae that use \fIformula\fR\. By default, \fBuses\fR shows all formulae that specify \fIformula\fR as a required or recommended dependency for their stable builds\.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -477,7 +477,7 @@ Include detailed version information\.
 .
 .TP
 \fB\-\-json\fR
-Print output in JSON format\. Currently the default and only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR\. By default, this option treats all arguments as formulae\. To treat arguments as casks, use the \-\-cask option\.
+Print output in JSON format\. There are two versions: v1 and v2\. v1 is deprecated and is currently the default if no version is specified\. v2 prints outdated formulae and casks\.
 .
 .TP
 \fB\-\-fetch\-HEAD\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Tests were not written because I think the same conditions hold for this PR as for [this other PR](https://github.com/Homebrew/brew/pull/7853#issuecomment-652268146)

`brew upgrade` upgrades both formulae and casks. 

`brew outdated` was tricky to integrate because of the `--json` option. It makes sense for `brew outdated` with no arguments to print all outdated formulae and casks, which implies `brew outdated --json` should print the json for formulae and casks. However, I did not want to change the behavior of `brew outdated --json` lest any scripts that depend on it break. I settled on the following compromise:
1. `brew outdated --json` prints json information for only formulae, which makes it equivalent to `brew outdated --json --formula-only`
2. `brew outdated --json --cask-only` prints json information for only casks. 

Another possibility is a v2 json API for `brew outdated`, but I haven't seen any demand for such feature

<details>
    <summary>A small script to install an outdated version of atom and youtube-dl (cask and formula respectively). Useful for testing</summary>

    echo "Uninstalling atom, youtube-dl"
    brew uninstall atom youtube-dl
    
    LR=$pwd
    
    echo "Installing atom 1.47.0"
    cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/
    git checkout a023e3d0754c0d8a5647891328f5b64caa5512ba -- Casks/atom.rb
    brew cask install atom
    git restore --staged Casks/atom.rb
    git restore Casks/atom.rb
    
    echo "Installing youtube-dl 2020.05.08"
    cd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/
    git checkout 877666acfa7af926b0623dcdc7839e182c8e95d4 -- Formula/youtube-dl.rb
    brew install youtube-dl
    git restore --staged Formula/youtube-dl.rb
    git restore Formula/youtube-dl.rb
    
    cd $LR
    
</details>