### PR TITLE
bump-formula-pr: handle pypi url version changes

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -165,7 +165,6 @@ module Homebrew
     old_formula_version = formula_version(formula, requested_spec)
     old_version = old_formula_version.to_s
     forced_version = new_version.present?
-    new_url ||= update_pypi_url(old_url, new_version) if old_url.match?(%r{^https?://files.pythonhosted.org/})
     new_url_hash = if new_url && new_hash
       check_all_pull_requests(formula, tap_full_name, url: new_url) unless new_version
       true
@@ -189,7 +188,11 @@ module Homebrew
     elsif !new_url && !new_version
       odie "#{formula}: no --url= or --version= argument specified!"
     else
-      new_url ||= old_url.gsub(old_version, new_version)
+      new_url ||= if old_url.match?(%r{^https?://files.pythonhosted.org/})
+        update_pypi_url(old_url, new_version)
+      else
+        old_url.gsub(old_version, new_version)
+      end
       if new_url == old_url
         odie <<~EOS
           You probably need to bump this formula manually since the new URL


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See #8032

This allows `bump-formula-pr` to work with pypi urls.

Example: run `brew bump-formula-pr python-openstackclient --version 5.3.1`

Before this change:

```patch
-  url "https://files.pythonhosted.org/packages/44/5e/d0785bd787af5f37b7f0b69c2b36a731cf222163a474aeb1be109252f4a7/python-openstackclient-5.3.0.tar.gz"
+  url "https://files.pythonhosted.org/packages/44/5e/d0785bd787af5f37b7f0b69c2b36a731cf222163a474aeb1be109252f4a7/python-openstackclient-5.3.1.tar.gz"
```

After this change:

```patch
-  url "https://files.pythonhosted.org/packages/44/5e/d0785bd787af5f37b7f0b69c2b36a731cf222163a474aeb1be109252f4a7/python-openstackclient-5.3.0.tar.gz"
+  url "https://files.pythonhosted.org/packages/84/19/e2453fa06c4f481beda7a6c2326e65884cd1c623177d13c8efc7850bc05e/python-openstackclient-5.3.1.tar.gz"
```

The middle part of the url is now updated as well