### PR TITLE
formula: use installed_prefixes in opt_or_installed_prefix_keg

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1618,8 +1618,8 @@ class Formula
     Formula.cache[:opt_or_installed_prefix_keg] ||= {}
     Formula.cache[:opt_or_installed_prefix_keg][name] ||= if optlinked? && opt_prefix.exist?
       Keg.new(opt_prefix)
-    elsif installed_prefix.directory?
-      Keg.new(installed_prefix)
+    elsif (latest_installed_prefix = installed_prefixes.last)
+      Keg.new(latest_installed_prefix)
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`installed_prefix` always refers to the latest version - which may not necessarily be installed like the name suggests.
`installed_prefixes` meanwhile guarantees to return paths that actually exist.

This should fix the `brew doctor` failure if an old `python` is installed, as seen in recent CI failures.