### PR TITLE
Remove trailing slash from SPDX license exception URL

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -388,7 +388,7 @@ module Homebrew
           problem <<~EOS
             Formula #{formula.name} contains invalid or deprecated SPDX license exceptions: #{invalid_exceptions}.
             For a list of valid license exceptions check:
-              #{Formatter.url("https://spdx.org/licenses/exceptions-index.html/")}
+              #{Formatter.url("https://spdx.org/licenses/exceptions-index.html")}
           EOS
         end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -354,7 +354,7 @@ module Homebrew
         expect(fa.problems.first).to match <<~EOS
           Formula cask contains invalid or deprecated SPDX license exceptions: ["zzz"].
           For a list of valid license exceptions check:
-            https://spdx.org/licenses/exceptions-index.html/
+            https://spdx.org/licenses/exceptions-index.html
         EOS
       end
 
@@ -373,7 +373,7 @@ module Homebrew
         expect(fa.problems.first).to match <<~EOS
           Formula cask contains invalid or deprecated SPDX license exceptions: ["#{deprecated_spdx_exception}"].
           For a list of valid license exceptions check:
-            https://spdx.org/licenses/exceptions-index.html/
+            https://spdx.org/licenses/exceptions-index.html
         EOS
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The URL for the SPDX license exception webpage is currently https://spdx.org/licenses/exceptions-index.html/:

https://github.com/Homebrew/brew/blob/39f07841080c3396bb560237a3e208ebef2779f7/Library/Homebrew/dev-cmd/audit.rb#L391

Because of the trailing slash, the SPDX website attempts to load—

https://spdx.org/licenses/exceptions-index.html/index.html

—which results in a 404 error. This pull request removes the trailing slash.