### PR TITLE
keep  BUNDLER_VERSION in sync with Gemfile.lock

### DIFF
--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -8,7 +8,7 @@ require "English"
 
 module Homebrew
   # Keep in sync with the Gemfile.lock's BUNDLED WITH.
-  HOMEBREW_BUNDLER_VERSION = "1.17.2"
+  HOMEBREW_BUNDLER_VERSION = "1.17.3"
 
   module_function
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The version in [master Gemfile.lock is 1.17.3](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/Gemfile.lock#L144),
maybe forgot to update here.
