### PR TITLE
update: delete python from cellar

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -598,6 +598,14 @@ EOS
     fi
   done
 
+  if [ -d "$HOMEBREW_CELLAR/python" ]; then
+    # We do not ship a "python" formula anymore and the migration
+    # to python@3.8 left the old python 3.7 folder around.
+    # Remove it because it confuses brew as this folder is not
+    # supposed to exist anymore
+    rm -rf "$HOMEBREW_CELLAR/python"
+  fi
+
   safe_cd "$HOMEBREW_REPOSITORY"
 
   if [[ -n "$HOMEBREW_UPDATED" ||


### PR DESCRIPTION
We do not ship a "python" formula anymore and the migration
to python@3.8 left the old python 3.7 folder around.
Remove it because it confuses brew as this folder is not
supposed to exist anymore

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
