### PR TITLE
upgrade: fix undefined method 'reinstall_formula'

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -170,6 +170,7 @@ module Homebrew
       oh1 "Checking for dependents of upgraded formulae..." unless args.dry_run?
       broken_dependents = CacheStoreDatabase.use(:linkage) do |db|
         installed_formulae.flat_map(&:runtime_installed_formula_dependents)
+                          .uniq
                           .select do |f|
           keg = f.opt_or_installed_prefix_keg
           next unless keg
@@ -221,7 +222,7 @@ module Homebrew
       return if args.dry_run?
 
       reinstallable_broken_dependents.each do |f|
-        reinstall_formula(f, build_from_source: true, args: args)
+        Homebrew.reinstall_formula(f, build_from_source: true, args: args)
       rescue FormulaInstallationAlreadyAttemptedError
         # We already attempted to reinstall f as part of the dependency tree of
         # another formula. In that case, don't generate an error, just move on.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I had some out of date bottles while installing a formula recently, but after identifying broken dependents I noticed the following undefined method `reinstall_formula` error:

~~~
==> Checking for dependents of upgraded formulae...
==> Reinstalling 16 broken dependents from source:
osrf/simulation/ignition-fuel-tools4, osrf/simulation/ignition-fuel-tools4, osrf/simulation/ignition-fuel-tools4, osrf/simulation/ignition-fuel-tools4, osrf/simulation/ignition-fuel-tools4, osrf/simulation/ignition-fuel-tools4, osrf/simulation/ignition-msgs1, osrf/simulation/ignition-msgs1, osrf/simulation/ignition-msgs5, osrf/simulation/ignition-msgs5, osrf/simulation/ignition-msgs5, osrf/simulation/ignition-transport4, osrf/simulation/ignition-transport4, osrf/simulation/ignition-transport8, osrf/simulation/ignition-transport8, osrf/simulation/ignition-transport8
Error: undefined method `reinstall_formula' for Homebrew::Upgrade:Module
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:224:in `block in check_installed_dependents'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:223:in `each'
/usr/local/Homebrew/Library/Homebrew/upgrade.rb:223:in `check_installed_dependents'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:266:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:113:in `<main>'
~~~

The `check_installed_dependents` method is inside the `Homebrew::Upgrade` module, but `reinstall_formula` is in `Homebrew`, so I prefixed the method call with the module name (`Homebrew.`), which allows `Homebrew::Upgrade::check_installed_dependents` to call `Homebrew::reinstall_formula`.

I also noticed a lot of duplicate formula names in the list of broken dependents, so I added a `uniq` to the `flat_map(...).select` call. I haven't included tests because this is tricky enough to test manually, and I'm not sure how to make an automated test.