### PR TITLE
pr-pull: implement autosquash option

### DIFF
--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -44,6 +44,14 @@ describe Utils::Git do
   let(:files_hash1) { [@h3[0..6], ["LICENSE.txt"]] }
   let(:files_hash2) { [@h2[0..6], ["README.md"]] }
 
+  describe "#cherry_pick!" do
+    it "aborts when cherry picking an existing hash" do
+      expect {
+        described_class.cherry_pick!(HOMEBREW_CACHE, file_hash1)
+      }.to raise_error(ErrorDuringExecution, /Merge conflict in README.md/)
+    end
+  end
+
   describe "#last_revision_commit_of_file" do
     it "gives last revision commit when before_commit is nil" do
       expect(

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "open3"
-
 module Utils
   # Helper functions for querying Git information.
   #
@@ -16,7 +14,7 @@ module Utils
     def version
       return @version if defined?(@version)
 
-      stdout, _, status = system_command(HOMEBREW_SHIMS_PATH/"scm/git", args: ["--version"], print_stderr: false)
+      stdout, _, status = system_command(git, args: ["--version"], print_stderr: false)
       @version = status.success? ? stdout.chomp[/git version (\d+(?:\.\d+)*)/, 1] : nil
     end
 
@@ -24,7 +22,13 @@ module Utils
       return unless available?
       return @path if defined?(@path)
 
-      @path = Utils.popen_read(HOMEBREW_SHIMS_PATH/"scm/git", "--homebrew=print-path").chomp.presence
+      @path = Utils.popen_read(git, "--homebrew=print-path").chomp.presence
+    end
+
+    def git
+      return @git if defined?(@git)
+
+      @git = HOMEBREW_SHIMS_PATH/"scm/git"
     end
 
     def remote_exists?(url)
@@ -36,6 +40,7 @@ module Utils
     def clear_available_cache
       remove_instance_variable(:@version) if defined?(@version)
       remove_instance_variable(:@path) if defined?(@path)
+      remove_instance_variable(:@git) if defined?(@git)
     end
 
     def last_revision_commit_of_file(repo, file, before_commit: nil)
@@ -45,12 +50,7 @@ module Utils
         [before_commit.split("..").first]
       end
 
-      out, = Open3.capture3(
-        HOMEBREW_SHIMS_PATH/"scm/git", "-C", repo,
-        "log", "--format=%h", "--abbrev=7", "--max-count=1",
-        *args, "--", file
-      )
-      out.chomp
+      Utils.popen_read(git, "-C", repo, "log", "--format=%h", "--abbrev=7", "--max-count=1", *args, "--", file).chomp
     end
 
     def last_revision_commit_of_files(repo, files, before_commit: nil)
@@ -66,12 +66,11 @@ module Utils
       #   <file_path2>
       #   ...
       # return [<commit_hash>, [file_path1, file_path2, ...]]
-      out, = Open3.capture3(
-        HOMEBREW_SHIMS_PATH/"scm/git", "-C", repo, "log",
+      rev, *paths = Utils.popen_read(
+        git, "-C", repo, "log",
         "--pretty=format:%h", "--abbrev=7", "--max-count=1",
         "--diff-filter=d", "--name-only", *args, "--", *files
-      )
-      rev, *paths = out.chomp.split(/\n/).reject(&:empty?)
+      ).lines.map(&:chomp).reject(&:empty?)
       [rev, paths]
     end
 
@@ -79,11 +78,7 @@ module Utils
       relative_file = Pathname(file).relative_path_from(repo)
 
       commit_hash = last_revision_commit_of_file(repo, relative_file, before_commit: before_commit)
-      out, = Open3.capture3(
-        HOMEBREW_SHIMS_PATH/"scm/git", "-C", repo,
-        "show", "#{commit_hash}:#{relative_file}"
-      )
-      out
+      Utils.popen_read(git, "-C", repo, "show", "#{commit_hash}:#{relative_file}")
     end
 
     def ensure_installed!
@@ -121,7 +116,7 @@ module Utils
     end
 
     def origin_branch(repo)
-      Utils.popen_read("git", "-C", repo, "symbolic-ref", "-q", "--short",
+      Utils.popen_read(git, "-C", repo, "symbolic-ref", "-q", "--short",
                        "refs/remotes/origin/HEAD").chomp.presence
     end
   end

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -119,5 +119,19 @@ module Utils
       Utils.popen_read(git, "-C", repo, "symbolic-ref", "-q", "--short",
                        "refs/remotes/origin/HEAD").chomp.presence
     end
+
+    # Special case of `git cherry-pick` that permits non-verbose output and
+    # optional resolution on merge conflict.
+    def cherry_pick!(repo, *args, resolve: false, verbose: false)
+      cmd = [git, "-C", repo, "cherry-pick"] + args
+      output = Utils.popen_read(*cmd, err: :out)
+      if $CHILD_STATUS.success?
+        puts output if verbose
+        output
+      else
+        system git, "-C", repo, "cherry-pick", "--abort" unless resolve
+        raise ErrorDuringExecution.new(cmd, status: $CHILD_STATUS, output: [[:stdout, output]])
+      end
+    end
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1096,12 +1096,16 @@ Requires write access to the repository.
   Do not amend the commits from pull requests.
 * `--keep-old`:
   If the formula specifies a rebuild version, attempt to preserve its value in the generated DSL.
+* `--autosquash`:
+  Automatically reformat and reword commits in the pull request to our preferred format.
 * `--branch-okay`:
   Do not warn if pulling to a branch besides master (useful for testing).
 * `--resolve`:
   When a patch fails to apply, leave in progress and allow user to resolve, instead of aborting.
 * `--warn-on-upload-failure`:
   Warn instead of raising an error if the bottle upload fails. Useful for repairing bottle uploads that previously failed.
+* `--message`:
+  Message to include when autosquashing revision bumps, deletions, and rebuilds.
 * `--workflow`:
   Retrieve artifacts from the specified workflow (default: `tests.yml`).
 * `--artifact`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1519,6 +1519,10 @@ Do not amend the commits from pull requests\.
 If the formula specifies a rebuild version, attempt to preserve its value in the generated DSL\.
 .
 .TP
+\fB\-\-autosquash\fR
+Automatically reformat and reword commits in the pull request to our preferred format\.
+.
+.TP
 \fB\-\-branch\-okay\fR
 Do not warn if pulling to a branch besides master (useful for testing)\.
 .
@@ -1529,6 +1533,10 @@ When a patch fails to apply, leave in progress and allow user to resolve, instea
 .TP
 \fB\-\-warn\-on\-upload\-failure\fR
 Warn instead of raising an error if the bottle upload fails\. Useful for repairing bottle uploads that previously failed\.
+.
+.TP
+\fB\-\-message\fR
+Message to include when autosquashing revision bumps, deletions, and rebuilds\.
 .
 .TP
 \fB\-\-workflow\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Step 1 of https://github.com/Homebrew/brew/issues/8093.

Maintainers should be able to run e.g. `brew pr-pull --autosquash 1234` and automagically get a reasonable-looking commit message. Still have some testing to do with pull requests with multiple authors and other edge cases but I'd like to get this feature out for review before I neglect it even more.

Simple version bump:

```console
% brew pr-pull --autosquash --no-upload https://github.com/Homebrew/homebrew-core/pull/61130
==> Fetching homebrew/core pull request #61130
==> Using 3 commits from #61130
HEAD is now at 6ab7a1fda2 benthos: update 3.28.0 bottle.
==> openfast 2.4.0
==> Downloading https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/17574672/zip
% git log -1
commit 8a9aa14ed99c30937fa964bb5a309d986189b761 (HEAD -> master)
Author: Rafael M Mudafort <rafmudaf@gmail.com>
Date:   Mon Sep 14 18:04:27 2020 -0500

    openfast 2.4.0

    * Update to v2.4.0
    * Update test case input file
    * Remove 'revision' line - brew test feedback

    Closes #61130.
```

New formula:

```console
% brew pr-pull --autosquash --no-upload https://github.com/Homebrew/homebrew-core/pull/61125
==> Fetching homebrew/core pull request #61125
==> Using 4 commits from #61125
HEAD is now at 6ab7a1fda2 benthos: update 3.28.0 bottle.
==> youtube-dlc 2020.09.13 (new formula)
Error: No artifact with the name `bottles` was found!
  https://github.com/Homebrew/homebrew-core/actions/runs/254441461
% git log -1
commit 68c7c77b92d993e240fa8791a6a86ac46a16769b (HEAD -> master)
Author: Christopher Nethercott <ccnethercott@gmail.com>
Date:   Mon Sep 14 20:25:43 2020 +0100

    youtube-dlc 2020.09.13 (new formula)

    * Added youtube-dlc
    * Removed unusued comments for youtube-dlc
    * Removed erroronous tabs
    * Removed redundent comment and used version as variable for the URL

    Closes #61125.
```

Rewording a commit:

```console
% brew pr-pull --autosquash --no-upload --message "for FLAC support" https://github.com/Homebrew/homebrew-core/pull/60740
==> Fetching homebrew/core pull request #60740
==> Using 2 commits from #60740
HEAD is now at 6ab7a1fda2 benthos: update 3.28.0 bottle.
==> sdl_mixer: revision for FLAC support
==> Downloading https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/16631782/zip
% git log -1
commit 4ad0537331a490af5aaf471ce89713e29e0c39d2 (HEAD -> master)
Author: Kreeblah <kreeblah@gmail.com>
Date:   Sun Sep 6 18:36:34 2020 -0700

    sdl_mixer: revision for FLAC support

    * Added FLAC music support to sdl_mixer formula
    * Added license

    Closes #60740.
```