### PR TITLE
style: require long urls for pypi and pythonhosted urls

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -291,20 +291,15 @@ module RuboCop
           urls += mirrors
 
           # Check pypi urls
-          @pypi_pattern = %r{^https?://pypi.python.org/(.*)}
-          audit_urls(urls, @pypi_pattern) do |match, url|
-            problem "#{url} should be `https://files.pythonhosted.org/#{match[1]}`"
+          pypi_pattern = %r{^https?://pypi.python.org/}
+          audit_urls(urls, pypi_pattern) do
+            problem "use the `files.pythonhosted.org` url found on the pypi downloads page"
           end
-        end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            url_string_node = parameters(node).first
-            url = string_content(url_string_node)
-            match = regex_match_group(url_string_node, @pypi_pattern)
-            correction = node.source.sub(url, "https://files.pythonhosted.org/#{match[1]}")
-            corrector.insert_before(node.source_range, correction)
-            corrector.remove(node.source_range)
+          # Require long files.pythonhosted.org urls
+          pythonhosted_pattern = %r{^https?://files.pythonhosted.org/packages/source/}
+          audit_urls(urls, pythonhosted_pattern) do
+            problem "use the url found on the pypi downloads page"
           end
         end
       end

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -292,15 +292,21 @@ module RuboCop
 
           # Check pypi urls
           pypi_pattern = %r{^https?://pypi.python.org/}
-          audit_urls(urls, pypi_pattern) do
-            problem "use the `files.pythonhosted.org` url found on the pypi downloads page"
+          audit_urls(urls, pypi_pattern) do |_, url|
+            problem "use the `Source` url found on PyPI downloads page (`#{get_pypi_url(url)}`)"
           end
 
           # Require long files.pythonhosted.org urls
           pythonhosted_pattern = %r{^https?://files.pythonhosted.org/packages/source/}
-          audit_urls(urls, pythonhosted_pattern) do
-            problem "use the url found on the pypi downloads page"
+          audit_urls(urls, pythonhosted_pattern) do |_, url|
+            problem "use the `Source` url found on PyPI downloads page (`#{get_pypi_url(url)}`)"
           end
+        end
+
+        def get_pypi_url(url)
+          package_file = File.basename(url)
+          package_name = package_file.match(/^(.+)-[a-z0-9.]+$/)[1]
+          "https://pypi.org/project/#{package_name}/#files"
         end
       end
     end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -251,7 +251,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
         class Foo < Formula
           desc "foo"
           url "https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use the `files.pythonhosted.org` url found on the pypi downloads page
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use the `Source` url found on PyPI downloads page (`https://pypi.org/project/foo/#files`)
         end
       RUBY
     end
@@ -261,7 +261,7 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
         class Foo < Formula
           desc "foo"
           url "https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use the url found on the pypi downloads page
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use the `Source` url found on PyPI downloads page (`https://pypi.org/project/foo/#files`)
         end
       RUBY
     end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -245,29 +245,32 @@ end
 describe RuboCop::Cop::FormulaAudit::PyPiUrls do
   subject(:cop) { described_class.new }
 
-  context "when a pypi.python.org URL is used" do
-    it "reports an offense" do
+  context "when a pypi URL is used" do
+    it "reports an offense for pypi.python.org urls" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
           url "https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz"
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz should be `https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz`
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use the `files.pythonhosted.org` url found on the pypi downloads page
         end
       RUBY
     end
 
-    it "support auto-correction" do
-      corrected = autocorrect_source(<<~RUBY)
+    it "reports an offense for short file.pythonhosted.org urls" do
+      expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url "https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz"
+          url "https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use the url found on the pypi downloads page
         end
       RUBY
+    end
 
-      expect(corrected).to eq <<~RUBY
+    it "reports no offenses for long file.pythonhosted.org urls" do
+      expect_no_offenses(<<~RUBY)
         class Foo < Formula
           desc "foo"
-          url "https://files.pythonhosted.org/packages/source/foo/foo-0.1.tar.gz"
+          url "https://files.pythonhosted.org/packages/a0/b1/a01b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f/foo-0.1.tar.gz"
         end
       RUBY
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See #8029 for the discussion behind this change

Require urls like `https://files.pythonhosted.org/packages/a0/b1/a01b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f/foo-0.1.tar.gz` instead of `https://files.pythonhosted.org/packages/source/f/foo/foo-0.1.tar.gz` or `https://pypi.python.org/packages/source/foo/foo-0.1.tar.gz`

Homebrew/core PR: https://github.com/Homebrew/homebrew-core/pull/58181

Tagging @SeekingMeaning, @dtrodrigues and @SMillerDev 