### PR TITLE
style: autocorrect readthedocs and GitHub .git homepages

### DIFF
--- a/Library/Homebrew/rubocops/homepage.rb
+++ b/Library/Homebrew/rubocops/homepage.rb
@@ -58,6 +58,14 @@ module RuboCop
           when %r{^http://([^/]*)\.(sf|sourceforge)\.net(/|$)}
             problem "#{homepage} should be `https://#{Regexp.last_match(1)}.sourceforge.io/`"
 
+          when /readthedocs\.org/
+            offending_node(parameters(homepage_node).first)
+            problem "#{homepage} should be `#{homepage.sub("readthedocs.org", "readthedocs.io")}`"
+
+          when %r{^https://github.com.*\.git}
+            offending_node(parameters(homepage_node).first)
+            problem "GitHub URLs (`#{homepage}`) should not end with .git"
+
           # There's an auto-redirect here, but this mistake is incredibly common too.
           # Only applies to the homepage and subdomains for now, not the FTP URLs.
           when %r{^http://((?:build|cloud|developer|download|extensions|git|
@@ -78,6 +86,17 @@ module RuboCop
                %r{^http://bitbucket\.org/},
                %r{^http://(?:[^/]*\.)?archive\.org}
             problem "Please use https:// for #{homepage}"
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            return if node.nil?
+
+            homepage = string_content(node)
+            homepage.sub!("readthedocs.org", "readthedocs.io")
+            homepage.delete_suffix!(".git") if homepage.start_with?("https://github.com")
+            corrector.replace(node.source_range, "\"#{homepage}\"")
           end
         end
       end

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -62,6 +62,8 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
         "sf3"    => "http://foo.sf.net/",
         "sf4"    => "http://foo.sourceforge.io/",
         "waldo"  => "http://www.gnu.org/waldo",
+        "dotgit" => "https://github.com/foo/bar.git",
+        "rtd"    => "https://foo.readthedocs.org",
       }
 
       formula_homepages.each do |name, homepage|
@@ -100,6 +102,18 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
                                   severity: :convention,
                                   line:     2,
                                   column:   2,
+                                  source:   source }]
+        elsif homepage.match?("https://github.com/foo/bar.git")
+          expected_offenses = [{  message:  "GitHub URLs (`#{homepage}`) should not end with .git",
+                                  severity: :convention,
+                                  line:     2,
+                                  column:   11,
+                                  source:   source }]
+        elsif homepage.match?("https://foo.readthedocs.org")
+          expected_offenses = [{  message:  "#{homepage} should be `https://foo.readthedocs.io`",
+                                  severity: :convention,
+                                  line:     2,
+                                  column:   11,
                                   source:   source }]
         else
           expected_offenses = [{  message:  "Please use https:// for #{homepage}",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Read the Docs sites are hosted on .io and not .org: https://blog.readthedocs.com/securing-subdomains/
.git on GitHub refers to the git repository, not the homepage

We should flag (and possibly autocorrect) these homepage URLs during style checks.