### PR TITLE
Fix “wrong number of arguments” error

### DIFF
--- a/Library/Homebrew/reinstall.rb
+++ b/Library/Homebrew/reinstall.rb
@@ -74,7 +74,7 @@ module Homebrew
     end
   end
 
-  def restore_backup(keg, keg_was_linked)
+  def restore_backup(keg, keg_was_linked, verbose:)
     path = backup_path(keg)
 
     return unless path.directory?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **Seven failing tests locally but none of them seem related.**

-----

This PR fixes an error introduced in #8187, which would surface on certain `brew install`/`brew reinstall`/`brew upgrade` failures.

Example:

```
==> Patching
patching file default_out.txt
Hunk #2 FAILED at 11.
1 out of 2 hunks FAILED -- saving rejects to file default_out.txt.rej
Error: wrong number of arguments (given 3, expected 2)
/usr/local/Homebrew/Library/Homebrew/reinstall.rb:77:in `restore_backup'
/usr/local/Homebrew/Library/Homebrew/reinstall.rb:52:in `block in reinstall_formula'
/usr/local/Homebrew/Library/Homebrew/utils.rb:377:in `ignore_interrupts'
/usr/local/Homebrew/Library/Homebrew/reinstall.rb:52:in `rescue in reinstall_formula'
/usr/local/Homebrew/Library/Homebrew/reinstall.rb:10:in `reinstall_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/reinstall.rb:71:in `block in reinstall'
/usr/local/Homebrew/Library/Homebrew/cmd/reinstall.rb:65:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/reinstall.rb:65:in `reinstall'
/usr/local/Homebrew/Library/Homebrew/brew.rb:112:in `<main>'
```
