### PR TITLE
sorbet: Regenerate RBI file for the `spoom` gem

### DIFF
--- a/Library/Homebrew/sorbet/rbi/gems/spoom@1.0.4.rbi
+++ b/Library/Homebrew/sorbet/rbi/gems/spoom@1.0.4.rbi
@@ -271,15 +271,15 @@ end
 
 module Spoom::Sorbet
   class << self
-    sig { params(path: String, capture_err: T::Boolean, arg: String).returns([String, T::Boolean]) }
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns([String, T::Boolean]) }
     def srb(*arg, path: T.unsafe(nil), capture_err: T.unsafe(nil)); end
     sig { params(config: Spoom::Sorbet::Config, path: String).returns(T::Array[String]) }
     def srb_files(config, path: T.unsafe(nil)); end
-    sig { params(path: String, capture_err: T::Boolean, arg: String).returns(T.nilable(Spoom::Sorbet::Metrics)) }
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns(T.nilable(Spoom::Sorbet::Metrics)) }
     def srb_metrics(*arg, path: T.unsafe(nil), capture_err: T.unsafe(nil)); end
-    sig { params(path: String, capture_err: T::Boolean, arg: String).returns([String, T::Boolean]) }
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns([String, T::Boolean]) }
     def srb_tc(*arg, path: T.unsafe(nil), capture_err: T.unsafe(nil)); end
-    sig { params(path: String, capture_err: T::Boolean, arg: String).returns(T.nilable(String)) }
+    sig { params(arg: String, path: String, capture_err: T::Boolean).returns(T.nilable(String)) }
     def srb_version(*arg, path: T.unsafe(nil), capture_err: T.unsafe(nil)); end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

- Sorbet was reporting parameter ordering errors in a previous version of this RBI file due to [a bug in Tapioca](https://github.com/Shopify/tapioca/issues/116).
- Rather than wait for a new version of the `spoom` gem for `brew typecheck --update-definitions` to work on, I manually deleted the RBI file and used that command to generate an updated one with the latest Tapioca version (0.4.5) which fixes the ordering bug.
- Before, `brew typecheck` surfaced 36 errors. Now, it surfaces 24. Much more pleasant.
