### PR TITLE
shellenv: Fix shell detection

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -6,8 +6,8 @@
 #:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 homebrew-shellenv() {
-  case "$SHELL" in
-    */fish|fish)
+  case "$(/bin/ps -p $PPID -o comm=)" in
+    fish|-fish)
       echo "set -gx HOMEBREW_PREFIX \"$HOMEBREW_PREFIX\";"
       echo "set -gx HOMEBREW_CELLAR \"$HOMEBREW_CELLAR\";"
       echo "set -gx HOMEBREW_REPOSITORY \"$HOMEBREW_REPOSITORY\";"
@@ -15,7 +15,7 @@ homebrew-shellenv() {
       echo "set -q MANPATH; or set MANPATH ''; set -gx MANPATH \"$HOMEBREW_PREFIX/share/man\" \$MANPATH;"
       echo "set -q INFOPATH; or set INFOPATH ''; set -gx INFOPATH \"$HOMEBREW_PREFIX/share/info\" \$INFOPATH;"
       ;;
-    */csh|csh|*/tcsh|tcsh)
+    csh|-csh|tcsh|-tcsh)
       echo "setenv HOMEBREW_PREFIX $HOMEBREW_PREFIX;"
       echo "setenv HOMEBREW_CELLAR $HOMEBREW_CELLAR;"
       echo "setenv HOMEBREW_REPOSITORY $HOMEBREW_REPOSITORY;"


### PR DESCRIPTION
It currently switches on `$SHELL`, which points to the user's login shell. However, `shellenv` may be used in contexts where the running shell isn't `$SHELL` (e.g. setting up Homebrew variables in the sanitized environment of csh-based `cron` scripts), and Linux desktop environments may set up user sessions in ways that trip up the current algorithm (see #7965 for a case study). To work correctly in all circumstances and environments, its output should be determined by the context (calling shell) instead.

As far as I can tell, `/bin/ps -p <pid> -o comm=` produces the same output in both macOS and Linux, so this script should still be portable.

Fixes #7965.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
