### PR TITLE
formulary: use formula path when loading from bottle

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -175,7 +175,7 @@ module Formulary
     def get_formula(spec, force_bottle: false, flags: [], **)
       contents = Utils::Bottles.formula_contents @bottle_filename, name: name
       formula = begin
-        Formulary.from_contents(name, @bottle_filename, contents, spec, force_bottle: force_bottle, flags: flags)
+        Formulary.from_contents(name, path, contents, spec, force_bottle: force_bottle, flags: flags)
       rescue FormulaUnreadableError => e
         opoo <<~EOS
           Unreadable formula in #{@bottle_filename}:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This makes a small but significant change to `Formulary::BottleLoader` - the call to `Formulary.from_contents` should be given the path to the formula instead of the bottle file path. This allows the formula tap to be properly determined as it uses the `path` argument to make this determination.

As far as I can tell, passing `@bottle_filename` was having no effect as usually this would be an arbitrary filepath that would make `Tap.from_path` return `nil`

For example,
- `path` could be `/usr/local/Homebrew/Library/Taps/myorg/mytap2/myformula.rb`, and
- `@bottle_filename` could be `~/Downloads/bottles/myformula--0.0.1.catalina.bottle.tar.gz`

This patch allows a formula that has the same name as another formula in a different tap to be installed from a bottle file.

Before:

```console
$ brew install myformula--0.0.1.catalina.bottle.tar.gz
Error: Formulae found in multiple taps: 
       * myorg/mytap1/myformula
       * myorg/mytap2/myformula

Please use the fully-qualified name (e.g. myorg/mytap1/myformula) to refer to the formula.
```

After:

```console
$ brew install myformula--0.0.1.catalina.bottle.tar.gz
==> Installing myformula from myorg/mytap2/myformula
🍺  /usr/local/Cellar/myformula/0.0.1: 42 files, 123.4KB
```