### PR TITLE
bump-revision: fixes for new style and license dsl

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -42,9 +42,14 @@ module Homebrew
       end
 
       old = if formula.license
+        license_string = if formula.license.length > 1
+          formula.license
+        else
+          "\"#{formula.license.first}\""
+        end
         # insert replacement revision after license
         <<~EOS
-          license "#{formula.license}"
+          license #{license_string}
         EOS
       elsif formula.path.read.include?("stable do\n")
         # insert replacement revision after homepage

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -64,7 +64,7 @@ module Homebrew
       else
         # insert replacement revision after :revision
         <<~EOS
-          :revision => "#{formula_spec.specs[:revision]}"
+          revision: "#{formula_spec.specs[:revision]}"
         EOS
       end
       replacement = old + "  revision 1\n"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

After #7953, `formula.license` returns an array even when only one license is specified. This PR adds logic to check whether there is more than one license and formats the `license` line appropriately.

Additionally, #7867 changed the style for `revision` from `:revision => "..."` to `revision: "..."`. This PR also handles that.