### PR TITLE
livecheck migration: add `brew livecheck` developer command

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+require "formula"
+require "livecheck/livecheck"
+require "livecheck/strategy"
+
+module Homebrew
+  module_function
+
+  WATCHLIST_PATH = (
+    ENV["HOMEBREW_LIVECHECK_WATCHLIST"] ||
+    Pathname.new(Dir.home)/".brew_livecheck_watchlist"
+  ).freeze
+
+  def livecheck_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `livecheck` [<formulae>]
+
+        Check for newer versions of formulae from upstream.
+
+        If no formula argument is passed, the list of formulae to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST`
+        or `~/.brew_livecheck_watchlist`.
+      EOS
+      switch "--full-name",
+             description: "Print formulae with fully-qualified names."
+      flag   "--tap=",
+             description: "Check the formulae within the given tap, specified as <user>`/`<repo>."
+      switch "--installed",
+             description: "Check formulae that are currently installed."
+      switch "--json",
+             description: "Output informations in JSON format."
+      switch "--all",
+             description: "Check all available formulae."
+      switch "--newer-only",
+             description: "Show the latest version only if it's newer than the formula."
+      conflicts "--debug", "--json"
+      conflicts "--tap=", "--all", "--installed"
+    end
+  end
+
+  def livecheck
+    args = livecheck_args.parse
+
+    if args.debug? && args.verbose?
+      puts args
+      puts ENV["HOMEBREW_LIVECHECK_WATCHLIST"] if ENV["HOMEBREW_LIVECHECK_WATCHLIST"].present?
+    end
+
+    formulae_to_check = if args.tap
+      Tap.fetch(args.tap).formula_names.map { |name| Formula[name] }
+    elsif args.installed?
+      Formula.installed
+    elsif args.all?
+      Formula
+    elsif args.formulae.present?
+      args.formulae
+    elsif File.exist?(WATCHLIST_PATH)
+      begin
+        WATCHLIST_PATH.read.lines.map do |line|
+          next if line.start_with?("#")
+
+          Formula[line.strip]
+        end.compact
+      rescue Errno::ENOENT => e
+        onoe e
+      end
+    end
+
+    raise UsageError, "No formulae to check." if formulae_to_check.blank?
+
+    Livecheck.livecheck_formulae(formulae_to_check, args)
+  end
+end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -173,6 +173,11 @@ module Homebrew
         default_text: 'The "Beer Mug" emoji.',
         default:      "🍺",
       },
+      HOMEBREW_LIVECHECK_WATCHLIST:       {
+        description: "Use this file to get the list of default Formulae to check when no Formula argument " \
+                     "is passed to `brew livecheck`",
+        default:     "$HOME/.brew_livecheck_watchlist",
+      },
       HOMEBREW_LOGS:                      {
         description:  "Use the specified directory to store log files.",
         default_text: "macOS: `$HOME/Library/Logs/Homebrew`, "\

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -23,6 +23,7 @@ DEPRECATED_OFFICIAL_TAPS = %w[
   games
   gui
   head-only
+  livecheck
   nginx
   php
   python

--- a/Library/Homebrew/test/.rubocop_todo.yml
+++ b/Library/Homebrew/test/.rubocop_todo.yml
@@ -75,6 +75,7 @@ RSpec/MultipleDescribes:
     - 'dev-cmd/formula_spec.rb'
     - 'dev-cmd/irb_spec.rb'
     - 'dev-cmd/linkage_spec.rb'
+    - 'dev-cmd/livecheck_spec.rb'
     - 'dev-cmd/pull_spec.rb'
     - 'dev-cmd/ruby_spec.rb'
     - 'dev-cmd/sh_spec.rb'

--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.livecheck_args" do
+  it_behaves_like "parseable arguments"
+end
+
+describe "brew livecheck", :integration_test do
+  it "reports the latest version of a Formula", :needs_network do
+    content = <<~RUBY
+      desc "Some test"
+      homepage "https://github.com/Homebrew/brew"
+      url "https://brew.sh/test-1.0.0.tgz"
+    RUBY
+    setup_test_formula("test", content)
+
+    expect { brew "livecheck", "test" }
+      .to output(/test : /).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -352,6 +352,17 @@ _brew_list() {
   fi
 }
 
+_brew_livecheck() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
+    -*)
+      __brewcomp "--verbose --quiet --debug --full-name --tap --installed --json --all --newer-only --help"
+      return
+      ;;
+  esac
+  __brew_complete_formulae
+}
+
 _brew_log() {
   # if git-completion is loaded, then we complete git-log options
   declare -F _git_log >/dev/null || return
@@ -860,6 +871,7 @@ _brew() {
     irb)                        _brew_irb ;;
     link|ln)                    _brew_link ;;
     list|ls)                    _brew_list ;;
+    livecheck)                  _brew_livecheck ;;
     log)                        _brew_log ;;
     man)                        _brew_man ;;
     missing)                    __brew_complete_formulae ;;

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -446,6 +446,20 @@ __fish_brew_complete_arg 'list ls;
     ' -l multiple -d "Only show formulae with multiple versions"
 
 
+__fish_brew_complete_cmd 'livecheck' "Check for newer versions of formulae from upstream"
+__fish_brew_complete_arg 'livecheck' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'livecheck' -s v -l verbose    -d "Make some output more verbose"
+__fish_brew_complete_arg 'livecheck' -s q -l quiet      -d "Suppress any warnings"
+__fish_brew_complete_arg 'livecheck' -s d -l debug      -d "Display any debugging information"
+__fish_brew_complete_arg 'livecheck'      -l full-name  -d "Print formulae with fully-qualified name"
+__fish_brew_complete_arg 'livecheck'      -l tap        -d "Check the formulae within the given tap, specified as user/repo"
+__fish_brew_complete_arg 'livecheck'      -l installed  -d "Check formulae that are currently installed"
+__fish_brew_complete_arg 'livecheck'      -l json       -d "Output information in JSON format"
+__fish_brew_complete_arg 'livecheck'      -l all        -d "Check all available formulae"
+__fish_brew_complete_arg 'livecheck'      -l newer-only -d "Show the latest version only if it is newer than the formula"
+__fish_brew_complete_arg 'livecheck' -s h -l help       -d "Show the help message"
+
+
 __fish_brew_complete_cmd 'log' "Show git log for formula"
 __fish_brew_complete_arg 'log' -a '(__fish_brew_suggest_formulae_all)'
 

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -47,6 +47,7 @@ leaves
 link
 linkage
 list
+livecheck
 ln
 log
 ls

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -504,6 +504,23 @@ _brew_list() {
     '*:: :__brew_installed_formulae'
 }
 
+# brew livecheck [--verbose] [--quiet] [--debug] [--full-name] [--tap user/repo]
+#                [--installed] [--json] [--all] [--newer-only] formulae
+_brew_livecheck() {
+  _arguments \
+    '(--verbose,-v)'{--verbose,-v}'[Make some output more verbose]' \
+    '(--quiet,-q)'{--quiet,-q}'[Suppress any warnings]' \
+    '(--debug,-d)'{--debug,-d}'[Display any debugging information]' \
+    '--full-name[Print formulae with fully-qualified name]' \
+    '--tap[Check the formulae within the given tap, specified as user/repo]' \
+    '--installed[Check formulae that are currently installed]' \
+    '--json[Output information in JSON format]' \
+    '--all[Check all available formulae]' \
+    '--newer-only[Show the latest version only if it is newer than the formula]' \
+    '(--help,-h)'{--help,-h}'[Show the help message]' \
+    '*:: :__brew_formulae'
+}
+
 # brew log [git-log-options] formula ...:
 _brew_log() {
   __brew_formulae

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -992,6 +992,26 @@ provided, check all kegs. Raises an error if run on uninstalled formulae.
 * `--cached`:
   Print the cached linkage values stored in `HOMEBREW_CACHE`, set by a previous `brew linkage` run.
 
+### `livecheck` [*`formulae`*]
+
+Check for newer versions of formulae from upstream.
+
+If no formula argument is passed, the list of formulae to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST`
+or `~/.brew_livecheck_watchlist`.
+
+* `--full-name`:
+  Print formulae with fully-qualified names.
+* `--tap`:
+  Check the formulae within the given tap, specified as *`user`*`/`*`repo`*.
+* `--installed`:
+  Check formulae that are currently installed.
+* `--json`:
+  Output informations in JSON format.
+* `--all`:
+  Check all available formulae.
+* `--newer-only`:
+  Show the latest version only if it's newer than the formula.
+
 ### `man` [*`options`*]
 
 Generate Homebrew's manpages.
@@ -1590,6 +1610,11 @@ For example, you might add something like the following to your ~/.profile, ~/.b
     Print this text before the installation summary of each successful build.
 
     *Default:* The "Beer Mug" emoji.
+
+  * `HOMEBREW_LIVECHECK_WATCHLIST`:
+    Use this file to get the list of default Formulae to check when no Formula argument is passed to `brew livecheck`
+
+    *Default:* `$HOME/.brew_livecheck_watchlist`.
 
   * `HOMEBREW_LOGS`:
     Use the specified directory to store log files.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1362,6 +1362,36 @@ For every library that a keg references, print its dylib path followed by the bi
 \fB\-\-cached\fR
 Print the cached linkage values stored in \fBHOMEBREW_CACHE\fR, set by a previous \fBbrew linkage\fR run\.
 .
+.SS "\fBlivecheck\fR [\fIformulae\fR]"
+Check for newer versions of formulae from upstream\.
+.
+.P
+If no formula argument is passed, the list of formulae to check is taken from \fBHOMEBREW_LIVECHECK_WATCHLIST\fR or \fB~/\.brew_livecheck_watchlist\fR\.
+.
+.TP
+\fB\-\-full\-name\fR
+Print formulae with fully\-qualified names\.
+.
+.TP
+\fB\-\-tap\fR
+Check the formulae within the given tap, specified as \fIuser\fR\fB/\fR\fIrepo\fR\.
+.
+.TP
+\fB\-\-installed\fR
+Check formulae that are currently installed\.
+.
+.TP
+\fB\-\-json\fR
+Output informations in JSON format\.
+.
+.TP
+\fB\-\-all\fR
+Check all available formulae\.
+.
+.TP
+\fB\-\-newer\-only\fR
+Show the latest version only if it\'s newer than the formula\.
+.
 .SS "\fBman\fR [\fIoptions\fR]"
 Generate Homebrew\'s manpages\.
 .
@@ -2179,6 +2209,13 @@ Print this text before the installation summary of each successful build\.
 .
 .IP
 \fIDefault:\fR The "Beer Mug" emoji\.
+.
+.TP
+\fBHOMEBREW_LIVECHECK_WATCHLIST\fR
+Use this file to get the list of default Formulae to check when no Formula argument is passed to \fBbrew livecheck\fR
+.
+.IP
+\fIDefault:\fR \fB$HOME/\.brew_livecheck_watchlist\fR\.
 .
 .TP
 \fBHOMEBREW_LOGS\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR integrates `livecheck` into Homebrew/brew as a developer command. It was almost just a copy-paste of files, but there were some style changes and a couple of minor differences as outlined by @samford. I've also brought over the command completions and placed them in the appropriate files (works on `zsh`, should also work on `bash` and `fish` based on my previous trials).

I tested this locally by also incorporating the changes in #8156 (without which we will get an `undefined method strategy` error), and it works as intended (I also untapped homebrew/livecheck).

Things to discuss:
1. What changes do we make to the livecheck code?
2. What tests do we write?
3. (Minor) Should livecheck be a common command (for completions)?

I will also be working on the RuboCops/audits in parallel. Looking forward to your reviews!