### PR TITLE
Remove need for separate `.rubocop_cask.yml`.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -298,7 +298,8 @@ Style/DocumentationMethod:
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
   Exclude:
-    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
+    - 'Taps/*/*/{Formula,Casks,}/*.rb'
+    - 'Homebrew/test/**/Casks/**/*.rb'
 
 # TODO: remove this when possible.
 Style/GlobalVars:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -8,6 +8,30 @@ AllCops:
   # enable all pending rubocops
   NewCops: enable
 
+Cask/Desc:
+  Description: 'Ensure that the desc stanza conforms to various content and style checks.'
+  Enabled: true
+
+Cask/HomepageMatchesUrl:
+  Description: 'Ensure that the homepage and url match, otherwise add a comment. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment'
+  Enabled: true
+
+Cask/HomepageUrlTrailingSlash:
+  Description: 'Ensure that the homepage url has a slash after the domain name.'
+  Enabled: true
+
+Cask/NoDslVersion:
+  Description: 'Do not use the deprecated DSL version syntax in your cask header.'
+  Enabled: true
+
+Cask/StanzaGrouping:
+  Description: 'Ensure that cask stanzas are grouped correctly. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order'
+  Enabled: true
+
+Cask/StanzaOrder:
+  Description: 'Ensure that cask stanzas are sorted correctly. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order'
+  Enabled: true
+
 # enable all formulae audits
 FormulaAudit:
   Enabled: true
@@ -195,11 +219,11 @@ Style/ClassVars:
   Exclude:
   - '**/developer/bin/*'
 
-# most of our APIs are internal so don't require docs
+# Don't enforce documentation in casks or formulae.
 Style/Documentation:
  Enabled: false
 
-# don't want this for formulae but re-enabled for Library/Homebrew
+# Not used for casks and formulae.
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -2,11 +2,19 @@
 
 require: ./Homebrew/rubocops.rb
 
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
+
 AllCops:
   TargetRubyVersion: 2.6
   DisplayCopNames: false
   # enable all pending rubocops
   NewCops: enable
+  Exclude:
+    - 'Homebrew/bin/*'
+    - 'Homebrew/**/vendor/**/*'
 
 Cask/Desc:
   Description: 'Ensure that the desc stanza conforms to various content and style checks.'
@@ -43,10 +51,6 @@ FormulaAuditStrict:
 # Use `<<~` for heredocs.
 Layout/HeredocIndentation:
   Enabled: true
-
-# Not useful in casks and formulae.
-Metrics/BlockLength:
-  Enabled: false
 
 # Keyword arguments don't have the same readability
 # problems as normal parameters.
@@ -94,7 +98,8 @@ Style/HashTransformValues:
 
 # Allow for license expressions
 Style/HashAsLastArrayItem:
-  Enabled: false
+  Exclude:
+    - 'Taps/*/*/{Formula/,}*.rb'
 
 # Enabled now LineLength is lowish.
 Style/IfUnlessModifier:
@@ -147,18 +152,21 @@ Performance/CaseWhenSplat:
 Performance/Caller:
   Enabled: false
 
-# don't allow cops to be disabled in formulae
+# Don't allow cops to be disabled in casks and formulae.
 Style/DisableCopsWithinSourceCodeDirective:
   Enabled: true
+  Include:
+    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
 
 # make our hashes consistent
 Layout/HashAlignment:
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
-# `system` is a special case and aligns on second argument
+# `system` is a special case and aligns on second argument, so allow this for formulae.
 Layout/ArgumentAlignment:
-  Enabled: false
+  Exclude:
+    - 'Taps/*/*/{Formula/,}*.rb'
 
 # this is a bit less "floaty"
 Layout/CaseIndentation:
@@ -183,25 +191,62 @@ Lint/AmbiguousBlockAssociation:
 # so many of these in formulae and can't be autocorrected
 # TODO: fix these as `ruby -w` complains about them.
 Lint/AmbiguousRegexpLiteral:
-  Enabled: false
+  Exclude:
+    - 'Taps/*/*/{Formula/,}*.rb'
 
 # so many of these in formulae and can't be autocorrected
 Lint/ParenthesesAsGroupedExpression:
-  Enabled: false
+  Exclude:
+    - 'Taps/*/*/{Formula/,}*.rb'
 
-# most metrics don't make sense to apply for formulae/taps
+# Most metrics don't make sense to apply for casks/formulae/taps.
 Metrics/AbcSize:
-  Enabled: false
+  Exclude:
+    - 'Taps/**/*'
+Metrics/BlockLength:
+  Exclude:
+    - 'Taps/**/*'
 Metrics/ClassLength:
-  Enabled: false
+  Exclude:
+    - 'Taps/**/*'
 Metrics/CyclomaticComplexity:
-  Enabled: false
+  Exclude:
+    - 'Taps/**/*'
 Metrics/MethodLength:
-  Enabled: false
+  Exclude:
+    - 'Taps/**/*'
 Metrics/ModuleLength:
-  Enabled: false
+  Exclude:
+    - 'Taps/**/*'
 Metrics/PerceivedComplexity:
-  Enabled: false
+  Exclude:
+    - 'Taps/**/*'
+
+# allow those that are standard
+# TODO: try to remove some of these
+Naming/MethodParameterName:
+  AllowedNames:
+    - '_'
+    - 'a'
+    - 'b'
+    - 'cc'
+    - 'c1'
+    - 'c2'
+    - 'd'
+    - 'e'
+    - 'f'
+    - 'ff'
+    - 'fn'
+    - 'id'
+    - 'io'
+    - 'o'
+    - 'p'
+    - 'pr'
+    - 'r'
+    - 'rb'
+    - 's'
+    - 'to'
+    - 'v'
 
 # GitHub diff UI wraps beyond 118 characters
 Layout/LineLength:
@@ -214,6 +259,27 @@ Layout/LineLength:
                     ' "~/Library/Application Support/', '"~/Library/Caches/', '"~/Application Support',
                     ' was verified as official when first introduced to the cask']
 
+# Avoid false positives on modifiers used on symbols of methods
+# See https://github.com/rubocop-hq/rubocop/issues/5953
+Style/AccessModifierDeclarations:
+  Enabled: false
+
+# don't group nicely documented or private attr_readers
+Style/AccessorGrouping:
+  Exclude:
+    - 'Homebrew/formula.rb'
+    - 'Homebrew/formulary.rb'
+    - 'Homebrew/migrator.rb'
+    - 'Homebrew/resource.rb'
+    - 'Homebrew/system_command.rb'
+    - 'Homebrew/tap.rb'
+
+# make rspec formatting more flexible
+Style/BlockDelimiters:
+  Exclude:
+    - 'Homebrew/**/*_spec.rb'
+    - 'Homebrew/**/shared_examples/**/*.rb'
+
 # TODO: remove this when possible.
 Style/ClassVars:
   Exclude:
@@ -221,11 +287,18 @@ Style/ClassVars:
 
 # Don't enforce documentation in casks or formulae.
 Style/Documentation:
- Enabled: false
+  Exclude:
+    - 'Taps/**/*'
+
+Style/DocumentationMethod:
+  Include:
+    - 'Homebrew/formula.rb'
 
 # Not used for casks and formulae.
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  EnforcedStyle: always
+  Exclude:
+    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
 
 # TODO: remove this when possible.
 Style/GlobalVars:
@@ -234,7 +307,8 @@ Style/GlobalVars:
 
 # potential for errors in formulae too high with this
 Style/GuardClause:
-  Enabled: false
+  Exclude:
+    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
 
 # avoid hash rockets where possible
 Style/HashSyntax:
@@ -242,7 +316,8 @@ Style/HashSyntax:
 
 # so many of these in formulae and can't be autocorrected
 Style/StringConcatenation:
-  Enabled: false
+  Exclude:
+    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
 
 # ruby style guide favorite
 Style/StringLiterals:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - 'Homebrew/bin/*'
-    - 'Homebrew/**/vendor/**/*'
+    - 'Homebrew/vendor/**/*'
 
 Cask/Desc:
   Description: 'Ensure that the desc stanza conforms to various content and style checks.'

--- a/Library/.rubocop_cask.yml
+++ b/Library/.rubocop_cask.yml
@@ -1,4 +1,4 @@
 # TODO: This file can be deleted once https://github.com/Homebrew/brew/pull/8542
 # is in a stable release and `rubocop.yml` has been removed from all cask taps.
 
-inherit_from: ./Homebrew/.rubocop.yml
+inherit_from: ./.rubocop.yml

--- a/Library/.rubocop_cask.yml
+++ b/Library/.rubocop_cask.yml
@@ -1,35 +1,4 @@
+# TODO: This file can be deleted once https://github.com/Homebrew/brew/pull/8542
+# is in a stable release and `rubocop.yml` has been removed from all cask taps.
+
 inherit_from: ./Homebrew/.rubocop.yml
-
-Cask/Desc:
-  Description: 'Ensure that the desc stanza conforms to various content and style checks.'
-  Enabled: true
-
-Cask/HomepageMatchesUrl:
-  Description: 'Ensure that the homepage and url match, otherwise add a comment. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-a-comment'
-  Enabled: true
-
-Cask/HomepageUrlTrailingSlash:
-  Description: 'Ensure that the homepage url has a slash after the domain name.'
-  Enabled: true
-
-Cask/NoDslVersion:
-  Description: 'Do not use the deprecated DSL version syntax in your cask header.'
-  Enabled: true
-
-Cask/StanzaGrouping:
-  Description: 'Ensure that cask stanzas are grouped correctly. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order'
-  Enabled: true
-
-Cask/StanzaOrder:
-  Description: 'Ensure that cask stanzas are sorted correctly. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order'
-  Enabled: true
-
-# don't want these for casks but re-enabled for Library/Homebrew
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false

--- a/Library/.rubocop_rspec.yml
+++ b/Library/.rubocop_rspec.yml
@@ -1,17 +1,5 @@
 inherit_from: ./.rubocop.yml
 
-AllCops:
-  Include:
-    - '**/cmd/**/*.rb'
-    - '**/lib/**/*.rb'
-    - '**/spec/**/*.rb'
-  Exclude:
-    - '**/vendor/**/*'
-
-# allow style to be disabled in non-formulae code
-Style/DisableCopsWithinSourceCodeDirective:
-  Enabled: false
-
 # Intentionally disabled as it doesn't fit with our code style.
 RSpec/AnyInstance:
   Enabled: false

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -2,26 +2,10 @@ inherit_from:
   - ../.rubocop_rspec.yml
   - .rubocop_todo.yml
 
-AllCops:
-  Include:
-    - '**/*.rb'
-    - 'Library/Homebrew/.simplecov'
-  Exclude:
-    - 'bin/*'
-    - '**/vendor/**/*'
-
-# messes up system formatting for formulae but good for Homebrew/brew
-Layout/ArgumentAlignment:
-  Enabled: true
-
 # make rspec formatting more flexible
 Layout/MultilineMethodCallIndentation:
   Exclude:
     - '**/*_spec.rb'
-
-# so many of these in formulae but none in here
-Lint/AmbiguousRegexpLiteral:
-  Enabled: true
 
 # TODO: add parentheses for these and remove
 Lint/AssignmentInCondition:
@@ -32,123 +16,39 @@ Lint/NestedMethodDefinition:
   Exclude:
     - 'test/**/*'
 
-# so many of these in formulae but none in here
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
-
-# TODO: try to bring down all metrics maximums
+# TODO: Try to bring down all metrics maximums.
 Metrics/AbcSize:
-  Enabled: true
   Max: 250
 Metrics/BlockLength:
-  Enabled: true
   Max: 100
   Exclude:
     - 'test/**/*'
 Metrics/BlockNesting:
-  Enabled: true
   Max: 5
 Metrics/ClassLength:
-  Enabled: true
   Max: 800
   Exclude:
     - 'formula.rb'
     - 'formula_installer.rb'
 Metrics/CyclomaticComplexity:
-  Enabled: true
   Max: 80
+Metrics/PerceivedComplexity:
+  Max: 90
 Metrics/MethodLength:
-  Enabled: true
   Max: 260
 Metrics/ModuleLength:
-  Enabled: true
   Max: 600
   Exclude:
     - 'test/**/*'
-Metrics/PerceivedComplexity:
-  Enabled: true
-  Max: 90
 
-# we won't change backward compatible predicate names
 Naming/PredicateName:
-  Exclude:
-    - 'compat/**/*'
-  # can't rename these
+  # Can't rename these.
   AllowedMethods: is_32_bit?, is_64_bit?
 
-# allow those that are standard
-# TODO: try to remove some of these
-Naming/MethodParameterName:
-  AllowedNames:
-    - '_'
-    - 'a'
-    - 'b'
-    - 'cc'
-    - 'c1'
-    - 'c2'
-    - 'd'
-    - 'e'
-    - 'f'
-    - 'ff'
-    - 'fn'
-    - 'id'
-    - 'io'
-    - 'o'
-    - 'p'
-    - 'pr'
-    - 'r'
-    - 'rb'
-    - 's'
-    - 'to'
-    - 'v'
-
-# Avoid false positives on modifiers used on symbols of methods
-# See https://github.com/rubocop-hq/rubocop/issues/5953
-Style/AccessModifierDeclarations:
-  Enabled: false
-
-# don't group nicely documented or private attr_readers
-Style/AccessorGrouping:
-  Exclude:
-    - 'formula.rb'
-    - 'formulary.rb'
-    - 'migrator.rb'
-    - 'resource.rb'
-    - 'system_command.rb'
-    - 'tap.rb'
-
-# make rspec formatting more flexible
-Style/BlockDelimiters:
-  Exclude:
-    - '**/*_spec.rb'
-    - '**/shared_examples/**/*.rb'
-
-# document our public APIs
-Style/Documentation:
-  Enabled: true
-
-Style/DocumentationMethod:
-  Enabled: true
-  Include:
-    - 'formula.rb'
-
-# don't want this for formulae but re-enabled for Library/Homebrew
 Style/FrozenStringLiteralComment:
-  Enabled: true
-  EnforcedStyle: always
   Exclude:
-  - '**/Casks/**/*.rb'
+    - '**/Casks/**/*.rb'
 
-# so many of these in formulae but none in here
-Style/GuardClause:
-  Enabled: true
-
-# so many of these in formulae but none in here
-Style/StringConcatenation:
-  Enabled: true
-
-# don't want this for formulae but re-enabled for Library/Homebrew
 Style/HashAsLastArrayItem:
-  Enabled: true
   Exclude:
     - 'test/utils/spdx_spec.rb'

--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -19,7 +19,7 @@ SimpleCov.start do
     command_name "#{SimpleCov.command_name} (#{pid})"
 
     # be quiet, the parent process will be in charge of output and checking coverage totals
-    print_error_status = false
+    SimpleCov.print_error_status = false
   end
 
   if ENV["HOMEBREW_INTEGRATION_TEST"]
@@ -27,7 +27,7 @@ SimpleCov.start do
     command_name "#{ENV["HOMEBREW_INTEGRATION_TEST"]} (#{$PROCESS_ID})"
 
     # be quiet, the parent process will be in charge of output and checking coverage totals
-    print_error_status = false
+    SimpleCov.print_error_status = false
 
     at_exit do
       exit_code = $ERROR_INFO.nil? ? 0 : $ERROR_INFO.status

--- a/Library/Homebrew/cask/cmd/style.rb
+++ b/Library/Homebrew/cask/cmd/style.rb
@@ -27,7 +27,7 @@ module Cask
 
         args = [
           "--force-exclusion",
-          "--config", "#{HOMEBREW_LIBRARY}/.rubocop_cask.yml"
+          "--config", HOMEBREW_LIBRARY/".rubocop.yml"
         ]
 
         if json


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

`Cask` cops only run on `cask "…" do` blocks, so we can just enable them globally.