### PR TITLE
rubocop/urls: add go@1.14 to binary URLs allowlist

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -35,6 +35,7 @@ module RuboCop
           go@1.11
           go@1.12
           go@1.13
+          go@1.14
           haskell-stack
           ldc
           mlton


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We're going to [add `go@1.14`](https://github.com/Homebrew/homebrew-core/pull/59486) to homebrew-core, so we need to allow it to use binary for bootstrapping. 
See https://github.com/Homebrew/homebrew-core/pull/59486/checks?check_run_id=976267306