### PR TITLE
Do not suggest use of deprecated brew cask reinstall

### DIFF
--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -99,7 +99,7 @@ module Cask
         Cask '#{token}' is already installed.
 
         To re-install #{token}, run:
-          #{Formatter.identifier("brew cask reinstall #{token}")}
+          #{Formatter.identifier("brew reinstall #{token}")}
       EOS
     end
   end

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -245,7 +245,7 @@ module Homebrew
           Your XQuartz (#{MacOS::XQuartz.version}) is outdated.
           Please install XQuartz #{MacOS::XQuartz.latest_version} (or delete the current version).
           XQuartz can be updated using Homebrew Cask by running:
-            brew cask reinstall xquartz
+            brew reinstall xquartz
         EOS
       end
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I got a warning `Warning: Calling brew cask reinstall is deprecated! Use brew reinstall instead.` after copy-pasting a suggestion from `brew cask install`, so I corrected the suggestion. Let me know if I should write tests for this!