### PR TITLE
formula_versions: handle references to too old MacOS in formulae

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -64,6 +64,9 @@ class FormulaVersions
         versions_seen = (map.keys + [f.pkg_version]).uniq.length
       end
       return map if versions_seen > MAX_VERSIONS_DEPTH
+    rescue MacOSVersionError => e
+      odebug "#{e} in #{name} at revision #{rev}" if debug?
+      break
     end
     map
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Bottling of `gource` formula fails with an error `Error: unknown or unsupported macOS version: :mountain_lion` (in https://github.com/Homebrew/homebrew-core/pull/59779)

When brew does `Determining gource bottle rebuild`, it went back to https://github.com/homebrew/homebrew-core/tree/44d524b9a505e14a4af60d231ca5162dadab18d7 revision which has line [`depends_on :macos => :mountain_lion`](https://github.com/Homebrew/homebrew-core/blob/44d524b9a505e14a4af60d231ca5162dadab18d7/Formula/gource.rb#L34)

This PR adds `mavericks` and `mountain_lion` versions to make `mountain_lion` known version. 
I'm not completely sure if this is a right solution (of we should handle such cases in `Homebrew#bottle_formula`, for example), but these changes look safe enough from the first glance. 

The full log is here:
```
$ brew bottle --verbose --json gource
==> Determining gource bottle rebuild...
Error: unknown or unsupported macOS version: :mountain_lion
bayandin@mbp:~/Desktop$ brew bottle --debug --verbose --json gource
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
==> Determining gource bottle rebuild...
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
/usr/local/Homebrew/Library/Homebrew/brew.rb (Formulary::FormulaContentsLoader): loading /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb
Error: unknown or unsupported macOS version: :mountain_lion
/usr/local/Homebrew/Library/Homebrew/os/mac/version.rb:20:in `block in from_symbol'
/usr/local/Homebrew/Library/Homebrew/os/mac/version.rb:20:in `fetch'
/usr/local/Homebrew/Library/Homebrew/os/mac/version.rb:20:in `from_symbol'
/usr/local/Homebrew/Library/Homebrew/requirements/macos_requirement.rb:15:in `initialize'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:127:in `new'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:127:in `parse_symbol_spec'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:101:in `parse_spec'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:53:in `build'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:40:in `block in fetch'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:40:in `fetch'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:40:in `fetch'
/usr/local/Homebrew/Library/Homebrew/dependency_collector.rb:30:in `add'
/usr/local/Homebrew/Library/Homebrew/software_spec.rb:164:in `depends_on'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2512:in `block in depends_on'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2512:in `each'
/usr/local/Homebrew/Library/Homebrew/formula.rb:2512:in `depends_on'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb:34:in `<class:Gource>'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gource.rb:1:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:40:in `module_eval'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:40:in `load_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:321:in `klass'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:132:in `get_formula'
/usr/local/Homebrew/Library/Homebrew/formulary.rb:404:in `from_contents'
/usr/local/Homebrew/Library/Homebrew/formula_versions.rb:44:in `block in formula_at_revision'
/usr/local/Homebrew/Library/Homebrew/utils.rb:393:in `nostdout'
/usr/local/Homebrew/Library/Homebrew/formula_versions.rb:44:in `formula_at_revision'
/usr/local/Homebrew/Library/Homebrew/formula_versions.rb:61:in `block in bottle_version_map'
/usr/local/Homebrew/Library/Homebrew/formula_versions.rb:30:in `block (2 levels) in rev_list'
/usr/local/Homebrew/Library/Homebrew/utils/popen.rb:31:in `block in popen'
/usr/local/Homebrew/Library/Homebrew/utils/popen.rb:27:in `popen'
/usr/local/Homebrew/Library/Homebrew/utils/popen.rb:27:in `popen'
/usr/local/Homebrew/Library/Homebrew/utils/popen.rb:5:in `popen_read'
/usr/local/Homebrew/Library/Homebrew/formula_versions.rb:29:in `block in rev_list'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:281:in `block in cd'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:281:in `chdir'
/usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:281:in `cd'
/usr/local/Homebrew/Library/Homebrew/formula_versions.rb:28:in `rev_list'
/usr/local/Homebrew/Library/Homebrew/formula_versions.rb:60:in `bottle_version_map'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:239:in `bottle_formula'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:92:in `block in bottle'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:91:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:91:in `bottle'
/usr/local/Homebrew/Library/Homebrew/brew.rb:112:in `<main>'
```