### PR TITLE
tap-new: enable bottles publishing

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -9,11 +9,15 @@ module Homebrew
   def tap_new_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `tap-new` <user>`/`<repo>
+        `tap-new` [<options>] <user>`/`<repo>
 
         Generate the template files for a new tap.
       EOS
 
+      switch "--no-git",
+             description: "Don't initialize a git repository for the tap."
+      flag   "--pull-label",
+             description: "Label name for pull requests ready to be pulled (default `pr-pull`)."
       named 1
     end
   end
@@ -21,8 +25,10 @@ module Homebrew
   def tap_new
     args = tap_new_args.parse
 
+    label = args.pull_label || "pr-pull"
+
     tap_name = args.named.first
-    tap = Tap.fetch(args.named.first)
+    tap = Tap.fetch(tap_name)
     raise "Invalid tap name '#{tap_name}'" unless tap.path.to_s.match?(HOMEBREW_TAP_PATH_REGEX)
 
     titleized_user = tap.user.dup
@@ -45,7 +51,7 @@ module Homebrew
     MARKDOWN
     write_path(tap, "README.md", readme)
 
-    actions = <<~YAML
+    actions_main = <<~YAML
       name: brew test-bot
       on:
         push:
@@ -53,10 +59,10 @@ module Homebrew
         pull_request:
       jobs:
         test-bot:
-          runs-on: ${{ matrix.os }}
           strategy:
             matrix:
               os: [ubuntu-latest, macOS-latest]
+          runs-on: ${{ matrix.os }}
           steps:
             - name: Set up Homebrew
               id: set-up-homebrew
@@ -82,12 +88,70 @@ module Homebrew
 
             - run: brew test-bot --only-formulae
               if: github.event_name == 'pull_request'
+
+            - name: Upload bottles as artifact
+              if: always() && github.event_name == 'pull_request'
+              uses: actions/upload-artifact@main
+              with:
+                name: bottles
+                path: '*.bottle.*'
+    YAML
+
+    actions_publish = <<~YAML
+      name: brew pr-pull
+      on:
+        pull_request_target:
+          types:
+            - labeled
+      jobs:
+        pr-pull:
+          if: contains(github.event.pull_request.labels.*.name, #{label})
+          runs-on: ubuntu-latest
+          steps:
+            - name: Set up Homebrew
+              uses: Homebrew/actions/setup-homebrew@master
+
+            - name: Set up git
+              uses: Homebrew/actions/git-user-config@master
+
+            - name: Pull bottles
+              env:
+                HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+                PULL_REQUEST: ${{ github.event.pull_request.number }}
+              run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+
+            - name: Push commits
+              uses: Homebrew/actions/git-try-push@master
+              with:
+                token: ${{ github.token }}
+
+            - name: Delete branch
+              if: github.event.pull_request.head.repo.fork == false
+              env:
+                BRANCH: ${{ github.event.pull_request.head.ref }}
+              run: git push --delete origin $BRANCH
     YAML
 
     (tap.path/".github/workflows").mkpath
-    write_path(tap, ".github/workflows/tests.yml", actions)
+    write_path(tap, ".github/workflows/tests.yml", actions_main)
+    write_path(tap, ".github/workflows/publish.yml", actions_publish)
+
+    unless args.no_git?
+      cd tap.path do
+        safe_system "git", "init"
+        safe_system "git", "add", "--all"
+        safe_system "git", "commit", "-m", "Create #{tap} tap"
+      end
+    end
+
     ohai "Created #{tap}"
-    puts tap.path.to_s
+    puts <<~EOS
+      #{tap.path}
+
+      When a pull request making changes to a formula (or formulae) becomes green
+      (all checks passed), then you can publish the built bottles.
+      To do so, label your PR as `#{label}` and the workflow will be triggered.
+    EOS
   end
 
   def write_path(tap, filename, content)

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1240,9 +1240,14 @@ including core code and all formulae.
 * `--except-cops`:
   Specify a comma-separated *`cops`* list to skip checking for violations of the listed RuboCop cops.
 
-### `tap-new` *`user`*`/`*`repo`*
+### `tap-new` [*`options`*] *`user`*`/`*`repo`*
 
 Generate the template files for a new tap.
+
+* `--no-git`:
+  Don't initialize a git repository for the tap.
+* `--pull-label`:
+  Label name for pull requests ready to be pulled (default `pr-pull`).
 
 ### `test` [*`options`*] *`formula`*
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1738,8 +1738,16 @@ Specify a comma\-separated \fIcops\fR list to check for violations of only the l
 \fB\-\-except\-cops\fR
 Specify a comma\-separated \fIcops\fR list to skip checking for violations of the listed RuboCop cops\.
 .
-.SS "\fBtap\-new\fR \fIuser\fR\fB/\fR\fIrepo\fR"
+.SS "\fBtap\-new\fR [\fIoptions\fR] \fIuser\fR\fB/\fR\fIrepo\fR"
 Generate the template files for a new tap\.
+.
+.TP
+\fB\-\-no\-git\fR
+Don\'t initialize a git repository for the tap\.
+.
+.TP
+\fB\-\-pull\-label\fR
+Label name for pull requests ready to be pulled (default \fBpr\-pull\fR)\.
 .
 .SS "\fBtest\fR [\fIoptions\fR] \fIformula\fR"
 Run the test method provided by an installed formula\. There is no standard output or return code, but generally it should notify the user if something is wrong with the installed formula\.


### PR DESCRIPTION
We now support bottles publishing to GitHub Releases.
Add a workflow for that and modify `tests.yml` a bit, so users can have bottles in their taps too and be happier.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----