### PR TITLE
std_meson_args: add release buildtype

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1420,7 +1420,7 @@ class Formula
 
   # Standard parameters for meson builds.
   def std_meson_args
-    ["--prefix=#{prefix}", "--libdir=#{lib}"]
+    ["--prefix=#{prefix}", "--libdir=#{lib}", "--buildtype=release"]
   end
 
   def shared_library(name, version = nil)


### PR DESCRIPTION
By default meson compiles using the debug buildtype, which corresponds
to -O0 -g. The release buildtype changes this to -O3.

Not sure how useful this is as Homebrew's superenv changes these flags
anyway, but something similar is done for CMake, so thought it would be ok to do the same thing for meson.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----