### PR TITLE
cmd/uses: add --tree

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -594,6 +594,8 @@ formulae that use *`formula`*. By default, `uses` shows all formulae that specif
   Show usage of *`formula`* by development builds.
 * `--HEAD`:
   Show usage of *`formula`* by HEAD builds.
+* `--tree`:
+  Show dependents as a tree.
 
 ### `--cache` [*`options`*] [*`formula`*]
 

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "July 2020" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "August 2020" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "July 2020" "Homebrew" "brew"
+.TH "BREW" "1" "August 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -784,6 +784,10 @@ Show usage of \fIformula\fR by development builds\.
 .TP
 \fB\-\-HEAD\fR
 Show usage of \fIformula\fR by HEAD builds\.
+.
+.TP
+\fB\-\-tree\fR
+Show dependents as a tree\.
 .
 .SS "\fB\-\-cache\fR [\fIoptions\fR] [\fIformula\fR]"
 Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Note: Unlike `brew deps`, specifying multiple formulae with `brew uses` does not show the dependents of each formula. Instead, it shows the _intersection_ of dependents of all specified formulae.

### Example usage

Dependents of `libzip` (only one level down, similar to `brew deps --1`):

```console
$ brew uses libzip --tree
libzip
├── ebook-tools
...
├── mgba
├── openrct2
├── osrm-backend
├── php
├── php@7.2
...
└── ykneomgr
```

Recursive dependents of `libzip`:

```console
$ brew uses libzip --tree --recursive
libzip
├── ebook-tools
...
├── mgba
├── openrct2
├── osrm-backend
├── php
│   ├── deployer
│   ├── easyengine
│   └── phplint
├── php@7.2
...
└── ykneomgr
```

Dependents of `libepoxy`:

```console
$ brew uses libepoxy --tree
libepoxy
├── gtk+3
├── mgba
├── nestopia-ue
└── pytouhou
```

`libzip` and `libepoxy` share a common dependent, `mgba`:

```console
$ brew uses libzip libepoxy --tree
libepoxy
libzip
└── mgba
```

---

<sup><a href="https://gist.github.com/SeekingMeaning/bf129363b32dc232e4f47d526363b733">Wonder what `brew uses openssl@1.1 --tree --recursive` looks like?</a></sup>