### PR TITLE
help: show help text for tapped external command

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -143,6 +143,7 @@ begin
       safe_system(*tap_commands)
     end
 
+    ARGV << "--help" if help_flag
     exec HOMEBREW_BREW_FILE, cmd, *ARGV
   end
 rescue UsageError => e


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #8641

Previously, running e.g. `brew help bundle` when homebrew-bundle was not tapped would tap homebrew-bundle and then run `brew bundle` showing `Error: No Brewfile found` instead of the expected help text.

I also added a message that lets the user know how to remove a tap that was automatically added. This was briefly discussed in #8641 but no conclusion was made so if this isn't wanted it can be easily removed.

Before:

```console
$ brew help bundle
==> Tapping homebrew/bundle
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle'...
remote: Enumerating objects: 14, done.
remote: Counting objects: 100% (14/14), done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 5159 (delta 4), reused 1 (delta 0), pack-reused 5145
Receiving objects: 100% (5159/5159), 1.15 MiB | 795.00 KiB/s, done.
Resolving deltas: 100% (3019/3019), done.
Tapped 1 command (104 files, 1.5MB).
Error: No Brewfile found
```

After:

```console
$ brew help bundle
==> Tapping homebrew/bundle
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-bundle'...
remote: Enumerating objects: 14, done.
remote: Counting objects: 100% (14/14), done.
remote: Compressing objects: 100% (14/14), done.
remote: Total 5159 (delta 4), reused 1 (delta 0), pack-reused 5145
Receiving objects: 100% (5159/5159), 1.15 MiB | 5.13 MiB/s, done.
Resolving deltas: 100% (3019/3019), done.
Tapped 1 command (104 files, 1.5MB).
Usage: brew bundle [subcommand]

Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store
and Whalebrew.
...
```