### PR TITLE
system_config.rb: show system Ruby info on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -4,6 +4,7 @@ require "formula"
 require "os/linux/glibc"
 
 module SystemConfig
+  SYSTEM_RUBY_PATH = "/usr/bin/ruby"
   class << self
     def host_glibc_version
       version = OS::Linux::Glibc.system_version
@@ -27,12 +28,20 @@ module SystemConfig
       "N/A"
     end
 
+    def system_ruby_version
+      out, _, status = system_command(SYSTEM_RUBY_PATH, args: ["-e", "puts RUBY_VERSION"], print_stderr: false)
+      return "N/A" unless status.success?
+
+      out
+    end
+
     def dump_verbose_config(out = $stdout)
       dump_generic_verbose_config(out)
       out.puts "Kernel: #{`uname -mors`.chomp}"
       out.puts "OS: #{OS::Linux.os_version}"
       out.puts "Host glibc: #{host_glibc_version}"
       out.puts "/usr/bin/gcc: #{host_gcc_version}"
+      out.puts "/usr/bin/ruby: #{system_ruby_version}" if RUBY_PATH != SYSTEM_RUBY_PATH
       ["glibc", "gcc", "xorg"].each do |f|
         out.puts "#{f}: #{formula_linked_version f}"
       end

--- a/Library/Homebrew/extend/os/linux/system_config.rb
+++ b/Library/Homebrew/extend/os/linux/system_config.rb
@@ -4,7 +4,8 @@ require "formula"
 require "os/linux/glibc"
 
 module SystemConfig
-  SYSTEM_RUBY_PATH = "/usr/bin/ruby"
+  HOST_RUBY_PATH = "/usr/bin/ruby"
+
   class << self
     def host_glibc_version
       version = OS::Linux::Glibc.system_version
@@ -28,8 +29,8 @@ module SystemConfig
       "N/A"
     end
 
-    def system_ruby_version
-      out, _, status = system_command(SYSTEM_RUBY_PATH, args: ["-e", "puts RUBY_VERSION"], print_stderr: false)
+    def host_ruby_version
+      out, _, status = system_command(HOST_RUBY_PATH, args: ["-e", "puts RUBY_VERSION"], print_stderr: false)
       return "N/A" unless status.success?
 
       out
@@ -41,7 +42,7 @@ module SystemConfig
       out.puts "OS: #{OS::Linux.os_version}"
       out.puts "Host glibc: #{host_glibc_version}"
       out.puts "/usr/bin/gcc: #{host_gcc_version}"
-      out.puts "/usr/bin/ruby: #{system_ruby_version}" if RUBY_PATH != SYSTEM_RUBY_PATH
+      out.puts "/usr/bin/ruby: #{host_ruby_version}" if RUBY_PATH != HOST_RUBY_PATH
       ["glibc", "gcc", "xorg"].each do |f|
         out.puts "#{f}: #{formula_linked_version f}"
       end


### PR DESCRIPTION
I propose to report the version of system Ruby in `config` as this info might be helpful for debugging purposes.

-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
