### PR TITLE
Add `cask-eid` to list of deprecated taps.

### DIFF
--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -14,6 +14,7 @@ OFFICIAL_CMD_TAPS = {
 DEPRECATED_OFFICIAL_TAPS = %w[
   apache
   binary
+  cask-eid
   completions
   devel-only
   dupes

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -234,9 +234,10 @@ class Tap
     require "descriptions"
 
     if official? && DEPRECATED_OFFICIAL_TAPS.include?(repo)
-      odie "#{name} was deprecated. This tap is now empty as all its formulae were migrated."
+      odie "#{name} was deprecated. This tap is now empty and all its contents were either deleted or migrated."
     elsif user == "caskroom"
-      odie "#{name} was moved. Tap homebrew/cask-#{repo} instead."
+      new_repo = repo == "cask" ? "cask" : "cask-#{repo}"
+      odie "#{name} was moved. Tap homebrew/#{new_repo} instead."
     end
 
     requested_remote = clone_target || default_remote


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

It's been deprecated for a while but you could still tap it.