### PR TITLE
update-license-data: only check against latest tag

### DIFF
--- a/Library/Homebrew/data/spdx.json
+++ b/Library/Homebrew/data/spdx.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "3.9-21-g1a796c7",
+  "licenseListVersion": "3.9",
   "licenses": [
     {
       "reference": "./0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "249",
+      "referenceNumber": "239",
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
@@ -17,7 +17,7 @@
       "reference": "./AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AAL.json",
-      "referenceNumber": "62",
+      "referenceNumber": "60",
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
@@ -29,7 +29,7 @@
       "reference": "./ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ADSL.json",
-      "referenceNumber": "226",
+      "referenceNumber": "217",
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -42,7 +42,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": "29",
+      "referenceNumber": "28",
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -56,7 +56,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": "231",
+      "referenceNumber": "222",
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -70,7 +70,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": "355",
+      "referenceNumber": "341",
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -83,7 +83,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": "260",
+      "referenceNumber": "249",
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -96,7 +96,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": "376",
+      "referenceNumber": "361",
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
@@ -110,7 +110,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": "179",
+      "referenceNumber": "175",
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -122,7 +122,7 @@
       "reference": "./AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": "73",
+      "referenceNumber": "71",
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -134,7 +134,7 @@
       "reference": "./AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": "172",
+      "referenceNumber": "168",
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -147,7 +147,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "151",
+      "referenceNumber": "148",
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
@@ -161,7 +161,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "310",
+      "referenceNumber": "298",
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
@@ -175,7 +175,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "163",
+      "referenceNumber": "160",
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
@@ -188,7 +188,7 @@
       "reference": "./AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "136",
+      "referenceNumber": "133",
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -200,7 +200,7 @@
       "reference": "./AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "160",
+      "referenceNumber": "157",
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -212,7 +212,7 @@
       "reference": "./AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "139",
+      "referenceNumber": "136",
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -224,7 +224,7 @@
       "reference": "./ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "45",
+      "referenceNumber": "44",
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -236,7 +236,7 @@
       "reference": "./APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "259",
+      "referenceNumber": "248",
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -248,7 +248,7 @@
       "reference": "./APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "289",
+      "referenceNumber": "278",
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
@@ -260,7 +260,7 @@
       "reference": "./APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "402",
+      "referenceNumber": "387",
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -272,7 +272,7 @@
       "reference": "./APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "352",
+      "referenceNumber": "338",
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -284,7 +284,7 @@
       "reference": "./APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "210",
+      "referenceNumber": "201",
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -297,7 +297,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "144",
+      "referenceNumber": "141",
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -309,7 +309,7 @@
       "reference": "./Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": "77",
+      "referenceNumber": "75",
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -321,7 +321,7 @@
       "reference": "./Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": "324",
+      "referenceNumber": "310",
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -333,7 +333,7 @@
       "reference": "./Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": "357",
+      "referenceNumber": "343",
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -345,7 +345,7 @@
       "reference": "./Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": "346",
+      "referenceNumber": "332",
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -357,7 +357,7 @@
       "reference": "./Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "329",
+      "referenceNumber": "315",
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -370,7 +370,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "33",
+      "referenceNumber": "32",
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -383,7 +383,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "285",
+      "referenceNumber": "274",
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
@@ -397,7 +397,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "381",
+      "referenceNumber": "366",
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
@@ -410,7 +410,7 @@
       "reference": "./Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "284",
+      "referenceNumber": "273",
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
@@ -422,7 +422,7 @@
       "reference": "./Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "319",
+      "referenceNumber": "306",
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -434,7 +434,7 @@
       "reference": "./Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": "239",
+      "referenceNumber": "229",
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
@@ -447,7 +447,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "80",
+      "referenceNumber": "78",
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
@@ -460,7 +460,7 @@
       "reference": "./BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "404",
+      "referenceNumber": "389",
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -472,7 +472,7 @@
       "reference": "./BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "320",
+      "referenceNumber": "307",
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
@@ -485,7 +485,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "292",
+      "referenceNumber": "281",
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -497,7 +497,7 @@
       "reference": "./BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "192",
+      "referenceNumber": "186",
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -509,7 +509,7 @@
       "reference": "./BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "377",
+      "referenceNumber": "362",
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -522,7 +522,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "211",
+      "referenceNumber": "202",
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
@@ -534,7 +534,7 @@
       "reference": "./BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "40",
+      "referenceNumber": "39",
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -547,7 +547,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "91",
+      "referenceNumber": "88",
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -559,7 +559,7 @@
       "reference": "./BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "150",
+      "referenceNumber": "147",
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -571,7 +571,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": "64",
+      "referenceNumber": "62",
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -583,7 +583,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "356",
+      "referenceNumber": "342",
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -595,7 +595,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "120",
+      "referenceNumber": "117",
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -607,7 +607,7 @@
       "reference": "./BSD-3-Clause-Open-MPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-      "referenceNumber": "223",
+      "referenceNumber": "214",
       "name": "BSD 3-Clause Open MPI variant",
       "licenseId": "BSD-3-Clause-Open-MPI",
       "seeAlso": [
@@ -621,7 +621,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "71",
+      "referenceNumber": "69",
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -633,7 +633,7 @@
       "reference": "./BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "387",
+      "referenceNumber": "372",
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -645,7 +645,7 @@
       "reference": "./BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "415",
+      "referenceNumber": "400",
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -657,7 +657,7 @@
       "reference": "./BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "173",
+      "referenceNumber": "169",
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -670,7 +670,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "307",
+      "referenceNumber": "295",
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
@@ -683,7 +683,7 @@
       "reference": "./Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "154",
+      "referenceNumber": "151",
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -695,7 +695,7 @@
       "reference": "./Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "131",
+      "referenceNumber": "128",
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -707,7 +707,7 @@
       "reference": "./Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Beerware.json",
-      "referenceNumber": "262",
+      "referenceNumber": "251",
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -720,7 +720,7 @@
       "reference": "./BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "216",
+      "referenceNumber": "207",
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -733,7 +733,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "195",
+      "referenceNumber": "188",
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -745,7 +745,7 @@
       "reference": "./BlueOak-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BlueOak-1.0.0.json",
-      "referenceNumber": "220",
+      "referenceNumber": "211",
       "name": "Blue Oak Model License 1.0.0",
       "licenseId": "BlueOak-1.0.0",
       "seeAlso": [
@@ -757,7 +757,7 @@
       "reference": "./Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "318",
+      "referenceNumber": "305",
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -769,7 +769,7 @@
       "reference": "./CAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CAL-1.0.json",
-      "referenceNumber": "61",
+      "referenceNumber": "59",
       "name": "Cryptographic Autonomy License 1.0",
       "licenseId": "CAL-1.0",
       "seeAlso": [
@@ -782,7 +782,7 @@
       "reference": "./CAL-1.0-Combined-Work-Exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
-      "referenceNumber": "82",
+      "referenceNumber": "80",
       "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
       "licenseId": "CAL-1.0-Combined-Work-Exception",
       "seeAlso": [
@@ -795,7 +795,7 @@
       "reference": "./CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "244",
+      "referenceNumber": "234",
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -807,7 +807,7 @@
       "reference": "./CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "24",
+      "referenceNumber": "23",
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -819,7 +819,7 @@
       "reference": "./CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "63",
+      "referenceNumber": "61",
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -831,7 +831,7 @@
       "reference": "./CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "193",
+      "referenceNumber": "187",
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -843,7 +843,7 @@
       "reference": "./CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "358",
+      "referenceNumber": "344",
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -852,23 +852,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-3.0-AT.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0-AT.json",
-      "referenceNumber": "236",
-      "name": "Creative Commons Attribution 3.0 Austria",
-      "licenseId": "CC-BY-3.0-AT",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./CC-BY-4.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "227",
+      "referenceNumber": "218",
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
@@ -880,7 +868,7 @@
       "reference": "./CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "241",
+      "referenceNumber": "231",
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
@@ -892,7 +880,7 @@
       "reference": "./CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "340",
+      "referenceNumber": "326",
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
@@ -904,7 +892,7 @@
       "reference": "./CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": "413",
+      "referenceNumber": "398",
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
@@ -916,7 +904,7 @@
       "reference": "./CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "350",
+      "referenceNumber": "336",
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
@@ -928,7 +916,7 @@
       "reference": "./CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "283",
+      "referenceNumber": "272",
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
@@ -940,7 +928,7 @@
       "reference": "./CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "105",
+      "referenceNumber": "102",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -952,7 +940,7 @@
       "reference": "./CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "141",
+      "referenceNumber": "138",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -964,7 +952,7 @@
       "reference": "./CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "31",
+      "referenceNumber": "30",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -976,7 +964,7 @@
       "reference": "./CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "42",
+      "referenceNumber": "41",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -988,7 +976,7 @@
       "reference": "./CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "176",
+      "referenceNumber": "172",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -1000,7 +988,7 @@
       "reference": "./CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "123",
+      "referenceNumber": "120",
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -1012,7 +1000,7 @@
       "reference": "./CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "427",
+      "referenceNumber": "411",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -1024,7 +1012,7 @@
       "reference": "./CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "224",
+      "referenceNumber": "215",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -1036,7 +1024,7 @@
       "reference": "./CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": "375",
+      "referenceNumber": "360",
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
@@ -1048,7 +1036,7 @@
       "reference": "./CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "345",
+      "referenceNumber": "331",
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -1060,7 +1048,7 @@
       "reference": "./CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "97",
+      "referenceNumber": "94",
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -1072,7 +1060,7 @@
       "reference": "./CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "47",
+      "referenceNumber": "46",
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1084,7 +1072,7 @@
       "reference": "./CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "28",
+      "referenceNumber": "27",
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
@@ -1096,7 +1084,7 @@
       "reference": "./CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "295",
+      "referenceNumber": "284",
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
@@ -1108,7 +1096,7 @@
       "reference": "./CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "332",
+      "referenceNumber": "318",
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
@@ -1120,7 +1108,7 @@
       "reference": "./CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "418",
+      "referenceNumber": "403",
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -1132,7 +1120,7 @@
       "reference": "./CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "382",
+      "referenceNumber": "367",
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -1144,7 +1132,7 @@
       "reference": "./CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "212",
+      "referenceNumber": "203",
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -1156,7 +1144,7 @@
       "reference": "./CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "243",
+      "referenceNumber": "233",
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -1165,23 +1153,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-SA-3.0-AT.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
-      "referenceNumber": "303",
-      "name": "Creative Commons Attribution-Share Alike 3.0 Austria",
-      "licenseId": "CC-BY-SA-3.0-AT",
-      "seeAlso": [
-        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./CC-BY-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "309",
+      "referenceNumber": "297",
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
@@ -1193,7 +1169,7 @@
       "reference": "./CC-PDDC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-PDDC.json",
-      "referenceNumber": "95",
+      "referenceNumber": "92",
       "name": "Creative Commons Public Domain Dedication and Certification",
       "licenseId": "CC-PDDC",
       "seeAlso": [
@@ -1206,7 +1182,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "68",
+      "referenceNumber": "66",
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -1219,7 +1195,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "349",
+      "referenceNumber": "335",
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
@@ -1231,7 +1207,7 @@
       "reference": "./CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "294",
+      "referenceNumber": "283",
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -1244,7 +1220,7 @@
       "reference": "./CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "111",
+      "referenceNumber": "108",
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -1256,7 +1232,7 @@
       "reference": "./CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "183",
+      "referenceNumber": "178",
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -1268,7 +1244,7 @@
       "reference": "./CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "11",
+      "referenceNumber": "10",
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -1280,7 +1256,7 @@
       "reference": "./CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "138",
+      "referenceNumber": "135",
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -1305,7 +1281,7 @@
       "reference": "./CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "148",
+      "referenceNumber": "145",
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -1318,7 +1294,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "96",
+      "referenceNumber": "93",
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -1331,7 +1307,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "250",
+      "referenceNumber": "240",
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -1343,7 +1319,7 @@
       "reference": "./CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": "126",
+      "referenceNumber": "123",
       "name": "CERN Open Hardware Licence v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -1355,7 +1331,7 @@
       "reference": "./CERN-OHL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.2.json",
-      "referenceNumber": "171",
+      "referenceNumber": "167",
       "name": "CERN Open Hardware Licence v1.2",
       "licenseId": "CERN-OHL-1.2",
       "seeAlso": [
@@ -1367,7 +1343,7 @@
       "reference": "./CERN-OHL-P-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CERN-OHL-P-2.0.json",
-      "referenceNumber": "266",
+      "referenceNumber": "255",
       "name": "CERN Open Hardware Licence Version 2 - Permissive",
       "licenseId": "CERN-OHL-P-2.0",
       "seeAlso": [
@@ -1379,7 +1355,7 @@
       "reference": "./CERN-OHL-S-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CERN-OHL-S-2.0.json",
-      "referenceNumber": "48",
+      "referenceNumber": "47",
       "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
       "licenseId": "CERN-OHL-S-2.0",
       "seeAlso": [
@@ -1391,7 +1367,7 @@
       "reference": "./CERN-OHL-W-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CERN-OHL-W-2.0.json",
-      "referenceNumber": "278",
+      "referenceNumber": "267",
       "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
       "licenseId": "CERN-OHL-W-2.0",
       "seeAlso": [
@@ -1403,7 +1379,7 @@
       "reference": "./CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "79",
+      "referenceNumber": "77",
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -1415,7 +1391,7 @@
       "reference": "./CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "99",
+      "referenceNumber": "96",
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -1427,7 +1403,7 @@
       "reference": "./CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "362",
+      "referenceNumber": "348",
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -1440,7 +1416,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "296",
+      "referenceNumber": "285",
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
@@ -1453,7 +1429,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "246",
+      "referenceNumber": "236",
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
@@ -1465,7 +1441,7 @@
       "reference": "./CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "240",
+      "referenceNumber": "230",
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -1477,7 +1453,7 @@
       "reference": "./CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "169",
+      "referenceNumber": "165",
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
@@ -1489,7 +1465,7 @@
       "reference": "./Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "261",
+      "referenceNumber": "250",
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1502,7 +1478,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "256",
+      "referenceNumber": "245",
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -1516,7 +1492,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "153",
+      "referenceNumber": "150",
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -1529,7 +1505,7 @@
       "reference": "./Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "104",
+      "referenceNumber": "101",
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -1541,7 +1517,7 @@
       "reference": "./CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "39",
+      "referenceNumber": "38",
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -1553,7 +1529,7 @@
       "reference": "./Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "406",
+      "referenceNumber": "391",
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -1565,7 +1541,7 @@
       "reference": "./D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "372",
+      "referenceNumber": "358",
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1584,7 +1560,7 @@
       "reference": "./DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "286",
+      "referenceNumber": "275",
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -1596,7 +1572,7 @@
       "reference": "./DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "277",
+      "referenceNumber": "266",
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -1608,7 +1584,7 @@
       "reference": "./Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "34",
+      "referenceNumber": "33",
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -1620,7 +1596,7 @@
       "reference": "./ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "434",
+      "referenceNumber": "418",
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -1645,7 +1621,7 @@
       "reference": "./EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "78",
+      "referenceNumber": "76",
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -1659,7 +1635,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "8",
+      "referenceNumber": "7",
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
@@ -1669,23 +1645,11 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./EPICS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/EPICS.json",
-      "referenceNumber": "373",
-      "name": "EPICS Open License",
-      "licenseId": "EPICS",
-      "seeAlso": [
-        "https://epics.anl.gov/license/open.php"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./EPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "288",
+      "referenceNumber": "277",
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
@@ -1699,7 +1663,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "432",
+      "referenceNumber": "416",
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -1713,7 +1677,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "274",
+      "referenceNumber": "263",
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
@@ -1726,7 +1690,7 @@
       "reference": "./EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "101",
+      "referenceNumber": "98",
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -1740,7 +1704,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "425",
+      "referenceNumber": "409",
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -1755,7 +1719,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "282",
+      "referenceNumber": "271",
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -1763,7 +1727,7 @@
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
         "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
         "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
-        "https://opensource.org/licenses/EUPL-1.2"
+        "https://opensource.org/licenses/EUPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -1771,7 +1735,7 @@
       "reference": "./Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "401",
+      "referenceNumber": "386",
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
@@ -1783,7 +1747,7 @@
       "reference": "./ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "423",
+      "referenceNumber": "408",
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -1795,7 +1759,7 @@
       "reference": "./Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "175",
+      "referenceNumber": "171",
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -1808,7 +1772,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "409",
+      "referenceNumber": "394",
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -1832,7 +1796,7 @@
       "reference": "./FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "322",
+      "referenceNumber": "308",
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -1845,7 +1809,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "389",
+      "referenceNumber": "374",
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -1858,7 +1822,7 @@
       "reference": "./Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "273",
+      "referenceNumber": "262",
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
@@ -1871,7 +1835,7 @@
       "reference": "./Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "388",
+      "referenceNumber": "373",
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -1883,7 +1847,7 @@
       "reference": "./FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "385",
+      "referenceNumber": "370",
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -1896,57 +1860,9 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "268",
+      "referenceNumber": "257",
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.1-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-invariants-only.json",
-      "referenceNumber": "204",
-      "name": "GNU Free Documentation License v1.1 only - invariants",
-      "licenseId": "GFDL-1.1-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.1-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
-      "referenceNumber": "84",
-      "name": "GNU Free Documentation License v1.1 or later - invariants",
-      "licenseId": "GFDL-1.1-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.1-no-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
-      "referenceNumber": "7",
-      "name": "GNU Free Documentation License v1.1 only - no invariants",
-      "licenseId": "GFDL-1.1-no-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.1-no-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
-      "referenceNumber": "253",
-      "name": "GNU Free Documentation License v1.1 or later - no invariants",
-      "licenseId": "GFDL-1.1-no-invariants-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
@@ -1957,7 +1873,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "107",
+      "referenceNumber": "104",
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -1970,7 +1886,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "127",
+      "referenceNumber": "124",
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -1983,57 +1899,9 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "205",
+      "referenceNumber": "197",
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-invariants-only.json",
-      "referenceNumber": "207",
-      "name": "GNU Free Documentation License v1.2 only - invariants",
-      "licenseId": "GFDL-1.2-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
-      "referenceNumber": "424",
-      "name": "GNU Free Documentation License v1.2 or later - invariants",
-      "licenseId": "GFDL-1.2-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2-no-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
-      "referenceNumber": "321",
-      "name": "GNU Free Documentation License v1.2 only - no invariants",
-      "licenseId": "GFDL-1.2-no-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.2-no-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
-      "referenceNumber": "194",
-      "name": "GNU Free Documentation License v1.2 or later - no invariants",
-      "licenseId": "GFDL-1.2-no-invariants-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
@@ -2044,7 +1912,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "93",
+      "referenceNumber": "90",
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -2057,7 +1925,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "135",
+      "referenceNumber": "132",
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -2070,57 +1938,9 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "380",
+      "referenceNumber": "365",
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-invariants-only.json",
-      "referenceNumber": "186",
-      "name": "GNU Free Documentation License v1.3 only - invariants",
-      "licenseId": "GFDL-1.3-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
-      "referenceNumber": "317",
-      "name": "GNU Free Documentation License v1.3 or later - invariants",
-      "licenseId": "GFDL-1.3-invariants-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3-no-invariants-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
-      "referenceNumber": "182",
-      "name": "GNU Free Documentation License v1.3 only - no invariants",
-      "licenseId": "GFDL-1.3-no-invariants-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GFDL-1.3-no-invariants-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
-      "referenceNumber": "166",
-      "name": "GNU Free Documentation License v1.3 or later - no invariants",
-      "licenseId": "GFDL-1.3-no-invariants-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
@@ -2131,7 +1951,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "209",
+      "referenceNumber": "200",
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -2144,7 +1964,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": "55",
+      "referenceNumber": "53",
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
@@ -2156,7 +1976,7 @@
       "reference": "./GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "328",
+      "referenceNumber": "314",
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -2165,22 +1985,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./GLWTPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GLWTPL.json",
-      "referenceNumber": "54",
-      "name": "Good Luck With That Public License",
-      "licenseId": "GLWTPL",
-      "seeAlso": [
-        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./GPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "344",
+      "referenceNumber": "330",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
@@ -2192,7 +2000,7 @@
       "reference": "./GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "214",
+      "referenceNumber": "205",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
@@ -2204,7 +2012,7 @@
       "reference": "./GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": "16",
+      "referenceNumber": "15",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
@@ -2216,7 +2024,7 @@
       "reference": "./GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "137",
+      "referenceNumber": "134",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -2229,7 +2037,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "370",
+      "referenceNumber": "356",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
@@ -2243,7 +2051,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "416",
+      "referenceNumber": "401",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
@@ -2257,7 +2065,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "245",
+      "referenceNumber": "235",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
@@ -2271,7 +2079,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "269",
+      "referenceNumber": "258",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
@@ -2284,7 +2092,7 @@
       "reference": "./GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "354",
+      "referenceNumber": "340",
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -2296,7 +2104,7 @@
       "reference": "./GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "37",
+      "referenceNumber": "36",
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -2308,7 +2116,7 @@
       "reference": "./GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "386",
+      "referenceNumber": "371",
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -2320,7 +2128,7 @@
       "reference": "./GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "237",
+      "referenceNumber": "227",
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -2332,7 +2140,7 @@
       "reference": "./GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": "25",
+      "referenceNumber": "24",
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
@@ -2345,7 +2153,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "430",
+      "referenceNumber": "414",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
@@ -2359,7 +2167,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "155",
+      "referenceNumber": "152",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
@@ -2373,7 +2181,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "130",
+      "referenceNumber": "127",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
@@ -2387,7 +2195,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "414",
+      "referenceNumber": "399",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
@@ -2412,7 +2220,7 @@
       "reference": "./GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "9",
+      "referenceNumber": "8",
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -2424,7 +2232,7 @@
       "reference": "./Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "394",
+      "referenceNumber": "379",
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -2436,7 +2244,7 @@
       "reference": "./Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "124",
+      "referenceNumber": "121",
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -2448,7 +2256,7 @@
       "reference": "./Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "215",
+      "referenceNumber": "206",
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -2461,7 +2269,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "157",
+      "referenceNumber": "154",
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
@@ -2473,7 +2281,7 @@
       "reference": "./HPND-sell-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": "168",
+      "referenceNumber": "164",
       "name": "Historical Permission Notice and Disclaimer - sell variant",
       "licenseId": "HPND-sell-variant",
       "seeAlso": [
@@ -2485,7 +2293,7 @@
       "reference": "./HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "221",
+      "referenceNumber": "212",
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -2497,7 +2305,7 @@
       "reference": "./Hippocratic-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Hippocratic-2.1.json",
-      "referenceNumber": "191",
+      "referenceNumber": "185",
       "name": "Hippocratic License 2.1",
       "licenseId": "Hippocratic-2.1",
       "seeAlso": [
@@ -2510,7 +2318,7 @@
       "reference": "./IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "251",
+      "referenceNumber": "241",
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -2522,7 +2330,7 @@
       "reference": "./ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "185",
+      "referenceNumber": "180",
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -2535,7 +2343,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "255",
+      "referenceNumber": "244",
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -2548,7 +2356,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "335",
+      "referenceNumber": "321",
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
@@ -2561,7 +2369,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "334",
+      "referenceNumber": "320",
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
@@ -2574,7 +2382,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "379",
+      "referenceNumber": "364",
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
@@ -2587,7 +2395,7 @@
       "reference": "./ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "351",
+      "referenceNumber": "337",
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -2600,7 +2408,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "143",
+      "referenceNumber": "140",
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -2613,7 +2421,7 @@
       "reference": "./Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "306",
+      "referenceNumber": "294",
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -2626,7 +2434,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "30",
+      "referenceNumber": "29",
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
@@ -2638,7 +2446,7 @@
       "reference": "./Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "254",
+      "referenceNumber": "243",
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -2650,7 +2458,7 @@
       "reference": "./Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "348",
+      "referenceNumber": "334",
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -2662,7 +2470,7 @@
       "reference": "./JPNIC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": "341",
+      "referenceNumber": "327",
       "name": "Japan Network Information Center License",
       "licenseId": "JPNIC",
       "seeAlso": [
@@ -2674,7 +2482,7 @@
       "reference": "./JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "213",
+      "referenceNumber": "204",
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -2686,7 +2494,7 @@
       "reference": "./JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "83",
+      "referenceNumber": "81",
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -2698,7 +2506,7 @@
       "reference": "./LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "162",
+      "referenceNumber": "159",
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -2710,7 +2518,7 @@
       "reference": "./LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "383",
+      "referenceNumber": "368",
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -2722,7 +2530,7 @@
       "reference": "./LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "297",
+      "referenceNumber": "286",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -2734,7 +2542,7 @@
       "reference": "./LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "147",
+      "referenceNumber": "144",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
@@ -2746,7 +2554,7 @@
       "reference": "./LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "353",
+      "referenceNumber": "339",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
@@ -2758,7 +2566,7 @@
       "reference": "./LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "36",
+      "referenceNumber": "35",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
@@ -2771,7 +2579,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "196",
+      "referenceNumber": "189",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -2785,7 +2593,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "218",
+      "referenceNumber": "209",
       "name": "GNU Library General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
@@ -2799,7 +2607,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": "146",
+      "referenceNumber": "143",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
@@ -2813,7 +2621,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "290",
+      "referenceNumber": "279",
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
@@ -2827,7 +2635,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "225",
+      "referenceNumber": "216",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
@@ -2841,7 +2649,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "238",
+      "referenceNumber": "228",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
@@ -2855,7 +2663,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "50",
+      "referenceNumber": "49",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
@@ -2869,7 +2677,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "342",
+      "referenceNumber": "328",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
@@ -2882,7 +2690,7 @@
       "reference": "./LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "433",
+      "referenceNumber": "417",
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -2894,7 +2702,7 @@
       "reference": "./LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "398",
+      "referenceNumber": "383",
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
@@ -2907,7 +2715,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "128",
+      "referenceNumber": "125",
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
@@ -2920,7 +2728,7 @@
       "reference": "./LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "89",
+      "referenceNumber": "86",
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -2932,7 +2740,7 @@
       "reference": "./LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "178",
+      "referenceNumber": "174",
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -2945,7 +2753,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "170",
+      "referenceNumber": "166",
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -2958,7 +2766,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "291",
+      "referenceNumber": "280",
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -2970,7 +2778,7 @@
       "reference": "./LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "134",
+      "referenceNumber": "131",
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
@@ -2983,7 +2791,7 @@
       "reference": "./Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "38",
+      "referenceNumber": "37",
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -2995,7 +2803,7 @@
       "reference": "./Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "325",
+      "referenceNumber": "311",
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -3007,7 +2815,7 @@
       "reference": "./LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "86",
+      "referenceNumber": "83",
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
@@ -3020,7 +2828,7 @@
       "reference": "./LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "313",
+      "referenceNumber": "301",
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
@@ -3033,7 +2841,7 @@
       "reference": "./LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "360",
+      "referenceNumber": "346",
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
@@ -3046,7 +2854,7 @@
       "reference": "./Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "403",
+      "referenceNumber": "388",
       "name": "libpng License",
       "licenseId": "Libpng",
       "seeAlso": [
@@ -3058,7 +2866,7 @@
       "reference": "./Linux-OpenIB.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": "233",
+      "referenceNumber": "224",
       "name": "Linux Kernel Variant of OpenIB.org license",
       "licenseId": "Linux-OpenIB",
       "seeAlso": [
@@ -3071,7 +2879,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "276",
+      "referenceNumber": "265",
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
@@ -3083,7 +2891,7 @@
       "reference": "./MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": "81",
+      "referenceNumber": "79",
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -3097,7 +2905,7 @@
       "reference": "./MIT-CMU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": "369",
+      "referenceNumber": "355",
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
@@ -3110,7 +2918,7 @@
       "reference": "./MIT-advertising.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": "208",
+      "referenceNumber": "199",
       "name": "Enlightenment License (e16)",
       "licenseId": "MIT-advertising",
       "seeAlso": [
@@ -3122,7 +2930,7 @@
       "reference": "./MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "56",
+      "referenceNumber": "54",
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -3134,7 +2942,7 @@
       "reference": "./MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "391",
+      "referenceNumber": "376",
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -3146,7 +2954,7 @@
       "reference": "./MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "361",
+      "referenceNumber": "347",
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -3158,7 +2966,7 @@
       "reference": "./MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "258",
+      "referenceNumber": "247",
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
@@ -3172,7 +2980,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "422",
+      "referenceNumber": "407",
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
@@ -3186,7 +2994,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "129",
+      "referenceNumber": "126",
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
@@ -3199,7 +3007,7 @@
       "reference": "./MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "197",
+      "referenceNumber": "190",
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
@@ -3213,7 +3021,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "392",
+      "referenceNumber": "377",
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
@@ -3240,7 +3048,7 @@
       "reference": "./MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "109",
+      "referenceNumber": "106",
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -3252,7 +3060,7 @@
       "reference": "./MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "368",
+      "referenceNumber": "354",
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -3264,7 +3072,7 @@
       "reference": "./MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "396",
+      "referenceNumber": "381",
       "name": "The MirOS Licence",
       "licenseId": "MirOS",
       "seeAlso": [
@@ -3276,7 +3084,7 @@
       "reference": "./Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "13",
+      "referenceNumber": "12",
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
@@ -3288,7 +3096,7 @@
       "reference": "./MulanPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MulanPSL-1.0.json",
-      "referenceNumber": "217",
+      "referenceNumber": "208",
       "name": "Mulan Permissive Software License, Version 1",
       "licenseId": "MulanPSL-1.0",
       "seeAlso": [
@@ -3301,7 +3109,7 @@
       "reference": "./MulanPSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MulanPSL-2.0.json",
-      "referenceNumber": "156",
+      "referenceNumber": "153",
       "name": "Mulan Permissive Software License, Version 2",
       "licenseId": "MulanPSL-2.0",
       "seeAlso": [
@@ -3313,7 +3121,7 @@
       "reference": "./Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "174",
+      "referenceNumber": "170",
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
@@ -3325,7 +3133,7 @@
       "reference": "./Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "330",
+      "referenceNumber": "316",
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -3337,7 +3145,7 @@
       "reference": "./NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "117",
+      "referenceNumber": "114",
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
@@ -3350,7 +3158,7 @@
       "reference": "./NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "18",
+      "referenceNumber": "17",
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -3362,7 +3170,7 @@
       "reference": "./NCGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NCGL-UK-2.0.json",
-      "referenceNumber": "234",
+      "referenceNumber": "225",
       "name": "Non-Commercial Government Licence",
       "licenseId": "NCGL-UK-2.0",
       "seeAlso": [
@@ -3375,7 +3183,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "201",
+      "referenceNumber": "194",
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
@@ -3388,7 +3196,7 @@
       "reference": "./NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "333",
+      "referenceNumber": "319",
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
@@ -3400,7 +3208,7 @@
       "reference": "./NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "142",
+      "referenceNumber": "139",
       "name": "Norwegian Licence for Open Government Data",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -3412,7 +3220,7 @@
       "reference": "./NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "331",
+      "referenceNumber": "317",
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -3425,7 +3233,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "407",
+      "referenceNumber": "392",
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -3438,7 +3246,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "264",
+      "referenceNumber": "253",
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -3451,7 +3259,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "438",
+      "referenceNumber": "422",
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -3463,7 +3271,7 @@
       "reference": "./NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "159",
+      "referenceNumber": "156",
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
@@ -3475,7 +3283,7 @@
       "reference": "./NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "108",
+      "referenceNumber": "105",
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -3487,7 +3295,7 @@
       "reference": "./NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "279",
+      "referenceNumber": "268",
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
@@ -3499,7 +3307,7 @@
       "reference": "./NTP-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NTP-0.json",
-      "referenceNumber": "199",
+      "referenceNumber": "192",
       "name": "NTP No Attribution",
       "licenseId": "NTP-0",
       "seeAlso": [
@@ -3511,7 +3319,7 @@
       "reference": "./Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "305",
+      "referenceNumber": "293",
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
@@ -3523,7 +3331,7 @@
       "reference": "./Net-SNMP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "299",
+      "referenceNumber": "288",
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -3535,7 +3343,7 @@
       "reference": "./NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "228",
+      "referenceNumber": "219",
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -3547,7 +3355,7 @@
       "reference": "./Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "384",
+      "referenceNumber": "369",
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -3560,7 +3368,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "133",
+      "referenceNumber": "130",
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
@@ -3572,7 +3380,7 @@
       "reference": "./Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "75",
+      "referenceNumber": "73",
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -3585,7 +3393,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "94",
+      "referenceNumber": "91",
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -3597,7 +3405,7 @@
       "reference": "./O-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/O-UDA-1.0.json",
-      "referenceNumber": "49",
+      "referenceNumber": "48",
       "name": "Open Use of Data Agreement v1.0",
       "licenseId": "O-UDA-1.0",
       "seeAlso": [
@@ -3609,7 +3417,7 @@
       "reference": "./OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "70",
+      "referenceNumber": "68",
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -3621,7 +3429,7 @@
       "reference": "./OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "366",
+      "referenceNumber": "352",
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
@@ -3634,7 +3442,7 @@
       "reference": "./ODC-By-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": "408",
+      "referenceNumber": "393",
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -3647,7 +3455,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "365",
+      "referenceNumber": "351",
       "name": "ODC Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -3660,7 +3468,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "87",
+      "referenceNumber": "84",
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -3672,7 +3480,7 @@
       "reference": "./OFL-1.0-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.0-RFN.json",
-      "referenceNumber": "323",
+      "referenceNumber": "309",
       "name": "SIL Open Font License 1.0 with Reserved Font Name",
       "licenseId": "OFL-1.0-RFN",
       "seeAlso": [
@@ -3684,7 +3492,7 @@
       "reference": "./OFL-1.0-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.0-no-RFN.json",
-      "referenceNumber": "76",
+      "referenceNumber": "74",
       "name": "SIL Open Font License 1.0 with no Reserved Font Name",
       "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
@@ -3697,7 +3505,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "336",
+      "referenceNumber": "322",
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
@@ -3710,7 +3518,7 @@
       "reference": "./OFL-1.1-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.1-RFN.json",
-      "referenceNumber": "44",
+      "referenceNumber": "43",
       "name": "SIL Open Font License 1.1 with Reserved Font Name",
       "licenseId": "OFL-1.1-RFN",
       "seeAlso": [
@@ -3723,7 +3531,7 @@
       "reference": "./OFL-1.1-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.1-no-RFN.json",
-      "referenceNumber": "257",
+      "referenceNumber": "246",
       "name": "SIL Open Font License 1.1 with no Reserved Font Name",
       "licenseId": "OFL-1.1-no-RFN",
       "seeAlso": [
@@ -3736,7 +3544,7 @@
       "reference": "./OGC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGC-1.0.json",
-      "referenceNumber": "393",
+      "referenceNumber": "378",
       "name": "OGC Software License, Version 1.0",
       "licenseId": "OGC-1.0",
       "seeAlso": [
@@ -3748,7 +3556,7 @@
       "reference": "./OGL-Canada-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-Canada-2.0.json",
-      "referenceNumber": "371",
+      "referenceNumber": "357",
       "name": "Open Government Licence - Canada",
       "licenseId": "OGL-Canada-2.0",
       "seeAlso": [
@@ -3760,7 +3568,7 @@
       "reference": "./OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": "374",
+      "referenceNumber": "359",
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -3772,7 +3580,7 @@
       "reference": "./OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": "14",
+      "referenceNumber": "13",
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -3784,7 +3592,7 @@
       "reference": "./OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": "22",
+      "referenceNumber": "21",
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -3796,7 +3604,7 @@
       "reference": "./OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "27",
+      "referenceNumber": "26",
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
@@ -3809,7 +3617,7 @@
       "reference": "./OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "59",
+      "referenceNumber": "57",
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -3821,7 +3629,7 @@
       "reference": "./OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "51",
+      "referenceNumber": "50",
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -3833,7 +3641,7 @@
       "reference": "./OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "43",
+      "referenceNumber": "42",
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -3845,7 +3653,7 @@
       "reference": "./OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "53",
+      "referenceNumber": "52",
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -3857,7 +3665,7 @@
       "reference": "./OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "26",
+      "referenceNumber": "25",
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -3869,7 +3677,7 @@
       "reference": "./OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "301",
+      "referenceNumber": "290",
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -3881,7 +3689,7 @@
       "reference": "./OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "429",
+      "referenceNumber": "413",
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -3893,7 +3701,7 @@
       "reference": "./OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "343",
+      "referenceNumber": "329",
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -3905,7 +3713,7 @@
       "reference": "./OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "411",
+      "referenceNumber": "396",
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -3917,7 +3725,7 @@
       "reference": "./OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "180",
+      "referenceNumber": "176",
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -3930,7 +3738,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "248",
+      "referenceNumber": "238",
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -3942,7 +3750,7 @@
       "reference": "./OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "122",
+      "referenceNumber": "119",
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -3954,7 +3762,7 @@
       "reference": "./OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "115",
+      "referenceNumber": "112",
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -3966,7 +3774,7 @@
       "reference": "./OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "116",
+      "referenceNumber": "113",
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -3979,7 +3787,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "247",
+      "referenceNumber": "237",
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -3991,7 +3799,7 @@
       "reference": "./OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "272",
+      "referenceNumber": "261",
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -4003,7 +3811,7 @@
       "reference": "./OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "181",
+      "referenceNumber": "177",
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -4015,7 +3823,7 @@
       "reference": "./OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "363",
+      "referenceNumber": "349",
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -4028,7 +3836,7 @@
       "reference": "./OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "219",
+      "referenceNumber": "210",
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
@@ -4042,7 +3850,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "102",
+      "referenceNumber": "99",
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
@@ -4055,7 +3863,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "190",
+      "referenceNumber": "184",
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -4068,7 +3876,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": "390",
+      "referenceNumber": "375",
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -4081,7 +3889,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "167",
+      "referenceNumber": "163",
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
@@ -4095,7 +3903,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "158",
+      "referenceNumber": "155",
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
@@ -4109,7 +3917,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "90",
+      "referenceNumber": "87",
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -4121,7 +3929,7 @@
       "reference": "./PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": "140",
+      "referenceNumber": "137",
       "name": "ODC Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
@@ -4133,7 +3941,7 @@
       "reference": "./PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "206",
+      "referenceNumber": "198",
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
@@ -4153,13 +3961,13 @@
       "seeAlso": [
         "http://www.php.net/license/3_01.txt"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
       "reference": "./PSF-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PSF-2.0.json",
-      "referenceNumber": "98",
+      "referenceNumber": "95",
       "name": "Python Software Foundation License 2.0",
       "licenseId": "PSF-2.0",
       "seeAlso": [
@@ -4171,7 +3979,7 @@
       "reference": "./Parity-6.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Parity-6.0.0.json",
-      "referenceNumber": "435",
+      "referenceNumber": "419",
       "name": "The Parity Public License 6.0.0",
       "licenseId": "Parity-6.0.0",
       "seeAlso": [
@@ -4183,7 +3991,7 @@
       "reference": "./Parity-7.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Parity-7.0.0.json",
-      "referenceNumber": "419",
+      "referenceNumber": "404",
       "name": "The Parity Public License 7.0.0",
       "licenseId": "Parity-7.0.0",
       "seeAlso": [
@@ -4195,7 +4003,7 @@
       "reference": "./Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "165",
+      "referenceNumber": "162",
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -4207,7 +4015,7 @@
       "reference": "./PolyForm-Noncommercial-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
-      "referenceNumber": "304",
+      "referenceNumber": "292",
       "name": "PolyForm Noncommercial License 1.0.0",
       "licenseId": "PolyForm-Noncommercial-1.0.0",
       "seeAlso": [
@@ -4219,7 +4027,7 @@
       "reference": "./PolyForm-Small-Business-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
-      "referenceNumber": "125",
+      "referenceNumber": "122",
       "name": "PolyForm Small Business License 1.0.0",
       "licenseId": "PolyForm-Small-Business-1.0.0",
       "seeAlso": [
@@ -4231,7 +4039,7 @@
       "reference": "./PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "12",
+      "referenceNumber": "11",
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
@@ -4245,7 +4053,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "421",
+      "referenceNumber": "406",
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
@@ -4258,7 +4066,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "312",
+      "referenceNumber": "300",
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
@@ -4271,7 +4079,7 @@
       "reference": "./Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "132",
+      "referenceNumber": "129",
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -4283,7 +4091,7 @@
       "reference": "./RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "66",
+      "referenceNumber": "64",
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -4295,7 +4103,7 @@
       "reference": "./RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "232",
+      "referenceNumber": "223",
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
@@ -4307,7 +4115,7 @@
       "reference": "./RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "112",
+      "referenceNumber": "109",
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
@@ -4320,7 +4128,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "57",
+      "referenceNumber": "55",
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
@@ -4333,7 +4141,7 @@
       "reference": "./RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "300",
+      "referenceNumber": "289",
       "name": "RSA Message-Digest License ",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -4345,7 +4153,7 @@
       "reference": "./RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "364",
+      "referenceNumber": "350",
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
@@ -4358,7 +4166,7 @@
       "reference": "./Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "347",
+      "referenceNumber": "333",
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -4371,7 +4179,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "15",
+      "referenceNumber": "14",
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -4383,7 +4191,7 @@
       "reference": "./SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "161",
+      "referenceNumber": "158",
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -4395,7 +4203,7 @@
       "reference": "./SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SCEA.json",
-      "referenceNumber": "145",
+      "referenceNumber": "142",
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -4407,7 +4215,7 @@
       "reference": "./SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "203",
+      "referenceNumber": "196",
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -4419,7 +4227,7 @@
       "reference": "./SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "311",
+      "referenceNumber": "299",
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -4432,7 +4240,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "32",
+      "referenceNumber": "31",
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -4444,7 +4252,7 @@
       "reference": "./SHL-0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SHL-0.5.json",
-      "referenceNumber": "52",
+      "referenceNumber": "51",
       "name": "Solderpad Hardware License v0.5",
       "licenseId": "SHL-0.5",
       "seeAlso": [
@@ -4456,7 +4264,7 @@
       "reference": "./SHL-0.51.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SHL-0.51.json",
-      "referenceNumber": "302",
+      "referenceNumber": "291",
       "name": "Solderpad Hardware License, Version 0.51",
       "licenseId": "SHL-0.51",
       "seeAlso": [
@@ -4469,7 +4277,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "85",
+      "referenceNumber": "82",
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
@@ -4482,7 +4290,7 @@
       "reference": "./SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": "67",
+      "referenceNumber": "65",
       "name": "Sun Industry Standards Source License v1.2",
       "licenseId": "SISSL-1.2",
       "seeAlso": [
@@ -4495,7 +4303,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "235",
+      "referenceNumber": "226",
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -4507,7 +4315,7 @@
       "reference": "./SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "113",
+      "referenceNumber": "110",
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -4519,7 +4327,7 @@
       "reference": "./SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "327",
+      "referenceNumber": "313",
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -4532,7 +4340,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "267",
+      "referenceNumber": "256",
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
@@ -4544,7 +4352,7 @@
       "reference": "./SSH-OpenSSH.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SSH-OpenSSH.json",
-      "referenceNumber": "23",
+      "referenceNumber": "22",
       "name": "SSH OpenSSH license",
       "licenseId": "SSH-OpenSSH",
       "seeAlso": [
@@ -4556,7 +4364,7 @@
       "reference": "./SSH-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SSH-short.json",
-      "referenceNumber": "72",
+      "referenceNumber": "70",
       "name": "SSH short notice",
       "licenseId": "SSH-short",
       "seeAlso": [
@@ -4570,7 +4378,7 @@
       "reference": "./SSPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SSPL-1.0.json",
-      "referenceNumber": "359",
+      "referenceNumber": "345",
       "name": "Server Side Public License, v 1",
       "licenseId": "SSPL-1.0",
       "seeAlso": [
@@ -4582,7 +4390,7 @@
       "reference": "./SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "100",
+      "referenceNumber": "97",
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -4594,7 +4402,7 @@
       "reference": "./Saxpath.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": "35",
+      "referenceNumber": "34",
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -4606,7 +4414,7 @@
       "reference": "./Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "316",
+      "referenceNumber": "304",
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -4619,7 +4427,7 @@
       "reference": "./Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": "188",
+      "referenceNumber": "182",
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -4632,7 +4440,7 @@
       "reference": "./SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "270",
+      "referenceNumber": "259",
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
@@ -4645,7 +4453,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "60",
+      "referenceNumber": "58",
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
@@ -4657,7 +4465,7 @@
       "reference": "./Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "198",
+      "referenceNumber": "191",
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -4669,7 +4477,7 @@
       "reference": "./Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "229",
+      "referenceNumber": "220",
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -4681,7 +4489,7 @@
       "reference": "./Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "69",
+      "referenceNumber": "67",
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -4694,7 +4502,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "308",
+      "referenceNumber": "296",
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -4706,7 +4514,7 @@
       "reference": "./SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "367",
+      "referenceNumber": "353",
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -4718,7 +4526,7 @@
       "reference": "./TAPR-OHL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": "10",
+      "referenceNumber": "9",
       "name": "TAPR Open Hardware License v1.0",
       "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
@@ -4730,7 +4538,7 @@
       "reference": "./TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "58",
+      "referenceNumber": "56",
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -4743,7 +4551,7 @@
       "reference": "./TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "252",
+      "referenceNumber": "242",
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -4755,7 +4563,7 @@
       "reference": "./TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "431",
+      "referenceNumber": "415",
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -4767,7 +4575,7 @@
       "reference": "./TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "202",
+      "referenceNumber": "195",
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -4779,7 +4587,7 @@
       "reference": "./TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "271",
+      "referenceNumber": "260",
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -4791,7 +4599,7 @@
       "reference": "./TU-Berlin-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": "399",
+      "referenceNumber": "384",
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -4803,7 +4611,7 @@
       "reference": "./TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": "420",
+      "referenceNumber": "405",
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -4815,7 +4623,7 @@
       "reference": "./UCL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/UCL-1.0.json",
-      "referenceNumber": "314",
+      "referenceNumber": "302",
       "name": "Upstream Compatibility License v1.0",
       "licenseId": "UCL-1.0",
       "seeAlso": [
@@ -4828,7 +4636,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "152",
+      "referenceNumber": "149",
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
@@ -4840,7 +4648,7 @@
       "reference": "./Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": "281",
+      "referenceNumber": "270",
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -4852,7 +4660,7 @@
       "reference": "./Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "397",
+      "referenceNumber": "382",
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -4864,7 +4672,7 @@
       "reference": "./Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "17",
+      "referenceNumber": "16",
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -4877,7 +4685,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "184",
+      "referenceNumber": "179",
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -4889,7 +4697,7 @@
       "reference": "./VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "378",
+      "referenceNumber": "363",
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -4901,7 +4709,7 @@
       "reference": "./VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "417",
+      "referenceNumber": "402",
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
@@ -4914,7 +4722,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "222",
+      "referenceNumber": "213",
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -4927,7 +4735,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "114",
+      "referenceNumber": "111",
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
@@ -4940,7 +4748,7 @@
       "reference": "./W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "287",
+      "referenceNumber": "276",
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -4952,7 +4760,7 @@
       "reference": "./W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "118",
+      "referenceNumber": "115",
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -4965,11 +4773,10 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "21",
+      "referenceNumber": "20",
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
-        "http://www.wtfpl.net/about/",
         "http://sam.zoy.org/wtfpl/COPYING"
       ],
       "isOsiApproved": false
@@ -4978,7 +4785,7 @@
       "reference": "./Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "149",
+      "referenceNumber": "146",
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
@@ -4990,7 +4797,7 @@
       "reference": "./Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "275",
+      "referenceNumber": "264",
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -5003,7 +4810,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "106",
+      "referenceNumber": "103",
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -5016,7 +4823,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "164",
+      "referenceNumber": "161",
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -5028,7 +4835,7 @@
       "reference": "./XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "88",
+      "referenceNumber": "85",
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -5040,7 +4847,7 @@
       "reference": "./Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "242",
+      "referenceNumber": "232",
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -5052,7 +4859,7 @@
       "reference": "./Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "338",
+      "referenceNumber": "324",
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
@@ -5064,7 +4871,7 @@
       "reference": "./YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "315",
+      "referenceNumber": "303",
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -5077,7 +4884,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "41",
+      "referenceNumber": "40",
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -5089,7 +4896,7 @@
       "reference": "./ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "92",
+      "referenceNumber": "89",
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -5102,7 +4909,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "119",
+      "referenceNumber": "116",
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
@@ -5116,7 +4923,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "395",
+      "referenceNumber": "380",
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -5128,7 +4935,7 @@
       "reference": "./Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "121",
+      "referenceNumber": "118",
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -5141,7 +4948,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "400",
+      "referenceNumber": "385",
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -5154,7 +4961,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "187",
+      "referenceNumber": "181",
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
       "seeAlso": [
@@ -5166,7 +4973,7 @@
       "reference": "./Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "412",
+      "referenceNumber": "397",
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -5179,7 +4986,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "46",
+      "referenceNumber": "45",
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
@@ -5192,7 +4999,7 @@
       "reference": "./blessing.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/blessing.json",
-      "referenceNumber": "326",
+      "referenceNumber": "312",
       "name": "SQLite Blessing",
       "licenseId": "blessing",
       "seeAlso": [
@@ -5205,7 +5012,7 @@
       "reference": "./bzip2-1.0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "200",
+      "referenceNumber": "193",
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -5218,7 +5025,7 @@
       "reference": "./bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "74",
+      "referenceNumber": "72",
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -5231,7 +5038,7 @@
       "reference": "./copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": "337",
+      "referenceNumber": "323",
       "name": "copyleft-next 0.3.0",
       "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
@@ -5243,7 +5050,7 @@
       "reference": "./copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": "405",
+      "referenceNumber": "390",
       "name": "copyleft-next 0.3.1",
       "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
@@ -5255,7 +5062,7 @@
       "reference": "./curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "339",
+      "referenceNumber": "325",
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -5267,7 +5074,7 @@
       "reference": "./diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "426",
+      "referenceNumber": "410",
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -5279,7 +5086,7 @@
       "reference": "./dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "20",
+      "referenceNumber": "19",
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -5292,7 +5099,7 @@
       "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "293",
+      "referenceNumber": "282",
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -5304,7 +5111,7 @@
       "reference": "./eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "230",
+      "referenceNumber": "221",
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -5317,7 +5124,7 @@
       "reference": "./etalab-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/etalab-2.0.json",
-      "referenceNumber": "280",
+      "referenceNumber": "269",
       "name": "Etalab Open License 2.0",
       "licenseId": "etalab-2.0",
       "seeAlso": [
@@ -5330,7 +5137,7 @@
       "reference": "./gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "177",
+      "referenceNumber": "173",
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -5343,7 +5150,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": "410",
+      "referenceNumber": "395",
       "name": "gnuplot License",
       "licenseId": "gnuplot",
       "seeAlso": [
@@ -5356,7 +5163,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "189",
+      "referenceNumber": "183",
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -5368,7 +5175,7 @@
       "reference": "./libpng-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": "110",
+      "referenceNumber": "107",
       "name": "PNG Reference Library version 2",
       "licenseId": "libpng-2.0",
       "seeAlso": [
@@ -5380,7 +5187,7 @@
       "reference": "./libselinux-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/libselinux-1.0.json",
-      "referenceNumber": "19",
+      "referenceNumber": "18",
       "name": "libselinux public domain notice",
       "licenseId": "libselinux-1.0",
       "seeAlso": [
@@ -5392,7 +5199,7 @@
       "reference": "./libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "436",
+      "referenceNumber": "420",
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -5404,7 +5211,7 @@
       "reference": "./mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "65",
+      "referenceNumber": "63",
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -5416,7 +5223,7 @@
       "reference": "./psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "437",
+      "referenceNumber": "421",
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -5428,7 +5235,7 @@
       "reference": "./psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "298",
+      "referenceNumber": "287",
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -5440,7 +5247,7 @@
       "reference": "./wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "263",
+      "referenceNumber": "252",
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
@@ -5453,7 +5260,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "428",
+      "referenceNumber": "412",
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -5465,7 +5272,7 @@
       "reference": "./xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "103",
+      "referenceNumber": "100",
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -5477,7 +5284,7 @@
       "reference": "./zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "265",
+      "referenceNumber": "254",
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -5486,5 +5293,5 @@
       "isOsiApproved": false
     }
   ],
-  "releaseDate": "2020-07-16"
+  "releaseDate": "2020-05-15"
 }

--- a/Library/Homebrew/dev-cmd/update-license-data.rb
+++ b/Library/Homebrew/dev-cmd/update-license-data.rb
@@ -1,28 +1,26 @@
 # frozen_string_literal: true
 
-require "commands"
 require "cli/parser"
-require "json"
-require "net/http"
-require "open-uri"
+require "utils/github"
 
 module Homebrew
   module_function
 
   SPDX_PATH = (HOMEBREW_LIBRARY_PATH/"data/spdx.json").freeze
-  SPDX_DATA_URL = "https://raw.githubusercontent.com/spdx/license-list-data/HEAD/json/licenses.json"
+  SPDX_API_URL = "https://api.github.com/repos/spdx/license-list-data/releases/latest"
 
   def update_license_data_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `update_license_data` <cmd>
+        `update-license-data` [<options>]
 
          Update SPDX license data in the Homebrew repository.
       EOS
       switch "--fail-if-changed",
              description: "Return a failing status code if current license data's version is different from " \
                           "the upstream. This can be used to notify CI when the SPDX license data is out of date."
-
+      switch "--commit",
+             description: "Commit changes to the SPDX license data."
       max_named 0
     end
   end
@@ -30,10 +28,18 @@ module Homebrew
   def update_license_data
     update_license_data_args.parse
     ohai "Updating SPDX license data..."
-    curl_download(SPDX_DATA_URL, to: SPDX_PATH, partial: false)
 
-    return unless args.fail_if_changed?
+    latest_tag = GitHub.open_api(SPDX_API_URL)["tag_name"]
+    data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{latest_tag}/json/licenses.json"
+    curl_download(data_url, to: SPDX_PATH, partial: false)
 
-    safe_system "git", "diff", "--stat", "--exit-code", SPDX_PATH
+    Homebrew.failed = !system("git", "diff", "--stat", "--exit-code", SPDX_PATH) if args.fail_if_changed?
+
+    return unless args.commit?
+
+    ohai "git add"
+    safe_system "git", "add", SPDX_PATH
+    ohai "git commit"
+    system "git", "commit", "--message", "data/spdx.json: update to #{latest_tag}"
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1048,12 +1048,14 @@ directory.
 * `-g`, `--git`:
   Initialise a Git repository in the unpacked source. This is useful for creating patches for the software.
 
-### `update_license_data` *`cmd`*
+### `update-license-data` [*`options`*]
 
  Update SPDX license data in the Homebrew repository.
 
 * `--fail-if-changed`:
   Return a failing status code if current license data's version is different from the upstream. This can be used to notify CI when the SPDX license data is out of date.
+* `--commit`:
+  Commit changes to the SPDX license data.
 
 ### `update-test` [*`options`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1357,12 +1357,16 @@ Patches for \fIformula\fR will be applied to the unpacked source\.
 \fB\-g\fR, \fB\-\-git\fR
 Initialise a Git repository in the unpacked source\. This is useful for creating patches for the software\.
 .
-.SS "\fBupdate_license_data\fR \fIcmd\fR"
+.SS "\fBupdate\-license\-data\fR [\fIoptions\fR]"
 Update SPDX license data in the Homebrew repository\.
 .
 .TP
 \fB\-\-fail\-if\-changed\fR
 Return a failing status code if current license data\'s version is different from the upstream\. This can be used to notify CI when the SPDX license data is out of date\.
+.
+.TP
+\fB\-\-commit\fR
+Commit changes to the SPDX license data\.
 .
 .SS "\fBupdate\-test\fR [\fIoptions\fR]"
 Run a test of \fBbrew update\fR with a new repository clone\. If no options are passed, use \fBorigin/master\fR as the start commit\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Upstream updates a bit too frequently for our tastes and given we have `brew update-license-data --fail-if-changed` in our CI checks it makes sense for this to fail less frequently to avoid annoying maintainers and confusing contributors.

@Bo98 this could simplify your workflow in https://github.com/Homebrew/brew/pull/8021 as I've added a `--commit` option (demonstrated in this pull request)

cc @lionellloh 