### PR TITLE
bump-formula-pr, bump-cask-pr: add `--online` switch for audit

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -27,6 +27,8 @@ module Homebrew
                           "to the cask file."
       switch "--no-audit",
              description: "Don't run `brew cask audit` before opening the PR."
+      switch "--online",
+             description: "Run `brew cask audit --online` before opening the PR."
       switch "--no-style",
              description: "Don't run `brew cask style --fix` before opening the PR."
       switch "--no-browse",
@@ -45,6 +47,7 @@ module Homebrew
              description: "Ignore duplicate open PRs."
 
       conflicts "--dry-run", "--write"
+      conflicts "--no-audit", "--online"
       named 1
     end
   end
@@ -225,6 +228,8 @@ module Homebrew
     if args.dry_run?
       if args.no_audit?
         ohai "Skipping `brew cask audit`"
+      elsif args.online?
+        ohai "brew cask audit --online #{cask.sourcefile_path.basename}"
       else
         ohai "brew cask audit #{cask.sourcefile_path.basename}"
       end
@@ -233,6 +238,9 @@ module Homebrew
     failed_audit = false
     if args.no_audit?
       ohai "Skipping `brew cask audit`"
+    elsif args.online?
+      system HOMEBREW_BREW_FILE, "cask", "audit", "--online", cask.sourcefile_path
+      failed_audit = !$CHILD_STATUS.success?
     else
       system HOMEBREW_BREW_FILE, "cask", "audit", cask.sourcefile_path
       failed_audit = !$CHILD_STATUS.success?

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -880,6 +880,8 @@ nor vice versa. It must use whichever style specification the formula already us
   Don't run `brew audit` before opening the PR.
 * `--strict`:
   Run `brew audit --strict` before opening the PR.
+* `--online`:
+  Run `brew audit --online` before opening the PR.
 * `--no-browse`:
   Print the pull request URL instead of opening in a browser.
 * `--no-fork`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -834,6 +834,8 @@ supplied by the user.
   When passed with `--write`, generate a new commit after writing changes to the cask file.
 * `--no-audit`:
   Don't run `brew cask audit` before opening the PR.
+* `--online`:
+  Run `brew cask audit --online` before opening the PR.
 * `--no-style`:
   Don't run `brew cask style --fix` before opening the PR.
 * `--no-browse`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1157,6 +1157,10 @@ When passed with \fB\-\-write\fR, generate a new commit after writing changes to
 Don\'t run \fBbrew cask audit\fR before opening the PR\.
 .
 .TP
+\fB\-\-online\fR
+Run \fBbrew cask audit \-\-online\fR before opening the PR\.
+.
+.TP
 \fB\-\-no\-style\fR
 Don\'t run \fBbrew cask style \-\-fix\fR before opening the PR\.
 .

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1224,6 +1224,10 @@ Don\'t run \fBbrew audit\fR before opening the PR\.
 Run \fBbrew audit \-\-strict\fR before opening the PR\.
 .
 .TP
+\fB\-\-online\fR
+Run \fBbrew audit \-\-online\fR before opening the PR\.
+.
+.TP
 \fB\-\-no\-browse\fR
 Print the pull request URL instead of opening in a browser\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This adds support for running `brew audit` with `--online`, similar to `--strict` — this would be useful for e.g. checking if a new version is a pre-release before creating a bump PR