### PR TITLE
dependencies: fix error in recursive_includes

### DIFF
--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -100,7 +100,7 @@ module DependenciesHelpers
         klass.prune if !includes.include?("optional?") && !dependent.build.with?(dep)
       elsif dep.build? || dep.test?
         keep = false
-        keep ||= dep.test? && includes.include?("test?") && dependent == formula
+        keep ||= dep.test? && includes.include?("test?") && dependent == root_dependent
         keep ||= dep.build? && includes.include?("build?")
         klass.prune unless keep
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

```
$ brew uses --include-build --include-test --recursive gettext
Error: Failed to import: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/diesel.rb
undefined local variable or method `formula' for Homebrew:Module
Error: Failed to import: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mutt.rb
undefined local variable or method `formula' for Homebrew:Module
Error: Failed to import: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/haxe.rb
undefined local variable or method `formula' for Homebrew:Module
```