### PR TITLE
Fix deprecated uses of Homebrew args methods

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -59,7 +59,7 @@ begin
 
   ARGV.delete_at(help_cmd_index) if help_cmd_index
 
-  Homebrew.args = Homebrew::CLI::Parser.new.parse(ARGV.dup.freeze, ignore_invalid_options: true)
+  Homebrew.args = Homebrew::CLI::Parser.new(global: true).parse(ARGV.dup.freeze, ignore_invalid_options: true)
 
   path = PATH.new(ENV["PATH"])
   homebrew_path = PATH.new(ENV["HOMEBREW_PATH"])

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -5,14 +5,15 @@ require "ostruct"
 module Homebrew
   module CLI
     class Args < OpenStruct
-      attr_reader :options_only, :flags_only
+      attr_reader :options_only, :flags_only, :global
 
       # undefine tap to allow --tap argument
       undef tap
 
-      def initialize
+      def initialize(global: false)
         super()
 
+        @global = global
         @processed_options = []
         @options_only = []
         @flags_only = []

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -36,7 +36,7 @@ module Homebrew
       def initialize(&block)
         @parser = OptionParser.new
 
-        @args = Homebrew::CLI::Args.new
+        @args = Homebrew::CLI::Args.new(global: false)
 
         @constraints = []
         @conflicts = []
@@ -228,6 +228,7 @@ module Homebrew
         @args.freeze_named_args!(named_args)
         @args.freeze_remaining_args!(non_options.empty? ? remaining : [*remaining, "--", non_options])
         @args.freeze_processed_options!(@processed_options)
+        Homebrew.args = @args
 
         @args_parsed = true
         @args

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -33,10 +33,10 @@ module Homebrew
         ]
       end
 
-      def initialize(&block)
+      def initialize(global: false, &block)
         @parser = OptionParser.new
 
-        @args = Homebrew::CLI::Args.new(global: false)
+        @args = Homebrew::CLI::Args.new(global: global)
 
         @constraints = []
         @conflicts = []

--- a/Library/Homebrew/compat.rb
+++ b/Library/Homebrew/compat.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "compat/dependencies_helpers"
 require "compat/extend/nil"
 require "compat/extend/string"
 require "compat/formula"

--- a/Library/Homebrew/compat/dependencies_helpers.rb
+++ b/Library/Homebrew/compat/dependencies_helpers.rb
@@ -2,8 +2,13 @@
 
 module DependenciesHelpers
   module Compat
+    @printed_includes_ignores_warning = false
+
     def argv_includes_ignores(argv)
-      odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores"
+      unless @printed_includes_ignores_warning
+        odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores"
+        @printed_includes_ignores_warning = true
+      end
       args_includes_ignores(Homebrew::CLI::Parser.new.parse(argv, ignore_invalid_options: true))
     end
   end

--- a/Library/Homebrew/compat/dependencies_helpers.rb
+++ b/Library/Homebrew/compat/dependencies_helpers.rb
@@ -6,7 +6,7 @@ module DependenciesHelpers
 
     def argv_includes_ignores(argv)
       unless @printed_includes_ignores_warning
-        odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores"
+        odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores", raise_exception: false
         @printed_includes_ignores_warning = true
       end
       args_includes_ignores(Homebrew::CLI::Parser.new.parse(argv, ignore_invalid_options: true))

--- a/Library/Homebrew/compat/dependencies_helpers.rb
+++ b/Library/Homebrew/compat/dependencies_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module DependenciesHelpers
+  module Compat
+    def argv_includes_ignores(argv)
+      odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores"
+      args_includes_ignores(Homebrew::CLI::Parser.new.parse(argv, ignore_invalid_options: true))
+    end
+  end
+
+  prepend Compat
+end

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -3,11 +3,6 @@
 require "cask_dependent"
 
 module DependenciesHelpers
-  def argv_includes_ignores(argv)
-    odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores"
-    args_includes_ignores(Homebrew::CLI::Parser.new.parse(argv, ignore_invalid_options: true))
-  end
-
   def args_includes_ignores(args)
     includes = []
     ignores = []

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -3,6 +3,11 @@
 require "cask_dependent"
 
 module DependenciesHelpers
+  def argv_includes_ignores(argv)
+    odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores"
+    args_includes_ignores(Homebrew::CLI::Parser.new.parse(argv, ignore_invalid_options: true))
+  end
+
   def args_includes_ignores(args)
     includes = []
     ignores = []

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -85,10 +85,9 @@ module Homebrew
 
     def args
       @args ||= CLI::Args.new(global: true)
-      unless @args.global || @printed_args_warning
-        odeprecated "Homebrew.args", "args = <command>_args.parse"
-        @printed_args_warning = true
-      end
+      return @args if @args.global || @printed_args_warning
+      odeprecated "Homebrew.args", "args = <command>_args.parse"
+      @printed_args_warning = true
       @args
     end
 

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -72,6 +72,8 @@ module Homebrew
   class << self
     attr_writer :failed, :raise_deprecation_exceptions, :auditing, :args
 
+    @printed_args_warning = false
+
     def Homebrew.default_prefix?(prefix = HOMEBREW_PREFIX)
       prefix.to_s == DEFAULT_PREFIX
     end
@@ -83,7 +85,10 @@ module Homebrew
 
     def args
       @args ||= CLI::Args.new(global: true)
-      odeprecated "Homebrew.args", "args = <command>_args.parse" unless @args.global
+      unless @args.global || @printed_args_warning
+        odeprecated "Homebrew.args", "args = <command>_args.parse"
+        @printed_args_warning = true
+      end
       @args
     end
 

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -82,7 +82,9 @@ module Homebrew
     end
 
     def args
-      @args ||= CLI::Args.new
+      @args ||= CLI::Args.new(global: true)
+      odeprecated "Homebrew.args", "args = <command>_args.parse" unless @args.global
+      @args
     end
 
     def messages

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -86,7 +86,8 @@ module Homebrew
     def args
       @args ||= CLI::Args.new(global: true)
       return @args if @args.global || @printed_args_warning
-      odeprecated "Homebrew.args", "args = <command>_args.parse"
+
+      odeprecated "Homebrew.args", "args = <command>_args.parse", raise_exception: false
       @printed_args_warning = true
       @args
     end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -126,7 +126,8 @@ module Kernel
     exit 1
   end
 
-  def odeprecated(method, replacement = nil, disable: false, disable_on: nil, caller: send(:caller))
+  def odeprecated(method, replacement = nil, disable: false, disable_on: nil, caller: send(:caller),
+                  raise_exception: Homebrew.raise_deprecation_exceptions?)
     replacement_message = if replacement
       "Use #{replacement} instead."
     else
@@ -176,7 +177,7 @@ module Kernel
     message << tap_message if tap_message
     message.freeze
 
-    if Homebrew::EnvConfig.developer? || disable || Homebrew.raise_deprecation_exceptions?
+    if Homebrew::EnvConfig.developer? || disable || raise_exception
       exception = MethodDeprecatedError.new(message)
       exception.set_backtrace(backtrace)
       raise exception


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related: #8144

Warning: Not thoroughly tested

Tested with:

- `brew deps --include-requirements` at commit 0fdf8f2 before it was fixed
- `brew livecheck` at commit https://github.com/Homebrew/homebrew-livecheck/commit/aafb126ada9c0625929aa4406532021a83ca8a4b before it was fixed
- [`beeftornado/rmtree`](https://github.com/beeftornado/homebrew-rmtree)
- [`claui/whence`](https://github.com/claui/homebrew-whence)

Todo:

- [x] Reduce warning spam
  - Example: https://gist.github.com/SeekingMeaning/4ee8dc139dbcd28c8d8c6f8e41dea188
- [x] Move now-deprecated `Homebrew.argv_includes_ignores` to `compat/dependencies_helpers.rb`