### PR TITLE
cli/named_args: Print correct cask ref when name is loaded as formula/keg

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -29,7 +29,7 @@ module Homebrew
           downcased_unique_named.each do |name|
             formulae_and_casks << Formulary.factory(name, spec)
 
-            puts "Treating #{name} as a formula. For the cask, use homebrew/cask/#{name}" if cask_exists_with_ref name
+            warn_if_cask_conflicts(name, "formula")
           rescue FormulaUnavailableError
             begin
               formulae_and_casks << Cask::CaskLoader.load(name)
@@ -56,7 +56,7 @@ module Homebrew
           downcased_unique_named.each do |name|
             resolved_formulae << Formulary.resolve(name, spec: spec(nil), force_bottle: @force_bottle, flags: @flags)
 
-            puts "Treating #{name} as a formula. For the cask, use homebrew/cask/#{name}" if cask_exists_with_ref name
+            warn_if_cask_conflicts(name, "formula")
           rescue FormulaUnavailableError
             begin
               casks << Cask::CaskLoader.load(name)
@@ -98,7 +98,7 @@ module Homebrew
           downcased_unique_named.each do |name|
             kegs << resolve_keg(name)
 
-            puts "Treating #{name} as a keg. For the cask, use homebrew/cask/#{name}" if cask_exists_with_ref name
+            warn_if_cask_conflicts(name, "keg")
           rescue NoSuchKegError, FormulaUnavailableError
             begin
               casks << Cask::CaskLoader.load(name)
@@ -174,10 +174,12 @@ module Homebrew
         end
       end
 
-      def cask_exists_with_ref(ref)
-        Cask::CaskLoader.load ref
+      def warn_if_cask_conflicts(ref, loaded_type)
+        cask = Cask::CaskLoader.load ref
+
+        puts "Treating #{ref} as a #{loaded_type}. For the cask, use #{cask.tap.name}/#{cask.token}"
       rescue Cask::CaskUnavailableError
-        false
+        # No ref conflict with a cask, do nothing
       end
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix a bug where the wrong ref was printed for a cask from a third-party tap with the same name as a formula. 

To recreate:
1. Create a new tap, e.g. `whoiswillma/cask`
2. Copy `homebrew/cask/crunch.rb` to `whoiswillma/cask`,
3. Rename `whoiswillma/cask/crunch` to `gifski` or some other formula
4. Run `brew home gifski`, which prints `Treating gifski as a formula. For the cask, use homebrew/cask/gifski`, when the correct ref should be `whoiswillma/cask/gifski`. 