### PR TITLE
args: Migrate usage of args loading methods to args.named

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -220,7 +220,7 @@ begin
 
   trap("INT", old_trap)
 
-  formula = args.formulae.first
+  formula = args.named.to_formulae.first
   options = Options.create(args.flags_only)
   build   = Build.new(formula, options, args: args)
   build.install

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -57,47 +57,56 @@ module Homebrew
       end
 
       def formulae
-        odeprecated "args.formulae", "args.named.formulae"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.formulae", "args.named.to_formulae"
         named.to_formulae
       end
 
       def formulae_and_casks
-        odeprecated "args.formulae_and_casks", "args.named.to_formulae_and_casks"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.formulae_and_casks", "args.named.to_formulae_and_casks"
         named.to_formulae_and_casks
       end
 
       def resolved_formulae
-        odeprecated "args.resolved_formulae", "args.named.to_resolved_formulae"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.resolved_formulae", "args.named.to_resolved_formulae"
         named.to_resolved_formulae
       end
 
       def resolved_formulae_casks
-        odeprecated "args.resolved_formulae_casks", "args.named.to_resolved_formulae_to_casks"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.resolved_formulae_casks", "args.named.to_resolved_formulae_to_casks"
         named.to_resolved_formulae_to_casks
       end
 
       def formulae_paths
-        odeprecated "args.formulae_paths", "args.named.to_formulae_paths"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.formulae_paths", "args.named.to_formulae_paths"
         named.to_formulae_paths
       end
 
       def casks
-        odeprecated "args.casks", "args.named.homebrew_tap_cask_names"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.casks", "args.named.homebrew_tap_cask_names"
         named.homebrew_tap_cask_names
       end
 
       def loaded_casks
-        odeprecated "args.loaded_casks", "args.named.to_cask"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.loaded_casks", "args.named.to_cask"
         named.to_casks
       end
 
       def kegs
-        odeprecated "args.kegs", "args.named.to_kegs"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.kegs", "args.named.to_kegs"
         named.to_kegs
       end
 
       def kegs_casks
-        odeprecated "args.kegs", "args.named.to_kegs_to_casks"
+        # TODO: enable for next major/minor release
+        # odeprecated "args.kegs", "args.named.to_kegs_to_casks"
         named.to_kegs_to_casks
       end
 

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -57,38 +57,47 @@ module Homebrew
       end
 
       def formulae
+        odeprecated "args.formulae", "args.named.formulae"
         named.to_formulae
       end
 
       def formulae_and_casks
+        odeprecated "args.formulae_and_casks", "args.named.to_formulae_and_casks"
         named.to_formulae_and_casks
       end
 
       def resolved_formulae
+        odeprecated "args.resolved_formulae", "args.named.to_resolved_formulae"
         named.to_resolved_formulae
       end
 
       def resolved_formulae_casks
+        odeprecated "args.resolved_formulae_casks", "args.named.to_resolved_formulae_to_casks"
         named.to_resolved_formulae_to_casks
       end
 
       def formulae_paths
+        odeprecated "args.formulae_paths", "args.named.to_formulae_paths"
         named.to_formulae_paths
       end
 
       def casks
+        odeprecated "args.casks", "args.named.homebrew_tap_cask_names"
         named.homebrew_tap_cask_names
       end
 
       def loaded_casks
+        odeprecated "args.loaded_casks", "args.named.to_cask"
         named.to_casks
       end
 
       def kegs
+        odeprecated "args.kegs", "args.named.to_kegs"
         named.to_kegs
       end
 
       def kegs_casks
+        odeprecated "args.kegs", "args.named.to_kegs_to_casks"
         named.to_kegs_to_casks
       end
 

--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -40,11 +40,11 @@ module Homebrew
     end
 
     formulae_or_casks = if args.formula?
-      args.formulae
+      args.named.to_formulae
     elsif args.cask?
-      args.loaded_casks
+      args.named.to_casks
     else
-      args.formulae_and_casks
+      args.named.to_formulae_and_casks
     end
 
     formulae_or_casks.each do |formula_or_cask|

--- a/Library/Homebrew/cmd/--caskroom.rb
+++ b/Library/Homebrew/cmd/--caskroom.rb
@@ -19,10 +19,10 @@ module Homebrew
   def __caskroom
     args = __caskroom_args.parse
 
-    if args.loaded_casks.blank?
+    if args.named.to_casks.blank?
       puts Cask::Caskroom.path
     else
-      args.loaded_casks.each do |cask|
+      args.named.to_casks.each do |cask|
         puts "#{Cask::Caskroom.path}/#{cask.token}"
       end
     end

--- a/Library/Homebrew/cmd/--cellar.rb
+++ b/Library/Homebrew/cmd/--cellar.rb
@@ -25,7 +25,7 @@ module Homebrew
     if args.no_named?
       puts HOMEBREW_CELLAR
     else
-      puts args.resolved_formulae.map(&:rack)
+      puts args.named.to_resolved_formulae.map(&:rack)
     end
   end
 end

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -30,7 +30,7 @@ module Homebrew
     args = __env_args.parse
 
     ENV.activate_extensions!(env: args.env)
-    ENV.deps = args.formulae if superenv?(args.env)
+    ENV.deps = args.named.to_formulae if superenv?(args.env)
     ENV.setup_build_environment
 
     shell = if args.plain?

--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -25,7 +25,7 @@ module Homebrew
     if args.no_named?
       puts HOMEBREW_PREFIX
     else
-      puts args.resolved_formulae.map { |f|
+      puts args.named.to_resolved_formulae.map { |f|
         f.opt_prefix.exist? ? f.opt_prefix : f.installed_prefix
       }
     end

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -65,7 +65,7 @@ module Homebrew
     Formulary.enable_factory_cache!
 
     recursive = !args.send("1?")
-    installed = args.installed? || dependents(args.formulae_and_casks).all?(&:any_version_installed?)
+    installed = args.installed? || dependents(args.named.to_formulae_and_casks).all?(&:any_version_installed?)
 
     @use_runtime_dependencies = installed && recursive &&
                                 !args.tree? &&
@@ -76,7 +76,7 @@ module Homebrew
 
     if args.tree?
       dependents = if args.named.present?
-        sorted_dependents(args.formulae_and_casks)
+        sorted_dependents(args.named.to_formulae_and_casks)
       elsif args.installed?
         sorted_dependents(Formula.installed + Cask::Caskroom.casks)
       else
@@ -89,7 +89,7 @@ module Homebrew
       puts_deps sorted_dependents(Formula.to_a + Cask::Cask.to_a), recursive: recursive, args: args
       return
     elsif !args.no_named? && args.for_each?
-      puts_deps sorted_dependents(args.formulae_and_casks), recursive: recursive, args: args
+      puts_deps sorted_dependents(args.named.to_formulae_and_casks), recursive: recursive, args: args
       return
     end
 
@@ -100,7 +100,7 @@ module Homebrew
       return
     end
 
-    dependents = dependents(args.formulae_and_casks)
+    dependents = dependents(args.named.to_formulae_and_casks)
 
     all_deps = deps_for_dependents(dependents, recursive: recursive, args: args, &(args.union? ? :| : :&))
     condense_requirements(all_deps, args: args)

--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -47,7 +47,7 @@ module Homebrew
 
     results = if search_type.nil?
       desc = {}
-      args.formulae.each { |f| desc[f.full_name] = f.desc }
+      args.named.to_formulae.each { |f| desc[f.full_name] = f.desc }
       Descriptions.new(desc)
     else
       query = args.named.join(" ")

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -50,13 +50,13 @@ module Homebrew
 
     if args.deps?
       bucket = []
-      args.formulae.each do |f|
+      args.named.to_formulae.each do |f|
         bucket << f
         bucket.concat f.recursive_dependencies.map(&:to_formula)
       end
       bucket.uniq!
     else
-      bucket = args.formulae
+      bucket = args.named.to_formulae
     end
 
     puts "Fetching: #{bucket * ", "}" if bucket.size > 1

--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -141,6 +141,6 @@ module Homebrew
 
     Install.perform_preinstall_checks(all_fatal: true)
     Install.perform_build_from_source_checks(all_fatal: true)
-    gistify_logs(args.resolved_formulae.first, args: args)
+    gistify_logs(args.named.to_resolved_formulae.first, args: args)
   end
 end

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -24,7 +24,7 @@ module Homebrew
       return
     end
 
-    homepages = args.formulae_and_casks.map do |formula_or_cask|
+    homepages = args.named.to_formulae_and_casks.map do |formula_or_cask|
       puts "Opening homepage for #{name_of(formula_or_cask)}"
       formula_or_cask.homepage
     end

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -88,7 +88,7 @@ module Homebrew
     elsif args.github?
       raise FormulaUnspecifiedError if args.no_named?
 
-      exec_browser(*args.formulae.map { |f| github_info(f) })
+      exec_browser(*args.named.to_formulae.map { |f| github_info(f) })
     else
       print_info(args: args)
     end
@@ -133,7 +133,7 @@ module Homebrew
     elsif args.installed?
       Formula.installed.sort
     else
-      args.formulae
+      args.named.to_formulae
     end
     json = ff.map(&:to_hash)
     puts JSON.generate(json)

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -115,13 +115,13 @@ module Homebrew
 
     formulae = []
 
-    unless args.casks.empty?
+    unless args.named.homebrew_tap_cask_names.empty?
       cask_args = []
       cask_args << "--force" if args.force?
       cask_args << "--debug" if args.debug?
       cask_args << "--verbose" if args.verbose?
 
-      args.casks.each do |c|
+      args.named.homebrew_tap_cask_names.each do |c|
         ohai "brew cask install #{c} #{cask_args.join " "}"
         system("#{HOMEBREW_PREFIX}/bin/brew", "cask", "install", c, *cask_args)
       end
@@ -131,7 +131,7 @@ module Homebrew
     # developer tools are available, we need to stop them early on
     FormulaInstaller.prevent_build_flags(args)
 
-    args.formulae.each do |f|
+    args.named.to_formulae.each do |f|
       # head-only without --HEAD is an error
       if !args.HEAD? && f.stable.nil? && f.devel.nil?
         raise <<~EOS

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -37,7 +37,7 @@ module Homebrew
       verbose:   args.verbose?,
     }
 
-    args.kegs.each do |keg|
+    args.named.to_kegs.each do |keg|
       keg_only = Formulary.keg_only?(keg.rack)
 
       if keg.linked?

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -89,9 +89,9 @@ module Homebrew
         safe_system "ls", *ls_args, HOMEBREW_CELLAR
       end
     elsif args.verbose? || !$stdout.tty?
-      system_command! "find", args: args.kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true
+      system_command! "find", args: args.named.to_kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true
     else
-      args.kegs.each { |keg| PrettyListing.new keg }
+      args.named.to_kegs.each { |keg| PrettyListing.new keg }
     end
   end
 
@@ -168,7 +168,7 @@ module Homebrew
 
   def list_casks(args:)
     Cask::Cmd::List.list_casks(
-      *args.loaded_casks,
+      *args.named.to_casks,
       one:       args.public_send(:'1?'),
       full_name: args.full_name?,
       versions:  args.versions?,

--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -25,7 +25,7 @@ module Homebrew
   def migrate
     args = migrate_args.parse
 
-    args.resolved_formulae.each do |f|
+    args.named.to_resolved_formulae.each do |f|
       if f.oldname
         unless (rack = HOMEBREW_CELLAR/f.oldname).exist? && !rack.subdirs.empty?
           raise NoSuchKegError, f.oldname

--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -31,7 +31,7 @@ module Homebrew
     ff = if args.no_named?
       Formula.installed.sort
     else
-      args.resolved_formulae.sort
+      args.named.to_resolved_formulae.sort
     end
 
     ff.each do |f|

--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -54,7 +54,7 @@ module Homebrew
     elsif args.no_named?
       raise FormulaUnspecifiedError
     else
-      puts_options args.formulae, args: args
+      puts_options args.named.to_formulae, args: args
     end
   end
 

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -170,7 +170,7 @@ module Homebrew
   end
 
   def outdated_formulae(args:)
-    select_outdated((args.resolved_formulae.presence || Formula.installed), args: args).sort
+    select_outdated((args.named.to_resolved_formulae.presence || Formula.installed), args: args).sort
   end
 
   def outdated_casks(args:)
@@ -182,7 +182,7 @@ module Homebrew
   end
 
   def outdated_formulae_casks(args:)
-    formulae, casks = args.resolved_formulae_casks
+    formulae, casks = args.named.to_resolved_formulae_to_casks
 
     if formulae.blank? && casks.blank?
       formulae = Formula.installed

--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -22,7 +22,7 @@ module Homebrew
   def pin
     args = pin_args.parse
 
-    args.resolved_formulae.each do |f|
+    args.named.to_resolved_formulae.each do |f|
       if f.pinned?
         opoo "#{f.name} already pinned"
       elsif !f.pinnable?

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -22,7 +22,7 @@ module Homebrew
   def postinstall
     args = postinstall_args.parse
 
-    args.resolved_formulae.each do |f|
+    args.named.to_resolved_formulae.each do |f|
       ohai "Postinstalling #{f}"
       fi = FormulaInstaller.new(f, debug: args.debug?, quiet: args.quiet?, verbose: args.verbose?)
       fi.post_install

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -61,7 +61,7 @@ module Homebrew
 
     Install.perform_preinstall_checks
 
-    resolved_formulae, casks = args.resolved_formulae_casks
+    resolved_formulae, casks = args.named.to_resolved_formulae_to_casks
     resolved_formulae.each do |f|
       if f.pinned?
         onoe "#{f.full_name} is pinned. You must unpin it to reinstall."

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -49,7 +49,7 @@ module Homebrew
         end
       end
     else
-      all_kegs, casks = args.kegs_casks
+      all_kegs, casks = args.named.to_kegs_to_casks
       kegs_by_rack = all_kegs.group_by(&:rack)
     end
 

--- a/Library/Homebrew/cmd/unlink.rb
+++ b/Library/Homebrew/cmd/unlink.rb
@@ -28,7 +28,7 @@ module Homebrew
 
     options = { dry_run: args.dry_run?, verbose: args.verbose? }
 
-    args.kegs.each do |keg|
+    args.named.to_kegs.each do |keg|
       if args.dry_run?
         puts "Would remove:"
         keg.unlink(**options)

--- a/Library/Homebrew/cmd/unpin.rb
+++ b/Library/Homebrew/cmd/unpin.rb
@@ -22,7 +22,7 @@ module Homebrew
   def unpin
     args = unpin_args.parse
 
-    args.resolved_formulae.each do |f|
+    args.named.to_resolved_formulae.each do |f|
       if f.pinned?
         f.unpin
       elsif !f.pinnable?

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -73,7 +73,7 @@ module Homebrew
   def upgrade
     args = upgrade_args.parse
 
-    formulae, casks = args.resolved_formulae_casks
+    formulae, casks = args.named.to_resolved_formulae_to_casks
     # If one or more formulae are specified, but no casks were
     # specified, we want to make note of that so we don't
     # try to upgrade all outdated casks.

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -56,7 +56,7 @@ module Homebrew
 
     used_formulae_missing = false
     used_formulae = begin
-      args.formulae
+      args.named.to_formulae
     rescue FormulaUnavailableError => e
       opoo e
       used_formulae_missing = true

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -98,9 +98,9 @@ module Homebrew
     elsif args.no_named?
       Formula
     else
-      args.resolved_formulae
+      args.named.to_resolved_formulae
     end
-    style_files = args.formulae_paths unless skip_style
+    style_files = args.named.to_formulae_paths unless skip_style
 
     only_cops = args.only_cops
     except_cops = args.except_cops

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -88,7 +88,7 @@ module Homebrew
     return merge(args: args) if args.merge?
 
     ensure_relocation_formulae_installed! unless args.skip_relocation?
-    args.resolved_formulae.each do |f|
+    args.named.to_resolved_formulae.each do |f|
       bottle_formula f, args: args
     end
   end

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -123,7 +123,7 @@ module Homebrew
     # Use the user's browser, too.
     ENV["BROWSER"] = Homebrew::EnvConfig.browser
 
-    formula = args.formulae.first
+    formula = args.named.to_formulae.first
 
     new_url = args.url
     formula ||= determine_formula_from_url(new_url) if new_url

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -30,7 +30,7 @@ module Homebrew
     # user path, too.
     ENV["PATH"] = ENV["HOMEBREW_PATH"]
 
-    args.formulae.each do |formula|
+    args.named.to_formulae.each do |formula|
       current_revision = formula.revision
 
       if current_revision.zero?

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -23,7 +23,7 @@ module Homebrew
   def bump
     args = bump_args.parse
 
-    requested_formulae = args.formulae.map(&:name) if args.formulae.present?
+    requested_formulae = args.named.to_formulae.map(&:name) if args.named.to_formulae.present?
 
     requested_limit = args.limit.to_i if args.limit.present?
 

--- a/Library/Homebrew/dev-cmd/cat.rb
+++ b/Library/Homebrew/dev-cmd/cat.rb
@@ -26,6 +26,6 @@ module Homebrew
     else
       "cat"
     end
-    safe_system pager, args.formulae_paths.first
+    safe_system pager, args.named.to_formulae_paths.first
   end
 end

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -28,7 +28,7 @@ module Homebrew
       EOS
     end
 
-    paths = args.formulae_paths.presence
+    paths = args.named.to_formulae_paths.presence
 
     # If no brews are listed, open the project root in an editor.
     paths ||= [HOMEBREW_REPOSITORY]

--- a/Library/Homebrew/dev-cmd/formula.rb
+++ b/Library/Homebrew/dev-cmd/formula.rb
@@ -21,6 +21,6 @@ module Homebrew
   def formula
     args = formula_args.parse
 
-    args.formulae_paths.each(&method(:puts))
+    args.named.to_formulae_paths.each(&method(:puts))
   end
 end

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -31,10 +31,10 @@ module Homebrew
     args = linkage_args.parse
 
     CacheStoreDatabase.use(:linkage) do |db|
-      kegs = if args.kegs.empty?
+      kegs = if args.named.to_kegs.empty?
         Formula.installed.map(&:opt_or_installed_prefix_keg).reject(&:nil?)
       else
-        args.kegs
+        args.named.to_kegs
       end
       kegs.each do |keg|
         ohai "Checking #{keg.name} linkage" if kegs.size > 1

--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -33,7 +33,7 @@ module Homebrew
 
     bintray = Bintray.new(org: bintray_org)
 
-    args.formulae.each do |formula|
+    args.named.to_formulae.each do |formula|
       mirror_url = bintray.mirror_formula(formula, repo: bintray_repo, publish_package: !args.no_publish?)
       ohai "Mirrored #{formula.full_name} to #{mirror_url}!"
     end

--- a/Library/Homebrew/dev-cmd/style.rb
+++ b/Library/Homebrew/dev-cmd/style.rb
@@ -44,7 +44,7 @@ module Homebrew
     elsif args.named.any? { |tap| tap.count("/") == 1 }
       args.named.map { |tap| Tap.fetch(tap).path }
     else
-      args.formulae_paths
+      args.named.to_formulae_paths
     end
 
     only_cops = args.only_cops

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -39,7 +39,7 @@ module Homebrew
     require "formula_assertions"
     require "formula_free_port"
 
-    args.resolved_formulae.each do |f|
+    args.named.to_resolved_formulae.each do |f|
       # Cannot test uninstalled formulae
       unless f.latest_version_installed?
         ofail "Testing requires the latest version of #{f.full_name}"

--- a/Library/Homebrew/dev-cmd/unpack.rb
+++ b/Library/Homebrew/dev-cmd/unpack.rb
@@ -33,7 +33,7 @@ module Homebrew
   def unpack
     args = unpack_args.parse
 
-    formulae = args.formulae
+    formulae = args.named.to_formulae
 
     if dir = args.destdir
       unpack_dir = Pathname.new(dir).expand_path

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -29,7 +29,7 @@ module Homebrew
   def update_python_resources
     args = update_python_resources_args.parse
 
-    args.formulae.each do |formula|
+    args.named.to_formulae.each do |formula|
       PyPI.update_python_resources! formula, args.version, print_only: args.print_only?, silent: args.silent?,
                                     ignore_non_pypi_packages: args.ignore_non_pypi_packages?
     end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -112,7 +112,7 @@ class FormulaInstaller
 
     return if build_flags.empty?
 
-    all_bottled = args.formulae.all?(&:bottled?)
+    all_bottled = args.named.to_formulae.all?(&:bottled?)
     raise BuildFlagsError.new(build_flags, bottled: all_bottled)
   end
 

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -16,7 +16,7 @@ begin
 
   trap("INT", old_trap)
 
-  formula = args.resolved_formulae.first
+  formula = args.named.to_resolved_formulae.first
   formula.extend(Debrew::Formula) if args.debug?
   formula.run_post_install
 rescue Exception => e # rubocop:disable Lint/RescueException

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -24,7 +24,7 @@ begin
 
   trap("INT", old_trap)
 
-  formula = args.resolved_formulae.first
+  formula = args.named.to_resolved_formulae.first
   formula.extend(Homebrew::Assertions)
   formula.extend(Homebrew::FreePort)
   formula.extend(Debrew::Formula) if args.debug?

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -270,38 +270,6 @@ describe Homebrew::CLI::Parser do
       expect(args.flags_only).to eq %w[--verbose --foo --bar=value]
     end
 
-    it "#formulae raises an error when a Formula is unavailable" do
-      args = parser.parse(["mxcl"])
-      expect { args.formulae }.to raise_error FormulaUnavailableError
-    end
-
-    it "#formulae returns an empty array when there are no Formulae" do
-      args = parser.parse([])
-      expect(args.formulae).to be_empty
-    end
-
-    it "#casks returns an empty array when there are no matching casks" do
-      args = parser.parse([])
-      expect(args.casks).to eq []
-    end
-
-    context "kegs" do
-      before do
-        keg = HOMEBREW_CELLAR/"mxcl/10.0"
-        keg.mkpath
-      end
-
-      it "when there are matching kegs returns an array of Kegs" do
-        args = parser.parse(["mxcl"])
-        expect(args.kegs.length).to eq 1
-      end
-
-      it "when there are no matching kegs returns an array of Kegs" do
-        args = parser.parse([])
-        expect(args.kegs).to be_empty
-      end
-    end
-
     it "#named returns an array of non-option arguments" do
       args = parser.parse(["foo", "-v", "-s"])
       expect(args.named).to eq ["foo"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Convert usages of args loading methods (e.g. `args.formulae`, `args.resolved_formulae`, `args.kegs`) to `args.named`. 
- Move named args tests in `parser_spec.rb` to `named_args_spec.rb` so when deprecations are enabled, tests still all pass

This is a continuation of https://github.com/Homebrew/brew/pull/8332

If/when the deprecated methods are removed, https://github.com/Homebrew/brew/pull/8229 can be reapplied 