### PR TITLE
cask/installer: don't call `installed?` if Formula

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -328,8 +328,12 @@ module Cask
 
     def missing_cask_and_formula_dependencies
       collect_cask_and_formula_dependencies.reject do |cask_or_formula|
-        (cask_or_formula.try(:installed?) || cask_or_formula.try(:any_version_installed?)) &&
-          (cask_or_formula.respond_to?(:opt_linked?) ? cask_or_formula.opt_linked? : true)
+        installed = if cask_or_formula.respond_to?(:any_version_installed?)
+          cask_or_formula.any_version_installed?
+        else
+          cask_or_formula.try(:installed?)
+        end
+        installed && (cask_or_formula.respond_to?(:opt_linked?) ? cask_or_formula.opt_linked? : true)
       end
     end
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related: Homebrew/homebrew-cask#85846, Homebrew/homebrew-cask#84037

This prevents `Formula#installed?` from being called, which causes an error in CI when it calls `odeprecated`:

https://github.com/Homebrew/brew/blob/47e3687/Library/Homebrew/compat/formula.rb#L5-L9