### PR TITLE
os/mac: silence AppleLanguages error, fallback to system prefs

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -59,13 +59,30 @@ module OS
     end
 
     def languages
-      @languages ||= [
+      return @languages if @languages
+
+      os_langs = Utils.popen_read("defaults", "read", "-g", "AppleLanguages")
+      if os_langs.blank?
+        # User settings don't exist so check the system-wide one.
+        os_langs = Utils.popen_read("defaults", "read", "/Library/Preferences/.GlobalPreferences", "AppleLanguages")
+      end
+      os_langs = os_langs.scan(/[^ \n"(),]+/)
+
+      @languages = [
         *Homebrew.args.value("language")&.split(","),
         *ENV["HOMEBREW_LANGUAGES"]&.split(","),
-        *Open3.capture2("defaults", "read", "-g", "AppleLanguages")
-              .first
-              .scan(/[^ \n"(),]+/),
+        *os_langs,
       ].uniq
+
+      # Ensure all languages are valid
+      @languages.select! do |lang|
+        Locale.parse(lang)
+        true
+      rescue Locale::ParserError
+        false
+      end
+
+      @languages
     end
 
     def language


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Utils.popen_read` rather than `Open3.capture2` to silence stderr.

`-g` searches `~/Library/Preferences/.GlobalPreferences.plist`. It's possible no languages setting will exist there so fall back to `/Library/Preferences/.GlobalPreferences.plist` if it doesn't. I'm not entirely sure if the OS behaviour is override (system-wide settings are ignored in presence of user settings) or merge (both user and system-wide settings are used) - I assume override here as that's a safer thing to do.