### PR TITLE
add aliases - dependencies and dependents

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -328,22 +328,24 @@ HOMEBREW_ARG_COUNT="$#"
 HOMEBREW_COMMAND="$1"
 shift
 case "$HOMEBREW_COMMAND" in
-  ls)          HOMEBREW_COMMAND="list" ;;
-  homepage)    HOMEBREW_COMMAND="home" ;;
-  -S)          HOMEBREW_COMMAND="search" ;;
-  up)          HOMEBREW_COMMAND="update" ;;
-  ln)          HOMEBREW_COMMAND="link" ;;
-  instal)      HOMEBREW_COMMAND="install" ;; # gem does the same
-  uninstal)    HOMEBREW_COMMAND="uninstall" ;;
-  rm)          HOMEBREW_COMMAND="uninstall" ;;
-  remove)      HOMEBREW_COMMAND="uninstall" ;;
-  configure)   HOMEBREW_COMMAND="diy" ;;
-  abv)         HOMEBREW_COMMAND="info" ;;
-  dr)          HOMEBREW_COMMAND="doctor" ;;
-  --repo)      HOMEBREW_COMMAND="--repository" ;;
-  environment) HOMEBREW_COMMAND="--env" ;;
-  --config)    HOMEBREW_COMMAND="config" ;;
-  -v)          HOMEBREW_COMMAND="--version" ;;
+  ls)           HOMEBREW_COMMAND="list" ;;
+  homepage)     HOMEBREW_COMMAND="home" ;;
+  -S)           HOMEBREW_COMMAND="search" ;;
+  up)           HOMEBREW_COMMAND="update" ;;
+  ln)           HOMEBREW_COMMAND="link" ;;
+  instal)       HOMEBREW_COMMAND="install" ;; # gem does the same
+  uninstal)     HOMEBREW_COMMAND="uninstall" ;;
+  rm)           HOMEBREW_COMMAND="uninstall" ;;
+  remove)       HOMEBREW_COMMAND="uninstall" ;;
+  configure)    HOMEBREW_COMMAND="diy" ;;
+  abv)          HOMEBREW_COMMAND="info" ;;
+  dr)           HOMEBREW_COMMAND="doctor" ;;
+  --repo)       HOMEBREW_COMMAND="--repository" ;;
+  environment)  HOMEBREW_COMMAND="--env" ;;
+  --config)     HOMEBREW_COMMAND="config" ;;
+  -v)           HOMEBREW_COMMAND="--version" ;;
+  dependencies) HOMEBREW_COMMAND="deps" ;;
+  dependents)   HOMEBREW_COMMAND="uses" ;;
 esac
 
 if [[ "$HOMEBREW_COMMAND" = "cask" ]]

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -10,7 +10,7 @@ module Homebrew
   def deps_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `deps` [<options>] [<formula>]
+        `deps`, `dependencies` [<options>] [<formula>]
 
         Show dependencies for <formula>. Additional options specific to <formula>
         may be appended to the command. When given multiple formula arguments,

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -13,7 +13,7 @@ module Homebrew
   def uses_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `uses` [<options>] <formula>
+        `uses`, `dependents` [<options>] <formula>
 
         Show formulae that specify <formula> as a dependency. When given multiple
         formula arguments, show the intersection of formulae that use <formula>.

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -6,22 +6,24 @@ module Commands
   HOMEBREW_CMD_PATH = (HOMEBREW_LIBRARY_PATH/"cmd").freeze
   HOMEBREW_DEV_CMD_PATH = (HOMEBREW_LIBRARY_PATH/"dev-cmd").freeze
   HOMEBREW_INTERNAL_COMMAND_ALIASES = {
-    "ls"          => "list",
-    "homepage"    => "home",
-    "-S"          => "search",
-    "up"          => "update",
-    "ln"          => "link",
-    "instal"      => "install", # gem does the same
-    "uninstal"    => "uninstall",
-    "rm"          => "uninstall",
-    "remove"      => "uninstall",
-    "configure"   => "diy",
-    "abv"         => "info",
-    "dr"          => "doctor",
-    "--repo"      => "--repository",
-    "environment" => "--env",
-    "--config"    => "config",
-    "-v"          => "--version",
+    "ls"           => "list",
+    "homepage"     => "home",
+    "-S"           => "search",
+    "up"           => "update",
+    "ln"           => "link",
+    "instal"       => "install", # gem does the same
+    "uninstal"     => "uninstall",
+    "rm"           => "uninstall",
+    "remove"       => "uninstall",
+    "configure"    => "diy",
+    "abv"          => "info",
+    "dr"           => "doctor",
+    "--repo"       => "--repository",
+    "environment"  => "--env",
+    "--config"     => "config",
+    "-v"           => "--version",
+    "dependencies" => "deps",
+    "dependents"   => "uses",
   }.freeze
 
   def valid_internal_cmd?(cmd)

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -845,7 +845,7 @@ _brew() {
     cleanup)                    _brew_cleanup ;;
     command)                    __brew_complete_commands ;;
     create)                     _brew_create ;;
-    deps)                       _brew_deps ;;
+    deps|dependencies)          _brew_deps ;;
     desc)                       _brew_desc ;;
     diy|configure)              _brew_diy ;;
     doctor|dr)                  _brew_doctor ;;
@@ -887,7 +887,7 @@ _brew() {
     untap)                      __brew_complete_tapped ;;
     update|up)                  _brew_update ;;
     upgrade)                    _brew_upgrade ;;
-    uses)                       _brew_uses ;;
+    uses|dependents)            _brew_uses ;;
     *)                          ;;
   esac
 }

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -279,25 +279,25 @@ __fish_brew_complete_cmd 'config' "Show Homebrew and system configuration for de
 
 __fish_brew_complete_cmd 'deps' "Show dependencies for given formulae"
 # accepts formulae argument only without --all or --installed options:
-__fish_brew_complete_arg 'deps; and not __fish_brew_opt --all --installed' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'deps dependencies; and not __fish_brew_opt --all --installed' -a '(__fish_brew_suggest_formulae_all)'
 # options that work only without --tree:
-__fish_brew_complete_arg 'deps; and not __fish_brew_opt --tree' -s n         -d "Show in topological order"
-__fish_brew_complete_arg 'deps; and not __fish_brew_opt --tree' -l 1         -d "Show only 1 level down"
-__fish_brew_complete_arg 'deps; and not __fish_brew_opt --tree' -l union     -d "Show the union of dependencies for formulae, instead of the intersection"
-__fish_brew_complete_arg 'deps; and not __fish_brew_opt --tree' -l full-name -d "List dependencies by their full name"
+__fish_brew_complete_arg 'deps dependencies; and not __fish_brew_opt --tree' -s n         -d "Show in topological order"
+__fish_brew_complete_arg 'deps dependencies; and not __fish_brew_opt --tree' -l 1         -d "Show only 1 level down"
+__fish_brew_complete_arg 'deps dependencies; and not __fish_brew_opt --tree' -l union     -d "Show the union of dependencies for formulae, instead of the intersection"
+__fish_brew_complete_arg 'deps dependencies; and not __fish_brew_opt --tree' -l full-name -d "List dependencies by their full name"
 # --all and --installed are mutually exclusive:
-__fish_brew_complete_arg 'deps; and not __fish_brew_opt --installed --tree' -l all       -d "Show dependencies for all formulae"
-__fish_brew_complete_arg 'deps; and not __fish_brew_opt --all'              -l installed -d "Show dependencies for installed formulae"
+__fish_brew_complete_arg 'deps dependencies; and not __fish_brew_opt --installed --tree' -l all       -d "Show dependencies for all formulae"
+__fish_brew_complete_arg 'deps dependencies; and not __fish_brew_opt --all'              -l installed -d "Show dependencies for installed formulae"
 # --tree works without options or with --installed
-__fish_brew_complete_arg 'deps;
+__fish_brew_complete_arg 'deps dependencies;
     and begin
         not __fish_brew_opts;
         or __fish_brew_opt --installed;
     end' -l tree -d "Show dependencies as tree"
 # filters can be passed with any other options
-__fish_brew_complete_arg 'deps' -l include-build    -d "Include the :build type dependencies"
-__fish_brew_complete_arg 'deps' -l include-optional -d "Include the :optional type dependencies"
-__fish_brew_complete_arg 'deps' -l skip-recommended -d "Skip :recommended  type  dependencies"
+__fish_brew_complete_arg 'deps dependencies' -l include-build    -d "Include the :build type dependencies"
+__fish_brew_complete_arg 'deps dependencies' -l include-optional -d "Include the :optional type dependencies"
+__fish_brew_complete_arg 'deps dependencies' -l skip-recommended -d "Skip :recommended  type  dependencies"
 
 
 __fish_brew_complete_cmd 'desc' "Show formulae description or search by name and/or description"
@@ -586,15 +586,15 @@ __fish_brew_complete_arg 'upgrade' -l fetch-HEAD -d "Fetch the upstream reposito
 
 
 __fish_brew_complete_cmd 'uses' "Show formulas that depend on specified formula"
-__fish_brew_complete_arg 'uses' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'uses' -l installed -d "List only installed formulae"
-__fish_brew_complete_arg 'uses' -l recursive -d "Resolve more than one level of dependencies"
-__fish_brew_complete_arg 'uses' -l include-build    -d "Include the :build type dependencies"
-__fish_brew_complete_arg 'uses' -l include-optional -d "Include the :optional type dependencies"
-__fish_brew_complete_arg 'uses' -l skip-recommended -d "Skip :recommended  type  dependencies"
+__fish_brew_complete_arg 'uses dependents' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'uses dependents' -l installed -d "List only installed formulae"
+__fish_brew_complete_arg 'uses dependents' -l recursive -d "Resolve more than one level of dependencies"
+__fish_brew_complete_arg 'uses dependents' -l include-build    -d "Include the :build type dependencies"
+__fish_brew_complete_arg 'uses dependents' -l include-optional -d "Include the :optional type dependencies"
+__fish_brew_complete_arg 'uses dependents' -l skip-recommended -d "Skip :recommended  type  dependencies"
 # --HEAD and --devel are mutually exclusive:
-__fish_brew_complete_arg 'uses; and not __fish_brew_opt --devel --HEAD' -l devel -d "Find cases development builds using formulae"
-__fish_brew_complete_arg 'uses; and not __fish_brew_opt --devel --HEAD' -l HEAD  -d "Find cases HEAD builds using formulae"
+__fish_brew_complete_arg 'uses dependents; and not __fish_brew_opt --devel --HEAD' -l devel -d "Find cases development builds using formulae"
+__fish_brew_complete_arg 'uses dependents; and not __fish_brew_opt --devel --HEAD' -l HEAD  -d "Find cases HEAD builds using formulae"
 
 
 __fish_brew_complete_cmd '--cache' "Display Homebrew/formula's cache location"

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -22,6 +22,8 @@ commands
 config
 configure
 create
+dependencies
+dependents
 deps
 desc
 diy

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -28,6 +28,8 @@ __brew_list_aliases() {
     environment '--env'
     '--config' config
     '-v' '--version'
+    dependencies deps
+    dependents uses
   )
   echo "${aliases}"
 }
@@ -312,9 +314,9 @@ _brew_create() {
     ':url:_urls'
 }
 
-# brew deps [--1] [-n] [--union] [--full-name] [--installed] [--include-build] [--include-optional] [--skip-recommended] [--include-requirements] formulae
-# brew deps --tree [--1] [filters] (formulae|--installed)
-# brew deps [filters] (--installed|--all)
+# brew deps, dependencies [--1] [-n] [--union] [--full-name] [--installed] [--include-build] [--include-optional] [--skip-recommended] [--include-requirements] formulae
+# brew deps, dependencies --tree [--1] [filters] (formulae|--installed)
+# brew deps, dependencies [filters] (--installed|--all)
 # The filters placeholder is any combination of options --include-build, --include-optional, and --skip-recommended as documented above.
 _brew_deps() {
   _arguments \
@@ -822,7 +824,7 @@ _brew_upgrade() {
 
 }
 
-# brew uses [--installed] [--recursive] [--include-build] [--include-optional]
+# brew uses, dependents [--installed] [--recursive] [--include-build] [--include-optional]
 #   [--skip-recommended] [--devel|--HEAD] formulae:
 _brew_uses() {
   _arguments \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -86,7 +86,7 @@ Show lists of built-in and external commands.
 Show Homebrew and system configuration info useful for debugging. If you file a
 bug report, you will be required to provide this information.
 
-### `deps` [*`options`*] [*`formula`*]
+### `deps`, `dependencies` [*`options`*] [*`formula`*]
 
 Show dependencies for *`formula`*. Additional options specific to *`formula`* may be
 appended to the command. When given multiple formula arguments, show the
@@ -557,7 +557,7 @@ the upgraded formulae or, every 30 days, for all formulae.
 * `-n`, `--dry-run`:
   Show what would be upgraded, but do not actually upgrade anything.
 
-### `uses` [*`options`*] *`formula`*
+### `uses`, `dependents` [*`options`*] *`formula`*
 
 Show formulae that specify *`formula`* as a dependency. When given multiple
 formula arguments, show the intersection of formulae that use *`formula`*. By

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -86,7 +86,7 @@ Include aliases of internal commands\.
 .SS "\fBconfig\fR"
 Show Homebrew and system configuration info useful for debugging\. If you file a bug report, you will be required to provide this information\.
 .
-.SS "\fBdeps\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fBdeps\fR, \fBdependencies\fR [\fIoptions\fR] [\fIformula\fR]"
 Show dependencies for \fIformula\fR\. Additional options specific to \fIformula\fR may be appended to the command\. When given multiple formula arguments, show the intersection of dependencies for each formula\.
 .
 .TP
@@ -722,7 +722,7 @@ Print install times for each formula at the end of the run\.
 \fB\-n\fR, \fB\-\-dry\-run\fR
 Show what would be upgraded, but do not actually upgrade anything\.
 .
-.SS "\fBuses\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBuses\fR, \fBdependents\fR [\fIoptions\fR] \fIformula\fR"
 Show formulae that specify \fIformula\fR as a dependency\. When given multiple formula arguments, show the intersection of formulae that use \fIformula\fR\. By default, \fBuses\fR shows all formulae that specify \fIformula\fR as a required or recommended dependency for their stable builds\.
 .
 .TP


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

<!-- detailed description of your proposed feature, the motivation for it and alternatives considered -->

**Description:**
Add aliases for `deps` &larr; `dependencies` and `uses` &larr; `dependents`

**Motivation:**
Why not? 😛 But to give an _actual_ reason, the `deps` command is easy to find, but `uses` is not obvious; `brew help uses` does not mention the word "dependent"

**Alternatives considered:**
Not adding these aliases as the distinction between the words "dependencies" and "dependents" might (somehow) be confusing or not obvious