### PR TITLE
utils/pypi: downcase name prior to excluding

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -106,7 +106,7 @@ module PyPI
     packages = JSON.parse(pipgrip_output).sort.to_h
 
     # Remove extra packages that may be included in pipgrip output
-    exclude_list = %W[#{pypi_name} argparse pip setuptools wheel wsgiref]
+    exclude_list = %W[#{pypi_name.downcase} argparse pip setuptools wheel wsgiref]
     packages.delete_if do |package|
       exclude_list.include? package
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Some PyPI names are not lowercase -- however, `pipgrip` returns all package names as lowercase. This causes the original package to not be excluded from the generated formula resource blocks for formulae such as `sphinx-doc` or `flintrock`. Lowercasing prior to excluding resolves this.