### PR TITLE
audit: don't allow both sha256 and tag/revision for formula

### DIFF
--- a/Library/Homebrew/rubocops/components_redundancy.rb
+++ b/Library/Homebrew/rubocops/components_redundancy.rb
@@ -18,6 +18,19 @@ module RuboCop
         STABLE_MSG = "`stable do` should not be present without a `head` or `devel` spec"
 
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          urls = find_method_calls_by_name(body_node, :url)
+
+          urls.each do |url|
+            url.arguments.each do |arg|
+              next if arg.class != RuboCop::AST::HashNode
+
+              url_args = arg.keys.each.map(&:value)
+              if method_called?(body_node, :sha256) && url_args.include?(:tag) && url_args.include?(:revision)
+                problem "Do not use both sha256 and tag/revision."
+              end
+            end
+          end
+
           stable_block = find_block(body_node, :stable)
           if stable_block
             [:url, :sha256, :mirror].each do |method_name|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
There are a few cases where formulae started using a source archive with a sha checksum and later moved to a git checkout with a tag/revision. In the best case case, the sha is no longer irrelevant to the git repository and in general it is out of date. This style check will detect and flag cases where a formula both has a `sha256` as well as a `tag` and `revision` in the `url`.

CI is expected to fail until changes to the formulae below are incorporated.

```
$ brew style homebrew/core
== aws-iam-authenticator.rb ==
C:  7:  3: Do not use both sha and tag/revision.
== krew.rb ==
C:  7:  3: Do not use both sha and tag/revision.
== ksync.rb ==
C:  7:  3: Do not use both sha and tag/revision.
== kubeseal.rb ==
C:  7:  3: Do not use both sha and tag/revision.
== mage.rb ==
C:  7:  3: Do not use both sha and tag/revision.
== shogun.rb ==
C:  7:  3: Do not use both sha and tag/revision.
== solarus.rb ==
C:  7:  3: Do not use both sha and tag/revision.

5200 files inspected, 7 offenses detected
```