### PR TITLE
Don't take name into account when calculating description length.

### DIFF
--- a/Library/Homebrew/rubocops/shared/desc_helper.rb
+++ b/Library/Homebrew/rubocops/shared/desc_helper.rb
@@ -8,6 +8,8 @@ module RuboCop
     module DescHelper
       include HelperFunctions
 
+      MAX_DESC_LENGTH = 80
+
       VALID_LOWERCASE_WORDS = %w[
         iOS
         iPhone
@@ -27,8 +29,8 @@ module RuboCop
         desc = desc_call.first_argument
 
         # Check if the desc is empty.
-        pure_desc_length = string_content(desc).length
-        if pure_desc_length.zero?
+        desc_length = string_content(desc).length
+        if desc_length.zero?
           problem "The desc (description) should not be an empty string."
           return
         end
@@ -64,13 +66,11 @@ module RuboCop
           problem "Description shouldn't end with a full stop."
         end
 
-        # Check if the desc length exceeds 80 characters.
-        desc_length = "#{name}: #{string_content(desc)}".length
-        max_desc_length = 80
-        return if desc_length <= max_desc_length
+        # Check if the desc length exceeds maximum length.
+        return if desc_length <= MAX_DESC_LENGTH
 
-        problem "Description is too long. \"name: desc\" should be less than #{max_desc_length} characters. " \
-                "The current combined length is #{desc_length}."
+        problem "Description is too long. It should be less than #{MAX_DESC_LENGTH} characters. " \
+                "The current length is #{desc_length}."
       end
 
       def autocorrect_desc(node, name)

--- a/Library/Homebrew/test/rubocops/formula_desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::Cop::FormulaAudit::Desc do
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
           desc 'Bar#{"bar" * 29}'
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description is too long. "name: desc" should be less than 80 characters. The current combined length is 95.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description is too long. It should be less than 80 characters. The current length is 90.
         end
       RUBY
     end
@@ -41,7 +41,7 @@ describe RuboCop::Cop::FormulaAudit::Desc do
           url 'https://brew.sh/foo-1.0.tgz'
           desc 'Bar#{"bar" * 9}'\
             '#{"foo" * 21}'
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description is too long. "name: desc" should be less than 80 characters. The current combined length is 98.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Description is too long. It should be less than 80 characters. The current length is 93.
         end
       RUBY
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This rule is kind of confusing, and seems like it isn't even applicable anymore: `brew info` prints the description on a separate line.