### PR TITLE
dev-cmd/audit: enforce uses_from_macos only if core tap

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -388,7 +388,8 @@ module Homebrew
             "use the canonical name '#{dep.to_formula.full_name}'."
           end
 
-          if @new_formula &&
+          if @core_tap &&
+             @new_formula &&
              dep_f.keg_only? &&
              dep_f.keg_only_reason.provided_by_macos? &&
              dep_f.keg_only_reason.applicable? &&

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -343,7 +343,7 @@ module Homebrew
           subject { fa }
 
           let(:fa) do
-            formula_auditor "foo", <<~RUBY, new_formula: true
+            formula_auditor "foo", <<~RUBY, new_formula: true, core_tap: true
               class Foo < Formula
                 url "https://brew.sh/foo-1.0.tgz"
                 homepage "https://brew.sh"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows formulae in non-core taps to depend on e.g. Homebrew `llvm` without getting an audit failure.

Supersedes #8066