### PR TITLE
Add a default back to INFOPATH

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -29,7 +29,7 @@ homebrew-shellenv() {
       echo "export HOMEBREW_REPOSITORY=\"$HOMEBREW_REPOSITORY\";"
       echo "export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin\${PATH+:\$PATH}\";"
       echo "export MANPATH=\"$HOMEBREW_PREFIX/share/man\${MANPATH+:\$MANPATH}:\";"
-      echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info:\${INFOPATH}\";"
+      echo "export INFOPATH=\"$HOMEBREW_PREFIX/share/info:\${INFOPATH:-}\";"
       ;;
   esac
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

It looks like #7738 removed the default unintentionally. This adds it back. 

For scripts that `set -u`, this will fail if $INFOPATH is not already set (`INFOPATH: unbound variable`). This provides an empty default, but one that will still satisfy the trailing colon requirement.