### PR TITLE
cmd/update-reset: fix handling of multiple relative directories

### DIFF
--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -35,16 +35,15 @@ homebrew-update-reset() {
   for DIR in "${REPOS[@]}"
   do
     [[ -d "$DIR/.git" ]] || continue
-    cd "$DIR" || continue
     ohai "Fetching $DIR..."
-    git fetch --force --tags origin
-    git remote set-head origin --auto >/dev/null
+    git -C "$DIR" fetch --force --tags origin
+    git -C "$DIR" remote set-head origin --auto >/dev/null
     echo
 
     ohai "Resetting $DIR..."
-    head="$(git symbolic-ref refs/remotes/origin/HEAD)"
+    head="$(git -C "$DIR" symbolic-ref refs/remotes/origin/HEAD)"
     head="${head#refs/remotes/origin/}"
-    git checkout --force -B "$head" origin/HEAD
+    git -C "$DIR" checkout --force -B "$head" origin/HEAD
     echo
   done
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Ensure we reset the the working directory to back as it was so that multiple relative directories are taken from the same base.

Fixes Homebrew/services not updating in the CI.