### PR TITLE
curl: ensure final_url is populated with the final URL requested

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -201,7 +201,8 @@ def curl_http_content_headers_and_checksum(url, hash_needed: false, user_agent: 
   while status_code == :unknown || status_code.to_s.start_with?("3")
     headers, _, output = output.partition("\r\n\r\n")
     status_code = headers[%r{HTTP/.* (\d+)}, 1]
-    final_url = headers[/^Location:\s*(.*)$/i, 1]&.chomp
+    location = headers[/^Location:\s*(.*)$/i, 1]
+    final_url = location.chomp if location
   end
 
   output_hash = Digest::SHA256.file(file.path) if hash_needed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
The current logic uses `--location` in the `curl` call to follow redirects and update the `final_url` variable based on the `location:` HTTP response header. However, this header is only populated for `3xx` redirects, so when the final request returns a `200`, there is no `location:` header. This sets the `final_url` value to `nil` and the hash returned by the function always has `url` equal to `final_url`.


This change only updates `final_url` if a location header is present so the intended value is returned.