### PR TITLE
rubocops: allow fails_with and keg_only in on_os blocks

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -148,12 +148,16 @@ module RuboCop
 
             valid_node ||= child.method_name.to_s == "patch"
             valid_node ||= child.method_name.to_s == "resource"
+            valid_node ||= child.method_name.to_s == "fails_with"
+            valid_node ||= child.method_name.to_s == "keg_only"
 
             @offensive_node = on_os_block
             @offense_source_range = on_os_block.source_range
-            unless valid_node
-              problem "`#{on_os_block.method_name}` can only include `depends_on`, `patch` and `resource` nodes."
-            end
+            next if valid_node
+
+            problem "`#{on_os_block.method_name}` can only include " \
+                    "`depends_on`, `patch`, `resource`, `fails_with` and `keg_only` " \
+                    "nodes."
           end
         end
 

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -362,7 +362,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
         on_macos do
-        ^^^^^^^^^^^ `on_macos` can only include `depends_on`, `patch` and `resource` nodes.
+        ^^^^^^^^^^^ `on_macos` can only include `depends_on`, `patch`, `resource`, `fails_with` and `keg_only` nodes.
           depends_on "readline"
           uses_from_macos "ncurses"
         end
@@ -375,7 +375,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
         on_linux do
-        ^^^^^^^^^^^ `on_linux` can only include `depends_on`, `patch` and `resource` nodes.
+        ^^^^^^^^^^^ `on_linux` can only include `depends_on`, `patch`, `resource`, `fails_with` and `keg_only` nodes.
           depends_on "readline"
           uses_from_macos "ncurses"
         end


### PR DESCRIPTION
We have a bunch of cases on Linux where we need to define `fails_with` in formulae, for example:
https://github.com/Homebrew/linuxbrew-core/blob/893685961791e68169ddd8d5433a08e8d0d30e82/Formula/protobuf.rb#L29-L33

And `keg_only`, for example:
https://github.com/Homebrew/linuxbrew-core/blob/ff1bee917b08cd4e5cd947e79eeb7fe461546a03/Formula/curl-openssl.rb#L24-L28

All those could be put in `on_linux` block after this PR is merged.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----