### PR TITLE
Add link to Homebrew Blog in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 See Homebrew's [releases on GitHub](https://github.com/Homebrew/brew/releases) for the changelog.
+
+Release notes for major and minor releases can also be found in the [Homebrew blog](https://brew.sh/blog/).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is in response to #8096.

I think it's worth adding a link to the [Homebrew blog](https://brew.sh/blog/) in CHANGELOG.md, as that's where people go to find a list of changes. The information on the GitHub releases page is helpful if you're trying to find a specific change, but it's a little too verbose for what some users may need. The blog, on the other hand, has a more readable summary of the major changes for each major/minor release.

While I agree that we took appropriate action in regards to removing the `prune` command (as described in https://github.com/Homebrew/brew/issues/8096#issuecomment-664075006), the author of #8096 raises a valid point that it's not super easy to find older changes. A blog is not where I (or, I think, many users) would think to look for release notes, so adding a link to the changelog should at least bring it to their attention.