### PR TITLE
utils/repology.rb: fix "String can't be coerced into Integer"

### DIFF
--- a/Library/Homebrew/utils/repology.rb
+++ b/Library/Homebrew/utils/repology.rb
@@ -38,7 +38,7 @@ module Repology
     while page_no <= MAX_PAGINATION
       odebug "Paginating Repology API page: #{page_no}"
 
-      response = query_api(last_package_index)
+      response = query_api(last_package_index.to_s)
       response_size = response.size
       outdated_packages.merge!(response)
       last_package_index = outdated_packages.size - 1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew bump` errors out with:

```
Error: String can't be coerced into Integer
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/repology.rb:12:in `+'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/repology.rb:12:in `query_api'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/repology.rb:42:in `parse_api_response'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump.rb:41:in `bump'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:112:in `<main>'
```

because `query_api` expects a String and `last_package_index` is an Integer (see line 44)