### PR TITLE
utils: add `tar`

### DIFF
--- a/Library/Homebrew/test/utils/tar_spec.rb
+++ b/Library/Homebrew/test/utils/tar_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "utils/tar"
+
+describe Utils::Tar do
+  before do
+    described_class.clear_executable_cache
+  end
+
+  describe ".available?" do
+    it "returns true if tar or gnu-tar is available" do
+      if described_class.executable.present?
+        expect(described_class).to be_available
+      else
+        expect(described_class).not_to be_available
+      end
+    end
+  end
+
+  describe ".validate_file" do
+    it "does not raise an error when tar and gnu-tar are unavailable" do
+      allow(described_class).to receive(:available?).and_return false
+      expect { described_class.validate_file "blah" }.not_to raise_error
+    end
+
+    context "when tar or gnu-tar is available" do
+      let(:testball_resource) { "#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz" }
+      let(:invalid_resource) { "#{TEST_TMPDIR}/invalid.tgz" }
+
+      before do
+        allow(described_class).to receive(:available?).and_return true
+      end
+
+      it "does not raise an error if file is not a tar file" do
+        expect { described_class.validate_file "blah" }.not_to raise_error
+      end
+
+      it "does not raise an error if file is valid tar file" do
+        expect { described_class.validate_file testball_resource }.not_to raise_error
+      end
+
+      it "raises an error if file is an invalid tar file" do
+        FileUtils.touch invalid_resource
+        expect { described_class.validate_file invalid_resource }.to raise_error SystemExit
+        FileUtils.rm_f invalid_resource
+      end
+    end
+  end
+end

--- a/Library/Homebrew/utils/tar.rb
+++ b/Library/Homebrew/utils/tar.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Utils
+  # Helper functions for interacting with tar files.
+  #
+  # @api private
+  module Tar
+    module_function
+
+    TAR_FILE_EXTENSIONS = %w[.tar .tb2 .tbz .tbz2 .tgz .tlz .txz .tZ].freeze
+
+    def available?
+      executable.present?
+    end
+
+    def executable
+      return @executable if defined?(@executable)
+
+      gnu_tar_gtar_path = HOMEBREW_PREFIX/"opt/gnu-tar/bin/gtar"
+      gnu_tar_gtar = gnu_tar_gtar_path if gnu_tar_gtar_path.executable?
+      @executable = which("gtar") || gnu_tar_gtar || which("tar")
+    end
+
+    def validate_file(path)
+      return unless available?
+
+      path = Pathname.new(path)
+      return unless TAR_FILE_EXTENSIONS.include? path.extname
+      return if Utils.popen_read(executable, "-tf", path).match?(%r{/.*\.})
+
+      odie "#{path} is not a valid tar file!"
+    end
+
+    def clear_executable_cache
+      remove_instance_variable(:@executable) if defined?(@executable)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds a helper function that checks if a file is a valid tar file

This would be useful for `brew bump-cask-pr` (#7986)