### PR TITLE
utils/github: add check_for_duplicate_pull_requests

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -491,20 +491,8 @@ module Homebrew
     end
   end
 
-  def fetch_pull_requests(query, tap_full_name, state: nil)
-    GitHub.issues_for_formula(query, tap_full_name: tap_full_name, state: state).select do |pr|
-      pr["html_url"].include?("/pull/") &&
-        /(^|\s)#{Regexp.quote(query)}(:|\s|$)/i =~ pr["title"]
-    end
-  rescue GitHub::RateLimitExceededError => e
-    opoo e.message
-    []
-  end
-
   def check_open_pull_requests(formula, tap_full_name, args:)
-    # check for open requests
-    pull_requests = fetch_pull_requests(formula.name, tap_full_name, state: "open")
-    check_for_duplicate_pull_requests(pull_requests, args: args)
+    GitHub.check_for_duplicate_pull_requests(formula.name, tap_full_name, state: "open", args: args)
   end
 
   def check_closed_pull_requests(formula, tap_full_name, version: nil, url: nil, tag: nil, args:)
@@ -514,28 +502,7 @@ module Homebrew
       version = Version.detect(url, specs)
     end
     # if we haven't already found open requests, try for an exact match across closed requests
-    pull_requests = fetch_pull_requests("#{formula.name} #{version}", tap_full_name, state: "closed")
-    check_for_duplicate_pull_requests(pull_requests, args: args)
-  end
-
-  def check_for_duplicate_pull_requests(pull_requests, args:)
-    return if pull_requests.blank?
-
-    duplicates_message = <<~EOS
-      These pull requests may be duplicates:
-      #{pull_requests.map { |pr| "#{pr["title"]} #{pr["html_url"]}" }.join("\n")}
-    EOS
-    error_message = "Duplicate PRs should not be opened. Use --force to override this error."
-    if args.force? && !args.quiet?
-      opoo duplicates_message
-    elsif !args.force? && args.quiet?
-      odie error_message
-    elsif !args.force?
-      odie <<~EOS
-        #{duplicates_message.chomp}
-        #{error_message}
-      EOS
-    end
+    GitHub.check_for_duplicate_pull_requests("#{formula.name} #{version}", tap_full_name, state: "closed", args: args)
   end
 
   def alias_update_pair(formula, new_formula_version)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Moved `check_for_duplicate_pull_requests` and `fetch_pull_requests` from `dev-cmd/bump-formula-pr.rb` to `utils/github.rb`

This will be useful for `brew bump-cask-pr` (#7986)

Tested with `write-good` ([open PR](https://github.com/Homebrew/homebrew-core/pull/59493)) and `swiftformat` ([closed PR](https://github.com/Homebrew/homebrew-core/pull/59489))

```console
$ brew bump-formula-pr write-good --version 1.0.3 --dry-run --force
Warning: These pull requests may be duplicates:
write-good 1.0.3 https://github.com/Homebrew/homebrew-core/pull/59493
==> Downloading https://registry.npmjs.org/write-good/-/write-good-1.0.3.tgz
...
$ brew bump-formula-pr swiftformat --version 0.45.6 --dry-run --force
Warning: These pull requests may be duplicates:
swiftformat 0.45.6 https://github.com/Homebrew/homebrew-core/pull/59489
==> Downloading https://github.com/nicklockwood/SwiftFormat/archive/0.45.6.tar.gz
...
```