### PR TITLE
cask: Add TODOs to deprecate integrated cask commands

### DIFF
--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -47,6 +47,16 @@ module Cask
       "dr"       => "doctor",
     }.freeze
 
+    DEPRECATED_COMMANDS = {
+      Cmd::Cache     => "brew --cache --cask",
+      Cmd::Doctor    => "brew doctor --verbose",
+      Cmd::Home      => "brew home",
+      Cmd::List      => "brew list --cask",
+      Cmd::Outdated  => "brew outdated --cask",
+      Cmd::Reinstall => "brew reinstall",
+      Cmd::Upgrade   => "brew upgrade --cask",
+    }.freeze
+
     def self.description
       max_command_len = Cmd.commands.map(&:length).max
 
@@ -211,6 +221,11 @@ module Cask
       command, argv = detect_internal_command(*argv) ||
                       detect_external_command(*argv) ||
                       [args.remaining.empty? ? NullCommand : UnknownSubcommand.new(args.remaining.first), argv]
+
+      # TODO: enable for next major/minor release
+      # if (replacement = DEPRECATED_COMMANDS[command])
+      #   odeprecated "brew cask #{command.command_name}", replacement
+      # end
 
       if args.help?
         puts command.help

--- a/Library/Homebrew/cask/cmd/--cache.rb
+++ b/Library/Homebrew/cask/cmd/--cache.rb
@@ -18,9 +18,6 @@ module Cask
       end
 
       def run
-        # TODO: enable for next major/minor release
-        # odeprecated "brew cask --cache", "brew --cache --cask"
-
         casks.each do |cask|
           puts self.class.cached_location(cask)
         end

--- a/Library/Homebrew/cask/cmd/home.rb
+++ b/Library/Homebrew/cask/cmd/home.rb
@@ -8,9 +8,6 @@ module Cask
       end
 
       def run
-        # TODO: enable for next major/minor release
-        # odeprecated "brew cask home", "brew home"
-
         if casks.none?
           odebug "Opening project homepage"
           self.class.open_url "https://brew.sh/"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Move deprecation from cask cmds and into `cmd.rb`.

When deprecating the `run` method of each command, tests had to be rewritten to avoid calling the `run` method since otherwise a deprecation exception was thrown. By deprecating at the `Cask::Cmd` level, all cask cmd tests continue to pass.