### PR TITLE
introduce ELFShim#rpath, refactor keg_relocate to use the same. return nil on no DT_RPATH, DT_RUNPATH, DT_SONAME, PT_INTERP 

### DIFF
--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -246,7 +246,7 @@ module ELFShim
       raise ErrorDuringExecution.new(cmd_rpath, status: $CHILD_STATUS, output: [[:stderr, rpath]])
     end
 
-    rpath
+    rpath unless rpath.blank?
   end
 
   def patchelf_patcher

--- a/Library/Homebrew/os/linux/elf.rb
+++ b/Library/Homebrew/os/linux/elf.rb
@@ -1,7 +1,45 @@
 # frozen_string_literal: true
 
+if HOMEBREW_PATCHELF_RB
+  require "utils/gems"
+  Homebrew.install_bundler_gems!
+  require "patchelf"
+
+  module PatchELF
+    refine Patcher do
+      # patchelf.rb throws exception when the requested entry is missing in the ELF file.
+      # We prefer an API that returns nil.
+
+      def rpath
+        super
+      rescue PatchELF::MissingTagError
+        nil
+      end
+
+      def runpath
+        super
+      rescue PatchELF::MissingTagError
+        nil
+      end
+
+      def soname
+        super
+      rescue PatchELF::MissingTagError
+        nil
+      end
+
+      def interpreter
+        super
+      rescue PatchELF::MissingSegmentError
+        nil
+      end
+    end
+  end
+end
+
 # @see https://en.wikipedia.org/wiki/Executable_and_Linkable_Format#File_header
 module ELFShim
+  using PatchELF if HOMEBREW_PATCHELF_RB
   MAGIC_NUMBER_OFFSET = 0
   MAGIC_NUMBER_ASCII = "\x7fELF"
 
@@ -68,16 +106,21 @@ module ELFShim
     elf_type == :executable
   end
 
+  def rpath
+    return @rpath if defined? @rpath
+
+    @rpath = if HOMEBREW_PATCHELF_RB
+      rpath_using_patchelf_rb
+    else
+      rpath_using_patchelf
+    end
+  end
+
   def interpreter
     return @interpreter if defined? @interpreter
 
     @interpreter = if HOMEBREW_PATCHELF_RB
-      begin
-        patchelf_patcher.interpreter
-      rescue PatchELF::PatchError => e
-        opoo e unless e.to_s.start_with? "No interpreter found"
-        nil
-      end
+      patchelf_patcher.interpreter
     elsif (patchelf = DevelopmentTools.locate "patchelf")
       interp = Utils.popen_read(patchelf, "--print-interpreter", to_s, err: :out).strip
       $CHILD_STATUS.success? ? interp : nil
@@ -147,21 +190,7 @@ module ELFShim
 
     def needed_libraries_using_patchelf_rb(path)
       patcher = path.patchelf_patcher
-      return [nil, []] unless patcher
-
-      soname = begin
-        patcher.soname
-      rescue PatchELF::PatchError => e
-        opoo e unless e.to_s.start_with? "Entry DT_SONAME not found, not a shared library?"
-        nil
-      end
-      needed = begin
-        patcher.needed
-      rescue PatchELF::PatchError => e
-        opoo e
-        []
-      end
-      [soname, needed]
+      [patcher.soname, patcher.needed]
     end
 
     def needed_libraries_using_patchelf(path)
@@ -198,14 +227,32 @@ module ELFShim
     end
   end
 
+  def rpath_using_patchelf_rb
+    patchelf_patcher.runpath || patchelf_patcher.rpath
+  end
+
+  def rpath_using_patchelf
+    patchelf = DevelopmentTools.locate "patchelf"
+    odie "Could not locate patchelf, please: brew install patchelf." if patchelf.nil?
+
+    cmd_rpath = [patchelf, "--print-rpath", to_s]
+    rpath = Utils.popen_read(*cmd_rpath, err: :out).strip
+
+    # patchelf requires that the ELF file have a .dynstr section.
+    # Skip ELF files that do not have a .dynstr section.
+    return if ["cannot find section .dynstr", "strange: no string table"].include?(rpath)
+
+    unless $CHILD_STATUS.success?
+      raise ErrorDuringExecution.new(cmd_rpath, status: $CHILD_STATUS, output: [[:stderr, rpath]])
+    end
+
+    rpath
+  end
+
   def patchelf_patcher
     return unless HOMEBREW_PATCHELF_RB
 
-    @patchelf_patcher ||= begin
-      Homebrew.install_bundler_gems!
-      require "patchelf"
-      PatchELF::Patcher.new to_s, logging: false
-    end
+    @patchelf_patcher ||= PatchELF::Patcher.new to_s, logging: false
   end
 
   def metadata

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "extend/pathname"
+
+describe Pathname do
+  let(:elf_dir) { described_class.new "#{TEST_FIXTURE_DIR}/elf" }
+  let(:sho) { elf_dir/"libhello.so.0" }
+  let(:exec) { elf_dir/"hello" }
+
+  describe "#interpreter" do
+    it "returns interpreter" do
+      expect(exec.interpreter).to eq "/lib64/ld-linux-x86-64.so.2"
+    end
+  end
+
+  describe "#rpath" do
+    it "returns nil when absent" do
+      expect(exec.rpath).to be_nil
+      expect(sho.rpath).to be_nil
+    end
+  end
+end

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -2,7 +2,7 @@
 
 require "extend/pathname"
 
-describe Pathname do
+describe Pathname, skip: HOMEBREW_PATCHELF_RB.blank? do
   let(:elf_dir) { described_class.new "#{TEST_FIXTURE_DIR}/elf" }
   let(:sho) { elf_dir/"libhello.so.0" }
   let(:exec) { elf_dir/"hello" }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

replace `patchelf --print-rpath` calls with `patchelf.rb`'s `.runpath` method.

