### PR TITLE
Fix brew test on Linux stdenv

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -10,7 +10,7 @@ module Stdenv
 
     return unless @formula
 
-    prepend_path "CPATH", formula.include
+    prepend_path "CPATH", @formula.include
     prepend_path "LIBRARY_PATH", @formula.lib
     prepend_path "LD_RUN_PATH", @formula.lib
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb). **No. I hope in this case that this is sufficiently self-explanatory.**
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Running `brew test hello` (amongst others) currently fails:

```
❯ brew test hello
Testing hello
Error: hello: failed
An exception occurred within a child process:
  NameError: undefined local variable or method `formula' for #<Object:0x000000000110f990>
Did you mean?  @formula
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/os/linux/extend/ENV/std.rb:13:in `setup_build_environment'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test.rb:31:in `<main>'
```

I'm guessing this was just an accidental omission [here](https://github.com/Homebrew/brew/pull/8112/files#diff-370a2647b3e88f8f31e832e26e4b133cR13) but I might be wrong.