### PR TITLE
named args: Warn when user references a formula with the same name as a cask

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -26,6 +26,8 @@ module Homebrew
 
           downcased_unique_named.each do |name|
             formulae_and_casks << Formulary.factory(name, spec)
+
+            puts "Treating #{name} as a formula. For the cask, use homebrew/cask/#{name}" if cask_exists_with_ref name
           rescue FormulaUnavailableError
             begin
               formulae_and_casks << Cask::CaskLoader.load(name)
@@ -51,6 +53,8 @@ module Homebrew
 
           downcased_unique_named.each do |name|
             resolved_formulae << Formulary.resolve(name, spec: spec(nil), force_bottle: @force_bottle, flags: @flags)
+
+            puts "Treating #{name} as a formula. For the cask, use homebrew/cask/#{name}" if cask_exists_with_ref name
           rescue FormulaUnavailableError
             begin
               casks << Cask::CaskLoader.load(name)
@@ -91,6 +95,8 @@ module Homebrew
 
           downcased_unique_named.each do |name|
             kegs << resolve_keg(name)
+
+            puts "Treating #{name} as a keg. For the cask, use homebrew/cask/#{name}" if cask_exists_with_ref name
           rescue NoSuchKegError, FormulaUnavailableError
             begin
               casks << Cask::CaskLoader.load(name)
@@ -162,6 +168,12 @@ module Homebrew
             Please delete (with rm -rf!) all but one and then try again.
           EOS
         end
+      end
+
+      def cask_exists_with_ref(ref)
+        Cask::CaskLoader.load ref
+      rescue Cask::CaskUnavailableError
+        false
       end
     end
   end

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -25,10 +25,7 @@ module Homebrew
     end
 
     homepages = args.formulae_and_casks.map do |formula_or_cask|
-      disclaimer = disclaimers(formula_or_cask)
-      disclaimer = " (#{disclaimer})" if disclaimer.present?
-
-      puts "Opening homepage for #{name_of(formula_or_cask)}#{disclaimer}"
+      puts "Opening homepage for #{name_of(formula_or_cask)}"
       formula_or_cask.homepage
     end
 
@@ -40,17 +37,6 @@ module Homebrew
       "Formula #{formula_or_cask.name}"
     else
       "Cask #{formula_or_cask.token}"
-    end
-  end
-
-  def disclaimers(formula_or_cask)
-    return unless formula_or_cask.is_a? Formula
-
-    begin
-      cask = Cask::CaskLoader.load formula_or_cask.name
-      "for the cask, use #{cask.tap.name}/#{cask.token}"
-    rescue Cask::CaskUnavailableError
-      nil
     end
   end
 end

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -39,8 +39,7 @@ describe Homebrew::CLI::NamedArgs do
 
   describe "#to_formulae" do
     it "returns formulae" do
-      allow(Formulary).to receive(:loader_for).and_call_original
-      stub_formula_loader foo
+      stub_formula_loader foo, call_original: true
       stub_formula_loader bar
 
       expect(described_class.new("foo", "bar").to_formulae).to eq [foo, bar]
@@ -49,9 +48,8 @@ describe Homebrew::CLI::NamedArgs do
 
   describe "#to_formulae_and_casks" do
     it "returns formulae and casks" do
-      allow(Formulary).to receive(:loader_for).and_call_original
-      stub_formula_loader foo
-      stub_cask_loader baz
+      stub_formula_loader foo, call_original: true
+      stub_cask_loader baz, call_original: true
 
       expect(described_class.new("foo", "baz").to_formulae_and_casks).to eq [foo, baz]
     end
@@ -69,7 +67,7 @@ describe Homebrew::CLI::NamedArgs do
     it "returns resolved formulae, as well as casks" do
       allow(Formulary).to receive(:resolve).and_call_original
       allow(Formulary).to receive(:resolve).with("foo", any_args).and_return foo
-      stub_cask_loader baz
+      stub_cask_loader baz, call_original: true
 
       resolved_formulae, casks = described_class.new("foo", "baz").to_resolved_formulae_to_casks
 
@@ -101,7 +99,8 @@ describe Homebrew::CLI::NamedArgs do
       named_args = described_class.new("foo", "baz")
       allow(named_args).to receive(:resolve_keg).and_call_original
       allow(named_args).to receive(:resolve_keg).with("foo").and_return foo_keg
-      stub_cask_loader baz
+
+      stub_cask_loader baz, call_original: true
 
       kegs, casks = named_args.to_kegs_to_casks
 

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -99,7 +99,6 @@ describe Homebrew::CLI::NamedArgs do
       named_args = described_class.new("foo", "baz")
       allow(named_args).to receive(:resolve_keg).and_call_original
       allow(named_args).to receive(:resolve_keg).with("foo").and_return foo_keg
-
       stub_cask_loader baz, call_original: true
 
       kegs, casks = named_args.to_kegs_to_casks

--- a/Library/Homebrew/test/support/helper/cask.rb
+++ b/Library/Homebrew/test/support/helper/cask.rb
@@ -5,7 +5,9 @@ require "cask/cask_loader"
 module Test
   module Helper
     module Cask
-      def stub_cask_loader(cask, ref = cask.token)
+      def stub_cask_loader(cask, ref = cask.token, call_original: false)
+        allow(::Cask::CaskLoader).to receive(:for).and_call_original if call_original
+
         loader = ::Cask::CaskLoader::FromInstanceLoader.new cask
         allow(::Cask::CaskLoader).to receive(:for).with(ref).and_return(loader)
       end

--- a/Library/Homebrew/test/support/helper/formula.rb
+++ b/Library/Homebrew/test/support/helper/formula.rb
@@ -11,7 +11,9 @@ module Test
 
       # Use a stubbed {Formulary::FormulaLoader} to make a given formula be found
       # when loading from {Formulary} with `ref`.
-      def stub_formula_loader(formula, ref = formula.full_name)
+      def stub_formula_loader(formula, ref = formula.full_name, call_original: false)
+        allow(Formulary).to receive(:loader_for).and_call_original if call_original
+
         loader = double(get_formula: formula)
         allow(Formulary).to receive(:loader_for).with(ref, from: :keg).and_return(loader)
         allow(Formulary).to receive(:loader_for).with(ref, from: nil).and_return(loader)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Print a warning/suggestion when a formula is referenced with the same name as a cask. 

In `brew home`, when a user opens the homepage of a formula that has the same name as a cask, homebrew prints a helpful message telling the user to load the homepage of the cask using `brew home homebrew/cask/<cask>`. This PR generalizes that to all formula/keg/cask loading.

e.g. `brew home crunch` prints
```
Treating crunch as a formula. For the cask, use homebrew/cask/crunch
Opening homepage for Formula crunch
```

e.g. `brew upgrade crunch` prints
```
Treating crunch as a formula. For the cask, use homebrew/cask/crunch
Warning: crunch 3.6 already installed
```

##### Next Step

After this PR, I plan to submit a PR that adds commented-out deprecations for cask commands that have already been integrated with brew