### PR TITLE
license: permit no license for non-core taps, add exempted license groups

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -61,6 +61,8 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: true
   Max: 500
+  Exclude:
+    - 'test/dev-cmd/audit_spec.rb'
 Metrics/PerceivedComplexity:
   Enabled: true
   Max: 80

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -60,9 +60,7 @@ Metrics/MethodLength:
   Max: 260
 Metrics/ModuleLength:
   Enabled: true
-  Max: 500
-  Exclude:
-    - 'test/dev-cmd/audit_spec.rb'
+  Max: 600
 Metrics/PerceivedComplexity:
   Enabled: true
   Max: 80

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -335,6 +335,14 @@ module Homebrew
       openssl@1.1
     ].freeze
 
+    PERMITTED_LICENSE_MISMATCHES = {
+      "AGPL-3.0" => ["AGPL-3.0-only", "AGPL-3.0-or-later"],
+      "GPL-2.0"  => ["GPL-2.0-only",  "GPL-2.0-or-later"],
+      "GPL-3.0"  => ["GPL-3.0-only",  "GPL-3.0-or-later"],
+      "LGPL-2.1" => ["LGPL-2.1-only", "LGPL-2.1-or-later"],
+      "LGPL-3.0" => ["LGPL-3.0-only", "LGPL-3.0-or-later"],
+    }.freeze
+
     def audit_license
       if formula.license.present?
         non_standard_licenses = formula.license.map do |license|
@@ -355,12 +363,12 @@ module Homebrew
 
         github_license = GitHub.get_repo_license(user, repo)
         return if github_license && (formula.license + ["NOASSERTION"]).include?(github_license)
+        return if PERMITTED_LICENSE_MISMATCHES[github_license]&.any? { |license| formula.license.include? license }
 
-        problem "License mismatch - GitHub license is: #{Array(github_license)}, "\
-                "but Formulae license states: #{formula.license}."
+        problem "Formula license #{formula.license} does not match GitHub license #{Array(github_license)}."
 
-      elsif @new_formula
-        problem "No license specified for package."
+      elsif @new_formula && @core_tap
+        problem "Formulae in homebrew/core must specify a license."
       end
     end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -102,14 +102,14 @@ module Homebrew
       end
 
       it "detects no license info" do
-        fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: true
+        fa = formula_auditor "foo", <<~RUBY, spdx_data: spdx_data, new_formula: true, core_tap: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
 
         fa.audit_license
-        expect(fa.problems.first).to match "No license specified for package."
+        expect(fa.problems.first).to match "Formulae in homebrew/core must specify a license."
       end
 
       it "detects if license is not a standard spdx-id" do
@@ -174,6 +174,34 @@ module Homebrew
         expect(fa.problems).to be_empty
       end
 
+      it "checks online and verifies that a standard license id is in the same exempted license group"\
+        "as what is indicated on its Github repo" do
+        fa = formula_auditor "cask", <<~RUBY, spdx_data: spdx_data, online: true, new_formula: true
+          class Cask < Formula
+            url "https://github.com/cask/cask/archive/v0.8.4.tar.gz"
+            head "https://github.com/cask/cask.git"
+            license "GPL-3.0-or-later"
+          end
+        RUBY
+
+        fa.audit_license
+        expect(fa.problems).to be_empty
+      end
+
+      it "checks online and verifies that a standard license array is in the same exempted license group"\
+        "as what is indicated on its Github repo" do
+        fa = formula_auditor "cask", <<~RUBY, spdx_data: spdx_data, online: true, new_formula: true
+          class Cask < Formula
+            url "https://github.com/cask/cask/archive/v0.8.4.tar.gz"
+            head "https://github.com/cask/cask.git"
+            license ["GPL-3.0-or-later", "MIT"]
+          end
+        RUBY
+
+        fa.audit_license
+        expect(fa.problems).to be_empty
+      end
+
       it "checks online and detects that a formula-specified license is not "\
         "the same as what is indicated on its Github repository" do
         fa = formula_auditor "cask", <<~RUBY, online: true, spdx_data: spdx_data, core_tap: true, new_formula: true
@@ -185,8 +213,8 @@ module Homebrew
         RUBY
 
         fa.audit_license
-        expect(fa.problems.first).to match "License mismatch - GitHub license is: [\"GPL-3.0\"], "\
-        "but Formulae license states: #{Array(standard_mismatch_spdx_id)}."
+        expect(fa.problems.first).to match "Formula license #{Array(standard_mismatch_spdx_id)} "\
+                                           "does not match GitHub license [\"GPL-3.0\"]."
       end
 
       it "checks online and detects that an array of license does not contain "\
@@ -200,8 +228,8 @@ module Homebrew
         RUBY
 
         fa.audit_license
-        expect(fa.problems.first).to match "License mismatch - GitHub license is: [\"GPL-3.0\"], "\
-        "but Formulae license states: #{Array(license_array_mismatch)}."
+        expect(fa.problems.first).to match "Formula license #{license_array_mismatch} "\
+          "does not match GitHub license [\"GPL-3.0\"]."
       end
 
       it "checks online and verifies that an array of license contains "\

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -174,8 +174,8 @@ module Homebrew
         expect(fa.problems).to be_empty
       end
 
-      it "checks online and verifies that a standard license id is in the same exempted license group"\
-        "as what is indicated on its Github repo" do
+      it "checks online and verifies that a standard license id is in the same exempted license group" \
+         "as what is indicated on its GitHub repo" do
         fa = formula_auditor "cask", <<~RUBY, spdx_data: spdx_data, online: true, new_formula: true
           class Cask < Formula
             url "https://github.com/cask/cask/archive/v0.8.4.tar.gz"
@@ -188,8 +188,8 @@ module Homebrew
         expect(fa.problems).to be_empty
       end
 
-      it "checks online and verifies that a standard license array is in the same exempted license group"\
-        "as what is indicated on its Github repo" do
+      it "checks online and verifies that a standard license array is in the same exempted license group" \
+         "as what is indicated on its GitHub repo" do
         fa = formula_auditor "cask", <<~RUBY, spdx_data: spdx_data, online: true, new_formula: true
           class Cask < Formula
             url "https://github.com/cask/cask/archive/v0.8.4.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

With this pull request, it's OK for non-core taps to either not specify a license or to say that the license is `NOASSERTION`. 

Furthermore, the GitHub license detection system is not perfect. Create groups of permitted licenses where the license will be considered matching if both the GitHub license and the formula license are members of the same groups. Currently this just applies to GPLv2 and GPLv3. cc @Rylan12 and @chenrui333 for feedback on if they've seen other bad license detection. 