### PR TITLE
bintray: Fix "uninitialized constant EnvConfig" errors

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -25,8 +25,8 @@ class Bintray
     args = extra_curl_args
 
     if auth
-      raise UsageError, "HOMEBREW_BINTRAY_USER is unset." unless (user = EnvConfig.bintray_user)
-      raise UsageError, "HOMEBREW_BINTRAY_KEY is unset." unless (key = EnvConfig.bintray_key)
+      raise UsageError, "HOMEBREW_BINTRAY_USER is unset." unless (user = Homebrew::EnvConfig.bintray_user)
+      raise UsageError, "HOMEBREW_BINTRAY_KEY is unset." unless (key = Homebrew::EnvConfig.bintray_key)
 
       args += ["--user", "#{user}:#{key}"]
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- This fix was suggested by Sorbet when I ran `HOMEBREW_SORBET=1 bundle exec srb tc` on the latest `master` while playing around with the latest changes post-GSoC meeting.
- Then I noticed it was actually a bug, introduced in adc36a05ffeadb54b94c87d86f62fba9dbb86795, found by us not being able to publish bottles for [this build of the `n` formula](https://github.com/Homebrew/homebrew-core/runs/910309641?check_suite_focus=true) in https://github.com/Homebrew/homebrew-core/pull/58606:

```
[master 31d32307bd] n: update 6.7.0 bottle.
 1 file changed, 3 insertions(+), 3 deletions(-)
curl: (22) The requested URL returned error: 404 Not Found
Error: uninitialized constant Bintray::EnvConfig
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:28:in `open_api'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:43:in `upload'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:186:in `block (2 levels) in upload_bottle_json'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:158:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:158:in `block in upload_bottle_json'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:153:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/bintray.rb:153:in `upload_bottle_json'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-upload.rb:54:in `pr_upload'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:111:in `<main>'
Error: Failure while executing; `/home/linuxbrew/.linuxbrew/bin/brew pr-upload --verbose --bintray-org=homebrew` exited with 1.
```

- I confirmed the fix works with `brew irb`:

```
irb(main):001:0> EnvConfig.bintray_user
Traceback (most recent call last):
        2: from /usr/local/Homebrew/Library/Homebrew/brew.rb:111:in `<main>'
        1: from (irb):1
NameError (uninitialized constant EnvConfig)
irb(main):002:0> Homebrew::EnvConfig.bintray_user
=> "issyl0"
```