### PR TITLE
cask/artifact/symlinked: do not overwrite files or symbolic links

### DIFF
--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -44,10 +44,10 @@ module Cask
                 "source '#{source}' is not there."
         end
 
-        if target.exist? && !target.symlink?
+        if target.exist?
           raise CaskError,
-                "It seems there is already #{self.class.english_article} " \
-                "#{self.class.english_name} at '#{target}'; not linking."
+                "It seems there already exists #{self.class.english_article} " \
+                "#{self.class.english_name} at '#{target}'; not overwriting."
         end
 
         ohai "Linking #{self.class.english_name} '#{source.basename}' to '#{target}'."

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -67,14 +67,16 @@ describe Cask::Artifact::Binary, :cask do
     expect(expected_path).not_to be :symlink?
   end
 
-  it "clobbers an existing symlink" do
+  it "avoids clobbering an existing symlink" do
     expected_path.make_symlink("/tmp")
 
-    artifacts.each do |artifact|
-      artifact.install_phase(command: NeverSudoSystemCommand, force: false)
-    end
+    expect {
+      artifacts.each do |artifact|
+        artifact.install_phase(command: NeverSudoSystemCommand, force: false)
+      end
+    }.to raise_error(Cask::CaskError)
 
-    expect(File.readlink(expected_path)).not_to eq("/tmp")
+    expect(File.readlink(expected_path)).to eq("/tmp")
   end
 
   it "creates parent directory if it doesn't exist" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When installing a Cask that includes a `binary` or a `manpage` there is the possibility that there already exists either a file or a symbolic link in `/usr/local/bin` or `/usr/local/share/man/*`.

At present, `brew install {some cask with a binary or a manpage}` will _not_ overwrite a file in `/usr/local/bin` or `/usr/local/share/man/*`, but _will_ overwrite a symbolic link in `/usr/local/bin` or `/usr/local/share/man/*`.

This change ensures that neither a file nor a symbolic link will be overwritten.

See [the issue here in `homebrew-cask`](https://github.com/Homebrew/homebrew-cask/issues/87304) for more background.

Thank you.