### PR TITLE
test/language/java_spec: drop version to 1.6+

### DIFF
--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -5,7 +5,7 @@ require "language/java"
 describe Language::Java do
   describe "::java_home" do
     it "returns valid JAVA_HOME if version is specified", :needs_java do
-      java_home = described_class.java_home("1.8+")
+      java_home = described_class.java_home("1.6+")
       expect(java_home/"bin/java").to be_an_executable
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

On one of my Mac machines I use an app that (still!) works best with the [legacy Java 6 provided by Apple](https://github.com/homebrew/homebrew-cask-versions/blob/master/Casks/java6.rb).

This is the only version of Java I have on this machine:
```
|-> java -version
java version "1.6.0_65"
Java(TM) SE Runtime Environment (build 1.6.0_65-b14-468)
Java HotSpot(TM) 64-Bit Server VM (build 20.65-b04-468, mixed mode)
```

However, having this version causes `brew tests` to (correctly) fail:
```
|-> brew tests --only=language/java
Randomized with seed 41360
1 processes for 1 specs, ~ 1 specs per process
.....F

Failures:

  1) Language::Java::java_home returns valid JAVA_HOME if version is specified
     Failure/Error: expect(java_home/"bin/java").to be_an_executable
     
     NoMethodError:
       undefined method `/' for nil:NilClass
     # ./test/language/java_spec.rb:9:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:194:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:193:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

Finished in 0.16638 seconds (files took 1.38 seconds to load)
6 examples, 1 failure

Failed examples:

rspec ./test/language/java_spec.rb:7 # Language::Java::java_home returns valid JAVA_HOME if version is specified


6 examples, 1 failure

Took 1 seconds
```

Changing the minimum version on `java_spec.rb` to `1.6+` fixes this error:
```
|-> brew tests --only=language/java
Randomized with seed 42928
1 processes for 1 specs, ~ 1 specs per process
......

Finished in 0.16627 seconds (files took 1.39 seconds to load)
6 examples, 0 failures


6 examples, 0 failures

Took 1 seconds
```

I know this is a _very_ old version fo Java, but it _is_ still provided by Apple, hence this PR.

Please feel free to reject this PR if this change would cause other issues that I may not be aware of.

Thank you.