### PR TITLE
dev-cmd/typecheck: Update the Sorbet TODO file in `--update-definitions`

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -40,6 +40,7 @@ module Homebrew
       if args.update_definitions?
         system "bundle", "exec", "tapioca", "sync"
         system "bundle", "exec", "srb", "rbi", "hidden-definitions"
+        system "bundle", "exec", "srb", "rbi", "todo"
 
         Homebrew.failed = system("git", "diff", "--stat", "--exit-code") if args.fail_if_not_changed?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- [Sorbet's TODO file](https://sorbet.org/docs/rbi#the-todo-rbi-file) is useful to be periodically regenerated when we're trying to deal with typing errors. The result is an updated `sorbet/rbi/todo.rbi` file that defines missing constants. During GSoC, we [did update this file on occasional Tapioca updates](https://github.com/Homebrew/brew/blame/master/Library/Homebrew/sorbet/rbi/todo.rbi), according to the history. That suggests to me that it should be part of this command.