### PR TITLE
Consistently use HOMEBREW_RUBY_WARNINGS when calling ruby

### DIFF
--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -30,6 +30,7 @@ module Homebrew
 
     begin
       safe_system RUBY_PATH,
+                  ENV["HOMEBREW_RUBY_WARNINGS"],
                   "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
                   "-rglobal", "-rdev-cmd/irb",
                   *ruby_sys_args

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -78,7 +78,7 @@ module Homebrew
       begin
         exec_args = %W[
           #{RUBY_PATH}
-          -W0
+          #{ENV["HOMEBREW_RUBY_WARNINGS"]}
           -I #{$LOAD_PATH.join(File::PATH_SEPARATOR)}
           --
           #{HOMEBREW_LIBRARY_PATH}/test.rb

--- a/Library/Homebrew/formula_info.rb
+++ b/Library/Homebrew/formula_info.rb
@@ -15,7 +15,7 @@ class FormulaInfo
   def self.lookup(name)
     json = Utils.popen_read(
       RUBY_PATH,
-      "-W0",
+      ENV["HOMEBREW_RUBY_WARNINGS"],
       "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
       HOMEBREW_LIBRARY_PATH/"brew.rb",
       "info",

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -798,7 +798,7 @@ class FormulaInstaller
     #    the easiest way to do this
     args = %W[
       nice #{RUBY_PATH}
-      -W0
+      #{ENV["HOMEBREW_RUBY_WARNINGS"]}
       -I #{$LOAD_PATH.join(File::PATH_SEPARATOR)}
       --
       #{HOMEBREW_LIBRARY_PATH}/build.rb
@@ -966,7 +966,7 @@ class FormulaInstaller
   def post_install
     args = %W[
       nice #{RUBY_PATH}
-      -W0
+      #{ENV["HOMEBREW_RUBY_WARNINGS"]}
       -I #{$LOAD_PATH.join(File::PATH_SEPARATOR)}
       --
       #{HOMEBREW_LIBRARY_PATH}/postinstall.rb

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -84,7 +84,7 @@ RSpec.shared_context "integration test" do
 
     @ruby_args ||= begin
       ruby_args = [
-        "-W0",
+        ENV["HOMEBREW_RUBY_WARNINGS"],
         "-I", $LOAD_PATH.join(File::PATH_SEPARATOR)
       ]
       if ENV["HOMEBREW_TESTS_COVERAGE"]


### PR DESCRIPTION
This allows us to suppress warnings like:
```
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/language/python.rb:8: warning: Insecure world writable dir /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/scm in PATH, mode 040777
```

Same option is passed in `dev-cmd/test.rb`:
https://github.com/Homebrew/brew/blob/8041649cac6ce135c52efe36549eb090ed7bc93a/Library/Homebrew/dev-cmd/test.rb#L81

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----