### PR TITLE
metafiles: copy all license files

### DIFF
--- a/Library/Homebrew/metafiles.rb
+++ b/Library/Homebrew/metafiles.rb
@@ -4,15 +4,13 @@
 #
 # @api private
 module Metafiles
+  LICENSES = Set.new(%w[copying copyright license licence]).freeze
   # https://github.com/github/markup#markups
   EXTENSIONS = Set.new(%w[
                          .adoc .asc .asciidoc .creole .html .markdown .md .mdown .mediawiki .mkdn
                          .org .pod .rdoc .rst .rtf .textile .txt .wiki
                        ]).freeze
-  BASENAMES = Set.new(%w[
-                        about authors changelog changes copying copyright history license licence
-                        news notes notice readme todo
-                      ]).freeze
+  BASENAMES = Set.new(%w[about authors changelog changes history news notes notice readme todo]).freeze
 
   module_function
 
@@ -24,6 +22,8 @@ module Metafiles
 
   def copy?(file)
     file = file.downcase
+    return true if LICENSES.include? file.split(".").first
+
     ext  = File.extname(file)
     file = File.basename(file, ext) if EXTENSIONS.include?(ext)
     BASENAMES.include?(file)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Relates to https://github.com/Homebrew/homebrew-core/pull/60066

`Metafiles.copy?` now returns true for any file that starts with `license.` (or `copying.`, `copyright.`, `licence.`) . This means that files like `COPYING.LESSER` will be copied while they wouldn't be copied in the past.

I'm not sure if there are other license filename conventions we should include here as well.

Closes https://github.com/Homebrew/brew/pull/8256