### PR TITLE
Allow multiple licenses to be specified as an array with a consistent internal API 

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -331,14 +331,14 @@ module Homebrew
     def audit_license
       if formula.license.present?
         non_standard_licenses = []
-        formula.license.each do |lic|
-          next if @spdx_data["licenses"].any? { |standard_lic| standard_lic["licenseId"] == lic }
+        formula.license.each do |license|
+          next if @spdx_data["licenses"].any? { |spdx| spdx["licenseId"] == license }
 
-          non_standard_licenses << lic
+          non_standard_licenses << license
         end
 
         if non_standard_licenses.present?
-          problem "Formula #{formula.name} contains non standard SPDX license: #{non_standard_licenses}."
+          problem "Formula #{formula.name} contains non-standard SPDX licenses: #{non_standard_licenses}."
         end
 
         return unless @online

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -330,16 +330,16 @@ module Homebrew
 
     def audit_license
       if formula.license.present?
-        if @spdx_data["licenses"].any? { |lic| lic["licenseId"] == formula.license }
+        if formula.license.any? { |lic| @spdx_data["licenses"].any? { |standard_lic| standard_lic["licenseId"] == lic } }
           return unless @online
 
           user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*}) if @new_formula
           return if user.blank?
 
           github_license = GitHub.get_repo_license(user, repo)
-          return if github_license && [formula.license, "NOASSERTION"].include?(github_license)
+          return if github_license && (formula.license +  ["NOASSERTION"]).include?(github_license)
 
-          problem "License mismatch - GitHub license is: #{github_license}, "\
+          problem "License mismatch - GitHub license is: #{Array(github_license)}, "\
                   "but Formulae license states: #{formula.license}."
         else
           problem "#{formula.license} is not a standard SPDX license."

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -333,6 +333,7 @@ module Homebrew
         non_standard_licenses = []
         formula.license.each do |lic|
           next if @spdx_data["licenses"].any? { |standard_lic| standard_lic["licenseId"] == lic }
+
           non_standard_licenses << lic
         end
 
@@ -340,17 +341,16 @@ module Homebrew
           problem "Formula #{formula.name} contains non standard SPDX license: #{non_standard_licenses}."
         end
 
-          return unless @online
+        return unless @online
 
-          user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*}) if @new_formula
-          return if user.blank?
+        user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*}) if @new_formula
+        return if user.blank?
 
-          github_license = GitHub.get_repo_license(user, repo)
-          return if github_license && (formula.license +  ["NOASSERTION"]).include?(github_license)
+        github_license = GitHub.get_repo_license(user, repo)
+        return if github_license && (formula.license + ["NOASSERTION"]).include?(github_license)
 
-          problem "License mismatch - GitHub license is: #{Array(github_license)}, "\
-                  "but Formulae license states: #{formula.license}."
-
+        problem "License mismatch - GitHub license is: #{Array(github_license)}, "\
+                "but Formulae license states: #{formula.license}."
 
       elsif @new_formula
         problem "No license specified for package."

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -337,7 +337,7 @@ module Homebrew
         end
 
         if non_standard_licenses.present?
-          problem "Formula #{formula.name} contains non standard SPDX license: #{non_standard_licenses} "
+          problem "Formula #{formula.name} contains non standard SPDX license: #{non_standard_licenses}."
         end
 
           return unless @online

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1682,7 +1682,7 @@ class Formula
       "aliases"                  => aliases.sort,
       "versioned_formulae"       => versioned_formulae.map(&:name),
       "desc"                     => desc,
-      "license"                  => license,
+      "license"                  => license.class == String ? [license] : license,
       "homepage"                 => homepage,
       "versions"                 => {
         "stable" => stable&.version&.to_s,
@@ -2210,7 +2210,17 @@ class Formula
     # Shows when running `brew info`.
     #
     # <pre>license "BSD-2-Clause"</pre>
-    attr_rw :license
+    def license args=nil
+      if args.blank?
+        return @licenses
+      else
+        @licenses = args.class == String ? [args] : args
+        puts @licenses
+      # license.
+      end
+    end
+
+    # attr_rw :license
 
     # @!attribute [w] homepage
     # The homepage for the software. Used by users to get more information

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2216,7 +2216,7 @@ class Formula
       if args.nil?
         return @licenses
       else
-        @licenses = Array(args)
+        @licenses = Array(args) unless args == ""
         puts @licenses
       # license.
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2214,11 +2214,11 @@ class Formula
     # <pre>license "BSD-2-Clause"</pre>
     def license(args = nil)
       if args.nil?
-        return @licenses
+        @licenses
       else
         @licenses = Array(args) unless args == ""
         puts @licenses
-      # license.
+        # license.
       end
     end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2208,13 +2208,15 @@ class Formula
     # @!attribute [w]
     # The SPDX ID of the open-source license that the formula uses.
     # Shows when running `brew info`.
+    # Multiple licenses means that the software is licensed under multiple licenses.
+    # Do not use multiple licenses if e.g. different parts are under different licenses.
     #
     # <pre>license "BSD-2-Clause"</pre>
-    def license args=nil
-      if args.blank?
+    def license(args = nil)
+      if args.nil?
         return @licenses
       else
-        @licenses = args.class == String ? [args] : args
+        @licenses = Array(args)
         puts @licenses
       # license.
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2215,7 +2215,7 @@ class Formula
       if args.nil?
         @licenses
       else
-        @licenses = Array(args) unless args == ""
+        @licenses = Array(args)
       end
     end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2210,19 +2210,14 @@ class Formula
     # Shows when running `brew info`.
     # Multiple licenses means that the software is licensed under multiple licenses.
     # Do not use multiple licenses if e.g. different parts are under different licenses.
-    #
     # <pre>license "BSD-2-Clause"</pre>
     def license(args = nil)
       if args.nil?
         @licenses
       else
         @licenses = Array(args) unless args == ""
-        puts @licenses
-        # license.
       end
     end
-
-    # attr_rw :license
 
     # @!attribute [w] homepage
     # The homepage for the software. Used by users to get more information

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1682,7 +1682,7 @@ class Formula
       "aliases"                  => aliases.sort,
       "versioned_formulae"       => versioned_formulae.map(&:name),
       "desc"                     => desc,
-      "license"                  => license.class == String ? [license] : license,
+      "license"                  => license,
       "homepage"                 => homepage,
       "versions"                 => {
         "stable" => stable&.version&.to_s,

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1131,7 +1131,7 @@ class FormulaInstaller
     end
     return if @only_deps
 
-    return unless formula.license.all? { |lic| forbidden_licenses.include? lic }
+    return unless formula.license.all? { |license| forbidden_licenses.include? license }
 
     raise CannotInstallFormulaError, <<~EOS
       #{formula.name}'s licenses are all forbidden: #{formula.license}.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1123,18 +1123,18 @@ class FormulaInstaller
       next if @ignore_deps
 
       dep_f = dep.to_formula
-      next unless forbidden_licenses.include? dep_f.license
+      next unless dep_f.license.all?{ |lic| forbidden_licenses.include? lic }
 
       raise CannotInstallFormulaError, <<~EOS
-        The installation of #{formula.name} has a dependency on #{dep.name} with a forbidden license #{dep_f.license}.
+        The installation of #{formula.name} has a dependency on #{dep.name} where all its licenses are forbidden: #{dep_f.license}.
       EOS
     end
     return if @only_deps
 
-    return unless forbidden_licenses.include? formula.license
+    return unless formula.license.all? { |lic| forbidden_licenses.include? lic }
 
     raise CannotInstallFormulaError, <<~EOS
-      #{formula.name} has a forbidden license #{formula.license}.
+      #{formula.name}'s licenses are all forbidden: #{formula.license}.
     EOS
   end
 end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1123,7 +1123,7 @@ class FormulaInstaller
       next if @ignore_deps
 
       dep_f = dep.to_formula
-      next unless dep_f.license.all? { |lic| forbidden_licenses.include? lic }
+      next unless dep_f.license.all? { |license| forbidden_licenses.include? license }
 
       raise CannotInstallFormulaError, <<~EOS
         The installation of #{formula.name} has a dependency on #{dep.name} where all its licenses are forbidden: #{dep_f.license}.

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1123,7 +1123,7 @@ class FormulaInstaller
       next if @ignore_deps
 
       dep_f = dep.to_formula
-      next unless dep_f.license.all?{ |lic| forbidden_licenses.include? lic }
+      next unless dep_f.license.all? { |lic| forbidden_licenses.include? lic }
 
       raise CannotInstallFormulaError, <<~EOS
         The installation of #{formula.name} has a dependency on #{dep.name} where all its licenses are forbidden: #{dep_f.license}.

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -130,7 +130,7 @@ module Homebrew
         fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
-            license "#{custom_spdx_id}"
+            license "#{license_array}"
           end
         RUBY
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -94,7 +94,6 @@ module Homebrew
         fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: false
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
-            license ""
           end
         RUBY
 
@@ -106,7 +105,6 @@ module Homebrew
         fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
-            license ""
           end
         RUBY
 
@@ -123,19 +121,19 @@ module Homebrew
         RUBY
 
         fa.audit_license
-        expect(fa.problems.first).to match "Formula foo contains non standard SPDX license: [\"zzz\"]."
+        expect(fa.problems.first).to match "Formula foo contains non-standard SPDX licenses: [\"zzz\"]."
       end
 
       it "detects if license array contains a non-standard spdx-id" do
         fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
-            license "#{license_array}"
+            license #{license_array_nonstandard}
           end
         RUBY
 
         fa.audit_license
-        expect(fa.problems.first).to match "Formula foo contains non standard SPDX license: [\"zzz\"]."
+        expect(fa.problems.first).to match "Formula foo contains non-standard SPDX licenses: [\"zzz\"]."
       end
 
       it "verifies that a license info is a standard spdx id" do

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -86,9 +86,9 @@ module Homebrew
 
       let(:custom_spdx_id) { "zzz" }
       let(:standard_mismatch_spdx_id) { "0BSD" }
-      let(:license_array) { ["0BSD", "GPL-3.0"] }
-      let(:license_array_mismatch) { ["0BSD", "MIT"] }
-      let(:license_array_nonstandard) { ["0BSD", "zzz", "MIT"] }
+      let(:license_array) { ['0BSD', 'GPL-3.0'] }
+      let(:license_array_mismatch) { ['0BSD', 'MIT'] }
+      let(:license_array_nonstandard) { ['0BSD', 'zzz', 'MIT'] }
 
       it "does not check if the formula is not a new formula" do
         fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: false

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -120,7 +120,7 @@ module Homebrew
         RUBY
 
         fa.audit_license
-        expect(fa.problems.first).to match "#{custom_spdx_id} is not a standard SPDX license."
+        expect(fa.problems.first).to match "Formula foo contains non standard SPDX license: [\"zzz\"]."
       end
 
       it "verifies that a license info is a standard spdx id" do
@@ -160,8 +160,8 @@ module Homebrew
         RUBY
 
         fa.audit_license
-        expect(fa.problems.first).to match "License mismatch - GitHub license is: GPL-3.0, "\
-        "but Formulae license states: #{standard_mismatch_spdx_id}."
+        expect(fa.problems.first).to match "License mismatch - GitHub license is: [\"GPL-3.0\"], "\
+        "but Formulae license states: #{Array(standard_mismatch_spdx_id)}."
       end
     end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -86,9 +86,9 @@ module Homebrew
 
       let(:custom_spdx_id) { "zzz" }
       let(:standard_mismatch_spdx_id) { "0BSD" }
-      let(:license_array) { ['0BSD', 'GPL-3.0'] }
-      let(:license_array_mismatch) { ['0BSD', 'MIT'] }
-      let(:license_array_nonstandard) { ['0BSD', 'zzz', 'MIT'] }
+      let(:license_array) { ["0BSD", "GPL-3.0"] }
+      let(:license_array_mismatch) { ["0BSD", "MIT"] }
+      let(:license_array_nonstandard) { ["0BSD", "zzz", "MIT"] }
 
       it "does not check if the formula is not a new formula" do
         fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This change allows for the indication that a package is licensed by mulltiple licenses. 
In this change, we make a distinction between an external interface and an internal API. 

In the external interface, in the formula definition file, we allow either `"MIT"` or `["MIT", "0BSD"]` for single and multi-valued licenses respectively. 

**In the internal API:** 
when license DSL is not stated -> `NilClass` 
`license ""` (stated but empty) -> `NilClass`, 
`"MIT"` -> ["MIT"],
`["MIT", "0BSD"]` -> `["MIT", "0BSD"]`

This change has a few implications with `brew audit` and `brew install`. Changes will be made accordingly and tests will be written to enforce and ensure the expected behaviours. 