### PR TITLE
Fix `brew audit Formula/formula.rb`

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -108,7 +108,8 @@ Style/HashTransformValues:
 # Allow for license expressions
 Style/HashAsLastArrayItem:
   Exclude:
-    - 'Taps/*/*/{Formula/,}*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/Formula/*.rb'
 
 # Enabled now LineLength is lowish.
 Style/IfUnlessModifier:
@@ -165,7 +166,8 @@ Performance/Caller:
 Style/DisableCopsWithinSourceCodeDirective:
   Enabled: true
   Include:
-    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/{Formula,Casks}/*.rb'
 
 # make our hashes consistent
 Layout/HashAlignment:
@@ -175,7 +177,8 @@ Layout/HashAlignment:
 # `system` is a special case and aligns on second argument, so allow this for formulae.
 Layout/ArgumentAlignment:
   Exclude:
-    - 'Taps/*/*/{Formula/,}*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/Formula/*.rb'
 
 # this is a bit less "floaty"
 Layout/CaseIndentation:
@@ -199,7 +202,8 @@ Lint/AmbiguousBlockAssociation:
 
 Lint/DuplicateBranch:
   Exclude:
-    - 'Taps/*/*/{Formula,Casks,}/*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/{Formula,Casks}/*.rb'
 
 # needed for lazy_object magic
 Naming/MemoizedInstanceVariableName:
@@ -210,7 +214,8 @@ Naming/MemoizedInstanceVariableName:
 # TODO: fix these as `ruby -w` complains about them.
 Lint/AmbiguousRegexpLiteral:
   Exclude:
-    - 'Taps/*/*/{Formula/,}*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/Formula/*.rb'
 
 # useful for metaprogramming in RSpec
 Lint/ConstantDefinitionInBlock:
@@ -220,30 +225,38 @@ Lint/ConstantDefinitionInBlock:
 # so many of these in formulae and can't be autocorrected
 Lint/ParenthesesAsGroupedExpression:
   Exclude:
-    - 'Taps/*/*/{Formula/,}*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/Formula/*.rb'
 
 # Most metrics don't make sense to apply for casks/formulae/taps.
 Metrics/AbcSize:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
 Metrics/BlockLength:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
 Metrics/ClassLength:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
 Metrics/MethodLength:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
 Metrics/PerceivedComplexity:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
 
 # allow those that are standard
 # TODO: try to remove some of these
@@ -284,7 +297,8 @@ Layout/LineLength:
 
 Sorbet/FalseSigil:
   Exclude:
-    - 'Taps/**/*.rb'
+    - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
     - 'Homebrew/test/**/Casks/**/*.rb'
 
 Sorbet/StrictSigil:
@@ -320,6 +334,7 @@ Style/ClassVars:
 Style/Documentation:
   Exclude:
     - 'Taps/**/*'
+    - '/**/{Formula,Casks}/*.rb'
     - '**/*.rbi'
 
 Style/DocumentationMethod:
@@ -330,7 +345,8 @@ Style/DocumentationMethod:
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
   Exclude:
-    - 'Taps/*/*/{Formula,Casks,}/*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/{Formula,Casks}/*.rb'
     - 'Homebrew/test/**/Casks/**/*.rb'
     - '**/*.rbi'
 
@@ -342,7 +358,8 @@ Style/GlobalVars:
 # potential for errors in formulae too high with this
 Style/GuardClause:
   Exclude:
-    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/{Formula,Casks}/*.rb'
 
 # avoid hash rockets where possible
 Style/HashSyntax:
@@ -351,7 +368,8 @@ Style/HashSyntax:
 # so many of these in formulae and can't be autocorrected
 Style/StringConcatenation:
   Exclude:
-    - 'Taps/*/*/{Formula/,Casks/,}*.rb'
+    - 'Taps/*/*/*.rb'
+    - '/**/{Formula,Casks}/*.rb'
 
 # ruby style guide favorite
 Style/StringLiterals:

--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -110,6 +110,7 @@ Style/HashAsLastArrayItem:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/Formula/*.rb'
+    - '**/Formula/*.rb'
 
 # Enabled now LineLength is lowish.
 Style/IfUnlessModifier:
@@ -168,6 +169,7 @@ Style/DisableCopsWithinSourceCodeDirective:
   Include:
     - 'Taps/*/*/*.rb'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 
 # make our hashes consistent
 Layout/HashAlignment:
@@ -179,6 +181,7 @@ Layout/ArgumentAlignment:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/Formula/*.rb'
+    - '**/Formula/*.rb'
 
 # this is a bit less "floaty"
 Layout/CaseIndentation:
@@ -204,6 +207,7 @@ Lint/DuplicateBranch:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 
 # needed for lazy_object magic
 Naming/MemoizedInstanceVariableName:
@@ -216,6 +220,7 @@ Lint/AmbiguousRegexpLiteral:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/Formula/*.rb'
+    - '**/Formula/*.rb'
 
 # useful for metaprogramming in RSpec
 Lint/ConstantDefinitionInBlock:
@@ -227,36 +232,44 @@ Lint/ParenthesesAsGroupedExpression:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/Formula/*.rb'
+    - '**/Formula/*.rb'
 
 # Most metrics don't make sense to apply for casks/formulae/taps.
 Metrics/AbcSize:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 Metrics/BlockLength:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 Metrics/ClassLength:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 Metrics/MethodLength:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 Metrics/PerceivedComplexity:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 
 # allow those that are standard
 # TODO: try to remove some of these
@@ -299,6 +312,7 @@ Sorbet/FalseSigil:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
     - 'Homebrew/test/**/Casks/**/*.rb'
 
 Sorbet/StrictSigil:
@@ -335,6 +349,7 @@ Style/Documentation:
   Exclude:
     - 'Taps/**/*'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
     - '**/*.rbi'
 
 Style/DocumentationMethod:
@@ -347,6 +362,7 @@ Style/FrozenStringLiteralComment:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
     - 'Homebrew/test/**/Casks/**/*.rb'
     - '**/*.rbi'
 
@@ -360,6 +376,7 @@ Style/GuardClause:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 
 # avoid hash rockets where possible
 Style/HashSyntax:
@@ -370,6 +387,7 @@ Style/StringConcatenation:
   Exclude:
     - 'Taps/*/*/*.rb'
     - '/**/{Formula,Casks}/*.rb'
+    - '**/{Formula,Casks}/*.rb'
 
 # ruby style guide favorite
 Style/StringLiterals:

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb
@@ -9,6 +9,6 @@ cask "with-conditional-caveats" do
 
   # a do block may print and use a DSL
   caveats do
-    puts "This caveat is conditional" if false # rubocop:disable Lint/LiteralAsCondition
+    puts "This caveat is conditional" unless String("Caffeine") == "Caffeine"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
~Reports the presence of `# rubocop:disable` as a violation in 70 cases.~
~Update: A couple of style checks fail, see below.~
**Update 2:** All style checks pass now for me.
- [ ] Have you successfully run `brew tests` with your changes locally?
~One test (`style_spec.rb`) fails for me but I feel it should pass, hence WIP.~
**Update:** A couple of tests fail on my local machine but they’re all unrelated.

-----

### Explanation

Fix a regression introduced in PR #8542, which wouldn’t exclude formulae and casks from stricter style checks properly unless tapped. This caused `brew audit Formula/formula.rb` to report violations which were not meant for formulae and casks.

The fix is to add Exclude patterns for formulae and casks in any `git clone`d tap’s working tree.

Working outside of the productive Homebrew installation makes sure that the latter doesn’t interfere with development, and vice versa. It also helps track work in progress, especially if one tends to forget things.

~WIP because `style_spec.rb` inexplicably fails for me.~
**Update:** passes now.

### Failing style checks

WIP because the following style checks still fail:

```
Offenses:

/usr/local/Homebrew/Library/Homebrew/load_path.rb:7:1: C: Missing top-level module documentation comment.
module LoadPath
^^^^^^
/usr/local/Homebrew/Library/Homebrew/load_path.rb:9:5: C: Add empty line after guard clause.
    return if $LOAD_PATH.include?(pathname.to_s)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/Homebrew/Library/Homebrew/tap.rb:390:5: C: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
    if lib_dir?
    ^^
/usr/local/Homebrew/Library/Homebrew/tap.rb:391:19: C: Prefer double-quoted strings unless you need single quotes to avoid extra backslashes for escaping.
      contents << 'custom code library'
                  ^^^^^^^^^^^^^^^^^^^^^
/usr/local/Homebrew/Library/Homebrew/test/support/fixtures/cask/Casks/with-conditional-caveats.rb:12:48: C: Comment to disable/enable RuboCop.
    puts "This caveat is conditional" if false # rubocop:disable Lint/LiteralAsCondition
```
