### PR TITLE
dev-cmd: add add-license command

### DIFF
--- a/Library/Homebrew/dev-cmd/add-license.rb
+++ b/Library/Homebrew/dev-cmd/add-license.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "formula"
+require "cli/parser"
+
+module Homebrew
+  module_function
+
+  def add_license_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `add-license` [<options>] <formula> <license>
+
+        Create a commit to add <license> to <formula>.
+      EOS
+      switch "-n", "--dry-run",
+             description: "Print what would be done rather than doing it."
+      switch "--no-audit",
+             description: "Don't run `brew audit` before committing."
+      switch "--strict",
+             description: "Run `brew audit --strict` before committing."
+      flag   "--message=",
+             description: "Append <message> to the default commit message."
+      switch :force
+      switch :quiet
+      switch :verbose
+      switch :debug
+      named 2
+    end
+  end
+
+  def add_license
+    add_license_args.parse
+
+    # As this command is simplifying user-run commands then let's just use a
+    # user path, too.
+    ENV["PATH"] = ENV["HOMEBREW_PATH"]
+
+    name = args.named.first
+    formula = Formula[name]
+    current_license = formula.license
+
+    old_contents = File.read(formula.path) unless args.dry_run?
+
+    license = args.named.second
+
+    if current_license.nil?
+      formula_spec = formula.stable
+      hash_type, old_hash = if (checksum = formula_spec.checksum)
+        [checksum.hash_type, checksum.hexdigest]
+      end
+
+      old = if formula.path.read.include?("stable do\n")
+        # insert replacement revision after homepage
+        <<~EOS
+          homepage "#{formula.homepage}"
+        EOS
+      elsif hash_type
+        # insert replacement revision after hash
+        <<~EOS
+          #{hash_type} "#{old_hash}"
+        EOS
+      else
+        # insert replacement revision after :revision
+        <<~EOS
+          :revision => "#{formula_spec.specs[:revision]}"
+        EOS
+      end
+      replacement = old + "  license \"#{license}\"\n"
+
+    elsif args.force?
+      if license == current_license
+        odie <<~EOS
+          The new license and old license are both #{license}.
+        EOS
+      end
+      old = "license \"#{current_license}\""
+      replacement = "license \"#{license}\""
+    else
+      odie <<~EOS
+        #{formula} already has a license: #{license}
+        Use --force to change the current license.
+      EOS
+    end
+
+    if args.dry_run?
+      ohai "replace #{old.inspect} with #{replacement.inspect}" unless args.quiet?
+    else
+      Utils::Inreplace.inreplace(formula.path) do |s|
+        s.gsub!(old, replacement)
+      end
+    end
+
+    run_audit(formula, old_contents)
+
+    message = "#{formula.name}: #{current_license ? "change" : "add"} license #{args.message}"
+    if args.dry_run?
+      ohai "git commit --no-edit --verbose --message=#{message} -- #{formula.path}"
+    else
+      formula.path.parent.cd do
+        safe_system "git", "commit", "--no-edit", "--verbose",
+                    "--message=#{message}", "--", formula.path
+      end
+    end
+  end
+
+  def run_audit(formula, old_contents)
+    if args.dry_run?
+      if args.no_audit?
+        ohai "Skipping `brew audit`"
+      elsif args.strict?
+        ohai "brew audit --strict #{formula.path.basename}"
+      else
+        ohai "brew audit #{formula.path.basename}"
+      end
+      return
+    end
+    failed_audit = false
+    if args.no_audit?
+      ohai "Skipping `brew audit`"
+    elsif args.strict?
+      system HOMEBREW_BREW_FILE, "audit", "--strict", formula.path
+      failed_audit = !$CHILD_STATUS.success?
+    else
+      system HOMEBREW_BREW_FILE, "audit", formula.path
+      failed_audit = !$CHILD_STATUS.success?
+    end
+    return unless failed_audit
+
+    formula.path.atomic_write(old_contents)
+    odie "`brew audit` failed!"
+  end
+end

--- a/Library/Homebrew/test/dev-cmd/add-license_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/add-license_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.add_license_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -9,6 +9,7 @@
 -S
 -v
 abv
+add-license
 analytics
 audit
 bottle

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -638,6 +638,19 @@ Homebrew/homebrew-cask (if tapped) to standard output.
 
 ## DEVELOPER COMMANDS
 
+### `add-license` [*`options`*] *`formula`* *`license`*
+
+Create a commit to add *`license`* to *`formula`*.
+
+* `-n`, `--dry-run`:
+  Print what would be done rather than doing it.
+* `--no-audit`:
+  Don't run `brew audit` before committing.
+* `--strict`:
+  Run `brew audit --strict` before committing.
+* `--message`:
+  Append *`message`* to the default commit message.
+
 ### `audit` [*`options`*] [*`formula`*]
 
 Check *`formula`* for Homebrew coding style violations. This should be run before

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -816,6 +816,25 @@ Print the version numbers of Homebrew, Homebrew/homebrew\-core and Homebrew/home
 .
 .SH "DEVELOPER COMMANDS"
 .
+.SS "\fBadd\-license\fR [\fIoptions\fR] \fIformula\fR \fIlicense\fR"
+Create a commit to add \fIlicense\fR to \fIformula\fR\.
+.
+.TP
+\fB\-n\fR, \fB\-\-dry\-run\fR
+Print what would be done rather than doing it\.
+.
+.TP
+\fB\-\-no\-audit\fR
+Don\'t run \fBbrew audit\fR before committing\.
+.
+.TP
+\fB\-\-strict\fR
+Run \fBbrew audit \-\-strict\fR before committing\.
+.
+.TP
+\fB\-\-message\fR
+Append \fImessage\fR to the default commit message\.
+.
 .SS "\fBaudit\fR [\fIoptions\fR] [\fIformula\fR]"
 Check \fIformula\fR for Homebrew coding style violations\. This should be run before submitting a new formula\. If no \fIformula\fR are provided, check all locally available formulae and skip style checks\. Will exit with a non\-zero status if any errors are found\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds `brew add-license`, a command that adds a license to a formula if it does not have one already or changes the current license if run with `--force`. (I'm uncertain about the name `add-license`. What do you guys think about <code>update&#8209;license</code>?)

This is useful for Homebrew/homebrew-core#58225

Example usage:

```console
% brew add-license sendemail GPL-2.0+
[licenses-s 2fd6f1572a] sendemail: add license
 1 file changed, 1 insertion(+)

% brew add-license curl curl --force
[licenses-c d18f574745] curl: change license
 1 file changed, 1 insertion(+), 1 deletion(-)
```

`brew help add-license`:

```
Usage: brew add-license [options] formula license

Create a commit to add license to formula.

    -n, --dry-run                    Print what would be done rather than doing
                                     it.
        --no-audit                   Don't run brew audit before committing.
        --strict                     Run brew audit --strict before
                                     committing.
        --message                    Append message to the default commit
                                     message.
    -f, --force                      Override warnings and enable potentially
                                     unsafe operations.
    -q, --quiet                      Suppress any warnings.
    -v, --verbose                    Make some output more verbose.
    -d, --debug                      Display any debugging information.
    -h, --help                       Show this message.
``