### PR TITLE
bottle: fix args

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -176,10 +176,10 @@ module Homebrew
       end
     end
 
-    keg_contain_absolute_symlink_starting_with?(string, keg) || result
+    keg_contain_absolute_symlink_starting_with?(string, keg, args: args) || result
   end
 
-  def keg_contain_absolute_symlink_starting_with?(string, keg)
+  def keg_contain_absolute_symlink_starting_with?(string, keg, args:)
     absolute_symlinks_start_with_string = []
     keg.find do |pn|
       next unless pn.symlink? && (link = pn.readlink).absolute?
@@ -331,7 +331,7 @@ module Homebrew
           relocatable = false if keg_contain?(repository, keg, ignores, args: args)
           relocatable = false if keg_contain?(cellar, keg, ignores, formula_and_runtime_deps_names, args: args)
           if prefix != prefix_check
-            relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg)
+            relocatable = false if keg_contain_absolute_symlink_starting_with?(prefix, keg, args: args)
             relocatable = false if keg_contain?("#{prefix}/etc", keg, ignores, args: args)
             relocatable = false if keg_contain?("#{prefix}/var", keg, ignores, args: args)
             relocatable = false if keg_contain?("#{prefix}/share/vim", keg, ignores, args: args)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix after #8144

`keg_contain_absolute_symlink_starting_with?` needs to have `args` passed so it can detect whether `--verbose` has been passed.