### PR TITLE
audit: compare current version to last committed version when seeing if revision should be reset

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -891,7 +891,8 @@ module Homebrew
         end
       end
 
-      if previous_version != newest_committed_version &&
+      if (previous_version != newest_committed_version ||
+         current_version != newest_committed_version) &&
          !current_revision.zero? &&
          current_revision == newest_committed_revision &&
          current_revision == previous_revision

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -727,6 +727,12 @@ module Homebrew
           it { is_expected.to match("'revision 2' should be removed") }
         end
 
+        context "should be removed with a newer local version" do
+          before { formula_gsub "foo-1.0.tar.gz", "foo-1.1.tar.gz" }
+
+          it { is_expected.to match("'revision 2' should be removed") }
+        end
+
         context "should not warn on an newer version revision removal" do
           before do
             formula_gsub_origin_commit "revision 2", ""


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
https://github.com/Homebrew/brew/pull/7684 refactored the logic to audit if formula version/revision numbers made sense. It compared the previous version with the newest committed version to see if the revision should have been reset. However, in the case where the last commit is a was a different version than the current formula, `previous_version` and `newest_committed_version` will be equal, even though they both differ from the current version.

This change now compares the current formula version with the previous committed version to see if the revision should have be reset.

See https://github.com/Homebrew/homebrew-core/pull/60536#discussion_r482239138

cc @MikeMcQuaid @SMillerDev 