### PR TITLE
Add HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -456,22 +456,32 @@ class ReporterHub
   private
 
   def dump_formula_report(key, title)
+    only_installed = Homebrew::EnvConfig.update_report_only_installed?
+
     formulae = select_formula(key).sort.map do |name, new_name|
       # Format list items of renamed formulae
       case key
       when :R
         name = pretty_installed(name) if installed?(name)
         new_name = pretty_installed(new_name) if installed?(new_name)
-        "#{name} -> #{new_name}"
+        "#{name} -> #{new_name}" unless only_installed
       when :A
-        name unless installed?(name)
+        name if !installed?(name) && !only_installed
       when :AC
-        name.split("/").last unless cask_installed?(name)
+        name.split("/").last if !cask_installed?(name) && !only_installed
       when :MC, :DC
         name = name.split("/").last
-        cask_installed?(name) ? pretty_installed(name) : name
+        if cask_installed?(name)
+          pretty_installed(name)
+        elsif !only_installed
+          name
+        end
       else
-        installed?(name) ? pretty_installed(name) : name
+        if installed?(name)
+          pretty_installed(name)
+        elsif !only_installed
+          name
+        end
       end
     end.compact
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -8,56 +8,56 @@ module Homebrew
     module_function
 
     ENVS = {
-      HOMEBREW_ARCH:                      {
+      HOMEBREW_ARCH:                         {
         description: "Linux only: Pass the set value to a type name representing the compiler's `-march` option.",
         default:     "native",
       },
-      HOMEBREW_ARTIFACT_DOMAIN:           {
+      HOMEBREW_ARTIFACT_DOMAIN:              {
         description: "Prefix all download URLs, including those for bottles, with this " \
                      "variable. For example, `HOMEBREW_ARTIFACT_DOMAIN=http://localhost:8080` will cause a " \
                      "formula with the URL `https://example.com/foo.tar.gz` to instead download from " \
                      "`http://localhost:8080/example.com/foo.tar.gz`.",
       },
-      HOMEBREW_AUTO_UPDATE_SECS:          {
+      HOMEBREW_AUTO_UPDATE_SECS:             {
         description: "Automatically check for updates once per this seconds interval.",
         default:     300,
       },
-      HOMEBREW_BAT:                       {
+      HOMEBREW_BAT:                          {
         description: "If set, use `bat` for the `brew cat` command.",
         boolean:     true,
       },
-      HOMEBREW_BAT_CONFIG_PATH:           {
+      HOMEBREW_BAT_CONFIG_PATH:              {
         description:  "Use the `bat` configuration file. For example, `HOMEBREW_BAT=$HOME/.bat/config`.",
         default_text: "$HOME/.bat/config",
       },
-      HOMEBREW_BINTRAY_KEY:               {
+      HOMEBREW_BINTRAY_KEY:                  {
         description: "Use this API key when accessing the Bintray API (where bottles are stored).",
       },
-      HOMEBREW_BINTRAY_USER:              {
+      HOMEBREW_BINTRAY_USER:                 {
         description: "Use this username when accessing the Bintray API (where bottles are stored).",
       },
-      HOMEBREW_BOTTLE_DOMAIN:             {
+      HOMEBREW_BOTTLE_DOMAIN:                {
         description:  "Use the specified URL as the download mirror for bottles. " \
         "For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to " \
         "download from the prefix `http://localhost:8080/`.",
         default_text: "macOS: `https://homebrew.bintray.com/`, Linux: `https://linuxbrew.bintray.com/`.",
         default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,
       },
-      HOMEBREW_BREW_GIT_REMOTE:           {
+      HOMEBREW_BREW_GIT_REMOTE:              {
         description: "Use the specified URL as the Homebrew/brew `git`(1) remote.",
         default:     HOMEBREW_BREW_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_BROWSER:                   {
+      HOMEBREW_BROWSER:                      {
         description:  "Use this as the browser when opening project homepages.",
         default_text: "`$BROWSER` or the OS's default browser.",
       },
-      HOMEBREW_CACHE:                     {
+      HOMEBREW_CACHE:                        {
         description:  "Use the specified directory as the download cache.",
         default_text: "macOS: `$HOME/Library/Caches/Homebrew`, " \
                       "Linux: `$XDG_CACHE_HOME/Homebrew` or `$HOME/.cache/Homebrew`.",
         default:      HOMEBREW_DEFAULT_CACHE,
       },
-      HOMEBREW_CASK_OPTS:                 {
+      HOMEBREW_CASK_OPTS:                    {
         description: "Options which should be used for all `cask` commands. All `--*dir` options, " \
                      "`--language`, `--require-sha`, `--no-quarantine` and `--no-binaries` are supported." \
                      "\n" \
@@ -65,92 +65,92 @@ module Homebrew
                      "~/.profile, ~/.bash_profile, or ~/.zshenv:\n\n" \
                      "`export HOMEBREW_CASK_OPTS='--appdir=~/Applications --fontdir=/Library/Fonts'`",
       },
-      HOMEBREW_CLEANUP_MAX_AGE_DAYS:      {
+      HOMEBREW_CLEANUP_MAX_AGE_DAYS:         {
         description: "Cleanup all cached files older than this many days.",
         default:     120,
       },
-      HOMEBREW_COLOR:                     {
+      HOMEBREW_COLOR:                        {
         description: "If set, force colour output on non-TTY outputs.",
         boolean:     true,
       },
-      HOMEBREW_CORE_GIT_REMOTE:           {
+      HOMEBREW_CORE_GIT_REMOTE:              {
         description:  "Use the specified URL as the Homebrew/homebrew-core `git`(1) remote.",
         default_text: "macOS: `https://github.com/Homebrew/homebrew-core`, " \
                       "Linux: `https://github.com/Homebrew/linuxbrew-core`.",
         default:      HOMEBREW_CORE_DEFAULT_GIT_REMOTE,
       },
-      HOMEBREW_CURLRC:                    {
+      HOMEBREW_CURLRC:                       {
         description: "If set, do not pass `--disable` when invoking `curl`(1), which disables the " \
                      "use of `curlrc`.",
         boolean:     true,
       },
-      HOMEBREW_CURL_RETRIES:              {
+      HOMEBREW_CURL_RETRIES:                 {
         description: "Pass the given retry count to `--retry` when invoking `curl`(1).",
         default:     3,
       },
-      HOMEBREW_CURL_VERBOSE:              {
+      HOMEBREW_CURL_VERBOSE:                 {
         description: "If set, pass `--verbose` when invoking `curl`(1).",
         boolean:     true,
       },
-      HOMEBREW_DEVELOPER:                 {
+      HOMEBREW_DEVELOPER:                    {
         description: "If set, tweak behaviour to be more relevant for Homebrew developers (active or " \
                      "budding) by e.g. turning warnings into errors.",
         boolean:     true,
       },
-      HOMEBREW_DISABLE_LOAD_FORMULA:      {
+      HOMEBREW_DISABLE_LOAD_FORMULA:         {
         description: "If set, refuse to load formulae. This is useful when formulae are not trusted (such " \
                      "as in pull requests).",
         boolean:     true,
       },
-      HOMEBREW_DISPLAY:                   {
+      HOMEBREW_DISPLAY:                      {
         description:  "Use this X11 display when opening a page in a browser, for example with " \
                      "`brew home`. Primarily useful on Linux.",
         default_text: "`$DISPLAY`.",
       },
-      HOMEBREW_DISPLAY_INSTALL_TIMES:     {
+      HOMEBREW_DISPLAY_INSTALL_TIMES:        {
         description: "If set, print install times for each formula at the end of the run.",
         boolean:     true,
       },
-      HOMEBREW_EDITOR:                    {
+      HOMEBREW_EDITOR:                       {
         description:  "Use this editor when editing a single formula, or several formulae in the " \
                      "same directory.\n\n    *Note:* `brew edit` will open all of Homebrew as discontinuous files " \
                      "and directories. Visual Studio Code can handle this correctly in project mode, but many " \
                      "editors will do strange things in this case.",
         default_text: "`$EDITOR` or `$VISUAL`.",
       },
-      HOMEBREW_FAIL_LOG_LINES:            {
+      HOMEBREW_FAIL_LOG_LINES:               {
         description: "Output this many lines of output on formula `system` failures.",
         default:     15,
       },
-      HOMEBREW_FORBIDDEN_LICENSES:        {
+      HOMEBREW_FORBIDDEN_LICENSES:           {
         description: "A space-separated list of licenses. Homebrew will refuse to install a " \
         "formula if that formula or any of its dependencies has a license on this list.",
       },
-      HOMEBREW_FORCE_BREWED_CURL:         {
+      HOMEBREW_FORCE_BREWED_CURL:            {
         description: "If set, always use a Homebrew-installed `curl`(1) rather than the system version. " \
                      "Automatically set if the system version of `curl` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_BREWED_GIT:          {
+      HOMEBREW_FORCE_BREWED_GIT:             {
         description: "If set, always use a Homebrew-installed `git`(1) rather than the system version. " \
                      "Automatically set if the system version of `git` is too old.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_HOMEBREW_ON_LINUX:   {
+      HOMEBREW_FORCE_HOMEBREW_ON_LINUX:      {
         description: "If set, running Homebrew on Linux will use URLs for macOS. This is useful when merging " \
                      "pull requests for macOS while on Linux.",
         boolean:     true,
       },
-      HOMEBREW_FORCE_VENDOR_RUBY:         {
+      HOMEBREW_FORCE_VENDOR_RUBY:            {
         description: "If set, always use Homebrew's vendored, relocatable Ruby version even if the system version " \
                      "of Ruby is new enough.",
         boolean:     true,
       },
-      HOMEBREW_GITHUB_API_PASSWORD:       {
+      HOMEBREW_GITHUB_API_PASSWORD:          {
         description: "Use this password for authentication with the GitHub API, for features " \
                      "such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.",
       },
-      HOMEBREW_GITHUB_API_TOKEN:          {
+      HOMEBREW_GITHUB_API_TOKEN:             {
         description: "Use this personal access token for the GitHub API, for features such as " \
                      "`brew search`. You can create one at <https://github.com/settings/tokens>. If set, " \
                      "GitHub will allow you a greater number of API requests. For more information, see: " \
@@ -158,33 +158,33 @@ module Homebrew
                      "    *Note:* Homebrew doesn't require permissions for any of the scopes, but some developer " \
                      "commands may require additional permissions.",
       },
-      HOMEBREW_GITHUB_API_USERNAME:       {
+      HOMEBREW_GITHUB_API_USERNAME:          {
         description: "Use this username for authentication with the GitHub API, for features " \
                      "such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.",
       },
-      HOMEBREW_GIT_EMAIL:                 {
+      HOMEBREW_GIT_EMAIL:                    {
         description: "Set the Git author and committer name to this value.",
       },
-      HOMEBREW_GIT_NAME:                  {
+      HOMEBREW_GIT_NAME:                     {
         description: "Set the Git author and committer email to this value.",
       },
-      HOMEBREW_INSTALL_BADGE:             {
+      HOMEBREW_INSTALL_BADGE:                {
         description:  "Print this text before the installation summary of each successful build.",
         default_text: 'The "Beer Mug" emoji.',
         default:      "🍺",
       },
-      HOMEBREW_LIVECHECK_WATCHLIST:       {
+      HOMEBREW_LIVECHECK_WATCHLIST:          {
         description: "Use this file to get the list of default Formulae to check when no Formula argument " \
                      "is passed to `brew livecheck`",
         default:     "$HOME/.brew_livecheck_watchlist",
       },
-      HOMEBREW_LOGS:                      {
+      HOMEBREW_LOGS:                         {
         description:  "Use the specified directory to store log files.",
         default_text: "macOS: `$HOME/Library/Logs/Homebrew`, "\
                       "Linux: `$XDG_CACHE_HOME/Homebrew/Logs` or `$HOME/.cache/Homebrew/Logs`.",
         default:      HOMEBREW_DEFAULT_LOGS,
       },
-      HOMEBREW_MAKE_JOBS:                 {
+      HOMEBREW_MAKE_JOBS:                    {
         description:  "Use this value as the number of parallel jobs to run when building with `make`(1).",
         default_text: "The number of available CPU cores.",
         default:      lambda {
@@ -193,64 +193,64 @@ module Homebrew
           Hardware::CPU.cores
         },
       },
-      HOMEBREW_NO_ANALYTICS:              {
+      HOMEBREW_NO_ANALYTICS:                 {
         description: "If set, do not send analytics. See: <https://docs.brew.sh/Analytics>.",
         boolean:     true,
       },
-      HOMEBREW_NO_AUTO_UPDATE:            {
+      HOMEBREW_NO_AUTO_UPDATE:               {
         description: "If set, do not automatically update before running " \
                      "`brew install`, `brew upgrade` or `brew tap`.",
         boolean:     true,
       },
-      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: {
+      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK:    {
         description: "If set, fail on the failure of installation from a bottle rather than " \
                      "falling back to building from source.",
         boolean:     true,
       },
-      HOMEBREW_NO_COLOR:                  {
+      HOMEBREW_NO_COLOR:                     {
         description:  "If set, do not print text with colour added.",
         default_text: "`$NO_COLOR`.",
         boolean:      true,
       },
-      HOMEBREW_NO_COMPAT:                 {
+      HOMEBREW_NO_COMPAT:                    {
         description: "If set, disable all use of legacy compatibility code.",
         boolean:     true,
       },
-      HOMEBREW_NO_EMOJI:                  {
+      HOMEBREW_NO_EMOJI:                     {
         description: "If set, do not print `HOMEBREW_INSTALL_BADGE` on a successful build." \
                      "\n\n    *Note:* Only tries to print emoji on OS X Lion or newer.",
         boolean:     true,
       },
-      HOMEBREW_NO_GITHUB_API:             {
+      HOMEBREW_NO_GITHUB_API:                {
         description: "If set, do not use the GitHub API, e.g. for searches or fetching relevant issues " \
                      "on a failed install.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSECURE_REDIRECT:      {
+      HOMEBREW_NO_INSECURE_REDIRECT:         {
         description: "If set, forbid redirects from secure HTTPS to insecure HTTP." \
                      "\n\n    *Note:* While ensuring your downloads are fully secure, this is likely to cause " \
                      "from-source SourceForge, some GNU & GNOME based formulae to fail to download.",
         boolean:     true,
       },
-      HOMEBREW_NO_INSTALL_CLEANUP:        {
+      HOMEBREW_NO_INSTALL_CLEANUP:           {
         description: "If set, `brew install`, `brew upgrade` and `brew reinstall` will never automatically " \
                      "cleanup installed/upgraded/reinstalled formulae or all formulae every 30 days.",
         boolean:     true,
       },
-      HOMEBREW_PRY:                       {
+      HOMEBREW_PRY:                          {
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
-      HOMEBREW_SKIP_OR_LATER_BOTTLES:     {
+      HOMEBREW_SKIP_OR_LATER_BOTTLES:        {
         description: "If set with `HOMEBREW_DEVELOPER`, do not use bottles from older versions " \
                      "of macOS. This is useful in development on new macOS versions.",
         boolean:     true,
       },
-      HOMEBREW_SVN:                       {
+      HOMEBREW_SVN:                          {
         description:  "Use this as the `svn`(1) binary.",
         default_text: "A Homebrew-built Subversion (if installed), or the system-provided binary.",
       },
-      HOMEBREW_TEMP:                      {
+      HOMEBREW_TEMP:                         {
         description:  "Use this path as the temporary directory for building packages. Changing " \
                       "this may be needed if your system temporary directory and Homebrew prefix are on " \
                       "different volumes, as macOS has trouble moving symlinks across volumes when the target " \
@@ -259,41 +259,45 @@ module Homebrew
         default_text: "macOS: `/private/tmp`, Linux: `/tmp`.",
         default:      HOMEBREW_DEFAULT_TEMP,
       },
-      HOMEBREW_UPDATE_TO_TAG:             {
+      HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED: {
+        description: "If set, `brew update` only outputs updates to installed software.",
+        boolean:     true,
+      },
+      HOMEBREW_UPDATE_TO_TAG:                {
         description: "If set, always use the latest stable tag (even if developer commands " \
                      "have been run).",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE:                   {
+      HOMEBREW_VERBOSE:                      {
         description: "If set, always assume `--verbose` when running commands.",
         boolean:     true,
       },
-      HOMEBREW_DEBUG:                     {
+      HOMEBREW_DEBUG:                        {
         description: "If set, always assume `--debug` when running commands.",
         boolean:     true,
       },
-      HOMEBREW_VERBOSE_USING_DOTS:        {
+      HOMEBREW_VERBOSE_USING_DOTS:           {
         description: "If set, verbose output will print a `.` no more than once a minute. This can be " \
                      "useful to avoid long-running Homebrew commands being killed due to no output.",
         boolean:     true,
       },
-      all_proxy:                          {
+      all_proxy:                             {
         description: "Use this SOCKS5 proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      ftp_proxy:                          {
+      ftp_proxy:                             {
         description: "Use this FTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      http_proxy:                         {
+      http_proxy:                            {
         description: "Use this HTTP proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      https_proxy:                        {
+      https_proxy:                           {
         description: "Use this HTTPS proxy for `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      no_proxy:                           {
+      no_proxy:                              {
         description: "A comma-separated list of hostnames and domain names excluded " \
                      "from proxying by `curl`(1), `git`(1) and `svn`(1) when downloading through Homebrew.",
       },
-      SUDO_ASKPASS:                       {
+      SUDO_ASKPASS:                          {
         description: "When this variable is set, the `-A` option is passed when calling `sudo`(8)",
       },
     }.freeze

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1703,6 +1703,9 @@ For example, you might add something like the following to your ~/.profile, ~/.b
 
     *Default:* macOS: `/private/tmp`, Linux: `/tmp`.
 
+  * `HOMEBREW_UPDATE_REPORT_ONLY_INSTALLED`:
+    If set, `brew update` only outputs updates to installed software.
+
   * `HOMEBREW_UPDATE_TO_TAG`:
     If set, always use the latest stable tag (even if developer commands have been run).
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2345,6 +2345,10 @@ Use this path as the temporary directory for building packages\. Changing this m
 \fIDefault:\fR macOS: \fB/private/tmp\fR, Linux: \fB/tmp\fR\.
 .
 .TP
+\fBHOMEBREW_UPDATE_REPORT_ONLY_INSTALLED\fR
+If set, \fBbrew update\fR only outputs updates to installed software\.
+.
+.TP
 \fBHOMEBREW_UPDATE_TO_TAG\fR
 If set, always use the latest stable tag (even if developer commands have been run)\.
 .


### PR DESCRIPTION
This allows reducing the volume of `brew update` output by only outputting the changes to formulae that you have installed.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----