### PR TITLE
rubocops/patches: GitHub/GitLab patches should end with .patch

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -48,6 +48,20 @@ module RuboCop
             problem "Use a commit hash URL rather than an unstable merge request URL: #{patch_url}"
           end
 
+          if regex_match_group(patch, %r{https://github.com/[^/]*/[^/]*/commit/[a-fA-F0-9]*\.diff})
+            problem <<~EOS.chomp
+              GitHub patches should end with .patch, not .diff:
+                #{patch_url}
+            EOS
+          end
+
+          if regex_match_group(patch, %r{.*gitlab.*/commit/[a-fA-F0-9]*\.diff})
+            problem <<~EOS.chomp
+              GitLab patches should end with .patch, not .diff:
+                #{patch_url}
+            EOS
+          end
+
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch, gh_patch_param_pattern) && !patch_url.match?(/\?full_index=\w+$/)
             problem <<~EOS

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -215,6 +215,8 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         "https://patch-diff.githubusercontent.com/raw/foo/foo-bar/pull/100.patch",
         "https://github.com/uber/h3/pull/362.patch?full_index=1",
         "https://gitlab.gnome.org/GNOME/gitg/-/merge_requests/142.diff",
+        "https://github.com/michaeldv/pit/commit/f64978d.diff?full_index=1",
+        "https://gitlab.gnome.org/GNOME/msitools/commit/248450a.diff",
       ]
       patch_urls.each do |patch_url|
         source = <<~RUBY
@@ -277,6 +279,26 @@ describe RuboCop::Cop::FormulaAudit::Patches do
              source:   source }]
         elsif patch_url.match?(%r{.*gitlab.*/merge_request.*})
           [{ message:  "Use a commit hash URL rather than an unstable merge request URL: #{patch_url}",
+             severity: :convention,
+             line:     5,
+             column:   9,
+             source:   source }]
+        elsif patch_url.match?(%r{https://github.com/[^/]*/[^/]*/commit/})
+          [{ message:
+                       <<~EOS.chomp,
+                         GitHub patches should end with .patch, not .diff:
+                           #{patch_url}
+                       EOS
+             severity: :convention,
+             line:     5,
+             column:   9,
+             source:   source }]
+        elsif patch_url.match?(%r{.*gitlab.*/commit/})
+          [{ message:
+                       <<~EOS.chomp,
+                         GitLab patches should end with .patch, not .diff:
+                           #{patch_url}
+                       EOS
              severity: :convention,
              line:     5,
              column:   9,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See discussion below

<details><summary>Old description</summary>

GitLab doesn't support `?full_index=1` for patch URLs, but instead we can use `.diff` to get full indices. This PR adds a check for GitLab patches ending with `.patch` that will be reported by `brew audit`

`brew audit gstreamer`:

```
gstreamer:
  * C: 33: col 10: GitLab patches should end with .diff, not .patch:
      https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/40c994cddee41954053f80dde40f56107ddfcfd4.patch
Error: 1 problem in 1 formula detected
```

https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/40c994c.patch (short indices):

```
index eefe1c9d646..4370acd9562 100755
```

https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/40c994c.diff (full indices):

```
index eefe1c9d646d81fc0f09a81e11482449f4f4e144..4370acd956210fe23abea91da162f0aa6c02e26f 100755
```

</details>