### PR TITLE
Print checksum in double quotes

### DIFF
--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -129,7 +129,7 @@ module Cask
     def to_s
       <<~EOS
         Cask '#{token}' requires a checksum:
-          #{Formatter.identifier("sha256 '#{actual}'")}
+          #{Formatter.identifier('sha256 "#{actual}"')}
       EOS
     end
   end


### PR DESCRIPTION
to match formatting used in formulas, for easier copy/pasting.