### PR TITLE
Remove cbmc from GITHUB_PRERELEASE_ALLOWLIST

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -29,7 +29,6 @@ module SharedAudits
 
   GITHUB_PRERELEASE_ALLOWLIST = {
     "amd-power-gadget" => :all,
-    "cbmc"             => "5.12.6",
     "elm-format"       => "0.8.3",
     "gitless"          => "0.8.8",
     "infrakit"         => "0.5",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`cbmc` has been updated to [version 5.13.1](https://github.com/Homebrew/homebrew-core/pull/60786) which is correctly tagged as the [latest release](https://github.com/diffblue/cbmc/releases/tag/cbmc-5.13.1), so this is no longer required.

Thank you.