### PR TITLE
test: check for pgrep/pkill for developers/CI.

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -24,6 +24,11 @@ begin
 
   trap("INT", old_trap)
 
+  if Homebrew::EnvConfig.developer? || ENV["CI"].present?
+    raise "cannot find child processes without `pgrep`, please install!" unless which("pgrep")
+    raise "cannot kill child processes without `pkill`, please install!" unless which("pkill")
+  end
+
   formula = args.named.to_resolved_formulae.first
   formula.extend(Homebrew::Assertions)
   formula.extend(Homebrew::FreePort)


### PR DESCRIPTION
If people are running `brew test` but don't have `pgrep` or `pkill` installed the forked processes may never be killed. This is not a big deal on a user's machine but on CI may make a job block and never complete/timeout successfully.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----