### PR TITLE
cmd/update-report: consistency across formulae and casks

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -198,8 +198,10 @@ class Reporter
       next unless dst.extname == ".rb"
 
       if paths.any? { |p| tap.cask_file?(p) }
-        # Currently only need to handle Cask deletion/migration.
         case status
+        when "A"
+          # Have a dedicated report array for new casks.
+          @report[:AC] << tap.formula_file_to_name(src)
         when "D"
           # Have a dedicated report array for deleted casks.
           @report[:DC] << tap.formula_file_to_name(src)
@@ -446,6 +448,7 @@ class ReporterHub
     end
     dump_formula_report :R, "Renamed Formulae"
     dump_formula_report :D, "Deleted Formulae"
+    dump_formula_report :AC, "New Casks"
     dump_formula_report :MC, "Updated Casks"
     dump_formula_report :DC, "Deleted Casks"
   end
@@ -462,6 +465,8 @@ class ReporterHub
         "#{name} -> #{new_name}"
       when :A
         name unless installed?(name)
+      when :AC
+        name unless cask_installed?(name)
       when :MC, :DC
         name = name.split("/").last
         cask_installed?(name) ? pretty_installed(name) : name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Currently, running `brew update` will list any new, updated or deleted formulae and any updated or deleted casks, but **not** new casks:

```
==> New Formulae
a shiny new formula
==> Updated Formulae
an updated formula
==> Deleted Formulae
a deleted formula
==> Updated Casks
an updated cask
==> Deleted Casks
a deleted cask
```
In the spirit of consistency, this change prints a similar message for new casks, so now:
```
==> New Formulae
a shiny new formula
==> Updated Formulae
an updated formula
==> Deleted Formulae
a deleted formula
==> New Casks
a shiny new cask
==> Updated Casks
an updated cask
==> Deleted Casks
a deleted cask
```

I have tested this change locally with fictitious new, updated and deleted formulae and casks in my personal tap, and everything works as I imagined -- hopefully I have not missed anything.

Thank you.