### PR TITLE
upgrade: avoid upgrading unrequested casks

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -64,9 +64,14 @@ module Homebrew
     args = upgrade_args.parse
 
     formulae, casks = args.resolved_formulae_casks
+    # If one or more formulae are specified, but no casks were
+    # specified, we want to make note of that so we don't
+    # try to upgrade all outdated casks.
+    named_formulae_specified = !formulae.empty? && casks.empty?
+    named_casks_specified = !casks.empty? && formulae.empty?
 
-    upgrade_outdated_formulae(formulae)
-    upgrade_outdated_casks(casks)
+    upgrade_outdated_formulae(formulae) unless named_casks_specified
+    upgrade_outdated_casks(casks) unless named_formulae_specified
   end
 
   def upgrade_outdated_formulae(formulae)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #8107.

In that issue, I noticed that running `brew upgrade` with named formulae will now try to upgrade all outdated casks. This is a regression from the old behaviour, where naming things on the commandline ensures that we only upgrade those requested items.

After some investigation, I determined this was introduced in 210d22e8199f2482b28f550838a33cca47380ce4. It turns out that `upgrade_outdated_casks`, if passed an empty array, will try to upgrade all outdated casks. That's the correct behaviour if no formulae are named either, but the wrong behaviour if at least one formula was named.

This PR fixes that by checking to see if any formulae were named; if at least one formula was named, but no casks were named, we skip the call to `upgrade_outdated_casks`.

cc @whoiswillma 