### PR TITLE
sorbet: set utils/git.rb to true

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -452,7 +452,6 @@ false:
   - ./utils/curl.rb
   - ./utils/fork.rb
   - ./utils/formatter.rb
-  - ./utils/git.rb
   - ./utils/github.rb
   - ./utils/notability.rb
   - ./utils/popen.rb
@@ -890,6 +889,7 @@ true:
   - ./test/support/helper/fixtures.rb
   - ./test/support/lib/config.rb
   - ./utils/bottles.rb
+  - ./utils/git.rb
   - ./utils/shell.rb
   - ./utils/svn.rb
   - ./utils/tty.rb

--- a/Library/Homebrew/sorbet/rbi/utils/git.rbi
+++ b/Library/Homebrew/sorbet/rbi/utils/git.rbi
@@ -1,0 +1,15 @@
+# typed: strict
+
+module Git
+  include Kernel
+
+  def last_revision_commit_of_file(repo, file, before_commit: nil)
+  end
+
+  sig { params(repo: Pathname, files: T::Array[Pathname], before_commit: T.nilable(String)).void }
+  def last_revision_commit_of_files(repo, files, before_commit: nil)
+  end
+
+  def last_revision_of_file(repo, file, before_commit: nil)
+  end
+end

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -36,7 +36,7 @@ module Git
     out, = Open3.capture3(
       HOMEBREW_SHIMS_PATH/"scm/git", "-C", repo, "log",
       "--pretty=format:%h", "--abbrev=7", "--max-count=1",
-      "--diff-filter=d", "--name-only", *args, "--", *files
+      "--diff-filter=d", "--name-only", *args, "--", files.join(" ")
     )
     rev, *paths = out.chomp.split(/\n/).reject(&:empty?)
     [rev, paths]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This PR moves `utils/gem.rb` from `false` to `true` in `sorbet/files.yaml`. Tests are expected to fail atm.