### PR TITLE
tap: add audit config for enabling core audits

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -102,6 +102,7 @@ class Tap
     @command_files = nil
     @formula_renames = nil
     @tap_migrations = nil
+    @audit_config = nil
     @config = nil
     remove_instance_variable(:@private) if instance_variable_defined?(:@private)
   end
@@ -547,6 +548,17 @@ class Tap
     end
   end
 
+  # Hash with audit config
+  def audit_config
+    require "json"
+
+    @audit_config ||= if (config_file = path/"audit_config.json").file?
+      JSON.parse(config_file.read)
+    else
+      {}
+    end
+  end
+
   def ==(other)
     other = Tap.fetch(other) if other.is_a?(String)
     self.class == other.class && name == other.name
@@ -681,6 +693,14 @@ class CoreTap < Tap
   # @private
   def tap_migrations
     @tap_migrations ||= begin
+      self.class.ensure_installed!
+      super
+    end
+  end
+
+  # @private
+  def audit_config
+    @audit_config ||= begin
       self.class.ensure_installed!
       super
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows audits that are usually only run for core taps to be configured to as enabled in other taps

Example `audit_config.json` with all core audits enabled:

```json
{
  "enabled_core_audits": [
    "bottle_disabled",
    "bottle_spec",
    "deps",
    "formula_name",
    "license",
    "postgresql",
    "repo_data",
    "reverse_migration",
    "specs",
    "versioned_keg_only"
  ]
}
```