### PR TITLE
audit: add CERT_ERROR_ALLOWLIST

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -545,12 +545,18 @@ module Homebrew
       problem "Versioned formulae in homebrew/core should use `keg_only :versioned_formula`"
     end
 
+    CERT_ERROR_ALLOWLIST = {
+      "monero" => "https://www.getmonero.org/",
+    }.freeze
+
     def audit_homepage
       homepage = formula.homepage
 
       return if homepage.nil? || homepage.empty?
 
       return unless @online
+
+      return if CERT_ERROR_ALLOWLIST[formula.name] == homepage
 
       return unless DevelopmentTools.curl_handles_most_https_certificates?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds `CERT_ERROR_ALLOWLIST` to workaround a problem with certificates issued by Sectigo, renamed from Comodo (see https://github.com/Homebrew/homebrew-core/issues/58854)

Currently, we know about only `monero` formula which uses a certificate issued by COMODO (which makes this PR red https://github.com/Homebrew/homebrew-core/pull/59671) 
