### PR TITLE
Deprecate global `Homebrew.args`.

### DIFF
--- a/Library/Homebrew/compat.rb
+++ b/Library/Homebrew/compat.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "compat/dependencies_helpers"
+require "compat/cli/parser"
 require "compat/extend/nil"
 require "compat/extend/string"
 require "compat/formula"

--- a/Library/Homebrew/compat/cli/parser.rb
+++ b/Library/Homebrew/compat/cli/parser.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Homebrew
+  module CLI
+    class Parser
+      module Compat
+        module DeprecatedArgs
+          def respond_to_missing?(*)
+            super
+          end
+
+          def method_missing(method, *)
+            if ![:debug?, :quiet?, :verbose?].include?(method) && !@printed_args_warning
+              odeprecated "Homebrew.args", "`args = <command>_args.parse` and pass `args` along the call chain"
+              @printed_args_warning = true
+            end
+
+            super
+          end
+        end
+
+        def parse(*)
+          args = super
+          Homebrew.args = args.dup.extend(DeprecatedArgs)
+          args
+        end
+      end
+
+      prepend Compat
+    end
+  end
+end

--- a/Library/Homebrew/compat/dependencies_helpers.rb
+++ b/Library/Homebrew/compat/dependencies_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "cli/args"
+
+module DependenciesHelpers
+  module Compat
+    def argv_includes_ignores(argv = nil)
+      unless @printed_includes_ignores_warning
+        odeprecated "Homebrew.argv_includes_ignores", "Homebrew.args_includes_ignores"
+        @printed_includes_ignores_warning = true
+      end
+      args_includes_ignores(argv ? Homebrew::CLI::Args.new : Homebrew.args)
+    end
+  end
+
+  prepend Compat
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Finished the implementation started by @SeekingMeaning in https://github.com/Homebrew/brew/pull/8204.

Closes https://github.com/Homebrew/brew/pull/8204.