### PR TITLE
Make Shell-Completion.md clearer and update it

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -8,7 +8,7 @@ You must configure your shell to enable its completion support. This is because 
 
 ## Configuring Completions in `bash`
 
-To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.bash_profile` if it exists or `~/.profile` otherwise:
+To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.bash_profile` (or, if it doesn't exist, `~/.profile):
 
 ```sh
 if type brew &>/dev/null; then

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -24,12 +24,7 @@ fi
 ```
 
 Should you later install the `bash-completion` formula, this will automatically use its initialization script to read the completions files.
-When installed, the `bash-completion` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory. This is done by adding a line to your `.bash_profile` -
-
-```
-[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
-```
-which is mentioned in the Caveats section upon the installation of `bash-completion`
+When installed, the `bash-completion` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory. This is done by adding a line to your `.bash_profile` which is given in the Caveats section upon the installation of `bash-completion`
 
 As both Homebrew's completion code given above and the Caveats line do the same thing, it is recommended to either not add the Caveats line or to comment the line out because Homebrew's completion code works even without installing the `bash-completion` formula.
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -23,12 +23,9 @@ if type brew &>/dev/null; then
 fi
 ```
 
-Should you later install the `bash-completion` formula, this will automatically use its initialization script to read the completions files.
-When installed, the `bash-completion` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory. This is done by adding a line to your `.bash_profile` which is given in the Caveats section upon the installation of `bash-completion`
+If you install the `bash-completion` formula, this will automatically source the completions' initialisation script (so you do not need to follow the instructions in the caveats).
 
-As both Homebrew's completion code given above and the Caveats line do the same thing, it is recommended to either not add the Caveats line or to comment the line out because Homebrew's completion code works even without installing the `bash-completion` formula.
-
-If you are using a version of `bash` newer than version 4.1 (like Homebrew's `bash`), we recommended you use the `bash-completion@2` formula instead because it is newer and has better performance. You can check the version of `bash` you have by running `bash --version`. MacOS ships with version 3.2.
+If you are using the `bash` formula as your shell (i.e. `bash` >= v4) you should use the `bash-completion@2` formula instead.
 
 
 ## Configuring Completions in `zsh`

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -8,7 +8,7 @@ You must configure your shell to enable its completion support. This is because 
 
 ## Configuring Completions in `bash`
 
-To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.profile` file:
+To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.profile` or `~/.bash_profile` file:
 
 ```sh
 if type brew &>/dev/null; then
@@ -23,7 +23,8 @@ if type brew &>/dev/null; then
 fi
 ```
 
-Should you later install the `bash-completion` formula, this will automatically use its initialization script to read the completions files.
+Should you later install the `bash-completion@2` formula, this will automatically use its initialization script to read the completions files.
+When installed, the `bash-completion@2` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory (If the Caveats section is followed after installation, of course). Therefore, it is recommended to comment out the block of code given above after installing `bash-completion@2` because it becomes redundant.
 
 ## Configuring Completions in `zsh`
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -23,15 +23,23 @@ if type brew &>/dev/null; then
 fi
 ```
 
-Should you later install the `bash-completion@2` formula, this will automatically use its initialization script to read the completions files.
-When installed, the `bash-completion@2` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory. This is done by adding a line to your `.bash_profile` -
+Should you later install the `bash-completion` formula, this will automatically use its initialization script to read the completions files.
+When installed, the `bash-completion` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory. This is done by adding a line to your `.bash_profile` -
 
 ```
 [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
 ```
-which is mentioned in the Caveats section upon the installation of `bash-completion@2`
+which is mentioned in the Caveats section upon the installation of `bash-completion`
 
-As both Homebrew's completion code given above and the Caveats line do the same thing, it is recommended to either not add the Caveats line or to comment the line out because Homebrew's completion code works even without installing the `bash-completion@2` formula.
+As both Homebrew's completion code given above and the Caveats line do the same thing, it is recommended to either not add the Caveats line or to comment the line out because Homebrew's completion code works even without installing the `bash-completion` formula.
+
+---
+**Note**
+
+If you are using a version of `bash` newer than version 4.1 (Like Homebrew's `bash`), it is recommended to use the `bash-completion@2` formula instead as it is newer and has better performance. You can check the version of `bash` you have by running `bash --version`. MacOS ships with version 3.2.
+
+---
+
 
 ## Configuring Completions in `zsh`
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -8,7 +8,7 @@ You must configure your shell to enable its completion support. This is because 
 
 ## Configuring Completions in `bash`
 
-To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.profile` or `~/.bash_profile` file:
+To make Homebrew's completions available in `bash`, you must source the definitions as part of your shell's startup. Add the following to your `~/.bash_profile` if it exists or `~/.profile` otherwise:
 
 ```sh
 if type brew &>/dev/null; then

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -24,7 +24,14 @@ fi
 ```
 
 Should you later install the `bash-completion@2` formula, this will automatically use its initialization script to read the completions files.
-When installed, the `bash-completion@2` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory (If the Caveats section is followed after installation, of course). Therefore, it is recommended to comment out the block of code given above after installing `bash-completion@2` because it becomes redundant.
+When installed, the `bash-completion@2` formula also runs `${HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh` and all files in the `bash_completion.d` directory. This is done by adding a line to your `.bash_profile` -
+
+```
+[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+```
+which is mentioned in the Caveats section upon the installation of `bash-completion@2`
+
+As both Homebrew's completion code given above and the Caveats line do the same thing, it is recommended to either not add the Caveats line or to comment the line out because Homebrew's completion code works even without installing the `bash-completion@2` formula.
 
 ## Configuring Completions in `zsh`
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -28,12 +28,7 @@ When installed, the `bash-completion` formula also runs `${HOMEBREW_PREFIX}/etc/
 
 As both Homebrew's completion code given above and the Caveats line do the same thing, it is recommended to either not add the Caveats line or to comment the line out because Homebrew's completion code works even without installing the `bash-completion` formula.
 
----
-**Note**
-
-If you are using a version of `bash` newer than version 4.1 (Like Homebrew's `bash`), it is recommended to use the `bash-completion@2` formula instead as it is newer and has better performance. You can check the version of `bash` you have by running `bash --version`. MacOS ships with version 3.2.
-
----
+If you are using a version of `bash` newer than version 4.1 (like Homebrew's `bash`), we recommended you use the `bash-completion@2` formula instead because it is newer and has better performance. You can check the version of `bash` you have by running `bash --version`. MacOS ships with version 3.2.
 
 
 ## Configuring Completions in `zsh`


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I made this change because the prompt in a new instance of bash had slowed down quite a bit after installing `bash-completion` (and following the installation instructions) while also having the Homebrew completion code in my `~/.bash_profile`. I found that the formula's script also did the same thing as the Homebrew completion code. After commenting the Homebrew code out, the prompt became much faster! Finding and installing a newer version of that formula - `bash-completion@2` made the prompt even faster.

So I added a clarification in the docs and changed mentions of `bash-completion` to `bash-completion@2`

This could help people have a performance boost and install a more updated version of a formula.

Thanks for having a look!
quackduck
