### PR TITLE
formula.rb: update missing libs feature

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -37,7 +37,7 @@ class Formula
 
     def ignore_missing_libraries(*libs)
       libraries = libs.flatten
-      unless libraries.all? { |x| x.is_a?(String) || x.is_a?(Regexp) }
+      if libraries.any? { |x| !x.is_a?(String) && !x.is_a?(Regexp) }
         raise FormulaSpecificationError, "#{__method__} can handle Strings and Regular Expressions only"
       end
 

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -9,7 +9,7 @@ class Formula
 
   undef allowed_missing_lib?
   def allowed_missing_lib?(lib)
-    raise TypeError "Library must be a string; got a #{lib.class} (#{lib})" unless lib.is_a? String
+    raise TypeError, "Library must be a string; got a #{lib.class} (#{lib})" unless lib.is_a? String
 
     # lib:   Full path to the missing library
     #        Ex.: /home/linuxbrew/.linuxbrew/lib/libsomething.so.1

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -7,25 +7,6 @@ class Formula
     "#{name}.so#{"." unless version.nil?}#{version}"
   end
 
-  undef allowed_missing_lib?
-  def allowed_missing_lib?(lib)
-    raise TypeError, "Library must be a string; got a #{lib.class} (#{lib})" unless lib.is_a? String
-
-    # lib:   Full path to the missing library
-    #        Ex.: /home/linuxbrew/.linuxbrew/lib/libsomething.so.1
-    # x -    Name of or a pattern for a library, linkage to which is allowed to be missing.
-    #        Ex. 1: "libONE.so.1"
-    #        Ex. 2: %r{(libONE|libTWO)\.so}
-    self.class.allowed_missing_libraries.any? do |x|
-      case x
-      when Regexp
-        x.match? lib
-      when String
-        lib.include? x
-      end
-    end
-  end
-
   class << self
     undef on_linux
 

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -9,6 +9,8 @@ class Formula
 
   undef allowed_missing_lib?
   def allowed_missing_lib?(lib)
+    raise TypeError "Library must be a string; got a #{lib.class} (#{lib})" unless lib.is_a? String
+
     # lib:   Full path to the missing library
     #        Ex.: /home/linuxbrew/.linuxbrew/lib/libsomething.so.1
     # x -    Name of or a pattern for a library, linkage to which is allowed to be missing.
@@ -19,7 +21,7 @@ class Formula
       when Regexp
         x.match? lib
       when String
-        lib.to_s.include? x
+        lib.include? x
       end
     end
   end

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -19,7 +19,7 @@ class Formula
       when Regexp
         x.match? lib
       when String
-        lib.include? x
+        lib.to_s.include? x
       end
     end
   end
@@ -31,9 +31,15 @@ class Formula
       yield
     end
 
+    undef ignore_missing_libraries
+
     def ignore_missing_libraries(*libs)
-      libs.flatten!
-      allowed_missing_libraries.merge(libs)
+      libraries = libs.flatten
+      unless libraries.all? { |x| x.is_a?(String) || x.is_a?(Regexp) }
+        raise FormulaSpecificationError, "#{__method__} can handle Strings and Regular Expressions only"
+      end
+
+      allowed_missing_libraries.merge(libraries)
     end
 
     # @private

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2763,6 +2763,10 @@ class Formula
     def link_overwrite_paths
       @link_overwrite_paths ||= Set.new
     end
+
+    def ignore_missing_libraries(*)
+      raise FormulaSpecificationError, "#{__method__} is available on Linux only"
+    end
   end
 end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1131,13 +1131,6 @@ class Formula
     end
   end
 
-  # Whether this {Formula} is allowed to have a broken linkage to specified library.
-  # Defaults to false.
-  # @return [Boolean]
-  def allowed_missing_lib?(*)
-    false
-  end
-
   # Whether this {Formula} is deprecated (i.e. warns on installation).
   # Defaults to false.
   # @method deprecated?

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -92,8 +92,8 @@ class LinkageChecker
 
   def broken_dylibs_with_expectations
     output = {}
-    @broken_dylibs.each do |lib|
-      output[lib] = if unexpected_broken_dylibs.include? lib
+    @broken_dylibs.each do |broken_lib|
+      output[broken_lib] = if unexpected_broken_dylibs.include? broken_lib
         ["unexpected"]
       else
         ["expected"]

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -81,7 +81,11 @@ class LinkageChecker
   def broken_dylibs_with_expectations
     output = {}
     @broken_dylibs.each do |lib|
-      output[lib] = (unexpected_broken_libs.include? lib) ? ["unexpected"] : ["expected"]
+      output[lib] = if unexpected_broken_libs.include? lib
+        ["unexpected"]
+      else
+        ["expected"]
+      end
     end
     output
   end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -75,28 +75,19 @@ class LinkageChecker
     [issues, unexpected_broken_dylibs].flatten.any?(&:present?)
   end
 
-  def allowed_missing_lib?(lib)
-    raise TypeError, "Library must be a string; got a #{lib.class} (#{lib})" unless lib.is_a? String
-
-    # lib:   Full path to the missing library
-    #        Ex.: /home/linuxbrew/.linuxbrew/lib/libsomething.so.1
-    # x -    Name of or a pattern for a library, linkage to which is allowed to be missing.
-    #        Ex. 1: "libONE.so.1"
-    #        Ex. 2: %r{(libONE|libTWO)\.so}
-    @formula.class.allowed_missing_libraries.any? do |x|
-      case x
-      when Regexp
-        x.match? lib
-      when String
-        lib.include? x
-      end
-    end
-  end
-
   def unexpected_broken_dylibs
     return @unexpected_broken_dylibs if @unexpected_broken_dylibs
 
-    @unexpected_broken_dylibs = @broken_dylibs.reject { |lib| allowed_missing_lib? lib }
+    @unexpected_broken_dylibs = @broken_dylibs.reject do |broken_lib|
+      @formula.class.allowed_missing_libraries.any? do |allowed_missing_lib|
+        case allowed_missing_lib
+        when Regexp
+          allowed_missing_lib.match? broken_lib
+        when String
+          broken_lib.include? allowed_missing_lib
+        end
+      end
+    end
   end
 
   def broken_dylibs_with_expectations


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

1. Raise an exception on macOS.
2. Verify that the missing libraries are specified either as Strings or
   Regular Expressions.

Explanation of changes:

* formula.rb: define `ignore_missing_libraries` which raises an Exception
* extend/os/linux/formula.rb: redefine `ignore_missing_libraries` and check input type
* extend/os/linux/formula.rb: `lib` ~> `lib.to_s` to make sure that we apply `.include?` method to a String because in `brew irb` it's possible to execute `:libxcb.f.allowed_missing_lib? 1` that would fail because `1` is an Integer and does not have `.include?` method associated with it.