### PR TITLE
pr-pull: don't require bintray credentials to be set

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -4,7 +4,6 @@ require "download_strategy"
 require "cli/parser"
 require "utils/github"
 require "tmpdir"
-require "bintray"
 require "formula"
 
 module Homebrew
@@ -24,7 +23,7 @@ module Homebrew
                           "upload the bottles to Bintray, but don't publish them."
       switch "--no-upload",
              description: "Download the bottles and apply the bottle commit, "\
-                          "but don't upload to Bintray."
+                          "but don't upload to Bintray or GitHub Releases."
       switch "-n", "--dry-run",
              description: "Print what would be done rather than doing it."
       switch "--clean",
@@ -211,16 +210,9 @@ module Homebrew
   def pr_pull
     args = pr_pull_args.parse
 
-    bintray_user = ENV["HOMEBREW_BINTRAY_USER"]
-    bintray_key = ENV["HOMEBREW_BINTRAY_KEY"]
-    bintray_org = args.bintray_org || "homebrew"
-
-    if (bintray_user.blank? || bintray_key.blank?) && !args.dry_run? && !args.no_upload?
-      odie "Missing HOMEBREW_BINTRAY_USER or HOMEBREW_BINTRAY_KEY variables!"
-    end
-
     workflow = args.workflow || "tests.yml"
     artifact = args.artifact || "bottles"
+    bintray_org = args.bintray_org || "homebrew"
     mirror_repo = args.bintray_mirror || "mirror"
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1085,7 +1085,7 @@ Requires write access to the repository.
 * `--no-publish`:
   Download the bottles, apply the bottle commit and upload the bottles to Bintray, but don't publish them.
 * `--no-upload`:
-  Download the bottles and apply the bottle commit, but don't upload to Bintray.
+  Download the bottles and apply the bottle commit, but don't upload to Bintray or GitHub Releases.
 * `-n`, `--dry-run`:
   Print what would be done rather than doing it.
 * `--clean`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1496,7 +1496,7 @@ Download the bottles, apply the bottle commit and upload the bottles to Bintray,
 .
 .TP
 \fB\-\-no\-upload\fR
-Download the bottles and apply the bottle commit, but don\'t upload to Bintray\.
+Download the bottles and apply the bottle commit, but don\'t upload to Bintray or GitHub Releases\.
 .
 .TP
 \fB\-n\fR, \fB\-\-dry\-run\fR


### PR DESCRIPTION
It blocks uploading to GitHub Releases where Bintray credentials are not needed.
Also those checks are already performed in `bintray.rb`.


- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----