### PR TITLE
Switch `greedy` argument to a keyword

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -197,7 +197,7 @@ module Homebrew
       if formula_or_cask.is_a?(Formula)
         formula_or_cask.outdated?(fetch_head: args.fetch_HEAD?)
       else
-        formula_or_cask.outdated?(args.greedy?)
+        formula_or_cask.outdated?(greedy: args.greedy?)
       end
     end
   end


### PR DESCRIPTION
The `greedy` parameter was switched to a keyword parameter in
3a91c37e66661781a236422c4ab8fc597e09a7a1 but this call wasn't updated
accordingly.

### STR:

Just run `brew outdated`:

```
$ brew outdated
Error: wrong number of arguments (given 1, expected 0)
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/cask/cask.rb:101:in `outdated?'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:200:in `block in select_outdated'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:196:in `select'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:196:in `select_outdated'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:192:in `outdated_formulae_casks'
/usr/local/Homebrew/Library/Homebrew/cmd/outdated.rb:83:in `outdated'
/usr/local/Homebrew/Library/Homebrew/brew.rb:112:in `<main>'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
