### PR TITLE
bump-formula-pr: handle pypi url version changes

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -183,11 +183,7 @@ module Homebrew
     elsif !new_url && !new_version
       odie "#{formula}: no --url= or --version= argument specified!"
     else
-      new_url ||= if old_url.start_with?(PyPI::PYTHONHOSTED_URL_PREFIX)
-        package_name = File.basename(old_url).match(/^(.+)-[a-z\d.]+$/)[1]
-        _, url = PyPI.get_pypi_info(package_name, new_version)
-        url
-      end
+      new_url ||= PyPI.update_pypi_url(old_url, new_version)
       new_url ||= old_url.gsub(old_version, new_version)
       if new_url == old_url
         odie <<~EOS

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -183,6 +183,11 @@ module Homebrew
     elsif !new_url && !new_version
       odie "#{formula}: no --url= or --version= argument specified!"
     else
+      new_url ||= if old_url.start_with?(PyPI::PYTHONHOSTED_URL_PREFIX)
+        package_name = File.basename(old_url).match(/^(.+)-[a-z\d.]+$/)[1]
+        _, url = PyPI.get_pypi_info(package_name, new_version)
+        url
+      end
       new_url ||= old_url.gsub(old_version, new_version)
       if new_url == old_url
         odie <<~EOS

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -7,6 +7,20 @@ module PyPI
 
   @pipgrip_installed = nil
 
+  def url_to_pypi_package_name(url)
+    return unless url.start_with? PYTHONHOSTED_URL_PREFIX
+
+    File.basename(url).match(/^(.+)-[a-z\d.]+$/)[1]
+  end
+
+  def update_pypi_url(url, version)
+    package = url_to_pypi_package_name url
+    return if package.nil?
+
+    _, url = get_pypi_info(package, version)
+    url
+  end
+
   # Get name, url, and version for a given pypi package
   def get_pypi_info(package, version)
     metadata_url = "https://pypi.org/pypi/#{package}/#{version}/json"
@@ -32,7 +46,7 @@ module PyPI
 
     # PyPI package name isn't always the same as the formula name. Try to infer from the URL.
     pypi_name = if formula.stable.url.start_with?(PYTHONHOSTED_URL_PREFIX)
-      File.basename(formula.stable.url).match(/^(.+)-[a-z\d.]+$/)[1]
+      url_to_pypi_package_name formula.stable.url
     else
       formula.name
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Remake of #8037

This allows `bump-formula-pr` to work with pypi urls.

Example: run `brew bump-formula-pr python-openstackclient --version 5.3.1`

Before this change:

```patch
-  url "https://files.pythonhosted.org/packages/44/5e/d0785bd787af5f37b7f0b69c2b36a731cf222163a474aeb1be109252f4a7/python-openstackclient-5.3.0.tar.gz"
+  url "https://files.pythonhosted.org/packages/44/5e/d0785bd787af5f37b7f0b69c2b36a731cf222163a474aeb1be109252f4a7/python-openstackclient-5.3.1.tar.gz"
```

After this change:

```patch
-  url "https://files.pythonhosted.org/packages/44/5e/d0785bd787af5f37b7f0b69c2b36a731cf222163a474aeb1be109252f4a7/python-openstackclient-5.3.0.tar.gz"
+  url "https://files.pythonhosted.org/packages/84/19/e2453fa06c4f481beda7a6c2326e65884cd1c623177d13c8efc7850bc05e/python-openstackclient-5.3.1.tar.gz"
```

The middle part of the url is now updated as well

---

We decided not to implement this before because it would encourage updating formulae without checking their resources. Now that `bump-formula-pr` automatically updates resources (#8059), this is no longer a concern.