### PR TITLE
Use `curl` workarounds for both `curl` and `curl_output`.

### DIFF
--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -183,9 +183,12 @@ describe CurlDownloadStrategy do
       let(:specs) { { user_agent: "Mozilla/25.0.1" } }
 
       it "adds the appropriate curl args" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2)).to include(["--user-agent", "Mozilla/25.0.1"])
-        }
+        expect(subject).to receive(:system_command).with(
+          /curl/,
+          hash_including(args: array_including_cons("--user-agent", "Mozilla/25.0.1")),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
 
         subject.fetch
       end
@@ -197,14 +200,15 @@ describe CurlDownloadStrategy do
       let(:specs) { { user_agent: :fake } }
 
       it "adds the appropriate curl args" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2).to_a).to include(
-            [
-              "--user-agent",
-              a_string_matching(/Mozilla.*Mac OS X 10.*AppleWebKit/),
-            ],
-          )
-        }
+        expect(subject).to receive(:system_command).with(
+          /curl/,
+          hash_including(args: array_including_cons(
+            "--user-agent",
+            a_string_matching(/Mozilla.*Mac OS X 10.*AppleWebKit/),
+          )),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
 
         subject.fetch
       end
@@ -221,9 +225,12 @@ describe CurlDownloadStrategy do
       }
 
       it "adds the appropriate curl args and does not URL-encode the cookies" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2)).to include(["-b", "coo=k/e;mon=ster"])
-        }
+        expect(subject).to receive(:system_command).with(
+          /curl/,
+          hash_including(args: array_including_cons("-b", "coo=k/e;mon=ster")),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
 
         subject.fetch
       end
@@ -233,9 +240,12 @@ describe CurlDownloadStrategy do
       let(:specs) { { referer: "https://somehost/also" } }
 
       it "adds the appropriate curl args" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2)).to include(["-e", "https://somehost/also"])
-        }
+        expect(subject).to receive(:system_command).with(
+          /curl/,
+          hash_including(args: array_including_cons("-e", "https://somehost/also")),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
 
         subject.fetch
       end
@@ -247,10 +257,12 @@ describe CurlDownloadStrategy do
       let(:specs) { { headers: ["foo", "bar"] } }
 
       it "adds the appropriate curl args" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2).to_a).to include(["--header", "foo"])
-          expect(args.each_cons(2).to_a).to include(["--header", "bar"])
-        }
+        expect(subject).to receive(:system_command).with(
+          /curl/,
+          hash_including(args: array_including_cons("--header", "foo").and(array_including_cons("--header", "bar"))),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
 
         subject.fetch
       end
@@ -327,10 +339,12 @@ describe CurlPostDownloadStrategy do
       }
 
       it "adds the appropriate curl args" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2)).to include(["-d", "form=data"])
-          expect(args.each_cons(2)).to include(["-d", "is=good"])
-        }
+        expect(subject).to receive(:system_command).with(
+          /curl/,
+          hash_including(args: array_including_cons("-d", "form=data").and(array_including_cons("-d", "is=good"))),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
 
         subject.fetch
       end
@@ -340,9 +354,12 @@ describe CurlPostDownloadStrategy do
       let(:specs) { { using: :post } }
 
       it "adds the appropriate curl args" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2)).to include(["-X", "POST"])
-        }
+        expect(subject).to receive(:system_command).with(
+          /curl/,
+          hash_including(args: array_including_cons("-X", "POST")),
+        )
+        .at_least(:once)
+        .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))
 
         subject.fetch
       end
@@ -364,8 +381,7 @@ describe SubversionDownloadStrategy do
 
       it "adds the appropriate svn args" do
         expect(subject).to receive(:system_command!)
-          .with("svn", args: array_including("--trust-server-cert",
-                                             "--non-interactive"))
+          .with("svn", hash_including(args: array_including("--trust-server-cert", "--non-interactive")))
         subject.fetch
       end
     end
@@ -374,9 +390,8 @@ describe SubversionDownloadStrategy do
       let(:specs) { { revision: "10" } }
 
       it "adds svn arguments for :revision" do
-        expect(subject).to receive(:system_command!) { |*, args:, **|
-          expect(args.each_cons(2)).to include(["-r", "10"])
-        }
+        expect(subject).to receive(:system_command!)
+          .with("svn", hash_including(args: array_including_cons("-r", "10")))
 
         subject.fetch
       end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -257,3 +257,10 @@ RSpec::Matchers.define :a_json_string do
     false
   end
 end
+
+# Match consecutive elements in an array.
+RSpec::Matchers.define :array_including_cons do |*cons|
+  match do |actual|
+    expect(actual.each_cons(cons.size)).to include(cons)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/Homebrew/homebrew-cask/pull/88717/checks?check_run_id=1074651704 is failing because of a “Error in the HTTP2 framing layer”, which can be worked around by using HTTP 1.1. Also, previously `curl_output` was not using the same workarounds as `curl`, now both are using the common `curl_with_workarounds` function with the workaround logic.