### PR TITLE
Strip escape codes from annotations.

### DIFF
--- a/Library/Homebrew/utils/github/actions.rb
+++ b/Library/Homebrew/utils/github/actions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "utils/tty"
+
 module GitHub
   # Helper functions for interacting with GitHub Actions.
   #
@@ -26,7 +28,7 @@ module GitHub
         raise ArgumentError, "Unsupported type: #{type.inspect}" unless [:warning, :error].include?(type)
 
         @type = type
-        @message = String(message)
+        @message = Tty.strip_ansi(message)
         @file = self.class.path_relative_to_workspace(file) if file
         @line = Integer(line) if line
         @column = Integer(column) if column


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Otherwise you end up with annotations like this:

```
download not possible: Checksum for Cask 'rescuetime' does not match.
Expected: [32me4a150a0e9278a32c787475c7549b5af47634b0061146e69552bc02a6396a2bf[0m
  Actual: [31m41f0f340ec75b8296756e4129f6df8743279ddfd77f581d825839c7d7725088f[0m
    File: /Users/runner/Library/Caches/Homebrew/downloads/6c16425385932119cb691c50100bf4fe56fbd2c9979a4db3433801a155ebf112--RescueTimeInstaller.pkg
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  [4mhttps://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/reporting_bugs/checksum_does_not_match_error.md[24m
```
