### PR TITLE
Require short pythonhosted urls

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -292,7 +292,7 @@ module RuboCop
 
           # Check pypi urls
           pypi_pattern = %r{^https?://pypi.python.org/(.*)}
-          audit_urls(urls, pypi_pattern) do |match, url|
+          audit_urls(urls, pypi_pattern) do |_match, url|
             problem "`#{url}` should be `#{convert_to_pythonhosted_url(url)}`"
           end
 
@@ -317,7 +317,7 @@ module RuboCop
 
         def convert_to_pythonhosted_url(url)
           package_file = File.basename(url)
-          package_name = package_file.match(/^(.*)-[0-9.]+\.tar\.gz/)[1]
+          package_name = package_file.match(/^(.+)-[a-z0-9.]+$/)[1]
           "https://files.pythonhosted.org/packages/source/#{package_name[0]}/#{package_name}/#{package_file}"
         end
       end

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -291,9 +291,9 @@ module RuboCop
           urls += mirrors
 
           # Check pypi urls
-          @pypi_pattern = %r{^https?://pypi.python.org/(.*)}
-          audit_urls(urls, @pypi_pattern) do |match, url|
-            problem "#{url} should be `https://files.pythonhosted.org/#{match[1]}`"
+          pypi_pattern = %r{^https?://pypi.python.org/(.*)}
+          audit_urls(urls, pypi_pattern) do |match, url|
+            problem "`#{url}` should be `https://files.pythonhosted.org/#{match[1]}`"
           end
 
           # Check for short files.pythonhosted.org urls

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -291,16 +291,14 @@ module RuboCop
           urls += mirrors
 
           # Check pypi urls
-          pypi_pattern = %r{^https?://pypi.python.org/(.*)}
-          audit_urls(urls, pypi_pattern) do |_match, url|
+          pypi_pattern = %r{^https?://pypi.python.org/}
+          audit_urls(urls, pypi_pattern) do |_, url|
             problem "`#{url}` should be `#{convert_to_pythonhosted_url(url)}`"
           end
 
-          # Check for short files.pythonhosted.org urls
-          pythonhosted_pattern = %r{^https?://files.pythonhosted.org/packages/(.*)}
-          audit_urls(urls, pythonhosted_pattern) do |match, url|
-            next if match[1].match?(%r{^source/})
-
+          # Check long files.pythonhosted.org urls
+          pythonhosted_pattern = %r{^https?://files.pythonhosted.org/packages/(?!source/)}
+          audit_urls(urls, pythonhosted_pattern) do |_, url|
             problem "`#{url}` should be `#{convert_to_pythonhosted_url(url)}`"
           end
         end

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -293,7 +293,7 @@ module RuboCop
           # Check pypi urls
           pypi_pattern = %r{^https?://pypi.python.org/(.*)}
           audit_urls(urls, pypi_pattern) do |match, url|
-            problem "`#{url}` should be `https://files.pythonhosted.org/#{match[1]}`"
+            problem "`#{url}` should be `#{convert_to_pythonhosted_url(url)}`"
           end
 
           # Check for short files.pythonhosted.org urls
@@ -318,7 +318,7 @@ module RuboCop
         def convert_to_pythonhosted_url(url)
           package_file = File.basename(url)
           package_name = package_file.match(/^(.*)-[0-9.]+\.tar\.gz/)[1]
-          "https://files.pythonhosted.org/packages/source/#{package_name}/#{package_file}"
+          "https://files.pythonhosted.org/packages/source/#{package_name[0]}/#{package_name}/#{package_file}"
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -251,7 +251,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
         class Foo < Formula
           desc "foo"
           url "https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz should be `https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz`
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz` should be `https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz`
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -246,7 +246,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
   subject(:cop) { described_class.new }
 
   context "when a pypi.python.org URL is used" do
-    it "reports an offense" do
+    it "reports an offense with a pypi url" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
@@ -256,7 +256,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
       RUBY
     end
 
-    it "support auto-correction" do
+    it "support auto-correction for pypi urls" do
       corrected = autocorrect_source(<<~RUBY)
         class Foo < Formula
           desc "foo"
@@ -265,6 +265,41 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
       RUBY
 
       expect(corrected).to eq <<~RUBY
+        class Foo < Formula
+          desc "foo"
+          url "https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz"
+        end
+      RUBY
+    end
+
+    it "reports an offense with a pythonhosted url" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/foo-0.1.tar.gz"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/foo-0.1.tar.gz` should be `https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz`
+        end
+      RUBY
+    end
+
+    it "support auto-correction for long pythonhosted urls" do
+      corrected = autocorrect_source(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/foo-0.1.tar.gz"
+        end
+      RUBY
+
+      expect(corrected).to eq <<~RUBY
+        class Foo < Formula
+          desc "foo"
+          url "https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz"
+        end
+      RUBY
+    end
+
+    it "reports no offenses with a short pythonhosted url" do
+      expect_no_offenses(<<~RUBY)
         class Foo < Formula
           desc "foo"
           url "https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz"

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -251,7 +251,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
         class Foo < Formula
           desc "foo"
           url "https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz` should be `https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz`
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz` should be `https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz`
         end
       RUBY
     end
@@ -267,7 +267,23 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
       expect(corrected).to eq <<~RUBY
         class Foo < Formula
           desc "foo"
-          url "https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz"
+          url "https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz"
+        end
+      RUBY
+    end
+
+    it "support auto-correction for packages with a capital first letter" do
+      corrected = autocorrect_source(<<~RUBY)
+        class Foo < Formula
+          desc "Foo"
+          url "https://pypi.python.org/packages/source/Foo/Foo-0.1.tar.gz"
+        end
+      RUBY
+
+      expect(corrected).to eq <<~RUBY
+        class Foo < Formula
+          desc "Foo"
+          url "https://files.pythonhosted.org/packages/source/F/Foo/Foo-0.1.tar.gz"
         end
       RUBY
     end
@@ -277,7 +293,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
         class Foo < Formula
           desc "foo"
           url "https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/foo-0.1.tar.gz` should be `https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz`
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/foo-0.1.tar.gz` should be `https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz`
         end
       RUBY
     end
@@ -293,7 +309,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
       expect(corrected).to eq <<~RUBY
         class Foo < Formula
           desc "foo"
-          url "https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz"
+          url "https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz"
         end
       RUBY
     end
@@ -302,7 +318,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url "https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz"
+          url "https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz"
         end
       RUBY
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Require urls like `https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz` instead of `https://files.pythonhosted.org/packages/cb/a2/d59c18cd6a143bf860c29acb70552b7351fd7e0f56213be86b624601106b/foo-0.1.tar.gz` for `pypi` and `pythonhosted` urls.

### Pros:
- Easier to read
- Easier to manually update
- `brew bump-formula-pr` can update with just `--version` instead of the full url
- Autocorrect can automatically convert urls to the right format

### Cons:
- This link isn't shown directly on the pypi downloads page
    - This should be a minor issue because:
        - It's much easier to predict what the url will be without needing to go to the downloads page
        - You can put the longer pypi download url in and use `brew style --fix` to convert it
- Other applications that generate urls (e.g. `homebrew-pypi-poet`) would generate them incorrectly
    - Again, this would be okay (temporarily) because of the autocorrect
    - These applications could be updated to the new style
- 245 formulae currently use the wrong style

(Marked as `do not merge` because there is still an ongoing discussion about this change)

Tagging @SeekingMeaning