### PR TITLE
style: don't allow patches to be PR/MR urls

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -38,6 +38,15 @@ module RuboCop
 
         def patch_problems(patch)
           patch_url = string_content(patch)
+
+          if regex_match_group(patch, %r{https://github.com/[^/]*/[^/]*/pull})
+            problem "Use a commit hash URL rather than an unstable pull request URL: #{patch_url}"
+          end
+
+          if regex_match_group(patch, %r{.*gitlab.*/merge_request.*})
+            problem "Use a commit hash URL rather than an unstable merge request URL: #{patch_url}"
+          end
+
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch, gh_patch_param_pattern)
             unless patch_url.match?(/\?full_index=\w+$/)
@@ -64,13 +73,8 @@ module RuboCop
 
           gh_patch_diff_pattern =
             %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}
-          if match_obj = regex_match_group(patch, gh_patch_diff_pattern)
-            problem <<~EOS
-              use GitHub pull request URLs:
-                https://github.com/#{match_obj[1]}/#{match_obj[2]}/pull/#{match_obj[3]}.patch?full_index=1
-              Rather than patch-diff:
-                #{patch_url}
-            EOS
+          if regex_match_group(patch, gh_patch_diff_pattern)
+            problem "Use a commit hash URL rather than patch-diff: #{patch_url}"
           end
 
           if regex_match_group(patch, %r{macports/trunk})

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         "http://trac.macports.org/export/102865/trunk/dports/mail/uudeview/files/inews.c.patch",
         "http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-libunac1.txt;att=1;bug=623340",
         "https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch",
-        "https://github.com/dlang/dub/pull/1221.patch",
+        "https://github.com/dlang/dub/commit/2c916b1a7999a050ac4970c3415ff8f91cd487aa.patch",
       ]
       patch_urls.each do |patch_url|
         source = <<~EOS
@@ -91,13 +91,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Layout/LineLength
-          [{ message:
-                       <<~EOS,
-                         use GitHub pull request URLs:
-                           https://github.com/foo/foo-bar/pull/100.patch?full_index=1
-                         Rather than patch-diff:
-                           https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch
-                       EOS
+          [{ message:  "Use a commit hash URL rather than patch-diff: #{patch_url}",
              severity: :convention,
              line:     5,
              column:   5,
@@ -218,6 +212,8 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         "http://trac.macports.org/export/102865/trunk/dports/mail/uudeview/files/inews.c.patch",
         "http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-libunac1.txt;att=1;bug=623340",
         "https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch",
+        "https://github.com/uber/h3/pull/362.patch?full_index=1",
+        "https://gitlab.gnome.org/GNOME/gitg/-/merge_requests/142.diff",
       ]
       patch_urls.each do |patch_url|
         source = <<~RUBY
@@ -272,16 +268,22 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   9,
              source:   source }]
+        elsif patch_url.match?(%r{https://github.com/[^/]*/[^/]*/pull})
+          [{ message:  "Use a commit hash URL rather than an unstable pull request URL: #{patch_url}",
+             severity: :convention,
+             line:     5,
+             column:   9,
+             source:   source }]
+        elsif patch_url.match?(%r{.*gitlab.*/merge_request.*})
+          [{ message:  "Use a commit hash URL rather than an unstable merge request URL: #{patch_url}",
+             severity: :convention,
+             line:     5,
+             column:   9,
+             source:   source }]
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Layout/LineLength
-          [{ message:
-                       <<~EOS,
-                         use GitHub pull request URLs:
-                           https://github.com/foo/foo-bar/pull/100.patch?full_index=1
-                         Rather than patch-diff:
-                           https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch
-                       EOS
+          [{ message:  "Use a commit hash URL rather than patch-diff: #{patch_url}",
              severity: :convention,
              line:     5,
              column:   9,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Having a patch be a PR url is risky because the contents of the PR may change. This prevents linking directly to PRs. The following formulae in the core taps currently have direct links to PRs/MRs:
- [x] [adios2.rb](https://github.com/Homebrew/homebrew-core/pull/58597)
- [x] [assimp.rb](https://github.com/Homebrew/homebrew-core/pull/58591)
- [x] [caffe.rb](https://github.com/Homebrew/homebrew-core/pull/58598)
- [x] [conjure-up.rb](https://github.com/Homebrew/homebrew-core/pull/58599)
- [x] [ctl.rb](https://github.com/Homebrew/homebrew-core/pull/58619)
- [x] [etcd.rb](https://github.com/Homebrew/homebrew-core/pull/58600)
- [x] [fontforge.rb](https://github.com/Homebrew/homebrew-core/pull/58699)
- [x] [gitg.rb](https://github.com/Homebrew/homebrew-core/pull/58694)
- [x] [gitless.rb](https://github.com/Homebrew/homebrew-core/pull/58593)
- [x] [h3.rb](https://github.com/Homebrew/homebrew-core/pull/58574)
- [x] [hashpump.rb](https://github.com/Homebrew/homebrew-core/pull/58601)
- [x] [include-what-you-use.rb](https://github.com/Homebrew/homebrew-core/pull/58586)
- [x] [john-jumbo.rb](https://github.com/Homebrew/homebrew-core/pull/58583)
- [x] [komposition.rb](https://github.com/Homebrew/homebrew-core/pull/58602)
- [x] [libcapn.rb](https://github.com/Homebrew/homebrew-core/pull/58639)
- [x] [mtr.rb](https://github.com/Homebrew/homebrew-core/pull/58580)
- [x] [nyancat.rb](https://github.com/Homebrew/homebrew-core/pull/58603)
- [x] [ooniprobe.rb](https://github.com/Homebrew/homebrew-core/pull/58604)
- [x] [pacvim.rb](https://github.com/Homebrew/linuxbrew-core/pull/20804)
- [x] [prodigal.rb](https://github.com/Homebrew/linuxbrew-core/pull/20803)
- [x] [pinentry-mac.rb](https://github.com/Homebrew/homebrew-core/pull/58605)
- [x] [scalapack.rb](https://github.com/Homebrew/homebrew-core/pull/58582)
- [x] [shellinabox.rb](https://github.com/Homebrew/homebrew-core/pull/58592)
- [x] [squashfs.rb](https://github.com/Homebrew/homebrew-core/pull/58682)
- [x] [telegram-cli.rb](https://github.com/Homebrew/homebrew-core/pull/58596)
- [x] [terraformer.rb](https://github.com/Homebrew/homebrew-core/pull/58607)
- [x] [tfenv.rb](https://github.com/Homebrew/homebrew-core/pull/58681)