### PR TITLE
Environment variable to request shallow taps

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -53,10 +53,10 @@ module Homebrew
     else
       full_clone = if args.full?
         true
-      elsif !args.shallow?
-        ENV["CI"].blank?
+      elsif args.shallow?
+        false
       else
-        !args.shallow?
+        ENV["HOMEBREW_TAP_SHALLOW"].blank? and ENV["CI"].blank?
       end
       odebug "Tapping as #{full_clone ? "full" : "shallow"} clone"
       tap = Tap.fetch(args.named.first)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] **TODO** Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] **TODO** Have you successfully run `brew style` with your changes locally?
- [ ] **TODO** Have you successfully run `brew tests` with your changes locally?

-----

I'm working on a procedure that will initialize Homebrew (for Linux) from scratch and use `brew bundle` to install various formulas. It would be useful to have a way to make the automatic tapping of `Homebrew/linuxbrew-core`, `Homebrew/homebrew-bundle`, and other taps from the Brewfile(s) happen as if I passed `--shallow` to all of them. I didn't see an example of passing arguments to `tap` in a Brewfile (though maybe it's possible), and I definitely haven't found a way to tap the core formula repo (`homebrew-core` or `linuxbrew-core`) in shallow mode.

I did find that `tap.rb` taps in shallow mode if `CI` is set in the environment, but the use of the `CI` variable seems to be related to the Homebrew project's CI, not mine, and I suspect there are other effects of using `CI` that might not make it the right choice to solve my use case.

Before I get further with writing tests and documentation, I wanted to see if this is something that makes sense to the project maintainers. I'd also appreciate suggestions on the environment variable name to conform to the style used by the project.