### PR TITLE
cli: fix error when formulae don't exist

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -74,9 +74,7 @@ module Homebrew
       end
 
       def to_formulae_paths
-        @to_formulae_paths ||= (downcased_unique_named - homebrew_tap_cask_names).map do |name|
-          Formulary.path(name)
-        end.uniq.freeze
+        @to_formulae_paths ||= to_formulae.map(&:path).uniq.freeze
       end
 
       def to_casks

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -20,7 +20,7 @@ module Homebrew
   def edit
     args = edit_args.parse
 
-    unless (HOMEBREW_REPOSITORY/".git").directory?
+    unless HOMEBREW_REPOSITORY.git?
       raise <<~EOS
         Changes will be lost!
         The first time you `brew update`, all local changes will be lost; you should
@@ -30,7 +30,7 @@ module Homebrew
 
     paths = args.named.to_formulae_paths.presence
 
-    # If no brews are listed, open the project root in an editor.
+    # If no formulae are listed, open the project root in an editor.
     paths ||= [HOMEBREW_REPOSITORY]
 
     exec_editor(*paths)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes an issue with editing, etc. formulae that don't exist.

Before:

```console
% brew cat mxcl
cat: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mxcl.rb: No such file or directory
Error: Failure while executing; `cat /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mxcl.rb` exited with 1.
% EDITOR=echo brew edit mxcl
Editing /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mxcl.rb
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mxcl.rb
% brew formula mxcl
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mxcl.rb
% brew style mxcl
Error: No such file or directory @ realpath_rec - /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/mxcl.rb
```


After:

```console
% brew cat mxcl
Error: No available formula with the name "mxcl"
% brew edit mxcl
Error: No available formula with the name "mxcl"
% brew formula mxcl
Error: No available formula with the name "mxcl"
% brew style mxcl
Error: No available formula with the name "mxcl"
```

Also tweak some things in dev-cmd/edit.rb that I noticed while investigating this.