### PR TITLE
std_meson_args: add --wrap-mode=nofallback

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1408,7 +1408,7 @@ class Formula
 
   # Standard parameters for meson builds.
   def std_meson_args
-    ["--prefix=#{prefix}", "--libdir=#{lib}", "--buildtype=release"]
+    ["--prefix=#{prefix}", "--libdir=#{lib}", "--buildtype=release", "--wrap-mode=nofallback"]
   end
 
   def shared_library(name, version = nil)


### PR DESCRIPTION
Otherwise projects may download missing dependencies and build and
install them. GNOME projects do this a lot in particular.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----