### PR TITLE
cask/audit: detect tag from URL

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -468,8 +468,9 @@ module Cask
       user, repo = get_repo_data(%r{https?://github\.com/([^/]+)/([^/]+)/?.*}) if @online
       return if user.nil?
 
-      # TODO: Detect tag from URL instead of using `cask.version`.
-      error = SharedAudits.github_release(user, repo, cask.version, cask: cask)
+      tag = SharedAudits.github_tag_from_url(cask.url)
+      tag ||= cask.version
+      error = SharedAudits.github_release(user, repo, tag, cask: cask)
       add_error error if error
     end
 
@@ -481,7 +482,9 @@ module Cask
 
       odebug "Auditing GitLab prerelease"
 
-      error = SharedAudits.gitlab_release(user, repo, cask.version)
+      tag = SharedAudits.gitlab_tag_from_url(cask.url)
+      tag ||= cask.version
+      error = SharedAudits.gitlab_release(user, repo, tag)
       add_error error if error
     end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -784,9 +784,7 @@ module Homebrew
         owner = Regexp.last_match(1)
         repo = Regexp.last_match(2)
 
-        tag = url.match(%r{^https://gitlab\.com/[\w-]+/[\w-]+/-/archive/([^/]+)/})
-                 .to_a
-                 .second
+        tag = SharedAudits.gitlab_tag_from_url(url)
         tag ||= stable.specs[:tag]
         tag ||= stable.version
 
@@ -797,12 +795,7 @@ module Homebrew
       when %r{^https://github.com/([\w-]+)/([\w-]+)}
         owner = Regexp.last_match(1)
         repo = Regexp.last_match(2)
-        tag = url.match(%r{^https://github\.com/[\w-]+/[\w-]+/archive/([^/]+)\.(tar\.gz|zip)$})
-                 .to_a
-                 .second
-        tag ||= url.match(%r{^https://github\.com/[\w-]+/[\w-]+/releases/download/([^/]+)/})
-                   .to_a
-                   .second
+        tag = SharedAudits.github_tag_from_url(url)
         tag ||= formula.stable.specs[:tag]
 
         if @online

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -164,4 +164,22 @@ module SharedAudits
 
     "Bitbucket repository not notable enough (<30 forks and <75 watchers)"
   end
+
+  def github_tag_from_url(url)
+    url = url.to_s
+    tag = url.match(%r{^https://github\.com/[\w-]+/[\w-]+/archive/([^/]+)\.(tar\.gz|zip)$})
+             .to_a
+             .second
+    tag ||= url.match(%r{^https://github\.com/[\w-]+/[\w-]+/releases/download/([^/]+)/})
+               .to_a
+               .second
+    tag
+  end
+
+  def gitlab_tag_from_url(url)
+    url = url.to_s
+    url.match(%r{^https://gitlab\.com/[\w-]+/[\w-]+/-/archive/([^/]+)/})
+       .to_a
+       .second
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The current method of using `cask.version` as a tag is not good enough as many repositories add a prefix such as `v` to their tags.

This PR adds two new methods to `SharedAudits`: `github_tag_from_url` and `gitlab_tag_from_url`, which can be used by `brew cask audit` to detect a version tag from GitHub/GitLab URLs.

Admittedly, GitLab uploads don't seem to include the tag in their URLs, but this is not a major problem as only two casks are downloaded from GitLab. (See https://github.com/Homebrew/homebrew-cask/search?q=%22gitlab.com%22) Perhaps as a workaround we could hardcode the tags for these two casks?

Related: Homebrew/homebrew-cask/pull/88936