### PR TITLE
update-python-resources: add blocklist

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -5,6 +5,12 @@ module PyPI
 
   PYTHONHOSTED_URL_PREFIX = "https://files.pythonhosted.org/packages/"
 
+  AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST = %w[
+    diffoscope
+    dxpy
+    molecule
+  ].freeze
+
   @pipgrip_installed = nil
 
   def url_to_pypi_package_name(url)
@@ -40,6 +46,11 @@ module PyPI
 
   def update_python_resources!(formula, version = nil, print_only: false, silent: false,
                                ignore_non_pypi_packages: false)
+
+    if !print_only && AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST.include?(formula.name)
+      odie "The resources for \"#{formula.name}\" need special attention. Please update them manually."
+      return
+    end
 
     # PyPI package name isn't always the same as the formula name. Try to infer from the URL.
     pypi_name = if formula.stable.url.start_with?(PYTHONHOSTED_URL_PREFIX)

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -47,7 +47,7 @@ module PyPI
   def update_python_resources!(formula, version = nil, print_only: false, silent: false,
                                ignore_non_pypi_packages: false)
 
-    if !print_only && AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST.include?(formula.name)
+    if !print_only && AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST.include?(formula.full_name)
       odie "The resources for \"#{formula.name}\" need special attention. Please update them manually."
       return
     end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -8,6 +8,7 @@ module PyPI
   AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST = %w[
     ansible
     ansible@2.8
+    cloudformation-cli
     diffoscope
     dxpy
     molecule

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -6,6 +6,8 @@ module PyPI
   PYTHONHOSTED_URL_PREFIX = "https://files.pythonhosted.org/packages/"
 
   AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST = %w[
+    ansible
+    ansible@2.8
     diffoscope
     dxpy
     molecule


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Add a blocklist for formulae that can't use `update-python-resources` automatically.

I've populated the list with some that I've come across in the past few days, but I expect more will be added over time by other maintainers