### PR TITLE
Revert "python_virtualenv_constants: upgrade virtualenv to 20.0.26"

### DIFF
--- a/Library/Homebrew/language/python_virtualenv_constants.rb
+++ b/Library/Homebrew/language/python_virtualenv_constants.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 PYTHON_VIRTUALENV_URL =
-  "https://files.pythonhosted.org/packages/c4/1b" \
-  "/09bb751c6e805bf4711bbaead5499c8d8caf92398ba8da92daa8bf19f60e" \
-  "/virtualenv-20.0.26.tar.gz"
+  "https://files.pythonhosted.org/packages/11/74" \
+  "/2c151a13ef41ab9fb43b3c4ff9e788e0496ed7923b2078d42cab30622bdf" \
+  "/virtualenv-16.7.4.tar.gz"
 PYTHON_VIRTUALENV_SHA256 =
-  "e10cc66f40cbda459720dfe1d334c4dc15add0d80f09108224f171006a97a172"
+  "94a6898293d07f84a98add34c4df900f8ec64a570292279f6d91c781d37fd305"
 
 PYTHON_VIRTUALENV_URL_MOJAVE =
   "https://files.pythonhosted.org/packages/b1/72" \


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This reverts commit 6dbcf83a21d36a0c03990a923cc07ef4a06e4e7f (#7941)

> While previous versions of `virtualenv` didn't have any dependencies, virtualenv 20.x does so this currently breaks CI on Catalina