### PR TITLE
upgrade: deduplicate list of outdated dependents

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -142,6 +142,7 @@ module Homebrew
 
       outdated_dependents =
         installed_formulae.flat_map(&:runtime_installed_formula_dependents)
+                          .uniq
                           .select(&:outdated?)
       return if outdated_dependents.blank? && already_broken_dependents.blank?
 


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

I have observed duplicates in the list of upgradable dependents printed at [upgrade.rb:171](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/upgrade.rb#L171). This PR calls `uniq` on the list of outdated dependents computed earlier in the method to remove duplicates right after calling `installed_formula.flat_map`, similar to a change made in #8500 when creating the `check_broken_dependents` method.