### PR TITLE
utils/ruby.sh: test_ruby(): keep temporary variables local

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -11,7 +11,9 @@ test_ruby () {
 
 setup-ruby-path() {
   local vendor_dir
+  local vendor_ruby_root
   local vendor_ruby_path
+  local vendor_ruby_terminfo
   local vendor_ruby_latest_version
   local vendor_ruby_current_version
   local usable_ruby


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

A couple of variables were not made local in 87931e1c03.

@Bo98, what's the logic behind
```
[[ -z "$HOMEBREW_MACOS" ]] && TERMINFO_DIRS="$vendor_ruby_terminfo"
```
lines? I couldn't find a PR/Issue associated with 87931e1c03, so not sure where to ask other than here. Don't we need TERMINFO_DIRS on Linux as well?
