### PR TITLE
Change the default locale to C.UTF-8 on Linux

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -1,7 +1,19 @@
+HOMEBREW_PROCESSOR="$(uname -m)"
+HOMEBREW_SYSTEM="$(uname -s)"
+case "$HOMEBREW_SYSTEM" in
+  Darwin) HOMEBREW_MACOS="1" ;;
+  Linux)  HOMEBREW_LINUX="1" ;;
+esac
+
 # Force UTF-8 to avoid encoding issues for users with broken locale settings.
 if [[ "$(locale charmap 2>/dev/null)" != "UTF-8" ]]
 then
-  export LC_ALL="en_US.UTF-8"
+  if [[ -n "$HOMEBREW_MACOS" ]]
+  then
+    export LC_ALL="en_US.UTF-8"
+  else
+    export LC_ALL="C.UTF-8"
+  fi
 fi
 
 # USER isn't always set so provide a fall back for `brew` and subprocesses.
@@ -86,13 +98,6 @@ then
   # it may work, but I only see pain this route and don't want to support it
   odie "Cowardly refusing to continue at this prefix: $HOMEBREW_PREFIX"
 fi
-
-HOMEBREW_PROCESSOR="$(uname -m)"
-HOMEBREW_SYSTEM="$(uname -s)"
-case "$HOMEBREW_SYSTEM" in
-  Darwin) HOMEBREW_MACOS="1" ;;
-  Linux)  HOMEBREW_LINUX="1" ;;
-esac
 
 if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
       -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]] &&


### PR DESCRIPTION
Change the default locale from `en_US.UTF-8` to `C.UTF-8`. The former locale is not included by default in common Docker images, whereas the latter locale is included by default.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----