### PR TITLE
Fix uninitialized constant Cask::Pkg

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -4,6 +4,7 @@ require "timeout"
 
 require "utils/user"
 require "cask/artifact/abstract_artifact"
+require "cask/pkg"
 require "extend/hash_validator"
 using HashValidator
 


### PR DESCRIPTION
Running `brew upgrade`, I had a error:

```
==> Uninstalling packages:
==> Purging files for version 2.2.9 of Cask vagrant
Error: uninitialized constant Cask::Pkg
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:304:in `block in uninstall_pkgutil'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:303:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:303:in `uninstall_pkgutil'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:68:in `dispatch_uninstall_directive'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/uninstall.rb:11:in `block in uninstall_phase'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/uninstall.rb:10:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/uninstall.rb:10:in `uninstall_phase'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:459:in `block in uninstall_artifacts'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/set.rb:777:in `each'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/set.rb:777:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:455:in `uninstall_artifacts'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:416:in `start_upgrade'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb:94:in `upgrade_cask'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb:48:in `block in run'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb:47:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/upgrade.rb:47:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:135:in `upgrade_outdated_casks'
/usr/local/Homebrew/Library/Homebrew/cmd/upgrade.rb:69:in `upgrade'
/usr/local/Homebrew/Library/Homebrew/brew.rb:111:in `<main>'
```

I had to manually add the require for it to work.