### PR TITLE
rubocop.yml: cask fixes for new style

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -181,7 +181,9 @@ Layout/LineLength:
   Max: 118
   # ignore manpage comments and long single-line strings
   IgnoredPatterns: ['#: ', ' url "', ' mirror "', ' plist_options ',
-                    ' appcast "', ' executable: "', '#{version.',
+                    ' appcast "', ' executable: "', ' font "', ' homepage "', ' name "',
+                    ' pkg "', ' pkgutil: "', '#{language}', '#{version.',
+                    ' "/Library/Application Support/', '"/Library/Caches/', '"/Library/PreferencePanes/',
                     ' "~/Library/Application Support/', '"~/Library/Caches/', '"~/Application Support',
                     ' was verified as official when first introduced to the cask']
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

There are a handful of casks in the `cask-versions`, `cask-drivers` and `cask-fonts` repositories that are failing because of   the `Line is too long` error in `brew cask style`.

I have added a few more cases to `IgnoredPatterns:` which should alleviate the vast majority of them (all but one, I think).

Ping @reitermarkus, @vitorgalvao, @ran-dall and @core-code.

Thank you.