### PR TITLE
os/linux: add no-op MacOS.sdk_path method.

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -57,6 +57,10 @@ module OS
       nil
     end
 
+    def sdk_path
+      nil
+    end
+
     module Xcode
       module_function
 


### PR DESCRIPTION
Fixes https://github.com/Homebrew/linuxbrew-core/issues/20938

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----