### PR TITLE
Improve linkage cache linkage_cache_performance

### DIFF
--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -9,9 +9,9 @@ describe CacheStoreDatabase do
     let(:type) { :test }
 
     it "creates a new `DatabaseCache` instance" do
-      cache_store = double("cache_store", close_if_open!: nil)
+      cache_store = double("cache_store", write_if_dirty!: nil)
       expect(described_class).to receive(:new).with(type).and_return(cache_store)
-      expect(cache_store).to receive(:close_if_open!)
+      expect(cache_store).to receive(:write_if_dirty!)
       described_class.use(type) { |_db| }
     end
   end
@@ -92,10 +92,10 @@ describe CacheStoreDatabase do
     end
   end
 
-  describe "#close_if_open!" do
+  describe "#write_if_dirty!" do
     context "database open" do
       it "does not raise an error when `close` is called on the database" do
-        expect { subject.close_if_open! }.not_to raise_error(NoMethodError)
+        expect { subject.write_if_dirty! }.not_to raise_error(NoMethodError)
       end
     end
 
@@ -105,7 +105,7 @@ describe CacheStoreDatabase do
       end
 
       it "does not raise an error when `close` is called on the database" do
-        expect { subject.close_if_open! }.not_to raise_error(NoMethodError)
+        expect { subject.write_if_dirty! }.not_to raise_error(NoMethodError)
       end
     end
   end


### PR DESCRIPTION
- Use reference counting so nested `CacheStoreDatabase.use` share the same underlying database (rather than rereading it every time).
- Only write out the cache database file when it has changed.
- Cleanup cache database entries on formula or full `brew cleanup`.

Fixes #8690

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----