### PR TITLE
sorbet/utils: move files to true

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -849,7 +849,6 @@ false:
   - ./unpack_strategy/uncompressed.rb
   - ./utils/gems.rb
   - ./utils/inreplace.rb
-  - ./utils/link.rb
   - ./utils/shebang.rb
   - ./version.rb
 
@@ -891,6 +890,7 @@ true:
   - ./test/support/helper/fixtures.rb
   - ./test/support/lib/config.rb
   - ./utils/bottles.rb
+  - ./utils/link.rb
   - ./utils/notability.rb
   - ./utils/shell.rb
   - ./utils/svn.rb

--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -849,7 +849,6 @@ false:
   - ./unpack_strategy/uncompressed.rb
   - ./utils/gems.rb
   - ./utils/inreplace.rb
-  - ./utils/shebang.rb
   - ./version.rb
 
 true:
@@ -892,6 +891,7 @@ true:
   - ./utils/bottles.rb
   - ./utils/link.rb
   - ./utils/notability.rb
+  - ./utils/shebang.rb
   - ./utils/shell.rb
   - ./utils/svn.rb
   - ./utils/tty.rb

--- a/Library/Homebrew/sorbet/rbi/utils/utils.rbi
+++ b/Library/Homebrew/sorbet/rbi/utils/utils.rbi
@@ -6,3 +6,7 @@ module Utils
   class Bottles
   end
 end
+
+module Utils::Link
+  include Kernel
+end

--- a/Library/Homebrew/sorbet/rbi/utils/utils.rbi
+++ b/Library/Homebrew/sorbet/rbi/utils/utils.rbi
@@ -5,8 +5,12 @@ module Utils
 
   class Bottles
   end
-end
 
-module Utils::Link
-  include Kernel
+  module Link
+    include Kernel
+  end
+
+  module Shebang
+    include Kernel
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
----
This PR moves `utils/link.rb` and `utils/shebang.rb` to `true` in `sorbet/files.yaml` and deals with the resulting type errors.