### PR TITLE
Fix missing methods in cask DSL.

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -282,6 +282,10 @@ module Cask
       end
     end
 
+    def respond_to_missing?(*)
+      super
+    end
+
     def method_missing(method, *)
       if method
         Utils.method_missing_message(method, token)
@@ -289,10 +293,6 @@ module Cask
       else
         super
       end
-    end
-
-    def respond_to_missing?(*)
-      super || true
     end
 
     def appdir

--- a/Library/Homebrew/cask/dsl/base.rb
+++ b/Library/Homebrew/cask/dsl/base.rb
@@ -18,6 +18,10 @@ module Cask
         @command.run!(executable, **options)
       end
 
+      def respond_to_missing?(*)
+        super
+      end
+
       def method_missing(method, *)
         if method
           underscored_class = self.class.name.gsub(/([[:lower:]])([[:upper:]][[:lower:]])/, '\1_\2').downcase
@@ -27,10 +31,6 @@ module Cask
         else
           super
         end
-      end
-
-      def respond_to_missing?(*)
-        super || true
       end
     end
   end

--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -80,12 +80,11 @@ module Cask
     end
 
     def self.method_missing_message(method, token, section = nil)
-      poo = []
-      poo << "Unexpected method '#{method}' called"
-      poo << "during #{section}" if section
-      poo << "on Cask #{token}."
+      message = +"Unexpected method '#{method}' called "
+      message << "during #{section} " if section
+      message << "on Cask #{token}."
 
-      opoo("#{poo.join(" ")}\n#{error_message_with_suggestions}")
+      opoo "#{message}\n#{error_message_with_suggestions}"
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`respond_to_missing?` should not return `true` since `method_missing` is only used for printing a warning.

Fixes https://github.com/Homebrew/homebrew-cask/issues/87852.
