### PR TITLE
livecheck: remove test for livecheck_formulae

### DIFF
--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -145,16 +145,4 @@ describe Homebrew::Livecheck do
         .to eq("https://github.com/Homebrew/brew.git")
     end
   end
-
-  describe "::livecheck_formulae", :needs_network do
-    it "checks for the latest versions of the formulae" do
-      allow(args).to receive(:debug?).and_return(true)
-      allow(args).to receive(:newer_only?).and_return(false)
-
-      expectation = expect { livecheck.livecheck_formulae([f], args) }
-      expectation.to output(/Strategy:.*PageMatch/).to_stdout
-      expectation.to output(/test : 0\.0\.1 ==> (\d+(?:\.\d+)+)/).to_stdout
-                 .and not_to_output.to_stderr
-    end
-  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR removes the network test for `livecheck_formulae` as it was failing sometimes. We will be adding network-related tests for livecheck later on in another PR after finding out why CI fails for GitHub URLs and now for other URLs too.