### PR TITLE
bump-formula-pr: fix `missing keyword: args` error

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -510,7 +510,7 @@ module Homebrew
     end
     # if we haven't already found open requests, try for an exact match across all requests
     pull_requests = fetch_pull_requests("#{formula.name} #{version}", tap_full_name) if pull_requests.blank?
-    check_for_duplicate_pull_requests(pull_requests)
+    check_for_duplicate_pull_requests(pull_requests, args: args)
   end
 
   def check_for_duplicate_pull_requests(pull_requests, args:)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes error:

```
Error: missing keyword: args
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:516:in `check_for_duplicate_pull_requests'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:513:in `check_all_pull_requests'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:131:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:110:in `<main>'
```