### PR TITLE
bottle --merge: Fix bug with cellar :any

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -446,10 +446,10 @@ module Homebrew
             first
           elsif second.start_with?("/")
             second
-          elsif cellars.include?(:any)
-            :any
-          elsif cellars.include?(:any_skip_relocation)
-            :any_skip_relocation
+          elsif cellars.include?("any")
+            "any"
+          elsif cellars.include?("any_skip_relocation")
+            "any_skip_relocation"
           else
             second
           end


### PR DESCRIPTION
`cellar :any` ought to have higher priority than `cellar :any_skip_relocation`.
The variables `first` and `second` are strings, not tags.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?