### PR TITLE
version: detect versions with final/full suffix

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -671,6 +671,27 @@ describe Version do
         .to be_detected_from("https://ftpmirror.gnu.org/libidn/libidn-1.29-win64.zip")
     end
 
+    specify "breseq version style" do
+      expect(described_class.create("0.35.1"))
+        .to be_detected_from(
+          "https://github.com/barricklab/breseq" \
+          "/releases/download/v0.35.1/breseq-0.35.1.Source.tar.gz",
+        )
+    end
+
+    specify "wildfly version style" do
+      expect(described_class.create("20.0.1"))
+        .to be_detected_from("https://download.jboss.org/wildfly/20.0.1.Final/wildfly-20.0.1.Final.tar.gz")
+    end
+
+    specify "trinity version style" do
+      expect(described_class.create("2.10.0"))
+        .to be_detected_from(
+          "https://github.com/trinityrnaseq/trinityrnaseq" \
+          "/releases/download/v2.10.0/trinityrnaseq-v2.10.0.FULL.tar.gz",
+        )
+    end
+
     specify "with arch" do
       expect(described_class.create("4.0.18-1"))
         .to be_detected_from("https://ftpmirror.gnu.org/mtools/mtools-4.0.18-1.i686.rpm")

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -301,7 +301,7 @@ class Version
     # e.g. foobar-4.5.1-1
     # e.g. unrtf_0.20.4-1
     # e.g. ruby-1.9.1-p243
-    m = /[-_]((?:\d+\.)*\d+\.\d+-(?:p|rc|RC)?\d+)(?:[-._](?:bin|dist|stable|src|sources))?$/.match(stem)
+    m = /[-_]((?:\d+\.)*\d+\.\d+-(?:p|rc|RC)?\d+)(?:[-._](?i:bin|dist|stable|src|sources?|final|full))?$/.match(stem)
     return m.captures.first unless m.nil?
 
     # URL with no extension
@@ -359,7 +359,7 @@ class Version
     return m.captures.first unless m.nil?
 
     # e.g. foobar-4.5.0-bin
-    m = /-((?:\d+\.)+\d+[abc]?)[-._](?:bin|dist|stable|src|sources?)$/.match(stem)
+    m = /[-vV]((?:\d+\.)+\d+[abc]?)[-._](?i:bin|dist|stable|src|sources?|final|full)$/.match(stem)
     return m.captures.first unless m.nil?
 
     # dash version style


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Included changes:

- Add `i` for case-insensitivity
- Add `?` to `sources` to match both `source` and `sources`
- Add `final` and `full`
- Match `v` (or `V`) prefix in addition to `-`

<!-- This affects [`wildfly-as`](https://formulae.brew.sh/formula/wildfly-as) of which the current version is `20.0.1.Final` and will become `20.0.1` if this PR is merged. Note: `20.0.1` is considered to be an older release compared to `20.0.1.Final` -->