### PR TITLE
download_strategy: silence detached head warning on git clone

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -757,6 +757,7 @@ class GitDownloadStrategy < VCSDownloadStrategy
     case @ref_type
     when :branch, :tag
       args << "--branch" << @ref
+      args << "-c" << "advice.detachedHead=false" # silences detached head warning
     end
 
     args << @url << cached_location


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Currently, when building a formula from a git repository, a git detached head warning is displayed:
```
$ rm -rf $(brew --cache)/dive--git && brew install -s dive
==> Cloning https://github.com/wagoodman/dive.git
Cloning into '/Users/username/Library/Caches/Homebrew/dive--git'...
Note: switching to '0872cc18d44a96ed9f59202ac95c556f7e7919a7'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

==> Checking out tag v0.9.2
HEAD is now at 0872cc1 cut release
==> go build -ldflags -s -w -X main.version=0.9.2
...
```

After the change:
```
 $ rm -rf $(brew --cache)/dive--git && brew install -s dive
==> Cloning https://github.com/wagoodman/dive.git
Cloning into '/Users/username/Library/Caches/Homebrew/dive--git'...
==> Checking out tag v0.9.2
HEAD is now at 0872cc1 cut release
==> go build -ldflags -s -w -X main.version=0.9.2
...
```