### PR TITLE
Prepend cask name to cask upgrade error message

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -47,7 +47,7 @@ module Cask
         upgradable_casks.each do |(old_cask, new_cask)|
           upgrade_cask(old_cask, new_cask)
         rescue => e
-          caught_exceptions << e
+          caught_exceptions << e.exception("#{new_cask.full_name}: #{e}")
           next
         end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When upgrading casks all exceptions are aggregated and displayed at the end. When multiple casks are upgraded, this makes it sometimes not obvious which cask the exception belongs to.

Solution: prepend the cask name to the error message.

Before
```
Error: pkg source file not found: 'gfortran-6.3-Sierra/gfortran.pkg'
```

After
```
Error: gfortran 6.3: pkg source file not found: 'gfortran-6.3-Sierra/gfortran.pkg'
```

(In this example the original error message contains `gfortran`. However in some cases the error message does not contain reference to the cask being upgraded at all.)