### PR TITLE
workflows/tests: tweak step naming.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,7 @@ jobs:
           sudo chmod -R g-w,o-w /home/linuxbrew /home/runner /opt
         fi
 
-    - name: Run brew style
+    - name: Run brew style on Homebrew/brew
       run: brew style --display-cop-names
 
     - name: Run brew man
@@ -160,16 +160,21 @@ jobs:
       run: brew readall --aliases
 
     - name: Run brew style on homebrew-core
+      if: matrix.os == 'macOS-latest'
+      run: brew style --display-cop-names homebrew/core
+
+    - name: Run brew style on linuxbrew-core
+      if: matrix.os == 'ubuntu-latest'
       run: brew style --display-cop-names homebrew/core
 
     - name: Run brew style on official taps
       run: brew style --display-cop-names homebrew/bundle homebrew/services homebrew/test-bot
 
-    - name: Run brew cask style
+    - name: Run brew cask style on all taps
       if: matrix.os == 'macOS-latest'
       run: brew cask style
 
-    - name: Run brew audit
+    - name: Run brew audit --skip-style on all taps
       run: brew audit --skip-style
 
     - name: Run vale for docs linting


### PR DESCRIPTION
This should make it a bit more obvious what is being tested each time.

The homebrew-core/linuxbrew-core style step actually runs the same command but, as far as I can tell, there's no way of altering the string that's output as the `name` based on the OS.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----