### PR TITLE
curl: alert on 301 redirect

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -127,6 +127,8 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
     return "The URL #{url} is not reachable"
   end
 
+  return "#{url} permanently redirects to #{details[:permanent_redirect]}" if url != details[:permanent_redirect]
+
   unless http_status_ok?(details[:status])
     return "The URL #{url} is not reachable (HTTP status code #{details[:status]})"
   end
@@ -203,20 +205,23 @@ def curl_http_content_headers_and_checksum(url, hash_needed: false, user_agent: 
     status_code = headers[%r{HTTP/.* (\d+)}, 1]
     location = headers[/^Location:\s*(.*)$/i, 1]
     final_url = location.chomp if location
+    permanent_redirect = location.chomp if status_code == "301"
   end
 
   output_hash = Digest::SHA256.file(file.path) if hash_needed
 
   final_url ||= url
+  permanent_redirect ||= url
 
   {
-    url:            url,
-    final_url:      final_url,
-    status:         status_code,
-    etag:           headers[%r{ETag: ([wW]/)?"(([^"]|\\")*)"}, 2],
-    content_length: headers[/Content-Length: (\d+)/, 1],
-    file_hash:      output_hash,
-    file:           output,
+    url:                url,
+    final_url:          final_url,
+    permanent_redirect: permanent_redirect,
+    status:             status_code,
+    etag:               headers[%r{ETag: ([wW]/)?"(([^"]|\\")*)"}, 2],
+    content_length:     headers[/Content-Length: (\d+)/, 1],
+    file_hash:          output_hash,
+    file:               output,
   }
 ensure
   file.unlink


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
There are situations where a URL within a formula permanently redirects to a new URL. In that case, we want to alert the user so the formula can be updated. Example output:
```
$ brew audit --online eject
eject:
  * https://github.com/Raizlabs/Eject permanently redirects to https://github.com/Rightpoint/Eject
  * Stable: https://github.com/Raizlabs/Eject/archive/0.1.27.tar.gz permanently redirects to https://github.com/Rightpoint/Eject/archive/0.1.27.tar.gz
Error: 2 problems in 1 formula detected
```