### PR TITLE
Add keep and unkeep commands

### DIFF
--- a/Library/Homebrew/cmd/keep.rb
+++ b/Library/Homebrew/cmd/keep.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "formula_keeper"
+require "cli/parser"
+
+module Homebrew
+  module_function
+
+  def keep_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `keep` <formula>
+
+        Keep the specified <formula>, preventing them from being uninstalled
+        when issuing the `brew uninstall` <formula> command without `--force`.
+        See also `unkeep`.
+      EOS
+
+      min_named :formula
+    end
+  end
+
+  def keep
+    args = keep_args.parse
+
+    args.resolved_formulae.each do |f|
+      if FormulaKeeper.keeping?(f)
+        opoo "Already keeping #{f.name}"
+      elsif !FormulaKeeper.keepable?(f)
+        onoe "#{f.name} not installed"
+      else
+        FormulaKeeper.keep(f)
+      end
+    end
+  end
+end

--- a/Library/Homebrew/cmd/keep.rb
+++ b/Library/Homebrew/cmd/keep.rb
@@ -14,7 +14,7 @@ module Homebrew
         Keep the specified <formula>, preventing them from being uninstalled
         when issuing the `brew uninstall` <formula> command without `--force`.
 
-        If no arguments are provided, list all formula being kept.
+        If no arguments are provided, list all formulae being kept.
 
         See also `unkeep`.
       EOS

--- a/Library/Homebrew/cmd/keep.rb
+++ b/Library/Homebrew/cmd/keep.rb
@@ -9,19 +9,25 @@ module Homebrew
   def keep_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `keep` <formula>
+        `keep` [<formula>]
 
         Keep the specified <formula>, preventing them from being uninstalled
         when issuing the `brew uninstall` <formula> command without `--force`.
+
+        If no arguments are provided, list all formula being kept.
+
         See also `unkeep`.
       EOS
-
-      min_named :formula
     end
   end
 
   def keep
     args = keep_args.parse
+
+    if args.no_named?
+      puts FormulaKeeper.kept_formula_names
+      return
+    end
 
     args.resolved_formulae.each do |f|
       if FormulaKeeper.keeping?(f)

--- a/Library/Homebrew/cmd/unkeep.rb
+++ b/Library/Homebrew/cmd/unkeep.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "formula_keeper"
+require "cli/parser"
+
+module Homebrew
+  module_function
+
+  def unkeep_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `unkeep` <formula>
+
+        Unkeep <formula>, allowing them to be uninstalled by `brew uninstall`
+        <formula> without `--force`. See also `keep`.
+      EOS
+
+      min_named :formula
+    end
+  end
+
+  def unkeep
+    args = unkeep_args.parse
+
+    args.resolved_formulae.each do |f|
+      if FormulaKeeper.keeping?(f)
+        FormulaKeeper.unkeep(f)
+      elsif !FormulaKeeper.keepable?(f)
+        onoe "#{f.name} not installed"
+      else
+        opoo "Not keeping #{f.name}"
+      end
+    end
+  end
+end

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -35,6 +35,9 @@ HOMEBREW_LINKED_KEGS = (HOMEBREW_PREFIX/"var/homebrew/linked").freeze
 # Where we store symlinks to currently version-pinned kegs
 HOMEBREW_PINNED_KEGS = (HOMEBREW_PREFIX/"var/homebrew/pinned").freeze
 
+# Where we store a "list" of formulae to keep; formulae are represented by files
+HOMEBREW_KEEP_FORMULAE = (HOMEBREW_PREFIX/"var/homebrew/keep").freeze
+
 # Where we store lock files
 HOMEBREW_LOCKS = (HOMEBREW_PREFIX/"var/homebrew/locks").freeze
 

--- a/Library/Homebrew/formula_keeper.rb
+++ b/Library/Homebrew/formula_keeper.rb
@@ -22,4 +22,8 @@ module FormulaKeeper
   def self.keepable?(f)
     !f.installed_prefixes.empty?
   end
+
+  def self.kept_formula_names
+    Dir[HOMEBREW_KEEP_FORMULAE/"*"].map { |f| File.basename(f) }.sort
+  end
 end

--- a/Library/Homebrew/formula_keeper.rb
+++ b/Library/Homebrew/formula_keeper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module FormulaKeeper
+  def self.path(f)
+    HOMEBREW_KEEP_FORMULAE/f.name
+  end
+
+  def self.keep(f)
+    HOMEBREW_KEEP_FORMULAE.mkpath
+    FileUtils.touch path(f) if !keeping?(f) && keepable?(f)
+  end
+
+  def self.unkeep(f)
+    FileUtils.rm_rf path(f) if keeping?(f)
+    HOMEBREW_KEEP_FORMULAE.rmdir_if_possible
+  end
+
+  def self.keeping?(f)
+    path(f).exist?
+  end
+
+  def self.keepable?(f)
+    !f.installed_prefixes.empty?
+  end
+end

--- a/Library/Homebrew/test/cmd/keep_spec.rb
+++ b/Library/Homebrew/test/cmd/keep_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "brew keep" do
+  describe "Homebrew.keep_args" do
+    it_behaves_like "parseable arguments"
+  end
+
+  describe "brew keep", :integration_test do
+    it "keeps a Formula" do
+      install_test_formula "testball"
+
+      expect { brew "keep", "testball" }.to be_a_success
+    end
+  end
+end

--- a/Library/Homebrew/test/cmd/unkeep_spec.rb
+++ b/Library/Homebrew/test/cmd/unkeep_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "formula_keeper"
+require "cmd/shared_examples/args_parse"
+
+describe "brew unkeep" do
+  describe "Homebrew.unkeep_args" do
+    it_behaves_like "parseable arguments"
+  end
+
+  describe "brew unkeep", :integration_test do
+    it "unkeeps a Formula's version" do
+      install_test_formula "testball"
+      FormulaKeeper.keep(Formula["testball"])
+
+      expect { brew "unkeep", "testball" }.to be_a_success
+    end
+  end
+end

--- a/Library/Homebrew/test/formula_keeper_spec.rb
+++ b/Library/Homebrew/test/formula_keeper_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "formula_keeper"
+
+describe FormulaKeeper do
+  let(:name) { "double" }
+  let(:formula) { instance_double(Formula, name: name, rack: HOMEBREW_CELLAR/name) }
+
+  before do
+    formula.rack.mkpath
+
+    allow(formula).to receive(:installed_prefixes) do
+      formula.rack.directory? ? formula.rack.subdirs.sort : []
+    end
+
+    allow(formula).to receive(:installed_kegs) do
+      formula.installed_prefixes.map { |prefix| Keg.new(prefix) }
+    end
+  end
+
+  it "is not keepable by default" do
+    expect(described_class.keepable?(formula)).to eq(false)
+  end
+
+  it "is keepable if the Keg exists" do
+    (formula.rack/"0.1").mkpath
+    expect(described_class.keepable?(formula)).to eq(true)
+  end
+
+  specify "#keep and #unkeep" do
+    (formula.rack/"0.1").mkpath
+
+    described_class.keep(formula)
+    expect(described_class.keeping?(formula)).to be(true)
+    expect(HOMEBREW_KEEP_FORMULAE/name).to be_a_file
+    expect(HOMEBREW_KEEP_FORMULAE.children.count).to eq(1)
+
+    described_class.unkeep(formula)
+    expect(described_class.keeping?(formula)).to be(false)
+    expect(HOMEBREW_KEEP_FORMULAE).not_to be_a_directory
+  end
+
+  describe "brew uninstall", :integration_test do
+    it "does not uninstall a kept Formula without `--force`" do
+      install_test_formula "testball"
+
+      expect { brew "keep", "testball" }.to be_a_success
+
+      expect { brew "uninstall", "testball" }
+        .to output(/Error/).to_stderr
+        .and not_to_output.to_stdout
+        .and be_a_success
+    end
+
+    it "uninstalls a kept Formula with `--force`" do
+      install_test_formula "testball"
+
+      expect { brew "keep", "testball" }.to be_a_success
+
+      expect { brew "uninstall", "--force", "testball" }
+        .to output(/Uninstalling testball/).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
+  end
+end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -217,6 +217,7 @@ RSpec.configure do |config|
         *Keg::MUST_EXIST_SUBDIRECTORIES,
         HOMEBREW_LINKED_KEGS,
         HOMEBREW_PINNED_KEGS,
+        HOMEBREW_KEEP_FORMULAE,
         HOMEBREW_PREFIX/"var",
         HOMEBREW_PREFIX/"Caskroom",
         HOMEBREW_PREFIX/"Frameworks",

--- a/Library/Homebrew/test/support/lib/config.rb
+++ b/Library/Homebrew/test/support/lib/config.rb
@@ -29,6 +29,7 @@ HOMEBREW_CACHE         = (HOMEBREW_PREFIX.parent/"cache").freeze
 HOMEBREW_CACHE_FORMULA = (HOMEBREW_PREFIX.parent/"formula_cache").freeze
 HOMEBREW_LINKED_KEGS   = (HOMEBREW_PREFIX.parent/"linked").freeze
 HOMEBREW_PINNED_KEGS   = (HOMEBREW_PREFIX.parent/"pinned").freeze
+HOMEBREW_KEEP_FORMULAE = (HOMEBREW_PREFIX.parent/"keep").freeze
 HOMEBREW_LOCKS         = (HOMEBREW_PREFIX.parent/"locks").freeze
 HOMEBREW_CELLAR        = (HOMEBREW_PREFIX.parent/"cellar").freeze
 HOMEBREW_LOGS          = (HOMEBREW_PREFIX.parent/"logs").freeze

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -41,6 +41,7 @@ instal
 install
 install-bundler-gems
 irb
+keep
 leaves
 link
 linkage
@@ -81,6 +82,7 @@ test
 tests
 uninstal
 uninstall
+unkeep
 unlink
 unpack
 unpin

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -258,11 +258,14 @@ the installed formulae or, every 30 days, for all formulae.
 * `-g`, `--git`:
   Create a Git repository, useful for creating patches to the software.
 
-### `keep` *`formula`*
+### `keep` [*`formula`*]
 
 Keep the specified *`formula`*, preventing them from being uninstalled when
-issuing the `brew uninstall` *`formula`* command without `--force`. See also
-`unkeep`.
+issuing the `brew uninstall` *`formula`* command without `--force`.
+
+If no arguments are provided, list all formula being kept.
+
+See also `unkeep`.
 
 ### `leaves`
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -263,7 +263,7 @@ the installed formulae or, every 30 days, for all formulae.
 Keep the specified *`formula`*, preventing them from being uninstalled when
 issuing the `brew uninstall` *`formula`* command without `--force`.
 
-If no arguments are provided, list all formula being kept.
+If no arguments are provided, list all formulae being kept.
 
 See also `unkeep`.
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -258,6 +258,12 @@ the installed formulae or, every 30 days, for all formulae.
 * `-g`, `--git`:
   Create a Git repository, useful for creating patches to the software.
 
+### `keep` *`formula`*
+
+Keep the specified *`formula`*, preventing them from being uninstalled when
+issuing the `brew uninstall` *`formula`* command without `--force`. See also
+`unkeep`.
+
 ### `leaves`
 
 List installed formulae that are not dependencies of another installed formula.
@@ -500,6 +506,11 @@ Uninstall *`formula`*.
   Delete all installed versions of *`formula`*.
 * `--ignore-dependencies`:
   Don't fail uninstall, even if *`formula`* is a dependency of any installed formulae.
+
+### `unkeep` *`formula`*
+
+Unkeep *`formula`*, allowing them to be uninstalled by `brew uninstall` *`formula`*
+without `--force`. See also `keep`.
 
 ### `unlink` [*`options`*] *`formula`*
 

--- a/manpages/brew-cask.1
+++ b/manpages/brew-cask.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW\-CASK" "1" "July 2020" "Homebrew" "brew-cask"
+.TH "BREW\-CASK" "1" "August 2020" "Homebrew" "brew-cask"
 .
 .SH "NAME"
 \fBbrew\-cask\fR \- a friendly binary installer for macOS

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "July 2020" "Homebrew" "brew"
+.TH "BREW" "1" "August 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -348,6 +348,9 @@ Download and patch \fIformula\fR, then open a shell\. This allows the user to ru
 \fB\-g\fR, \fB\-\-git\fR
 Create a Git repository, useful for creating patches to the software\.
 .
+.SS "\fBkeep\fR \fIformula\fR"
+Keep the specified \fIformula\fR, preventing them from being uninstalled when issuing the \fBbrew uninstall\fR \fIformula\fR command without \fB\-\-force\fR\. See also \fBunkeep\fR\.
+.
 .SS "\fBleaves\fR"
 List installed formulae that are not dependencies of another installed formula\.
 .
@@ -661,6 +664,9 @@ Delete all installed versions of \fIformula\fR\.
 .TP
 \fB\-\-ignore\-dependencies\fR
 Don\'t fail uninstall, even if \fIformula\fR is a dependency of any installed formulae\.
+.
+.SS "\fBunkeep\fR \fIformula\fR"
+Unkeep \fIformula\fR, allowing them to be uninstalled by \fBbrew uninstall\fR \fIformula\fR without \fB\-\-force\fR\. See also \fBkeep\fR\.
 .
 .SS "\fBunlink\fR [\fIoptions\fR] \fIformula\fR"
 Remove symlinks for \fIformula\fR from Homebrew\'s prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink\fR \fIformula\fR \fB&&\fR \fIcommands\fR \fB&& brew link\fR \fIformula\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -348,8 +348,14 @@ Download and patch \fIformula\fR, then open a shell\. This allows the user to ru
 \fB\-g\fR, \fB\-\-git\fR
 Create a Git repository, useful for creating patches to the software\.
 .
-.SS "\fBkeep\fR \fIformula\fR"
-Keep the specified \fIformula\fR, preventing them from being uninstalled when issuing the \fBbrew uninstall\fR \fIformula\fR command without \fB\-\-force\fR\. See also \fBunkeep\fR\.
+.SS "\fBkeep\fR [\fIformula\fR]"
+Keep the specified \fIformula\fR, preventing them from being uninstalled when issuing the \fBbrew uninstall\fR \fIformula\fR command without \fB\-\-force\fR\.
+.
+.P
+If no arguments are provided, list all formula being kept\.
+.
+.P
+See also \fBunkeep\fR\.
 .
 .SS "\fBleaves\fR"
 List installed formulae that are not dependencies of another installed formula\.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -352,7 +352,7 @@ Create a Git repository, useful for creating patches to the software\.
 Keep the specified \fIformula\fR, preventing them from being uninstalled when issuing the \fBbrew uninstall\fR \fIformula\fR command without \fB\-\-force\fR\.
 .
 .P
-If no arguments are provided, list all formula being kept\.
+If no arguments are provided, list all formulae being kept\.
 .
 .P
 See also \fBunkeep\fR\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds `brew keep` and `brew unkeep`

- `brew keep <formula>`
  - Keep the specified formula, preventing them from being uninstalled when issuing the `brew uninstall` <formula> command without `--force`.
  - Creates an empty file in `HOMEBREW_KEEP_FORMULAE` with the name `formula` if `formula` is installed
- `brew unkeep <formula>`
  - Unkeep formula, allowing them to be uninstalled by `brew uninstall` <formula> without `--force`.
  - Deletes the file/directory in `HOMEBREW_KEEP_FORMULAE` with the name `formula` if it exists
- `HOMEBREW_KEEP_FORMULAE`
  - Defaults to `/usr/local/var/homebrew/keep`

Closes #8206