### PR TITLE
Revert "style: don't allow PR/MR urls for patches"

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -38,15 +38,6 @@ module RuboCop
 
         def patch_problems(patch)
           patch_url = string_content(patch)
-
-          if regex_match_group(patch, %r{https://github.com/[^/]*/[^/]*/pull})
-            problem "Use a commit hash URL rather than an unstable pull request URL: #{patch_url}"
-          end
-
-          if regex_match_group(patch, %r{.*gitlab.*/merge_request.*})
-            problem "Use a commit hash URL rather than an unstable merge request URL: #{patch_url}"
-          end
-
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch, gh_patch_param_pattern)
             unless patch_url.match?(/\?full_index=\w+$/)
@@ -73,8 +64,13 @@ module RuboCop
 
           gh_patch_diff_pattern =
             %r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)}
-          if regex_match_group(patch, gh_patch_diff_pattern)
-            problem "Use a commit hash URL rather than patch-diff: #{patch_url}"
+          if match_obj = regex_match_group(patch, gh_patch_diff_pattern)
+            problem <<~EOS
+              use GitHub pull request URLs:
+                https://github.com/#{match_obj[1]}/#{match_obj[2]}/pull/#{match_obj[3]}.patch?full_index=1
+              Rather than patch-diff:
+                #{patch_url}
+            EOS
           end
 
           if regex_match_group(patch, %r{macports/trunk})

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         "http://trac.macports.org/export/102865/trunk/dports/mail/uudeview/files/inews.c.patch",
         "http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-libunac1.txt;att=1;bug=623340",
         "https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch",
-        "https://github.com/dlang/dub/commit/2c916b1a7999a050ac4970c3415ff8f91cd487aa.patch",
+        "https://github.com/dlang/dub/pull/1221.patch",
       ]
       patch_urls.each do |patch_url|
         source = <<~EOS
@@ -91,7 +91,13 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Layout/LineLength
-          [{ message:  "Use a commit hash URL rather than patch-diff: #{patch_url}",
+          [{ message:
+                       <<~EOS,
+                         use GitHub pull request URLs:
+                           https://github.com/foo/foo-bar/pull/100.patch?full_index=1
+                         Rather than patch-diff:
+                           https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch
+                       EOS
              severity: :convention,
              line:     5,
              column:   5,
@@ -212,8 +218,6 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         "http://trac.macports.org/export/102865/trunk/dports/mail/uudeview/files/inews.c.patch",
         "http://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=patch-libunac1.txt;att=1;bug=623340",
         "https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch",
-        "https://github.com/uber/h3/pull/362.patch?full_index=1",
-        "https://gitlab.gnome.org/GNOME/gitg/-/merge_requests/142.diff",
       ]
       patch_urls.each do |patch_url|
         source = <<~RUBY
@@ -268,22 +272,16 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              line:     5,
              column:   9,
              source:   source }]
-        elsif patch_url.match?(%r{https://github.com/[^/]*/[^/]*/pull})
-          [{ message:  "Use a commit hash URL rather than an unstable pull request URL: #{patch_url}",
-             severity: :convention,
-             line:     5,
-             column:   9,
-             source:   source }]
-        elsif patch_url.match?(%r{.*gitlab.*/merge_request.*})
-          [{ message:  "Use a commit hash URL rather than an unstable merge request URL: #{patch_url}",
-             severity: :convention,
-             line:     5,
-             column:   9,
-             source:   source }]
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Layout/LineLength
-          [{ message:  "Use a commit hash URL rather than patch-diff: #{patch_url}",
+          [{ message:
+                       <<~EOS,
+                         use GitHub pull request URLs:
+                           https://github.com/foo/foo-bar/pull/100.patch?full_index=1
+                         Rather than patch-diff:
+                           https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch
+                       EOS
              severity: :convention,
              line:     5,
              column:   9,


### PR DESCRIPTION
This reverts commit 7a2483728c18e9cfb45e4b3f079687ec5a8e1503.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
