### PR TITLE
Make Homebrew work with Xcode 12 Beta 2 on Apple Silicon

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -2,7 +2,9 @@
 
 module Hardware
   def self.oldest_cpu(version = MacOS.version)
-    if version >= :mojave
+    if CPU.arch == :arm64
+      :arm_vortex_tempest
+    elsif version >= :mojave
       :nehalem
     else
       generic_oldest_cpu

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -12,14 +12,15 @@ module Hardware
     class << self
       def optimization_flags
         @optimization_flags ||= {
-          native:  arch_flag("native"),
-          nehalem: "-march=nehalem",
-          core2:   "-march=core2",
-          core:    "-march=prescott",
-          armv6:   "-march=armv6",
-          armv8:   "-march=armv8-a",
-          ppc64:   "-mcpu=powerpc64",
-          ppc64le: "-mcpu=powerpc64le",
+          native:             arch_flag("native"),
+          nehalem:            "-march=nehalem",
+          core2:              "-march=core2",
+          core:               "-march=prescott",
+          arm_vortex_tempest: "",
+          armv6:              "-march=armv6",
+          armv8:              "-march=armv8-a",
+          ppc64:              "-mcpu=powerpc64",
+          ppc64le:            "-mcpu=powerpc64le",
         }.freeze
       end
       alias generic_optimization_flags optimization_flags

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -43,6 +43,10 @@ module OS
 
       # For OS::Mac::Version compatibility
       def requires_nehalem_cpu?
+        unless Hardware::CPU.intel?
+          raise "Unexpected architecture: #{Hardware::CPU.arch}. This only works with Intel architecture."
+        end
+
         Hardware.oldest_cpu(self) == :nehalem
       end
       # https://en.wikipedia.org/wiki/Nehalem_(microarchitecture)

--- a/Library/Homebrew/test/os/mac/version_spec.rb
+++ b/Library/Homebrew/test/os/mac/version_spec.rb
@@ -50,6 +50,7 @@ describe OS::Mac::Version do
   end
 
   specify "#requires_nehalem_cpu?" do
+    expect(Hardware::CPU).to receive(:type).at_least(:twice).and_return(:intel)
     expect(described_class.new("10.14").requires_nehalem_cpu?).to be true
     expect(described_class.new("10.12").requires_nehalem_cpu?).to be false
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Starting with Xcode 12 Beta 2, builds that used to work on Apple Silicon [now break](https://github.com/Homebrew/brew/issues/7857#issuecomment-655536261) due to `Hardware#oldest_cpu` returning `:nehalem`.

This PR is the first in a series of improvements to `Hardware#oldest_cpu`. It resolves the Xcode 12 Beta 2 issue for now.

**Update:** Confirmed to work on Xcode 12 Beta 1 (Apple Silicon), Xcode 12 Beta 2 (Apple Silicon) and Intel Macs.
