### PR TITLE
Gemfile: drop sorbet environment

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -13,11 +13,9 @@ gem "rspec-retry", require: false
 gem "rspec-wait", require: false
 gem "rubocop"
 gem "simplecov", require: false
-if ENV["HOMEBREW_SORBET"]
-  gem "sorbet", "0.5.5823"
-  gem "sorbet-runtime", "0.5.5823"
-  gem "tapioca"
-end
+gem "sorbet", "0.5.5823"
+gem "sorbet-runtime", "0.5.5823"
+gem "tapioca"
 
 # vendored gems
 gem "activesupport"

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -14,7 +14,10 @@ GEM
       colorize
       json
       simplecov
+    coderay (1.1.3)
     colorize (0.8.1)
+    commander (4.5.2)
+      highline (~> 2.0.0)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
     diff-lcs (1.4.4)
@@ -23,6 +26,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     elftools (1.1.2)
       bindata (~> 2)
+    highline (2.0.3)
     hpricot (0.8.6)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -38,6 +42,7 @@ GEM
       nokogiri (~> 1.6)
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (>= 0.0.9, < 0.2)
+    method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
@@ -53,11 +58,19 @@ GEM
     parallel (1.19.2)
     parallel_tests (3.1.0)
       parallel
+    parlour (4.0.1)
+      commander (~> 4.5)
+      parser
+      rainbow (~> 3.0)
+      sorbet-runtime (>= 0.5)
     parser (2.7.1.4)
       ast (~> 2.4.1)
     patchelf (1.2.0)
       elftools (~> 1.1)
     plist (3.5.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rainbow (3.0.0)
     rdiscount (2.2.0.1)
     regexp_parser (1.7.1)
@@ -107,6 +120,17 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
+    sorbet (0.5.5823)
+      sorbet-static (= 0.5.5823)
+    sorbet-runtime (0.5.5823)
+    sorbet-static (0.5.5823-universal-darwin-14)
+    tapioca (0.4.1)
+      parlour (>= 2.1.0)
+      pry (>= 0.12.2)
+      sorbet-runtime
+      sorbet-static (>= 0.4.4471)
+      thor (>= 0.19.2)
+    thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -139,6 +163,9 @@ DEPENDENCIES
   rubocop-rspec
   ruby-macho
   simplecov
+  sorbet (= 0.5.5823)
+  sorbet-runtime (= 0.5.5823)
+  tapioca
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
We're now aiming on introducing developers to Sorbet, hence it seems like a good time to abandon `ENV["HOMEBREW_SORBET"]` in our Gemfile and introduce Sorbet.
cc - @issyl0 @mistydemeo 