### PR TITLE
workflows/tests: run brew test-bot --only-formulae.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,12 +181,12 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: docker build -t brew --build-arg=version=16.04 .
 
-    - name: Run brew test-bot
+    - name: Run brew test-bot --only-formulae --test-default-formula
       run: |
         if [ "$RUNNER_OS" = "Linux" ]; then
-          docker run --rm brew brew test-bot
+          docker run --rm brew brew test-bot --only-formulae --test-default-formula
         else
-          brew test-bot
+          brew test-bot --only-formulae --test-default-formula
         fi
 
     - name: Deploy the Docker image to GitHub and Docker Hub


### PR DESCRIPTION
This will avoid some duplicate steps already run by this workflow while continuing to provide an integration test of the formula testing formula.

Not sure if I want this as-is but opening a PR to compare speed difference vs. having a more thorough integration test.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----