### PR TITLE
Fix --formula and --cask flags.

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -23,12 +23,12 @@ module Homebrew
              description: "Show the cache file used when building from source."
       switch "--force-bottle",
              description: "Show the cache file used when pouring a bottle."
-      switch "--formulae",
+      switch "--formula",
              description: "Only show cache files for formulae."
-      switch "--casks",
+      switch "--cask",
              description: "Only show cache files for casks."
       conflicts "--build-from-source", "--force-bottle"
-      conflicts "--formulae", "--casks"
+      conflicts "--formula", "--cask"
     end
   end
 
@@ -37,11 +37,11 @@ module Homebrew
 
     if args.no_named?
       puts HOMEBREW_CACHE
-    elsif args.formulae?
+    elsif args.formula?
       args.named.each do |name|
         print_formula_cache name, args: args
       end
-    elsif args.casks?
+    elsif args.cask?
       args.named.each do |name|
         print_cask_cache name
       end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -32,9 +32,9 @@ module Homebrew
       switch "--pinned",
              description: "Show the versions of pinned formulae, or only the specified (pinned) "\
                           "formulae if <formula> are provided. See also `pin`, `unpin`."
-      switch "--formulae",
+      switch "--formula", "--formulae",
              description: "List only formulae."
-      switch "--casks",
+      switch "--cask", "--casks",
              description: "List only casks."
       # passed through to ls
       switch "-1",
@@ -48,8 +48,8 @@ module Homebrew
       switch "-t",
              description: "Sort by time modified, listing most recently modified first."
 
-      ["--formulae", "--unbrewed", "--multiple", "--pinned", "-l", "-r", "-t"].each do |flag|
-        conflicts "--casks", flag
+      ["--formula", "--unbrewed", "--multiple", "--pinned", "-l", "-r", "-t"].each do |flag|
+        conflicts "--cask", flag
       end
     end
   end
@@ -57,7 +57,7 @@ module Homebrew
   def list
     args = list_args.parse
 
-    return list_casks(args: args) if args.casks?
+    return list_casks(args: args) if args.cask?
 
     return list_unbrewed if args.unbrewed?
 

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -21,9 +21,9 @@ module Homebrew
              description: "List only the names of outdated kegs (takes precedence over `--verbose`)."
       switch "-v", "--verbose",
              description: "Include detailed version information."
-      switch "--formulae",
+      switch "--formula",
              description: "Only output outdated formulae."
-      switch "--casks",
+      switch "--cask",
              description: "Only output outdated casks."
       flag   "--json",
              description: "Print output in JSON format. There are two versions: v1 and v2. " \
@@ -37,7 +37,7 @@ module Homebrew
              description: "Print outdated casks with `auto_updates` or `version :latest`."
 
       conflicts "--quiet", "--verbose", "--json"
-      conflicts "--formulae", "--casks"
+      conflicts "--formula", "--cask"
     end
   end
 
@@ -49,7 +49,7 @@ module Homebrew
       # TODO: enable for next major/minor release
       # odeprecated "brew outdated --json#{json_version == :v1 ? "=v1" : ""}", "brew outdated --json=v2"
 
-      outdated = if args.formulae? || !args.casks?
+      outdated = if args.formula? || !args.cask?
         outdated_formulae args: args
       else
         outdated_casks args: args
@@ -58,9 +58,9 @@ module Homebrew
       puts JSON.generate(json_info(outdated, args: args))
 
     when :v2
-      formulae, casks = if args.formulae?
+      formulae, casks = if args.formula?
         [outdated_formulae(args: args), []]
-      elsif args.casks?
+      elsif args.cask?
         [[], outdated_casks(args: args)]
       else
         outdated_formulae_casks args: args
@@ -75,9 +75,9 @@ module Homebrew
       outdated = formulae + casks
 
     else
-      outdated = if args.formulae?
+      outdated = if args.formula?
         outdated_formulae args: args
-      elsif args.casks?
+      elsif args.cask?
         outdated_casks args: args
       else
         outdated_formulae_casks(args: args).flatten

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -36,10 +36,10 @@ module Homebrew
         If no <text> is provided, list all locally available formulae (including tapped ones).
         No online search is performed.
       EOS
-      switch "--formulae",
+      switch "--formula", "--formulae",
              description: "Without <text>, list all locally available formulae (no online search is performed). " \
                           "With <text>, search online and locally for formulae."
-      switch "--casks",
+      switch "--cask", "--casks",
              description: "Without <text>, list all locally available casks (including tapped ones, no online " \
                           "search is performed). With <text>, search online and locally for casks."
       switch "--desc",
@@ -66,8 +66,8 @@ module Homebrew
     end
 
     if args.no_named?
-      if args.casks?
-        raise UsageError, "specifying both --formulae and --casks requires <text>" if args.formulae?
+      if args.cask?
+        raise UsageError, "specifying both --formula and --cask requires <text>" if args.formula?
 
         puts Formatter.columns(Cask::Cask.to_a.map(&:full_name).sort)
       else
@@ -92,8 +92,8 @@ module Homebrew
       local_casks = search_casks(string_or_regex)
       remote_casks = remote_results[:casks]
       all_casks = local_casks + remote_casks
-      print_formulae = args.formulae?
-      print_casks = args.casks?
+      print_formulae = args.formula?
+      print_casks = args.cask?
       print_formulae = print_casks = true if !print_formulae && !print_casks
 
       if print_formulae && all_formulae.any?
@@ -102,7 +102,7 @@ module Homebrew
       end
 
       if print_casks && all_casks.any?
-        puts if args.formulae? && all_formulae.any?
+        puts if args.formula? && all_formulae.any?
         ohai "Casks"
         puts Formatter.columns(all_casks)
       end

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -26,9 +26,9 @@ module Homebrew
       switch "-d", "--debug",
              description: "If brewing fails, open an interactive debugging session with access to IRB "\
                           "or a shell inside the temporary build directory."
-      switch "--formulae",
+      switch "--formula",
              description: "Only upgrade outdated formulae."
-      switch "--casks",
+      switch "--cask",
              description: "Only upgrade outdated casks."
       switch "-s", "--build-from-source",
              description: "Compile <formula> from source even if a bottle is available."
@@ -60,11 +60,11 @@ module Homebrew
       switch "--greedy",
              description: "Upgrade casks with `auto_updates` or `version :latest`"
       conflicts "--build-from-source", "--force-bottle"
-      conflicts "--formulae", "--greedy"
-      ["--formulae", "-s", "--build-from-source", "-i", "--interactive",
+      conflicts "--formula", "--greedy"
+      ["--formula", "-s", "--build-from-source", "-i", "--interactive",
        "--force-bottle", "--fetch-HEAD", "--ignore-pinned", "--keep-tmp",
        "--display-times"].each do |flag|
-        conflicts "--casks", flag
+        conflicts "--cask", flag
       end
       formula_options
     end
@@ -77,8 +77,8 @@ module Homebrew
     # If one or more formulae are specified, but no casks were
     # specified, we want to make note of that so we don't
     # try to upgrade all outdated casks.
-    upgrade_formulae = formulae.present? && casks.blank? && !args.casks?
-    upgrade_casks = casks.present? && formulae.blank? && !args.formulae?
+    upgrade_formulae = formulae.present? && casks.blank? && !args.cask?
+    upgrade_casks = casks.present? && formulae.blank? && !args.formula?
 
     upgrade_outdated_formulae(formulae, args: args) unless upgrade_casks
     upgrade_outdated_casks(casks, args: args) unless upgrade_formulae

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -453,7 +453,7 @@ _brew_search() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     -*)
-      __brewcomp "--casks --debian --desc --fedora --fink --macports --opensuse --ubuntu"
+      __brewcomp "--cask --debian --desc --fedora --fink --macports --opensuse --ubuntu"
       return
       ;;
   esac

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -208,7 +208,7 @@ function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the in
 end
 
 function __fish_brew_suggest_casks_all -d "Lists locally available casks"
-    brew search --casks
+    brew search --cask
 end
 
 

--- a/completions/zsh/_brew_cask
+++ b/completions/zsh/_brew_cask
@@ -22,7 +22,7 @@ __brew_all_casks() {
   local comp_cachename=brew_casks
 
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew search --casks) )
+    list=( $(brew search --cask) )
     _store_cache $comp_cachename list
   fi
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -290,9 +290,9 @@ If *`formula`* is provided, summarise the paths within its current keg.
   Only show formulae with multiple versions installed.
 * `--pinned`:
   Show the versions of pinned formulae, or only the specified (pinned) formulae if *`formula`* are provided. See also `pin`, `unpin`.
-* `--formulae`:
+* `--formula`:
   List only formulae.
-* `--casks`:
+* `--cask`:
   List only casks.
 * `-1`:
   Force output to be one entry per line. This is the default when output is not to a terminal.
@@ -359,9 +359,9 @@ otherwise.
   List only the names of outdated kegs (takes precedence over `--verbose`).
 * `-v`, `--verbose`:
   Include detailed version information.
-* `--formulae`:
+* `--formula`:
   Only output outdated formulae.
-* `--casks`:
+* `--cask`:
   Only output outdated casks.
 * `--json`:
   Print output in JSON format. There are two versions: v1 and v2. v1 is deprecated and is currently the default if no version is specified. v2 prints outdated formulae and casks. 
@@ -425,9 +425,9 @@ search for *`text`* is extended online to `homebrew/core` and `homebrew/cask`.
 If no *`text`* is provided, list all locally available formulae (including tapped
 ones). No online search is performed.
 
-* `--formulae`:
+* `--formula`:
   Without *`text`*, list all locally available formulae (no online search is performed). With *`text`*, search online and locally for formulae.
-* `--casks`:
+* `--cask`:
   Without *`text`*, list all locally available casks (including tapped ones, no online search is performed). With *`text`*, search online and locally for casks.
 * `--desc`:
   Search for formulae with a description matching *`text`* and casks with a name matching *`text`*.
@@ -550,9 +550,9 @@ the upgraded formulae or, every 30 days, for all formulae.
 
 * `-d`, `--debug`:
   If brewing fails, open an interactive debugging session with access to IRB or a shell inside the temporary build directory.
-* `--formulae`:
+* `--formula`:
   Only upgrade outdated formulae.
-* `--casks`:
+* `--cask`:
   Only upgrade outdated casks.
 * `-s`, `--build-from-source`:
   Compile *`formula`* from source even if a bottle is available.
@@ -611,9 +611,9 @@ If *`formula`* is provided, display the file or directory used to cache *`formul
   Show the cache file used when building from source.
 * `--force-bottle`:
   Show the cache file used when pouring a bottle.
-* `--formulae`:
+* `--formula`:
   Only show cache files for formulae.
-* `--casks`:
+* `--cask`:
   Only show cache files for casks.
 
 ### `--caskroom` [*`cask`*]
@@ -1219,11 +1219,11 @@ flags which will help find keg-only dependencies like `openssl`, `icu4c`, etc.
   `install` won't output a `Brewfile.lock.json`.
 * `--all`:
   `list` all dependencies.
-* `--formulae`:
+* `--formula`:
   `list` Homebrew dependencies.
-* `--casks`:
+* `--cask`:
   `list` Homebrew Cask dependencies.
-* `--taps`:
+* `--tap`:
   `list` tap dependencies.
 * `--mas`:
   `list` Mac App Store dependencies.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -393,11 +393,11 @@ Only show formulae with multiple versions installed\.
 Show the versions of pinned formulae, or only the specified (pinned) formulae if \fIformula\fR are provided\. See also \fBpin\fR, \fBunpin\fR\.
 .
 .TP
-\fB\-\-formulae\fR
+\fB\-\-formula\fR
 List only formulae\.
 .
 .TP
-\fB\-\-casks\fR
+\fB\-\-cask\fR
 List only casks\.
 .
 .TP
@@ -484,11 +484,11 @@ List only the names of outdated kegs (takes precedence over \fB\-\-verbose\fR)\.
 Include detailed version information\.
 .
 .TP
-\fB\-\-formulae\fR
+\fB\-\-formula\fR
 Only output outdated formulae\.
 .
 .TP
-\fB\-\-casks\fR
+\fB\-\-cask\fR
 Only output outdated casks\.
 .
 .TP
@@ -565,11 +565,11 @@ Perform a substring search of cask tokens and formula names for \fItext\fR\. If 
 If no \fItext\fR is provided, list all locally available formulae (including tapped ones)\. No online search is performed\.
 .
 .TP
-\fB\-\-formulae\fR
+\fB\-\-formula\fR
 Without \fItext\fR, list all locally available formulae (no online search is performed)\. With \fItext\fR, search online and locally for formulae\.
 .
 .TP
-\fB\-\-casks\fR
+\fB\-\-cask\fR
 Without \fItext\fR, list all locally available casks (including tapped ones, no online search is performed)\. With \fItext\fR, search online and locally for casks\.
 .
 .TP
@@ -711,11 +711,11 @@ Unless \fBHOMEBREW_NO_INSTALL_CLEANUP\fR is set, \fBbrew cleanup\fR will then be
 If brewing fails, open an interactive debugging session with access to IRB or a shell inside the temporary build directory\.
 .
 .TP
-\fB\-\-formulae\fR
+\fB\-\-formula\fR
 Only upgrade outdated formulae\.
 .
 .TP
-\fB\-\-casks\fR
+\fB\-\-cask\fR
 Only upgrade outdated casks\.
 .
 .TP
@@ -812,11 +812,11 @@ Show the cache file used when building from source\.
 Show the cache file used when pouring a bottle\.
 .
 .TP
-\fB\-\-formulae\fR
+\fB\-\-formula\fR
 Only show cache files for formulae\.
 .
 .TP
-\fB\-\-casks\fR
+\fB\-\-cask\fR
 Only show cache files for casks\.
 .
 .SS "\fB\-\-caskroom\fR [\fIcask\fR]"
@@ -1585,15 +1585,15 @@ Read the \fBBrewfile\fR from \fB~/\.Brewfile\fR\.
 \fBlist\fR all dependencies\.
 .
 .TP
-\fB\-\-formulae\fR
+\fB\-\-formula\fR
 \fBlist\fR Homebrew dependencies\.
 .
 .TP
-\fB\-\-casks\fR
+\fB\-\-cask\fR
 \fBlist\fR Homebrew Cask dependencies\.
 .
 .TP
-\fB\-\-taps\fR
+\fB\-\-tap\fR
 \fBlist\fR tap dependencies\.
 .
 .TP


### PR DESCRIPTION
These were all made `--formulae` and `--casks` for consistency but that doesn't behave as expected because they have special behaviours in `args`. Instead, use the singular form everywhere.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----