### PR TITLE
bottle: use File.lutime instead of system call

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -278,10 +278,7 @@ module Homebrew
 
         keg.find do |file|
           if file.symlink?
-            # Ruby does not support `File.lutime` yet.
-            # Shellout using `touch` to change modified time of symlink itself.
-            system "/usr/bin/touch", "-h",
-                   "-t", tab.source_modified_time.strftime("%Y%m%d%H%M.%S"), file
+            File.lutime(tab.source_modified_time, tab.source_modified_time, file)
           else
             file.utime(tab.source_modified_time, tab.source_modified_time)
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Now that Ruby has `File.lutime` included (https://ruby-doc.org/core-2.5.0/File.html#method-c-lutime) in versions that are older than the minimum Ruby version required by Homebrew, use `File.lutime` instead of the `touch` system call.