### PR TITLE
Fix broken github action when running brew tap-new

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -59,6 +59,7 @@ module Homebrew
               os: [ubuntu-latest, macOS-latest]
           steps:
             - name: Set up Homebrew
+              id: set-up-homebrew
               uses: Homebrew/actions/setup-homebrew@master
 
             - name: Cache Homebrew Bundler RubyGems


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently, when pushing a new tap to GitHub Actions you get a failure with an error is a failure with the error "Input requred and not supplied: path"

<img width="634" alt="grafik" src="https://user-images.githubusercontent.com/133327/89818849-bf31db80-db4a-11ea-8ed7-c1149033a445.png">

This is failing because of a missing id in the GitHub Action. This adds that ID.
