### PR TITLE
sorbet: set compat files to true

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -842,6 +842,7 @@ true:
   - ./compat/os/mac.rb
   - ./compilers.rb
   - ./config.rb
+  - ./dependable.rb
   - ./dependency_collector.rb
   - ./description_cache_store.rb
   - ./descriptions.rb

--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -457,13 +457,8 @@ false:
   - ./cask/dsl/version.rb
   - ./cask/topological_hash.rb
   - ./cmd/cask.rb
-  - ./compat/extend/nil.rb
-  - ./compat/extend/string.rb
-  - ./compat/formula.rb
   - ./compat/language/haskell.rb
   - ./compat/language/java.rb
-  - ./compat/os/mac.rb
-  - ./dependable.rb
   - ./extend/git_repository.rb
   - ./extend/hash_validator.rb
   - ./extend/io.rb
@@ -841,6 +836,10 @@ true:
   - ./cask/url.rb
   - ./checksum.rb
   - ./cleaner.rb
+  - ./compat/extend/nil.rb
+  - ./compat/extend/string.rb
+  - ./compat/formula.rb
+  - ./compat/os/mac.rb
   - ./compilers.rb
   - ./config.rb
   - ./dependency_collector.rb

--- a/Library/Homebrew/sorbet/rbi/homebrew.rbi
+++ b/Library/Homebrew/sorbet/rbi/homebrew.rbi
@@ -12,3 +12,32 @@ module Language::Perl::Shebang
   include Kernel
 end
 
+module Dependable
+  def tags; end
+end
+
+class Formula
+  module Compat
+    include Kernel
+
+    def latest_version_installed?; end
+
+    def active_spec; end
+
+    def patches; end
+  end
+end
+
+class NilClass
+  module Compat
+    include Kernel
+  end
+end
+
+class String
+  module Compat
+    include Kernel
+
+    def chomp; end
+  end
+end

--- a/Library/Homebrew/sorbet/rbi/os.rbi
+++ b/Library/Homebrew/sorbet/rbi/os.rbi
@@ -12,3 +12,11 @@ module OS
     include Kernel
   end
 end
+
+module OS::Mac
+  class << self
+    module Compat
+      include Kernel
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This PR sets the following files to true in sorbet/files.yaml:
- ./compat/extend/nil.rb
- ./compat/extend/string.rb
- ./compat/formula.rb
- ./compat/os/mac.rb
- ./dependable.rb