### PR TITLE
Remove usages of HOMEBREW_INSTALL_BUNDLER_GEMS_FIRST

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -17,12 +17,6 @@ if RUBY_X < 2 || (RUBY_X == 2 && RUBY_Y < 6)
   raise "Homebrew must be run under Ruby 2.6! You're running #{RUBY_VERSION}."
 end
 
-# Load Bundler first of all if it's needed to avoid Gem version conflicts.
-if ENV["HOMEBREW_INSTALL_BUNDLER_GEMS_FIRST"]
-  require_relative "utils/gems"
-  Homebrew.install_bundler_gems!
-end
-
 # Also define here so we can rescue regardless of location.
 class MissingEnvironmentVariables < RuntimeError; end
 

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -378,11 +378,6 @@ then
   esac
 fi
 
-if [[ "$HOMEBREW_COMMAND" = "audit" || "$HOMEBREW_COMMAND" = "style" ]]
-then
-  export HOMEBREW_INSTALL_BUNDLER_GEMS_FIRST="1"
-fi
-
 # Set HOMEBREW_DEV_CMD_RUN for users who have run a development command.
 # This makes them behave like HOMEBREW_DEVELOPERs for brew update.
 if [[ -z "$HOMEBREW_DEVELOPER" ]]


### PR DESCRIPTION
```
==> brew audit dawidd6/test/test-formula-git-revision --online --git --skip-style
Fetching gem metadata from https://rubygems.org/.........
Fetching thread_safe 0.3.6
Fetching concurrent-ruby 1.1.7
Fetching minitest 5.14.1
Installing minitest 5.14.1
Installing concurrent-ruby 1.1.7
Installing thread_safe 0.3.6
Fetching zeitwerk 2.4.0
Installing zeitwerk 2.4.0
Fetching ast 2.4.1
Fetching bindata 2.4.8
Installing ast 2.4.1
Using bundler 1.17.2
.
.
.
```

I think above shouldn't happen.

Also there is no need to export this env variable, as bundler gems are automatically installed if needed anyway.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----