### PR TITLE
sorbet: set os.rb to true

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -229,7 +229,6 @@ false:
   - ./lock_file.rb
   - ./migrator.rb
   - ./missing_formula.rb
-  - ./os/linux.rb
   - ./os/mac.rb
   - ./os/mac/keg.rb
   - ./os/mac/mach.rb
@@ -499,7 +498,6 @@ false:
   - ./messages.rb
   - ./mktemp.rb
   - ./options.rb
-  - ./os.rb
   - ./os/linux/elf.rb
   - ./os/linux/glibc.rb
   - ./os/linux/global.rb
@@ -879,6 +877,8 @@ true:
   - ./locale.rb
   - ./metafiles.rb
   - ./official_taps.rb
+  - ./os.rb
+  - ./os/linux.rb
   - ./rubocops/cask/ast/cask_header.rb
   - ./rubocops/cask/ast/stanza.rb
   - ./rubocops/cask/constants/stanza.rb

--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -499,9 +499,7 @@ false:
   - ./mktemp.rb
   - ./options.rb
   - ./os/linux/elf.rb
-  - ./os/linux/glibc.rb
   - ./os/linux/global.rb
-  - ./os/linux/kernel.rb
   - ./os/mac/architecture_list.rb
   - ./pkg_version.rb
   - ./requirements/arch_requirement.rb
@@ -879,6 +877,8 @@ true:
   - ./official_taps.rb
   - ./os.rb
   - ./os/linux.rb
+  - ./os/linux/glibc.rb
+  - ./os/linux/kernel.rb
   - ./rubocops/cask/ast/cask_header.rb
   - ./rubocops/cask/ast/stanza.rb
   - ./rubocops/cask/constants/stanza.rb

--- a/Library/Homebrew/sorbet/rbi/os.rbi
+++ b/Library/Homebrew/sorbet/rbi/os.rbi
@@ -1,0 +1,14 @@
+# typed: true
+
+module OS
+  module Linux
+    include Kernel
+
+    def which(cmd, path = ENV["PATH"])
+    end
+  end
+
+  module Mac
+    include Kernel
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR moves `os.rb` and `os/linux.rb` to true in `sorbet/files.yaml` and deals with the resulting type errors. 