### PR TITLE
os: add `kernel_version`

### DIFF
--- a/Library/Homebrew/extend/os/linux/diagnostic.rb
+++ b/Library/Homebrew/extend/os/linux/diagnostic.rb
@@ -100,7 +100,7 @@ module Homebrew
         return unless OS::Linux::Kernel.below_minimum_version?
 
         <<~EOS
-          Your Linux kernel #{OS::Linux::Kernel.version} is too old.
+          Your Linux kernel #{OS.kernel_version} is too old.
           We only support kernel #{OS::Linux::Kernel.minimum_version} or later.
           You will be unable to use binary packages (bottles).
           #{please_create_pull_requests}

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -13,6 +13,10 @@ module OS
     RbConfig::CONFIG["host_os"].include? "linux"
   end
 
+  def self.kernel_version
+    @kernel_version ||= Version.new(Utils.safe_popen_read("uname", "-r").chomp)
+  end
+
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]
 
   if OS.mac?

--- a/Library/Homebrew/os/linux/kernel.rb
+++ b/Library/Homebrew/os/linux/kernel.rb
@@ -5,21 +5,12 @@ module OS
     module Kernel
       module_function
 
-      def version
-        return @version if @version
-
-        version = Utils.popen_read("uname", "-r").chomp
-        return Version::NULL unless version
-
-        @version = Version.new version
-      end
-
       def minimum_version
         Version.new "2.6.32"
       end
 
       def below_minimum_version?
-        version < minimum_version
+        OS.kernel_version < minimum_version
       end
     end
   end

--- a/Library/Homebrew/test/os/os_spec.rb
+++ b/Library/Homebrew/test/os/os_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe OS do
+  describe ".kernel_version" do
+    it "is not empty" do
+      expect(described_class.kernel_version).not_to be_empty
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This allows for e.g. `` `uname -r`.split(".").first `` in [`homebrew/core/gcc`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gcc.rb#L51) to be replaced with `OS.kernel_version.major`

Uses:

- `` `uname -r`.split(".").first `` &rarr; `OS.kernel_version.major`
- `` `uname -r`.to_i `` &rarr; `OS.kernel_version.major`
- `` `uname -r`.chomp `` &rarr; `OS.kernel_version`
- `shell_output("uname -r").strip` &rarr; `OS.kernel_version`
- `Utils.safe_popen_read("uname", "-r").chomp` &rarr; `OS.kernel_version`