### PR TITLE
list: pass args properly

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -53,7 +53,7 @@ module Homebrew
   def list
     args = list_args.parse
 
-    return list_casks if args.cask?
+    return list_casks(args: args) if args.cask?
 
     return list_unbrewed if args.unbrewed?
 
@@ -66,7 +66,7 @@ module Homebrew
     end
 
     if args.pinned? || args.versions?
-      filtered_list
+      filtered_list args: args
     elsif args.no_named?
       if args.full_name?
         full_names = Formula.installed.map(&:full_name).sort(&tap_and_name_comparison)
@@ -134,7 +134,7 @@ module Homebrew
     safe_system "find", *arguments
   end
 
-  def filtered_list
+  def filtered_list(args:)
     names = if args.no_named?
       Formula.racks
     else
@@ -163,7 +163,7 @@ module Homebrew
     end
   end
 
-  def list_casks
+  def list_casks(args:)
     cask_list = Cask::Cmd::List.new args.named
     cask_list.one = ARGV.include? "-1"
     cask_list.versions = args.versions?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #8170.

After #8144 some commands don't pass args properly. In this case, `brew list --pinned` displayed all formulae not just pinned ones.