### PR TITLE
pr-pull: pass --keep-old option to pr-upload

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -28,6 +28,9 @@ module Homebrew
              description: "Print what would be done rather than doing it."
       switch "--clean",
              description: "Do not amend the commits from pull requests."
+      switch "--keep-old",
+             description: "If the formula specifies a rebuild version, " \
+                          "attempt to preserve its value in the generated DSL."
       switch "--branch-okay",
              description: "Do not warn if pulling to a branch besides master (useful for testing)."
       switch "--resolve",
@@ -262,8 +265,9 @@ module Homebrew
           upload_args << "--verbose" if args.verbose?
           upload_args << "--no-publish" if args.no_publish?
           upload_args << "--dry-run" if args.dry_run?
+          upload_args << "--keep-old" if args.keep_old?
           upload_args << "--warn-on-upload-failure" if args.warn_on_upload_failure?
-          upload_args << "--root_url=#{args.root_url}" if args.root_url
+          upload_args << "--root-url=#{args.root_url}" if args.root_url
           upload_args << "--bintray-org=#{bintray_org}"
           safe_system HOMEBREW_BREW_FILE, *upload_args
         end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1034,6 +1034,8 @@ Requires write access to the repository.
   Print what would be done rather than doing it.
 * `--clean`:
   Do not amend the commits from pull requests.
+* `--keep-old`:
+  If the formula specifies a rebuild version, attempt to preserve its value in the generated DSL.
 * `--branch-okay`:
   Do not warn if pulling to a branch besides master (useful for testing).
 * `--resolve`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1424,6 +1424,10 @@ Print what would be done rather than doing it\.
 Do not amend the commits from pull requests\.
 .
 .TP
+\fB\-\-keep\-old\fR
+If the formula specifies a rebuild version, attempt to preserve its value in the generated DSL\.
+.
+.TP
 \fB\-\-branch\-okay\fR
 Do not warn if pulling to a branch besides master (useful for testing)\.
 .


### PR DESCRIPTION
Also fix typo in `--root-url` option.

This is needed for `linuxbrew-core` to properly migrate to `pr-*` workflow.


- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----