### PR TITLE
uses: fix recursive dependency checking

### DIFF
--- a/Library/Homebrew/dependencies.rb
+++ b/Library/Homebrew/dependencies.rb
@@ -100,7 +100,7 @@ module DependenciesHelpers
         klass.prune if !includes.include?("optional?") && !dependent.build.with?(dep)
       elsif dep.build? || dep.test?
         keep = false
-        keep ||= dep.test? && includes.include?("test?") && dependent == formula
+        keep ||= dep.test? && includes.include?("test?") && dependent == root_dependent
         keep ||= dep.build? && includes.include?("build?")
         klass.prune unless keep
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

During #8126, `formula` was renamed `root_dependent` in [`recursive_includes`](https://github.com/Homebrew/brew/blob/8d97029b03d4054d7923c55827d28b6d4c3a351c/Library/Homebrew/dependencies.rb#L87-L116) but one instance was missed.

Before this change:

```
❯ brew uses --recursive --include-test php
Error: Failed to import: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/diesel.rb
undefined local variable or method `formula' for Homebrew:Module
Error: Failed to import: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mutt.rb
undefined local variable or method `formula' for Homebrew:Module
...
```

After this change:
```
❯ brew uses --recursive --include-test php
brew-php-switcher     deployer              easyengine            phplint               phpmyadmin            phpstan               phpunit
```

This applies when `--include-test` or `--include-build` are passed with `--recursive`