### PR TITLE
bintray: don't output raw JSON

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -37,8 +37,8 @@ class Bintray
     end
 
     curl(*args, url,
-         show_output: verbose?,
-         secrets:     key)
+         print_stdout: false,
+         secrets:      key)
   end
 
   def upload(local_file, repo:, package:, version:, remote_file:, sha256: nil)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -81,8 +81,8 @@ def curl_with_workarounds(*args, secrets: nil, print_stdout: nil, print_stderr: 
   result
 end
 
-def curl(*args, **options)
-  result = curl_with_workarounds(*args, print_stdout: true, **options)
+def curl(*args, print_stdout: true, **options)
+  result = curl_with_workarounds(*args, print_stdout: print_stdout, **options)
   result.assert_success!
   result
 end


### PR DESCRIPTION
Current situation:
https://github.com/Homebrew/homebrew-core/runs/1018446727?check_suite_focus=true#step:5:46

Situation after this PR:
https://github.com/dawidd6/homebrew-tap/runs/1018549880#step:5:44

With this PR, we no longer see the JSON received from Bintray.
It's redundant to see it, it lacks final newline and messes the whole output a bit.
We already parse and check this JSON, no need to output it too.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----