### PR TITLE
commands: Print cask commands

### DIFF
--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -88,6 +88,10 @@ module Cask
       @lookup.fetch(command_name, nil)
     end
 
+    def self.aliases
+      ALIASES
+    end
+
     def self.run(*args)
       new(*args).run
     end

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -36,9 +36,18 @@ module Homebrew
     ohai "Built-in developer commands", Formatter.columns(Commands.internal_developer_commands)
 
     external_commands = Commands.external_commands
-    return if external_commands.blank?
+    if external_commands.present?
+      puts
+      ohai "External commands", Formatter.columns(external_commands)
+    end
 
     puts
-    ohai "External commands", Formatter.columns(external_commands)
+    ohai "Cask commands", Formatter.columns(Commands.cask_internal_commands)
+
+    cask_external_commands = Commands.cask_external_commands
+    if cask_external_commands.present?
+      puts
+      ohai "External cask commands", Formatter.columns(cask_external_commands)
+    end
   end
 end

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -31,18 +31,20 @@ module Homebrew
       return
     end
 
-    first = true
+    prepend_separator = false
 
-    [["Built-in commands", Commands.internal_commands],
-     ["Built-in developer commands", Commands.internal_developer_commands],
-     ["External commands", Commands.external_commands],
-     ["Cask commands", Commands.cask_internal_commands],
-     ["External cask commands", Commands.cask_external_commands]]
+    { "Built-in commands"           => Commands.internal_commands,
+      "Built-in developer commands" => Commands.internal_developer_commands,
+      "External commands"           => Commands.external_commands,
+      "Cask commands"               => Commands.cask_internal_commands,
+      "External cask commands"      => Commands.cask_external_commands }
       .each do |title, commands|
-      if commands.present?
-        first = !first && puts
-        ohai title, Formatter.columns(commands)
-      end
+      next if commands.blank?
+
+      puts if prepend_separator
+      ohai title, Formatter.columns(commands)
+
+      prepend_separator = true
     end
   end
 end

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -40,7 +40,7 @@ module Homebrew
       "Cask commands"               => Commands.cask_internal_commands,
       "External cask commands"      => Commands.cask_external_commands,
     }.each do |title, commands|
-     next if commands.blank?
+      next if commands.blank?
 
       puts if prepend_separator
       ohai title, Formatter.columns(commands)

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -31,17 +31,17 @@ module Homebrew
       return
     end
 
-    [["Built-in commands", -> { Commands.internal_commands }],
-     ["Built-in developer commands", -> { Commands.internal_developer_commands }],
-     ["External commands", -> { Commands.external_commands }],
-     ["Cask commands", -> { Commands.cask_internal_commands }],
-     ["External cask commands", -> { Commands.cask_external_commands }]]
-      .each_with_index do |title_and_proc, index|
-      title, proc = title_and_proc
-      cmds = proc.call
-      if cmds.present?
-        puts unless index.zero?
-        ohai title, Formatter.columns(cmds)
+    first = true
+
+    [["Built-in commands", Commands.internal_commands],
+     ["Built-in developer commands", Commands.internal_developer_commands],
+     ["External commands", Commands.external_commands],
+     ["Cask commands", Commands.cask_internal_commands],
+     ["External cask commands", Commands.cask_external_commands]]
+      .each do |title, commands|
+      if commands.present?
+        first = !first && puts
+        ohai title, Formatter.columns(commands)
       end
     end
   end

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -31,23 +31,18 @@ module Homebrew
       return
     end
 
-    ohai "Built-in commands", Formatter.columns(Commands.internal_commands)
-    puts
-    ohai "Built-in developer commands", Formatter.columns(Commands.internal_developer_commands)
-
-    external_commands = Commands.external_commands
-    if external_commands.present?
-      puts
-      ohai "External commands", Formatter.columns(external_commands)
-    end
-
-    puts
-    ohai "Cask commands", Formatter.columns(Commands.cask_internal_commands)
-
-    cask_external_commands = Commands.cask_external_commands
-    if cask_external_commands.present?
-      puts
-      ohai "External cask commands", Formatter.columns(cask_external_commands)
+    [["Built-in commands", -> { Commands.internal_commands }],
+     ["Built-in developer commands", -> { Commands.internal_developer_commands }],
+     ["External commands", -> { Commands.external_commands }],
+     ["Cask commands", -> { Commands.cask_internal_commands }],
+     ["External cask commands", -> { Commands.cask_external_commands }]]
+      .each_with_index do |title_and_proc, index|
+      title, proc = title_and_proc
+      cmds = proc.call
+      if cmds.present?
+        puts unless index.zero?
+        ohai title, Formatter.columns(cmds)
+      end
     end
   end
 end

--- a/Library/Homebrew/cmd/commands.rb
+++ b/Library/Homebrew/cmd/commands.rb
@@ -33,18 +33,19 @@ module Homebrew
 
     prepend_separator = false
 
-    { "Built-in commands"           => Commands.internal_commands,
+    {
+      "Built-in commands"           => Commands.internal_commands,
       "Built-in developer commands" => Commands.internal_developer_commands,
       "External commands"           => Commands.external_commands,
       "Cask commands"               => Commands.cask_internal_commands,
-      "External cask commands"      => Commands.cask_external_commands }
-      .each do |title, commands|
-      next if commands.blank?
+      "External cask commands"      => Commands.cask_external_commands,
+    }.each do |title, commands|
+     next if commands.blank?
 
       puts if prepend_separator
       ohai title, Formatter.columns(commands)
 
-      prepend_separator = true
+      prepend_separator ||= true
     end
   end
 end

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'cask/cmd'
+require "cask/cmd"
 
 module Commands
   module_function
@@ -160,10 +160,7 @@ module Commands
   end
 
   def cask_external_commands
-    tap_cmd_directories = Tap.cmd_directories
-    path = PATH.new(tap_cmd_directories, ENV["HOMEBREW_PATH"])
-
-    path.flat_map do |search_path|
+    PATH.new(Tap.cmd_directories, ENV["HOMEBREW_PATH"]).flat_map do |search_path|
       find_commands(search_path).map do |possible_command|
         p = possible_command.to_path
         command_name = p.match(/brewcask-(.*)\.rb/) { |data| data[1].delete_suffix(".rb") }

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -140,19 +140,12 @@ module Commands
   def cask_commands(aliases: false)
     cmds = cask_internal_commands
     cmds += cask_internal_command_aliases if aliases
-    cmds += cask_unstable_internal_commands
     cmds += cask_external_commands
     cmds
   end
 
   def cask_internal_commands
-    Cask::Cmd.commands - cask_unstable_internal_commands
-  end
-
-  def cask_unstable_internal_commands
-    Cask::Cmd.commands.select do |command|
-      command.start_with? "_"
-    end
+    Cask::Cmd.commands
   end
 
   def cask_internal_command_aliases

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -155,10 +155,10 @@ module Commands
   def cask_external_commands
     PATH.new(Tap.cmd_directories, ENV["HOMEBREW_PATH"]).flat_map do |search_path|
       find_commands(search_path).map do |possible_command|
-        p = possible_command.to_path
-        command_name = p.match(/brewcask-(.*)\.rb/) { |data| data[1].delete_suffix(".rb") }
+        path = possible_command.to_path
+        command_name = path.match(/brewcask-(.*)\.rb/) { |data| data[1].delete_suffix(".rb") }
         if command_name.blank? && possible_command.executable?
-          command_name = p.match(/brewcask-(.*)/) { |data| data[1] }
+          command_name = path.match(/brewcask-(.*)/) { |data| data[1] }
         end
         command_name
       end.compact

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -4,6 +4,7 @@ require "keg_relocate"
 require "language/python"
 require "lock_file"
 require "ostruct"
+require "extend/cachable"
 
 class Keg
   extend Cachable


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Print cask commands and external cask commands with `brew commands`. 

There are five sections:
1. Built-in commands
2. Built-in developer commands
3. External commands
4. Cask commands (rename to Built-in Cask Commands?)
5. External cask commands

Some design decisions:
* Originally, external cask commands were under "External commands" and are now under their own section.
* When using `--quiet`, cask commands are prefixed with `cask `. Since external cask commands were originally prefixed with `cask ` anyways, I don't think this will cause very many issues.