### PR TITLE
bump-revision: fix for new license syntax

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -40,10 +40,12 @@ module Homebrew
         end
 
         old = if formula.license
-          license_string = if formula.license.length > 1
-            formula.license
+          license_string = if formula.license.is_a? String
+            "\"#{formula.license}\""
           else
-            "\"#{formula.license.first}\""
+            formula.license.to_s.gsub(/:(\w+)=>/, '\1: ')                   # Change `:any_of=>` to `any_of: `
+                   .tr("{}", "")                                            # Remove braces
+                   .gsub(/=>with: "([a-zA-Z0-9-]+)"/, ' => { with: "\1" }') # Add braces and spacing around exceptions
           end
           # insert replacement revision after license
           <<~EOS

--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -40,8 +40,11 @@ module Homebrew
         end
 
         old = if formula.license
-          license_string = if formula.license.is_a? String
+          license_string = case formula.license
+          when String
             "\"#{formula.license}\""
+          when Symbol
+            ":#{formula.license}"
           else
             formula.license.to_s.gsub(/:(\w+)=>/, '\1: ')                   # Change `:any_of=>` to `any_of: `
                    .tr("{}", "")                                            # Remove braces


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fix `bump-revision` to work with the new license syntax

`bump-revision` can now handle license strings and license hashes (I didn't add support for arrays because they are deprecated as of 2.5.0)

I've tested with the following licenses:

```ruby
license "MIT"

license :public_domain

license "MIT" => { with: "LLVM-exception" }

license any_of: ["MIT", "0BSD"]

license all_of: ["MIT", "0BSD"]

license any_of: ["MIT", all_of: ["0BSD", "Zlib"]]

license any_of: ["GPL-2.0-or-later", "MIT" => { with: "LLVM-exception" }, any_of: ["MIT", "0BSD"]]
```