### PR TITLE
livecheck: skip formula even if quiet

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -191,29 +191,23 @@ module Homebrew
       if formula.deprecated? && !formula.livecheckable?
         return status_hash(formula, "deprecated", args: args) if args.json?
 
-        unless args.quiet?
-          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : deprecated"
-          return
-        end
+        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : deprecated" unless args.quiet?
+        return
       end
 
       if formula.versioned_formula? && !formula.livecheckable?
         return status_hash(formula, "versioned", args: args) if args.json?
 
-        unless args.quiet?
-          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : versioned"
-          return
-        end
+        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : versioned" unless args.quiet?
+        return
       end
 
       if formula.head? && !formula.any_version_installed?
         head_only_msg = "HEAD only formula must be installed to be livecheckable"
         return status_hash(formula, "error", [head_only_msg], args: args) if args.json?
 
-        unless args.quiet?
-          puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : #{head_only_msg}"
-          return
-        end
+        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : #{head_only_msg}" unless args.quiet?
+        return
       end
 
       is_gist = formula.stable&.url&.include?("gist.github.com")
@@ -232,8 +226,8 @@ module Homebrew
         unless args.quiet?
           puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : skipped" \
               "#{" - #{skip_msg}" if skip_msg.present?}"
-          return
         end
+        return
       end
 
       false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

It was discovered in Homebrew/homebrew-core/pull/60897 that running `brew livecheck --quiet` overrides any skips for e.g. versioned formulae. This PR moves a few `return` statements to always execute regardless of whether or not `--quiet` is passed as an argument.