### PR TITLE
cmd/log.rb: new --repo flag to show log for Homebrew taps

### DIFF
--- a/Library/Homebrew/cmd/log.rb
+++ b/Library/Homebrew/cmd/log.rb
@@ -20,6 +20,8 @@ module Homebrew
              description: "Also print diffstat from commit."
       switch "--oneline",
              description: "Print only one line per commit."
+      flag   "--repo=",
+             description: "Show log for the specified Homebrew repository."
       switch "-1",
              description: "Print only one commit."
       flag   "-n", "--max-count=",
@@ -37,7 +39,14 @@ module Homebrew
     ENV["PATH"] = ENV["HOMEBREW_PATH"]
 
     if args.no_named?
-      git_log HOMEBREW_REPOSITORY, args: args
+      if args.repo.present?
+        tap = Tap.fetch(args.repo)
+        raise TapUnavailableError, tap.name unless tap.installed?
+
+        git_log tap.path, args: args
+      else
+        git_log HOMEBREW_REPOSITORY, args: args
+      end
     else
       path = Formulary.path(args.named.first)
       tap = Tap.from_path(path)

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -405,6 +405,8 @@ if no formula is provided.
   Also print diffstat from commit.
 * `--oneline`:
   Print only one line per commit.
+* `--repo`:
+  Show log for the specified Homebrew repository.
 * `-1`:
   Print only one commit.
 * `-n`, `--max-count`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -607,6 +607,10 @@ Also print diffstat from commit\.
 Print only one line per commit\.
 .
 .TP
+\fB\-\-repo\fR
+Show log for the specified Homebrew repository\.
+.
+.TP
 \fB\-1\fR
 Print only one commit\.
 .


### PR DESCRIPTION
Enable `brew log` to show commit logs for Homebrew repositories, e.g.:

```sh
brew log --repo homebrew/cask
```

-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
