### PR TITLE
formulary: accept formula renames in tap_migrations.json

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -254,7 +254,8 @@ module Formulary
           name = new_name
           new_name = @tap.core_tap? ? name : "#{@tap}/#{name}"
         elsif (new_tap_name = @tap.tap_migrations[name])
-          new_tap_user, new_tap_repo, = new_tap_name.split("/")
+          new_tap_user, new_tap_repo, new_formula_name = new_tap_name.split("/")
+          name = new_formula_name if new_formula_name
           new_tap_name = "#{new_tap_user}/#{new_tap_repo}"
           new_tap = Tap.fetch new_tap_name
           new_tap.install unless new_tap.installed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Example `tap_migrations.json` in repository named `example/homebrew-tap`:

```json
{
  "rcc": "homebrew/core/saltwater"
}
```

`brew install example/tap/rcc` without this patch:

```console
$ brew install example/tap/rcc
Warning: Use rcc instead of deprecated example/tap/rcc
Warning: Use rcc instead of deprecated example/tap/rcc
Error: No available formula with the name "homebrew/core/rcc" 
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
```

With this patch:

```console
$ brew install example/tap/rcc
Warning: Use saltwater instead of deprecated example/tap/rcc
Warning: Use saltwater instead of deprecated example/tap/rcc
==> Downloading https://homebrew.bintray.com/bottles/saltwater-0.11.0.catalina.bottle.tar.gz
==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/750182bb83130c00ce6a9ea828261aed154c5c9914a1965172575be861985
######################################################################## 100.0%
==> Pouring saltwater-0.11.0.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/saltwater/0.11.0: 8 files, 3.4MB
```

This matches with the existing format for formulae that have migrated from `homebrew/core` to `homebrew/cask`. For example:

```json
  "schismtracker": "homebrew/cask/schism-tracker",
  "transmission-remote-gtk": "homebrew/cask/transmission-remote-gui",
```

https://github.com/Homebrew/homebrew-core/blob/master/tap_migrations.json#L29-L30