### PR TITLE
extend/os/mac: install svn on catalina and newer

### DIFF
--- a/Library/Homebrew/extend/os/mac/dependency_collector.rb
+++ b/Library/Homebrew/extend/os/mac/dependency_collector.rb
@@ -6,7 +6,9 @@ class DependencyCollector
 
   def git_dep_if_needed(tags); end
 
-  def subversion_dep_if_needed(tags); end
+  def subversion_dep_if_needed(tags)
+    Dependency.new("subversion", tags) if MacOS.version >= :catalina
+  end
 
   def cvs_dep_if_needed(tags)
     Dependency.new("cvs", tags)

--- a/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
+++ b/Library/Homebrew/test/os/mac/dependency_collector_spec.rb
@@ -32,6 +32,10 @@ describe DependencyCollector do
   specify "Resource dependency from a Subversion URL" do
     resource = Resource.new
     resource.url("svn://brew.sh/foo/bar")
-    expect(subject.add(resource)).to be nil
+    if MacOS.version < :catalina
+      expect(subject.add(resource)).to be nil
+    else
+      expect(subject.add(resource)).not_to be nil
+    end
   end
 end


### PR DESCRIPTION
Subversion is no longer available on Catalina and supposedly won't be available in newer macOS releases.

With this PR we can avoid specifying svn as build dependency, like here:
https://github.com/Homebrew/homebrew-core/pull/59776

Failed workflow run (only on Catalina):
https://github.com/Homebrew/homebrew-core/runs/993661520?check_suite_focus=true#step:5:44

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----