### PR TITLE
Always audit GitHub license

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -350,6 +350,11 @@ module Homebrew
       "LGPL-3.0" => ["LGPL-3.0-only", "LGPL-3.0-or-later"],
     }.freeze
 
+    PERMITTED_FORMULA_LICENSE_MISMATCHES = {
+      "cmockery" => "0.1.2",
+      "scw@1"    => "1.20",
+    }.freeze
+
     def audit_license
       if formula.license.present?
         non_standard_licenses = formula.license.map do |license|
@@ -380,12 +385,13 @@ module Homebrew
 
         return unless @online
 
-        user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*}) if @new_formula
+        user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*})
         return if user.blank?
 
         github_license = GitHub.get_repo_license(user, repo)
         return if github_license && (formula.license + ["NOASSERTION"]).include?(github_license)
         return if PERMITTED_LICENSE_MISMATCHES[github_license]&.any? { |license| formula.license.include? license }
+        return if PERMITTED_FORMULA_LICENSE_MISMATCHES[formula.name] == formula.version
 
         problem "Formula license #{formula.license} does not match GitHub license #{Array(github_license)}."
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
The current logic only checks the GitHub license for new formulae. This change will always check for the license GitHub for formulae hosted on GitHub in case the license has changed and none of the Homebrew licenses for a formula match the license in GitHub. This logic detected the issues in https://github.com/Homebrew/homebrew-core/pull/59728.

This also excludes checking versioned formulae because the GitHub API only returns the license for the default branch and the license information for a versioned branch may be different (see `scw@1` vs `scw`).