### PR TITLE
Add `head_only?` to Formula, replace `head?` in livecheck

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -38,6 +38,7 @@ class AbstractDownloadStrategy
     @version = version
     @cache = meta.fetch(:cache, HOMEBREW_CACHE)
     @meta = meta
+    @quiet = false
     extend Pourable if meta[:bottle]
   end
 
@@ -53,6 +54,10 @@ class AbstractDownloadStrategy
   # @api public
   def shutup!
     @quiet = true
+  end
+
+  def quiet?
+    Context.current.quiet? || @quiet
   end
 
   # Unpack {#cached_location} into the current working directory, and possibly

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -333,6 +333,12 @@ class Formula
     active_spec == head
   end
 
+  # Is this formula HEAD-only?
+  # @private
+  def head_only?
+    head && !stable
+  end
+
   delegate [ # rubocop:disable Layout/HashAlignment
     :bottle_unneeded?,
     :bottle_disabled?,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The `brew livecheck --installed` command is supposed to run `livecheck` for all formulae that have been installed. As `livecheck` reports new versions of software from upstream (compared to the homebrew-core version and not the system-installed version), one would expect this command to work just like `brew livecheck` does but only limits the Formulae checked.

However,
```
➜ brew livecheck arduino-cli     
arduino-cli : 0.12.1 ==> 0.12.1
➜ brew livecheck --installed                   
adns : 1.6.0 ==> 1.6.0
anime-downloader : 4.6.4 ==> 4.6.4
aom : 2.0.0 ==> 2.0.0
==> Cloning https://github.com/arduino/arduino-cli.git
Updating /Users/nanda/Library/Caches/Homebrew/arduino-cli--git
From https://github.com/arduino/arduino-cli
   f1877ef..693a045  master     -> origin/master
==> Checking out branch master
Already on 'master'
Your branch is behind 'origin/master' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at 693a045 [skip changelog] Completely document resources not inherited from referenced platform (#940)
arduino-cli : b8cf32d ==> 693a045
```
This happens because I have a `HEAD`-version of `arduino-cli` installed, despite it not being a HEAD-only formula.

This PR fixes the `--installed` flag to check only installed formulae, but report their stable version instead (if it exists).

```
➜ brew livecheck --installed
adns : 1.6.0 ==> 1.6.0
anime-downloader : 4.6.4 ==> 4.6.4
aom : 2.0.0 ==> 2.0.0
arduino-cli : 0.12.1 ==> 0.12.1
```

For a HEAD-only formula, we continue to report HEAD version updates.

One problem still persists, for HEAD-only formulae, the output of `fetch_latest_commit` is not silenced despite the `formula.head.downloader.shutup!`. While I tried looking through `Context` and `AbstractDownloadStrategy`, I wasn't able to come up with a fix. It seems like setting `@quiet = true` isn't working. Any idea why?