### PR TITLE
cask/dsl/base: fix undefined method `method_missing_message'

### DIFF
--- a/Library/Homebrew/cask/dsl/base.rb
+++ b/Library/Homebrew/cask/dsl/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "cask/utils"
+
 module Cask
   class DSL
     class Base


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This has popped up a fair bit in bug reports in the past couple years.

e.g. #8244