### PR TITLE
pr-upload: fix getting existing github release

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -92,8 +92,9 @@ module Homebrew
 
         # Ensure a release is created.
         release = begin
-          GitHub.get_release user, repo, tag
+          rel = GitHub.get_release user, repo, tag
           odebug "Existing GitHub release \"#{tag}\" found"
+          rel
         rescue GitHub::HTTPNotFoundError
           odebug "Creating new GitHub release \"#{tag}\""
           GitHub.create_or_update_release user, repo, tag


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Need to return actual release hash, not odebug's output.