### PR TITLE
workflows/tapioca: Reset to `master` before running Tapioca commands

### DIFF
--- a/.github/workflows/tapioca.yml
+++ b/.github/workflows/tapioca.yml
@@ -34,13 +34,13 @@ jobs:
         id: update
         run: |
           cd "$GITHUB_WORKSPACE/Library/Homebrew"
+          git fetch origin master
+          git reset --hard origin/master
 
           # TODO: replace with `brew typecheck`
           bundle exec tapioca sync --exclude json
           bundle exec srb rbi hidden-definitions
 
-          git fetch origin master
-          git reset --hard origin/master
           git checkout -B tapioca-update
           git add sorbet
           if ! git diff --no-patch --exit-code HEAD -- sorbet; then


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~

-----

- Otherwise the `reset --hard` will get rid of local changes. :weary:

