### PR TITLE
Refactor `cask audit` warnings.

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -30,8 +30,8 @@ module Cask
       appcast = online if appcast.nil?
       download = online if download.nil?
 
-      # `strict` implies `token_conflicts`
-      token_conflicts = strict if token_conflicts.nil?
+      # `new_cask` implies `token_conflicts`
+      token_conflicts = new_cask if token_conflicts.nil?
 
       @cask = cask
       @appcast = appcast
@@ -91,7 +91,11 @@ module Cask
     end
 
     def add_warning(message)
-      warnings << message
+      if strict?
+        add_error message
+      else
+        warnings << message
+      end
     end
 
     def errors?
@@ -299,11 +303,9 @@ module Cask
     end
 
     def check_desc
-      return unless new_cask?
-
       return if cask.desc.present?
 
-      add_error "Cask should have a description. Please add a `desc` stanza."
+      add_warning "Cask should have a description. Please add a `desc` stanza."
     end
 
     def check_url
@@ -380,7 +382,7 @@ module Cask
     end
 
     def check_token_bad_words
-      return unless strict?
+      return unless new_cask?
 
       token = cask.token
 

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -143,7 +143,7 @@ module Cask
 
       return unless cask.artifacts.any? { |k| k.is_a?(Artifact::Pkg) && k.stanza_options.key?(:allow_untrusted) }
 
-      add_warning "allow_untrusted is not permitted in official Homebrew Cask taps"
+      add_error "allow_untrusted is not permitted in official Homebrew Cask taps"
     end
 
     def check_stanza_requires_uninstall
@@ -152,14 +152,14 @@ module Cask
       return if cask.artifacts.none? { |k| k.is_a?(Artifact::Pkg) || k.is_a?(Artifact::Installer) }
       return if cask.artifacts.any? { |k| k.is_a?(Artifact::Uninstall) }
 
-      add_warning "installer and pkg stanzas require an uninstall stanza"
+      add_error "installer and pkg stanzas require an uninstall stanza"
     end
 
     def check_single_pre_postflight
       odebug "Auditing preflight and postflight stanzas"
 
       if cask.artifacts.count { |k| k.is_a?(Artifact::PreflightBlock) && k.directives.key?(:preflight) } > 1
-        add_warning "only a single preflight stanza is allowed"
+        add_error "only a single preflight stanza is allowed"
       end
 
       count = cask.artifacts.count do |k|
@@ -168,14 +168,14 @@ module Cask
       end
       return unless count > 1
 
-      add_warning "only a single postflight stanza is allowed"
+      add_error "only a single postflight stanza is allowed"
     end
 
     def check_single_uninstall_zap
       odebug "Auditing single uninstall_* and zap stanzas"
 
       if cask.artifacts.count { |k| k.is_a?(Artifact::Uninstall) } > 1
-        add_warning "only a single uninstall stanza is allowed"
+        add_error "only a single uninstall stanza is allowed"
       end
 
       count = cask.artifacts.count do |k|
@@ -183,18 +183,18 @@ module Cask
           k.directives.key?(:uninstall_preflight)
       end
 
-      add_warning "only a single uninstall_preflight stanza is allowed" if count > 1
+      add_error "only a single uninstall_preflight stanza is allowed" if count > 1
 
       count = cask.artifacts.count do |k|
         k.is_a?(Artifact::PostflightBlock) &&
           k.directives.key?(:uninstall_postflight)
       end
 
-      add_warning "only a single uninstall_postflight stanza is allowed" if count > 1
+      add_error "only a single uninstall_postflight stanza is allowed" if count > 1
 
       return unless cask.artifacts.count { |k| k.is_a?(Artifact::Zap) } > 1
 
-      add_warning "only a single zap stanza is allowed"
+      add_error "only a single zap stanza is allowed"
     end
 
     def check_required_stanzas
@@ -267,14 +267,14 @@ module Cask
       return unless cask.version.latest?
       return unless cask.appcast
 
-      add_warning "Casks with an appcast should not use version :latest"
+      add_error "Casks with an appcast should not use version :latest"
     end
 
     def check_latest_with_auto_updates
       return unless cask.version.latest?
       return unless cask.auto_updates
 
-      add_warning "Casks with `version :latest` should not use `auto_updates`"
+      add_error "Casks with `version :latest` should not use `auto_updates`"
     end
 
     def check_hosting_with_appcast
@@ -286,15 +286,15 @@ module Cask
       when %r{github.com/([^/]+)/([^/]+)/releases/download/(\S+)}
         return if cask.version.latest?
 
-        add_warning "Download uses GitHub releases, #{add_appcast}"
+        add_error "Download uses GitHub releases, #{add_appcast}"
       when %r{sourceforge.net/(\S+)}
         return if cask.version.latest?
 
-        add_warning "Download is hosted on SourceForge, #{add_appcast}"
+        add_error "Download is hosted on SourceForge, #{add_appcast}"
       when %r{dl.devmate.com/(\S+)}
-        add_warning "Download is hosted on DevMate, #{add_appcast}"
+        add_error "Download is hosted on DevMate, #{add_appcast}"
       when %r{rink.hockeyapp.net/(\S+)}
-        add_warning "Download is hosted on HockeyApp, #{add_appcast}"
+        add_error "Download is hosted on HockeyApp, #{add_appcast}"
       end
     end
 
@@ -303,7 +303,7 @@ module Cask
 
       return if cask.desc.present?
 
-      add_warning "Cask should have a description. Please add a `desc` stanza."
+      add_error "Cask should have a description. Please add a `desc` stanza."
     end
 
     def check_url
@@ -315,9 +315,9 @@ module Cask
     def check_download_url_format
       odebug "Auditing URL format"
       if bad_sourceforge_url?
-        add_warning "SourceForge URL format incorrect. See https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/url.md#sourceforgeosdn-urls"
+        add_error "SourceForge URL format incorrect. See https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/url.md#sourceforgeosdn-urls"
       elsif bad_osdn_url?
-        add_warning "OSDN URL format incorrect. See https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/url.md#sourceforgeosdn-urls"
+        add_error "OSDN URL format incorrect. See https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/url.md#sourceforgeosdn-urls"
       end
     end
 
@@ -363,29 +363,20 @@ module Cask
     end
 
     def check_token_valid
-      return unless strict?
-
-      add_warning "cask token is not lowercase" if cask.token.downcase!
-
-      add_warning "cask token contains non-ascii characters" unless cask.token.ascii_only?
-
-      add_warning "cask token + should be replaced by -plus-" if cask.token.include? "+"
-
-      add_warning "cask token @ should be replaced by -at-" if cask.token.include? "@"
-
-      add_warning "cask token whitespace should be replaced by hyphens" if cask.token.include? " "
-
-      add_warning "cask token underscores should be replaced by hyphens" if cask.token.include? "_"
+      add_error "cask token contains non-ascii characters" unless cask.token.ascii_only?
+      add_error "cask token + should be replaced by -plus-" if cask.token.include? "+"
+      add_error "cask token whitespace should be replaced by hyphens" if cask.token.include? " "
+      add_error "cask token @ should be replaced by -at-" if cask.token.include? "@"
+      add_error "cask token underscores should be replaced by hyphens" if cask.token.include? "_"
+      add_error "cask token should not contain double hyphens" if cask.token.include? "--"
 
       if cask.token.match?(/[^a-z0-9\-]/)
-        add_warning "cask token should only contain alphanumeric characters and hyphens"
+        add_error "cask token should only contain lowercase alphanumeric characters and hyphens"
       end
 
-      add_warning "cask token should not contain double hyphens" if cask.token.include? "--"
+      return unless cask.token.start_with?("-") || cask.token.end_with?("-")
 
-      return unless cask.token.end_with?("-") || cask.token.start_with?("-")
-
-      add_warning "cask token should not have leading or trailing hyphens"
+      add_error "cask token should not have leading or trailing hyphens"
     end
 
     def check_token_bad_words
@@ -393,12 +384,12 @@ module Cask
 
       token = cask.token
 
-      add_warning "cask token contains .app" if token.end_with? ".app"
+      add_error "cask token contains .app" if token.end_with? ".app"
 
       if /-(?<designation>alpha|beta|rc|release-candidate)$/ =~ cask.token &&
          cask.tap&.official? &&
          cask.tap != "homebrew/cask-versions"
-        add_warning "cask token contains version designation '#{designation}'"
+        add_error "cask token contains version designation '#{designation}'"
       end
 
       add_warning "cask token mentions launcher" if token.end_with? "launcher"
@@ -433,7 +424,7 @@ module Cask
       downloaded_path = download.perform
       Verify.all(cask, downloaded_path)
     rescue => e
-      add_error "download not possible: #{e.message}"
+      add_error "download not possible: #{e}"
     end
 
     def check_appcast_contains_version
@@ -458,7 +449,7 @@ module Cask
       end
       return if appcast_contents.include? adjusted_version_stanza
 
-      add_warning "appcast at URL '#{appcast_stanza}' does not contain"\
+      add_error "appcast at URL '#{appcast_stanza}' does not contain"\
                   " the version number '#{adjusted_version_stanza}':\n#{appcast_contents}"
     end
 

--- a/Library/Homebrew/cask/cmd/audit.rb
+++ b/Library/Homebrew/cask/cmd/audit.rb
@@ -59,8 +59,6 @@ module Cask
           odebug "Auditing Cask #{cask}"
           result = Auditor.audit(cask, **options)
 
-          next true if result[:warnings].empty? && result[:errors].empty?
-
           if ENV["GITHUB_ACTIONS"]
             cask_path = cask.sourcefile_path
             annotations = (result[:warnings].map { |w| [:warning, w] } + result[:errors].map { |e| [:error, e] })
@@ -71,7 +69,7 @@ module Cask
             end
           end
 
-          false
+          result[:errors].empty?
         end
 
         return if failed_casks.empty?

--- a/Library/Homebrew/test/cask/cmd/cat_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/cat_spec.rb
@@ -15,6 +15,8 @@ describe Cask::Cmd::Cat, :cask do
           sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
 
           url "https://brew.sh/TestCask.dmg"
+          name "Basic Cask"
+          desc "Cask for testing basic functionality"
           homepage "https://brew.sh/"
 
           app "TestCask.app"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/adobe-air.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/adobe-air.rb
@@ -3,7 +3,8 @@ cask "adobe-air" do
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
 
   url "https://brew.sh/TestCask.dmg"
-  name "Adobe Air"
+  name "Adobe AIR"
+  desc "Cross-platform application runtime"
   homepage "https://brew.sh/"
 
   app "TestCask.app"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/auto-updates.rb
@@ -3,6 +3,8 @@ cask "auto-updates" do
   sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
+  name "Auto-Updates"
+  desc "Cask which auto-updates"
   homepage "https://brew.sh/MyFancyApp"
 
   auto_updates true

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/basic-cask.rb
@@ -3,6 +3,8 @@ cask "basic-cask" do
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
 
   url "https://brew.sh/TestCask.dmg"
+  name "Basic Cask"
+  desc "Cask for testing basic functionality"
   homepage "https://brew.sh/"
 
   app "TestCask.app"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/latest-with-auto-updates.rb
@@ -3,6 +3,8 @@ cask "latest-with-auto-updates" do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "Latest with Auto-Updates"
+  desc "Unversioned cask which auto-updates"
   homepage "https://brew.sh/latest-with-auto-updates"
 
   auto_updates true

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/pkg-without-uninstall.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/pkg-without-uninstall.rb
@@ -3,6 +3,8 @@ cask "pkg-without-uninstall" do
   sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
 
   url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyPkg.zip"
+  name "PKG without Uninstall"
+  desc "Cask with a package installer and no uninstall stanza"
   homepage "https://brew.sh/fancy-pkg"
 
   pkg "Fancy.pkg"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/version-latest.rb
@@ -3,6 +3,8 @@ cask "version-latest" do
   sha256 :no_check
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeines.zip"
+  name "Version Latest"
+  desc "Unversioned cask"
   homepage "https://brew.sh/"
 
   app "Caffeine Mini.app"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-binary.rb
@@ -3,6 +3,8 @@ cask "with-binary" do
   sha256 "d5b2dfbef7ea28c25f7a77cd7fa14d013d82b626db1d82e00e25822464ba19e2"
 
   url "file://#{TEST_FIXTURE_DIR}/cask/AppWithBinary.zip"
+  name "With Binary"
+  desc "Cask with a binary stanza"
   homepage "https://brew.sh/with-binary"
 
   app "App.app"

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-installer-manual.rb
@@ -3,6 +3,8 @@ cask "with-installer-manual" do
   sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
 
   url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
+  name "With Installer Manual"
+  desc "Cask with a manual installer"
   homepage "https://brew.sh/"
 
   installer manual: "Caffeine.app"

--- a/Library/Homebrew/test/support/fixtures/third-party/Casks/pharo.rb
+++ b/Library/Homebrew/test/support/fixtures/third-party/Casks/pharo.rb
@@ -4,6 +4,7 @@ cask "pharo" do
 
   url "https://brew.sh/ThirdParty.dmg"
   name "Pharo"
+  desc "Cask from a third-party tap"
   homepage "https://brew.sh/"
 
   app "ThirdParty.app"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Previously `cask audit` would fail on both warnings and errors. This makes it so it only fails on errors. For this, some warnings are now hard errors (no casks should be failing these anyways).

This allows showing a warning for existing casks and hard errors for new casks, e.g. for the `desc` stanza. This way contributors will hopefully notice that we want a description to be added while not making CI fail for simple version bumps.
