### PR TITLE
check_tmpdir_executable: Remove a stray call to undent

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -38,7 +38,7 @@ module Homebrew
         f.close
         return if system f.path
 
-        <<~EOS.undent
+        <<~EOS
           The directory #{HOMEBREW_TEMP} does not permit executing
           programs. It is likely mounted as "noexec". Please set HOMEBREW_TEMP
           in your #{shell_profile} to a different directory, for example:


### PR DESCRIPTION
Fix the error:
```
Error: undefined method undent for #<String>
.../extend/os/linux/diagnostic.rb:41:in check_tmpdir_executable
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See https://discourse.brew.sh/t/error-while-trying-to-install-any-packages/8575