### PR TITLE
utils: add SPDX module

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -4,6 +4,7 @@ require "formula"
 require "formula_versions"
 require "utils/curl"
 require "utils/notability"
+require "utils/spdx"
 require "extend/ENV"
 require "formula_cellar_checks"
 require "cmd/search"
@@ -118,8 +119,7 @@ module Homebrew
     # Check style in a single batch run up front for performance
     style_results = Style.check_style_json(style_files, options) if style_files
     # load licenses
-    spdx = HOMEBREW_LIBRARY_PATH/"data/spdx.json"
-    spdx_data = JSON.parse(spdx.read)
+    spdx_data = SPDX.spdx_data
     new_formula_problem_lines = []
     audit_formulae.sort.each do |f|
       only = only_cops ? ["style"] : args.only

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "utils/spdx"
+
+describe SPDX do
+  describe ".spdx_data" do
+    it "has the license list version" do
+      expect(described_class.spdx_data["licenseListVersion"]).not_to eq(nil)
+    end
+
+    it "has the release date" do
+      expect(described_class.spdx_data["releaseDate"]).not_to eq(nil)
+    end
+
+    it "has licenses" do
+      expect(described_class.spdx_data["licenses"].length).not_to eq(0)
+    end
+  end
+
+  describe ".download_latest_license_data!", :needs_network do
+    let(:tmp_json_path) { Pathname.new("#{TEST_TMPDIR}/spdx.json") }
+
+    after do
+      FileUtils.rm tmp_json_path
+    end
+
+    it "downloads latest license data" do
+      described_class.download_latest_license_data! to: tmp_json_path
+      expect(tmp_json_path).to exist
+    end
+  end
+end

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "utils/github"
+
+module SPDX
+  module_function
+
+  JSON_PATH = (HOMEBREW_LIBRARY_PATH/"data/spdx.json").freeze
+  API_URL = "https://api.github.com/repos/spdx/license-list-data/releases/latest"
+
+  def spdx_data
+    @spdx_data ||= JSON.parse(JSON_PATH.read)
+  end
+
+  def download_latest_license_data!
+    latest_tag = GitHub.open_api(API_URL)["tag_name"]
+    data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{latest_tag}/json/licenses.json"
+    curl_download(data_url, to: JSON_PATH, partial: false)
+  end
+end

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -12,9 +12,9 @@ module SPDX
     @spdx_data ||= JSON.parse(JSON_PATH.read)
   end
 
-  def download_latest_license_data!
+  def download_latest_license_data!(to: JSON_PATH)
     latest_tag = GitHub.open_api(API_URL)["tag_name"]
     data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{latest_tag}/json/licenses.json"
-    curl_download(data_url, to: JSON_PATH, partial: false)
+    curl_download(data_url, to: to, partial: false)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Adds two new functions:
  - `SPDX.spdx_data` - returns the parsed JSON of `Library/Homebrew/data/spdx.json`
  - `SPDX.update_license_data` - updates `Library/Homebrew/data/spdx.json` to latest
- Replaces the two uses of `HOMEBREW_LIBRARY_PATH/"data/spdx.json"` with `SPDX.SPDX_PATH`
- Allows for use of SPDX data in external scripts, for example in `brew irb`:

```
irb(main):001:0> require "utils/spdx"
=> true
irb(main):002:0> SPDX.spdx_data["licenses"][0]["licenseId"]
=> "0BSD"
```