### PR TITLE
Add Git diff driver for `.drawio.svg` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Diff drivers for textconv
+
+*.drawio.svg    text diff=drawio-mxfile-svg eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@
 # Unignore our root-level metadata files.
 !/.dockerignore
 !/.editorconfig
+!/.gitattributes
 !/.gitignore
 !/.yardopts
 !/.vale.ini

--- a/docs/Diagram-Guidelines.md
+++ b/docs/Diagram-Guidelines.md
@@ -43,3 +43,67 @@ img[src$=".drawio.svg"] {
   }
 }
 ```
+
+## The Git diff driver
+
+Setting up a Git diff driver for `.drawio.svg` files is optional. The diff driver is useful to have though: it makes `git diff` ignore the SVG part and look at the original source only.
+
+### How a diff driver helps
+
+Without a diff driver:
+
+```diff
+--- a/managing-pull-requests.drawio.svg
++++ b/managing-pull-requests.drawio.svg
+@@ -1,4 +1,4 @@
+-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="759px" height="936px" viewBox="-0.5 -0.5 759 936" content="&lt;mxfile host=&quot;&quot; modified=&quot;2020-07-16T21:15:00.400Z&quot; agent=&quot;5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.46.1 Chrome/78.0.3904.130 Electron/7.3.1 Safari/537.36&quot; etag=&quot;pmHBLrtnrX4nNGyRVqOD&quot; version=&quot;13.1.3&quot;&gt;&lt;diagram id=&quot;6hGFLwfOUW9BJ-s0fimq&quot; name=&quot;Page-1&quot;&gt;7Vzbkps4EP0aP3oKxM1+nOsmVcnWVGUr2TylsJFtdjFyhJix8/UrgWSQBLbHCHuozcsMSKIR6u7TRy3JI+d+vf0Dh5vVZxTBZASsaDtyHkYA2Baw6T9WsitLJrZXFixxHPFGVcGX+BcUT/LSPI5gJjUkCCUk3siFc5SmcE
+[…] (184 lines omitted)
+```
+
+With the diff driver:
+
+```diff
+--- a/managing-pull-requests.drawio.svg
++++ b/managing-pull-requests.drawio.svg
+@@ -188,5 +188,8 @@
+     <mxCell id="54" parent="1" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=trapezoid;perimeter=trapezoidPerimeter;whiteSpace=wrap;size=0.23;arcSize=10;flipV=1;" vertex="1" value="Push the button">
+       <mxGeometry x="560" y="550" width="100" height="60" as="geometry"/>
+     </mxCell>
++    <mxCell id="70" parent="1" style="" vertex="1" value="Cheers!">
++      <mxGeometry x="92" y="900" width="120" height="60" as="geometry"/>
++    </mxCell>
+   </root>
+ </mxGraphModel>
+```
+
+### Installing the diff driver on macOS
+
+To add the `drawio-mxfile-svg` diff driver to your `~/.gitconfig` file, run the following command line from your terminal:
+
+```bash
+git config --global diff.drawio-mxfile-svg.textconv "f() { post_processor=\"\${HOMEBREW_REPOSITORY:-\$(brew --repository)}/docs/contrib/git-textconv/git-textconv-drawio-mxfile.xml\"; if [ -e \"\${post_processor}\" ]; then sed -e '/^<"'!'"DOCTYPE/d' \"\$@\" | xmllint --xpath 'string(/*/@content)' - | xmllint --xpath '/mxfile/diagram/text()' - | base64 --decode | bash -c 'cat <(/usr/bin/xxd -r -p <<< \"1f 8b 08 08 d1 ee 75 58 00 03 63 6f 6e 74 65 6e 74 2e 62 61 73 65 36 34 00\") -' | gunzip 2>/dev/null | ruby -rcgi -pe '\$_ = CGI::unescape(\$_)' | xsltproc \"\${post_processor}\" -; else cat \"\$@\"; fi; }; f"
+```
+
+### Installing the diff driver on Linux
+
+The `drawio-mxfile-svg` diff driver hasn’t been tested yet on Linux.
+
+The diff driver depends on the command-line utilities `base64`, `bash`, `gunzip`, `ruby`, `sed`, `xmllint` and `xsltproc`. Some of those utilities may not be preinstalled on all Linux distributions.
+
+### How the diff driver is implemented
+
+Homebrew’s `.gitattributes` file has a `textconv` entry, which associates the diff driver with `.drawio.svg` files.
+That should be enough information to use the diff driver.
+Just in case the diff driver ever needs debugging, here’s a rundown on its implementation:
+
+1. Call a shell function `f`. This allows the `textconv` logic to accept not only a single command but a sequence of commands.
+1. Accept a path to a *.drawio.svg file, controlled by Git.
+  (The diff driver will not modify that file nor any other file.)
+1. Remove the XML document declaration so `xmllint` can read the file.
+1. Extract the embedded draw.io source code from the SVG file. This is a two-stage process: the first `xmllint` command extracts serialized XML from the `content` attribute, the second one selects the `/mxfile/diagram` part from the payload.
+1. Base64-decode the result to a headerless zipped stream.
+1. Prepend a ZIP header so `gunzip` can process the stream.
+1. Unzip the result.
+1. Unescape URL-encoded bytes.
+1. Post-process the source code to rearrange XML attributes into a defined order.
+1. Print the result to standard output, ready to be read back by Git.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,6 +6,7 @@ remote_theme: Homebrew/brew.sh
 exclude:
   - bin
   - CNAME
+  - contrib
   - Gemfile*
   - vale-styles
   - vendor

--- a/docs/contrib/git-textconv/git-textconv-drawio-mxfile.xml
+++ b/docs/contrib/git-textconv/git-textconv-drawio-mxfile.xml
@@ -1,0 +1,55 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+	<xsl:output method="xml" indent="yes"/>
+
+	<xsl:template match="mxGraphModel">
+		<xsl:copy>
+			<xsl:for-each select="@grid"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@gridSize"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@guides"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@tooltips"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@connect"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@arrows"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@fold"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@page"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@pageScale"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@pageWidth"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@pageHeight"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@background"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@math"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@shadow"><xsl:copy/></xsl:for-each>
+			<xsl:apply-templates select="*|text()" />
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="mxCell">
+		<xsl:copy>
+			<xsl:for-each select="@edge"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@id"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@parent"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@style"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@target"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@vertex"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@*"><xsl:copy/></xsl:for-each>
+			<xsl:apply-templates select="*|text()" />
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="mxPoint">
+		<xsl:copy>
+			<xsl:for-each select="@as"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@x"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@y"><xsl:copy/></xsl:for-each>
+			<xsl:for-each select="@*"><xsl:copy/></xsl:for-each>
+			<xsl:apply-templates select="*|text()" />
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="*">
+		<xsl:copy>
+			<xsl:for-each select="@*">
+				<xsl:copy />
+			</xsl:for-each>
+			<xsl:apply-templates select="*|text()" />
+		</xsl:copy>
+	</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

## Summary

Originally part of #8627 but spun off as @SMillerDev [suggested](https://github.com/Homebrew/brew/pull/8627#issuecomment-687711397).

The diff driver helps with `git diff` on [diagrams](https://github.com/Homebrew/brew/blob/master/docs/Diagram-Guidelines.md) in the draw.io format.
The driver requires an XSLT file, which is included in this PR. The XSLT code enforces a defined order for XML attributes, which removes noise from diffs.

## Setting up and using the driver

This PR adds the necessary information to the Diagram Guidelines.

## Comparison of `git diff` outputs

### Without a diff driver

```diff
--- a/managing-pull-requests.drawio.svg
+++ b/managing-pull-requests.drawio.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="759px" height="936px" viewBox="-0.5 -0.5 759 936" content="&lt;mxfile host=&quot;&quot; modified=&quot;2020-07-16T21:15:00.400Z&quot; agent=&quot;5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.46.1 Chrome/78.0.3904.130 Electron/7.3.1 Safari/537.36&quot; etag=&quot;pmHBLrtnrX4nNGyRVqOD&quot; version=&quot;13.1.3&quot;&gt;&lt;diagram id=&quot;6hGFLwfOUW9BJ-s0fimq&quot; name=&quot;Page-1&quot;&gt;7Vzbkps4EP0aP3oKxM1+nOsmVcnWVGUr2TylsJFtdjFyhJix8/UrgWSQBLbHCHuozcsMSKIR6u7TRy3JI+d+vf0Dh5vVZxTBZASsaDtyHkYA2Baw6T9WsitLJrZXFixxHPFGVcGX+BcUT/LSPI5gJjUkCCUk3siFc5SmcE
[…] (184 lines omitted)
```

### With a diff driver:

```diff
--- a/managing-pull-requests.drawio.svg
+++ b/managing-pull-requests.drawio.svg
@@ -188,5 +188,8 @@
     <mxCell id="54" parent="1" style="verticalLabelPosition=bottom;verticalAlign=top;html=1;shape=trapezoid;perimeter=trapezoidPerimeter;whiteSpace=wrap;size=0.23;arcSize=10;flipV=1;" vertex="1" value="Push the button">
       <mxGeometry x="560" y="550" width="100" height="60" as="geometry"/>
     </mxCell>
+    <mxCell id="70" parent="1" style="" vertex="1" value="Cheers!">
+      <mxGeometry x="92" y="900" width="120" height="60" as="geometry"/>
+    </mxCell>
   </root>
 </mxGraphModel>
```
