### PR TITLE
list.rb: --size (-s) flag to sort installed formulae by size

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -391,6 +391,8 @@ If *`formula`* is provided, summarise the paths within its current keg.
   List in long format. If the output is to a terminal, a total sum for all the file sizes is printed before the long listing.
 * `-r`:
   Reverse the order of the sort to list the oldest entries first.
+* `-s`, `--size`:
+  Sort by the size, listing largest formulae last.
 * `-t`:
   Sort by time modified, listing most recently modified first.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -588,6 +588,10 @@ List in long format\. If the output is to a terminal, a total sum for all the fi
 Reverse the order of the sort to list the oldest entries first\.
 .
 .TP
+\fB\-s\fR, \fB\-\-size\fR
+Sort by the size, listing largest formulae last\.
+.
+.TP
 \fB\-t\fR
 Sort by time modified, listing most recently modified first\.
 .


### PR DESCRIPTION
New `-s` / `--size` flag to list installed formulae by size using the `du` utility program.

-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
