### PR TITLE
formula: rename `installed_prefix` and `opt_or_installed_prefix_keg`

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -163,7 +163,7 @@ module Homebrew
               Formulary.from_rack(rack)
             end
 
-            unless (prefix = f.installed_prefix).directory?
+            unless (prefix = f.latest_installed_prefix).directory?
               raise MultipleVersionsInstalledError, "#{rack.basename} has multiple installed versions"
             end
 

--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -26,7 +26,7 @@ module Homebrew
       puts HOMEBREW_PREFIX
     else
       puts args.named.to_resolved_formulae.map { |f|
-        f.opt_prefix.exist? ? f.opt_prefix : f.installed_prefix
+        f.opt_prefix.exist? ? f.opt_prefix : f.latest_installed_prefix
       }
     end
   end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -219,8 +219,7 @@ module Homebrew
         end
         opoo msg if msg
       elsif !f.any_version_installed? && old_formula = f.old_installed_formulae.first
-        installed_version = old_formula.any_installed_keg.version
-        msg = "#{old_formula.full_name} #{installed_version} already installed"
+        msg = "#{old_formula.full_name} #{old_formula.any_installed_version} already installed"
         if !old_formula.linked? && !old_formula.keg_only?
           msg = <<~EOS
             #{msg}, it's just not linked.

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -219,7 +219,7 @@ module Homebrew
         end
         opoo msg if msg
       elsif !f.any_version_installed? && old_formula = f.old_installed_formulae.first
-        installed_version = old_formula.opt_or_installed_prefix_keg.version
+        installed_version = old_formula.any_installed_keg.version
         msg = "#{old_formula.full_name} #{installed_version} already installed"
         if !old_formula.linked? && !old_formula.keg_only?
           msg = <<~EOS

--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -16,6 +16,22 @@ class Formula
 
       super
     end
+
+    def installed_prefix
+      # TODO: deprecate for Homebrew 2.5
+      # odeprecated "Formula#installed_prefix",
+      #             "Formula#latest_installed_prefix (or Formula#any_installed_prefix)"
+      latest_installed_prefix
+    end
+
+    # The currently installed version for this formula. Will raise an exception
+    # if the formula is not installed.
+    # @private
+    def installed_version
+      # TODO: deprecate for Homebrew 2.5
+      # odeprecated "Formula#installed_version"
+      Keg.new(latest_installed_prefix).version
+    end
   end
 
   prepend Compat

--- a/Library/Homebrew/compat/formula.rb
+++ b/Library/Homebrew/compat/formula.rb
@@ -32,6 +32,12 @@ class Formula
       # odeprecated "Formula#installed_version"
       Keg.new(latest_installed_prefix).version
     end
+
+    def opt_or_installed_prefix_keg
+      # TODO: deprecate for Homebrew 2.5
+      # odeprecated "Formula#opt_or_installed_prefix_keg", "Formula#any_installed_keg"
+      any_installed_keg
+    end
   end
 
   prepend Compat

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -32,7 +32,7 @@ module Homebrew
 
     CacheStoreDatabase.use(:linkage) do |db|
       kegs = if args.named.to_kegs.empty?
-        Formula.installed.map(&:opt_or_installed_prefix_keg).reject(&:nil?)
+        Formula.installed.map(&:any_installed_keg).reject(&:nil?)
       else
         args.named.to_kegs
       end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -73,7 +73,7 @@ module Homebrew
     else
       if gnupg.any_version_installed?
         path = PATH.new(ENV.fetch("PATH"))
-        path.prepend(gnupg.opt_or_installed_prefix_keg/"bin")
+        path.prepend(gnupg.any_installed_prefix/"bin")
         ENV["PATH"] = path
       end
     end

--- a/Library/Homebrew/dev-cmd/pull.rb
+++ b/Library/Homebrew/dev-cmd/pull.rb
@@ -60,7 +60,7 @@ module Homebrew
       else
         if gnupg.any_version_installed?
           path = PATH.new(ENV.fetch("PATH"))
-          path.prepend(gnupg.opt_or_installed_prefix_keg/"bin")
+          path.prepend(gnupg.any_installed_prefix/"bin")
           ENV["PATH"] = path
         end
       end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1625,6 +1625,10 @@ class Formula
     end
   end
 
+  def any_installed_version
+    any_installed_keg&.version
+  end
+
   # Returns a list of Dependency objects that are required at runtime.
   # @private
   def runtime_dependencies(read_from_tab: true, undeclared: true)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -559,13 +559,6 @@ class Formula
     end
   end
 
-  # The currently installed version for this formula. Will raise an exception
-  # if the formula is not installed.
-  # @private
-  def installed_version
-    Keg.new(latest_installed_prefix).version
-  end
-
   # The directory in the cellar that the formula is installed to.
   # This directory points to {#opt_prefix} if it exists and if #{prefix} is not
   # called from within the same formula's {#install} or {#post_install} methods.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -488,11 +488,11 @@ class Formula
   delegate compiler_failures: :active_spec
 
   # If this {Formula} is installed.
-  # This is actually just a check for if the {#installed_prefix} directory
+  # This is actually just a check for if the {#latest_installed_prefix} directory
   # exists and is not empty.
   # @private
   def latest_version_installed?
-    (dir = installed_prefix).directory? && !dir.children.empty?
+    (dir = latest_installed_prefix).directory? && !dir.children.empty?
   end
 
   # If at least one version of {Formula} is installed.
@@ -547,7 +547,7 @@ class Formula
   # The latest prefix for this formula. Checks for {#head}, then {#devel}
   # and then {#stable}'s {#prefix}
   # @private
-  def installed_prefix
+  def latest_installed_prefix
     if head && (head_version = latest_head_version) && !head_version_outdated?(head_version)
       latest_head_prefix
     elsif devel && (devel_prefix = prefix(PkgVersion.new(devel.version, revision))).directory?
@@ -563,7 +563,7 @@ class Formula
   # if the formula is not installed.
   # @private
   def installed_version
-    Keg.new(installed_prefix).version
+    Keg.new(latest_installed_prefix).version
   end
 
   # The directory in the cellar that the formula is installed to.

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -14,7 +14,7 @@ module Language
         next false unless f.any_version_installed?
 
         unless version.zero?
-          major = f.opt_or_installed_prefix_keg.version.major
+          major = f.any_installed_keg.version.major
           next false if major < version
           next false if major > version && !can_be_newer
         end

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -14,7 +14,7 @@ module Language
         next false unless f.any_version_installed?
 
         unless version.zero?
-          major = f.any_installed_keg.version.major
+          major = f.any_installed_version.major
           next false if major < version
           next false if major > version && !can_be_newer
         end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -81,7 +81,7 @@ module Homebrew
         formula.head.downloader.shutup! if formula.head?
 
         current = if formula.head?
-          formula.opt_or_installed_prefix_keg.version.version.commit
+          formula.any_installed_keg.version.version.commit
         else
           formula.version
         end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -81,7 +81,7 @@ module Homebrew
         formula.head.downloader.shutup! if formula.head?
 
         current = if formula.head?
-          formula.any_installed_keg.version.version.commit
+          formula.any_installed_version.version.commit
         else
           formula.version
         end

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -145,7 +145,7 @@ class Tab < OpenStruct
       paths << dirs.first
     end
 
-    paths << f.installed_prefix
+    paths << f.latest_installed_prefix
 
     path = paths.map { |pn| pn/FILENAME }.find(&:file?)
 

--- a/Library/Homebrew/test/cmd/link_spec.rb
+++ b/Library/Homebrew/test/cmd/link_spec.rb
@@ -9,7 +9,7 @@ end
 describe "brew link", :integration_test do
   it "links a given Formula" do
     install_test_formula "testball"
-    Formula["testball"].opt_or_installed_prefix_keg.unlink
+    Formula["testball"].any_installed_keg.unlink
 
     expect { brew "link", "testball" }
       .to output(/Linking/).to_stdout

--- a/Library/Homebrew/test/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cmd/uninstall_spec.rb
@@ -28,17 +28,17 @@ describe Homebrew do
     end
   end
 
-  let(:kegs_by_rack) { { dependency.rack => [Keg.new(dependency.installed_prefix)] } }
+  let(:kegs_by_rack) { { dependency.rack => [Keg.new(dependency.latest_installed_prefix)] } }
 
   before do
     [dependency, dependent].each do |f|
-      f.installed_prefix.mkpath
-      Keg.new(f.installed_prefix).optlink
+      f.latest_installed_prefix.mkpath
+      Keg.new(f.latest_installed_prefix).optlink
     end
 
     tab = Tab.empty
     tab.homebrew_version = "1.1.6"
-    tab.tabfile = dependent.installed_prefix/Tab::FILENAME
+    tab.tabfile = dependent.latest_installed_prefix/Tab::FILENAME
     tab.runtime_dependencies = [
       { "full_name" => "dependency", "version" => "1" },
     ]

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1344,4 +1344,22 @@ describe Formula do
       end
     end
   end
+
+  describe "#any_installed_version" do
+    let(:f) do
+      Class.new(Testball) do
+        version "1.0"
+        revision 1
+      end.new
+    end
+
+    it "returns nil when not installed" do
+      expect(f.any_installed_version).to be nil
+    end
+
+    it "returns package version when installed" do
+      f.brew { f.install }
+      expect(f.any_installed_version).to eq(PkgVersion.parse("1.0_1"))
+    end
+  end
 end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -282,23 +282,23 @@ describe Formula do
   describe "#latest_version_installed?" do
     let(:f) { Testball.new }
 
-    it "returns false if the #installed_prefix is not a directory" do
-      allow(f).to receive(:installed_prefix).and_return(double(directory?: false))
+    it "returns false if the #latest_installed_prefix is not a directory" do
+      allow(f).to receive(:latest_installed_prefix).and_return(double(directory?: false))
       expect(f).not_to be_latest_version_installed
     end
 
-    it "returns false if the #installed_prefix does not have children" do
-      allow(f).to receive(:installed_prefix).and_return(double(directory?: true, children: []))
+    it "returns false if the #latest_installed_prefix does not have children" do
+      allow(f).to receive(:latest_installed_prefix).and_return(double(directory?: true, children: []))
       expect(f).not_to be_latest_version_installed
     end
 
-    it "returns true if the #installed_prefix has children" do
-      allow(f).to receive(:installed_prefix).and_return(double(directory?: true, children: [double]))
+    it "returns true if the #latest_installed_prefix has children" do
+      allow(f).to receive(:latest_installed_prefix).and_return(double(directory?: true, children: [double]))
       expect(f).to be_latest_version_installed
     end
   end
 
-  describe "#installed prefix" do
+  describe "#latest_installed_prefix" do
     let(:f) do
       formula do
         url "foo"
@@ -311,17 +311,17 @@ describe Formula do
     let(:head_prefix) { HOMEBREW_CELLAR/f.name/f.head.version }
 
     it "is the same as #prefix by default" do
-      expect(f.installed_prefix).to eq(f.prefix)
+      expect(f.latest_installed_prefix).to eq(f.prefix)
     end
 
     it "returns the stable prefix if it is installed" do
       stable_prefix.mkpath
-      expect(f.installed_prefix).to eq(stable_prefix)
+      expect(f.latest_installed_prefix).to eq(stable_prefix)
     end
 
     it "returns the head prefix if it is installed" do
       head_prefix.mkpath
-      expect(f.installed_prefix).to eq(head_prefix)
+      expect(f.latest_installed_prefix).to eq(head_prefix)
     end
 
     it "returns the stable prefix if head is outdated" do
@@ -332,12 +332,12 @@ describe Formula do
       tab.source["versions"] = { "stable" => "1.0" }
       tab.write
 
-      expect(f.installed_prefix).to eq(stable_prefix)
+      expect(f.latest_installed_prefix).to eq(stable_prefix)
     end
 
     it "returns the head prefix if the active specification is :head" do
       f.active_spec = :head
-      expect(f.installed_prefix).to eq(head_prefix)
+      expect(f.latest_installed_prefix).to eq(head_prefix)
     end
   end
 
@@ -728,7 +728,7 @@ describe Formula do
       dependency = formula("dependency") { url "f-1.0" }
 
       formula.brew { formula.install }
-      keg = Keg.for(formula.installed_prefix)
+      keg = Keg.for(formula.latest_installed_prefix)
       keg.link
 
       linkage_checker = double("linkage checker", undeclared_deps: [dependency.name])
@@ -745,7 +745,7 @@ describe Formula do
       tab.runtime_dependencies = ["foo"]
       tab.write
 
-      keg = Keg.for(formula.installed_prefix)
+      keg = Keg.for(formula.latest_installed_prefix)
       keg.link
 
       expect(formula.runtime_dependencies.map(&:name)).to be_empty
@@ -865,7 +865,7 @@ describe Formula do
         head("foo")
       end
 
-      stable_prefix = f.installed_prefix
+      stable_prefix = f.latest_installed_prefix
       stable_prefix.mkpath
 
       [["000000_1", 1], ["111111", 2], ["111111_1", 2]].each do |pkg_version_suffix, stamp|

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -125,7 +125,7 @@ module Homebrew
         installed_formulae.flat_map(&:runtime_installed_formula_dependents)
                           .uniq
                           .select do |f|
-          keg = f.opt_or_installed_prefix_keg
+          keg = f.any_installed_keg
           next unless keg
 
           LinkageChecker.new(keg, cache_db: db)
@@ -245,7 +245,7 @@ module Homebrew
     end
 
     def depends_on(a, b)
-      if a.opt_or_installed_prefix_keg
+      if a.any_installed_keg
          &.runtime_dependencies
          &.any? { |d| d["full_name"] == b.full_name }
         1

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -15,7 +15,7 @@ module Utils
       def built_as?(f)
         return false unless f.latest_version_installed?
 
-        tab = Tab.for_keg(f.installed_prefix)
+        tab = Tab.for_keg(f.latest_installed_prefix)
         tab.built_as_bottle
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The names `installed_prefix` and `installed_version` are misnomers as `installed_prefix` returns the prefix for the latest version of the formula, regardless of what versions may already be installed.

Proposed renames:
`installed_prefix` &rarr; `latest_installed_prefix`
`opt_or_installed_prefix_keg` &rarr; `any_installed_keg`