### PR TITLE
sandbox: use Dir.home instead of HOME

### DIFF
--- a/Library/Homebrew/sandbox.rb
+++ b/Library/Homebrew/sandbox.rb
@@ -47,12 +47,12 @@ class Sandbox
   end
 
   def allow_cvs
-    allow_write_path "#{ENV["HOME"]}/.cvspass"
+    allow_write_path "#{Dir.home(ENV["USER"])}/.cvspass"
   end
 
   def allow_fossil
-    allow_write_path "#{ENV["HOME"]}/.fossil"
-    allow_write_path "#{ENV["HOME"]}/.fossil-journal"
+    allow_write_path "#{Dir.home(ENV["USER"])}/.fossil"
+    allow_write_path "#{Dir.home(ENV["USER"])}/.fossil-journal"
   end
 
   def allow_write_cellar(formula)
@@ -63,7 +63,7 @@ class Sandbox
 
   # Xcode projects expect access to certain cache/archive dirs.
   def allow_write_xcode
-    allow_write_path "#{ENV["HOME"]}/Library/Developer"
+    allow_write_path "#{Dir.home(ENV["USER"])}/Library/Developer"
   end
 
   def allow_write_log(formula)


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

~~This reverts commit 23cb93ff1c8f4536924c11d16669d2a51247fa50 (#7897)~~

Currently, xcodebuild formulae fail on CI due to being unable to write to `/Users/brew/Library/Developer/Xcode`, ~~which I think can be fixed by reverting #7897~~

~~Of course, this should only be a temporary fix for now until a better solution is found.~~

Related homebrew-core pull requests:

- bluepill Homebrew/homebrew-core#57389
- yacas Homebrew/homebrew-core#57460
- ios-deploy Homebrew/homebrew-core#57738