### PR TITLE
update-license-data: fix latest_tag error

### DIFF
--- a/Library/Homebrew/dev-cmd/update-license-data.rb
+++ b/Library/Homebrew/dev-cmd/update-license-data.rb
@@ -35,6 +35,6 @@ module Homebrew
     ohai "git add"
     safe_system "git", "add", SPDX::JSON_PATH
     ohai "git commit"
-    system "git", "commit", "--message", "data/spdx.json: update to #{latest_tag}"
+    system "git", "commit", "--message", "data/spdx.json: update to #{SPDX.latest_tag}"
   end
 end

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -12,8 +12,11 @@ module SPDX
     @spdx_data ||= JSON.parse(JSON_PATH.read)
   end
 
+  def latest_tag
+    @latest_tag ||= GitHub.open_api(API_URL)["tag_name"]
+  end
+
   def download_latest_license_data!(to: JSON_PATH)
-    latest_tag = GitHub.open_api(API_URL)["tag_name"]
     data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{latest_tag}/json/licenses.json"
     curl_download(data_url, to: to, partial: false)
   end


### PR DESCRIPTION
<!--
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
-->

Add `latest_tag` method to `utils/spdx`

Related: #8215, #8284

cc @issyl0