### PR TITLE
Fix order and grouping of cask stanzas

### DIFF
--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -6,7 +6,7 @@ module RuboCop
     module Constants
       STANZA_GROUPS = [
         [:version, :sha256],
-        [:url, :appcast, :desc, :name, :homepage],
+        [:url, :appcast, :name, :desc, :homepage],
         [
           :auto_updates,
           :conflicts_with,
@@ -32,6 +32,7 @@ module RuboCop
           :service,
           :audio_unit_plugin,
           :vst_plugin,
+          :vst3_plugin,
           :artifact,
           :stage_only,
         ],


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I found some inconsistencies when I started preparing the documentation update after #8137. This PR makes the following changes:

- Put `desc` stanza after the `name` stanza (I mistakenly introduced it to the wrong array position in #8137)
- Add missing `language` stanza to its own group, as shown [here](https://github.com/Homebrew/homebrew-cask/blob/581d91990936122933ac21066599c2b13775f537/doc/cask_language_reference/readme.md#L125).
  - I also adjusted the test that used this stanza, to conform to the `stanzas within the same group should have no lines between them` rule.
- Add missing `vst3_plugin` stanza to the group containing `vst_plugin`, as shown [here](https://github.com/Homebrew/homebrew-cask/blob/581d91990936122933ac21066599c2b13775f537/doc/cask_language_reference/readme.md#L154)

Should there also be a `target` stanza here, according to [this](https://github.com/Homebrew/homebrew-cask/blob/581d91990936122933ac21066599c2b13775f537/doc/cask_language_reference/readme.md#L155)?