### PR TITLE
Correct warning

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -50,7 +50,7 @@ module Homebrew
       on:
         push:
           branches: master
-        pull_request: []
+        pull_request:
       jobs:
         test-bot:
           runs-on: ${{ matrix.os }}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Correct warning

Currently, if you open up an action generated by the tap-new command in
the Github GUI, you get a warning saying "pull_requests should be an
object". This fixes that.
    
This wasn't stopping anything working currently, though I suppose it may
in the future.