### PR TITLE
bump-formula-pr: fix when no 'version' stanza in formula found

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -276,10 +276,15 @@ module Homebrew
           /^( +)(mirror "#{Regexp.escape(new_mirrors.last)}"\n)/m,
           "\\1\\2\\1version \"#{new_version}\"\n",
         ]
-      else
+      elsif new_url
         [
           /^( +)(url "#{Regexp.escape(new_url)}"\n)/m,
           "\\1\\2\\1version \"#{new_version}\"\n",
+        ]
+      elsif new_revision
+        [
+          /^( {2})( +)(:revision => "#{new_revision}"\n)/m,
+          "\\1\\2\\3\\1version \"#{new_version}\"\n",
         ]
       end
     elsif forced_version && new_version == "0"
@@ -288,7 +293,7 @@ module Homebrew
         "",
       ]
     end
-    new_contents = inreplace_pairs(formula.path, replacement_pairs.uniq)
+    new_contents = inreplace_pairs(formula.path, replacement_pairs.uniq.compact)
 
     new_formula_version = formula_version(formula, requested_spec, new_contents)
 


### PR DESCRIPTION
Without this fix, a command like:

    brew bump-formula-pr --version=0.3.3 --tag=v0.3.3 --revision=... test-formula-git-revision

will fail because:

```
Error: no implicit conversion of nil into String
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:281:in `escape'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:281:in `bump_formula_pr'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:111:in `<main>'
```

Additionally, reject all `nil` replacement pairs by calling `compact` method.


- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----