### PR TITLE
chmod recursively to satisfy zsh "insecure directories" warning

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -52,7 +52,7 @@ You may also need to forcibly rebuild `zcompdump`:
 Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting to load these completions, you may need to run this:
 
 ```sh
-  chmod go-w "$(brew --prefix)/share"
+  chmod -R go-w "$(brew --prefix)/share"
 ```
 
 ## Configuring Completions in `fish`


### PR DESCRIPTION
without `-R` only `share` is updated, leaving `share/zsh/site-functions` unchanged, so the warning won't go away

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
