### PR TITLE
sorbet: set utils/notability.rb to true

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -454,7 +454,6 @@ false:
   - ./utils/fork.rb
   - ./utils/formatter.rb
   - ./utils/github.rb
-  - ./utils/notability.rb
   - ./utils/popen.rb
   - ./utils/user.rb
 
@@ -891,6 +890,7 @@ true:
   - ./test/support/helper/fixtures.rb
   - ./test/support/lib/config.rb
   - ./utils/bottles.rb
+  - ./utils/notability.rb
   - ./utils/git.rb
   - ./utils/shell.rb
   - ./utils/svn.rb

--- a/Library/Homebrew/sorbet/rbi/utils/notability.rbi
+++ b/Library/Homebrew/sorbet/rbi/utils/notability.rbi
@@ -1,0 +1,15 @@
+# typed: strict
+
+module SharedAudits
+  def github(user, repo)
+  end
+
+  def gitlab(user, repo)
+  end
+
+  def bitbucket(user, repo)
+  end
+
+  def curl_output(*args, secrets: [], **options)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This PR moves `utils/notability.rb` to `true` in `sorbet/files.yaml`