### PR TITLE
Modify StringToken::PATTERN to fix comparison

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -57,7 +57,7 @@ class Version
   NULL_TOKEN = NullToken.new.freeze
 
   class StringToken < Token
-    PATTERN = /[a-z]+[0-9]*/i.freeze
+    PATTERN = /[a-z]+/i.freeze
 
     def initialize(value)
       @value = value.to_s


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`StringToken`'s `PATTERN` regex (`/[a-z]+[0-9]*/i`) is consuming numeric parts of the version string that should probably be tokenized separately as a `NumericToken`. As a result, you can end up with incorrect version comparisons when part of the version string consists of letters with trailing numbers.

Taking Homebrew/homebrew-core#58711 as an example, `4.0ga10` is treated as older than `4.0ga9`. This is because `4.0ga10` is currently tokenized as follows:

```
[#<Version::NumericToken 4>,
 #<Version::NumericToken 0>,
 #<Version::StringToken "ga10">]
```

When `ga10` is compared to `ga9` (i.e., `"ga10" <=> "ga9"`), it's reported as being lower (`-1`). To address this, we can compare `ga` and `10`/`9` separately (as a `StringToken` and `NumericToken` respectively).

---

This PR removes the `[0-9]*` from `StringToken`'s `PATTERN` regex, which results in the aforementioned version being tokenized as follows:

```
[#<Version::NumericToken 4>,
 #<Version::NumericToken 0>,
 #<Version::StringToken "ga">,
 #<Version::NumericToken 10>]
```

This produces the comparison result that we would expect, where `4.0ga10` is treated as newer than `4.0ga9`.

I did a full `livecheck` run over the homebrew-core formulae with/without the change in this PR and the only difference was with `x3270`. At least from the perspective of `livecheck`, this change doesn't seem to result in any undesirable version comparison issues.

---

I've left this as a draft for the moment because I have a question about how we should be doing `StringToken` comparisons. It seems like we should treat `ga` and `GA` as the same, otherwise `4.0ga10` would be treated as newer than `4.0GA11`. To address this, we would seemingly need to modify `StringToken` comparisons to ignore case.

Is anyone aware of any situations where letter case is used to indicate something newer (e.g., cycling through lowercase a-z before proceeding to uppercase A-Z)? Once we've decided how to proceed in this area, I'll add some additional tests and mark this as ready for review.