### PR TITLE
dev-cmd/bump-formula-pr.rb: fix StringInreplaceExtension usage

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -445,8 +445,8 @@ module Homebrew
 
   def inreplace_pairs(path, replacement_pairs)
     if args.dry_run?
-      contents = path.open("r") { |f| Formulary.ensure_utf8_encoding(f).read }
-      contents.extend(StringInreplaceExtension)
+      str = path.open("r") { |f| Formulary.ensure_utf8_encoding(f).read }
+      contents = StringInreplaceExtension.new(str)
       replacement_pairs.each do |old, new|
         ohai "replace #{old.inspect} with #{new.inspect}" unless args.quiet?
         raise "No old value for new value #{new}! Did you pass the wrong arguments?" unless old
@@ -455,8 +455,8 @@ module Homebrew
       end
       raise Utils::InreplaceError, path => contents.errors unless contents.errors.empty?
 
-      path.atomic_write(contents) if args.write?
-      contents
+      path.atomic_write(contents.inreplace_string) if args.write?
+      contents.inreplace_string
     else
       Utils::Inreplace.inreplace(path) do |s|
         replacement_pairs.each do |old, new|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
We missed one occurrence of the old behaviour of `StringInreplaceExtension` , in `--dry-run` of `brew bump-formula-pr`:

```
$ brew bump-formula-pr torsocks --tag v2.4.0 --revision cec4a733c081e09fb34f0aa4224ffd7b687fb310 -n -w --force
Error: wrong argument type Class (expected Module)
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:449:in `extend'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:449:in `inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:296:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:111:in `<main>'
```

This PR fixes the above usage of `StringInreplaceExtension`