### PR TITLE
Fix printing MultipleVersionsInstalledError details

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -164,7 +164,10 @@ module Homebrew
             end
 
             unless (prefix = f.latest_installed_prefix).directory?
-              raise MultipleVersionsInstalledError, "#{rack.basename} has multiple installed versions"
+              raise MultipleVersionsInstalledError, <<~EOS
+                #{rack.basename} has multiple installed versions
+                Run `brew uninstall --force #{rack.basename}` to remove all versions.
+              EOS
             end
 
             Keg.new(prefix)

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -134,7 +134,6 @@ module Homebrew
     )
   rescue MultipleVersionsInstalledError => e
     ofail e
-    puts "Run `brew uninstall --force #{e.name}` to remove all versions."
   ensure
     # If we delete Cellar/newname, then Cellar/oldname symlink
     # can become broken and we have to remove it.

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -3,9 +3,19 @@
 require "exceptions"
 
 describe MultipleVersionsInstalledError do
-  subject { described_class.new("foo has multiple installed versions") }
+  subject {
+    described_class.new <<~EOS
+      foo has multiple installed versions
+      Run `brew uninstall --force foo` to remove all versions.
+    EOS
+  }
 
-  its(:to_s) { is_expected.to eq("foo has multiple installed versions") }
+  its(:to_s) {
+    is_expected.to eq <<~EOS
+      foo has multiple installed versions
+      Run `brew uninstall --force foo` to remove all versions.
+    EOS
+  }
 end
 
 describe NoSuchKegError do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The refactor in 6e8f5d0958247e4b4d629866099ed2836a0e0863 means that the exception no longer exposes the name of the package with multiple versions, and as a result the rescuer is unable to print this information.

Because we now have a path in which `MultipleVersionsInstalledError` doesn't have the name at all, we can't reasonably restore the old behaviour. And since rack resolution happens purely internal to the function that raises the exception, the caller has no way to know what name to use. However, since the exception text gets printed anyway, we can just move this text into the exception itself.

Fixes the following error:

```
Error: mpd has multiple installed versions
Error: undefined method `name' for #<MultipleVersionsInstalledError:0x00007fc6009d8870>
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:137:in `rescue in uninstall'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:135:in `uninstall'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```

New behaviour:

```
Error: mpd has multiple installed versions
Run `brew uninstall --force mpd` to remove all versions.
```

cc @whoiswillma 