### PR TITLE
Fix issue where the cask_opts env variable was not respected when running upgrade, reinstall, uninstall

### DIFF
--- a/Library/Homebrew/cask/cmd/reinstall.rb
+++ b/Library/Homebrew/cask/cmd/reinstall.rb
@@ -4,13 +4,42 @@ module Cask
   class Cmd
     class Reinstall < Install
       def run
+        self.class.reinstall_casks(
+          *casks,
+          binaries: binaries?,
+          verbose: verbose?,
+          force: force?,
+          skip_cask_deps: skip_cask_deps?,
+          require_sha: require_sha?,
+          quarantine: quarantine?,
+        )
+      end
+
+      def self.reinstall_casks(
+        *casks,
+        binaries: nil,
+        verbose: nil,
+        force: nil,
+        skip_cask_deps: nil,
+        require_sha: nil,
+        quarantine: nil
+      )
+        # TODO: Handle this in `CLI::Parser`.
+        binaries       = Homebrew::EnvConfig.cask_opts_binaries?       if binaries.nil?
+        force          = Homebrew::EnvConfig.cask_opts_force?          if force.nil?
+        quarantine     = Homebrew::EnvConfig.cask_opts_quarantine?     if quarantine.nil?
+        require_sha    = Homebrew::EnvConfig.cask_opts_require_sha?    if require_sha.nil?
+        skip_cask_deps = Homebrew::EnvConfig.cask_opts_skip_cask_deps? if skip_cask_deps.nil?
+        verbose        = Homebrew::EnvConfig.cask_opts_verbose?        if verbose.nil?
+
         casks.each do |cask|
-          Installer.new(cask, binaries:       binaries?,
-                              verbose:        verbose?,
-                              force:          force?,
-                              skip_cask_deps: skip_cask_deps?,
-                              require_sha:    require_sha?,
-                              quarantine:     quarantine?).reinstall
+          Installer.new(cask,
+                        binaries:       binaries,
+                        verbose:        verbose,
+                        force:          force,
+                        skip_cask_deps: skip_cask_deps,
+                        require_sha:    require_sha,
+                        quarantine:     quarantine).reinstall
         end
       end
 

--- a/Library/Homebrew/cask/cmd/reinstall.rb
+++ b/Library/Homebrew/cask/cmd/reinstall.rb
@@ -6,31 +6,28 @@ module Cask
       def run
         self.class.reinstall_casks(
           *casks,
-          binaries: binaries?,
-          verbose: verbose?,
-          force: force?,
+          binaries:       binaries?,
+          verbose:        verbose?,
+          force:          force?,
           skip_cask_deps: skip_cask_deps?,
-          require_sha: require_sha?,
-          quarantine: quarantine?,
+          require_sha:    require_sha?,
+          quarantine:     quarantine?,
         )
       end
 
       def self.reinstall_casks(
         *casks,
+        verbose: false,
+        force: false,
+        skip_cask_deps: false,
         binaries: nil,
-        verbose: nil,
-        force: nil,
-        skip_cask_deps: nil,
         require_sha: nil,
         quarantine: nil
       )
         # TODO: Handle this in `CLI::Parser`.
-        binaries       = Homebrew::EnvConfig.cask_opts_binaries?       if binaries.nil?
-        force          = Homebrew::EnvConfig.cask_opts_force?          if force.nil?
-        quarantine     = Homebrew::EnvConfig.cask_opts_quarantine?     if quarantine.nil?
-        require_sha    = Homebrew::EnvConfig.cask_opts_require_sha?    if require_sha.nil?
-        skip_cask_deps = Homebrew::EnvConfig.cask_opts_skip_cask_deps? if skip_cask_deps.nil?
-        verbose        = Homebrew::EnvConfig.cask_opts_verbose?        if verbose.nil?
+        binaries = Homebrew::EnvConfig.cask_opts_binaries? if binaries.nil?
+        quarantine = Homebrew::EnvConfig.cask_opts_quarantine? if quarantine.nil?
+        require_sha = Homebrew::EnvConfig.cask_opts_require_sha? if require_sha.nil?
 
         casks.each do |cask|
           Installer.new(cask,

--- a/Library/Homebrew/cask/cmd/uninstall.rb
+++ b/Library/Homebrew/cask/cmd/uninstall.rb
@@ -11,17 +11,31 @@ module Cask
       end
 
       def run
+        self.class.uninstall_casks(
+          *casks,
+          binaries: binaries?,
+          verbose: verbose?,
+          force: force?
+        )
+      end
+
+      def self.uninstall_casks(*casks, binaries: nil, verbose: nil, force: nil)
+        # TODO: Handle this in `CLI::Parser`.
+        binaries = Homebrew::EnvConfig.cask_opts_binaries? if binaries.nil?
+        force    = Homebrew::EnvConfig.cask_opts_force?    if force.nil?
+        verbose  = Homebrew::EnvConfig.cask_opts_verbose?  if verbose.nil?
+
         casks.each do |cask|
           odebug "Uninstalling Cask #{cask}"
 
-          raise CaskNotInstalledError, cask unless cask.installed? || force?
+          raise CaskNotInstalledError, cask unless cask.installed? || force
 
           if cask.installed? && !cask.installed_caskfile.nil?
             # use the same cask file that was used for installation, if possible
             cask = CaskLoader.load(cask.installed_caskfile) if cask.installed_caskfile.exist?
           end
 
-          Installer.new(cask, binaries: binaries?, verbose: verbose?, force: force?).uninstall
+          Installer.new(cask, binaries: binaries, verbose: verbose, force: force).uninstall
 
           next if (versions = cask.versions).empty?
 

--- a/Library/Homebrew/cask/cmd/uninstall.rb
+++ b/Library/Homebrew/cask/cmd/uninstall.rb
@@ -14,16 +14,13 @@ module Cask
         self.class.uninstall_casks(
           *casks,
           binaries: binaries?,
-          verbose: verbose?,
-          force: force?
+          verbose:  verbose?,
+          force:    force?,
         )
       end
 
-      def self.uninstall_casks(*casks, binaries: nil, verbose: nil, force: nil)
-        # TODO: Handle this in `CLI::Parser`.
+      def self.uninstall_casks(*casks, verbose: false, force: false, binaries: nil)
         binaries = Homebrew::EnvConfig.cask_opts_binaries? if binaries.nil?
-        force    = Homebrew::EnvConfig.cask_opts_force?    if force.nil?
-        verbose  = Homebrew::EnvConfig.cask_opts_verbose?  if verbose.nil?
 
         casks.each do |cask|
           odebug "Uninstalling Cask #{cask}"

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -33,23 +33,19 @@ module Cask
 
       def self.upgrade_casks(
         *casks,
-        force: nil,
-        greedy: nil,
-        dry_run: nil,
+        force: false,
+        greedy: false,
+        dry_run: false,
+        skip_cask_deps: false,
+        verbose: false,
         binaries: nil,
-        skip_cask_deps: nil,
-        verbose: nil,
         quarantine: nil,
         require_sha: nil
       )
         # TODO: Handle this in `CLI::Parser`.
-        binaries    = Homebrew::EnvConfig.cask_opts_binaries?    if binaries.nil?
-        dry_run     = Homebrew::EnvConfig.cask_opts_dry_run?     if dry_run.nil?
-        force       = Homebrew::EnvConfig.cask_opts_force?       if force.nil?
-        greedy      = Homebrew::EnvConfig.cask_opts_greedy?      if greedy.nil?
-        quarantine  = Homebrew::EnvConfig.cask_opts_quarantine?  if quarantine.nil?
+        binaries = Homebrew::EnvConfig.cask_opts_binaries? if binaries.nil?
+        quarantine = Homebrew::EnvConfig.cask_opts_quarantine? if quarantine.nil?
         require_sha = Homebrew::EnvConfig.cask_opts_require_sha? if require_sha.nil?
-        verbose     = Homebrew::EnvConfig.cask_opts_verbose?     if verbose.nil?
 
         outdated_casks = if casks.empty?
           Caskroom.casks.select do |cask|

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "env_config"
 require "cask/config"
 
 module Cask
@@ -17,14 +18,38 @@ module Cask
       end
 
       def run
-        outdated_casks = casks(alternative: lambda {
-          Caskroom.casks.select do |cask|
-            cask.outdated?(greedy?)
-          end
-        }).select do |cask|
-          raise CaskNotInstalledError, cask unless cask.installed? || force?
+        self.class.upgrade_casks(
+          *casks,
+          force:          force?,
+          greedy:         greedy?,
+          dry_run:        dry_run?,
+          binaries:       binaries?,
+          quarantine:     quarantine?,
+          require_sha:    require_sha?,
+          skip_cask_deps: skip_cask_deps?,
+          verbose:        verbose?,
+        )
+      end
 
-          cask.outdated?(true)
+      def self.upgrade_casks(
+        *casks,
+        force: false, greedy: false, dry_run: false, binaries: true, skip_cask_deps: false, verbose: false,
+        quarantine: nil, require_sha: nil
+      )
+        # TODO: Handle this in `CLI::Parser`.
+        quarantine = Homebrew::EnvConfig.cask_opts_quarantine? if quarantine.nil?
+        require_sha = Homebrew::EnvConfig.cask_opts_require_sha? if require_sha.nil?
+
+        outdated_casks = if casks.empty?
+          Caskroom.casks.select do |cask|
+            cask.outdated?(greedy)
+          end
+        else
+          casks.select do |cask|
+            raise CaskNotInstalledError, cask unless cask.installed? || force
+
+            cask.outdated?(true)
+          end
         end
 
         if outdated_casks.empty?
@@ -32,9 +57,11 @@ module Cask
           return
         end
 
-        ohai "Casks with `auto_updates` or `version :latest` will not be upgraded" if args.empty? && !greedy?
-        verb = dry_run? ? "Would upgrade" : "Upgrading"
+        ohai "Casks with `auto_updates` or `version :latest` will not be upgraded" if casks.empty? && !greedy
+
+        verb = dry_run ? "Would upgrade" : "Upgrading"
         oh1 "#{verb} #{outdated_casks.count} #{"outdated package".pluralize(outdated_casks.count)}:"
+
         caught_exceptions = []
 
         upgradable_casks = outdated_casks.map { |c| [CaskLoader.load(c.installed_caskfile), c] }
@@ -42,10 +69,14 @@ module Cask
         puts upgradable_casks
           .map { |(old_cask, new_cask)| "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}" }
           .join(", ")
-        return if dry_run?
+        return if dry_run
 
         upgradable_casks.each do |(old_cask, new_cask)|
-          upgrade_cask(old_cask, new_cask)
+          upgrade_cask(
+            old_cask, new_cask,
+            binaries: binaries, force: force, skip_cask_deps: skip_cask_deps, verbose: verbose,
+            quarantine: quarantine, require_sha: require_sha
+          )
         rescue => e
           caught_exceptions << e.exception("#{new_cask.full_name}: #{e}")
           next
@@ -56,26 +87,29 @@ module Cask
         raise caught_exceptions.first if caught_exceptions.count == 1
       end
 
-      def upgrade_cask(old_cask, new_cask)
+      def self.upgrade_cask(
+        old_cask, new_cask,
+        binaries:, force:, quarantine:, require_sha:, skip_cask_deps:, verbose:
+      )
         odebug "Started upgrade process for Cask #{old_cask}"
         old_config = old_cask.config
 
         old_cask_installer =
-          Installer.new(old_cask, binaries: binaries?,
-                                  verbose:  verbose?,
-                                  force:    force?,
+          Installer.new(old_cask, binaries: binaries,
+                                  verbose:  verbose,
+                                  force:    force,
                                   upgrade:  true)
 
         new_cask.config = Config.global.merge(old_config)
 
         new_cask_installer =
-          Installer.new(new_cask, binaries:       binaries?,
-                                  verbose:        verbose?,
-                                  force:          force?,
-                                  skip_cask_deps: skip_cask_deps?,
-                                  require_sha:    require_sha?,
+          Installer.new(new_cask, binaries:       binaries,
+                                  verbose:        verbose,
+                                  force:          force,
+                                  skip_cask_deps: skip_cask_deps,
+                                  require_sha:    require_sha,
                                   upgrade:        true,
-                                  quarantine:     quarantine?)
+                                  quarantine:     quarantine)
 
         started_upgrade = false
         new_artifacts_installed = false

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -33,12 +33,23 @@ module Cask
 
       def self.upgrade_casks(
         *casks,
-        force: false, greedy: false, dry_run: false, binaries: true, skip_cask_deps: false, verbose: false,
-        quarantine: nil, require_sha: nil
+        force: nil,
+        greedy: nil,
+        dry_run: nil,
+        binaries: nil,
+        skip_cask_deps: nil,
+        verbose: nil,
+        quarantine: nil,
+        require_sha: nil
       )
         # TODO: Handle this in `CLI::Parser`.
-        quarantine = Homebrew::EnvConfig.cask_opts_quarantine? if quarantine.nil?
+        binaries    = Homebrew::EnvConfig.cask_opts_binaries?    if binaries.nil?
+        dry_run     = Homebrew::EnvConfig.cask_opts_dry_run?     if dry_run.nil?
+        force       = Homebrew::EnvConfig.cask_opts_force?       if force.nil?
+        greedy      = Homebrew::EnvConfig.cask_opts_greedy?      if greedy.nil?
+        quarantine  = Homebrew::EnvConfig.cask_opts_quarantine?  if quarantine.nil?
         require_sha = Homebrew::EnvConfig.cask_opts_require_sha? if require_sha.nil?
+        verbose     = Homebrew::EnvConfig.cask_opts_verbose?     if verbose.nil?
 
         outdated_casks = if casks.empty?
           Caskroom.casks.select do |cask|

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -78,9 +78,14 @@ module Homebrew
 
     return if casks.blank?
 
-    reinstall_cmd = Cask::Cmd::Reinstall.new(casks)
-    reinstall_cmd.verbose = args.verbose?
-    reinstall_cmd.force = args.force?
-    reinstall_cmd.run
+    Cask::Cmd::Reinstall.reinstall_casks(
+      *casks,
+      binaries:       args.binaries?,
+      verbose:        args.verbose?,
+      force:          args.force?,
+      require_sha:    args.require_sha?,
+      skip_cask_deps: args.skip_cask_deps?,
+      quarantine:     args.quarantine?,
+    )
   end
 end

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -127,10 +127,12 @@ module Homebrew
 
     return if casks.blank?
 
-    cask_uninstall = Cask::Cmd::Uninstall.new(casks)
-    cask_uninstall.force = args.force?
-    cask_uninstall.verbose = args.verbose?
-    cask_uninstall.run
+    Cask::Cmd::Uninstall.uninstall_casks(
+      *casks,
+      binaries: args.binaries?,
+      verbose:  args.verbose?,
+      force:    args.force?,
+    )
   rescue MultipleVersionsInstalledError => e
     ofail e
     puts "Run `brew uninstall --force #{e.name}` to remove all versions."

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -133,10 +133,16 @@ module Homebrew
   end
 
   def upgrade_outdated_casks(casks, args:)
-    cask_upgrade = Cask::Cmd::Upgrade.new(casks)
-    cask_upgrade.force = args.force?
-    cask_upgrade.dry_run = args.dry_run?
-    cask_upgrade.greedy = args.greedy?
-    cask_upgrade.run
+    Cask::Cmd::Upgrade.upgrade_casks(
+      *casks,
+      force:          args.force?,
+      greedy:         args.greedy?,
+      dry_run:        args.dry_run?,
+      binaries:       args.binaries?,
+      quarantine:     args.quarantine?,
+      require_sha:    args.require_sha?,
+      skip_cask_deps: args.skip_cask_deps?,
+      verbose:        args.verbose?,
+    )
   end
 end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -54,6 +54,9 @@ module Homebrew
                       "Linux: `$XDG_CACHE_HOME/Homebrew` or `$HOME/.cache/Homebrew`.",
         default:      HOMEBREW_DEFAULT_CACHE,
       },
+      HOMEBREW_CASK_OPTS:                 {
+        description: "Options which should be used for all `cask` commands.",
+      },
       HOMEBREW_CLEANUP_MAX_AGE_DAYS:      {
         description: "Cleanup all cached files older than this many days.",
         default:     120,
@@ -293,7 +296,7 @@ module Homebrew
         end
       elsif hash[:default].present?
         # Needs a custom implementation.
-        next if env == "HOMEBREW_MAKE_JOBS"
+        next if ["HOMEBREW_MAKE_JOBS", "HOMEBREW_CASK_OPTS"].include?(env)
 
         define_method(method_name) do
           ENV[env].presence || hash.fetch(:default).to_s
@@ -314,6 +317,23 @@ module Homebrew
           .fetch(:default)
           .call
           .to_s
+    end
+
+    def cask_opts
+      Shellwords.shellsplit(ENV.fetch("HOMEBREW_CASK_OPTS", ""))
+    end
+
+    def cask_opts_quarantine?
+      cask_opts.reverse_each do |opt|
+        return true if opt == "--quarantine"
+        return false if opt == "--no-quarantine"
+      end
+
+      true
+    end
+
+    def cask_opts_require_sha?
+      cask_opts.include?("--require-sha")
     end
   end
 end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -332,18 +332,6 @@ module Homebrew
       true
     end
 
-    def cask_opts_dry_run?
-      cask_opts.include?("--dry-run")
-    end
-
-    def cask_opts_force?
-      cask_opts.include?("--force")
-    end
-
-    def cask_opts_greedy?
-      cask_opts.include?("--greedy")
-    end
-
     def cask_opts_quarantine?
       cask_opts.reverse_each do |opt|
         return true if opt == "--quarantine"
@@ -355,14 +343,6 @@ module Homebrew
 
     def cask_opts_require_sha?
       cask_opts.include?("--require-sha")
-    end
-
-    def cask_opts_skip_cask_deps?
-      cask_opts.include?("--skip-cask-deps")
-    end
-
-    def cask_opts_verbose?
-      cask_opts.include?("--verbose")
     end
   end
 end

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -323,6 +323,27 @@ module Homebrew
       Shellwords.shellsplit(ENV.fetch("HOMEBREW_CASK_OPTS", ""))
     end
 
+    def cask_opts_binaries?
+      cask_opts.reverse_each do |opt|
+        return true if opt == "--binaries"
+        return false if opt == "--no-binaries"
+      end
+
+      true
+    end
+
+    def cask_opts_dry_run?
+      cask_opts.include?("--dry-run")
+    end
+
+    def cask_opts_force?
+      cask_opts.include?("--force")
+    end
+
+    def cask_opts_greedy?
+      cask_opts.include?("--greedy")
+    end
+
     def cask_opts_quarantine?
       cask_opts.reverse_each do |opt|
         return true if opt == "--quarantine"
@@ -334,6 +355,14 @@ module Homebrew
 
     def cask_opts_require_sha?
       cask_opts.include?("--require-sha")
+    end
+
+    def cask_opts_skip_cask_deps?
+      cask_opts.include?("--skip-cask-deps")
+    end
+
+    def cask_opts_verbose?
+      cask_opts.include?("--verbose")
     end
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1398,6 +1398,9 @@ Note that environment variables must have a value set to be detected. For exampl
 
     *Default:* macOS: `$HOME/Library/Caches/Homebrew`, Linux: `$XDG_CACHE_HOME/Homebrew` or `$HOME/.cache/Homebrew`.
 
+  * `HOMEBREW_CASK_OPTS`:
+    Options which should be used for all `cask` commands.
+
   * `HOMEBREW_CLEANUP_MAX_AGE_DAYS`:
     Cleanup all cached files older than this many days.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1818,6 +1818,10 @@ Use the specified directory as the download cache\.
 \fIDefault:\fR macOS: \fB$HOME/Library/Caches/Homebrew\fR, Linux: \fB$XDG_CACHE_HOME/Homebrew\fR or \fB$HOME/\.cache/Homebrew\fR\.
 .
 .TP
+\fBHOMEBREW_CASK_OPTS\fR
+Options which should be used for all \fBcask\fR commands\.
+.
+.TP
 \fBHOMEBREW_CLEANUP_MAX_AGE_DAYS\fR
 Cleanup all cached files older than this many days\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Process options using Cask::Cmd and pass the processed arguments to reinstall, uninstall, upgrade.

I'm pretty sure this fixes https://github.com/Homebrew/homebrew-cask/issues/87045. I inspected the verbose/debug output and found that quarantine was not being propagated, although I'm not sure what that means. Is there a robust way to detect whether a cask has been quarantined, so that I might write a test for this? 