### PR TITLE
commands: fix for external ruby commands

### DIFF
--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -63,13 +63,13 @@ module Commands
 
   # Ruby commands which can be `require`d without being run.
   def external_ruby_v2_cmd_path(cmd)
-    path = which("#{cmd}.rb", Tap.cmd_directories)
+    path = which("#{cmd}.rb", Tap.cmd_directories, require_executable: false)
     path if require?(path)
   end
 
   # Ruby commands which are run by being `require`d.
   def external_ruby_cmd_path(cmd)
-    which("brew-#{cmd}.rb", PATH.new(ENV["PATH"]).append(Tap.cmd_directories))
+    which("brew-#{cmd}.rb", PATH.new(ENV["PATH"]).append(Tap.cmd_directories), require_executable: false)
   end
 
   def external_cmd_path(cmd)

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -275,7 +275,7 @@ module Kernel
     end
   end
 
-  def which(cmd, path = ENV["PATH"])
+  def which(cmd, path = ENV["PATH"], require_executable: true)
     PATH.new(path).each do |p|
       begin
         pcmd = File.expand_path(cmd, p)
@@ -284,7 +284,7 @@ module Kernel
         # See https://github.com/Homebrew/legacy-homebrew/issues/32789
         next
       end
-      return Pathname.new(pcmd) if File.file?(pcmd) && File.executable?(pcmd)
+      return Pathname.new(pcmd) if File.file?(pcmd) && (File.executable?(pcmd) || !require_executable)
     end
     nil
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Do not require ruby files to have execute permission (i.e. do not require `chmod +x my-command.rb`)

This adds to `Homebrew.which` a `require_executable` parameter that defaults to `true`