### PR TITLE
Add support for -march=sandybridge

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -14,6 +14,7 @@ module Hardware
         @optimization_flags ||= {
           native:             arch_flag("native"),
           nehalem:            "-march=nehalem",
+          sandybridge:        "-march=sandybridge",
           core2:              "-march=core2",
           core:               "-march=prescott",
           arm_vortex_tempest: "",


### PR DESCRIPTION
HHVM's been building with this (or equivalent predecessor patches); it
gets us a 20x speedup on real-world workloads, at the cost of slightly
worse compatibility.

This doesn't change the default, just makes it available as an explicit
choice.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
   - No: I looked for the existing flags here, and don't see a great way to test. Happy to add them with some guidance
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
   - Unsuccessfully: fails on master for me with no changes due to github API rate limits. No additional failures

-----
