### PR TITLE
sorbet: Add a RBI file for `utils/svn.rb` typechecking

### DIFF
--- a/Library/Homebrew/sorbet/rbi/utils/svn.rbi
+++ b/Library/Homebrew/sorbet/rbi/utils/svn.rbi
@@ -1,0 +1,14 @@
+# typed: strict
+
+module Utils::Svn
+  include Kernel
+
+  sig { returns(T::Boolean) }
+  def available?; end
+
+  sig { returns(T.nilable(String)) }
+  def version; end
+
+  sig { params(url: String).returns(T::Boolean) }
+  def remote_exists?(url); end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Needed to `include Kernel` otherwise Sorbet couldn't find the `system_command` method.
- I've also attempted to construct method signatures for all the methods.
- Before, `brew typecheck` surfaced 36 errors. Now we're down to 33 errors.
