### PR TITLE
dev-cmd/ruby: improve args passing

### DIFF
--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -13,21 +13,26 @@ module Homebrew
         Run a Ruby instance with Homebrew's libraries loaded, e.g.
         `brew ruby -e "puts :gcc.f.deps"` or `brew ruby script.rb`.
       EOS
-      switch "-r",
-             description: "Load a library using `require`."
-      switch "-e",
-             description: "Execute the given text string as a script."
+      flag "-r=",
+           description: "Load a library using `require`."
+      flag "-e=",
+           description: "Execute the given text string as a script."
     end
   end
 
   def ruby
-    ruby_args.parse
+    args = ruby_args.parse
+
+    ruby_sys_args = []
+    ruby_sys_args << "-r#{args.r}" if args.r
+    ruby_sys_args << "-e #{args.e}" if args.e
+    ruby_sys_args += args.named
 
     begin
       safe_system RUBY_PATH,
                   "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
                   "-rglobal", "-rdev-cmd/irb",
-                  *ARGV
+                  *ruby_sys_args
     rescue ErrorDuringExecution => e
       exit e.status.exitstatus
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

* Remove the need for directly using `ARGV`.
* Properly denote `-r` and `-e` as flags.
* Bonus: allow the user to pass any Ruby argment like `brew ruby -- -v`