### PR TITLE
workflows: migrate to GitHub Container Registry.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,11 +35,11 @@ jobs:
         run: |
           brew_version=${GITHUB_REF:10}
           echo "::set-env name=brew_version::$brew_version"
-          docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
-          docker tag brew "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:$brew_version"
-          docker push "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:$brew_version"
-          docker tag brew "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:latest"
-          docker push "docker.pkg.github.com/homebrew/brew/ubuntu${{matrix.version}}:latest"
+          docker login ghcr.io -u BrewTestBot -p ${{secrets.HOMEBREW_GITHUB_PACKAGES_API_TOKEN}}
+          docker tag brew "ghcr.io/homebrew/ubuntu${{matrix.version}}:$brew_version"
+          docker push "ghcr.io/homebrew/ubuntu${{matrix.version}}:$brew_version"
+          docker tag brew "ghcr.io/homebrew/ubuntu${{matrix.version}}:latest"
+          docker push "ghcr.io/homebrew/ubuntu${{matrix.version}}:latest"
 
       - name: Deploy the tagged Docker image to Docker Hub
         if: startsWith(github.ref, 'refs/tags/')
@@ -53,10 +53,10 @@ jobs:
       - name: Deploy the homebrew/brew Docker image to GitHub and Docker Hub
         if: startsWith(github.ref, 'refs/tags/') && matrix.version == '20.04'
         run: |
-          docker tag brew "docker.pkg.github.com/homebrew/brew/brew:$brew_version"
-          docker push "docker.pkg.github.com/homebrew/brew/brew:$brew_version"
-          docker tag brew "docker.pkg.github.com/homebrew/brew/brew:latest"
-          docker push "docker.pkg.github.com/homebrew/brew/brew:latest"
+          docker tag brew "ghcr.io/homebrew/brew:$brew_version"
+          docker push "ghcr.io/homebrew/brew:$brew_version"
+          docker tag brew "ghcr.io/homebrew/brew:latest"
+          docker push "ghcr.io/homebrew/brew:latest"
           docker tag brew "homebrew/brew:$brew_version"
           docker push "homebrew/brew:$brew_version"
           docker tag brew "homebrew/brew:latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,9 +142,9 @@ jobs:
     - name: Deploy the Docker image to GitHub and Docker Hub
       if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master'
       run: |
-        docker login docker.pkg.github.com -u BrewTestBot -p ${{secrets.GITHUB_TOKEN}}
-        docker tag brew "docker.pkg.github.com/homebrew/brew/ubuntu16.04:master"
-        docker push "docker.pkg.github.com/homebrew/brew/ubuntu16.04:master"
+        docker login ghcr.io -u BrewTestBot -p ${{secrets.HOMEBREW_GITHUB_PACKAGES_API_TOKEN}}
+        docker tag brew "ghcr.io/homebrew/ubuntu16.04:master"
+        docker push "ghcr.io/homebrew/ubuntu16.04:master"
         docker login -u brewtestbot -p ${{secrets.DOCKER_TOKEN}}
         docker tag brew "homebrew/ubuntu16.04:master"
         docker push "homebrew/ubuntu16.04:master"


### PR DESCRIPTION
This seems a better fit for us (unauthenticated anonymous access) than GitHub Packages Docker registry was.

Followed steps on https://docs.github.com/en/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----