### PR TITLE
cleanup: fix input handling

### DIFF
--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -33,6 +33,10 @@ module Homebrew
   def cleanup
     args = cleanup_args.parse
 
+    if args.prune.present? && !Integer(args.prune, exception: false) && args.prune != "all"
+      raise UsageError, "--prune= expects an integer or 'all'."
+    end
+
     cleanup = Cleanup.new(*args.named, dry_run: args.dry_run?, scrub: args.s?, days: args.prune&.to_i)
     if args.prune_prefix?
       cleanup.prune_prefix_symlinks_and_directories


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`--prune` flag expects an integer and when anything else is specified, it gets converted to `0` (`args.prune&.to_i`).
That implicit conversion to `0` made the integration test for cleanup that uses `--prune=all` to pass.