### PR TITLE
cleanup.rb: quiet down Ruby test

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -357,8 +357,8 @@ module Homebrew
       else
         check_ruby_version = HOMEBREW_LIBRARY_PATH/"utils/ruby_check_version_script.rb"
         rubies.uniq.any? do |ruby|
-          system ruby, "--enable-frozen-string-literal", "--disable=gems,did_you_mean,rubyopt",
-                 check_ruby_version, HOMEBREW_REQUIRED_RUBY_VERSION
+          quiet_system ruby, "--enable-frozen-string-literal", "--disable=gems,did_you_mean,rubyopt",
+                       check_ruby_version, HOMEBREW_REQUIRED_RUBY_VERSION
         end
       end
 


### PR DESCRIPTION
On systems with Ruby that doesn't support `frozen-string-literal`, running `brew cleanup` shows the following message

```
$ brew cleanup 
/usr/bin/ruby: invalid option --enable-frozen-string-literal  (-h will show valid options)
```
We don't really care about the message here because we use the exit code of the `ruby_check_version_script.rb` script, so we can suppress it.

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
