### PR TITLE
keg: delete more alias LinkedKegs symlinks.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -281,11 +281,7 @@ class Keg
       end
 
       alias_linkedkegs_symlink = linkedkegs/a
-      if alias_linkedkegs_symlink.symlink? && alias_linkedkegs_symlink.exist?
-        alias_linkedkegs_symlink.delete if alias_linkedkegs_symlink.realpath == linked_keg_record.realpath
-      elsif alias_linkedkegs_symlink.symlink? || alias_linkedkegs_symlink.exist?
-        alias_linkedkegs_symlink.delete
-      end
+      alias_linkedkegs_symlink.delete if alias_linkedkegs_symlink.symlink? || alias_linkedkegs_symlink.exist?
     end
 
     Pathname.glob("#{opt_record}@*").each do |a|
@@ -298,9 +294,7 @@ class Keg
       end
 
       alias_linkedkegs_symlink = linkedkegs/a
-      if alias_linkedkegs_symlink.symlink? && alias_linkedkegs_symlink.exist?
-        alias_linkedkegs_symlink.delete if rack == alias_linkedkegs_symlink.realpath.parent
-      end
+      alias_linkedkegs_symlink.delete if alias_linkedkegs_symlink.symlink? || alias_linkedkegs_symlink.exist?
     end
   end
 


### PR DESCRIPTION
We don't actually care what it points to because we shouldn't have LinkedKegs around for aliases at all (unlike `opt` links).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----