### PR TITLE
audit: forbid deprecated licenses with --strict

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -364,6 +364,21 @@ module Homebrew
           problem "Formula #{formula.name} contains non-standard SPDX licenses: #{non_standard_licenses}."
         end
 
+        if @strict
+          deprecated_licenses = formula.license.map do |license|
+            next if license == :public_domain
+            next if @spdx_data["licenses"].any? do |spdx|
+              spdx["licenseId"] == license && !spdx["isDeprecatedLicenseId"]
+            end
+
+            license
+          end.compact
+
+          if deprecated_licenses.present?
+            problem "Formula #{formula.name} contains deprecated SPDX licenses: #{deprecated_licenses}."
+          end
+        end
+
         return unless @online
 
         user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*}) if @new_formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Don't allow licenses that are listed as deprecated in the SPDX list.

For example, we should use `GPL-3.0-or-later` or `GPL-3.0-only` instead of `GPL-3.0`.

See https://github.com/Homebrew/homebrew-core/issues/58225#issuecomment-667768278