### PR TITLE
Utils::Bottles::tag: ARM tag is arm64_big_sur

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -87,6 +87,7 @@ then
   odie "Cowardly refusing to continue at this prefix: $HOMEBREW_PREFIX"
 fi
 
+HOMEBREW_PROCESSOR="$(uname -m)"
 HOMEBREW_SYSTEM="$(uname -s)"
 case "$HOMEBREW_SYSTEM" in
   Darwin) HOMEBREW_MACOS="1" ;;
@@ -119,11 +120,9 @@ fi
 
 if [[ -n "$HOMEBREW_MACOS" ]]
 then
-  HOMEBREW_PROCESSOR="$(uname -p)"
   HOMEBREW_PRODUCT="Homebrew"
   HOMEBREW_SYSTEM="Macintosh"
-  # This is i386 even on x86_64 machines
-  [[ "$HOMEBREW_PROCESSOR" = "i386" ]] && HOMEBREW_PROCESSOR="Intel"
+  [[ "$HOMEBREW_PROCESSOR" = "x86_64" ]] && HOMEBREW_PROCESSOR="Intel"
   HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
   HOMEBREW_OS_VERSION="macOS $HOMEBREW_MACOS_VERSION"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
@@ -166,7 +165,6 @@ then
     HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH="1"
   fi
 else
-  HOMEBREW_PROCESSOR="$(uname -m)"
   HOMEBREW_PRODUCT="${HOMEBREW_SYSTEM}brew"
   [[ -n "$HOMEBREW_LINUX" ]] && HOMEBREW_OS_VERSION="$(lsb_release -sd 2>/dev/null)"
   : "${HOMEBREW_OS_VERSION:=$(uname -r)}"

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -9,7 +9,7 @@ module Utils
         if Hardware::CPU.intel?
           MacOS.version.to_sym
         else
-          "#{ENV["HOMEBREW_PROCESSOR"]}_#{MacOS.version.to_sym}".to_sym
+          "#{Hardware::CPU.arch}_#{MacOS.version.to_sym}".to_sym
         end
       end
     end

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -6,9 +6,11 @@ module Utils
       undef tag
 
       def tag
-        tag = MacOS.version.to_sym
-        tag = "#{tag}_arm".to_sym if Hardware::CPU.arm?
-        tag
+        if Hardware::CPU.intel?
+          MacOS.version.to_sym
+        else
+          "#{ENV["HOMEBREW_PROCESSOR"]}_#{MacOS.version.to_sym}".to_sym
+        end
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Consistent with the Linux bottle tags, `aarch64_linux`, `armv7_linux`, and `x86_64_linux`.

See https://github.com/Homebrew/brew/blob/d1f6296f0fef3c06ddd29630ca00f950a8f7b762/Library/Homebrew/utils/bottles.rb#L9