### PR TITLE
cli/named_args: handle missing cask tap.

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -180,8 +180,9 @@ module Homebrew
 
       def warn_if_cask_conflicts(ref, loaded_type)
         cask = Cask::CaskLoader.load ref
-
-        opoo "Treating #{ref} as a #{loaded_type}. For the cask, use #{cask.tap.name}/#{cask.token}"
+        message = "Treating #{ref} as a #{loaded_type}."
+        message += " For the cask, use #{cask.tap.name}/#{cask.token}" if cask.tap.present?
+        opoo message.freeze
       rescue Cask::CaskUnavailableError
         # No ref conflict with a cask, do nothing
       end


### PR DESCRIPTION
Casks (and indeed formulae) don't always have taps.

Fixes #8535

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----