### PR TITLE
dev-cmd: add update-python-resources command

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -2,6 +2,7 @@
 
 require "formula"
 require "cli/parser"
+require "utils/pypi"
 
 module Homebrew
   module_function
@@ -327,6 +328,11 @@ module Homebrew
     if alias_rename.present?
       ohai "renaming alias #{alias_rename.first} to #{alias_rename.last}"
       alias_rename.map! { |a| formula.tap.alias_dir/a }
+    end
+
+    ohai "brew update-python-resources #{formula.name}"
+    if !args.dry_run? || (args.dry_run? && args.write?)
+      PyPI.update_python_resources! formula, new_formula_version, silent: true, ignore_non_pypi_packages: true
     end
 
     run_audit(formula, alias_rename, old_contents)

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -4,6 +4,7 @@ require "formula"
 require "formula_creator"
 require "missing_formula"
 require "cli/parser"
+require "utils/pypi"
 
 module Homebrew
   module_function
@@ -136,6 +137,8 @@ module Homebrew
     end
 
     fc.generate!
+
+    PyPI.update_python_resources! Formula[fc.name], ignore_non_pypi_packages: true if args.python?
 
     puts "Please run `brew audit --new-formula #{fc.name}` before submitting, thanks."
     exec_editor fc.path

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require "utils/pypi"
+
+module Homebrew
+  module_function
+
+  def update_python_resources_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `update-python-resources` [<options>] <formula>
+
+        Update versions for PyPI resource blocks in <formula>.
+      EOS
+      switch "-p", "--print-only",
+             description: "Print the updated resource blocks instead of changing <formula>."
+      switch "-s", "--silent",
+             description: "Suppress any output."
+      switch "--ignore-non-pypi-packages",
+             description: "Don't fail if <formula> is not a PyPI package."
+      flag "--version=",
+           description: "Use the specified <version> when finding resources for <formula>. "\
+                        "If no version is specified, the current version for <formula> will be used."
+      min_named :formula
+    end
+  end
+
+  def update_python_resources
+    args = update_python_resources_args.parse
+
+    args.formulae.each do |formula|
+      PyPI.update_python_resources! formula, args.version, print_only: args.print_only?, silent: args.silent?,
+                                    ignore_non_pypi_packages: args.ignore_non_pypi_packages?
+    end
+  end
+end

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -134,7 +134,7 @@ module Homebrew
           # depends_on "cmake" => :build
         <% end %>
 
-        <% if mode == :perl || mode == :python %>
+        <% if mode == :perl %>
           # Additional dependency
           # resource "" do
           #   url ""

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module PyPI
+  module_function
+
+  PYTHONHOSTED_URL_PREFIX = "https://files.pythonhosted.org/packages/"
+
+  @pipgrip_installed = nil
+
+  # Get name, url, and version for a given pypi package
+  def get_pypi_info(package, version)
+    metadata_url = "https://pypi.org/pypi/#{package}/#{version}/json"
+    out, _, status = curl_output metadata_url, "--location"
+
+    return unless status.success?
+
+    begin
+      json = JSON.parse out
+    rescue JSON::ParserError
+      return
+    end
+
+    sdist = json["urls"].find { |url| url["packagetype"] == "sdist" }
+    [json["info"]["name"], sdist["url"], sdist["digests"]["sha256"]]
+  end
+
+  def update_python_resources!(formula, version = nil, print_only: false, silent: false,
+                               ignore_non_pypi_packages: false)
+
+    @pipgrip_installed ||= Formula["pipgrip"].any_version_installed?
+    odie '"pipgrip" must be installed (`brew install pipgrip`)' unless @pipgrip_installed
+
+    # PyPI package name isn't always the same as the formula name. Try to infer from the URL.
+    pypi_name = if formula.stable.url.start_with?(PYTHONHOSTED_URL_PREFIX)
+      File.basename(formula.stable.url).match(/^(.+)-[a-z\d.]+$/)[1]
+    else
+      formula.name
+    end
+
+    version ||= formula.version
+
+    if get_pypi_info(pypi_name, version).blank?
+      odie "\"#{pypi_name}\" at version #{version} is not available on PyPI." unless ignore_non_pypi_packages
+      return
+    end
+
+    non_pypi_resources = formula.resources.reject do |resource|
+      resource.url.start_with? PYTHONHOSTED_URL_PREFIX
+    end
+
+    if non_pypi_resources.present? && !print_only
+      odie "\"#{formula.name}\" contains non-PyPI resources. Please update the resources manually."
+    end
+
+    ohai "Retrieving PyPI dependencies for \"#{pypi_name}==#{version}\"" if !print_only && !silent
+    pipgrip_output = Utils.popen_read Formula["pipgrip"].bin/"pipgrip", "--json", "#{pypi_name}==#{version}"
+    unless $CHILD_STATUS.success?
+      odie <<~EOS
+        Unable to determine dependencies for \"#{pypi_name}\" because of a failure when running
+        `pipgrip --json #{pypi_name}==#{version}`. Please update the resources for \"#{formula.name}\" manually.
+      EOS
+    end
+
+    packages = JSON.parse(pipgrip_output).sort.to_h
+
+    # Remove extra packages that may be included in pipgrip output
+    exclude_list = %W[#{pypi_name} argparse pip setuptools wheel wsgiref]
+    packages.delete_if do |package|
+      exclude_list.include? package
+    end
+
+    new_resource_blocks = ""
+    packages.each do |package, package_version|
+      name, url, checksum = get_pypi_info package, package_version
+      # Fail if unable to find name, url or checksum for any resource
+      if name.blank?
+        odie "Unable to resolve some dependencies. Please update the resources for \"#{formula.name}\" manually."
+      elsif url.blank? || checksum.blank?
+        odie <<~EOS
+          Unable to find the URL and/or sha256 for the \"#{name}\" resource.
+          Please update the resources for \"#{formula.name}\" manually.
+        EOS
+      end
+
+      # Append indented resource block
+      new_resource_blocks += <<-EOS
+  resource "#{name}" do
+    url "#{url}"
+    sha256 "#{checksum}"
+  end
+
+      EOS
+    end
+
+    if print_only
+      puts new_resource_blocks.chomp
+      return
+    end
+
+    # Check whether resources already exist (excluding homebrew-virtualenv)
+    if formula.resources.blank? ||
+       (formula.resources.length == 1 && formula.resources.first.name == "homebrew-virtualenv")
+      # Place resources above install method
+      inreplace_regex = /  def install/
+      new_resource_blocks += "  def install"
+    else
+      # Replace existing resource blocks with new resource blocks
+      inreplace_regex = /  (resource .* do\s+url .*\s+sha256 .*\s+ end\s*)+/
+      new_resource_blocks += "  "
+    end
+
+    ohai "Updating resource blocks" unless silent
+    Utils::Inreplace.inreplace formula.path do |s|
+      if s.inreplace_string.scan(inreplace_regex).length > 1
+        odie "Unable to update resource blocks for \"#{formula.name}\" automatically. Please update them manually."
+      end
+      s.sub! inreplace_regex, new_resource_blocks
+    end
+  end
+end

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -88,6 +88,7 @@ untap
 up
 update
 update-license-data
+update-python-resources
 update-report
 update-reset
 update-test

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1081,6 +1081,19 @@ directory.
 * `--commit`:
   Commit changes to the SPDX license data.
 
+### `update-python-resources` [*`options`*] *`formula`*
+
+Update versions for PyPI resource blocks in *`formula`*.
+
+* `-p`, `--print-only`:
+  Print the updated resource blocks instead of changing *`formula`*.
+* `-s`, `--silent`:
+  Suppress any output.
+* `--ignore-non-pypi-packages`:
+  Don't fail if *`formula`* is not a PyPI package.
+* `--version`:
+  Use the specified *`version`* when finding resources for *`formula`*. If no version is specified, the current version for *`formula`* will be used.
+
 ### `update-test` [*`options`*]
 
 Run a test of `brew update` with a new repository clone. If no options are

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1416,6 +1416,25 @@ Return a failing status code if current license data\'s version is the same as t
 \fB\-\-commit\fR
 Commit changes to the SPDX license data\.
 .
+.SS "\fBupdate\-python\-resources\fR [\fIoptions\fR] \fIformula\fR"
+Update versions for PyPI resource blocks in \fIformula\fR\.
+.
+.TP
+\fB\-p\fR, \fB\-\-print\-only\fR
+Print the updated resource blocks instead of changing \fIformula\fR\.
+.
+.TP
+\fB\-s\fR, \fB\-\-silent\fR
+Suppress any output\.
+.
+.TP
+\fB\-\-ignore\-non\-pypi\-packages\fR
+Don\'t fail if \fIformula\fR is not a PyPI package\.
+.
+.TP
+\fB\-\-version\fR
+Use the specified \fIversion\fR when finding resources for \fIformula\fR\. If no version is specified, the current version for \fIformula\fR will be used\.
+.
 .SS "\fBupdate\-test\fR [\fIoptions\fR]"
 Run a test of \fBbrew update\fR with a new repository clone\. If no options are passed, use \fBorigin/master\fR as the start commit\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

## Description

The ultimate goal for this PR is to migrate [`homebrew-pypi-poet`](https://github.com/tdsmith/homebrew-pypi-poet) to be part of Homebrew.

Currently, this serves more as a wrapper to `homebrew-pypi-poet` than a rewrite. Ideally, this would be rewritten in ruby, but this is the first step.

Resolves #8032

## Desired Optimizations

1. Figure out dependency tree without having to `pip install` the package
    - Unfortunately, there doesn't seem to be an easy way to do this
    - The good news is that adding this command makes it much easier to install. It takes care of creating the virtual environment and installing everything.
1. Rewrite code in Ruby
    -  I'm not sure how exactly to go about this. `homebrew-pypi-poet` uses the `pkg_resources` package (which comes with `pip`) to find the dependencies. I haven't found a way to implement something like this in Ruby, but I'm certainly open to ideas.
    - A good option may be to run a smaller Python script that retrieves the dependencies, and then the generation of the `resource` blocks can be done in Ruby. This is good because it gives us more control over the resources. This also means that we don't have to wait for `homebrew-pypi-poet` to be updated if Homebrew changes something

## Potential Issues

1. This is a very primitive solution. It relies on the `resource` blocks being in a specific format and does a simple Regex replace instead of a more intelligent solution.
1. This isn't designed to handle formulae that also have non-`files.pythonhosted.org` resources
1. This requires the formula name to be the same as the `pip` package (this might always be true but I'm not positive)

## Todo

1. Separate the Python components (creating the dependency tree) from the Homebrew/ruby components (creating/updating `resource` blocks
1. Implement `poet_lint`
1. Determine which formulae to apply to (possibly using an allowlist). See https://github.com/Homebrew/brew/issues/8032#issuecomment-661979078
1. Extract this functionality so it can be called by `bump-formula-pr`

## Questions

1. Is there an alternative way to find the requirements that doesn't need the package to be installed?
1. Are there ways to simplify the virtual environment creation/installation? I looked at the [`Virtualenv` module](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/language/python.rb#L114) (specifically `virtualenv_create` and `pip_install`) but it seemed like they weren't usable outside of a formula
1. What's the best way to update the resources? My current goal is to have ruby (rather than `homebrew-pypi-poet`) handle creating the `resource` blocks. I should then be able to update the blocks on a case-by-case basis which would eliminate the nasty regex replace going on right now.