### PR TITLE
Added basic formulae memoization to speed up install completion

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -603,6 +603,8 @@ EOS
     fi
   done
 
+  brew search > "$HOMEBREW_CACHE"/all_formulae_list.txt
+
   safe_cd "$HOMEBREW_REPOSITORY"
 
   if [[ -n "$HOMEBREW_UPDATED" ||
@@ -610,6 +612,7 @@ EOS
         -n "$HOMEBREW_UPDATE_FORCE" ||
         -d "$HOMEBREW_LIBRARY/LinkedKegs" ||
         ! -f "$HOMEBREW_CACHE/all_commands_list.txt" ||
+        ! -f "$HOMEBREW_CACHE/all_formulae_list.txt" ||
         (-n "$HOMEBREW_DEVELOPER" && -z "$HOMEBREW_UPDATE_PREINSTALL") ]]
   then
     brew update-report "$@"

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -50,9 +50,25 @@ __brewcomp() {
 # it is too slow and is not worth it just for duplicate elimination.
 __brew_complete_formulae() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
-  local formulas="$(brew search)"
-  local shortnames="$(echo "$formulas" | \grep / | \cut -d / -f 3)"
-  COMPREPLY=($(compgen -W "$formulas $shortnames" -- "$cur"))
+  local taplib="$(brew --repository)/Library/Taps"
+  HOMEBREW_CACHE=$(brew --cache)
+  HOMEBREW_REPOSITORY=$(brew --repo)
+
+  for dir in "$taplib"/*/*
+  do
+    [[ -d "$dir" ]] || continue
+    if [[ -n "$(git -C $dir status --porcelain)" ]]; then
+      local clean=0
+      break
+    fi
+  done
+
+  if [[ -v $clean || ! -f "$HOMEBREW_CACHE/all_formulae_list.txt" ]]; then
+    brew search > $HOMEBREW_CACHE/all_formulae_list.txt
+  fi
+
+  local cmds="$(cat "$HOMEBREW_CACHE/all_formulae_list.txt")"
+  COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
 }
 
 __brew_complete_installed() {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
-----

This is a fairly straightforward pull request.  It uses the same technique that brew is already using to speed up command completion (by caching available commands in a text file), but to speed up formula name completion for the `brew install` command.  

It is very possible there is some edge case I have overlooked, so I welcome any constructive criticism or problems with this method.  If they are addressable, I'll do my best to do so.  

Presently, brew generates the completion list for formula names by calling `brew search` every time.  This pull request still uses that method, but caches the list, specifically upon `brew update`, as well as any time that a change (like new untracked files) are detected in any tap by git, triggered by the tab completion function itself.  This way, the completion will always has the latest list of available formula, even if they have been added (or removed) by the user.  At the same time, the list is only regenerated when needed, instead of every single time tab completion is called. 

`brew search` is fairly heavyweight and takes several seconds to complete, and while using git to check every tap for changes is likewise not terribly performant, it is still much faster than calling brew search.  Any time that call can be avoided, there is a very noticeable speed up in completion.  

This list could also be used to speed up other formulae-related completions potentially, but that can wait - I want to see what everyone thinks of this change first.  

I have been testing this for a few days now, and it has made brew feel a lot snapper and completion is very fast now.  Given the simplicity, the lack of any changes to the actual ruby code base, and the resulting performance increase, I would argue that it is worthwhile.

The only downside is that this would cause the number of taps a user had installed to impact the completion speed, then again, this is already how completion behaves with the `brew search` command.  The time increase is linear, and still much less when using the cached results than the increase to brew search.  In other words, while there is a performance dependence on the number of taps the user has, that performance dependence already exists with `brew search`, and the impact is proportionally less when simply calling `git status --porcelain` once per tap, so regardless of the number of taps, this should always be faster.  

Thoughts?