### PR TITLE
os/mac: use Xcode SDK as alternative when CLT SDK unavailable

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -102,7 +102,7 @@ module OS
     # if available. Otherwise, the latest SDK is returned.
 
     def sdk_locator
-      if CLT.installed? && CLT.provides_sdk?
+      if CLT.installed? && CLT.provides_sdk? && (!CLT.sdk.nil? || Xcode.sdk.nil?)
         CLT.sdk_locator
       else
         Xcode.sdk_locator


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
-----
Feature: switch to Xcode SDK when CLT SDK is not available for current OS version.
For a pre-released macOS version, CLT will not be updated through software update. 
Currently, as the update instruction suggests, the CLT have to be updated manually or deleted.
However, instead of manually downloading the beta version, a Xcode SDK may be available when Xcode beta is installed. 
This commit enables using Xcode SDK as an alternative in this situation.

This commit solves several SDK related failures on a macOS 11.0 machine, where a Xcode beta installed and CLT beta not installed.
However, in `brew tests` 4 failures related to install produces, as warnings for macOS version and CLT version printed. No other failures other than these. I don't know how to disable these warnings during tests. Can anyone help me?
```
Failures:

  1) brew reinstall reinstalls a Formula
     Failure/Error:
       expect { brew "reinstall", "testball" }
         .to output(/Reinstalling testball/).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     
          expected block to not output to stderr, but output "Warning: You are using macOS 11.0.\nWe do not provide support for this pre-release version.\nYou will encounter build failures with some formulae.\nPlease create pull requests instead of asking for help on Homebrew's GitHub,\nDiscourse, Twitter or IRC. You are responsible for resolving any issues you\nexperience while you are running this pre-release version.\n\nWarning: A newer Command Line Tools release is available.\nUpdate them from Software Update in System Preferences or run:\n  softwareupdate --all --install --force\n\nIf that doesn't show you an update run:\n  sudo rm -rf /Library/Developer/CommandLineTools\n  sudo xcode-select --install\n\nAlternatively, manually download them from:\n  https://developer.apple.com/download/more/.\n\nError: An exception occurred within a child process:\n  NoMethodError: undefined method `path' for nil:NilClass\nDid you mean?  paths\n"
     
       ...and:
     
          expected #<Proc:0x00007f9cb2307bd0@/usr/local/Homebrew/Library/Homebrew/test/cmd/reinstall_spec.rb:17> to be a success
     # ./test/cmd/reinstall_spec.rb:17:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:47:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:187:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:186:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

Finished in 4 minutes 45.6 seconds (files took 8.98 seconds to load)
302 examples, 1 failure, 1 pending

Failed examples:

rspec ./test/cmd/reinstall_spec.rb:11 # brew reinstall reinstalls a Formula
```
```
Failures:

  1) brew install can install keg-only Formulae
     Failure/Error:
       expect { brew "install", "testball1" }
         .to output(%r{#{HOMEBREW_CELLAR}/testball1/1\.0}).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     
       expected block to not output to stderr, but output "Warning: You are using macOS 11.0.\nWe do not provide support for this pre-release version.\nYou will encounter build failures with some formulae.\nPlease create pull requests instead of asking for help on Homebrew's GitHub,\nDiscourse, Twitter or IRC. You are responsible for resolving any issues you\nexperience while you are running this pre-release version.\n\nWarning: A newer Command Line Tools release is available.\nUpdate them from Software Update in System Preferences or run:\n  softwareupdate --all --install --force\n\nIf that doesn't show you an update run:\n  sudo rm -rf /Library/Developer/CommandLineTools\n  sudo xcode-select --install\n\nAlternatively, manually download them from:\n  https://developer.apple.com/download/more/.\n\n"
     # ./test/cmd/install_spec.rb:37:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:47:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:187:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:186:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

  2) brew install installs formulae with options
     Failure/Error:
       expect { brew "install", "testball1", "--with-foo" }
         .to output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     
       expected block to not output to stderr, but output "Warning: You are using macOS 11.0.\nWe do not provide support for this pre-release version.\nYou will encounter build failures with some formulae.\nPlease create pull requests instead of asking for help on Homebrew's GitHub,\nDiscourse, Twitter or IRC. You are responsible for resolving any issues you\nexperience while you are running this pre-release version.\n\nWarning: A newer Command Line Tools release is available.\nUpdate them from Software Update in System Preferences or run:\n  softwareupdate --all --install --force\n\nIf that doesn't show you an update run:\n  sudo rm -rf /Library/Developer/CommandLineTools\n  sudo xcode-select --install\n\nAlternatively, manually download them from:\n  https://developer.apple.com/download/more/.\n\n"
     # ./test/cmd/install_spec.rb:23:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:47:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:187:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:186:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

  3) brew install installs formulae
     Failure/Error:
       expect { brew "install", "testball1" }
         .to output(%r{#{HOMEBREW_CELLAR}/testball1/0\.1}).to_stdout
         .and not_to_output.to_stderr
         .and be_a_success
     
       expected block to not output to stderr, but output "Warning: You are using macOS 11.0.\nWe do not provide support for this pre-release version.\nYou will encounter build failures with some formulae.\nPlease create pull requests instead of asking for help on Homebrew's GitHub,\nDiscourse, Twitter or IRC. You are responsible for resolving any issues you\nexperience while you are running this pre-release version.\n\nWarning: A newer Command Line Tools release is available.\nUpdate them from Software Update in System Preferences or run:\n  softwareupdate --all --install --force\n\nIf that doesn't show you an update run:\n  sudo rm -rf /Library/Developer/CommandLineTools\n  sudo xcode-select --install\n\nAlternatively, manually download them from:\n  https://developer.apple.com/download/more/.\n\n"
     # ./test/cmd/install_spec.rb:13:in `block (2 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/integration_test.rb:47:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:187:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:186:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

Finished in 5 minutes 28 seconds (files took 9.22 seconds to load)
390 examples, 3 failures, 6 pending

Failed examples:

rspec ./test/cmd/install_spec.rb:30 # brew install can install keg-only Formulae
rspec ./test/cmd/install_spec.rb:20 # brew install installs formulae with options
rspec ./test/cmd/install_spec.rb:10 # brew install installs formulae
```
