### PR TITLE
bundler: use 1.17.2 again.

### DIFF
--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -168,4 +168,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -8,7 +8,7 @@ require "English"
 
 module Homebrew
   # Keep in sync with the Gemfile.lock's BUNDLED WITH.
-  HOMEBREW_BUNDLER_VERSION = "1.17.3"
+  HOMEBREW_BUNDLER_VERSION = "1.17.2"
 
   module_function
 


### PR DESCRIPTION
This was what is included with macOS system Ruby 2.6.3.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----