### PR TITLE
bump-formula-pr: add args to check_all_pull_requests

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -128,7 +128,7 @@ module Homebrew
     check_open_pull_requests(formula, tap_full_name, args: args)
 
     new_version = args.version
-    check_all_pull_requests(formula, tap_full_name, version: new_version) if new_version
+    check_all_pull_requests(formula, tap_full_name, version: new_version, args: args) if new_version
 
     requested_spec = :stable
     formula_spec = formula.stable
@@ -159,10 +159,10 @@ module Homebrew
     old_version = old_formula_version.to_s
     forced_version = new_version.present?
     new_url_hash = if new_url && new_hash
-      check_all_pull_requests(formula, tap_full_name, url: new_url) unless new_version
+      check_all_pull_requests(formula, tap_full_name, url: new_url, args: args) unless new_version
       true
     elsif new_tag && new_revision
-      check_all_pull_requests(formula, tap_full_name, url: old_url, tag: new_tag) unless new_version
+      check_all_pull_requests(formula, tap_full_name, url: old_url, tag: new_tag, args: args) unless new_version
       false
     elsif !hash_type
       odie "#{formula}: no --tag= or --version= argument specified!" if !new_tag && !new_version
@@ -173,7 +173,7 @@ module Homebrew
           and old tag are both #{new_tag}.
         EOS
       end
-      check_all_pull_requests(formula, tap_full_name, url: old_url, tag: new_tag) unless new_version
+      check_all_pull_requests(formula, tap_full_name, url: old_url, tag: new_tag, args: args) unless new_version
       resource_path, forced_version = fetch_resource(formula, new_version, old_url, tag: new_tag)
       new_revision = Utils.popen_read("git -C \"#{resource_path}\" rev-parse -q --verify HEAD")
       new_revision = new_revision.strip
@@ -190,7 +190,7 @@ module Homebrew
             #{new_url}
         EOS
       end
-      check_all_pull_requests(formula, tap_full_name, url: new_url) unless new_version
+      check_all_pull_requests(formula, tap_full_name, url: new_url, args: args) unless new_version
       resource_path, forced_version = fetch_resource(formula, new_version, new_url)
       tar_file_extensions = %w[.tar .tb2 .tbz .tbz2 .tgz .tlz .txz .tZ]
       if tar_file_extensions.any? { |extension| new_url.include? extension }
@@ -502,7 +502,7 @@ module Homebrew
     check_for_duplicate_pull_requests(pull_requests, args: args)
   end
 
-  def check_all_pull_requests(formula, tap_full_name, version: nil, url: nil, tag: nil)
+  def check_all_pull_requests(formula, tap_full_name, version: nil, url: nil, tag: nil, args:)
     unless version
       specs = {}
       specs[:tag] = tag if tag


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #8144.

In #8144, the `args:` parameter was added to most methods in `bump-formula-pr`. `check_all_pull_requests` was missed, causing arguments to not be passed correctly.

## Example

### Setup

Checkout https://github.com/Homebrew/homebrew-core/commit/731f2b10fb01d715688f04f1cdc6c28adeb7f174

```console
$ cd $(brew --repository homebrew/core)
$ git checkout 731f2b10fb01d715688f04f1cdc6c28adeb7f174 && git switch -c test
```

### Before this PR

```console
$ brew bump-formula-pr -nwf dxpy --url https://files.pythonhosted.org/packages/27/0d/4849e89891e1dc49681018d203b736073919dd9933738d78487a70e341d8/dxpy-0.298.1.tar.gz
Error: These pull requests may be duplicates:
dxpy 0.298.1 https://github.com/Homebrew/homebrew-core/pull/58880
Duplicate PRs should not be opened. Use --force to override this error.
```

Even though `-f` was passed

### After this PR

```console
$ brew bump-formula-pr -nwf dxpy --url https://files.pythonhosted.org/packages/27/0d/4849e89891e1dc49681018d203b736073919dd9933738d78487a70e341d8/dxpy-0.298.1.tar.gz
Warning: These pull requests may be duplicates:
dxpy 0.298.1 https://github.com/Homebrew/homebrew-core/pull/58880
==> Downloading https://files.pythonhosted.org/packages/27/0d/4849e89891e1dc49681018d203b736073919dd9933738d78487a70e341d8/dxpy-0.298.1.tar.gz
Already downloaded: /Users/rylanpolster/Library/Caches/Homebrew/downloads/efb31e8178325f50b7dc555b0ae8be6c0f75ea22b5a08d72d6ecc844165043bd--dxpy-0.298.1.tar.gz
Warning: Cannot verify integrity of efb31e8178325f50b7dc555b0ae8be6c0f75ea22b5a08d72d6ecc844165043bd--dxpy-0.298.1.tar.gz
A checksum was not provided for this resource.
For your reference the SHA-256 is: 280fe87450d0357d7d677c3732ac2a95b2ec7364cd6bea19db1f92738c1bdd37
==> replace /https:\/\/files\.pythonhosted\.org\/packages\/3d\/1a\/46c00205e2ee4d01e3d923c838f1b770b9af09f4147a4cd3e3dad1102b8b\/dxpy\-0\.297\.1\.tar\.gz/ wit==> replace "7cc680c5e2f44b80fb6ffd392eaffafd8b6ade722bf7e5c8d253c389b6602a64" with "280fe87450d0357d7d677c3732ac2a95b2ec7364cd6bea19db1f92738c1bdd37"
==> brew update-python-resources dxpy
...
```

Works as expected