### PR TITLE
increase readall test timeout

### DIFF
--- a/Library/Homebrew/test/cmd/readall_spec.rb
+++ b/Library/Homebrew/test/cmd/readall_spec.rb
@@ -6,7 +6,7 @@ describe "Homebrew.readall_args" do
   it_behaves_like "parseable arguments"
 end
 
-describe "brew readall", :integration_test, timeout: 180 do
+describe "brew readall", :integration_test, timeout: 240 do
   it "imports all Formulae for a given Tap" do
     formula_file = setup_test_formula "testball"
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
The `brew readall --aliases --syntax` test can take longer than the 180 second timeout it's given. Locally it took around 210 seconds. Increasing the timeout to 240 seconds to avoid false negative tests.