### PR TITLE
audit: temporarily allow python3.9 rc

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -712,6 +712,11 @@ module Homebrew
       "vbindiff"        => "3.0_beta",
     }.freeze
 
+    # used for formulae that are unstable but need CI run without being in homebrew/core
+    UNSTABLE_DEVEL_ALLOWLIST = {
+      "python@3.9" => "3.9.0rc",
+    }.freeze
+
     GNOME_DEVEL_ALLOWLIST = {
       "libart"              => "2.3",
       "gtk-mac-integration" => "2.1",
@@ -784,6 +789,7 @@ module Homebrew
         matched = Regexp.last_match(1)
         version_prefix = stable_version_string.sub(/\d+$/, "")
         return if UNSTABLE_ALLOWLIST[formula.name] == version_prefix
+        return if UNSTABLE_DEVEL_ALLOWLIST[formula.name] == version_prefix
 
         problem "Stable version URLs should not contain #{matched}"
       when %r{download\.gnome\.org/sources}, %r{ftp\.gnome\.org/pub/GNOME/sources}i


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
Temporarily allow the python 3.9 release candidate In support of https://github.com/Homebrew/homebrew-core/pull/61163 so that the audit doesn't fail.