### PR TITLE
bump-formula-pr: fix regression when formula.tap is nil

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -105,8 +105,10 @@ module Homebrew
         end
       end
     end
-    origin_branch = Utils.popen_read("git", "-C", formula.tap.path.to_s, "symbolic-ref", "-q", "--short",
-                                     "refs/remotes/origin/HEAD").chomp.presence
+    if formula.tap
+      origin_branch = Utils.popen_read("git", "-C", formula.tap.path.to_s, "symbolic-ref", "-q", "--short",
+                                       "refs/remotes/origin/HEAD").chomp.presence
+    end
     origin_branch ||= "origin/master"
     [formula.tap&.full_name, origin_branch, "-"]
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The change from https://github.com/homebrew/brew/commit/bf16c7a78f37edeb07d3686d20b470fcc0ad3647 causes `bump-formula-pr` to crash if `formula.tap` is `nil` (formula is loaded from path or URL). This PR restores the original behavior in that case.