### PR TITLE
cask/installer: fix reference to opt_linked/optlinked

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -332,7 +332,7 @@ module Cask
         else
           cask_or_formula.try(:installed?)
         end
-        installed && (cask_or_formula.respond_to?(:opt_linked?) ? cask_or_formula.opt_linked? : true)
+        installed && (cask_or_formula.respond_to?(:optlinked?) ? cask_or_formula.optlinked? : true)
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`opt_linked?` does not exist and should instead be `optlinked?`

`grep` output for references to `opt_linked`:

```console
$ grep -r 'opt_linked' .                 
./Library/Homebrew/cask/installer.rb:        installed && (cask_or_formula.respond_to?(:opt_linked?) ? cask_or_formula.opt_linked? : true)
```

Possible alternative:

- Change this:

```rb
installed = if cask_or_formula.respond_to?(:any_version_installed?)
  cask_or_formula.any_version_installed?
else
  cask_or_formula.try(:installed?)
end
installed && (cask_or_formula.respond_to?(:opt_linked?) ? cask_or_formula.opt_linked? : true)
```

- to this:

```rb
if cask_or_formula.is_a?(Formula)
  cask_or_formula.any_version_installed? && cask_or_formula.optlinked?
else
  cask_or_formula.installed?
end
```