### PR TITLE
Remove `--force` from `global_options`.

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -34,7 +34,6 @@ module Homebrew
           quiet:   [["-q", "--quiet"], :quiet, "Suppress any warnings."],
           verbose: [["-v", "--verbose"], :verbose, "Make some output more verbose."],
           debug:   [["-d", "--debug"], :debug, "Display any debugging information."],
-          force:   [["-f", "--force"], :force, "Override warnings and enable potentially unsafe operations."],
         }
       end
 

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -21,7 +21,7 @@ module Homebrew
              description: "Fetch HEAD version instead of stable version."
       switch "--devel",
              description: "Fetch development version instead of stable version."
-      switch :force,
+      switch "-f", "--force",
              description: "Remove a previously cached version and re-fetch."
       switch :verbose,
              description: "Do a verbose VCS checkout, if the URL represents a VCS. This is useful for "\

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -71,7 +71,7 @@ module Homebrew
              depends_on:  "--build-bottle",
              description: "Optimise bottles for the specified architecture rather than the oldest "\
                           "architecture supported by the version of macOS the bottles are built on."
-      switch :force,
+      switch "-f", "--force",
              description: "Install without checking for previously installed keg-only or "\
                           "non-migrated versions."
       switch :verbose,

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -21,7 +21,7 @@ module Homebrew
       switch "-n", "--dry-run",
              description: "List files which would be linked or deleted by "\
                           "`brew link --overwrite` without actually linking or deleting any files."
-      switch :force,
+      switch "-f", "--force",
              description: "Allow keg-only formulae to be linked."
       switch :verbose
       switch :debug

--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -14,7 +14,7 @@ module Homebrew
         Migrate renamed packages to new names, where <formula> are old names of
         packages.
       EOS
-      switch :force,
+      switch "-f", "--force",
              description: "Treat installed <formula> and provided <formula> as if they are from "\
                           "the same taps and migrate them anyway."
       switch :verbose

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -14,7 +14,6 @@ module Homebrew
 
         Rerun the post-install steps for <formula>.
       EOS
-      switch :force
       switch :verbose
       switch :debug
       min_named :keg
@@ -27,7 +26,6 @@ module Homebrew
     args.resolved_formulae.each do |f|
       ohai "Postinstalling #{f}"
       fi = FormulaInstaller.new(f)
-      fi.force = args.force?
       fi.post_install
     end
   end

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -39,7 +39,7 @@ module Homebrew
                           "macOS, even if it would not normally be used for installation."
       switch "--keep-tmp",
              description: "Retain the temporary files created during installation."
-      switch :force,
+      switch "-f", "--force",
              description: "Install without checking for previously installed keg-only or "\
                           "non-migrated versions."
       switch :verbose,

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -19,7 +19,7 @@ module Homebrew
 
         Uninstall <formula>.
       EOS
-      switch :force,
+      switch "-f", "--force",
              description: "Delete all installed versions of <formula>."
       switch "--ignore-dependencies",
              description: "Don't fail uninstall, even if <formula> is a dependency of any installed "\

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -27,7 +27,9 @@ module Homebrew
       EOS
       switch "--preinstall",
              description: "Run in 'auto-update' mode (faster, less output)."
-      switch :force
+      switch "-f", "--force",
+             description: "Treat installed and updated formulae as if they are from "\
+                          "the same taps and migrate them anyway."
       switch :quiet
       switch :verbose
       switch :debug

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -43,7 +43,7 @@ module Homebrew
              description: "Set a successful exit status even if pinned formulae are not upgraded."
       switch "--keep-tmp",
              description: "Retain the temporary files created during installation."
-      switch :force,
+      switch "-f", "--force",
              description: "Install without checking for previously installed keg-only or "\
                           "non-migrated versions."
       switch :verbose,

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -62,7 +62,8 @@ module Homebrew
       flag   "--revision=",
              depends_on:  "--tag=",
              description: "Specify the new git commit <revision> corresponding to the specified <tag>."
-      switch :force
+      switch "-f", "--force",
+             description: "Ignore duplicate open PRs. Remove all mirrors if --mirror= was not specified."
       switch :quiet
       switch :verbose
       switch :debug

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -18,7 +18,6 @@ module Homebrew
              description: "Print what would be done rather than doing it."
       flag   "--message=",
              description: "Append <message> to the default commit message."
-      switch :force
       switch :quiet
       switch :verbose
       switch :debug
@@ -27,7 +26,7 @@ module Homebrew
   end
 
   def bump_revision
-    bump_revision_args.parse
+    args = bump_revision_args.parse
 
     # As this command is simplifying user-run commands then let's just use a
     # user path, too.

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -53,7 +53,8 @@ module Homebrew
              description: "Explicitly set the <license> of the new formula."
       flag   "--tap=",
              description: "Generate the new formula within the given tap, specified as <user>`/`<repo>."
-      switch :force
+      switch "-f", "--force",
+             description: "Ignore errors for disallowed formula names and named that shadow aliases."
       switch :verbose
       switch :debug
       conflicts "--autotools", "--cmake", "--crystal", "--go", "--meson", "--node", "--perl", "--python", "--rust"

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -89,7 +89,8 @@ module Homebrew
       EOS
       flag   "--version=",
              description: "Extract the specified <version> of <formula> instead of the most recent."
-      switch :force
+      switch "-f", "--force",
+             description: "Overwrite the destination formula if it already exists."
       switch :debug
       named 2
     end

--- a/Library/Homebrew/dev-cmd/unpack.rb
+++ b/Library/Homebrew/dev-cmd/unpack.rb
@@ -22,7 +22,8 @@ module Homebrew
       switch "-g", "--git",
              description: "Initialise a Git repository in the unpacked source. This is useful for creating "\
                           "patches for the software."
-      switch :force
+      switch "-f", "--force",
+             description: "Overwrite the destination directory if it already exists."
       switch :verbose
       switch :debug
       conflicts "--git", "--patch"

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -753,6 +753,8 @@ uses.
   Specify the new git commit *`tag`* for the formula.
 * `--revision`:
   Specify the new git commit *`revision`* corresponding to the specified *`tag`*.
+* `-f`, `--force`:
+  Ignore duplicate open PRs. Remove all mirrors if --mirror= was not specified.
 
 ### `bump-revision` [*`options`*] *`formula`*
 
@@ -811,6 +813,8 @@ a simple example. For the complete API, see: <https://rubydoc.brew.sh/Formula>
   Explicitly set the *`license`* of the new formula.
 * `--tap`:
   Generate the new formula within the given tap, specified as *`user`*`/`*`repo`*.
+* `-f`, `--force`:
+  Ignore errors for disallowed formula names and named that shadow aliases.
 
 ### `diy` [*`options`*]
 
@@ -838,6 +842,8 @@ formula from a tap that is not `homebrew/core` use its fully-qualified form of
 
 * `--version`:
   Extract the specified *`version`* of *`formula`* instead of the most recent.
+* `-f`, `--force`:
+  Overwrite the destination formula if it already exists.
 
 ### `formula` *`formula`*
 
@@ -1057,6 +1063,8 @@ directory.
   Patches for *`formula`* will be applied to the unpacked source.
 * `-g`, `--git`:
   Initialise a Git repository in the unpacked source. This is useful for creating patches for the software.
+* `-f`, `--force`:
+  Overwrite the destination directory if it already exists.
 
 ### `update-license-data` [*`options`*]
 
@@ -1097,9 +1105,6 @@ These options are applicable across multiple subcommands.
 
 * `-d`, `--debug`:
   Display any debugging information.
-
-* `-f`, `--force`:
-  Override warnings and enable potentially unsafe operations.
 
 ## OFFICIAL EXTERNAL COMMANDS
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -993,6 +993,10 @@ Specify the new git commit \fItag\fR for the formula\.
 \fB\-\-revision\fR
 Specify the new git commit \fIrevision\fR corresponding to the specified \fItag\fR\.
 .
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Ignore duplicate open PRs\. Remove all mirrors if \-\-mirror= was not specified\.
+.
 .SS "\fBbump\-revision\fR [\fIoptions\fR] \fIformula\fR"
 Create a commit to increment the revision of \fIformula\fR\. If no revision is present, "revision 1" will be added\.
 .
@@ -1077,6 +1081,10 @@ Explicitly set the \fIlicense\fR of the new formula\.
 \fB\-\-tap\fR
 Generate the new formula within the given tap, specified as \fIuser\fR\fB/\fR\fIrepo\fR\.
 .
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Ignore errors for disallowed formula names and named that shadow aliases\.
+.
 .SS "\fBdiy\fR [\fIoptions\fR]"
 Automatically determine the installation prefix for non\-Homebrew software\. Using the output from this command, you can install your own software into the Cellar and then link it into Homebrew\'s prefix with \fBbrew link\fR\.
 .
@@ -1097,6 +1105,10 @@ Look through repository history to find the most recent version of \fIformula\fR
 .TP
 \fB\-\-version\fR
 Extract the specified \fIversion\fR of \fIformula\fR instead of the most recent\.
+.
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Overwrite the destination formula if it already exists\.
 .
 .SS "\fBformula\fR \fIformula\fR"
 Display the path where \fIformula\fR is located\.
@@ -1377,6 +1389,10 @@ Patches for \fIformula\fR will be applied to the unpacked source\.
 \fB\-g\fR, \fB\-\-git\fR
 Initialise a Git repository in the unpacked source\. This is useful for creating patches for the software\.
 .
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Overwrite the destination directory if it already exists\.
+.
 .SS "\fBupdate\-license\-data\fR [\fIoptions\fR]"
 Update SPDX license data in the Homebrew repository\.
 .
@@ -1424,10 +1440,6 @@ Make some output more verbose\.
 .TP
 \fB\-d\fR, \fB\-\-debug\fR
 Display any debugging information\.
-.
-.TP
-\fB\-f\fR, \fB\-\-force\fR
-Override warnings and enable potentially unsafe operations\.
 .
 .SH "OFFICIAL EXTERNAL COMMANDS"
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Added descriptions for all commands supporting the `--force` flags and removed it from commands that don't use it.