### PR TITLE
bump-cask-pr: fix branch name for versions with colon

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -193,7 +193,7 @@ module Homebrew
       sourcefile_path: cask.sourcefile_path,
       old_contents:    old_contents,
       origin_branch:   origin_branch,
-      branch_name:     "bump-#{cask.token}-#{new_version}",
+      branch_name:     "bump-#{cask.token}-#{new_version.tr(",:", "-")}",
       commit_message:  "Update #{cask.token} from #{old_version} to #{new_version}",
       previous_branch: previous_branch,
       tap:             cask.tap,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Sometimes cask versions include a comma and a colon. However, colons are not allowed in Git branch names, so this PR adds a fix for `brew bump-cask-pr` by replacing the colon with another comma. (Originally, I used a semicolon but this doesn't work well with the Terminal shell as it sees it as the end of a command if it's not placed in quotes)