### PR TITLE
pr-pull: require formula

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -5,6 +5,7 @@ require "cli/parser"
 require "utils/github"
 require "tmpdir"
 require "bintray"
+require "formula"
 
 module Homebrew
   module_function


### PR DESCRIPTION
This caused bottle publishes to think that no bottles were needed. See https://github.com/Homebrew/homebrew-core/pull/59974#issuecomment-678561221

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----