### PR TITLE
cmd/vendor-install.sh: fix interpreter and RPATH on Linux when necessary

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -174,6 +174,7 @@ install() {
   tar "$tar_args" "$CACHED_LOCATION"
   safe_cd "$VENDOR_DIR/portable-$VENDOR_NAME"
 
+  # On Linux, set the dynamic linker/loader of vendored executables to $HOMEBREW_DYNAMIC_LINKER 
   if [[ -n $HOMEBREW_LINUX ]]; then
     if [[ -x "$HOMEBREW_PREFIX"/opt/patchelf/bin/patchelf ]]; then
       for file in ./"$VENDOR_VERSION"/bin/*; do

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -174,6 +174,18 @@ install() {
   tar "$tar_args" "$CACHED_LOCATION"
   safe_cd "$VENDOR_DIR/portable-$VENDOR_NAME"
 
+  if [[ -n $HOMEBREW_LINUX ]]; then
+    if [[ -x "$HOMEBREW_PREFIX"/opt/patchelf/bin/patchelf ]]; then
+      for file in ./"$VENDOR_VERSION"/bin/*; do
+        if grep --quiet --ignore-case elf <(file "$file"); then
+          chmod u+w "$file"
+          "$HOMEBREW_PREFIX"/opt/patchelf/bin/patchelf --set-interpreter "$HOMEBREW_DYNAMIC_LINKER" "$file"
+          chmod u-w "$file"
+        fi
+      done
+    fi
+  fi
+
   if quiet_stderr "./$VENDOR_VERSION/bin/$VENDOR_NAME" --version >/dev/null
   then
     ln -sfn "$VENDOR_VERSION" current


### PR DESCRIPTION
I couldn't install and use vendored Ruby on a Linux system with non-default Homebrew prefix that requires Homebrew's Glibc:

* `RPATH` hardcoded in vendored Ruby points to directories in `/home/linuxbrew/.linuxbrew/`
* Interpreter hardcoded in vendored Ruby points to the host Glibc.

On Linux systems with Glibc prior to 2.23, Homebrew installs a new version of Glibc, so we need to point to that one instead.
On Linux systems with non-`/home/linuxbrew/.linuxbrew` prefix, we need to update `RPATH`.

CC @sjackman

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
