### PR TITLE
README.md: Add link to Homebrew blog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 ## Users
 
 - [`brew` man-page (command documentation)](Manpage.md)
+- [Homebrew Blog (news on major updates)](https://brew.sh/blog/)
 - [Troubleshooting](Troubleshooting.md)
 - [Installation](Installation.md)
 - [Frequently Asked Questions](FAQ.md)


### PR DESCRIPTION
Inspired by https://github.com/Homebrew/brew/issues/8096 and https://github.com/Homebrew/brew/pull/8098. I think the blog is an important way for regular users to keep up-to-date with Homebrew evolution, so it deserves an entry in the main docs page.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
