### PR TITLE
Set `Accept-Language` header for all `curl` requests.

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -32,6 +32,8 @@ def curl_args(*extra_args, show_output: false, user_agent: :default)
     user_agent
   end
 
+  args << "--header" << "Accept-Language: en"
+
   unless show_output
     args << "--fail"
     args << "--progress-bar" unless Context.current.verbose?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

https://github.com/Homebrew/homebrew-cask/pull/89251 is currently failing because `curl` without the `Accept-Language` header is returning a 404 for https://www.minecraft.net/.

I don't think it hurts passing this header to all requests (tried `brew fetch` with a bunch of formulae and casks).

```
curl -LI https://www.minecraft.net/ # 404
curl -LI -H 'Accept-Language: en' https://www.minecraft.net/ # 200
```
