### PR TITLE
home: Deprecate brew cask home

### DIFF
--- a/Library/Homebrew/cask/cmd/home.rb
+++ b/Library/Homebrew/cask/cmd/home.rb
@@ -8,6 +8,8 @@ module Cask
       end
 
       def run
+        # odeprecated "brew cask home", "brew home"
+
         if casks.none?
           odebug "Opening project homepage"
           self.class.open_url "https://brew.sh/"

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -25,7 +25,10 @@ module Homebrew
     end
 
     homepages = args.formulae_and_casks.map do |formula_or_cask|
-      puts "Opening homepage for #{name_of(formula_or_cask)}"
+      disclaimer = disclaimers(formula_or_cask)
+      disclaimer = " (#{disclaimer})" if disclaimer.present?
+
+      puts "Opening homepage for #{name_of(formula_or_cask)}#{disclaimer}"
       formula_or_cask.homepage
     end
 
@@ -37,6 +40,17 @@ module Homebrew
       "Formula #{formula_or_cask.name}"
     else
       "Cask #{formula_or_cask.token}"
+    end
+  end
+
+  def disclaimers(formula_or_cask)
+    return unless formula_or_cask.is_a? Formula
+
+    begin
+      cask = Cask::CaskLoader.load formula_or_cask.name
+      "for the cask, use #{cask.tap.name}/#{cask.token}"
+    rescue Cask::CaskUnavailableError
+      nil
     end
   end
 end

--- a/Library/Homebrew/test/cask/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/home_spec.rb
@@ -8,20 +8,4 @@ describe Cask::Cmd::Home, :cask do
   end
 
   it_behaves_like "a command that handles invalid options"
-
-  it "opens the homepage for the specified Cask" do
-    expect(described_class).to receive(:open_url).with("https://brew.sh/")
-    described_class.run("local-caffeine")
-  end
-
-  it "works for multiple Casks" do
-    expect(described_class).to receive(:open_url).with("https://brew.sh/")
-    expect(described_class).to receive(:open_url).with("https://transmissionbt.com/")
-    described_class.run("local-caffeine", "local-transmission")
-  end
-
-  it "opens the project page when no Cask is specified" do
-    expect(described_class).to receive(:open_url).with("https://brew.sh/")
-    described_class.run
-  end
 end

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -20,6 +20,13 @@ describe "brew home", :integration_test do
     Cask::CaskLoader.load(local_caffeine_path).homepage
   }
 
+  it "opens the project page when no formula or cask is specified" do
+    expect { brew "home", "HOMEBREW_BROWSER" => "echo" }
+      .to output("https://brew.sh\n").to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
+
   it "opens the homepage for a given Formula" do
     setup_test_formula "testballhome"
 
@@ -30,7 +37,7 @@ describe "brew home", :integration_test do
   end
 
   it "opens the homepage for a given Cask" do
-    expect { brew "home", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
+    expect { brew "home", local_caffeine_path, "HOMEBREW_BROWSER" => "echo" }
       .to output(/#{local_caffeine_homepage}/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
@@ -39,7 +46,7 @@ describe "brew home", :integration_test do
   it "opens the homepages for a given formula and Cask" do
     setup_test_formula "testballhome"
 
-    expect { brew "home", "testballhome", cask_path("local-caffeine"), "HOMEBREW_BROWSER" => "echo" }
+    expect { brew "home", "testballhome", local_caffeine_path, "HOMEBREW_BROWSER" => "echo" }
       .to output(/#{testballhome_homepage} #{local_caffeine_homepage}/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Deprecate `brew cask home` since it has been integrated with `brew home`. Move unit tests to `brew home`.

What other commands should be deprecated? Here's the list of brew cask cmds that have been integrated:
 * --cache
 * doctor
 * home
 * list
 * outdated
 * reinstall
 * uninstall
 * upgrade
 * info

There are ~90 casks that share names with formulae. If we were to deprecate cask commands, then one way to reference casks would be `brew cmd /homebrew/cask/<cask>`, which is more clunky than `brew cask cmd <cask>`. Thoughts about how to address this naming issue?
