### PR TITLE
audit: return if no github license were found

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -398,6 +398,7 @@ module Homebrew
         return if user.blank?
 
         github_license = GitHub.get_repo_license(user, repo)
+        return unless github_license
         return if github_license && (licenses + ["NOASSERTION"]).include?(github_license)
         return if PERMITTED_LICENSE_MISMATCHES[github_license]&.any? { |license| licenses.include? license }
         return if PERMITTED_FORMULA_LICENSE_MISMATCHES[formula.name] == formula.version

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -399,7 +399,7 @@ module Homebrew
 
         github_license = GitHub.get_repo_license(user, repo)
         return unless github_license
-        return if github_license && (licenses + ["NOASSERTION"]).include?(github_license)
+        return if (licenses + ["NOASSERTION"]).include?(github_license)
         return if PERMITTED_LICENSE_MISMATCHES[github_license]&.any? { |license| licenses.include? license }
         return if PERMITTED_FORMULA_LICENSE_MISMATCHES[formula.name] == formula.version
 


### PR DESCRIPTION
Fixes audit problems when GitHub API returns `nil` license, like this:
https://github.com/Homebrew/homebrew-core/pull/59865#issuecomment-676432174

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----