### PR TITLE
Add `language` stanza to cask rubocops

### DIFF
--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -6,6 +6,7 @@ module RuboCop
     module Constants
       STANZA_GROUPS = [
         [:version, :sha256],
+        [:language],
         [:url, :appcast, :name, :desc, :homepage],
         [
           :auto_updates,

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-languages.rb
@@ -5,7 +5,6 @@ cask "with-languages" do
     sha256 "abc123"
     "zh-CN"
   end
-
   language "en-US", default: true do
     sha256 "xyz789"
     "en-US"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

These changes have been split out from #8265. The language stanza should be in its own group, but current practice is to separate multiple language blocks with newlines, which contradicts the `stanzas within the same group should have no lines between them` rule in [test/rubocops/cask/stanza_grouping_spec.rb](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/rubocops/cask/stanza_grouping_spec.rb). This PR is kept as a draft until a decision is made in how to address that. For example, we could:

- Edit the casks in Homebrew/homebrew-cask to remove the blank line between language blocks
- Make an exception for the `language` stanza in the `stanzas within the same group should have no lines between them` rule.
- Keep the `language` stanza out of the sorting/grouping validation (as it was before)
- Something else

How should I proceed?