### PR TITLE
version: allow implicitly converting tokens to strings

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -38,6 +38,12 @@ describe Version::Token do
     expect(v <=> Object.new).to be nil
     expect { v > Object.new }.to raise_error(ArgumentError)
   end
+
+  describe "#to_str" do
+    it "implicitly converts token to string" do
+      expect(String.try_convert(described_class.new("foo"))).not_to be nil
+    end
+  end
 end
 
 describe Version::NULL do

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -65,6 +65,7 @@ class Version
     def to_s
       value.to_s
     end
+    alias to_str to_s
 
     def numeric?
       false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add alias for `to_str` that allows `Version::Token` to be implicitly converted to string, which we already can do with `Version`

Example usage:

```rb
Formula["gcc"].lib/"gcc"/Formula["gcc"].version.major
```