### PR TITLE
utils/github: Fix 'uninitialized constant Utils::Shell'

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -3,6 +3,7 @@
 require "tempfile"
 require "uri"
 require "utils/github/actions"
+require "utils/shell"
 
 # Helper functions for interacting with the GitHub API.
 #


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- I tried `brew pr-publish` on Linux (as we don't have an auto-merge Action over there) and it failed with the following error:

```
Error: uninitialized constant Utils::Shell
Please report this issue:
https://docs.brew.sh/Troubleshooting
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/github.rb:69:in `initialize'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/github.rb:278:in `exception'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/github.rb:278:in `raise'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/github.rb:278:in `raise_api_error'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/github.rb:228:in `open_api'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/github.rb:464:in `workflow_dispatch_event'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-publish.rb:43:in `block in pr_publish'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-publish.rb:33:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-publish.rb:33:in `pr_publish'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```
