### PR TITLE
style: use direct method matching instead of regex

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -114,20 +114,9 @@ module RuboCop
             return
           end
 
-          # Matches `depends_on "foo" if build.with?("bar")` or depends_on "foo" if build.without?("bar")`
-          depends_on_build_regex = /depends_on .+ (if build\.with(out)?\?\(["']\w+["']\))/
-
-          find_instance_method_call(body_node, :build, :with?) do |n|
-            # TODO: this should be refactored to a direct method match
-            next unless match = n.parent.source.match(depends_on_build_regex)
-
-            problem "Use `:optional` or `:recommended` instead of `#{match[1]}`"
-          end
-
-          find_instance_method_call(body_node, :build, :without?) do |n|
-            next unless match = n.parent.source.match(depends_on_build_regex)
-
-            problem "Use `:optional` or `:recommended` instead of `#{match[1]}`"
+          depends_on_build_with(body_node) do |build_with_node|
+            offending_node(build_with_node)
+            problem "Use `:optional` or `:recommended` instead of `if #{build_with_node.source}`"
           end
 
           find_instance_method_call(body_node, :build, :without?) do |method|
@@ -181,6 +170,11 @@ module RuboCop
 
           node.modifier_form? && node.unless?
         end
+
+        # Finds `depends_on "foo" if build.with?("bar")` or `depends_on "foo" if build.without?("bar")`
+        def_node_search :depends_on_build_with, <<~EOS
+          (if $(send (send nil? :build) {:with? :without?} str) (send nil? :depends_on str) nil?)
+        EOS
       end
 
       class MpiCheck < FormulaCop

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -173,7 +173,8 @@ module RuboCop
 
         # Finds `depends_on "foo" if build.with?("bar")` or `depends_on "foo" if build.without?("bar")`
         def_node_search :depends_on_build_with, <<~EOS
-          (if $(send (send nil? :build) {:with? :without?} str) (send nil? :depends_on str) nil?)
+          (if $(send (send nil? :build) {:with? :without?} str)
+            (send nil? :depends_on str) nil?)
         EOS
       end
 

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -132,12 +132,12 @@ module RuboCop
             problem "`env :userpaths` in homebrew/core formulae is deprecated"
           end
 
-          share_formula_name(body_node) do |share_node|
+          share_path_starts_with(body_node, @formula_name) do |share_node|
             offending_node(share_node)
             problem "Use `pkgshare` instead of `share/\"#{@formula_name}\"`"
           end
 
-          share_formula_name_dstr(body_node) do |share_node|
+          interpolated_share_path_starts_with(body_node, "/#{@formula_name}") do |share_node|
             offending_node(share_node)
             problem "Use `\#{pkgshare}` instead of `\#{share}/#{@formula_name}`"
           end
@@ -150,18 +150,18 @@ module RuboCop
         end
 
         # Check whether value starts with the formula name and then a "/", " " or EOS
-        def starts_with_formula_name?(value, prefix = "")
-          value.match?(%r{^#{Regexp.escape(prefix + @formula_name)}(/| |$)})
+        def path_starts_with?(path, starts_with)
+          path.match?(%r{^#{Regexp.escape(starts_with)}(/| |$)})
         end
 
         # Find "#{share}/foo"
-        def_node_search :share_formula_name_dstr, <<~EOS
-          $(dstr (begin (send nil? :share)) (str #starts_with_formula_name?("/")))
+        def_node_search :interpolated_share_path_starts_with, <<~EOS
+          $(dstr (begin (send nil? :share)) (str #path_starts_with?(%1)))
         EOS
 
         # Find share/"foo"
-        def_node_search :share_formula_name, <<~EOS
-          $(send (send nil? :share) :/ (str #starts_with_formula_name?))
+        def_node_search :share_path_starts_with, <<~EOS
+          $(send (send nil? :share) :/ (str #path_starts_with?(%1)))
         EOS
       end
     end

--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -150,13 +150,13 @@ module RuboCop
         end
 
         # Check whether value starts with the formula name and then a "/", " " or EOS
-        def starts_with_formula_name?(value)
-          value.match?(%r{#{Regexp.escape(@formula_name)}(/| |$)})
+        def starts_with_formula_name?(value, prefix = "")
+          value.match?(%r{^#{Regexp.escape(prefix + @formula_name)}(/| |$)})
         end
 
         # Find "#{share}/foo"
         def_node_search :share_formula_name_dstr, <<~EOS
-          $(dstr (begin (send nil? :share)) (str #starts_with_formula_name?))
+          $(dstr (begin (send nil? :share)) (str #starts_with_formula_name?("/")))
         EOS
 
         # Find share/"foo"

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -449,5 +449,25 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
         end
       RUBY
     end
+
+    it "when formula name appears afer `share/\"bar\"`" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          def install
+            ohai share/"bar/foo"
+          end
+        end
+      RUBY
+    end
+
+    it "when formula name appears afer `\"\#{share}/bar\"`" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
+        class Foo < Formula
+          def install
+            ohai "\#{share}/bar/foo"
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #7909 

Some of the cops added in the previous PR were done using regex matching. While this works fine, it is better to match the methods directly.

This uses `def_node_matcher` and `def_node_search` which made the method matching much easier.

I didn't add new tests as all of the changes are already covered by existing rubocop tests.

Let me know if there are other cops that could use similar refactoring and should be added to this PR