### PR TITLE
update-python-resources: add --no-cache-dir flag

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -53,11 +53,13 @@ module PyPI
     end
 
     ohai "Retrieving PyPI dependencies for \"#{pypi_name}==#{version}\"" if !print_only && !silent
-    pipgrip_output = Utils.popen_read Formula["pipgrip"].bin/"pipgrip", "--json", "#{pypi_name}==#{version}"
+    pipgrip_output = Utils.popen_read Formula["pipgrip"].bin/"pipgrip", "--json", "--no-cache-dir",
+                                      "#{pypi_name}==#{version}"
     unless $CHILD_STATUS.success?
       odie <<~EOS
         Unable to determine dependencies for \"#{pypi_name}\" because of a failure when running
-        `pipgrip --json #{pypi_name}==#{version}`. Please update the resources for \"#{formula.name}\" manually.
+        `pipgrip --json --no-cache-dir #{pypi_name}==#{version}`.
+        Please update the resources for \"#{formula.name}\" manually.
       EOS
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Add back `--no-cache-dir` to the `pipgrip` call in `update-python-resources`. We had removed it after `pipgrip` version 0.4.2 (https://github.com/Homebrew/brew/pull/8059#issuecomment-664122010) because we thought it was resolved, but a user experienced the `wheel` issue again in https://github.com/Homebrew/homebrew-core/pull/58856.

Adding `--no-cache-dir` solved the issue for that user, so we may as well add it back for all users so there are no issues.

CC: @jonchang