### PR TITLE
deprecate_disable: refactor and add to `info`

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -9,6 +9,7 @@ require "keg"
 require "tab"
 require "json"
 require "utils/spdx"
+require "deprecate_disable"
 
 module Homebrew
   module_function
@@ -175,6 +176,15 @@ module Homebrew
     puts "#{f.full_name}: #{specs * ", "}#{" [#{attrs * ", "}]" unless attrs.empty?}"
     puts f.desc if f.desc
     puts Formatter.url(f.homepage) if f.homepage
+
+    deprecate_disable_type, deprecate_disable_reason = DeprecateDisable.deprecate_disable_info f
+    if deprecate_disable_type.present?
+      if deprecate_disable_reason.present?
+        puts "#{deprecate_disable_type.capitalize} because it #{deprecate_disable_reason}!"
+      else
+        puts "#{deprecate_disable_type.capitalize}!"
+      end
+    end
 
     conflicts = f.conflicts.map do |c|
       reason = " (because #{c.reason})" if c.reason

--- a/Library/Homebrew/deprecate_disable.rb
+++ b/Library/Homebrew/deprecate_disable.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Helper module for handling disable! and deprecate!
+#
+# @api private
+module DeprecateDisable
+  module_function
+
+  DEPRECATE_DISABLE_REASONS = {
+    does_not_build:      "does not build",
+    no_license:          "has no license",
+    repo_archived:       "has an archived upstream repository",
+    repo_removed:        "has a removed upstream repository",
+    unmaintained:        "is not maintained upstream",
+    unsupported:         "is not supported upstream",
+    deprecated_upstream: "is deprecated upstream",
+    versioned_formula:   "is a versioned formula",
+  }.freeze
+
+  def deprecate_disable_info(formula)
+    return unless formula.deprecated? || formula.disabled?
+
+    if formula.deprecated?
+      type = :deprecated
+      reason = formula.deprecation_reason
+    else
+      type = :disabled
+      reason = formula.disable_reason
+    end
+
+    reason = DEPRECATE_DISABLE_REASONS[reason] if DEPRECATE_DISABLE_REASONS.key? reason
+
+    [type, reason]
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Refactor the `deprecate_disable` reason logic to a separate module.

This allows code to be used to show deprecation and disable information in `brew info`.

I will almost always run `brew info` before installing something, so it would be helpful to see whether the formula I'm about to install is deprecated or disabled.

Before:

```console
$ brew info tj
tj: stable 7.0.0 (bottled)
Line timestamping tool
https://github.com/sgreben/tj
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/tj.rb
==> Dependencies
Build: go ✘
==> Analytics
install: 0 (30 days), 1 (90 days), 21 (365 days)
install-on-request: 0 (30 days), 1 (90 days), 21 (365 days)
build-error: 0 (30 days)
```

After:

```console
$ brew info tj
tj: stable 7.0.0 (bottled)
Line timestamping tool
https://github.com/sgreben/tj
Disabled because it has no license!
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/tj.rb
==> Dependencies
Build: go ✘
==> Analytics
install: 0 (30 days), 1 (90 days), 21 (365 days)
install-on-request: 0 (30 days), 1 (90 days), 21 (365 days)
build-error: 0 (30 days)
```