### PR TITLE
Allow `toggl-track` to be a pre-release.

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -35,6 +35,7 @@ module SharedAudits
     "pock"             => :all,
     "riff"             => "0.5.0",
     "telegram-cli"     => "1.3.1",
+    "toggl-track"      => :all,
     "volta"            => "0.8.6",
   }.freeze
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

CI for https://github.com/Homebrew/homebrew-cask/pull/89179 is currently failing because of this. There are only pre-releases so far.