### PR TITLE
--cache, home: Use convenience methods to load formulae and casks

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -2,8 +2,7 @@
 
 require "fetch"
 require "cli/parser"
-require "cask/cmd"
-require "cask/cask_loader"
+require "cask/download"
 
 module Homebrew
   extend Fetch
@@ -37,29 +36,27 @@ module Homebrew
 
     if args.no_named?
       puts HOMEBREW_CACHE
-    elsif args.formula?
-      args.named.each do |name|
-        print_formula_cache name, args: args
-      end
+      return
+    end
+
+    formulae_or_casks = if args.formula?
+      args.formulae
     elsif args.cask?
-      args.named.each do |name|
-        print_cask_cache name
-      end
+      args.loaded_casks
     else
-      args.named.each do |name|
-        print_formula_cache name, args: args
-      rescue FormulaUnavailableError
-        begin
-          print_cask_cache name
-        rescue Cask::CaskUnavailableError
-          odie "No available formula or cask with the name \"#{name}\""
-        end
+      args.formulae_and_casks
+    end
+
+    formulae_or_casks.each do |formula_or_cask|
+      if formula_or_cask.is_a? Formula
+        print_formula_cache formula_or_cask, args: args
+      else
+        print_cask_cache formula_or_cask
       end
     end
   end
 
-  def print_formula_cache(name, args:)
-    formula = Formulary.factory(name, force_bottle: args.force_bottle?, flags: args.flags_only)
+  def print_formula_cache(formula, args:)
     if fetch_bottle?(formula, args: args)
       puts formula.bottle.cached_download
     else
@@ -67,8 +64,7 @@ module Homebrew
     end
   end
 
-  def print_cask_cache(name)
-    cask = Cask::CaskLoader.load name
-    puts Cask::Cmd::Cache.cached_location(cask)
+  def print_cask_cache(cask)
+    puts Cask::Download.new(cask).downloader.cached_location
   end
 end

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "cli/parser"
-require "cask/cask_loader"
-require "cask/exceptions"
 
 module Homebrew
   module_function
@@ -23,21 +21,22 @@ module Homebrew
 
     if args.no_named?
       exec_browser HOMEBREW_WWW
+      return
+    end
+
+    homepages = args.formulae_and_casks.map do |formula_or_cask|
+      puts "Opening homepage for #{name_of(formula_or_cask)}"
+      formula_or_cask.homepage
+    end
+
+    exec_browser(*homepages)
+  end
+
+  def name_of(formula_or_cask)
+    if formula_or_cask.is_a? Formula
+      "Formula #{formula_or_cask.name}"
     else
-      homepages = args.named.map do |name|
-        f = Formulary.factory(name)
-        puts "Opening homepage for formula #{name}"
-        f.homepage
-      rescue FormulaUnavailableError
-        begin
-          c = Cask::CaskLoader.load(name)
-          puts "Opening homepage for cask #{name}"
-          c.homepage
-        rescue Cask::CaskUnavailableError
-          odie "No available formula or cask with the name \"#{name}\""
-        end
-      end
-      exec_browser(*homepages)
+      "Cask #{formula_or_cask.token}"
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Small refactoring change. Instead of loading formulae and casks manually, use convenience methods that already exist on `CLI::Args` to load formulae and casks.