### PR TITLE
formula_creator: generate `head` stanza after `license`

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -91,9 +91,7 @@ module Homebrew
         <% end %>
           desc "#{desc}"
           homepage "#{homepage}"
-        <% if head? %>
-          head "#{url}"
-        <% else %>
+        <% unless head? %>
           url "#{url}"
         <% unless version.nil? or version.detected_from_url? %>
           version "#{version}"
@@ -101,6 +99,9 @@ module Homebrew
           sha256 "#{sha256}"
         <% end %>
           license "#{license}"
+        <% if head? %>
+          head "#{url}"
+        <% end %>
 
         <% if mode == :cmake %>
           depends_on "cmake" => :build


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes this audit failure:

```
  * C: 5: col 3: `license` (line 5) should be put before `head` (line 4)
```