### PR TITLE
caskroom: Add --caskroom to match --cellar

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -41,6 +41,7 @@ case "$*" in
   --prefix)            echo "$HOMEBREW_PREFIX"; exit 0 ;;
   --cellar)            echo "$HOMEBREW_CELLAR"; exit 0 ;;
   --repository|--repo) echo "$HOMEBREW_REPOSITORY"; exit 0 ;;
+  --caskroom)          echo "$HOMEBREW_PREFIX/Caskroom"; exit 0 ;;
 esac
 
 # A depth of 1 means this command was directly invoked by a user.

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -35,6 +35,7 @@ module Homebrew
         @resolved_formulae_casks = nil
         @formulae_paths = nil
         @casks = nil
+        @loaded_casks = nil
         @kegs = nil
         @kegs_casks = nil
 
@@ -123,6 +124,10 @@ module Homebrew
       def casks
         @casks ||= downcased_unique_named.grep(HOMEBREW_CASK_TAP_CASK_REGEX)
                                          .freeze
+      end
+
+      def loaded_casks
+        @loaded_casks ||= downcased_unique_named.map(&Cask::CaskLoader.method(:load)).freeze
       end
 
       def kegs

--- a/Library/Homebrew/cmd/--caskroom.rb
+++ b/Library/Homebrew/cmd/--caskroom.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Homebrew
+  module_function
+
+  def __caskroom_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `--caskroom` [<cask>]
+
+        Display Homebrew's Caskroom path.
+
+        If <cask> is provided, display the location in the Caskroom where <cask>
+        would be installed, without any sort of versioned directory as the last path.
+      EOS
+    end
+  end
+
+  def __caskroom
+    args = __caskroom_args.parse
+
+    if args.loaded_casks.blank?
+      puts Cask::Caskroom.path
+    else
+      args.loaded_casks.each do |cask|
+        puts "#{Cask::Caskroom.path}/#{cask.token}"
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/cmd/--caskroom_spec.rb
+++ b/Library/Homebrew/test/cmd/--caskroom_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe "brew --caskroom", :integration_test do
+  let(:local_transmission) {
+    Cask::CaskLoader.load(cask_path("local-transmission"))
+  }
+
+  let(:local_caffeine) {
+    Cask::CaskLoader.load(cask_path("local-caffeine"))
+  }
+
+  it "outputs Homebrew's caskroom" do
+    expect { brew "--caskroom" }
+      .to output("#{HOMEBREW_PREFIX/"Caskroom"}\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
+  it "outputs the caskroom path of casks" do
+    expect { brew "--caskroom", cask_path("local-transmission"), cask_path("local-caffeine") }
+      .to output("#{HOMEBREW_PREFIX/"Caskroom"/"local-transmission"}\n" \
+                 "#{HOMEBREW_PREFIX/"Caskroom"/"local-caffeine\n"}").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+end

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -1,4 +1,5 @@
 --cache
+--caskroom
 --cellar
 --config
 --env

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -610,6 +610,13 @@ If *`formula`* is provided, display the file or directory used to cache *`formul
 * `--cask`:
   Only show cache files for casks.
 
+### `--caskroom` [*`cask`*]
+
+Display Homebrew's Caskroom path.
+
+If *`cask`* is provided, display the location in the Caskroom where *`cask`* would
+be installed, without any sort of versioned directory as the last path.
+
 ### `--cellar` [*`formula`*]
 
 Display Homebrew's Cellar path. *Default:* `$(brew --prefix)/Cellar`, or if that

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "July 2020" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "August 2020" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "July 2020" "Homebrew" "brew"
+.TH "BREW" "1" "August 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -806,6 +806,12 @@ Only show cache files for formulae\.
 .TP
 \fB\-\-cask\fR
 Only show cache files for casks\.
+.
+.SS "\fB\-\-caskroom\fR [\fIcask\fR]"
+Display Homebrew\'s Caskroom path\.
+.
+.P
+If \fIcask\fR is provided, display the location in the Caskroom where \fIcask\fR would be installed, without any sort of versioned directory as the last path\.
 .
 .SS "\fB\-\-cellar\fR [\fIformula\fR]"
 Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add `brew --caskroom` to print the homebrew caskroom path.

Thoughts on merging this command with `brew --cellar`? `brew --cellar atom` would output the caskroom path of `atom`.