### PR TITLE
Raise TypeError in Livecheck DSL methods, expand tests, improve documentation comments

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-# Livecheck can be used to check for newer versions of the software.
-# The livecheck DSL specified in the formula is evaluated the methods
-# of this class, which set the instance variables accordingly. The
-# information is used by brew livecheck when checking for newer versions
-# of the software.
+# The `Livecheck` class implements the DSL methods used in a formula's
+# `livecheck` block and stores related instance variables. Most of these methods
+# also return the related instance variable when no argument is provided.
+#
+# This information is used by the `brew livecheck` command to control its
+# behavior.
 class Livecheck
-  # The reason for skipping livecheck for the formula.
-  # e.g. `Not maintained`
+  # A very brief description of why the formula is skipped (e.g., `No longer
+  # developed or maintained`).
+  # @return [String, nil]
   attr_reader :skip_msg
 
   def initialize(formula)
@@ -19,8 +21,10 @@ class Livecheck
     @url = nil
   end
 
-  # Sets the regex instance variable to the argument given, returns the
-  # regex instance variable when no argument is given.
+  # Sets the `@regex` instance variable to the provided `Regexp` or returns the
+  # `@regex` instance variable when no argument is provided.
+  # @param pattern [Regexp] regex to use for matching versions in content
+  # @return [Regexp, nil]
   def regex(pattern = nil)
     case pattern
     when nil
@@ -32,10 +36,12 @@ class Livecheck
     end
   end
 
-  # Sets the skip instance variable to true, indicating that livecheck
-  # must be skipped for the formula. If an argument is given and present,
-  # its value is assigned to the skip_msg instance variable, else nil is
-  # assigned.
+  # Sets the `@skip` instance variable to `true` and sets the `@skip_msg`
+  # instance variable if a `String` is provided. `@skip` is used to indicate
+  # that the formula should be skipped and the `skip_msg` very briefly describes
+  # why the formula is skipped (e.g., `No longer developed or maintained`).
+  # @param skip_msg [String] string describing why the formula is skipped
+  # @return [Boolean]
   def skip(skip_msg = nil)
     if skip_msg.is_a?(String)
       @skip_msg = skip_msg
@@ -46,16 +52,17 @@ class Livecheck
     @skip = true
   end
 
-  # Should livecheck be skipped for the formula?
+  # Should `livecheck` skip this formula?
   def skip?
     @skip
   end
 
-  # Sets the strategy instance variable to the provided symbol or returns the
-  # strategy instance variable when no argument is provided. The strategy
+  # Sets the `@strategy` instance variable to the provided `Symbol` or returns
+  # the `@strategy` instance variable when no argument is provided. The strategy
   # symbols use snake case (e.g., `:page_match`) and correspond to the strategy
   # file name.
   # @param symbol [Symbol] symbol for the desired strategy
+  # @return [Symbol, nil]
   def strategy(symbol = nil)
     case symbol
     when nil
@@ -67,8 +74,12 @@ class Livecheck
     end
   end
 
-  # Sets the url instance variable to the argument given, returns the url
-  # instance variable when no argument is given.
+  # Sets the `@url` instance variable to the provided argument or returns the
+  # `@url` instance variable when no argument is provided. The argument can be
+  # a `String` (a URL) or a supported `Symbol` corresponding to a URL in the
+  # formula (e.g., `:stable`, `:homepage`, or `:head`).
+  # @param val [String, Symbol] URL to check for version information
+  # @return [String, nil]
   def url(val = nil)
     @url = case val
     when nil
@@ -84,7 +95,8 @@ class Livecheck
     end
   end
 
-  # Returns a Hash of all instance variable values.
+  # Returns a `Hash` of all instance variable values.
+  # @return [Hash]
   def to_hash
     {
       "regex"    => @regex,

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -22,9 +22,14 @@ class Livecheck
   # Sets the regex instance variable to the argument given, returns the
   # regex instance variable when no argument is given.
   def regex(pattern = nil)
-    return @regex if pattern.nil?
-
-    @regex = pattern
+    case pattern
+    when nil
+      @regex
+    when Regexp
+      @regex = pattern
+    else
+      raise TypeError, "Livecheck#regex expects a Regexp"
+    end
   end
 
   # Sets the skip instance variable to true, indicating that livecheck
@@ -32,8 +37,13 @@ class Livecheck
   # its value is assigned to the skip_msg instance variable, else nil is
   # assigned.
   def skip(skip_msg = nil)
+    if skip_msg.is_a?(String)
+      @skip_msg = skip_msg
+    elsif skip_msg.present?
+      raise TypeError, "Livecheck#skip expects a String"
+    end
+
     @skip = true
-    @skip_msg = skip_msg.presence
   end
 
   # Should livecheck be skipped for the formula?
@@ -60,15 +70,17 @@ class Livecheck
   # Sets the url instance variable to the argument given, returns the url
   # instance variable when no argument is given.
   def url(val = nil)
-    return @url if val.nil?
-
     @url = case val
+    when nil
+      return @url
     when :head, :stable, :devel
       @formula.send(val).url
     when :homepage
       @formula.homepage
-    else
+    when String
       val
+    else
+      raise TypeError, "Livecheck#url expects a String or valid Symbol"
     end
   end
 

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -20,6 +20,12 @@ describe Livecheck do
       livecheckable.regex(/foo/)
       expect(livecheckable.regex).to eq(/foo/)
     end
+
+    it "raises a TypeError if the argument isn't a Regexp" do
+      expect {
+        livecheckable.regex("foo")
+      }.to raise_error(TypeError, "Livecheck#regex expects a Regexp")
+    end
   end
 
   describe "#skip" do
@@ -33,6 +39,12 @@ describe Livecheck do
       livecheckable.skip("foo")
       expect(livecheckable.instance_variable_get(:@skip)).to be true
       expect(livecheckable.instance_variable_get(:@skip_msg)).to eq("foo")
+    end
+
+    it "raises a TypeError if the argument isn't a String" do
+      expect {
+        livecheckable.skip(/foo/)
+      }.to raise_error(TypeError, "Livecheck#skip expects a String")
     end
   end
 
@@ -69,6 +81,11 @@ describe Livecheck do
     it "returns the URL if set" do
       livecheckable.url("foo")
       expect(livecheckable.url).to eq("foo")
+
+    it "raises a TypeError if the argument isn't a String or Symbol" do
+      expect {
+        livecheckable.url(/foo/)
+      }.to raise_error(TypeError, "Livecheck#url expects a String or valid Symbol")
     end
   end
 

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -4,19 +4,25 @@ require "formula"
 require "livecheck"
 
 describe Livecheck do
+  HOMEPAGE_URL = "https://example.com/"
+  STABLE_URL = "https://example.com/example-1.2.3.tar.gz"
+  HEAD_URL = "https://example.com/example.git"
+
   let(:f) do
     formula do
-      url "https://brew.sh/test-0.1.tbz"
+      homepage HOMEPAGE_URL
+      url STABLE_URL
+      head HEAD_URL
     end
   end
   let(:livecheckable) { described_class.new(f) }
 
   describe "#regex" do
-    it "returns nil if unset" do
+    it "returns nil if not set" do
       expect(livecheckable.regex).to be nil
     end
 
-    it "returns the Regex if set" do
+    it "returns the Regexp if set" do
       livecheckable.regex(/foo/)
       expect(livecheckable.regex).to eq(/foo/)
     end
@@ -29,14 +35,14 @@ describe Livecheck do
   end
 
   describe "#skip" do
-    it "sets the instance variable skip to true and skip_msg to nil when the argument is not present" do
-      livecheckable.skip
+    it "sets @skip to true when no argument is provided" do
+      expect(livecheckable.skip).to be true
       expect(livecheckable.instance_variable_get(:@skip)).to be true
       expect(livecheckable.instance_variable_get(:@skip_msg)).to be nil
     end
 
-    it "sets the instance variable skip to true and skip_msg to the argument when present" do
-      livecheckable.skip("foo")
+    it "sets @skip to true and @skip_msg to the provided String" do
+      expect(livecheckable.skip("foo")).to be true
       expect(livecheckable.instance_variable_get(:@skip)).to be true
       expect(livecheckable.instance_variable_get(:@skip_msg)).to eq("foo")
     end
@@ -49,8 +55,9 @@ describe Livecheck do
   end
 
   describe "#skip?" do
-    it "returns the value of the instance variable skip" do
+    it "returns the value of @skip" do
       expect(livecheckable.skip?).to be false
+
       livecheckable.skip
       expect(livecheckable.skip?).to be true
     end
@@ -74,13 +81,23 @@ describe Livecheck do
   end
 
   describe "#url" do
-    it "returns nil if unset" do
+    it "returns nil if not set" do
       expect(livecheckable.url).to be nil
     end
 
     it "returns the URL if set" do
       livecheckable.url("foo")
       expect(livecheckable.url).to eq("foo")
+
+      livecheckable.url(:homepage)
+      expect(livecheckable.url).to eq(HOMEPAGE_URL)
+
+      livecheckable.url(:stable)
+      expect(livecheckable.url).to eq(STABLE_URL)
+
+      livecheckable.url(:head)
+      expect(livecheckable.url).to eq(HEAD_URL)
+    end
 
     it "raises a TypeError if the argument isn't a String or Symbol" do
       expect {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds `raise TypeError` logic to the `Livecheck` DSL methods when an invalid argument type is provided. This change brings the existing methods in line with the `#strategy` method added in #8156. Relevant tests have been added as well.

This also makes some changes to the existing tests for the `Livecheck` DSL, to better test the methods.

Past that, this reworks the documentation comments a bit and adds `@param`/`@return` information.