### PR TITLE
utils/git_spec: Add a test for `last_revision_commit_of_files`

### DIFF
--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -9,35 +9,67 @@ describe Git do
     HOMEBREW_CACHE.cd do
       system git, "init"
 
-      File.open(file, "w") { |f| f.write("blah") }
-      system git, "add", HOMEBREW_CACHE/file
+      File.open("blah.rb", "w") { |f| f.write("blah") }
+      system git, "add", HOMEBREW_CACHE/"blah.rb"
       system git, "commit", "-m", "'File added'"
       @h1 = `git rev-parse HEAD`
 
-      File.open(file, "w") { |f| f.write("brew") }
-      system git, "add", HOMEBREW_CACHE/file
+      File.open("blah.rb", "w") { |f| f.write("brew") }
+      system git, "add", HOMEBREW_CACHE/"blah.rb"
       system git, "commit", "-m", "'written to File'"
       @h2 = `git rev-parse HEAD`
+
+      File.open("bleh.rb", "w") { |f| f.write("bleh") }
+      system git, "add", HOMEBREW_CACHE/"bleh.rb"
+      system git, "commit", "-m", "'File added'"
+      @h3 = `git rev-parse HEAD`
+
+      File.open("bleh.rb", "w") { |f| f.write("blehbleh") }
+      system git, "add", HOMEBREW_CACHE/"bleh.rb"
+      system git, "commit", "-m", "'written to File'"
     end
   end
 
   let(:file) { "blah.rb" }
-  let(:hash1) { @h1[0..6] }
-  let(:hash2) { @h2[0..6] }
+  let(:file_hash1) { @h1[0..6] }
+  let(:file_hash2) { @h2[0..6] }
+  let(:files) { ["blah.rb", "bleh.rb"] }
+  let(:files_hash1) { [@h3[0..6], ["bleh.rb"]] }
+  let(:files_hash2) { [@h2[0..6], ["blah.rb"]] }
 
   describe "#last_revision_commit_of_file" do
     it "gives last revision commit when before_commit is nil" do
       expect(
         described_class.last_revision_commit_of_file(HOMEBREW_CACHE, file),
-      ).to eq(hash1)
+      ).to eq(file_hash1)
     end
 
     it "gives revision commit based on before_commit when it is not nil" do
       expect(
         described_class.last_revision_commit_of_file(HOMEBREW_CACHE,
                                                      file,
-                                                     before_commit: hash2),
-      ).to eq(hash2)
+                                                     before_commit: file_hash2),
+      ).to eq(file_hash2)
+    end
+  end
+
+  describe "#last_revision_commit_of_files" do
+    context "when before_commit is nil" do
+      it "gives last revision commit" do
+        expect(
+          described_class.last_revision_commit_of_files(HOMEBREW_CACHE, files),
+        ).to eq(files_hash1)
+      end
+    end
+
+    context "when before_commit is not nil" do
+      it "gives last revision commit" do
+        expect(
+          described_class.last_revision_commit_of_files(HOMEBREW_CACHE,
+                                                        files,
+                                                        before_commit: file_hash2),
+        ).to eq(files_hash2)
+      end
     end
   end
 

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -9,33 +9,33 @@ describe Git do
     HOMEBREW_CACHE.cd do
       system git, "init"
 
-      File.open("blah.rb", "w") { |f| f.write("blah") }
-      system git, "add", HOMEBREW_CACHE/"blah.rb"
+      File.open("README.md", "w") { |f| f.write("README") }
+      system git, "add", HOMEBREW_CACHE/"README.md"
       system git, "commit", "-m", "'File added'"
       @h1 = `git rev-parse HEAD`
 
-      File.open("blah.rb", "w") { |f| f.write("brew") }
-      system git, "add", HOMEBREW_CACHE/"blah.rb"
+      File.open("README.md", "w") { |f| f.write("# README") }
+      system git, "add", HOMEBREW_CACHE/"README.md"
       system git, "commit", "-m", "'written to File'"
       @h2 = `git rev-parse HEAD`
 
-      File.open("bleh.rb", "w") { |f| f.write("bleh") }
-      system git, "add", HOMEBREW_CACHE/"bleh.rb"
+      File.open("LICENSE.txt", "w") { |f| f.write("LICENCE") }
+      system git, "add", HOMEBREW_CACHE/"LICENSE.txt"
       system git, "commit", "-m", "'File added'"
       @h3 = `git rev-parse HEAD`
 
-      File.open("bleh.rb", "w") { |f| f.write("blehbleh") }
-      system git, "add", HOMEBREW_CACHE/"bleh.rb"
+      File.open("LICENSE.txt", "w") { |f| f.write("LICENSE") }
+      system git, "add", HOMEBREW_CACHE/"LICENSE.txt"
       system git, "commit", "-m", "'written to File'"
     end
   end
 
-  let(:file) { "blah.rb" }
+  let(:file) { "README.md" }
   let(:file_hash1) { @h1[0..6] }
   let(:file_hash2) { @h2[0..6] }
-  let(:files) { ["blah.rb", "bleh.rb"] }
-  let(:files_hash1) { [@h3[0..6], ["bleh.rb"]] }
-  let(:files_hash2) { [@h2[0..6], ["blah.rb"]] }
+  let(:files) { ["README.md", "LICENSE.txt"] }
+  let(:files_hash1) { [@h3[0..6], ["LICENSE.txt"]] }
+  let(:files_hash2) { [@h2[0..6], ["README.md"]] }
 
   describe "#last_revision_commit_of_file" do
     it "gives last revision commit when before_commit is nil" do
@@ -78,14 +78,14 @@ describe Git do
       expect(
         described_class.last_revision_of_file(HOMEBREW_CACHE,
                                               HOMEBREW_CACHE/file),
-      ).to eq("blah")
+      ).to eq("README")
     end
 
     it "returns last revision of file based on before_commit" do
       expect(
         described_class.last_revision_of_file(HOMEBREW_CACHE, HOMEBREW_CACHE/file,
                                               before_commit: "0..3"),
-      ).to eq("brew")
+      ).to eq("# README")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This method, called from `brew extract` in the case of extraction from third-party taps, was untested. This led to it breaking when we refactored some of it to appease Sorbet (see #7933 and #7951). If I make the same (flawed) change here and run these tests, they fail.
- There's a fair bit going on here, but most of it is setup for committing changes to more files, as we're testing operations on multiple files in a Homebrew repo.
- I originally tried to write tests for `brew extract`, but that required _a lot_ of refactoring because those tests (and their helper methods) aren't designed for third-party taps - they rely on `CoreTap`. So testing the underlying method is a better solution.