### PR TITLE
test/utils/spdx_spec: don't error if test is skipped

### DIFF
--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -35,8 +35,8 @@ describe SPDX do
     let(:tmp_json_path) { Pathname.new(TEST_TMPDIR) }
 
     after do
-      FileUtils.rm tmp_json_path/"spdx_licenses.json"
-      FileUtils.rm tmp_json_path/"spdx_exceptions.json"
+      FileUtils.rm_f tmp_json_path/"spdx_licenses.json"
+      FileUtils.rm_f tmp_json_path/"spdx_exceptions.json"
     end
 
     it "downloads latest license data" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If the test isn't run, these files will not exist and thus cause `FileUtils.rm` to raise `Errno::ENOENT`.

We also have `exist` checks in the actual test so we don't need error twice should they fail.