### PR TITLE
bash completion: Avoid cask deprecation warnings, learn --cask

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -312,7 +312,7 @@ _brew_link() {
 }
 
 _brew_list() {
-  local allopts="--unbrewed --verbose --pinned --versions --multiple"
+  local allopts="--unbrewed --verbose --pinned --versions --multiple --cask"
   local cur="${COMP_WORDS[COMP_CWORD]}"
 
   case "$cur" in
@@ -408,7 +408,7 @@ _brew_outdated() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     -*)
-      __brewcomp "--quiet --json=v1 --fetch-HEAD"
+      __brewcomp "--quiet --cask --json=v1 --fetch-HEAD"
       return
       ;;
   esac
@@ -578,6 +578,7 @@ _brew_upgrade() {
         --all
         --build-from-source --build-bottle --force-bottle
         --cleanup
+        --cask
         --debug
         --verbose
         --fetch-HEAD
@@ -656,7 +657,7 @@ __brew_cask_complete_formulae ()
 __brew_cask_complete_installed ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local inst=$(brew cask list -1)
+    local inst=$(brew list --cask -1)
     COMPREPLY=($(compgen -W "$inst" -- "$cur"))
 }
 
@@ -672,7 +673,7 @@ __brew_cask_complete_outdated ()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
     local greedy=$(__brew_caskcomp_words_include "--greedy" && echo "--greedy")
-    local outdated=$(brew cask outdated --quiet $greedy)
+    local outdated=$(brew outdated --cask --quiet $greedy)
     COMPREPLY=($(compgen -W "$outdated" -- "$cur"))
 }
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
As noted in #8709, this would remove some warnings in bash completion and make `brew` more aware of `--cask` when appropriate.