### PR TITLE
Detect unexpected linkage

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -24,12 +24,5 @@ class Formula
 
       allowed_missing_libraries.merge(libraries)
     end
-
-    undef allowed_missing_libraries
-
-    # @private
-    def allowed_missing_libraries
-      @allowed_missing_libraries ||= Set.new
-    end
   end
 end

--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -25,6 +25,8 @@ class Formula
       allowed_missing_libraries.merge(libraries)
     end
 
+    undef allowed_missing_libraries
+
     # @private
     def allowed_missing_libraries
       @allowed_missing_libraries ||= Set.new

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2760,6 +2760,11 @@ class Formula
     def ignore_missing_libraries(*)
       raise FormulaSpecificationError, "#{__method__} is available on Linux only"
     end
+
+    # @private
+    def allowed_missing_libraries
+      raise NotImplementedError, "#{__method__} is available on Linux only"
+    end
   end
 end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2763,7 +2763,7 @@ class Formula
 
     # @private
     def allowed_missing_libraries
-      raise NotImplementedError, "#{__method__} is available on Linux only"
+      @allowed_missing_libraries ||= Set.new
     end
   end
 end

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -16,6 +16,7 @@ class LinkageChecker
     @system_dylibs    = Set.new
     @broken_dylibs    = Set.new
     @unexpected_broken_dylibs = nil
+    @unexpected_present_dylibs = nil
     @variable_dylibs  = Set.new
     @brewed_dylibs    = Hash.new { |h, k| h[k] = Set.new }
     @reverse_links    = Hash.new { |h, k| h[k] = Set.new }
@@ -57,6 +58,7 @@ class LinkageChecker
 
   def display_test_output(puts_output: true)
     display_items "Missing libraries", broken_dylibs_with_expectations, puts_output: puts_output
+    display_items "Unused missing linkage information", unexpected_present_dylibs, puts_output: puts_output
     display_items "Broken dependencies", @broken_deps, puts_output: puts_output
     display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
     display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
@@ -66,13 +68,15 @@ class LinkageChecker
     elsif unexpected_broken_dylibs.empty?
       puts "No unexpected broken library linkage detected."
     else
-      puts "Broken library linkage detected"
+      puts "Unexpected missing library linkage detected"
     end
+
+    puts "Unexpected non-missing linkage detected" if unexpected_present_dylibs.present?
   end
 
   def broken_library_linkage?
     issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps]
-    [issues, unexpected_broken_dylibs].flatten.any?(&:present?)
+    [issues, unexpected_broken_dylibs, unexpected_present_dylibs].flatten.any?(&:present?)
   end
 
   def unexpected_broken_dylibs
@@ -80,6 +84,21 @@ class LinkageChecker
 
     @unexpected_broken_dylibs = @broken_dylibs.reject do |broken_lib|
       @formula.class.allowed_missing_libraries.any? do |allowed_missing_lib|
+        case allowed_missing_lib
+        when Regexp
+          allowed_missing_lib.match? broken_lib
+        when String
+          broken_lib.include? allowed_missing_lib
+        end
+      end
+    end
+  end
+
+  def unexpected_present_dylibs
+    return @unexpected_present_dylibs if @unexpected_present_dylibs
+
+    @unexpected_present_dylibs = @formula.class.allowed_missing_libraries.reject do |allowed_missing_lib|
+      @broken_dylibs.any? do |broken_lib|
         case allowed_missing_lib
         when Regexp
           allowed_missing_lib.match? broken_lib
@@ -291,7 +310,11 @@ class LinkageChecker
       end
     else
       things.sort.each do |item|
-        output += "\n  #{item}"
+        output += if item.is_a? Regexp
+          "\n #{item.inspect}"
+        else
+          "\n  #{item}"
+        end
       end
     end
     puts output if puts_output

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -95,9 +95,7 @@ class LinkageChecker
   end
 
   def unexpected_present_dylibs
-    return @unexpected_present_dylibs if @unexpected_present_dylibs
-
-    @unexpected_present_dylibs = @formula.class.allowed_missing_libraries.reject do |allowed_missing_lib|
+    @unexpected_present_dylibs ||= @formula.class.allowed_missing_libraries.reject do |allowed_missing_lib|
       @broken_dylibs.any? do |broken_lib|
         case allowed_missing_lib
         when Regexp

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -311,7 +311,7 @@ class LinkageChecker
     else
       things.sort.each do |item|
         output += if item.is_a? Regexp
-          "\n #{item.inspect}"
+          "\n  #{item.inspect}"
         else
           "\n  #{item}"
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a linkage checking step that verifies that all libraries (and regex-es) missing linkage to which is ignored are, in fact, "missing".

I have to admit that I had hard time coming up with good labels / output messages here because we're talking about libraries and regular expressions for libraries that are not missing but the formula specifies them as "missing".

I tweaked `display_items` a little so that regular expressions appear a bit nicer.

`unexpected_present_dylibs` is very similar to `unexpected_broken_dylibs` so if there is a way to combine these two together -- please let me know.