### PR TITLE
cask/cmd/upgrade: output cask upgrades on new line

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -72,7 +72,7 @@ module Cask
 
         puts upgradable_casks
           .map { |(old_cask, new_cask)| "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}" }
-          .join(", ")
+          .join("\n")
         return if dry_run
 
         upgradable_casks.each do |(old_cask, new_cask)|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This changes the output of which casks are to be upgraded from a single line separated by `, ` to each cask to be upgraded being printed on a new line; this is consistent with how [formula upgrades are listed](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/upgrade.rb#L135).

This should also (hopefully) help with things like [this](https://discourse.brew.sh/t/brew-upgrade-now-upgrades-casks-but-i-dont-want-that/8459/10).

Thank you.