### PR TITLE
CPU: add ability to check for Rosetta

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -63,6 +63,14 @@ module Hardware
         [arch_64_bit, arch_32_bit].extend ArchitectureListExtension
       end
 
+      # True when running under an Intel-based shell via Rosetta on an
+      # Apple Silicon Mac. This can be detected via seeing if there's a
+      # conflict between what `uname` report and the underlying `sysctl` flags,
+      # since the `sysctl` flags don't change behaviour under Rosetta.
+      def running_under_rosetta?
+        intel? && physical_cpu_arm64?
+      end
+
       def features
         @features ||= sysctl_n(
           "machdep.cpu.features",
@@ -108,6 +116,12 @@ module Hardware
       end
 
       private
+
+      # Note: this is more reliable than checking uname.
+      # `sysctl` returns the right answer even when running in Rosetta.
+      def physical_cpu_arm64?
+        sysctl_bool("hw.optional.arm64")
+      end
 
       def sysctl_bool(key)
         sysctl_int(key) == 1

--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -67,7 +67,7 @@ module Hardware
       # Apple Silicon Mac. This can be detected via seeing if there's a
       # conflict between what `uname` report and the underlying `sysctl` flags,
       # since the `sysctl` flags don't change behaviour under Rosetta.
-      def running_under_rosetta?
+      def in_rosetta?
         intel? && physical_cpu_arm64?
       end
 

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -154,6 +154,10 @@ module Hardware
 
         "-march=#{arch}"
       end
+
+      def running_under_rosetta?
+        false
+      end
     end
   end
 

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -155,7 +155,7 @@ module Hardware
         "-march=#{arch}"
       end
 
-      def running_under_rosetta?
+      def in_rosetta?
         false
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When running within an Intel terminal, `uname -m` and friends return Intel-based values for compatibility. An Intel shell will also prefer to launch Intel slices of programs unless the program is ARM-only.

It's an open question how Homebrew should manage running in Intel mode. Should it continue to behave as though the Mac is Intel-based, like it does now? Should it recognize it's ARM-based? Either way, it's useful for us to be able to tell whether the Mac is running under Rosetta or whether it's a real Intel Mac.