### PR TITLE
pr-upload: fix formula version

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -39,7 +39,7 @@ module Homebrew
 
     hashes.each do |name, hash|
       formula_path = HOMEBREW_REPOSITORY/hash["formula"]["path"]
-      formula_version = Formulary.factory(formula_path).version
+      formula_version = Formulary.factory(formula_path).pkg_version
       bottle_version = Version.new hash["formula"]["pkg_version"]
       next if formula_version == bottle_version
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/Homebrew/homebrew-core/runs/922157314?check_suite_focus=true

```
Error: Bottles are for spdlog 1.7.0_1 but formula is version 1.7.0!
```