### PR TITLE
update-python-resources: handle no sdist for package

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -35,6 +35,8 @@ module PyPI
     end
 
     sdist = json["urls"].find { |url| url["packagetype"] == "sdist" }
+    return json["info"]["name"] if sdist.nil?
+
     [json["info"]["name"], sdist["url"], sdist["digests"]["sha256"]]
   end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -21,7 +21,7 @@ module PyPI
     url
   end
 
-  # Get name, url, and version for a given pypi package
+  # Get name, url and sha256 for a given pypi package
   def get_pypi_info(package, version)
     metadata_url = "https://pypi.org/pypi/#{package}/#{version}/json"
     out, _, status = curl_output metadata_url, "--location"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`update-python-resources` now has a nice error message if a package doesn't have an `sdist` url.

Before:

```
Error: Unable to resolve some dependencies. Please update the resources for "<formula>" manually.
```

After:

```
Error: Unable to find the URL and/or sha256 for the "<package>" resource.
Please update the resources for "<formula>" manually.
```

CC: @dtrodrigues