### PR TITLE
dev-cmd/update-license-data: Fix "undefined variable `latest_tag`"

### DIFF
--- a/Library/Homebrew/dev-cmd/update-license-data.rb
+++ b/Library/Homebrew/dev-cmd/update-license-data.rb
@@ -35,6 +35,6 @@ module Homebrew
     ohai "git add"
     safe_system "git", "add", SPDX::JSON_PATH
     ohai "git commit"
-    system "git", "commit", "--message", "data/spdx.json: update to #{latest_tag}"
+    system "git", "commit", "--message", "data/spdx.json: update to #{@latest_tag}"
   end
 end

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -13,8 +13,8 @@ module SPDX
   end
 
   def download_latest_license_data!(to: JSON_PATH)
-    latest_tag = GitHub.open_api(API_URL)["tag_name"]
-    data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{latest_tag}/json/licenses.json"
+    @latest_tag = GitHub.open_api(API_URL)["tag_name"]
+    data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{@latest_tag}/json/licenses.json"
     curl_download(data_url, to: to, partial: false)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- This was broken by some refactoring in https://github.com/Homebrew/brew/pull/8215.
- I noticed that the [Actions runs for the scheduled task](https://github.com/Homebrew/brew/runs/966560393?check_suite_focus=true#step:4:17) had a funny way of succeeding:

```
==> Updating SPDX license data...
==> git add
Error: undefined local variable or method `latest_tag' for Homebrew:Module
Please report this issue:
==> git commit
  https://docs.brew.sh/Troubleshooting
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/update-license-data.rb:38:in `update_license_data'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:112:in `<main>'
```
