### PR TITLE
tap-new: update GitHub Actions.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -53,23 +53,37 @@ module Homebrew
         pull_request: []
       jobs:
         test-bot:
-          runs-on: macos-latest
+          runs-on: [ubuntu-latest, macos-latest]
           steps:
+            - name: Update Homebrew
+              run: brew update
+
             - name: Set up Git repository
               uses: actions/checkout@v2
-            - name: Run brew test-bot
+
+            - name: Set up Homebrew
               run: |
-                set -e
-                brew update
                 HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/#{tap.full_name}"
                 mkdir -p "$HOMEBREW_TAP_DIR"
                 rm -rf "$HOMEBREW_TAP_DIR"
                 ln -s "$PWD" "$HOMEBREW_TAP_DIR"
-                brew test-bot
+
+            - name: Run brew test-bot --only-cleanup-before
+              run: brew test-bot --only-cleanup-before
+
+            - name: Run brew test-bot --only-setup
+              run: brew test-bot --only-setup
+
+            - name: Run brew test-bot --only-tap-syntax
+              run: brew test-bot --only-tap-syntax
+
+            - name: Run brew test-bot --only-formulae
+              if: github.event_name == 'pull_request'
+              run: brew test-bot --only-formulae
     YAML
 
     (tap.path/".github/workflows").mkpath
-    write_path(tap, ".github/workflows/main.yml", actions)
+    write_path(tap, ".github/workflows/tests.yml", actions)
     ohai "Created #{tap}"
     puts tap.path.to_s
   end

--- a/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/tap-new_spec.rb
@@ -7,13 +7,13 @@ describe "Homebrew.tap_new_args" do
 end
 
 describe "brew tap-new", :integration_test do
-  it "initializes a new Tap with a ReadMe file and GitHub Actions CI" do
+  it "initializes a new tap with a README file and GitHub Actions CI" do
     expect { brew "tap-new", "homebrew/foo", "--verbose" }
       .to be_a_success
       .and output(%r{homebrew/foo}).to_stdout
       .and not_to_output.to_stderr
 
     expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/README.md").to exist
-    expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/main.yml").to exist
+    expect(HOMEBREW_LIBRARY/"Taps/homebrew/homebrew-foo/.github/workflows/tests.yml").to exist
   end
 end


### PR DESCRIPTION
This should be using the split options for a better user experience and can use both Linux and macOS now.

CC @dawidd6 are your actions ready to be used here (or in homebrew/core, homebrew/brew) now? If so: can you make some suggested changes?

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----