### PR TITLE
Support bottle uploads to GitHub Releases

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -148,11 +148,7 @@ class Bintray
     end
   end
 
-  def upload_bottle_json(json_files, publish_package: false, warn_on_error: false)
-    bottles_hash = json_files.reduce({}) do |hash, json_file|
-      hash.deep_merge(JSON.parse(IO.read(json_file)))
-    end
-
+  def upload_bottles(bottles_hash, publish_package: false, warn_on_error: false)
     formula_packaged = {}
 
     bottles_hash.each do |formula_name, bottle_hash|

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -112,6 +112,8 @@ HOMEBREW_PULL_API_REGEX =
   %r{https://api\.github\.com/repos/([\w-]+)/([\w-]+)?/pulls/(\d+)}.freeze
 HOMEBREW_PULL_OR_COMMIT_URL_REGEX =
   %r[https://github\.com/([\w-]+)/([\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})].freeze
+HOMEBREW_RELEASES_URL_REGEX =
+  %r{https://github\.com/([\w-]+)/([\w-]+)?/releases/download/(.+)}.freeze
 
 require "PATH"
 

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -175,7 +175,7 @@ module GitHub
     end
   end
 
-  def open_api(url, data: nil, request_method: nil, scopes: [].freeze, parse_json: true)
+  def open_api(url, data: nil, data_binary_path: nil, request_method: nil, scopes: [].freeze, parse_json: true)
     # This is a no-op if the user is opting out of using the GitHub API.
     return block_given? ? yield({}) : {} if Homebrew::EnvConfig.no_github_api?
 
@@ -198,6 +198,11 @@ module GitHub
       rescue JSON::ParserError => e
         raise Error, "Failed to parse JSON request:\n#{e.message}\n#{data}", e.backtrace
       end
+    end
+
+    if data_binary_path.present?
+      args += ["--data-binary", "@#{data_binary_path}"]
+      args += ["--header", "Content-Type: application/gzip"]
     end
 
     headers_tmpfile = Tempfile.new("github_api_headers", HOMEBREW_TEMP)
@@ -465,6 +470,33 @@ module GitHub
     open_api(url, data:           { ref: ref, inputs: inputs },
                   request_method: :POST,
                   scopes:         CREATE_ISSUE_FORK_OR_PR_SCOPES)
+  end
+
+  def get_release(user, repo, tag)
+    url = "#{API_URL}/repos/#{user}/#{repo}/releases/tags/#{tag}"
+    open_api(url, request_method: :GET)
+  end
+
+  def create_or_update_release(user, repo, tag, id: nil, name: nil, draft: false)
+    url = "#{API_URL}/repos/#{user}/#{repo}/releases"
+    method = if id
+      url += "/#{id}"
+      :PATCH
+    else
+      :POST
+    end
+    data = {
+      tag_name: tag,
+      name:     name || tag,
+      draft:    draft,
+    }
+    open_api(url, data: data, request_method: method, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
+  end
+
+  def upload_release_asset(user, repo, id, local_file: nil, remote_file: nil)
+    url = "https://uploads.github.com/repos/#{user}/#{repo}/releases/#{id}/assets"
+    url += "?name=#{remote_file}" if remote_file
+    open_api(url, data_binary_path: local_file, request_method: :POST, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
   end
 
   def get_artifact_url(user, repo, pr, workflow_id: "tests.yml", artifact_name: "bottles")

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1113,7 +1113,7 @@ Requires write access to the repository.
 
 ### `pr-upload` [*`options`*]
 
-Apply the bottle commit and publish bottles to Bintray.
+Apply the bottle commit and publish bottles to Bintray or GitHub Releases.
 
 * `--no-publish`:
   Apply the bottle commit and upload the bottles, but don't publish them.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1547,7 +1547,7 @@ Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew
 Use the specified Bintray repository to automatically mirror stable URLs defined in the formulae (default: \fBmirror\fR)\.
 .
 .SS "\fBpr\-upload\fR [\fIoptions\fR]"
-Apply the bottle commit and publish bottles to Bintray\.
+Apply the bottle commit and publish bottles to Bintray or GitHub Releases\.
 .
 .TP
 \fB\-\-no\-publish\fR


### PR DESCRIPTION
In this PR I'll try to add support for an alternative to Bintray, that is GitHub Releases.
It will be mostly useful for third-party taps, they won't have to create Bintray accounts and stuff.

Idea from @MikeMcQuaid

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----