### PR TITLE
add ipython into `update-python-resources` blocklist

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -12,6 +12,7 @@ module PyPI
     cloudformation-cli
     diffoscope
     dxpy
+    ipython
     molecule
     xonsh
   ].freeze


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
ipython is not suitable for using `brew bump-formula-pr ipython --version=7.17.0`

See https://github.com/Homebrew/homebrew-core/pull/59036#issuecomment-667719531