### PR TITLE
dev-cmd/audit: add llvm to depends_on allow list

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -324,6 +324,7 @@ module Homebrew
       apr
       apr-util
       libressl
+      llvm
       openblas
       openssl@1.1
     ].freeze


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Apple llvm does not provide `llvm-config`

Related StackOverflow thread: https://stackoverflow.com/questions/32959627/where-is-the-system-llvm-config-on-macos