### PR TITLE
debrew: fix irb start

### DIFF
--- a/Library/Homebrew/debrew/irb.rb
+++ b/Library/Homebrew/debrew/irb.rb
@@ -11,7 +11,7 @@ module IRB
 
     def start_within(binding)
       unless @setup_done
-        setup(nil)
+        setup(nil, argv: [])
         @setup_done = true
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`irb` doesn't start from debug menu with an error `FrozenError: can't modify frozen #<Class:#<Array:0x00007fd4b48840b0>>`. 
`irb#setup` method defaults `argv` to `::ARGV` and tries to shift it, which fails for out case when `::ARGV` is frozen.

This PR defaults `argv` to an empty array (also we don't really want to pass brew cli arguments to`irb`).


The whole log looks like this:
```
brew install -s -d hello
...
RuntimeError: boom
1. raise
2. ignore
3. backtrace
4. irb
5. shell
Choose an action: 4
When you exit this IRB session, execution will continue.

WARNING: This version of ruby is included in macOS for compatibility with legacy software. 
In future versions of macOS the ruby runtime will not be available by 
default, and may require you to install an additional package.

/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/irb/init.rb:134:in `shift'
FrozenError: can't modify frozen #<Class:#<Array:0x00007fd4b48840b0>>
1. raise
2. backtrace
3. shell
Choose an action: 2
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/irb/init.rb:134:in `shift'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/irb/init.rb:134:in `parse_opts'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/irb/init.rb:27:in `setup'
/usr/local/Homebrew/Library/Homebrew/debrew/irb.rb:14:in `start_within'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:127:in `block (5 levels) in debug'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mutex_m.rb:78:in `synchronize'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/mutex_m.rb:78:in `mu_synchronize'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:127:in `block (4 levels) in debug'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:17:in `raise'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/hello.rb:22:in `install'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:24:in `block in install'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:94:in `debrew'
/usr/local/Homebrew/Library/Homebrew/debrew.rb:24:in `install'
/usr/local/Homebrew/Library/Homebrew/build.rb:174:in `block (2 levels) in install'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1187:in `block in brew'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2174:in `block (2 levels) in stage'
/usr/local/Homebrew/Library/Homebrew/utils.rb:494:in `with_env'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2173:in `block in stage'
/usr/local/Homebrew/Library/Homebrew/resource.rb:112:in `block in unpack'
/usr/local/Homebrew/Library/Homebrew/resource.rb:198:in `block in mktemp'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `block in run'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `chdir'
/usr/local/Homebrew/Library/Homebrew/mktemp.rb:57:in `run'
/usr/local/Homebrew/Library/Homebrew/resource.rb:197:in `mktemp'
/usr/local/Homebrew/Library/Homebrew/resource.rb:107:in `unpack'
/usr/local/Homebrew/Library/Homebrew/resource.rb:82:in `stage'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/forwardable.rb:230:in `stage'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2153:in `stage'
/usr/local/Homebrew/Library/Homebrew/formula.rb:1180:in `brew'
/usr/local/Homebrew/Library/Homebrew/build.rb:142:in `block in install'
/usr/local/Homebrew/Library/Homebrew/utils.rb:494:in `with_env'
/usr/local/Homebrew/Library/Homebrew/build.rb:137:in `install'
/usr/local/Homebrew/Library/Homebrew/build.rb:226:in `<main>'
1. raise
2. backtrace
3. shell
...
```

