### PR TITLE
cask --cache: Deprecate command

### DIFF
--- a/Library/Homebrew/cask/cmd/--cache.rb
+++ b/Library/Homebrew/cask/cmd/--cache.rb
@@ -18,6 +18,9 @@ module Cask
       end
 
       def run
+        # TODO: enable for next major/minor release
+        # odeprecated "brew cask --cache", "brew --cache --cask"
+
         casks.each do |cask|
           puts self.class.cached_location(cask)
         end

--- a/Library/Homebrew/cask/cmd/home.rb
+++ b/Library/Homebrew/cask/cmd/home.rb
@@ -8,6 +8,7 @@ module Cask
       end
 
       def run
+        # TODO: enable for next major/minor release
         # odeprecated "brew cask home", "brew home"
 
         if casks.none?

--- a/Library/Homebrew/test/cask/cmd/cache_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/cache_spec.rb
@@ -25,14 +25,9 @@ describe Cask::Cmd::Cache, :cask do
       cache: Cask::Cache.path, **local_caffeine.url.specs
     ).cached_location
 
-    expect do
-      described_class.run("local-transmission", "local-caffeine")
-    end.to output("#{transmission_location}\n#{caffeine_location}\n").to_stdout
-  end
-
-  it "properly handles Casks that are not present" do
-    expect {
-      described_class.run("notacask")
-    }.to raise_error(Cask::CaskUnavailableError)
+    expect(described_class.cached_location(local_transmission))
+      .to eql transmission_location
+    expect(described_class.cached_location(local_caffeine))
+      .to eql caffeine_location
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add a TODO to deprecate `brew cask --cache` for the next release (and sneak a TODO for brew cask home as well). 

Since calling `odeprecated` in tests throws an exception, modify the tests such that they pass to avoid failing a lot of tests when the deprecation is enabled. 