### PR TITLE
Add strategy to livecheck DSL

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -15,6 +15,7 @@ class Livecheck
     @regex = nil
     @skip = false
     @skip_msg = nil
+    @strategy = nil
     @url = nil
   end
 
@@ -40,6 +41,22 @@ class Livecheck
     @skip
   end
 
+  # Sets the strategy instance variable to the provided symbol or returns the
+  # strategy instance variable when no argument is provided. The strategy
+  # symbols use snake case (e.g., `:page_match`) and correspond to the strategy
+  # file name.
+  # @param symbol [Symbol] symbol for the desired strategy
+  def strategy(symbol = nil)
+    case symbol
+    when nil
+      @strategy
+    when Symbol
+      @strategy = symbol
+    else
+      raise TypeError, "Livecheck#strategy expects a Symbol"
+    end
+  end
+
   # Sets the url instance variable to the argument given, returns the url
   # instance variable when no argument is given.
   def url(val = nil)
@@ -61,6 +78,7 @@ class Livecheck
       "regex"    => @regex,
       "skip"     => @skip,
       "skip_msg" => @skip_msg,
+      "strategy" => @strategy,
       "url"      => @url,
     }
   end

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -44,6 +44,23 @@ describe Livecheck do
     end
   end
 
+  describe "#strategy" do
+    it "returns nil if not set" do
+      expect(livecheckable.strategy).to be nil
+    end
+
+    it "returns the Symbol if set" do
+      livecheckable.strategy(:page_match)
+      expect(livecheckable.strategy).to eq(:page_match)
+    end
+
+    it "raises a TypeError if the argument isn't a Symbol" do
+      expect {
+        livecheckable.strategy("page_match")
+      }.to raise_error(TypeError, "Livecheck#strategy expects a Symbol")
+    end
+  end
+
   describe "#url" do
     it "returns nil if unset" do
       expect(livecheckable.url).to be nil
@@ -57,7 +74,15 @@ describe Livecheck do
 
   describe "#to_hash" do
     it "returns a Hash of all instance variables" do
-      expect(livecheckable.to_hash).to eq({ "regex"=>nil, "skip"=>false, "skip_msg"=>nil, "url"=>nil })
+      expect(livecheckable.to_hash).to eq(
+        {
+          "regex"    => nil,
+          "skip"     => false,
+          "skip_msg" => nil,
+          "strategy" => nil,
+          "url"      => nil,
+        },
+      )
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `strategy` feature was recently merged in Homebrew/homebrew-livecheck and this required me to extend the existing `livecheck` DSL in the process. This works for now but will become a problem for any formulae that use `strategy` in the `livecheck` block during/after the homebrew-core migration.

This PR takes care of adding `strategy` to `livecheck.rb` here, so we don't have to worry about it during the homebrew-core migration. Originally we were simply going to handle this during the Homebrew/brew migration but I had overlooked the fact that any formula with a `livecheck` block that uses `strategy` will encounter an error like `undefined method 'strategy' for #<Livecheck:0x00007f9cb280f600>`, which basically breaks the formula.

I've added a related test to `livecheck_spec.rb` and modified the existing `#to_hash` test in include `"strategy"`. Extending the `#to_hash` test led to the line becoming too long, so I modified it to resolve the issue. I decided on the format you see in this PR, as the following alternatives weren't as pleasant:

```ruby
expect(livecheckable.to_hash).to eq({
                                      "regex"    => nil,
                                      "skip"     => false,
                                      "skip_msg" => nil,
                                      "strategy" => nil,
                                      "url"      => nil,
                                    })
```

```ruby
expect(livecheckable.to_hash)
  .to eq({
           "regex"    => nil,
           "skip"     => false,
           "skip_msg" => nil,
           "strategy" => nil,
           "url"      => nil,
         })
```

Let me know if there's anything I've missed here or if changes are needed.