### PR TITLE
pr-automerge: fix variable name

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -40,7 +40,7 @@ module Homebrew
     query = "is:pr is:open repo:#{tap.full_name}"
     query += Homebrew.args.ignore_failures? ? " -status:pending" : " status:success"
     query += " review:approved" unless Homebrew.args.without_approval?
-    query += " label:\"#{with_label}\"" if Homebrew.args.with_label
+    query += " label:\"#{args.with_label}\"" if Homebrew.args.with_label
     without_labels&.each { |label| query += " -label:\"#{label}\"" }
     odebug "Searching: #{query}"
 


### PR DESCRIPTION
This somehow slipped through PRs.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----