### PR TITLE
cask/cmd/update: output message consistency

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -59,10 +59,7 @@ module Cask
           end
         end
 
-        if outdated_casks.empty?
-          oh1 "No Casks to upgrade"
-          return
-        end
+        return if outdated_casks.empty?
 
         ohai "Casks with `auto_updates` or `version :latest` will not be upgraded" if casks.empty? && !greedy
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The merging of https://github.com/Homebrew/brew/pull/7927 has resulted in the command `brew upgrade` upgrading both formulae and casks, which is a good thing.

[These lines](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cask/cmd/upgrade.rb#L62-L65) of `cask/cmd/upgrade` print the message `No Casks to upgrade` when all of one's installed casks are up-to-date, like so:
```
|-> brew upgrade
==> No Casks to upgrade
```

In the spirit of consistency, this change prints a similar message when all of one's installed formulae are up-to-date, like so:
```
|-> brew upgrade
==> No Formulae to upgrade
==> No Casks to upgrade
```

Thank you.