### PR TITLE
args: Deprecate methods related to loading formula/cask/kegs

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -57,56 +57,47 @@ module Homebrew
       end
 
       def formulae
-        # TODO: enable for next major/minor release
-        # odeprecated "args.formulae", "args.named.to_formulae"
+        odeprecated "args.formulae", "args.named.to_formulae"
         named.to_formulae
       end
 
       def formulae_and_casks
-        # TODO: enable for next major/minor release
-        # odeprecated "args.formulae_and_casks", "args.named.to_formulae_and_casks"
+        odeprecated "args.formulae_and_casks", "args.named.to_formulae_and_casks"
         named.to_formulae_and_casks
       end
 
       def resolved_formulae
-        # TODO: enable for next major/minor release
-        # odeprecated "args.resolved_formulae", "args.named.to_resolved_formulae"
+        odeprecated "args.resolved_formulae", "args.named.to_resolved_formulae"
         named.to_resolved_formulae
       end
 
       def resolved_formulae_casks
-        # TODO: enable for next major/minor release
-        # odeprecated "args.resolved_formulae_casks", "args.named.to_resolved_formulae_to_casks"
+        odeprecated "args.resolved_formulae_casks", "args.named.to_resolved_formulae_to_casks"
         named.to_resolved_formulae_to_casks
       end
 
       def formulae_paths
-        # TODO: enable for next major/minor release
-        # odeprecated "args.formulae_paths", "args.named.to_formulae_paths"
+        odeprecated "args.formulae_paths", "args.named.to_formulae_paths"
         named.to_formulae_paths
       end
 
       def casks
-        # TODO: enable for next major/minor release
-        # odeprecated "args.casks", "args.named.homebrew_tap_cask_names"
+        odeprecated "args.casks", "args.named.homebrew_tap_cask_names"
         named.homebrew_tap_cask_names
       end
 
       def loaded_casks
-        # TODO: enable for next major/minor release
-        # odeprecated "args.loaded_casks", "args.named.to_cask"
+        odeprecated "args.loaded_casks", "args.named.to_cask"
         named.to_casks
       end
 
       def kegs
-        # TODO: enable for next major/minor release
-        # odeprecated "args.kegs", "args.named.to_kegs"
+        odeprecated "args.kegs", "args.named.to_kegs"
         named.to_kegs
       end
 
       def kegs_casks
-        # TODO: enable for next major/minor release
-        # odeprecated "args.kegs", "args.named.to_kegs_to_casks"
+        odeprecated "args.kegs", "args.named.to_kegs_to_casks"
         named.to_kegs_to_casks
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Deprecate methods for loading formula/cask/kegs for v2.5