### PR TITLE
Fix reading HOMEBREW_LIVECHECK_WATCHLIST file

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -10,7 +10,7 @@ module Homebrew
 
   WATCHLIST_PATH = (
     ENV["HOMEBREW_LIVECHECK_WATCHLIST"] ||
-     "#{Dir.home}/.brew_livecheck_watchlist"
+    "#{Dir.home}/.brew_livecheck_watchlist"
   ).freeze
 
   def livecheck_args

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -58,7 +58,7 @@ module Homebrew
       args.formulae
     elsif File.exist?(WATCHLIST_PATH)
       begin
-        WATCHLIST_PATH.read.lines.map do |line|
+        Pathname.new(WATCHLIST_PATH).read.lines.map do |line|
           next if line.start_with?("#")
 
           Formula[line.strip]

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -10,7 +10,7 @@ module Homebrew
 
   WATCHLIST_PATH = (
     ENV["HOMEBREW_LIVECHECK_WATCHLIST"] ||
-    Pathname.new(Dir.home)/".brew_livecheck_watchlist"
+     "#{Dir.home}/.brew_livecheck_watchlist"
   ).freeze
 
   def livecheck_args


### PR DESCRIPTION
When setting a `HOMEBREW_LIVECHECK_WATCHLIST` environment variable, `livecheck` attempts to perform an IO read on a String when it probably expected a Pathname.

```
$ HOMEBREW_LIVECHECK_WATCHLIST="my_brew_livecheck_watchlist"  brew livecheck
Error: undefined method `read' for "my_brew_livecheck_watchlist":String
/usr/local/Homebrew/Library/Homebrew/dev-cmd/livecheck.rb:61:in `livecheck'
/usr/local/Homebrew/Library/Homebrew/brew.rb:113:in `<main>'
```

Looks like this may have been lost in the shuffle of moving livecheck into core.

https://github.com/Homebrew/homebrew-livecheck/blob/6b4a6e342a1a39c0179a1704cf5497cbe9054d8d/cmd/livecheck.rb#L99-L101

(BTW livecheck is ✨)

-----

CC: @MikeMcQuaid 
