### PR TITLE
formula_creator: autodetect license from GitHub when available

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -75,6 +75,7 @@ module Homebrew
             metadata = GitHub.repository(@user, @name)
             @desc = metadata["description"]
             @homepage = metadata["homepage"]
+            @license = metadata["license"]["spdx_id"] if metadata["license"]
           rescue GitHub::HTTPNotFoundError
             # If there was no repository found assume the network connection is at
             # fault rather than the input URL.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
When a user provides a GitHub repository as the url when creating a new formula, `brew` currently retrieves the desciption and homepage to pre-populate the formula. This change will now also check to see if a license is present, and if it is, add that to the formula.
