### PR TITLE
cask/artifact/symlinked: allow --force to overwrite symbolic links

### DIFF
--- a/Library/Homebrew/cask/artifact/symlinked.rb
+++ b/Library/Homebrew/cask/artifact/symlinked.rb
@@ -40,7 +40,7 @@ module Cask
 
       private
 
-      def link(**options)
+      def link(force: false, **options)
         unless source.exist?
           raise CaskError,
                 "It seems the #{self.class.link_type_english_name.downcase} " \
@@ -48,9 +48,16 @@ module Cask
         end
 
         if target.exist?
-          raise CaskError,
-                "It seems there already exists #{self.class.english_article} " \
-                "#{self.class.english_name} at '#{target}'; not overwriting."
+          message = "It seems there is already #{self.class.english_article} " \
+                    "#{self.class.english_name} at '#{target}'"
+
+          if force && target.symlink? && \
+             (target.realpath == source.realpath || target.realpath.to_s.start_with?("#{cask.caskroom_path}/"))
+            opoo "#{message}; overwriting."
+            target.delete
+          else
+            raise CaskError, "#{message}."
+          end
         end
 
         ohai "Linking #{self.class.english_name} '#{source.basename}' to '#{target}'."


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In a [previous PR](https://github.com/Homebrew/brew/pull/8370) I changed how `binary` and `manpage` links were handled for casks to ensure that neither an existing file nor an existing symbolic link would be overwritten.

This change allows the `--force` flag to override this check, essentially using the same logic as in [`cask/artifact/moved`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cask/artifact/moved.rb#L33-L41).

I have tested this locally, and running `brew cask install {something with a conflicting binary name}` outputs the error:
```
Error: It seems there already exists a Binary at '/usr/local/bin/{conflicting name}'; not overwriting.
```
and hence the install fails, while running `brew cask install --force {something with a conflicting binary name}` outputs the warning:
```
Warning: It seems there already exists a Binary at '/usr/local/bin/{conflicting name}'; overwriting.
```
and the install succeeds.

This should (hopefully) resolve https://github.com/Homebrew/homebrew-cask/issues/88401.

Ping @reitermarkus and @vitorgalvao for thoughts and review.

Thank you.