### PR TITLE
Refactor usages of global `Homebrew.args`.

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -10,30 +10,27 @@ class Bintray
   end
 
   def inspect
-    "#<Bintray: user=#{@bintray_user} org=#{@bintray_org} key=***>"
+    "#<Bintray: org=#{@bintray_org}>"
   end
 
-  def initialize(user: ENV["HOMEBREW_BINTRAY_USER"], key: ENV["HOMEBREW_BINTRAY_KEY"], org: "homebrew", clear: true)
-    @bintray_user = user
-    @bintray_key = key
+  def initialize(org: "homebrew")
     @bintray_org = org
-
-    if !@bintray_user || !@bintray_key
-      unless Homebrew.args.dry_run?
-        raise UsageError, "Missing HOMEBREW_BINTRAY_USER or HOMEBREW_BINTRAY_KEY variables!"
-      end
-    end
 
     raise UsageError, "Must set a Bintray organisation!" unless @bintray_org
 
     ENV["HOMEBREW_FORCE_HOMEBREW_ON_LINUX"] = "1" if @bintray_org == "homebrew" && !OS.mac?
-
-    ENV.delete "HOMEBREW_BINTRAY_KEY" if clear
   end
 
   def open_api(url, *extra_curl_args, auth: true)
     args = extra_curl_args
-    args += ["--user", "#{@bintray_user}:#{@bintray_key}"] if auth
+
+    if auth
+      raise UsageError, "HOMEBREW_BINTRAY_USER is unset." unless (user = EnvConfig.bintray_user)
+      raise UsageError, "HOMEBREW_BINTRAY_KEY is unset." unless (key = EnvConfig.bintray_key)
+
+      args += ["--user", "#{user}:#{key}"]
+    end
+
     curl(*args, url,
          show_output: Homebrew.args.verbose?,
          secrets:     @bintray_key)

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -150,7 +150,7 @@ rescue BuildError => e
   Utils::Analytics.report_build_error(e)
   e.dump
 
-  output_unsupported_error if Homebrew.args.HEAD? || e.formula.deprecated? || e.formula.disabled?
+  output_unsupported_error if e.formula.head? || e.formula.deprecated? || e.formula.disabled?
 
   exit 1
 rescue RuntimeError, SystemCallError => e

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -83,20 +83,20 @@ class Build
       fixopt(dep) unless dep.opt_prefix.directory?
     end
 
-    ENV.activate_extensions!
+    ENV.activate_extensions!(args: args)
 
-    if superenv?
+    if superenv?(args: args)
       ENV.keg_only_deps = keg_only_deps
       ENV.deps = formula_deps
       ENV.run_time_deps = run_time_deps
       ENV.x11 = reqs.any? { |rq| rq.is_a?(X11Requirement) }
-      ENV.setup_build_environment(formula)
+      ENV.setup_build_environment(formula, args: args)
       post_superenv_hacks
-      reqs.each(&:modify_build_environment)
+      reqs.each { |req| req.modify_build_environment(args: args) }
       deps.each(&:modify_build_environment)
     else
-      ENV.setup_build_environment(formula)
-      reqs.each(&:modify_build_environment)
+      ENV.setup_build_environment(formula, args: args)
+      reqs.each { |req| req.modify_build_environment(args: args) }
       deps.each(&:modify_build_environment)
 
       keg_only_deps.each do |dep|

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -121,12 +121,11 @@ class Build
 
       formula.update_head_version
 
-      formula.brew(fetch: false) do |_formula, staging|
+      formula.brew(fetch: false, keep_tmp: args.keep_tmp?, interactive: args.interactive?) do |_formula, _staging|
         # For head builds, HOMEBREW_FORMULA_PREFIX should include the commit,
         # which is not known until after the formula has been staged.
         ENV["HOMEBREW_FORMULA_PREFIX"] = formula.prefix
 
-        staging.retain! if args.keep_tmp?
         formula.patch
 
         if args.git?

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -16,13 +16,14 @@ require "socket"
 require "cmd/install"
 
 class Build
-  attr_reader :formula, :deps, :reqs
+  attr_reader :formula, :deps, :reqs, :args
 
-  def initialize(formula, options)
+  def initialize(formula, options, args:)
     @formula = formula
     @formula.build = BuildOptions.new(options, formula.options)
+    @args = args
 
-    if Homebrew.args.ignore_deps?
+    if args.ignore_deps?
       @deps = []
       @reqs = []
     else
@@ -125,19 +126,19 @@ class Build
         # which is not known until after the formula has been staged.
         ENV["HOMEBREW_FORMULA_PREFIX"] = formula.prefix
 
-        staging.retain! if Homebrew.args.keep_tmp?
+        staging.retain! if args.keep_tmp?
         formula.patch
 
-        if Homebrew.args.git?
+        if args.git?
           system "git", "init"
           system "git", "add", "-A"
         end
-        if Homebrew.args.interactive?
+        if args.interactive?
           ohai "Entering interactive mode"
           puts "Type `exit` to return and finalize the installation."
           puts "Install to this prefix: #{formula.prefix}"
 
-          if Homebrew.args.git?
+          if args.git?
             puts "This directory is now a git repo. Make your changes and then use:"
             puts "  git diff | pbcopy"
             puts "to copy the diff to the clipboard."
@@ -190,15 +191,15 @@ class Build
 end
 
 begin
-  Homebrew.install_args.parse
+  args = Homebrew.install_args.parse
   error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
   error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
 
   trap("INT", old_trap)
 
-  formula = Homebrew.args.formulae.first
-  options = Options.create(Homebrew.args.flags_only)
-  build   = Build.new(formula, options)
+  formula = args.formulae.first
+  options = Options.create(args.flags_only)
+  build   = Build.new(formula, options, args: args)
   build.install
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_hash = JSON.parse e.to_json

--- a/Library/Homebrew/cask/cmd/info.rb
+++ b/Library/Homebrew/cask/cmd/info.rb
@@ -46,7 +46,7 @@ module Cask
 
       def self.info(cask)
         puts get_info(cask)
-        ::Utils::Analytics.cask_output(cask)
+        ::Utils::Analytics.cask_output(cask, args: Homebrew::CLI::Args.new)
       end
 
       def self.title_info(cask)

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -171,7 +171,7 @@ module Homebrew
         Homebrew.args = @args
 
         @args_parsed = true
-        @parser
+        @args
       end
 
       def global_option?(name, desc)

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -6,6 +6,8 @@ require "cask/cmd"
 require "cask/cask_loader"
 
 module Homebrew
+  extend Fetch
+
   module_function
 
   def __cache_args
@@ -58,7 +60,7 @@ module Homebrew
 
   def print_formula_cache(name)
     formula = Formulary.factory name
-    if Fetch.fetch_bottle?(formula)
+    if fetch_bottle?(formula)
       puts formula.bottle.cached_download
     else
       puts formula.cached_download

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -27,11 +27,11 @@ module Homebrew
   end
 
   def __env
-    __env_args.parse
+    args = __env_args.parse
 
-    ENV.activate_extensions!
-    ENV.deps = args.formulae if superenv?
-    ENV.setup_build_environment
+    ENV.activate_extensions!(args: args)
+    ENV.deps = args.formulae if superenv?(args: args)
+    ENV.setup_build_environment(args: args)
 
     shell = if args.plain?
       nil

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -5,6 +5,8 @@ require "ostruct"
 require "cli/parser"
 
 module Homebrew
+  extend DependenciesHelpers
+
   module_function
 
   def deps_args

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -5,6 +5,8 @@ require "fetch"
 require "cli/parser"
 
 module Homebrew
+  extend Fetch
+
   module_function
 
   def fetch_args
@@ -62,7 +64,7 @@ module Homebrew
       f.print_tap_action verb: "Fetching"
 
       fetched_bottle = false
-      if Fetch.fetch_bottle?(f)
+      if fetch_bottle?(f)
         begin
           fetch_formula(f.bottle)
         rescue Interrupt

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -256,7 +256,7 @@ module Homebrew
   def decorate_requirements(requirements)
     req_status = requirements.map do |req|
       req_s = req.display_s
-      req.satisfied? ? pretty_installed(req_s) : pretty_uninstalled(req_s)
+      req.satisfied?(args: args) ? pretty_installed(req_s) : pretty_uninstalled(req_s)
     end
     req_status.join(", ")
   end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -96,7 +96,7 @@ module Homebrew
   def print_info
     if args.no_named?
       if args.analytics?
-        Utils::Analytics.output
+        Utils::Analytics.output(args: args)
       elsif HOMEBREW_CELLAR.exist?
         count = Formula.racks.length
         puts "#{count} #{"keg".pluralize(count)}, #{HOMEBREW_CELLAR.dup.abv}"
@@ -107,13 +107,13 @@ module Homebrew
         begin
           formula = Formulary.factory(f)
           if args.analytics?
-            Utils::Analytics.formula_output(formula)
+            Utils::Analytics.formula_output(formula, args: args)
           else
-            info_formula(formula)
+            info_formula(formula, args: args)
           end
         rescue FormulaUnavailableError => e
           if args.analytics?
-            Utils::Analytics.output(filter: f)
+            Utils::Analytics.output(filter: f, args: args)
             next
           end
           ofail e.message
@@ -159,7 +159,7 @@ module Homebrew
     end
   end
 
-  def info_formula(f)
+  def info_formula(f, args:)
     specs = []
 
     if stable = f.stable
@@ -239,7 +239,7 @@ module Homebrew
     caveats = Caveats.new(f)
     ohai "Caveats", caveats.to_s unless caveats.empty?
 
-    Utils::Analytics.formula_output(f)
+    Utils::Analytics.formula_output(f, args: args)
   end
 
   def decorate_dependencies(dependencies)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -94,7 +94,7 @@ module Homebrew
   end
 
   def install
-    install_args.parse
+    args = install_args.parse
 
     args.named.each do |name|
       next if File.exist?(name)
@@ -263,7 +263,7 @@ module Homebrew
       Cleanup.install_formula_clean!(f)
     end
 
-    check_installed_dependents
+    check_installed_dependents(args: args)
 
     Homebrew.messages.display_messages
   rescue FormulaUnreadableError, FormulaClassUnavailableError,
@@ -323,13 +323,18 @@ module Homebrew
     f.print_tap_action
     build_options = f.build
 
-    fi = FormulaInstaller.new(f)
+    fi = FormulaInstaller.new(f, force_bottle: args.force_bottle?, include_test: args.include_test?)
     fi.options              = build_options.used_options
+    fi.env                  = args.env
+    fi.force                = args.force?
+    fi.keep_tmp             = args.keep_tmp?
     fi.ignore_deps          = args.ignore_dependencies?
     fi.only_deps            = args.only_dependencies?
     fi.build_bottle         = args.build_bottle?
+    fi.bottle_arch          = args.bottle_arch
     fi.interactive          = args.interactive?
     fi.git                  = args.git?
+    fi.cc                   = args.cc
     fi.prelude
     fi.fetch
     fi.install

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -22,11 +22,12 @@ module Homebrew
   end
 
   def postinstall
-    postinstall_args.parse
+    args = postinstall_args.parse
 
     args.resolved_formulae.each do |f|
       ohai "Postinstalling #{f}"
       fi = FormulaInstaller.new(f)
+      fi.force = args.force?
       fi.post_install
     end
   end

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -54,7 +54,7 @@ module Homebrew
   end
 
   def reinstall
-    reinstall_args.parse
+    args = reinstall_args.parse
 
     FormulaInstaller.prevent_build_flags unless DevelopmentTools.installed?
 
@@ -67,11 +67,11 @@ module Homebrew
         next
       end
       Migrator.migrate_if_needed(f)
-      reinstall_formula(f)
+      reinstall_formula(f, args: args)
       Cleanup.install_formula_clean!(f)
     end
 
-    check_installed_dependents
+    check_installed_dependents(args: args)
 
     Homebrew.messages.display_messages
 

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -56,7 +56,7 @@ module Homebrew
   end
 
   def upgrade
-    upgrade_args.parse
+    args = upgrade_args.parse
 
     FormulaInstaller.prevent_build_flags unless DevelopmentTools.installed?
 
@@ -109,9 +109,9 @@ module Homebrew
       puts formulae_upgrades.join("\n")
     end
 
-    upgrade_formulae(formulae_to_install)
+    upgrade_formulae(formulae_to_install, args: args)
 
-    check_installed_dependents
+    check_installed_dependents(args: args)
 
     Homebrew.messages.display_messages
   end

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -8,6 +8,8 @@ require "formula"
 require "cli/parser"
 
 module Homebrew
+  extend DependenciesHelpers
+
   module_function
 
   def uses_args

--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -56,9 +56,7 @@ class Requirements < DelegateClass(Set)
   end
 end
 
-module Homebrew
-  module_function
-
+module DependenciesHelpers
   def argv_includes_ignores(argv)
     includes = []
     ignores = []
@@ -81,7 +79,7 @@ module Homebrew
       ignores << "optional?"
     end
 
-    ignores << "recommended?" if Homebrew.args.skip_recommended?
+    ignores << "recommended?" if args.skip_recommended?
 
     [includes, ignores]
   end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -73,7 +73,7 @@ module Homebrew
   end
 
   def audit
-    audit_args.parse
+    args = audit_args.parse
 
     Homebrew.auditing = true
     inject_dump_stats!(FormulaAuditor, /^audit_/) if args.audit_debug?
@@ -88,8 +88,8 @@ module Homebrew
     git = args.git?
     skip_style = args.skip_style? || args.no_named?
 
-    ENV.activate_extensions!
-    ENV.setup_build_environment
+    ENV.activate_extensions!(args: args)
+    ENV.setup_build_environment(args: args)
 
     audit_formulae = args.no_named? ? Formula : args.resolved_formulae
     style_files = args.formulae_paths unless skip_style

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -63,7 +63,7 @@ module Homebrew
 
   # Create a formula from a tarball URL
   def create
-    create_args.parse
+    args = create_args.parse
 
     # Ensure that the cache exists so we can fetch the tarball
     HOMEBREW_CACHE.mkpath
@@ -75,7 +75,7 @@ module Homebrew
     license = args.set_license
     tap = args.tap
 
-    fc = FormulaCreator.new
+    fc = FormulaCreator.new(args)
     fc.name = name
     fc.version = version
     fc.license = license

--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -27,7 +27,7 @@ module Homebrew
   end
 
   def mirror
-    mirror_args.parse
+    args = mirror_args.parse
 
     bintray_org = args.bintray_org || "homebrew"
     bintray_repo = args.bintray_repo || "mirror"

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -33,7 +33,7 @@ module Homebrew
   end
 
   def pr_upload
-    pr_upload_args.parse
+    args = pr_upload_args.parse
 
     bintray_org = args.bintray_org || "homebrew"
     bintray = Bintray.new(org: bintray_org)

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -48,13 +48,9 @@ module Homebrew
 
     if args.dry_run?
       puts "brew #{bottle_args.join " "}"
-    else
-      safe_system HOMEBREW_BREW_FILE, *bottle_args
-    end
-
-    if args.dry_run?
       puts "Upload bottles described by these JSON files to Bintray:\n  #{Dir["*.json"].join("\n  ")}"
     else
+      safe_system HOMEBREW_BREW_FILE, *bottle_args
       bintray.upload_bottle_json(Dir["*.json"],
                                  publish_package: !args.no_publish?,
                                  warn_on_error:   args.warn_on_upload_failure?)

--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -27,16 +27,16 @@ module Homebrew
   end
 
   def sh
-    sh_args.parse
+    args = sh_args.parse
 
-    ENV.activate_extensions!
+    ENV.activate_extensions!(args: args)
 
-    if superenv?
+    if superenv?(args: args)
       ENV.set_x11_env_if_installed
       ENV.deps = Formula.installed.select { |f| f.keg_only? && f.opt_prefix.directory? }
     end
-    ENV.setup_build_environment
-    if superenv?
+    ENV.setup_build_environment(args: args)
+    if superenv?(args: args)
       # superenv stopped adding brew's bin but generally users will want it
       ENV["PATH"] = PATH.new(ENV["PATH"]).insert(1, HOMEBREW_PREFIX/"bin")
     end

--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -123,6 +123,6 @@ module Homebrew
       end
     end
   ensure
-    FileUtils.rm_rf "update-test" unless Homebrew.args.keep_tmp?
+    FileUtils.rm_rf "update-test" unless args.keep_tmp?
   end
 end

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -5,24 +5,24 @@ require "extend/ENV/shared"
 require "extend/ENV/std"
 require "extend/ENV/super"
 
-def superenv?
-  Homebrew.args.env != "std" && Superenv.bin
+def superenv?(args:)
+  args&.env != "std" && Superenv.bin
 end
 
 module EnvActivation
-  def activate_extensions!
-    if superenv?
+  def activate_extensions!(args:)
+    if superenv?(args: args)
       extend(Superenv)
     else
       extend(Stdenv)
     end
   end
 
-  def with_build_environment
+  def with_build_environment(args:)
     old_env = to_hash.dup
     tmp_env = to_hash.dup.extend(EnvActivation)
-    tmp_env.activate_extensions!
-    tmp_env.setup_build_environment
+    tmp_env.activate_extensions!(args: args)
+    tmp_env.setup_build_environment(args: args)
     replace(tmp_env)
     yield
   ensure

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -29,8 +29,9 @@ module SharedEnvExtension
   ].freeze
 
   # @private
-  def setup_build_environment(formula = nil)
+  def setup_build_environment(formula = nil, args: nil)
     @formula = formula
+    @args = args
     reset
   end
 
@@ -162,7 +163,7 @@ module SharedEnvExtension
   #   ENV.append_to_cflags "-I ./missing/includes"
   # end</pre>
   def compiler
-    @compiler ||= if (cc = Homebrew.args.cc)
+    @compiler ||= if (cc = @args.cc)
       warn_about_non_apple_gcc($&) if cc =~ GNU_GCC_REGEXP
       fetch_compiler(cc, "--cc")
     elsif (cc = homebrew_cc)
@@ -254,8 +255,8 @@ module SharedEnvExtension
 
   # @private
   def effective_arch
-    if Homebrew.args.build_bottle? && Homebrew.args.bottle_arch
-      Homebrew.args.bottle_arch.to_sym
+    if @args&.build_bottle? && @args&.bottle_arch
+      @args.bottle_arch.to_sym
     else
       Hardware.oldest_cpu
     end

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -11,7 +11,7 @@ module Stdenv
   SAFE_CFLAGS_FLAGS = "-w -pipe"
 
   # @private
-  def setup_build_environment(formula = nil)
+  def setup_build_environment(formula = nil, args: nil)
     super
 
     self["HOMEBREW_ENV"] = "std"
@@ -110,14 +110,14 @@ module Stdenv
   end
 
   def clang
-    super
+    super()
     replace_in_cflags(/-Xarch_#{Hardware::CPU.arch_32_bit} (-march=\S*)/, '\1')
     map = Hardware::CPU.optimization_flags.dup
     if DevelopmentTools.clang_build_version < 700
       # Clang mistakenly enables AES-NI on plain Nehalem
       map[:nehalem] = "-march=nehalem -Xclang -target-feature -Xclang -aes"
     end
-    set_cpu_cflags map
+    set_cpu_cflags(map)
   end
 
   def m64
@@ -186,7 +186,7 @@ module Stdenv
 
   # @private
   def set_cpu_cflags(map = Hardware::CPU.optimization_flags) # rubocop:disable Naming/AccessorMethodName
-    set_cpu_flags CC_FLAG_VARS, map
+    set_cpu_flags(CC_FLAG_VARS, map)
   end
 
   def make_jobs

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -36,7 +36,7 @@ module Superenv
   end
 
   # @private
-  def setup_build_environment(formula = nil)
+  def setup_build_environment(formula = nil, args: nil)
     super
     send(compiler)
 

--- a/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/shared.rb
@@ -3,9 +3,9 @@
 module SharedEnvExtension
   # @private
   def effective_arch
-    if Homebrew.args.build_bottle? && Homebrew.args.bottle_arch
-      Homebrew.args.bottle_arch.to_sym
-    elsif Homebrew.args.build_bottle?
+    if @args&.build_bottle? && @args&.bottle_arch
+      @args.bottle_arch.to_sym
+    elsif @args&.build_bottle?
       Hardware.oldest_cpu
     else
       :native

--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Stdenv
-  def setup_build_environment(formula = nil)
-    generic_setup_build_environment(formula)
+  def setup_build_environment(formula = nil, args: nil)
+    generic_setup_build_environment(formula, args: args)
 
     prepend_path "CPATH", HOMEBREW_PREFIX/"include"
     prepend_path "LIBRARY_PATH", HOMEBREW_PREFIX/"lib"

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -7,8 +7,8 @@ module Superenv
   end
 
   # @private
-  def setup_build_environment(formula = nil)
-    generic_setup_build_environment(formula)
+  def setup_build_environment(formula = nil, args: nil)
+    generic_setup_build_environment(formula, args: args)
     self["HOMEBREW_OPTIMIZATION_LEVEL"] = "O2"
     self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path
     self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(formula)

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -32,8 +32,8 @@ module Stdenv
     append "CFLAGS", "-I#{MacOS::X11.include}" unless MacOS::CLT.installed?
   end
 
-  def setup_build_environment(formula = nil)
-    generic_setup_build_environment formula
+  def setup_build_environment(formula = nil, args: nil)
+    generic_setup_build_environment(formula, args: args)
 
     # sed is strict, and errors out when it encounters files with
     # mixed character sets

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -106,7 +106,7 @@ module Superenv
   end
 
   # @private
-  def setup_build_environment(formula = nil)
+  def setup_build_environment(formula = nil, args: nil)
     sdk = formula ? MacOS.sdk_for_formula(formula) : MacOS.sdk
     if MacOS.sdk_root_needed? || sdk&.source == :xcode
       self["HOMEBREW_SDKROOT"] = sdk.path
@@ -119,7 +119,7 @@ module Superenv
       self["HOMEBREW_SDKROOT"] = nil
       self["HOMEBREW_DEVELOPER_DIR"] = nil
     end
-    generic_setup_build_environment(formula)
+    generic_setup_build_environment(formula, args: args)
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/fetch.rb
+++ b/Library/Homebrew/fetch.rb
@@ -2,12 +2,10 @@
 
 module Homebrew
   module Fetch
-    module_function
-
     def fetch_bottle?(f)
-      return true if Homebrew.args.force_bottle? && f.bottle
+      return true if args.force_bottle? && f.bottle
       return false unless f.bottle && f.pour_bottle?
-      return false if Homebrew.args.build_formula_from_source?(f)
+      return false if args.build_formula_from_source?(f)
       return false unless f.bottle.compatible_cellar?
 
       true

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1163,11 +1163,11 @@ class Formula
   # yields |self,staging| with current working directory set to the uncompressed tarball
   # where staging is a Mktemp staging context
   # @private
-  def brew(fetch: true)
+  def brew(fetch: true, keep_tmp: false, interactive: false)
     @prefix_returns_versioned_prefix = true
     active_spec.fetch if fetch
-    stage do |staging|
-      staging.retain! if Homebrew.args.keep_tmp?
+    stage(interactive: interactive) do |staging|
+      staging.retain! if keep_tmp
 
       prepare_patches
       fetch_patches if fetch
@@ -1175,7 +1175,7 @@ class Formula
       begin
         yield self, staging
       rescue
-        staging.retain! if Homebrew.args.interactive? || Homebrew.args.debug?
+        staging.retain! if interactive || Homebrew.args.debug?
         raise
       ensure
         cp Dir["config.log", "CMakeCache.txt"], logs
@@ -1792,7 +1792,7 @@ class Formula
   end
 
   # @private
-  def run_test
+  def run_test(keep_tmp: false)
     @prefix_returns_versioned_prefix = true
 
     test_env = {
@@ -1808,7 +1808,7 @@ class Formula
     Utils.set_git_name_email!
 
     mktemp("#{name}-test") do |staging|
-      staging.retain! if Homebrew.args.keep_tmp?
+      staging.retain! if keep_tmp
       @testpath = staging.tmpdir
       test_env[:HOME] = @testpath
       setup_home @testpath
@@ -2134,7 +2134,7 @@ class Formula
     }
   end
 
-  def stage
+  def stage(interactive: false)
     active_spec.stage do |staging|
       @source_modified_time = active_spec.source_modified_time
       @buildpath = Pathname.pwd
@@ -2145,7 +2145,7 @@ class Formula
         HOMEBREW_PATH: nil,
       }
 
-      unless Homebrew.args.interactive?
+      unless interactive
         stage_env[:HOME] = env_home
         stage_env.merge!(common_stage_test_env)
       end

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -5,8 +5,12 @@ require "erb"
 
 module Homebrew
   class FormulaCreator
-    attr_reader :url, :sha256, :desc, :homepage
+    attr_reader :args, :url, :sha256, :desc, :homepage
     attr_accessor :name, :version, :tap, :path, :mode, :license
+
+    def initialize(args)
+      @args = args
+    end
 
     def url=(url)
       @url = url
@@ -41,11 +45,11 @@ module Homebrew
     end
 
     def fetch?
-      !Homebrew.args.no_fetch?
+      !args.no_fetch?
     end
 
     def head?
-      @head || Homebrew.args.HEAD?
+      @head || args.HEAD?
     end
 
     def generate!

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -38,25 +38,31 @@ class FormulaInstaller
   end
 
   attr_reader :formula
-  attr_accessor :options, :build_bottle, :installed_as_dependency, :installed_on_request, :link_keg
+  attr_accessor :cc, :env, :options, :build_bottle, :bottle_arch,
+                :installed_as_dependency, :installed_on_request, :link_keg
 
   mode_attr_accessor :show_summary_heading, :show_header
   mode_attr_accessor :build_from_source, :force_bottle, :include_test
-  mode_attr_accessor :ignore_deps, :only_deps, :interactive, :git
+  mode_attr_accessor :ignore_deps, :only_deps, :interactive, :git, :force, :keep_tmp
   mode_attr_accessor :verbose, :debug, :quiet
 
-  def initialize(formula)
+  def initialize(formula, force_bottle: false, include_test: false, build_from_source: false, cc: nil)
     @formula = formula
+    @env = nil
+    @force = false
+    @keep_tmp = false
     @link_keg = !formula.keg_only?
     @show_header = false
     @ignore_deps = false
     @only_deps = false
-    @build_from_source = Homebrew.args.build_from_source?
+    @build_from_source = build_from_source
     @build_bottle = false
-    @force_bottle = Homebrew.args.force_bottle?
-    @include_test = Homebrew.args.include_test?
+    @bottle_arch = nil
+    @force_bottle = force_bottle
+    @include_test = include_test
     @interactive = false
     @git = false
+    @cc = cc
     @verbose = Homebrew.args.verbose?
     @quiet = Homebrew.args.quiet?
     @debug = Homebrew.args.debug?
@@ -108,7 +114,7 @@ class FormulaInstaller
     return false if !formula.bottled? && !formula.local_bottle_path
     return true  if force_bottle?
     return false if build_from_source? || build_bottle? || interactive?
-    return false if Homebrew.args.cc
+    return false if cc
     return false unless options.empty?
     return false if formula.bottle_disabled?
 
@@ -280,7 +286,7 @@ class FormulaInstaller
 
     return if only_deps?
 
-    if build_bottle? && (arch = Homebrew.args.bottle_arch) && !Hardware::CPU.optimization_flags.include?(arch.to_sym)
+    if build_bottle? && (arch = bottle_arch) && !Hardware::CPU.optimization_flags.include?(arch.to_sym)
       raise "Unrecognized architecture for --bottle-arch: #{arch}"
     end
 
@@ -367,7 +373,7 @@ class FormulaInstaller
   end
 
   def check_conflicts
-    return if Homebrew.args.force?
+    return if force?
 
     conflicts = formula.conflicts.select do |c|
       f = Formulary.factory(c.name)
@@ -576,11 +582,12 @@ class FormulaInstaller
 
   def fetch_dependency(dep)
     df = dep.to_formula
-    fi = FormulaInstaller.new(df)
+    fi = FormulaInstaller.new(df, force_bottle:      false,
+                                  include_test:      Homebrew.args.include_formula_test_deps?(df),
+                                  build_from_source: Homebrew.args.build_formula_from_source?(df))
 
-    fi.build_from_source       = Homebrew.args.build_formula_from_source?(df)
-    fi.force_bottle            = false
-    fi.include_test            = Homebrew.args.include_formula_test_deps?(df)
+    fi.force                   = force?
+    fi.keep_tmp                = keep_tmp?
     fi.verbose                 = verbose?
     fi.quiet                   = quiet?
     fi.debug                   = debug?
@@ -616,14 +623,16 @@ class FormulaInstaller
       EOS
     end
 
-    fi = FormulaInstaller.new(df)
+    fi = FormulaInstaller.new(df, force_bottle:      false,
+                                  include_test:      Homebrew.args.include_formula_test_deps?(df),
+                                  build_from_source: Homebrew.args.build_formula_from_source?(df))
+
     fi.options                |= tab.used_options
     fi.options                |= Tab.remap_deprecated_options(df.deprecated_options, dep.options)
     fi.options                |= inherited_options
     fi.options                &= df.options
-    fi.build_from_source       = Homebrew.args.build_formula_from_source?(df)
-    fi.force_bottle            = false
-    fi.include_test            = Homebrew.args.include_formula_test_deps?(df)
+    fi.force                   = force?
+    fi.keep_tmp                = keep_tmp?
     fi.verbose                 = verbose?
     fi.quiet                   = quiet?
     fi.debug                   = debug?
@@ -732,18 +741,18 @@ class FormulaInstaller
 
     if build_bottle?
       args << "--build-bottle"
-      args << "--bottle-arch=#{Homebrew.args.bottle_arch}" if Homebrew.args.bottle_arch
+      args << "--bottle-arch=#{bottle_arch}" if bottle_arch
     end
 
     args << "--git" if git?
     args << "--interactive" if interactive?
     args << "--verbose" if verbose?
     args << "--debug" if debug?
-    args << "--cc=#{Homebrew.args.cc}" if Homebrew.args.cc
-    args << "--keep-tmp" if Homebrew.args.keep_tmp?
+    args << "--cc=#{cc}" if cc
+    args << "--keep-tmp" if keep_tmp?
 
-    if Homebrew.args.env.present?
-      args << "--env=#{Homebrew.args.env}"
+    if env.present?
+      args << "--env=#{env}"
     elsif formula.env.std? || formula.deps.select(&:build?).any? { |d| d.name == "scons" }
       args << "--env=std"
     end
@@ -789,7 +798,7 @@ class FormulaInstaller
         sandbox = Sandbox.new
         formula.logs.mkpath
         sandbox.record_log(formula.logs/"build.sandbox.log")
-        sandbox.allow_write_path(ENV["HOME"]) if Homebrew.args.interactive?
+        sandbox.allow_write_path(ENV["HOME"]) if interactive?
         sandbox.allow_write_temp_and_cache
         sandbox.allow_write_log(formula)
         sandbox.allow_cvs

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -469,7 +469,7 @@ class FormulaInstaller
 
         if req.prune_from_option?(build)
           Requirement.prune
-        elsif req.satisfied?
+        elsif req.satisfied?(args: Homebrew.args)
           Requirement.prune
         elsif (req.build? || req.test?) && !keep_build_test
           Requirement.prune

--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -7,7 +7,7 @@ require "messages"
 module Homebrew
   module_function
 
-  def reinstall_formula(f, build_from_source: false)
+  def reinstall_formula(f, build_from_source: false, args:)
     return if args.dry_run?
 
     if f.opt_prefix.directory?
@@ -23,11 +23,13 @@ module Homebrew
     options |= f.build.used_options
     options &= f.options
 
-    fi = FormulaInstaller.new(f)
+    fi = FormulaInstaller.new(f, force_bottle: args.force_bottle?, include_test: args.include_test?)
     fi.options              = options
-    fi.build_bottle         = Homebrew.args.build_bottle?
-    fi.interactive          = Homebrew.args.interactive?
-    fi.git                  = Homebrew.args.git?
+    fi.force                = args.force?
+    fi.keep_tmp             = args.keep_tmp?
+    fi.build_bottle         = args.build_bottle?
+    fi.interactive          = args.interactive?
+    fi.git                  = args.git?
     fi.link_keg           ||= keg_was_linked if keg_had_linked_opt
     fi.build_from_source    = true if build_from_source
     if tab

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -53,16 +53,15 @@ class Requirement
 
   # Overriding {#satisfied?} is unsupported.
   # Pass a block or boolean to the satisfy DSL method instead.
-  def satisfied?
+  def satisfied?(args: nil)
     satisfy = self.class.satisfy
     return true unless satisfy
 
-    @satisfied_result = satisfy.yielder { |p| instance_eval(&p) }
+    @satisfied_result = satisfy.yielder(args: args) { |p| instance_eval(&p) }
     return false unless @satisfied_result
 
     true
   end
-  alias installed? satisfied?
 
   # Overriding {#fatal?} is unsupported.
   # Pass a boolean to the fatal DSL method instead.
@@ -82,8 +81,8 @@ class Requirement
 
   # Overriding {#modify_build_environment} is unsupported.
   # Pass a block to the env DSL method instead.
-  def modify_build_environment
-    satisfied?
+  def modify_build_environment(args:)
+    satisfied?(args: args)
     instance_eval(&env_proc) if env_proc
 
     # XXX If the satisfy block returns a Pathname, then make sure that it
@@ -182,12 +181,12 @@ class Requirement
       @proc = block
     end
 
-    def yielder
+    def yielder(args:)
       if instance_variable_defined?(:@satisfied)
         @satisfied
       elsif @options[:build_env]
         require "extend/ENV"
-        ENV.with_build_environment { yield @proc }
+        ENV.with_build_environment(args: args) { yield @proc }
       else
         yield @proc
       end

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -28,7 +28,7 @@ begin
   formula.extend(Debrew::Formula) if Homebrew.args.debug?
 
   ENV.extend(Stdenv)
-  ENV.setup_build_environment(formula)
+  ENV.setup_build_environment(formula, args: args)
 
   # tests can also return false to indicate failure
   Timeout.timeout TEST_TIMEOUT_SECONDS do

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -16,13 +16,13 @@ require "dev-cmd/test"
 TEST_TIMEOUT_SECONDS = 5 * 60
 
 begin
-  Homebrew.test_args.parse
+  args = Homebrew.test_args.parse
   error_pipe = UNIXSocket.open(ENV["HOMEBREW_ERROR_PIPE"], &:recv_io)
   error_pipe.fcntl(Fcntl::F_SETFD, Fcntl::FD_CLOEXEC)
 
   trap("INT", old_trap)
 
-  formula = Homebrew.args.resolved_formulae.first
+  formula = args.resolved_formulae.first
   formula.extend(Homebrew::Assertions)
   formula.extend(Homebrew::FreePort)
   formula.extend(Debrew::Formula) if Homebrew.args.debug?
@@ -32,7 +32,7 @@ begin
 
   # tests can also return false to indicate failure
   Timeout.timeout TEST_TIMEOUT_SECONDS do
-    raise "test returned false" if formula.run_test == false
+    raise "test returned false" if formula.run_test(keep_tmp: args.keep_tmp?) == false
   end
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.puts e.to_json

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "extend/ENV"
 
 shared_examples EnvActivation do
@@ -14,10 +15,12 @@ shared_examples EnvActivation do
   end
 
   describe "#with_build_environment" do
+    let(:args) { Homebrew::CLI::Args.new }
+
     it "restores the environment" do
       before = subject.dup
 
-      subject.with_build_environment do
+      subject.with_build_environment(args: args) do
         subject["foo"] = "bar"
       end
 
@@ -29,7 +32,7 @@ shared_examples EnvActivation do
       before = subject.dup
 
       expect {
-        subject.with_build_environment do
+        subject.with_build_environment(args: args) do
           subject["foo"] = "bar"
           raise StandardError
         end
@@ -40,13 +43,13 @@ shared_examples EnvActivation do
     end
 
     it "returns the value of the block" do
-      expect(subject.with_build_environment { 1 }).to eq(1)
+      expect(subject.with_build_environment(args: args) { 1 }).to eq(1)
     end
 
     it "does not mutate the interface" do
       expected = subject.methods
 
-      subject.with_build_environment do
+      subject.with_build_environment(args: args) do
         expect(subject.methods).to eq(expected)
       end
 

--- a/Library/Homebrew/test/bintray_spec.rb
+++ b/Library/Homebrew/test/bintray_spec.rb
@@ -3,7 +3,13 @@
 require "bintray"
 
 describe Bintray, :needs_network do
-  bintray = described_class.new(user: "BrewTestBot", key: "deadbeef", org: "homebrew")
+  subject(:bintray) { described_class.new(org: "homebrew") }
+
+  before do
+    ENV["HOMEBREW_BINTRAY_USER"] = "BrewTestBot"
+    ENV["HOMEBREW_BINTRAY_KEY"] = "deadbeef"
+  end
+
   describe "::file_published?" do
     it "detects a published file" do
       results = bintray.file_published?(repo: "bottles", remote_file: "hello-2.10.catalina.bottle.tar.gz")

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -17,10 +17,10 @@ describe FormulaInstaller do
     match(&:poured_from_bottle)
   end
 
-  def temporary_install(formula)
+  def temporary_install(formula, **options)
     expect(formula).not_to be_latest_version_installed
 
-    installer = described_class.new(formula)
+    installer = described_class.new(formula, **options)
 
     installer.fetch
     installer.install
@@ -89,9 +89,7 @@ describe FormulaInstaller do
   end
 
   specify "Formula is not poured from bottle when compiler specified" do
-    expect(Homebrew.args.cc).to be nil
-    Homebrew.install_args.parse(["--cc=clang", "testball_bottle"])
-    temporary_install(TestballBottle.new) do |f|
+    temporary_install(TestballBottle.new, cc: "clang") do |f|
       tab = Tab.for_formula(f)
       expect(tab.compiler).to eq("clang")
     end

--- a/Library/Homebrew/test/java_requirement_spec.rb
+++ b/Library/Homebrew/test/java_requirement_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "requirements/java_requirement"
 
 describe JavaRequirement do
@@ -40,14 +41,16 @@ describe JavaRequirement do
   describe "#satisfied?" do
     subject { described_class.new(%w[1.8]) }
 
+    let(:args) { Homebrew::CLI::Args.new }
+
     it "returns false if no `java` executable can be found" do
       allow(File).to receive(:executable?).and_return(false)
-      expect(subject).not_to be_satisfied
+      expect(subject).not_to be_satisfied(args: args)
     end
 
     it "returns true if #preferred_java returns a path" do
       allow(subject).to receive(:preferred_java).and_return(Pathname.new("/usr/bin/java"))
-      expect(subject).to be_satisfied
+      expect(subject).to be_satisfied(args: args)
     end
 
     context "when #possible_javas contains paths" do
@@ -71,17 +74,17 @@ describe JavaRequirement do
 
         it "returns false if all are lower" do
           setup_java_with_version "1.6.0_5"
-          expect(subject).not_to be_satisfied
+          expect(subject).not_to be_satisfied(args: args)
         end
 
         it "returns true if one is equal" do
           setup_java_with_version "1.7.0_5"
-          expect(subject).to be_satisfied
+          expect(subject).to be_satisfied(args: args)
         end
 
         it "returns false if all are higher" do
           setup_java_with_version "1.8.0_5"
-          expect(subject).not_to be_satisfied
+          expect(subject).not_to be_satisfied(args: args)
         end
       end
 
@@ -90,17 +93,17 @@ describe JavaRequirement do
 
         it "returns false if all are lower" do
           setup_java_with_version "1.6.0_5"
-          expect(subject).not_to be_satisfied
+          expect(subject).not_to be_satisfied(args: args)
         end
 
         it "returns true if one is equal" do
           setup_java_with_version "1.7.0_5"
-          expect(subject).to be_satisfied
+          expect(subject).to be_satisfied(args: args)
         end
 
         it "returns true if one is higher" do
           setup_java_with_version "1.8.0_5"
-          expect(subject).to be_satisfied
+          expect(subject).to be_satisfied(args: args)
         end
       end
     end

--- a/Library/Homebrew/test/os/mac/java_requirement_spec.rb
+++ b/Library/Homebrew/test/os/mac/java_requirement_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "requirements/java_requirement"
 require "fileutils"
 
@@ -8,6 +9,8 @@ describe JavaRequirement do
 
   let(:java_home) { mktmpdir }
 
+  let(:args) { Homebrew::CLI::Args.new }
+
   before do
     FileUtils.mkdir java_home/"bin"
     FileUtils.touch java_home/"bin/java"
@@ -15,23 +18,23 @@ describe JavaRequirement do
   end
 
   specify "Apple Java environment" do
-    expect(subject).to be_satisfied
+    expect(subject).to be_satisfied(args: args)
 
     expect(ENV).to receive(:prepend_path)
     expect(ENV).to receive(:append_to_cflags)
 
-    subject.modify_build_environment
+    subject.modify_build_environment(args: args)
     expect(ENV["JAVA_HOME"]).to eq(java_home.to_s)
   end
 
   specify "Oracle Java environment" do
-    expect(subject).to be_satisfied
+    expect(subject).to be_satisfied(args: args)
 
     FileUtils.mkdir java_home/"include"
     expect(ENV).to receive(:prepend_path)
     expect(ENV).to receive(:append_to_cflags).twice
 
-    subject.modify_build_environment
+    subject.modify_build_environment(args: args)
     expect(ENV["JAVA_HOME"]).to eq(java_home.to_s)
   end
 end

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "extend/ENV"
 require "requirement"
 
@@ -9,6 +10,8 @@ describe Requirement do
   subject { klass.new }
 
   let(:klass) { Class.new(described_class) }
+
+  let(:args) { Homebrew::CLI::Args.new }
 
   describe "#tags" do
     subject { described_class.new(tags) }
@@ -64,7 +67,7 @@ describe Requirement do
         end
       end
 
-      it { is_expected.to be_satisfied }
+      it { is_expected.to be_satisfied(args: args) }
     end
 
     describe "#satisfy with block and build_env returns false" do
@@ -76,7 +79,7 @@ describe Requirement do
         end
       end
 
-      it { is_expected.not_to be_satisfied }
+      it { is_expected.not_to be_satisfied(args: args) }
     end
 
     describe "#satisfy returns true" do
@@ -86,7 +89,7 @@ describe Requirement do
         end
       end
 
-      it { is_expected.to be_satisfied }
+      it { is_expected.to be_satisfied(args: args) }
     end
 
     describe "#satisfy returns false" do
@@ -96,7 +99,7 @@ describe Requirement do
         end
       end
 
-      it { is_expected.not_to be_satisfied }
+      it { is_expected.not_to be_satisfied(args: args) }
     end
 
     describe "#satisfy with block returning true and without :build_env" do
@@ -110,7 +113,7 @@ describe Requirement do
 
       it "sets up build environment" do
         expect(ENV).to receive(:with_build_environment).and_call_original
-        subject.satisfied?
+        subject.satisfied?(args: args)
       end
     end
 
@@ -125,7 +128,7 @@ describe Requirement do
 
       it "skips setting up build environment" do
         expect(ENV).not_to receive(:with_build_environment)
-        subject.satisfied?
+        subject.satisfied?(args: args)
       end
     end
 
@@ -140,8 +143,8 @@ describe Requirement do
 
       it "infers path from #satisfy result" do
         expect(ENV).to receive(:prepend_path).with("PATH", Pathname.new("/foo/bar"))
-        subject.satisfied?
-        subject.modify_build_environment
+        subject.satisfied?(args: args)
+        subject.modify_build_environment(args: args)
       end
     end
   end
@@ -179,7 +182,7 @@ describe Requirement do
       let(:klass) { Class.new(described_class) }
 
       it "returns nil" do
-        expect(subject.modify_build_environment).to be nil
+        expect(subject.modify_build_environment(args: args)).to be nil
       end
     end
   end

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "requirements/linux_requirement"
 
 describe LinuxRequirement do
   subject(:requirement) { described_class.new }
 
   describe "#satisfied?" do
+    let(:args) { Homebrew::CLI::Args.new }
+
     it "returns true on Linux" do
-      expect(requirement.satisfied?).to eq(OS.linux?)
+      expect(requirement.satisfied?(args: args)).to eq(OS.linux?)
     end
   end
 end

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -1,23 +1,26 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "requirements/macos_requirement"
 
 describe MacOSRequirement do
   subject(:requirement) { described_class.new }
 
   describe "#satisfied?" do
+    let(:args) { Homebrew::CLI::Args.new }
+
     it "returns true on macOS" do
-      expect(requirement.satisfied?).to eq OS.mac?
+      expect(requirement.satisfied?(args: args)).to eq OS.mac?
     end
 
     it "supports version symbols", :needs_macos do
       requirement = described_class.new([MacOS.version.to_sym])
-      expect(requirement).to be_satisfied
+      expect(requirement).to be_satisfied(args: args)
     end
 
     it "supports maximum versions", :needs_macos do
       requirement = described_class.new([:catalina], comparator: "<=")
-      expect(requirement.satisfied?).to eq MacOS.version <= :catalina
+      expect(requirement.satisfied?(args: args)).to eq MacOS.version <= :catalina
     end
   end
 end

--- a/Library/Homebrew/test/requirements/osxfuse_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/osxfuse_requirement_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "requirements/osxfuse_requirement"
 
 describe OsxfuseRequirement do
@@ -21,21 +22,23 @@ describe OsxfuseRequirement do
   end
 
   describe "#modify_build_environment", :needs_macos do
+    let(:args) { Homebrew::CLI::Args.new }
+
     it "adds the fuse directories to PKG_CONFIG_PATH" do
       allow(ENV).to receive(:append_path)
-      requirement.modify_build_environment
+      requirement.modify_build_environment(args: args)
       expect(ENV).to have_received(:append_path).with("PKG_CONFIG_PATH", any_args)
     end
 
     it "adds the fuse directories to HOMEBREW_LIBRARY_PATHS" do
       allow(ENV).to receive(:append_path)
-      requirement.modify_build_environment
+      requirement.modify_build_environment(args: args)
       expect(ENV).to have_received(:append_path).with("HOMEBREW_LIBRARY_PATHS", any_args)
     end
 
     it "adds the fuse directories to HOMEBREW_INCLUDE_PATHS" do
       allow(ENV).to receive(:append_path)
-      requirement.modify_build_environment
+      requirement.modify_build_environment(args: args)
       expect(ENV).to have_received(:append_path).with("HOMEBREW_INCLUDE_PATHS", any_args)
     end
   end

--- a/Library/Homebrew/test/x11_requirement_spec.rb
+++ b/Library/Homebrew/test/x11_requirement_spec.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require "cli/args"
 require "requirements/x11_requirement"
 
 describe X11Requirement do
   let(:default_name) { "x11" }
+
+  let(:args) { Homebrew::CLI::Args.new }
 
   describe "#name" do
     it "defaults to x11" do
@@ -22,7 +25,7 @@ describe X11Requirement do
     it "calls ENV#x11" do
       allow(subject).to receive(:satisfied?).and_return(true)
       expect(ENV).to receive(:x11)
-      subject.modify_build_environment
+      subject.modify_build_environment(args: args)
     end
   end
 
@@ -30,12 +33,12 @@ describe X11Requirement do
     it "returns true if X11 is installed" do
       expect(MacOS::XQuartz).to receive(:version).and_return("2.7.5")
       expect(MacOS::XQuartz).to receive(:installed?).and_return(true)
-      expect(subject).to be_satisfied
+      expect(subject).to be_satisfied(args: args)
     end
 
     it "returns false if X11 is not installed" do
       expect(MacOS::XQuartz).to receive(:installed?).and_return(false)
-      expect(subject).not_to be_satisfied
+      expect(subject).not_to be_satisfied(args: args)
     end
   end
 end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -9,7 +9,7 @@ require "cleanup"
 module Homebrew
   module_function
 
-  def upgrade_formulae(formulae_to_install)
+  def upgrade_formulae(formulae_to_install, args:)
     return if formulae_to_install.empty?
     return if args.dry_run?
 
@@ -28,7 +28,7 @@ module Homebrew
     formulae_to_install.each do |f|
       Migrator.migrate_if_needed(f)
       begin
-        upgrade_formula(f)
+        upgrade_formula(f, args: args)
         Cleanup.install_formula_clean!(f)
       rescue UnsatisfiedRequirements => e
         Homebrew.failed = true
@@ -37,7 +37,7 @@ module Homebrew
     end
   end
 
-  def upgrade_formula(f)
+  def upgrade_formula(f, args:)
     return if args.dry_run?
 
     if f.opt_prefix.directory?
@@ -63,8 +63,10 @@ module Homebrew
     options |= f.build.used_options
     options &= f.options
 
-    fi = FormulaInstaller.new(f)
+    fi = FormulaInstaller.new(f, force_bottle: args.force_bottle?, include_test: args.include_test?)
     fi.options = options
+    fi.force = args.force?
+    fi.keep_tmp = args.keep_tmp?
     fi.build_bottle = args.build_bottle?
     fi.installed_on_request = args.named.present?
     fi.link_keg           ||= keg_was_linked if keg_had_linked_opt
@@ -112,7 +114,7 @@ module Homebrew
     end
   end
 
-  def check_installed_dependents
+  def check_installed_dependents(args:)
     installed_formulae = FormulaInstaller.installed.to_a
     return if installed_formulae.empty?
 
@@ -156,7 +158,7 @@ module Homebrew
       puts formulae_upgrades.join(", ")
     end
 
-    upgrade_formulae(upgradeable_dependents)
+    upgrade_formulae(upgradeable_dependents, args: args)
 
     # Assess the dependents tree again now we've upgraded.
     oh1 "Checking for dependents of upgraded formulae..." unless args.dry_run?
@@ -213,7 +215,7 @@ module Homebrew
     return if args.dry_run?
 
     reinstallable_broken_dependents.each do |f|
-      reinstall_formula(f, build_from_source: true)
+      reinstall_formula(f, build_from_source: true, args: args)
     rescue FormulaInstallationAlreadyAttemptedError
       # We already attempted to reinstall f as part of the dependency tree of
       # another formula. In that case, don't generate an error, just move on.

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -116,9 +116,9 @@ module Utils
         config_delete(:analyticsuuid)
       end
 
-      def output(filter: nil)
-        days = Homebrew.args.days || "30"
-        category = Homebrew.args.category || "install"
+      def output(filter: nil, args:)
+        days = args.days || "30"
+        category = args.category || "install"
         json = formulae_brew_sh_json("analytics/#{category}/#{days}d.json")
         return if json.blank? || json["items"].blank?
 
@@ -147,8 +147,8 @@ module Utils
         table_output(category, days, results, os_version: os_version, cask_install: cask_install)
       end
 
-      def get_analytics(json)
-        full_analytics = Homebrew.args.analytics? || Homebrew.args.verbose?
+      def get_analytics(json, args:)
+        full_analytics = args.analytics? || Homebrew.args.verbose?
 
         ohai "Analytics"
         json["analytics"].each do |category, value|
@@ -158,11 +158,11 @@ module Utils
           value.each do |days, results|
             days = days.to_i
             if full_analytics
-              if Homebrew.args.days.present?
-                next if Homebrew.args.days&.to_i != days
+              if args.days.present?
+                next if args.days&.to_i != days
               end
-              if Homebrew.args.category.present?
-                next if Homebrew.args.category != category
+              if args.category.present?
+                next if args.category != category
               end
 
               table_output(category, days, results)
@@ -176,18 +176,18 @@ module Utils
         end
       end
 
-      def formula_output(f)
+      def formula_output(f, args:)
         json = formulae_brew_sh_json("#{formula_path}/#{f}.json")
         return if json.blank? || json["analytics"].blank?
 
-        get_analytics(json)
+        get_analytics(json, args: args)
       end
 
-      def cask_output(cask)
+      def cask_output(cask, args:)
         json = formulae_brew_sh_json("#{cask_path}/#{cask}.json")
         return if json.blank? || json["analytics"].blank?
 
-        get_analytics(json)
+        get_analytics(json, args: args)
       end
 
       def custom_prefix_label


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Pass `args` down the call chain instead of using global state everywhere. This should make refactoring `CLI::Parser` possible in order to use it for `cask` subcommands.