### PR TITLE
Return standard output in `popen_write`

### DIFF
--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -26,11 +26,49 @@ describe Utils do
   end
 
   describe "::popen_write" do
-    it "with supports writing to a command's standard input" do
+    let(:foo) { mktmpdir/"foo" }
+
+    before { foo.write "Foo\n" }
+
+    it "supports writing to a command's standard input" do
       subject.popen_write("grep", "-q", "success") do |pipe|
-        pipe.write("success\n")
+        pipe.write "success\n"
       end
       expect($CHILD_STATUS).to be_a_success
+    end
+
+    it "returns the command's standard output before writing" do
+      child_stdout = subject.popen_write("cat", foo, "-") do |pipe|
+        pipe.write "Bar\n"
+      end
+      expect($CHILD_STATUS).to be_a_success
+      expect(child_stdout).to eq <<~EOS
+        Foo
+        Bar
+      EOS
+    end
+
+    it "returns the command's standard output after writing" do
+      child_stdout = subject.popen_write("cat", "-", foo) do |pipe|
+        pipe.write "Bar\n"
+      end
+      expect($CHILD_STATUS).to be_a_success
+      expect(child_stdout).to eq <<~EOS
+        Bar
+        Foo
+      EOS
+    end
+
+    it "supports interleaved writing between two reads" do
+      child_stdout = subject.popen_write("cat", foo, "-", foo) do |pipe|
+        pipe.write "Bar\n"
+      end
+      expect($CHILD_STATUS).to be_a_success
+      expect(child_stdout).to eq <<~EOS
+        Foo
+        Bar
+        Foo
+      EOS
     end
   end
 end

--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Utils
+  IO_DEFAULT_BUFFER_SIZE = 4096
+  private_constant :IO_DEFAULT_BUFFER_SIZE
+
   def self.popen_read(*args, **options, &block)
     popen(args, "rb", options, &block)
   end
@@ -18,7 +21,7 @@ module Utils
 
       # Before we yield to the block, capture as much output as we can
       loop do
-        output += pipe.read_nonblock(4096)
+        output += pipe.read_nonblock(IO_DEFAULT_BUFFER_SIZE)
       rescue IO::WaitReadable, EOFError
         break
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

## Expected behaviour

We expect the `popen_write` method to return the standard output of the child process.

This expectation is evident in how `safe_popen_write` is written:

```ruby
  def self.safe_popen_write(*args, **options, &block)
    output = popen_write(*args, **options, &block)
    return output if $CHILD_STATUS.success?

    raise ErrorDuringExecution.new(args, status: $CHILD_STATUS, output: [[:stdout, output]])
  end
```

## Actual behaviour

Contrary to what the above code suggests, no code has been written to actually obtain any output from the child process. Newly-written tests show that `popen_write` only returns a number ("4") instead of the expected standard output.

For example, given a file `foo` with the content `Foo\n`, one of the tests calls `popen_write` with `cat foo -` and an input of `Bar`. The expected output would be `Foo\nBar\n` but the actual output is the number 4 (which is what Ruby’s `IO#write` method returns).

## Fix

By having `popen_write` transparently capture standard output, we restore the intended semantics.

The practical purpose of this PR is that when an [embedded formula patch](https://github.com/Homebrew/brew/blob/56ed27af15dafb8e8f2e884656ccad546d784482/Library/Homebrew/patch.rb#L72) fails, it now displays the actual output of the `patch` binary (instead of the length of the patch).

Fixes #8244.
