### PR TITLE
extend/pathname: use absolute path to java in write_jar_script

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -374,8 +374,11 @@ class Pathname
 
   # Writes an exec script that invokes a Java jar
   def write_jar_script(target_jar, script_name, java_opts = "", java_version: nil)
-    (self/script_name).write_env_script "java", "#{java_opts} -jar \"#{target_jar}\"",
-                                        Language::Java.overridable_java_home_env(java_version)
+    (self/script_name).write <<~EOS
+      #!/bin/bash
+      export JAVA_HOME="#{Language::Java.overridable_java_home_env(java_version)[:JAVA_HOME]}"
+      exec "${JAVA_HOME}/bin/java" #{java_opts} -jar "#{target_jar}" "$@"
+    EOS
   end
 
   def install_metafiles(from = Pathname.pwd)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This fixes #8154. The solution is not as simple as replacing `java` with `${JAVA_HOME}/bin/java` because the brace expansion of `${JAVA_HOME}` will occur before `JAVA_HOME` is assigned a value. Thus, we have to explicitly `export JAVA_HOME`, or we could try something like `JAVA_HOME=...; exec "${JAVA_HOME}/bin/java" ...`. In any case, my point is that piggybacking off of `write_env_script` as it currently exists doesn't seem to be possible.

To be clear, this is really only an issue for Linux users. On macOS, `/usr/bin/java` is a stub that will execute the Java that `JAVA_HOME` points to, and `/usr/bin/java` should always be on `PATH`.

As always, I'm open to suggestions, especially on style, especially on that `export JAVA_HOME=...` Ruby glob. It's not looking too pretty.