### PR TITLE
cmd/update-report: fix output of new casks

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -466,7 +466,7 @@ class ReporterHub
       when :A
         name unless installed?(name)
       when :AC
-        name unless cask_installed?(name)
+        name.split("/").last unless cask_installed?(name)
       when :MC, :DC
         name = name.split("/").last
         cask_installed?(name) ? pretty_installed(name) : name


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

[In a recent PR](https://github.com/Homebrew/brew/pull/8395) I added an output for "New Casks" to `brew update`, like so:
```
==> New Casks
a_shiny_new_cask
```
However, after merging I noticed that the output was actually being shown as follows:
```
==> New Casks
homebrew/cask/a_shiny_new_cask
```
This trivial change fixes this oversight.

Apologies for missing this in my original PR.

Thank you.