### PR TITLE
sorbet: add cli/args.rb to true

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -82,7 +82,6 @@ false:
   - ./cask/verify.rb
   - ./caveats.rb
   - ./cleanup.rb
-  - ./cli/args.rb
   - ./cli/parser.rb
   - ./cmd/--cache.rb
   - ./cmd/--cellar.rb
@@ -836,6 +835,7 @@ true:
   - ./cask/url.rb
   - ./checksum.rb
   - ./cleaner.rb
+  - ./cli/args.rb
   - ./compat/extend/nil.rb
   - ./compat/extend/string.rb
   - ./compat/formula.rb

--- a/Library/Homebrew/sorbet/rbi/cli.rbi
+++ b/Library/Homebrew/sorbet/rbi/cli.rbi
@@ -1,0 +1,19 @@
+# typed: strict
+
+module Homebrew::CLI
+  class Args < OpenStruct
+    def devel?; end
+
+    def HEAD?; end
+
+    def include_test?; end
+
+    def build_bottle?; end
+
+    def build_universal?; end
+
+    def build_from_source?; end
+
+    def named_args; end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
This PR moves `cli/args.rb` to true in `sorbet/files.yaml` and deals with the resulting type errors.