### PR TITLE
rubocop: disallow https://dl.google.com url for golang

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -266,6 +266,17 @@ module RuboCop
             EOS
           end
 
+          # https://golang.org/dl/gox.x.x.src.tar.gz is more officialy documented
+          golang_url_pattern = %r{https://dl.google.com/.*\.tar\.gz$}
+          audit_urls(urls, golang_url_pattern) do |match, url|
+            problem <<~EOS
+              Use offical golang url
+              https://golang.org/dl/#{match[1]}.tar.gz
+              Rather than codeload:
+                #{url}
+            EOS
+          end
+
           # Check for Maven Central urls, prefer HTTPS redirector over specific host
           maven_pattern = %r{https?://(?:central|repo\d+)\.maven\.org/maven2/(.+)$}
           audit_urls(urls, maven_pattern) do |match, url|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
