### PR TITLE
list: Replace Cask::Cmd with class method

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -168,11 +168,12 @@ module Homebrew
   end
 
   def list_casks(args:)
-    cask_list = Cask::Cmd::List.new args.named
-    cask_list.one = args.public_send(:'1?')
-    cask_list.versions = args.versions?
-    cask_list.full_name = args.full_name?
-    cask_list.run
+    Cask::Cmd::List.list_casks(
+      *args.loaded_casks,
+      one:       args.public_send(:'1?'),
+      full_name: args.full_name?,
+      versions:  args.versions?,
+    )
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In the same vein as https://github.com/Homebrew/brew/pull/8214, replace usage of `Cask::Cmd::List` with a class method, and call that class method directly. 