### PR TITLE
bump-formula-pr: make `--dry-run` conflict with `--write`

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -841,7 +841,9 @@ nor vice versa. It must use whichever style specification the formula already us
 * `-n`, `--dry-run`:
   Print what would be done rather than doing it.
 * `--write`:
-  When passed along with `--dry-run`, perform a not-so-dry run by making the expected file modifications but not taking any Git actions.
+  Make the expected file modifications without taking any Git actions.
+* `--commit`:
+  When passed with `--write`, generate a new commit after writing changes to the formula file.
 * `--no-audit`:
   Don't run `brew audit` before opening the PR.
 * `--strict`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1155,7 +1155,11 @@ Print what would be done rather than doing it\.
 .
 .TP
 \fB\-\-write\fR
-When passed along with \fB\-\-dry\-run\fR, perform a not\-so\-dry run by making the expected file modifications but not taking any Git actions\.
+Make the expected file modifications without taking any Git actions\.
+.
+.TP
+\fB\-\-commit\fR
+When passed with \fB\-\-write\fR, generate a new commit after writing changes to the formula file\.
 .
 .TP
 \fB\-\-no\-audit\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Related: https://github.com/Homebrew/brew/pull/8177#issuecomment-667866639

> I'd expect `--dry-run` and `--write` to conflict and there to be a e.g. `--no-commit` if you want to avoid committing (this is also what `brew bottle` does with `--write` and `--no-commit`).

This PR keeps the existing behavior for `--write`, i.e. it does not perform any git operations by default. To create a commit without opening a pull request, we can use the new `--commit` switch 