### PR TITLE
move throttle info into formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -572,15 +572,6 @@ module Homebrew
       imagemagick@6
     ].freeze
 
-    THROTTLED_FORMULAE = {
-      "aws-sdk-cpp" => 10,
-      "awscli@1"    => 10,
-      "balena-cli"  => 10,
-      "gatsby-cli"  => 10,
-      "quicktype"   => 10,
-      "vim"         => 50,
-    }.freeze
-
     UNSTABLE_ALLOWLIST = {
       "aalib"           => "1.4rc",
       "automysqlbackup" => "3.0-rc",
@@ -679,9 +670,9 @@ module Homebrew
                                                        .map(&:to_i)
 
       formula_suffix = stable_version_string.split(".").last.to_i
-      throttled_rate = THROTTLED_FORMULAE[formula.name]
-      if throttled_rate && formula_suffix.modulo(throttled_rate).nonzero?
-        problem "should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
+      throttle_rate = formula.throttle_rate
+      if throttle_rate && formula_suffix.modulo(throttle_rate).nonzero?
+        problem "should only be updated every #{throttle_rate} releases on multiples of #{throttle_rate}"
       end
 
       case (url = stable.url)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -147,6 +147,9 @@ class Formula
   # Used to change version schemes for packages
   attr_reader :version_scheme
 
+  # Used to limit how often a formula is updated
+  attr_reader :throttle_rate
+
   # The current working directory during builds.
   # Will only be non-`nil` inside {#install}.
   attr_reader :buildpath
@@ -188,6 +191,7 @@ class Formula
     @alias_name = (File.basename(alias_path) if alias_path)
     @revision = self.class.revision || 0
     @version_scheme = self.class.version_scheme || 0
+    @throttle_rate = self.class.throttle_rate
 
     @tap = if path == Formulary.core_path(name)
       CoreTap.instance
@@ -1699,6 +1703,7 @@ class Formula
       "urls"                     => {},
       "revision"                 => revision,
       "version_scheme"           => version_scheme,
+      "throttle_rate"            => throttle_rate,
       "bottle"                   => {},
       "keg_only"                 => keg_only?,
       "bottle_disabled"          => bottle_disabled?,
@@ -2267,6 +2272,13 @@ class Formula
     #
     # <pre>version_scheme 1</pre>
     attr_rw :version_scheme
+
+    # @!attribute [w] throttle_rate
+    # Used to limit the rate in which we update formulae for formaule that
+    # have frequent releases.
+    #
+    # <pre>throttle_rate 10</pre>
+    attr_rw :throttle_rate
 
     # A list of the {.stable}, {.devel} and {.head} {SoftwareSpec}s.
     # @private

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -28,6 +28,7 @@ module RuboCop
             [{ name: :revision, type: :method_call }],
             [{ name: :version_scheme, type: :method_call }],
             [{ name: :head,      type: :method_call }],
+            [{ name: :throttle_rate, type: :method_call }],
             [{ name: :stable,    type: :block_call }],
             [{ name: :livecheck, type: :block_call }],
             [{ name: :bottle,    type: :block_call }],

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -542,7 +542,6 @@ module Homebrew
     include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_ALLOWLIST
     include_examples "formulae exist", described_class::VERSIONED_HEAD_SPEC_ALLOWLIST
     include_examples "formulae exist", described_class::USES_FROM_MACOS_ALLOWLIST
-    include_examples "formulae exist", described_class::THROTTLED_FORMULAE.keys
     include_examples "formulae exist", described_class::UNSTABLE_ALLOWLIST.keys
     include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Currently, specific formula update throttle information for `homebrew-core` is located within `audit.rb` along with a comment in the formula itself indicating the throttle rate. This change moves the information into formulae so that comments don't have to be kept in sync with code in a separate repository.

Corresponding `homebrew-core` PR: https://github.com/Homebrew/homebrew-core/pull/58280/.

It also may make sense to do a similar change for `VERSIONED_HEAD_SPEC_ALLOWLIST`, `UNSTABLE_ALLOWLIST`, `GNOME_DEVEL_ALLOWLIST`, and `GITHUB_PRERELEASE_ALLOWLIST`.