### PR TITLE
update: fix latest_tag in homebrew/brew update

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -430,8 +430,8 @@ EOS
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     latest_tag="$(git ls-remote --tags --refs -q origin |
                   cut -d/ -f3 | 
-                  sort --field-separator=. --key=1,1nr -k 2,2nr -k 3,3nr|
-                  head -n1)"
+                  sort --numeric-sort --field-separator=. --key=1,1 --key=2,2 --key=3,3 |
+                  tail -n1)"
     latest_ref="refs/tags/$latest_tag"
     git fetch --force origin --shallow-since="$latest_ref"
   fi

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -428,8 +428,12 @@ EOS
     echo "HOMEBREW_BREW_GIT_REMOTE set: using $HOMEBREW_BREW_GIT_REMOTE for Homebrew/brew Git remote."
     git remote set-url origin "$HOMEBREW_BREW_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    latest_tag="$(git ls-remote --tags --refs --sort=v:refname -q origin | tail -n1 | cut -f2)"
-    git fetch --force origin --shallow-since="$latest_tag"
+    latest_tag="$(git ls-remote --tags --refs -q origin |
+                  cut -d/ -f3 | 
+                  sort --field-separator=. --key=1,1nr -k 2,2nr -k 3,3nr|
+                  head -n1)"
+    latest_ref="refs/tags/$latest_tag"
+    git fetch --force origin --shallow-since="$latest_ref"
   fi
 
   if [[ "$HOMEBREW_CORE_DEFAULT_GIT_REMOTE" != "$HOMEBREW_CORE_GIT_REMOTE" ]] &&

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -428,7 +428,7 @@ EOS
     echo "HOMEBREW_BREW_GIT_REMOTE set: using $HOMEBREW_BREW_GIT_REMOTE for Homebrew/brew Git remote."
     git remote set-url origin "$HOMEBREW_BREW_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    latest_tag="$(git ls-remote --tags --refs -q origin | tail -n1 | cut -f2)"
+    latest_tag="$(git ls-remote --tags --refs --sort=v:refname -q origin | tail -n1 | cut -f2)"
     git fetch --force origin --shallow-since="$latest_tag"
   fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
`brew update` fetches commit history since latest_tag for Homebrew/brew. However, `git ls-remote` sorts the tag in lexicographical order by default. So the current command does not always get the latest tag.
For the moment,`git ls-remote --tags --refs -q origin | tail -n1 | cut -f2` outputs `refs/tags/2.4.9` instead of `refs/tags/2.4.16`. This commit provides a fix.
