### PR TITLE
utils/pypi: add salt to blocklist

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -14,6 +14,7 @@ module PyPI
     dxpy
     ipython
     molecule
+    salt
     xonsh
   ].freeze
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR blocks `salt` resources to be automatically updated.
`salt` has quite many dependencies and all of their versions are frozen by upstream (see https://github.com/saltstack/salt/tree/v3001.1/requirements)

The formula itself only installs some additional resources: `M2Crypto` and `pygit2` (and their dependencies) and does not install `PyObjC` due to its linkage problems on non latest macOS.  Given all of these, we can't update resources automatically. 