### PR TITLE
bump-formula-pr: restore formula if duplicate PR exists

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -316,7 +316,7 @@ module Homebrew
 
     new_formula_version = formula_version(formula, requested_spec, new_contents)
 
-    check_for_duplicate_pull_requests(formula, tap_full_name, new_formula_version.to_s)
+    check_for_duplicate_pull_requests(formula, backup_file, tap_full_name, new_formula_version.to_s)
 
     if !new_mirrors && !formula_spec.mirrors.empty?
       if args.force?
@@ -481,7 +481,7 @@ module Homebrew
     []
   end
 
-  def check_for_duplicate_pull_requests(formula, tap_full_name, version)
+  def check_for_duplicate_pull_requests(formula, backup_file, tap_full_name, version)
     # check for open requests
     pull_requests = fetch_pull_requests(formula.name, tap_full_name, state: "open")
 
@@ -497,8 +497,10 @@ module Homebrew
     if args.force? && !args.quiet?
       opoo duplicates_message
     elsif !args.force? && args.quiet?
+      formula.path.atomic_write(backup_file) unless args.dry_run?
       odie error_message
     elsif !args.force?
+      formula.path.atomic_write(backup_file) unless args.dry_run?
       odie <<~EOS
         #{duplicates_message.chomp}
         #{error_message}


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I figured this made sense since formulae are restored for bumps that are downgrades or don't actually change the version: https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L332-L344