### PR TITLE
install, livecheck: use `opt_or_installed_prefix_keg`

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -219,7 +219,8 @@ module Homebrew
         end
         opoo msg if msg
       elsif !f.any_version_installed? && old_formula = f.old_installed_formulae.first
-        msg = "#{old_formula.full_name} #{old_formula.installed_version} already installed"
+        installed_version = old_formula.opt_or_installed_prefix_keg.version
+        msg = "#{old_formula.full_name} #{installed_version} already installed"
         if !old_formula.linked? && !old_formula.keg_only?
           msg = <<~EOS
             #{msg}, it's just not linked.

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -80,7 +80,11 @@ module Homebrew
 
         formula.head.downloader.shutup! if formula.head?
 
-        current = formula.head? ? formula.installed_version.version.commit : formula.version
+        current = if formula.head?
+          formula.opt_or_installed_prefix_keg.version.version.commit
+        else
+          formula.version
+        end
 
         latest = if formula.stable?
           version_info = latest_version(formula, args: args)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Similar to #8525 but for `install` and `livecheck`

> `installed_prefix` does not actually return the installed version - see #8431