### PR TITLE
disable!, deprecate!: add reason

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2780,6 +2780,9 @@ class Formula
     # will not be deprecated.
     # <pre>deprecate! date: "2020-08-27", because: "it is no longer maintained"</pre>
     def deprecate!(date: nil, because: nil)
+      # TODO: enable for next major/minor release
+      # odeprecated "`deprecate!` without a reason", "`deprecate! because: \"reason\"`" if because.blank?
+
       return if date.present? && Date.parse(date) > Date.today
 
       @deprecation_reason = because if because.present?
@@ -2803,6 +2806,9 @@ class Formula
     # will be deprecated instead of disabled.
     # <pre>disable! date: "2020-08-27", because: "it no longer builds"</pre>
     def disable!(date: nil, because: nil)
+      # TODO: enable for next major/minor release
+      # odeprecated "`disable!` without a reason", "`disable! because: \"reason\"`" if because.blank?
+
       if date.present? && Date.parse(date) > Date.today
         @deprecation_reason = because if because.present?
         @deprecated = true

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1148,11 +1148,23 @@ class Formula
   # @return [Boolean]
   delegate deprecated?: :"self.class"
 
+  # The reason this {Formula} is deprecated.
+  # Returns `nil` if no reason is specified or the formula is not deprecated.
+  # @method deprecation_reason
+  # @return [String]
+  delegate deprecation_reason: :"self.class"
+
   # Whether this {Formula} is disabled (i.e. cannot be installed).
   # Defaults to false.
   # @method disabled?
   # @return [Boolean]
   delegate disabled?: :"self.class"
+
+  # The reason this {Formula} is disabled.
+  # Returns `nil` if no reason is specified or the formula is not disabled.
+  # @method disable_reason
+  # @return [String]
+  delegate disable_reason: :"self.class"
 
   def skip_cxxstdlib_check?
     false
@@ -2766,9 +2778,11 @@ class Formula
     # Deprecates a {Formula} (on a given date, if provided) so a warning is
     # shown on each installation. If the date has not yet passed the formula
     # will not be deprecated.
-    def deprecate!(date: nil)
+    # <pre>deprecate! date: "2020-08-27", because: "it is no longer maintained"</pre>
+    def deprecate!(date: nil, because: nil)
       return if date.present? && Date.parse(date) > Date.today
 
+      @deprecation_reason = because if because.present?
       @deprecated = true
     end
 
@@ -2779,15 +2793,23 @@ class Formula
       @deprecated == true
     end
 
+    # The reason for deprecation of a {Formula}.
+    # Returns `nil` if no reason was provided or the formula is not deprecated.
+    # @return [String]
+    attr_reader :deprecation_reason
+
     # Disables a {Formula}  (on a given date, if provided) so it cannot be
     # installed. If the date has not yet passed the formula
     # will be deprecated instead of disabled.
-    def disable!(date: nil)
+    # <pre>disable! date: "2020-08-27", because: "it no longer builds"</pre>
+    def disable!(date: nil, because: nil)
       if date.present? && Date.parse(date) > Date.today
+        @deprecation_reason = because if because.present?
         @deprecated = true
         return
       end
 
+      @disable_reason = because if because.present?
       @disabled = true
     end
 
@@ -2797,6 +2819,11 @@ class Formula
     def disabled?
       @disabled == true
     end
+
+    # The reason for a {Formula} is disabled.
+    # Returns `nil` if no reason was provided or the formula is not disabled.
+    # @return [String]
+    attr_reader :disable_reason
 
     # @private
     def link_overwrite(*paths)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -203,9 +203,17 @@ class FormulaInstaller
     raise FormulaInstallationAlreadyAttemptedError, formula if self.class.attempted.include?(formula)
 
     if formula.deprecated?
-      opoo "#{formula.full_name} has been deprecated!"
+      if formula.deprecation_reason.present?
+        opoo "#{formula.full_name} has been deprecated because #{formula.deprecation_reason}!"
+      else
+        opoo "#{formula.full_name} has been deprecated!"
+      end
     elsif formula.disabled?
-      odie "#{formula.full_name} has been disabled!"
+      if formula.disable_reason.present?
+        odie "#{formula.full_name} has been disabled because #{formula.disable_reason}!"
+      else
+        odie "#{formula.full_name} has been disabled!"
+      end
     end
 
     return if ignore_deps?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Resolves #8501

Add a reason for disabling and deprecating a formula. This means that the error that a user gets when trying to install one of these has more information and makes it easier to figure out what the problem is.

Example:

```ruby
disable! because: "it cannot be built from source"
```

Right now, the `because:` parameter is optional. I plan on making it required by `brew style`, but I think we need to wait for the next release so that Homebrew/core formulae can accept the reason.