### PR TITLE
shared_audits: ensure GitLab API response is valid

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -74,7 +74,7 @@ module SharedAudits
     @gitlab_release_data ||= {}
     @gitlab_release_data[id] ||= begin
       out, _, status= curl_output(
-        "--request", "GET", "https://gitlab.com/api/v4/projects/#{user}%2F#{repo}/releases/#{tag}"
+        "https://gitlab.com/api/v4/projects/#{user}%2F#{repo}/releases/#{tag}", "--fail"
       )
       return unless status.success?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
The GitLab API returns an HTTP 403 and a body of 
`{"message":"403 Forbidden"}`
if a release doesn't exist, eg https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-runner/releases/does-not-exist. This causes the current audit logic to fail when trying to get release_date.  The change will ensure there's a `release_date` in the response before continuing.

For a more robust solution, the HTTP response code should be considered for GitLab API calls prior to working with the data.

Resolves audit exception in https://github.com/Homebrew/homebrew-core/pull/60669