### PR TITLE
Allow listing casks when using brew list

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -32,7 +32,7 @@ module Homebrew
       switch "--pinned",
              description: "Show the versions of pinned formulae, or only the specified (pinned) "\
                           "formulae if <formula> are provided. See also `pin`, `unpin`."
-      switch "--casks",
+      switch "--cask",
              description: "List casks"
       # passed through to ls
       switch "-1",
@@ -47,14 +47,14 @@ module Homebrew
              description: "Sort by time modified, listing most recently modified first."
       switch :verbose
       switch :debug
-      ["--unbrewed", "--multiple", "--pinned", "-l", "-r", "-t"].each { |flag| conflicts "--casks", flag }
+      ["--unbrewed", "--multiple", "--pinned", "-l", "-r", "-t"].each { |flag| conflicts "--cask", flag }
     end
   end
 
   def list
     list_args.parse
 
-    return list_casks if args.casks?
+    return list_casks if args.cask?
 
     return list_unbrewed if args.unbrewed?
 

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -47,7 +47,7 @@ module Homebrew
              description: "Sort by time modified, listing most recently modified first."
       switch :verbose
       switch :debug
-      conflicts "--casks", "--unbrewed", "--multiple", "--pinned", "-l", "-r", "-t"
+      ["--unbrewed", "--multiple", "--pinned", "-l", "-r", "-t"].each { |flag| conflicts "--casks", flag }
     end
   end
 

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -3,6 +3,7 @@
 require "metafiles"
 require "formula"
 require "cli/parser"
+require "cask/cmd"
 
 module Homebrew
   module_function
@@ -31,6 +32,8 @@ module Homebrew
       switch "--pinned",
              description: "Show the versions of pinned formulae, or only the specified (pinned) "\
                           "formulae if <formula> are provided. See also `pin`, `unpin`."
+      switch "--casks",
+             description: "List casks"
       # passed through to ls
       switch "-1",
              description: "Force output to be one entry per line. " \
@@ -44,11 +47,14 @@ module Homebrew
              description: "Sort by time modified, listing most recently modified first."
       switch :verbose
       switch :debug
+      conflicts "--casks", "--unbrewed", "--multiple", "--pinned", "-l", "-r", "-t"
     end
   end
 
   def list
     list_args.parse
+
+    return list_casks if args.casks?
 
     return list_unbrewed if args.unbrewed?
 
@@ -149,6 +155,14 @@ module Homebrew
         puts "#{d.basename} #{versions * " "}"
       end
     end
+  end
+
+  def list_casks
+    cask_list = Cask::Cmd::List.new args.named
+    cask_list.one = ARGV.include? "-1"
+    cask_list.versions = args.versions?
+    cask_list.full_name = args.full_name?
+    cask_list.run
   end
 end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -290,6 +290,8 @@ If *`formula`* is provided, summarise the paths within its current keg.
   Only show formulae with multiple versions installed.
 * `--pinned`:
   Show the versions of pinned formulae, or only the specified (pinned) formulae if *`formula`* are provided. See also `pin`, `unpin`.
+* `--cask`:
+  List casks
 * `-1`:
   Force output to be one entry per line. This is the default when output is not to a terminal.
 * `-l`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -393,6 +393,10 @@ Only show formulae with multiple versions installed\.
 Show the versions of pinned formulae, or only the specified (pinned) formulae if \fIformula\fR are provided\. See also \fBpin\fR, \fBunpin\fR\.
 .
 .TP
+\fB\-\-cask\fR
+List casks
+.
+.TP
 \fB\-1\fR
 Force output to be one entry per line\. This is the default when output is not to a terminal\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Allow listing casks when running `brew list --casks`. Since `brew list` either lists formulae or casks, flags that are not accepted by `brew cask list` are forbidden by `brew list --casks`.