### PR TITLE
spec_helper: increase tests timeout.

### DIFF
--- a/Library/Homebrew/test/cmd/reinstall_spec.rb
+++ b/Library/Homebrew/test/cmd/reinstall_spec.rb
@@ -7,7 +7,7 @@ describe "Homebrew.reinstall_args" do
   it_behaves_like "parseable arguments"
 end
 
-describe "brew reinstall", :integration_test, timeout: 120 do
+describe "brew reinstall", :integration_test do
   it "reinstalls a Formula" do
     install_test_formula "testball"
     foo_dir = HOMEBREW_CELLAR/"testball/0.1/bin"

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -7,7 +7,7 @@ describe "Homebrew.test_args" do
 end
 
 # randomly segfaults on Linux with portable-ruby.
-describe "brew test", :integration_test, :needs_macos, timeout: 120 do
+describe "brew test", :integration_test, :needs_macos do
   it "tests a given Formula" do
     install_test_formula "testball", <<~'RUBY'
       test do

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -181,7 +181,7 @@ RSpec.configure do |config|
       end
 
       begin
-        timeout = example.metadata.fetch(:timeout, 60)
+        timeout = example.metadata.fetch(:timeout, 120)
         inner_timeout = nil
         Timeout.timeout(timeout) do
           example.run


### PR DESCRIPTION
When GitHub Actions is congested some tests can take longer than this (particularly as we're running in parallel). Globally double the time we allow for all tests.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----