### PR TITLE
utils/tty: handling a TTY stderr

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -256,7 +256,7 @@ class Tap
         return if !full_clone || !shallow?
       end
 
-      ohai "Unshallowing #{name}" unless quiet
+      $stderr.ohai "Unshallowing #{name}" unless quiet
       args = %w[fetch --unshallow]
       args << "-q" if quiet
       path.cd { safe_system "git", *args }
@@ -265,7 +265,7 @@ class Tap
 
     clear_cache
 
-    ohai "Tapping #{name}" unless quiet
+    $stderr.ohai "Tapping #{name}" unless quiet
     args =  %W[clone #{requested_remote} #{path}]
     args << "--depth=1" unless full_clone
     args << "-q" if quiet
@@ -291,7 +291,7 @@ class Tap
     link_completions_and_manpages
 
     formatted_contents = contents.presence&.to_sentence&.dup&.prepend(" ")
-    puts "Tapped#{formatted_contents} (#{path.abv})." unless quiet
+    $stderr.puts "Tapped#{formatted_contents} (#{path.abv})." unless quiet
     CacheStoreDatabase.use(:descriptions) do |db|
       DescriptionCacheStore.new(db)
                            .update_from_formula_names!(formula_names)
@@ -301,7 +301,7 @@ class Tap
     return unless private?
     return if quiet
 
-    puts <<~EOS
+    $stderr.puts <<~EOS
       It looks like you tapped a private repository. To avoid entering your
       credentials each time you update, you can use git HTTP credential
       caching or issue the following command:
@@ -321,7 +321,7 @@ class Tap
     require "descriptions"
     raise TapUnavailableError, name unless installed?
 
-    puts "Untapping #{name}..."
+    $stderr.puts "Untapping #{name}..."
 
     abv = path.abv
     formatted_contents = contents.presence&.to_sentence&.dup&.prepend(" ")
@@ -335,7 +335,7 @@ class Tap
     Utils::Link.unlink_completions(path)
     path.rmtree
     path.parent.rmdir_if_possible
-    puts "Untapped#{formatted_contents} (#{abv})."
+    $stderr.puts "Untapped#{formatted_contents} (#{abv})."
 
     Commands.rebuild_commands_completion_list
     clear_cache
@@ -625,7 +625,9 @@ class CoreTap < Tap
 
   def install(full_clone: true, quiet: false, clone_target: nil, force_auto_update: nil)
     remote = Homebrew::EnvConfig.core_git_remote
-    puts "HOMEBREW_CORE_GIT_REMOTE set: using #{remote} for Homebrew/core Git remote URL." if remote != default_remote
+    if remote != default_remote
+      $stderr.puts "HOMEBREW_CORE_GIT_REMOTE set: using #{remote} for Homebrew/core Git remote URL."
+    end
     super(full_clone: full_clone, quiet: quiet, clone_target: remote, force_auto_update: force_auto_update)
   end
 

--- a/Library/Homebrew/test/cmd/tap_spec.rb
+++ b/Library/Homebrew/test/cmd/tap_spec.rb
@@ -11,8 +11,7 @@ describe "brew tap", :integration_test do
     path = setup_test_tap
 
     expect { brew "tap", "--force-auto-update", "--full", "homebrew/bar", path/".git" }
-      .to output(/Tapped/).to_stdout
-      .and output(/Cloning/).to_stderr
+      .to output(/Tapped/).to_stderr
       .and be_a_success
   end
 end

--- a/Library/Homebrew/test/cmd/untap_spec.rb
+++ b/Library/Homebrew/test/cmd/untap_spec.rb
@@ -11,8 +11,8 @@ describe "brew untap", :integration_test do
     setup_test_tap
 
     expect { brew "untap", "homebrew/foo" }
-      .to output(/Untapped/).to_stdout
-      .and not_to_output.to_stderr
+      .to output(/Untapped/).to_stderr
+      .and not_to_output.to_stdout
       .and be_a_success
   end
 end

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -131,11 +131,15 @@ module Kernel
 
   # Print a warning (do this rarely)
   def opoo(message)
-    $stderr.puts Formatter.warning(message, label: "Warning")
+    Tty.with($stderr) do |stderr|
+      stderr.puts Formatter.warning(message, label: "Warning")
+    end
   end
 
   def onoe(message)
-    $stderr.puts Formatter.error(message, label: "Error")
+    Tty.with($stderr) do |stderr|
+      stderr.puts Formatter.error(message, label: "Error")
+    end
   end
 
   def ofail(error)

--- a/Library/Homebrew/utils/tty.rb
+++ b/Library/Homebrew/utils/tty.rb
@@ -4,7 +4,18 @@
 #
 # @api private
 module Tty
+  @stream = $stdout
+
   module_function
+
+  def with(stream)
+    previous_stream = @stream
+    @stream = stream
+
+    yield stream
+  ensure
+    @stream = previous_stream
+  end
 
   def strip_ansi(string)
     string.gsub(/\033\[\d+(;\d+)*m/, "")
@@ -78,6 +89,6 @@ module Tty
     return false if Homebrew::EnvConfig.no_color?
     return true if Homebrew::EnvConfig.color?
 
-    $stdout.tty?
+    @stream.tty?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

In the current implementation of the `Tty` module, the result of `$stdout.tty?` is used to decide whether the output can contain special TTY codes (colours, formatting and so on).

However there are some problems with this, as discussed in #8577:

* Redirection of only `stderr` to a file: if there are coloured outputs in stderr (such as in `onoe`), the special characters feature in the file. For example, without a Livecheck Watchlist, `brew livecheck 2> test.txt` results in `text.txt` containing colour-code characters.
* Redirection of only `stdout`: stderr loses colour output.

This PR aims to fix these, and I think using an `@output` variable (which is `$stdout` by default and can be changed to `$stderr`) makes sense. Here are the options I've considered, though I'm not sure all of these would make sense:

* Override `$stderr.puts` – set `@output` to `$stderr`, carry out the normal `puts` logic, reset `@output` – maybe not a great idea.
* A new `Tty::Error` module (current implementation) – only difference is that `@output` is set to `$stderr` – I'm not satisfied with it, doesn't seem like a good fix.
* Changing `Tty` to a class and using an `$stdout` instance and an `$stderr` instance as required.

I'm not sure anything else that's crossed my mind is either possible or worth considering. I'd love to hear your comments and suggestions on how we can proceed with this. Thanks!

<details>
<summary>Redirection examples</summary>
<br>
<ol>
<li>
<code>$stderr</code> to a file
<br>
<pre>
➜ brew livecheck --tap 2> output.json
</pre>
<code>output.json</code>
<pre>
^[[31mError:^[[0m missing argument: --tap
</pre>
</li>
<li>
<code>$stdout</code> to a file
<pre>
➜ brew livecheck --tap > output.json 
Error: missing argument: --tap
</pre>
Note: `Error` was not coloured red.
</li>
</ol>
</details>