### PR TITLE
Ignore URLs protected by CloudFlare when auditing.

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -128,6 +128,13 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
   end
 
   unless http_status_ok?(details[:status])
+    # The URL is protected by CloudFlare.
+    if details[:status].to_i == 503 &&
+       details[:file].include?("set-cookie: __cfduid=") &&
+       details[:file].include?("server: cloudflare")
+      return
+    end
+
     return "The URL #{url} is not reachable (HTTP status code #{details[:status]})"
   end
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -128,7 +128,7 @@ def curl_check_http_content(url, user_agents: [:default], check_content: false, 
   end
 
   unless http_status_ok?(details[:status])
-    # The URL is protected by CloudFlare.
+    # Check if the URL is protected by CloudFlare.
     if details[:status].to_i == 503 &&
        details[:file].include?("set-cookie: __cfduid=") &&
        details[:file].include?("server: cloudflare")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise audit will fail on URLs protected by CloudFlare, despite them being available in a browser.

CI failure here: https://github.com/Homebrew/homebrew-cask/pull/88655