### PR TITLE
livecheck: add support for casks

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -278,7 +278,7 @@ module Cask
 
     def livecheck(&block)
       @livecheck ||= Livecheck.new(self)
-      return @livecheck unless block_given?
+      return @livecheck unless block
 
       raise CaskInvalidError.new(cask, "'livecheck' stanza may only appear once.") if @livecheckable
 

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -85,7 +85,7 @@ module Homebrew
         names = Pathname.new(WATCHLIST_PATH).read.lines
                         .reject { |line| line.start_with?("#") || line.blank? }
                         .map(&:strip)
-        named_args = CLI::NamedArgs.new(*names)
+        named_args = T.unsafe(CLI::NamedArgs).new(*names)
         if args.formula?
           named_args.to_formulae
         elsif args.cask?

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -24,8 +24,9 @@ module Homebrew
 
         Check for newer versions of formulae and/or casks from upstream.
 
-        If no formula or cask argument is passed, the list of formulae and casks to check is taken from
-        `HOMEBREW_LIVECHECK_WATCHLIST` or `~/.brew_livecheck_watchlist`.
+        If no formula or cask argument is passed, the list of formulae and
+        casks to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST` or
+        `~/.brew_livecheck_watchlist`.
       EOS
       switch "--full-name",
              description: "Print formulae/casks with fully-qualified names."

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -20,23 +20,23 @@ module Homebrew
   def livecheck_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `livecheck` [<formulae>]
+        `livecheck` [<formulae>|<casks>]
 
-        Check for newer versions of formulae from upstream.
+        Check for newer versions of formulae and/or casks from upstream.
 
-        If no formula argument is passed, the list of formulae to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST`
-        or `~/.brew_livecheck_watchlist`.
+        If no formula or cask argument is passed, the list of formulae and casks to check is taken from
+        `HOMEBREW_LIVECHECK_WATCHLIST` or `~/.brew_livecheck_watchlist`.
       EOS
       switch "--full-name",
-             description: "Print formulae with fully-qualified names."
+             description: "Print formulae/casks with fully-qualified names."
       flag   "--tap=",
-             description: "Check formulae within the given tap, specified as <user>`/`<repo>."
+             description: "Check formulae/casks within the given tap, specified as <user>`/`<repo>."
       switch "--all",
-             description: "Check all available formulae."
+             description: "Check all available formulae/casks."
       switch "--installed",
-             description: "Check formulae that are currently installed."
+             description: "Check formulae/casks that are currently installed."
       switch "--newer-only",
-             description: "Show the latest version only if it's newer than the formula."
+             description: "Show the latest version only if it's newer than the formula/cask."
       switch "--json",
              description: "Output information in JSON format."
       switch "-q", "--quiet",

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -61,16 +61,16 @@ module Homebrew
 
     formulae_and_casks_to_check = if args.tap
       tap = Tap.fetch(args.tap)
-      formulae = !args.cask? ? tap.formula_names.map { |name| Formula[name] } : []
-      casks = !args.formula? ? tap.cask_tokens.map { |token| Cask::CaskLoader.load(token) } : []
+      formulae = args.cask? ? [] : tap.formula_names.map { |name| Formula[name] }
+      casks = args.formula? ? [] : tap.cask_tokens.map { |token| Cask::CaskLoader.load(token) }
       formulae + casks
     elsif args.installed?
-      formulae = !args.cask? ? Formula.installed : []
-      casks = !args.formula? ? Cask::Caskroom.casks : []
+      formulae = args.cask? ? [] : Formula.installed
+      casks = args.formula? ? [] : Cask::Caskroom.casks
       formulae + casks
     elsif args.all?
-      formulae = !args.cask? ? Formula.to_a : []
-      casks = !args.formula? ? Cask::Cask.to_a : []
+      formulae = args.cask? ? [] : Formula.to_a
+      casks = args.formula? ? [] : Cask::Cask.to_a
       formulae + casks
     elsif args.named.present?
       if args.formula?

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -74,6 +74,8 @@ module Homebrew
       rescue Errno::ENOENT => e
         onoe e
       end
+    end.sort_by do |formula_or_cask|
+      formula_or_cask.respond_to?("token") ? formula_or_cask.token : formula_or_cask.name
     end
 
     raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank?

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -80,6 +80,6 @@ module Homebrew
 
     raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank?
 
-    Livecheck.livecheck_formulae_and_casks(formulae_and_casks_to_check, args)
+    Livecheck.run_checks(formulae_and_casks_to_check, args)
   end
 end

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -61,8 +61,8 @@ module Homebrew
 
     formulae_and_casks_to_check = if args.tap
       tap = Tap.fetch(args.tap)
-      formulae = args.cask? ? [] : tap.formula_names.map { |name| Formula[name] }
-      casks = args.formula? ? [] : tap.cask_tokens.map { |token| Cask::CaskLoader.load(token) }
+      formulae = args.cask? ? [] : tap.formula_files.map { |path| Formulary.factory(path) }
+      casks = args.formula? ? [] : tap.cask_files.map { |path| Cask::CaskLoader.load(path) }
       formulae + casks
     elsif args.installed?
       formulae = args.cask? ? [] : Formula.installed

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -67,7 +67,9 @@ module Homebrew
       args.named.to_formulae_and_casks
     elsif File.exist?(WATCHLIST_PATH)
       begin
-        names = Pathname.new(WATCHLIST_PATH).read.lines.reject { |line| line.start_with?("#") }.map(&:strip)
+        names = Pathname.new(WATCHLIST_PATH).read.lines
+                        .reject { |line| line.start_with?("#") || line.blank? }
+                        .map(&:strip)
         CLI::NamedArgs.new(*names).to_formulae_and_casks
       rescue Errno::ENOENT => e
         onoe e

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -97,7 +97,7 @@ module Homebrew
         onoe e
       end
     end.sort_by do |formula_or_cask|
-      formula_or_cask.respond_to?("token") ? formula_or_cask.token : formula_or_cask.name
+      formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
     end
 
     raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank?

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -86,13 +86,11 @@ module Homebrew
         names = Pathname.new(WATCHLIST_PATH).read.lines
                         .reject { |line| line.start_with?("#") || line.blank? }
                         .map(&:strip)
+
         named_args = T.unsafe(CLI::NamedArgs).new(*names)
-        if args.formula?
-          named_args.to_formulae
-        elsif args.cask?
-          named_args.to_casks
-        else
-          named_args.to_formulae_and_casks
+        named_args.to_formulae_and_casks.reject do |formula_or_cask|
+          (args.formula? && !formula_or_cask.is_a?(Formula)) ||
+            (args.cask? && !formula_or_cask.is_a?(Cask::Cask))
         end
       rescue Errno::ENOENT => e
         onoe e

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -1,20 +1,20 @@
 # typed: true
 # frozen_string_literal: true
 
-# The {Livecheck} class implements the DSL methods used in a formula's
+# The {Livecheck} class implements the DSL methods used in a formula's or cask's
 # `livecheck` block and stores related instance variables. Most of these methods
 # also return the related instance variable when no argument is provided.
 #
 # This information is used by the `brew livecheck` command to control its
 # behavior.
 class Livecheck
-  # A very brief description of why the formula is skipped (e.g. `No longer
+  # A very brief description of why the formula/cask is skipped (e.g. `No longer
   # developed or maintained`).
   # @return [String, nil]
   attr_reader :skip_msg
 
-  def initialize(formula)
-    @formula = formula
+  def initialize(formula_or_cask)
+    @formula_or_cask = formula_or_cask
     @regex = nil
     @skip = false
     @skip_msg = nil
@@ -40,10 +40,10 @@ class Livecheck
 
   # Sets the `@skip` instance variable to `true` and sets the `@skip_msg`
   # instance variable if a `String` is provided. `@skip` is used to indicate
-  # that the formula should be skipped and the `skip_msg` very briefly describes
-  # why the formula is skipped (e.g. "No longer developed or maintained").
+  # that the formula/cask should be skipped and the `skip_msg` very briefly
+  # describes why it is skipped (e.g. "No longer developed or maintained").
   #
-  # @param skip_msg [String] string describing why the formula is skipped
+  # @param skip_msg [String] string describing why the formula/cask is skipped
   # @return [Boolean]
   def skip(skip_msg = nil)
     if skip_msg.is_a?(String)
@@ -55,7 +55,7 @@ class Livecheck
     @skip = true
   end
 
-  # Should `livecheck` skip this formula?
+  # Should `livecheck` skip this formula/cask?
   def skip?
     @skip
   end
@@ -81,7 +81,7 @@ class Livecheck
   # Sets the `@url` instance variable to the provided argument or returns the
   # `@url` instance variable when no argument is provided. The argument can be
   # a `String` (a URL) or a supported `Symbol` corresponding to a URL in the
-  # formula (e.g. `:stable`, `:homepage`, or `:head`).
+  # formula/cask (e.g. `:stable`, `:homepage`, or `:head`).
   #
   # @param val [String, Symbol] URL to check for version information
   # @return [String, nil]
@@ -89,14 +89,36 @@ class Livecheck
     @url = case val
     when nil
       return @url
+    when :cask_url
+      @formula_or_cask.url
     when :head, :stable
-      @formula.send(val).url
+      @formula_or_cask.send(val).url
     when :homepage
-      @formula.homepage
+      @formula_or_cask.homepage
     when String
       val
     else
       raise TypeError, "Livecheck#url expects a String or valid Symbol"
+    end
+  end
+
+  # TODO: documentation
+  def version(val = nil)
+    @version = case val
+    when nil
+      return @version
+    when :before_comma
+      [",", :first]
+    when :after_comma
+      [",", :second]
+    when :before_colon
+      [":", :first]
+    when :after_colon
+      [":", :second]
+    when String
+      val
+    else
+      raise TypeError, "Livecheck#version expects a String or valid Symbol"
     end
   end
 
@@ -109,6 +131,7 @@ class Livecheck
       "skip_msg" => @skip_msg,
       "strategy" => @strategy,
       "url"      => @url,
+      "version"  => @version,
     }
   end
 end

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -106,22 +106,12 @@ class Livecheck
 
   # TODO: documentation
   def version(val = nil)
-    @version = case val
-    when nil
-      return @version
-    when :before_comma
-      [",", :first]
-    when :after_comma
-      [",", :second]
-    when :before_colon
-      [":", :first]
-    when :after_colon
-      [":", :second]
-    when String
-      val
-    else
+    return @version if val.nil?
+    unless val.is_a?(String) || (val.is_a?(Symbol) && Cask::DSL::Version.method_defined?(val))
       raise TypeError, "Livecheck#version expects a String or valid Symbol"
     end
+
+    @version = val
   end
 
   # Returns a `Hash` of all instance variable values.

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -20,7 +20,6 @@ class Livecheck
     @skip_msg = nil
     @strategy = nil
     @url = nil
-    @version = nil
   end
 
   # Sets the `@regex` instance variable to the provided `Regexp` or returns the
@@ -104,16 +103,6 @@ class Livecheck
     end
   end
 
-  # TODO: documentation
-  def version(val = nil)
-    return @version if val.nil?
-    unless val.is_a?(String) || (val.is_a?(Symbol) && Cask::DSL::Version.method_defined?(val))
-      raise TypeError, "Livecheck#version expects a String or valid Symbol"
-    end
-
-    @version = val
-  end
-
   # Returns a `Hash` of all instance variable values.
   # @return [Hash]
   def to_hash
@@ -123,7 +112,6 @@ class Livecheck
       "skip_msg" => @skip_msg,
       "strategy" => @strategy,
       "url"      => @url,
-      "version"  => @version,
     }
   end
 end

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -81,8 +81,7 @@ class Livecheck
   # Sets the `@url` instance variable to the provided argument or returns the
   # `@url` instance variable when no argument is provided. The argument can be
   # a `String` (a URL) or a supported `Symbol` corresponding to a URL in the
-  # formula/cask (e.g. `:stable`, `:homepage`, or `:head`).
-  #
+  # formula/cask (e.g. `:stable`, `:homepage`, `:head`, `:cask_url`, `:appcast`).
   # @param val [String, Symbol] URL to check for version information
   # @return [String, nil]
   def url(val = nil)
@@ -90,7 +89,9 @@ class Livecheck
     when nil
       return @url
     when :cask_url
-      @formula_or_cask.url
+      @formula_or_cask.url.to_s
+    when :appcast
+      @formula_or_cask.appcast.to_s
     when :head, :stable
       @formula_or_cask.send(val).url
     when :homepage

--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -20,6 +20,7 @@ class Livecheck
     @skip_msg = nil
     @strategy = nil
     @url = nil
+    @version = nil
   end
 
   # Sets the `@regex` instance variable to the provided `Regexp` or returns the
@@ -88,10 +89,10 @@ class Livecheck
     @url = case val
     when nil
       return @url
-    when :cask_url
-      @formula_or_cask.url.to_s
     when :appcast
       @formula_or_cask.appcast.to_s
+    when :cask_url
+      @formula_or_cask.url.to_s
     when :head, :stable
       @formula_or_cask.send(val).url
     when :homepage

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -153,19 +153,18 @@ module Homebrew
 
         is_newer_than_upstream = (formula&.stable? || cask) && (current > latest)
 
-        info = {
-          version: {
-            current:             current.to_s,
-            latest:              latest.to_s,
-            outdated:            is_outdated,
-            newer_than_upstream: is_newer_than_upstream,
-          },
-          meta:    {
-            livecheckable: formula_or_cask.livecheckable?,
-          },
-        }
+        info = {}
         info[:formula] = formula_name(formula, args: args) if formula
         info[:cask] = cask_name(cask, args: args) if cask
+        info[:version] = {
+          current:             current.to_s,
+          latest:              latest.to_s,
+          outdated:            is_outdated,
+          newer_than_upstream: is_newer_than_upstream,
+        }
+        info[:meta] = {
+          livecheckable: formula_or_cask.livecheckable?,
+        }
         info[:meta][:head_only] = true if formula&.head_only?
         info[:meta].merge!(version_info[:meta]) if version_info.present? && version_info.key?(:meta)
 
@@ -231,16 +230,14 @@ module Homebrew
     def status_hash(formula_or_cask, status_str, messages = nil, args:)
       formula = formula_or_cask if formula_or_cask.is_a?(Formula)
 
-      status_hash = {
-        status: status_str,
-      }
-      status_hash[:messages] = messages if messages.is_a?(Array)
-
+      status_hash = {}
       if formula
         status_hash[:formula] = formula_name(formula, args: args)
       else
         status_hash[:cask] = cask_name(formula_or_cask, args: args)
       end
+      status_hash[:status] = status_str
+      status_hash[:messages] = messages if messages.is_a?(Array)
 
       if args.verbose?
         status_hash[:meta] = {

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -123,11 +123,11 @@ module Homebrew
           Version.new(formula_or_cask.version)
         end
 
-        latest = if formula&.stable? || cask
+        latest = if formula&.head_only?
+          formula.head.downloader.fetch_last_commit
+        else
           version_info = latest_version(formula_or_cask, args: args)
           version_info[:latest] if version_info.present?
-        else
-          formula.head.downloader.fetch_last_commit
         end
 
         if latest.blank?

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -250,7 +250,7 @@ module Homebrew
       if formula
         status_hash[:formula] = formula_name(formula, args: args)
       else
-        status_hash[:cask] = formula_name(formula_or_cask, args: args)
+        status_hash[:cask] = cask_name(formula_or_cask, args: args)
       end
 
       if args.verbose?

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -120,15 +120,15 @@ module Homebrew
           separator, method = livecheck_version
           Version.new(formula_or_cask.version.to_s.split(separator, 2).try(method))
         elsif formula
-            if formula.head_only?
-              formula.any_installed_version.version.commit
-            else
-              formula.stable.version
-            end
+          if formula.head_only?
+            formula.any_installed_version.version.commit
+          else
+            formula.stable.version
+          end
         elsif livecheck_version.is_a?(Symbol)
           Version.new(Cask::DSL::Version.new(formula_or_cask.version).try(livecheck_version))
-          else
-            Version.new(formula_or_cask.version)
+        else
+          Version.new(formula_or_cask.version)
         end
 
         latest = if formula&.stable? || cask
@@ -269,9 +269,9 @@ module Homebrew
       if formula&.deprecated? && !formula.livecheckable?
         return status_hash(formula, "deprecated", args: args) if args.json?
 
-          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : deprecated" unless args.quiet?
-          return
-        end
+        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : deprecated" unless args.quiet?
+        return
+      end
 
       if formula&.disabled? && !formula.livecheckable?
         return status_hash(formula, "disabled", args: args) if args.json?
@@ -283,17 +283,17 @@ module Homebrew
       if formula&.versioned_formula? && !formula.livecheckable?
         return status_hash(formula, "versioned", args: args) if args.json?
 
-          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : versioned" unless args.quiet?
-          return
-        end
+        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : versioned" unless args.quiet?
+        return
+      end
 
       if formula&.head_only? && !formula.any_version_installed?
         head_only_msg = "HEAD only formula must be installed to be livecheckable"
         return status_hash(formula, "error", [head_only_msg], args: args) if args.json?
 
-          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : #{head_only_msg}" unless args.quiet?
-          return
-        end
+        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : #{head_only_msg}" unless args.quiet?
+        return
+      end
 
       is_gist = formula&.stable&.url&.include?("gist.github.com")
       if formula_or_cask.livecheck.skip? || is_gist
@@ -312,7 +312,7 @@ module Homebrew
           puts "#{Tty.red}#{formula_or_cask_name(formula_or_cask, args: args)}#{Tty.reset} : skipped" \
               "#{" - #{skip_msg}" if skip_msg.present?}"
         end
-          return
+        return
       end
 
       false

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -125,6 +125,8 @@ module Homebrew
             else
               formula.stable.version
             end
+        elsif livecheck_version.is_a?(Symbol)
+          Version.new(Cask::DSL::Version.new(formula_or_cask.version).try(livecheck_version))
           else
             Version.new(formula_or_cask.version)
         end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -358,6 +358,7 @@ module Homebrew
 
     def checkable_cask_urls(cask)
       urls = []
+      urls << cask.appcast.to_s if cask.appcast
       urls << cask.url.to_s
       urls << cask.homepage if cask.homepage
       urls.compact

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -41,18 +41,18 @@ module Homebrew
       rc
     ].freeze
 
-    # Executes the livecheck logic for each formula in the `formulae_to_check` array
-    # and prints the results.
+    # Executes the livecheck logic for each formula/cask in the
+    # `formulae_and_casks_to_check` array and prints the results.
     # @return [nil]
-    def livecheck_formulae(formulae_to_check, args)
+    def livecheck_formulae_and_casks(formulae_and_casks_to_check, args)
       # Identify any non-homebrew/core taps in use for current formulae
       non_core_taps = {}
-      formulae_to_check.each do |f|
-        next if f.tap.blank?
-        next if f.tap.name == CoreTap.instance.name
-        next if non_core_taps[f.tap.name]
+      formulae_and_casks_to_check.each do |fc|
+        next if fc.tap.blank?
+        next if fc.tap.name == CoreTap.instance.name
+        next if non_core_taps[fc.tap.name]
 
-        non_core_taps[f.tap.name] = f.tap
+        non_core_taps[fc.tap.name] = fc.tap
       end
       non_core_taps = non_core_taps.sort.to_h
 
@@ -73,10 +73,10 @@ module Homebrew
       has_a_newer_upstream_version = false
 
       if args.json? && !args.quiet? && $stderr.tty?
-        total_formulae = if formulae_to_check == Formula
-          formulae_to_check.count
+        total_formulae = if formulae_and_casks_to_check == Formula
+          formulae_and_casks_to_check.count
         else
-          formulae_to_check.length
+          formulae_and_casks_to_check.length
         end
 
         Tty.with($stderr) do |stderr|
@@ -92,7 +92,10 @@ module Homebrew
         )
       end
 
-      formulae_checked = formulae_to_check.sort.map.with_index do |formula, i|
+      formulae_checked = formulae_and_casks_to_check.sort_by(&:name).map.with_index do |formula_or_cask, i|
+        formula = formula_or_cask if formula_or_cask.is_a?(Formula)
+        cask = formula_or_cask if formula_or_cask.is_a?(Cask::Cask)
+
         if args.debug? && i.positive?
           puts <<~EOS
 
@@ -101,7 +104,7 @@ module Homebrew
           EOS
         end
 
-        skip_result = skip_conditions(formula, args: args)
+        skip_result = skip_conditions(formula_or_cask, args: args)
         next skip_result if skip_result != false
 
         formula.head&.downloader&.shutup!
@@ -110,17 +113,32 @@ module Homebrew
         # head-only formulae. A formula with `stable` and `head` that's
         # installed using `--head` will still use the `stable` version for
         # comparison.
-        current = if formula.head_only?
-          formula.any_installed_version.version.commit
+        livecheck_version = formula_or_cask.livecheck.version
+        current = if livecheck_version.is_a?(String)
+          livecheck_version
         else
-          formula.stable.version
+          version = if formula
+            if formula.head_only?
+              formula.any_installed_version.version.commit
+            else
+              formula.stable.version
+            end
+          else
+            Version.new(formula_or_cask.version)
+          end
+          if livecheck_version.is_a?(Array)
+            separator, method = livecheck_version
+            Version.new(version.to_s.split(separator, 2).try(method))
+          else
+            version
+          end
         end
 
-        latest = if formula.head_only?
-          formula.head.downloader.fetch_last_commit
-        else
-          version_info = latest_version(formula, args: args)
+        latest = if formula&.stable? || cask
+          version_info = latest_version(formula_or_cask, args: args)
           version_info[:latest] if version_info.present?
+        else
+          formula.head.downloader.fetch_last_commit
         end
 
         if latest.blank?
@@ -129,14 +147,14 @@ module Homebrew
 
           next version_info if version_info.is_a?(Hash) && version_info[:status] && version_info[:messages]
 
-          next status_hash(formula, "error", [no_versions_msg], args: args)
+          next status_hash(formula_or_cask, "error", [no_versions_msg], args: args)
         end
 
         if (m = latest.to_s.match(/(.*)-release$/)) && !current.to_s.match(/.*-release$/)
           latest = Version.new(m[1])
         end
 
-        is_outdated = if formula.head_only?
+        is_outdated = if formula&.head_only?
           # A HEAD-only formula is considered outdated if the latest upstream
           # commit hash is different than the installed version's commit hash
           (current != latest)
@@ -144,10 +162,9 @@ module Homebrew
           (current < latest)
         end
 
-        is_newer_than_upstream = formula.stable? && (current > latest)
+        is_newer_than_upstream = (formula&.stable? || cask) && (current > latest)
 
         info = {
-          formula: formula_name(formula, args: args),
           version: {
             current:             current.to_s,
             latest:              latest.to_s,
@@ -155,10 +172,12 @@ module Homebrew
             newer_than_upstream: is_newer_than_upstream,
           },
           meta:    {
-            livecheckable: formula.livecheckable?,
+            livecheckable: formula_or_cask.livecheckable?,
           },
         }
-        info[:meta][:head_only] = true if formula.head_only?
+        info[:formula] = formula_name(formula, args: args) if formula
+        info[:cask] = cask_name(cask, args: args) if cask
+        info[:meta][:head_only] = true if formula&.head_only?
         info[:meta].merge!(version_info[:meta]) if version_info.present? && version_info.key?(:meta)
 
         next if args.newer_only? && !info[:version][:outdated]
@@ -178,9 +197,9 @@ module Homebrew
 
         if args.json?
           progress&.increment
-          status_hash(formula, "error", [e.to_s], args: args)
+          status_hash(formula_or_cask, "error", [e.to_s], args: args)
         elsif !args.quiet?
-          onoe "#{Tty.blue}#{formula_name(formula, args: args)}#{Tty.reset}: #{e}"
+          onoe "#{Tty.blue}#{formula_or_cask_name(formula_or_cask, args: args)}#{Tty.reset}: #{e}"
           nil
         end
       end
@@ -201,6 +220,18 @@ module Homebrew
       puts JSON.generate(formulae_checked.compact)
     end
 
+    def formula_or_cask_name(formula_or_cask, args:)
+      if formula_or_cask.is_a?(Formula)
+        formula_name(formula_or_cask, args: args)
+      else
+        cask_name(formula_or_cask, args: args)
+      end
+    end
+
+    def cask_name(cask, args:)
+      args.full_name? ? cask.full_name : cask.token
+    end
+
     # Returns the fully-qualified name of a formula if the `full_name` argument is
     # provided; returns the name otherwise.
     # @return [String]
@@ -208,18 +239,25 @@ module Homebrew
       args.full_name? ? formula.full_name : formula.name
     end
 
-    def status_hash(formula, status_str, messages = nil, args:)
+    def status_hash(formula_or_cask, status_str, messages = nil, args:)
+      formula = formula_or_cask if formula_or_cask.is_a?(Formula)
+
       status_hash = {
-        formula: formula_name(formula, args: args),
-        status:  status_str,
+        status: status_str,
       }
       status_hash[:messages] = messages if messages.is_a?(Array)
 
+      if formula
+        status_hash[:formula] = formula_name(formula, args: args)
+      else
+        status_hash[:cask] = formula_name(formula_or_cask, args: args)
+      end
+
       if args.verbose?
         status_hash[:meta] = {
-          livecheckable: formula.livecheckable?,
+          livecheckable: formula_or_cask.livecheckable?,
         }
-        status_hash[:meta][:head_only] = true if formula.head_only?
+        status_hash[:meta][:head_only] = true if formula&.head_only?
       end
 
       status_hash
@@ -228,54 +266,56 @@ module Homebrew
     # If a formula has to be skipped, it prints or returns a Hash contaning the reason
     # for doing so; returns false otherwise.
     # @return [Hash, nil, Boolean]
-    def skip_conditions(formula, args:)
-      if formula.deprecated? && !formula.livecheckable?
+    def skip_conditions(formula_or_cask, args:)
+      formula = formula_or_cask if formula_or_cask.is_a?(Formula)
+
+      if formula&.deprecated? && !formula.livecheckable?
         return status_hash(formula, "deprecated", args: args) if args.json?
 
-        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : deprecated" unless args.quiet?
-        return
-      end
+          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : deprecated" unless args.quiet?
+          return
+        end
 
-      if formula.disabled? && !formula.livecheckable?
+      if formula&.disabled? && !formula.livecheckable?
         return status_hash(formula, "disabled", args: args) if args.json?
 
         puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : disabled" unless args.quiet?
         return
       end
 
-      if formula.versioned_formula? && !formula.livecheckable?
+      if formula&.versioned_formula? && !formula.livecheckable?
         return status_hash(formula, "versioned", args: args) if args.json?
 
-        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : versioned" unless args.quiet?
-        return
-      end
+          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : versioned" unless args.quiet?
+          return
+        end
 
-      if formula.head_only? && !formula.any_version_installed?
+      if formula&.head_only? && !formula.any_version_installed?
         head_only_msg = "HEAD only formula must be installed to be livecheckable"
         return status_hash(formula, "error", [head_only_msg], args: args) if args.json?
 
-        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : #{head_only_msg}" unless args.quiet?
-        return
-      end
+          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : #{head_only_msg}" unless args.quiet?
+          return
+        end
 
-      is_gist = formula.stable&.url&.include?("gist.github.com")
-      if formula.livecheck.skip? || is_gist
-        skip_msg = if formula.livecheck.skip_msg.is_a?(String) &&
-                      formula.livecheck.skip_msg.present?
-          formula.livecheck.skip_msg.to_s
+      is_gist = formula&.stable&.url&.include?("gist.github.com")
+      if formula_or_cask.livecheck.skip? || is_gist
+        skip_msg = if formula_or_cask.livecheck.skip_msg.is_a?(String) &&
+                      formula_or_cask.livecheck.skip_msg.present?
+          formula_or_cask.livecheck.skip_msg.to_s
         elsif is_gist
           "Stable URL is a GitHub Gist"
         else
           ""
         end
 
-        return status_hash(formula, "skipped", (skip_msg.blank? ? nil : [skip_msg]), args: args) if args.json?
+        return status_hash(formula_or_cask, "skipped", (skip_msg.blank? ? nil : [skip_msg]), args: args) if args.json?
 
         unless args.quiet?
-          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : skipped" \
+          puts "#{Tty.red}#{formula_or_cask_name(formula_or_cask, args: args)}#{Tty.reset} : skipped" \
               "#{" - #{skip_msg}" if skip_msg.present?}"
         end
-        return
+          return
       end
 
       false
@@ -284,8 +324,8 @@ module Homebrew
     # Formats and prints the livecheck result for a formula.
     # @return [nil]
     def print_latest_version(info, args:)
-      formula_s = "#{Tty.blue}#{info[:formula]}#{Tty.reset}"
-      formula_s += " (guessed)" if !info[:meta][:livecheckable] && args.verbose?
+      formula_or_cask_s = "#{Tty.blue}#{info[:formula] || info[:cask]}#{Tty.reset}"
+      formula_or_cask_s += " (guessed)" if !info[:meta][:livecheckable] && args.verbose?
 
       current_s = if info[:version][:newer_than_upstream]
         "#{Tty.red}#{info[:version][:current]}#{Tty.reset}"
@@ -299,12 +339,12 @@ module Homebrew
         info[:version][:latest]
       end
 
-      puts "#{formula_s} : #{current_s} ==> #{latest_s}"
+      puts "#{formula_or_cask_s} : #{current_s} ==> #{latest_s}"
     end
 
     # Returns an Array containing the formula URLs that can be used by livecheck.
     # @return [Array]
-    def checkable_urls(formula)
+    def checkable_formula_urls(formula)
       urls = []
       urls << formula.head.url if formula.head
       if formula.stable
@@ -314,6 +354,21 @@ module Homebrew
       urls << formula.homepage if formula.homepage
 
       urls.compact
+    end
+
+    def checkable_cask_urls(cask)
+      urls = []
+      urls << cask.url.to_s
+      urls << cask.homepage if cask.homepage
+      urls.compact
+    end
+
+    def checkable_urls(formula_or_cask)
+      if formula_or_cask.is_a?(Formula)
+        checkable_formula_urls(formula_or_cask)
+      else
+        checkable_cask_urls(formula_or_cask)
+      end
     end
 
     # Preprocesses and returns the URL used by livecheck.
@@ -357,20 +412,26 @@ module Homebrew
     # Identifies the latest version of the formula and returns a Hash containing
     # the version information. Returns nil if a latest version couldn't be found.
     # @return [Hash, nil]
-    def latest_version(formula, args:)
-      has_livecheckable = formula.livecheckable?
-      livecheck = formula.livecheck
+    def latest_version(formula_or_cask, args:)
+      formula = formula_or_cask if formula_or_cask.is_a?(Formula)
+
+      has_livecheckable = formula_or_cask.livecheckable?
+      livecheck = formula_or_cask.livecheck
       livecheck_regex = livecheck.regex
       livecheck_strategy = livecheck.strategy
       livecheck_url = livecheck.url
 
       urls = [livecheck_url] if livecheck_url.present?
-      urls ||= checkable_urls(formula)
+      urls ||= checkable_urls(formula_or_cask)
 
       if args.debug?
         puts
-        puts "Formula:          #{formula_name(formula, args: args)}"
-        puts "Head only?:       true" if formula.head_only?
+        if formula
+          puts "Formula:          #{formula_name(formula, args: args)}"
+          puts "Head only?:       true" if formula.head_only?
+        else
+          puts "Cask:             #{cask_name(formula_or_cask, args: args)}"
+        end
         puts "Livecheckable?:   #{has_livecheckable ? "Yes" : "No"}"
       end
 

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -47,12 +47,12 @@ module Homebrew
     def run_checks(formulae_and_casks_to_check, args)
       # Identify any non-homebrew/core taps in use for current formulae
       non_core_taps = {}
-      formulae_and_casks_to_check.each do |fc|
-        next if fc.tap.blank?
-        next if fc.tap.name == CoreTap.instance.name
-        next if non_core_taps[fc.tap.name]
+      formulae_and_casks_to_check.each do |formula_or_cask|
+        next if formula_or_cask.tap.blank?
+        next if formula_or_cask.tap.name == CoreTap.instance.name
+        next if non_core_taps[formula_or_cask.tap.name]
 
-        non_core_taps[fc.tap.name] = fc.tap
+        non_core_taps[formula_or_cask.tap.name] = formula_or_cask.tap
       end
       non_core_taps = non_core_taps.sort.to_h
 
@@ -73,7 +73,7 @@ module Homebrew
       has_a_newer_upstream_version = false
 
       if args.json? && !args.quiet? && $stderr.tty?
-        total_formulae = if formulae_and_casks_to_check == Formula
+        formulae_and_casks_total = if formulae_and_casks_to_check == Formula
           formulae_and_casks_to_check.count
         else
           formulae_and_casks_to_check.length
@@ -84,7 +84,7 @@ module Homebrew
         end
 
         progress = ProgressBar.create(
-          total:          total_formulae,
+          total:          formulae_and_casks_total,
           progress_mark:  "#",
           remainder_mark: ".",
           format:         " %t: [%B] %c/%C ",

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -339,34 +339,26 @@ module Homebrew
       puts "#{formula_or_cask_s} : #{current_s} ==> #{latest_s}"
     end
 
-    # Returns an Array containing the formula URLs that can be used by livecheck.
+    # Returns an Array containing the formula/cask URLs that can be used by livecheck.
     # @return [Array]
-    def checkable_formula_urls(formula)
-      urls = []
-      urls << formula.head.url if formula.head
-      if formula.stable
-        urls << formula.stable.url
-        urls.concat(formula.stable.mirrors)
-      end
-      urls << formula.homepage if formula.homepage
-
-      urls.compact
-    end
-
-    def checkable_cask_urls(cask)
-      urls = []
-      urls << cask.appcast.to_s if cask.appcast
-      urls << cask.url.to_s
-      urls << cask.homepage if cask.homepage
-      urls.compact
-    end
-
     def checkable_urls(formula_or_cask)
-      if formula_or_cask.is_a?(Formula)
-        checkable_formula_urls(formula_or_cask)
-      else
-        checkable_cask_urls(formula_or_cask)
+      urls = []
+
+      case formula_or_cask
+      when Formula
+        urls << formula_or_cask.head.url if formula_or_cask.head
+        if formula_or_cask.stable
+          urls << formula_or_cask.stable.url
+          urls.concat(formula_or_cask.stable.mirrors)
+        end
+        urls << formula_or_cask.homepage if formula_or_cask.homepage
+      when Cask::Cask
+        urls << formula_or_cask.appcast.to_s if formula_or_cask.appcast
+        urls << formula_or_cask.url.to_s if formula_or_cask.url
+        urls << formula_or_cask.homepage if formula_or_cask.homepage
       end
+
+      urls.compact
     end
 
     # Preprocesses and returns the URL used by livecheck.

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -115,9 +115,11 @@ module Homebrew
         # comparison.
         livecheck_version = formula_or_cask.livecheck.version
         current = if livecheck_version.is_a?(String)
-          livecheck_version
-        else
-          version = if formula
+          Version.new(livecheck_version)
+        elsif livecheck_version.is_a?(Array)
+          separator, method = livecheck_version
+          Version.new(formula_or_cask.version.to_s.split(separator, 2).try(method))
+        elsif formula
             if formula.head_only?
               formula.any_installed_version.version.commit
             else
@@ -125,13 +127,6 @@ module Homebrew
             end
           else
             Version.new(formula_or_cask.version)
-          end
-          if livecheck_version.is_a?(Array)
-            separator, method = livecheck_version
-            Version.new(version.to_s.split(separator, 2).try(method))
-          else
-            version
-          end
         end
 
         latest = if formula&.stable? || cask

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -92,7 +92,7 @@ module Homebrew
         )
       end
 
-      formulae_checked = formulae_and_casks_to_check.sort_by(&:name).map.with_index do |formula_or_cask, i|
+      formulae_checked = formulae_and_casks_to_check.map.with_index do |formula_or_cask, i|
         formula = formula_or_cask if formula_or_cask.is_a?(Formula)
         cask = formula_or_cask if formula_or_cask.is_a?(Cask::Cask)
 

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -107,7 +107,7 @@ module Homebrew
         skip_result = skip_conditions(formula_or_cask, args: args)
         next skip_result if skip_result != false
 
-        formula.head&.downloader&.shutup!
+        formula&.head&.downloader&.shutup!
 
         # Use the `stable` version for comparison except for installed
         # head-only formulae. A formula with `stable` and `head` that's

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -209,9 +209,10 @@ module Homebrew
     end
 
     def formula_or_cask_name(formula_or_cask, args:)
-      if formula_or_cask.is_a?(Formula)
+      case formula_or_cask
+      when Formula
         formula_name(formula_or_cask, args: args)
-      else
+      when Cask::Cask
         cask_name(formula_or_cask, args: args)
       end
     end
@@ -229,11 +230,12 @@ module Homebrew
 
     def status_hash(formula_or_cask, status_str, messages = nil, args:)
       formula = formula_or_cask if formula_or_cask.is_a?(Formula)
+      cask = formula_or_cask if formula_or_cask.is_a?(Cask::Cask)
 
       status_hash = {}
       if formula
         status_hash[:formula] = formula_name(formula, args: args)
-      else
+      elsif cask
         status_hash[:cask] = cask_name(formula_or_cask, args: args)
       end
       status_hash[:status] = status_str
@@ -393,6 +395,7 @@ module Homebrew
     # @return [Hash, nil]
     def latest_version(formula_or_cask, args:)
       formula = formula_or_cask if formula_or_cask.is_a?(Formula)
+      cask = formula_or_cask if formula_or_cask.is_a?(Cask::Cask)
 
       has_livecheckable = formula_or_cask.livecheckable?
       livecheck = formula_or_cask.livecheck
@@ -408,7 +411,7 @@ module Homebrew
         if formula
           puts "Formula:          #{formula_name(formula, args: args)}"
           puts "Head only?:       true" if formula.head_only?
-        else
+        elsif cask
           puts "Cask:             #{cask_name(formula_or_cask, args: args)}"
         end
         puts "Livecheckable?:   #{has_livecheckable ? "Yes" : "No"}"

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -44,7 +44,7 @@ module Homebrew
     # Executes the livecheck logic for each formula/cask in the
     # `formulae_and_casks_to_check` array and prints the results.
     # @return [nil]
-    def livecheck_formulae_and_casks(formulae_and_casks_to_check, args)
+    def run_checks(formulae_and_casks_to_check, args)
       # Identify any non-homebrew/core taps in use for current formulae
       non_core_taps = {}
       formulae_and_casks_to_check.each do |fc|

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -116,9 +116,6 @@ module Homebrew
         livecheck_version = formula_or_cask.livecheck.version
         current = if livecheck_version.is_a?(String)
           Version.new(livecheck_version)
-        elsif livecheck_version.is_a?(Array)
-          separator, method = livecheck_version
-          Version.new(formula_or_cask.version.to_s.split(separator, 2).try(method))
         elsif formula
           if formula.head_only?
             formula.any_installed_version.version.commit

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -113,17 +113,12 @@ module Homebrew
         # head-only formulae. A formula with `stable` and `head` that's
         # installed using `--head` will still use the `stable` version for
         # comparison.
-        livecheck_version = formula_or_cask.livecheck.version
-        current = if livecheck_version.is_a?(String)
-          Version.new(livecheck_version)
-        elsif formula
+        current = if formula
           if formula.head_only?
             formula.any_installed_version.version.commit
           else
             formula.stable.version
           end
-        elsif livecheck_version.is_a?(Symbol)
-          Version.new(Cask::DSL::Version.new(formula_or_cask.version).try(livecheck_version))
         else
           Version.new(formula_or_cask.version)
         end

--- a/Library/Homebrew/rubocops/cask/constants/stanza.rb
+++ b/Library/Homebrew/rubocops/cask/constants/stanza.rb
@@ -9,6 +9,7 @@ module RuboCop
         [:version, :sha256],
         [:language],
         [:url, :appcast, :name, :desc, :homepage],
+        [:livecheck],
         [
           :auto_updates,
           :conflicts_with,

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -85,7 +85,6 @@ describe Homebrew::Livecheck do
 
         livecheck do
           url "https://formulae.brew.sh/api/formula/ruby.json"
-          version :before_comma
           regex(/"stable":"(\d+(?:\.\d+)+)"/i)
         end
       end

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -107,6 +107,26 @@ describe Livecheck do
     end
   end
 
+  describe "#version" do
+    it "returns nil if not set" do
+      expect(livecheckable.version).to be nil
+    end
+
+    it "returns value if set" do
+      livecheckable.version("foo")
+      expect(livecheckable.version).to eq("foo")
+
+      livecheckable.version(:before_comma)
+      expect(livecheckable.version).to eq([",", :first])
+    end
+
+    it "raises a TypeError if the argument isn't a String or Symbol" do
+      expect {
+        livecheckable.version(/foo/)
+      }.to raise_error(TypeError, "Livecheck#version expects a String or valid Symbol")
+    end
+  end
+
   describe "#to_hash" do
     it "returns a Hash of all instance variables" do
       expect(livecheckable.to_hash).to eq(
@@ -116,6 +136,7 @@ describe Livecheck do
           "skip_msg" => nil,
           "strategy" => nil,
           "url"      => nil,
+          "version"  => nil,
         },
       )
     end

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -117,7 +117,7 @@ describe Livecheck do
       expect(livecheckable.version).to eq("1.2.3")
 
       livecheckable.version(:before_comma)
-      expect(livecheckable.version).to eq([",", :first])
+      expect(livecheckable.version).to eq(:before_comma)
     end
 
     it "raises a TypeError if the argument isn't a String or Symbol" do

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -113,8 +113,8 @@ describe Livecheck do
     end
 
     it "returns value if set" do
-      livecheckable.version("foo")
-      expect(livecheckable.version).to eq("foo")
+      livecheckable.version("1.2.3")
+      expect(livecheckable.version).to eq("1.2.3")
 
       livecheckable.version(:before_comma)
       expect(livecheckable.version).to eq([",", :first])

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -107,26 +107,6 @@ describe Livecheck do
     end
   end
 
-  describe "#version" do
-    it "returns nil if not set" do
-      expect(livecheckable.version).to be nil
-    end
-
-    it "returns value if set" do
-      livecheckable.version("1.2.3")
-      expect(livecheckable.version).to eq("1.2.3")
-
-      livecheckable.version(:before_comma)
-      expect(livecheckable.version).to eq(:before_comma)
-    end
-
-    it "raises a TypeError if the argument isn't a String or Symbol" do
-      expect {
-        livecheckable.version(/foo/)
-      }.to raise_error(TypeError, "Livecheck#version expects a String or valid Symbol")
-    end
-  end
-
   describe "#to_hash" do
     it "returns a Hash of all instance variables" do
       expect(livecheckable.to_hash).to eq(
@@ -136,7 +116,6 @@ describe Livecheck do
           "skip_msg" => nil,
           "strategy" => nil,
           "url"      => nil,
-          "version"  => nil,
         },
       )
     end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1048,8 +1048,9 @@ provided, check all kegs. Raises an error if run on uninstalled formulae.
 
 Check for newer versions of formulae and/or casks from upstream.
 
-If no formula or cask argument is passed, the list of formulae and casks to check is taken from
-`HOMEBREW_LIVECHECK_WATCHLIST` or `~/.brew_livecheck_watchlist`.
+If no formula or cask argument is passed, the list of formulae and
+casks to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST` or
+`~/.brew_livecheck_watchlist`.
 
 * `--full-name`:
   Print formulae/casks with fully-qualified names.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1044,27 +1044,31 @@ provided, check all kegs. Raises an error if run on uninstalled formulae.
 * `--cached`:
   Print the cached linkage values stored in `HOMEBREW_CACHE`, set by a previous `brew linkage` run.
 
-### `livecheck` [*`formulae`*]
+### `livecheck` [*`formulae`*|*`casks`*]
 
-Check for newer versions of formulae from upstream.
+Check for newer versions of formulae and/or casks from upstream.
 
-If no formula argument is passed, the list of formulae to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST`
-or `~/.brew_livecheck_watchlist`.
+If no formula or cask argument is passed, the list of formulae and casks to check is taken from
+`HOMEBREW_LIVECHECK_WATCHLIST` or `~/.brew_livecheck_watchlist`.
 
 * `--full-name`:
-  Print formulae with fully-qualified names.
+  Print formulae/casks with fully-qualified names.
 * `--tap`:
-  Check formulae within the given tap, specified as *`user`*`/`*`repo`*.
+  Check formulae/casks within the given tap, specified as *`user`*`/`*`repo`*.
 * `--all`:
-  Check all available formulae.
+  Check all available formulae/casks.
 * `--installed`:
-  Check formulae that are currently installed.
+  Check formulae/casks that are currently installed.
 * `--newer-only`:
-  Show the latest version only if it's newer than the formula.
+  Show the latest version only if it's newer than the formula/cask.
 * `--json`:
   Output information in JSON format.
 * `-q`, `--quiet`:
   Suppress warnings, don't print a progress bar for JSON output.
+* `--formula`:
+  Only check formulae.
+* `--cask`:
+  Only check casks.
 
 ### `man` [*`options`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1442,31 +1442,31 @@ For every library that a keg references, print its dylib path followed by the bi
 \fB\-\-cached\fR
 Print the cached linkage values stored in \fBHOMEBREW_CACHE\fR, set by a previous \fBbrew linkage\fR run\.
 .
-.SS "\fBlivecheck\fR [\fIformulae\fR]"
-Check for newer versions of formulae from upstream\.
+.SS "\fBlivecheck\fR [\fIformulae\fR|\fIcasks\fR]"
+Check for newer versions of formulae and/or casks from upstream\.
 .
 .P
-If no formula argument is passed, the list of formulae to check is taken from \fBHOMEBREW_LIVECHECK_WATCHLIST\fR or \fB~/\.brew_livecheck_watchlist\fR\.
+If no formula or cask argument is passed, the list of formulae and casks to check is taken from \fBHOMEBREW_LIVECHECK_WATCHLIST\fR or \fB~/\.brew_livecheck_watchlist\fR\.
 .
 .TP
 \fB\-\-full\-name\fR
-Print formulae with fully\-qualified names\.
+Print formulae/casks with fully\-qualified names\.
 .
 .TP
 \fB\-\-tap\fR
-Check formulae within the given tap, specified as \fIuser\fR\fB/\fR\fIrepo\fR\.
+Check formulae/casks within the given tap, specified as \fIuser\fR\fB/\fR\fIrepo\fR\.
 .
 .TP
 \fB\-\-all\fR
-Check all available formulae\.
+Check all available formulae/casks\.
 .
 .TP
 \fB\-\-installed\fR
-Check formulae that are currently installed\.
+Check formulae/casks that are currently installed\.
 .
 .TP
 \fB\-\-newer\-only\fR
-Show the latest version only if it\'s newer than the formula\.
+Show the latest version only if it\'s newer than the formula/cask\.
 .
 .TP
 \fB\-\-json\fR
@@ -1475,6 +1475,14 @@ Output information in JSON format\.
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Suppress warnings, don\'t print a progress bar for JSON output\.
+.
+.TP
+\fB\-\-formula\fR
+Only check formulae\.
+.
+.TP
+\fB\-\-cask\fR
+Only check casks\.
 .
 .SS "\fBman\fR [\fIoptions\fR]"
 Generate Homebrew\'s manpages\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This allows `brew livecheck` to work on casks and adds a new `livecheck` stanza to the Cask DSL. Since many casks use methods such as `version.before_comma`, a new `version` field is added to the `Livecheck` class that accepts either a `String` or a valid `Symbol` (`before_comma`, `after_comma`, `before_colon`, `after_colon`)

Example `livecheck` for `ansible-dk`:

```rb
livecheck do
  url :homepage
  version :before_comma
end
```