### PR TITLE
utils/github: delete redundant `GitHub.` and `GitHub::`

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -391,7 +391,7 @@ module Homebrew
           else
             exec_browser url
           end
-        rescue *GitHub.api_errors => e
+        rescue *GitHub::API_ERRORS => e
           odie "Unable to open pull request: #{e.message}!"
         end
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

* Deleted occurrences of `GitHub.` and `GitHub::` that are redundant
* Replaced `api_errors` method with constant `API_ERRORS`