### PR TITLE
prof: improve `brew prof` functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@
 **/vendor/bundle/ruby/*/gems/ruby-progressbar-*/
 **/vendor/bundle/ruby/*/gems/simplecov-*/
 **/vendor/bundle/ruby/*/gems/simplecov-html-*/
+**/vendor/bundle/ruby/*/gems/stackprof-*/
 **/vendor/bundle/ruby/*/gems/thor-*/
 **/vendor/bundle/ruby/*/gems/unf_ext-*/
 **/vendor/bundle/ruby/*/gems/unf-*/

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+if ENV["HOMEBREW_STACKPROF"]
+  require_relative "utils/gems"
+  Homebrew.setup_gem_environment!
+  require "stackprof"
+  StackProf.start(mode: :wall, raw: true)
+end
+
 raise "HOMEBREW_BREW_FILE was not exported! Please call bin/brew directly!" unless ENV["HOMEBREW_BREW_FILE"]
 
 std_trap = trap("INT") { exit! 130 } # no backtrace thanks
@@ -186,4 +193,9 @@ rescue Exception => e # rubocop:disable Lint/RescueException
   exit 1
 else
   exit 1 if Homebrew.failed?
+ensure
+  if ENV["HOMEBREW_STACKPROF"]
+    StackProf.stop
+    StackProf.results("prof/stackprof.dump")
+  end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1082,7 +1082,10 @@ Apply the bottle commit and publish bottles to Bintray.
 
 ### `prof` [*`command`*]
 
-Run Homebrew with the Ruby profiler, e.g. `brew prof readall`.
+Run Homebrew with a Ruby profiler, e.g. `brew prof readall`.
+
+* `--stackprof`:
+  Use `stackprof` instead of `ruby-prof` (the default).
 
 ### `release-notes` [*`options`*] [*`previous_tag`*] [*`end_ref`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1498,7 +1498,11 @@ Upload to the specified Bintray organisation (default: \fBhomebrew\fR)\.
 Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
 .
 .SS "\fBprof\fR [\fIcommand\fR]"
-Run Homebrew with the Ruby profiler, e\.g\. \fBbrew prof readall\fR\.
+Run Homebrew with a Ruby profiler, e\.g\. \fBbrew prof readall\fR\.
+.
+.TP
+\fB\-\-stackprof\fR
+Use \fBstackprof\fR instead of \fBruby\-prof\fR (the default)\.
 .
 .SS "\fBrelease\-notes\fR [\fIoptions\fR] [\fIprevious_tag\fR] [\fIend_ref\fR]"
 Print the merged pull requests on Homebrew/brew between two Git refs\. If no \fIprevious_tag\fR is provided it defaults to the latest tag\. If no \fIend_ref\fR is provided it defaults to \fBorigin/master\fR\.


### PR DESCRIPTION
- Add `--stackprof` to allow using stackprof
- Use Bundler for installing all gems
- Use the latest version of `ruby-prof`
- Automatically open the generated HTML output

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----