### PR TITLE
language/java: check installed openjdk version instead of latest version

### DIFF
--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -11,7 +11,7 @@ module Language
         next false unless f.any_version_installed?
 
         unless version.zero?
-          major = f.version.to_s[/\d+/].to_i
+          major = f.opt_or_installed_prefix_keg.version.major
           next false if major < version
           next false if major > version && !can_be_newer
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This changes `Language::Java.find_openjdk_formula` to check the installed version of `openjdk` instead of the latest version in the formula.

Using `version` is incorrect if for example the user has `openjdk` pinned to version 13 when the latest version is 14.