### PR TITLE
dev-cmd/bump-revision: insert revision after license

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -42,7 +42,12 @@ module Homebrew
         [checksum.hash_type, checksum.hexdigest]
       end
 
-      old = if formula.path.read.include?("stable do\n")
+      old = if formula.license
+        # insert replacement revision after license
+        <<~EOS
+          license "#{formula.license}"
+        EOS
+      elsif formula.path.read.include?("stable do\n")
         # insert replacement revision after homepage
         <<~EOS
           homepage "#{formula.homepage}"


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Tested this on Homebrew/homebrew-core#57884 for bumping the revisions for hashlink and ortp

Fixes problem with style audit:

```
== Formula/hashlink.rb ==
C:  7:  3: license (line 7) should be put before revision (line 6)
```