### PR TITLE
style: fix deprecation date check

### DIFF
--- a/Library/Homebrew/rubocops/deprecate.rb
+++ b/Library/Homebrew/rubocops/deprecate.rb
@@ -5,16 +5,14 @@ require "rubocops/extend/formula"
 module RuboCop
   module Cop
     module FormulaAudit
-      # This cop audits deprecate!
-      class Deprecate < FormulaCop
+      # This cop audits deprecate! date
+      class DeprecateDate < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           deprecate_node = find_node_method_by_name(body_node, :deprecate!)
 
-          return if deprecate_node.nil? || deprecate_node.children.length < 3
+          return if deprecate_node.nil?
 
-          date_node = find_strings(deprecate_node).first
-
-          begin
+          deprecate_date(deprecate_node) do |date_node|
             Date.iso8601(string_content(date_node))
           rescue ArgumentError
             fixed_date_string = Date.parse(string_content(date_node)).iso8601
@@ -29,6 +27,10 @@ module RuboCop
             corrector.replace(node.source_range, "\"#{fixed_fixed_date_string}\"")
           end
         end
+
+        def_node_search :deprecate_date, <<~EOS
+          (pair (sym :date) $str)
+        EOS
       end
     end
   end

--- a/Library/Homebrew/test/rubocops/deprecate_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_spec.rb
@@ -2,16 +2,26 @@
 
 require "rubocops/deprecate"
 
-describe RuboCop::Cop::FormulaAudit::Deprecate do
+describe RuboCop::Cop::FormulaAudit::DeprecateDate do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula for deprecate!" do
+  context "When auditing formula for deprecate! date:" do
     it "deprecation date is not ISO 8601 compliant" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
-          deprecate! :date => "June 25, 2020"
-                              ^^^^^^^^^^^^^^^ Use `2020-06-25` to comply with ISO 8601
+          deprecate! date: "June 25, 2020"
+                           ^^^^^^^^^^^^^^^ Use `2020-06-25` to comply with ISO 8601
+        end
+      RUBY
+    end
+
+    it "deprecation date is not ISO 8601 compliant with reason" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! because: "is broken", date: "June 25, 2020"
+                                                 ^^^^^^^^^^^^^^^ Use `2020-06-25` to comply with ISO 8601
         end
       RUBY
     end
@@ -20,7 +30,16 @@ describe RuboCop::Cop::FormulaAudit::Deprecate do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
-          deprecate! :date => "2020-06-25"
+          deprecate! date: "2020-06-25"
+        end
+      RUBY
+    end
+
+    it "deprecation date is ISO 8601 compliant with reason" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! because: "is broken", date: "2020-06-25"
         end
       RUBY
     end
@@ -34,18 +53,46 @@ describe RuboCop::Cop::FormulaAudit::Deprecate do
       RUBY
     end
 
+    it "no deprecation date with reason" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! because: "is broken"
+        end
+      RUBY
+    end
+
     it "auto corrects to ISO 8601 format" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
-          deprecate! :date => "June 25, 2020"
+          deprecate! date: "June 25, 2020"
         end
       RUBY
 
       corrected_source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
-          deprecate! :date => "2020-06-25"
+          deprecate! date: "2020-06-25"
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "auto corrects to ISO 8601 format with reason" do
+      source = <<~RUBY
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! because: "is broken", date: "June 25, 2020"
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          url 'https://brew.sh/foo-1.0.tgz'
+          deprecate! because: "is broken", date: "2020-06-25"
         end
       RUBY
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #8512
Blocking https://github.com/Homebrew/homebrew-core/pull/60336 (and, consequently, the release of 2.5.0)

#8512 exposed a bug in rubocop that checked the first argument to `disable!` or `deprecate!` and assumed it was `date:`. When adding `because:` arguments to `disable!`, rubocop failed when trying to parse a reason as a date.

Running `brew style` on the following fails before this but succeeds after this PR:

```ruby
deprecate! because: "is broken"
```