### PR TITLE
pr-upload: fix for non-homebrew-core taps

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -39,7 +39,7 @@ module Homebrew
 
     hashes.each do |name, hash|
       formula_path = HOMEBREW_REPOSITORY/hash["formula"]["path"]
-      formula_version = Formulary::FormulaLoader.new(name, formula_path).get_formula("stable").version
+      formula_version = Formulary.factory(formula_path).version
       bottle_version = Version.new hash["formula"]["pkg_version"]
       next if formula_version == bottle_version
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before:

```console
$ brew pr-upload --bintray-org=seeker --root-url=https://dl.bintray.com/seeker/bottles-languages
Error: No available formula with the name "seekingmeaning/languages/qbe" 
In formula file: /usr/local/Homebrew/Library/Taps/seekingmeaning/homebrew-languages/Formula/qbe.rb
Expected to find class Seekingmeaning/languages/qbe, but only found: Qbe.
```

After:

```console
$ brew pr-upload --bintray-org=seeker --root-url=https://dl.bintray.com/seeker/bottles-languages
==> seekingmeaning/languages/qbe
  bottle do
    root_url "https://dl.bintray.com/seeker/bottles-languages"
    cellar :any_skip_relocation
    sha256 "988f3c35fd0815a37069f9acc300dd2db302a49df9635c0c9a9e9383e2eb3779" => :catalina
    sha256 "63da44d545ab2ad20cd50412558842830de3bdb33f7d723ca8016c049df012c0" => :x86_64_linux
  end
[develop d4ebc2f] qbe: add 2019-11-25 bottle.
 1 file changed, 7 insertions(+)
curl: (22) The requested URL returned error: 404 Not Found
######################################################################## 100.0%
{"message":"success"}curl: (22) The requested URL returned error: 404 Not Found
######################################################################## 100.0%
######################################################################## 100.0%                    
{"files":2}
```