### PR TITLE
dev-cmd/pr-pull: fail on syntax errors.

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -178,16 +178,12 @@ module Homebrew
     Utils.popen_read("git", "-C", tap.path, "diff-tree",
                      "-r", "--name-only", "--diff-filter=AM",
                      original_commit, "HEAD", "--", tap.formula_dir)
-         .lines.map do |line|
+         .lines
+         .map do |line|
       next unless line.end_with? ".rb\n"
 
       name = "#{tap.name}/#{File.basename(line.chomp, ".rb")}"
-      begin
-        Formula[name]
-      rescue Exception # rubocop:disable Lint/RescueException
-        # Make sure we catch syntax errors.
-        next
-      end
+      Formula[name]
     end.compact
   end
 


### PR DESCRIPTION
This logic was pulled over from `brew pull` where it made sense (as we wanted to be able to pull broken commits) but doesn't really apply here where we can easily end up ignoring broken formulae and pushing their commits anyway.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----