### PR TITLE
download_strategy: more direct SVN modified date detection

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "json"
-require "rexml/document"
 require "time"
 require "unpack_strategy"
 require "lazy_object"
@@ -518,9 +517,14 @@ class SubversionDownloadStrategy < VCSDownloadStrategy
   end
 
   def source_modified_time
-    out, = system_command("svn", args: ["info", "--xml"], chdir: cached_location)
-    xml = REXML::Document.new(out)
-    Time.parse REXML::XPath.first(xml, "//date/text()").to_s
+    time = if Version.create(Utils.svn_version) >= Version.create("1.9")
+      out, = system_command("svn", args: ["info", "--show-item", "last-changed-date"], chdir: cached_location)
+      out
+    else
+      out, = system_command("svn", args: ["info"], chdir: cached_location)
+      out[/^Last Changed Date: (.+)$/, 1]
+    end
+    Time.parse time
   end
 
   def last_commit

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -120,7 +120,7 @@ describe Utils do
   describe "::git_version" do
     it "returns nil when git is not available" do
       stub_const("HOMEBREW_SHIMS_PATH", HOMEBREW_PREFIX/"bin/shim")
-      expect(described_class.git_path).to eq(nil)
+      expect(described_class.git_version).to eq(nil)
     end
 
     it "returns version of git when git is available" do

--- a/Library/Homebrew/test/utils/svn_spec.rb
+++ b/Library/Homebrew/test/utils/svn_spec.rb
@@ -17,6 +17,21 @@ describe Utils do
     end
   end
 
+  describe "#self.svn_version" do
+    before do
+      described_class.clear_svn_version_cache
+    end
+
+    it "returns nil when svn is not available" do
+      allow(described_class).to receive(:svn_available?).and_return(false)
+      expect(described_class.svn_version).to eq(nil)
+    end
+
+    it "returns version of svn when svn is available", :needs_svn do
+      expect(described_class.svn_version).not_to be_nil
+    end
+  end
+
   describe "#self.svn_remote_exists?" do
     it "returns true when svn is not available" do
       allow(described_class).to receive(:svn_available?).and_return(false)

--- a/Library/Homebrew/utils/svn.rb
+++ b/Library/Homebrew/utils/svn.rb
@@ -2,13 +2,23 @@
 
 module Utils
   def self.clear_svn_version_cache
-    remove_instance_variable(:@svn) if instance_variable_defined?(:@svn)
+    remove_instance_variable(:@svn_available) if defined?(@svn_available)
+    remove_instance_variable(:@svn_version) if defined?(@svn_version)
   end
 
   def self.svn_available?
-    return @svn if instance_variable_defined?(:@svn)
+    return @svn_available if defined?(@svn_available)
 
-    @svn = quiet_system HOMEBREW_SHIMS_PATH/"scm/svn", "--version"
+    @svn_available = quiet_system HOMEBREW_SHIMS_PATH/"scm/svn", "--version"
+  end
+
+  def self.svn_version
+    return unless svn_available?
+    return @svn_version if defined?(@svn_version)
+
+    @svn_version = Utils.popen_read(
+      HOMEBREW_SHIMS_PATH/"scm/svn", "--version"
+    ).chomp[/svn, version (\d+(?:\.\d+)*)/, 1]
   end
 
   def self.svn_remote_exists?(url)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`svn info --show-item last-changed-date` avoids the need for parsing.

I could keep REXML for the < 1.9 case. Though the fragile nature of plain grepping doesn't really apply here, since any breaking changes wouldn't suddenly apply to < 1.9.