### PR TITLE
formula: add `any_installed_prefix` and `any_installed_version`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1626,6 +1626,8 @@ class Formula
     end
   end
 
+  alias any_installed_prefix opt_or_installed_prefix_keg
+
   # Returns a list of Dependency objects that are required at runtime.
   # @private
   def runtime_dependencies(read_from_tab: true, undeclared: true)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1628,6 +1628,10 @@ class Formula
 
   alias any_installed_prefix opt_or_installed_prefix_keg
 
+  def any_installed_version
+    any_installed_prefix&.version
+  end
+
   # Returns a list of Dependency objects that are required at runtime.
   # @private
   def runtime_dependencies(read_from_tab: true, undeclared: true)

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1344,4 +1344,22 @@ describe Formula do
       end
     end
   end
+
+  describe "#any_installed_version" do
+    let(:f) do
+      Class.new(Testball) do
+        version "1.0"
+        revision 1
+      end.new
+    end
+
+    it "returns nil when not installed" do
+      expect(f.any_installed_version).to be nil
+    end
+
+    it "returns package version when installed" do
+      f.brew { f.install }
+      expect(f.any_installed_version).to eq(PkgVersion.parse("1.0_1"))
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds the method `opt_or_installed_version` that returns nil if the formula is not installed. This will be helpful for formulae that need the version of a dependency, for example:

```rb
Formula["gcc"].opt_or_installed_version.major
```

Formulae that this applies to (that are currently using the confusingly named `installed_version`; see #8431):

- [`augustus`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/augustus.rb#L43)
- [`dynare`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/dynare.rb#L66)
- [`gromacs`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gromacs.rb#L28-L29)
- [`imake`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/imake.rb#L32)
- [`kahip`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kahip.rb#L20-L21)
- [`lcov`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/lcov.rb#L58-L59)
- [`mikutter`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/mikutter.rb#L220)
- [`pipgrip`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/pipgrip.rb#L56)