### PR TITLE
update-python-resources: add `--package-name` flag

### DIFF
--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -22,6 +22,9 @@ module Homebrew
       flag "--version=",
            description: "Use the specified <version> when finding resources for <formula>. "\
                         "If no version is specified, the current version for <formula> will be used."
+      flag "--package-name=",
+           description: "Use the specified <package-name> when finding resources for <formula>. "\
+                        "If no package name is specified, it will be inferred from the formula's stable URL."
       min_named :formula
     end
   end
@@ -30,7 +33,10 @@ module Homebrew
     args = update_python_resources_args.parse
 
     args.named.to_formulae.each do |formula|
-      PyPI.update_python_resources! formula, args.version, print_only: args.print_only?, silent: args.silent?,
+      PyPI.update_python_resources! formula, args.version,
+                                    package_name:             args.package_name,
+                                    print_only:               args.print_only?,
+                                    silent:                   args.silent?,
                                     ignore_non_pypi_packages: args.ignore_non_pypi_packages?
     end
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1290,6 +1290,8 @@ Update versions for PyPI resource blocks in *`formula`*.
   Don't fail if *`formula`* is not a PyPI package.
 * `--version`:
   Use the specified *`version`* when finding resources for *`formula`*. If no version is specified, the current version for *`formula`* will be used.
+* `--package-name`:
+  Use the specified *`package-name`* when finding resources for *`formula`*. If no package name is specified, it will be inferred from the formula's stable URL.
 
 ### `update-test` [*`options`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1786,6 +1786,10 @@ Don\'t fail if \fIformula\fR is not a PyPI package\.
 \fB\-\-version\fR
 Use the specified \fIversion\fR when finding resources for \fIformula\fR\. If no version is specified, the current version for \fIformula\fR will be used\.
 .
+.TP
+\fB\-\-package\-name\fR
+Use the specified \fIpackage\-name\fR when finding resources for \fIformula\fR\. If no package name is specified, it will be inferred from the formula\'s stable URL\.
+.
 .SS "\fBupdate\-test\fR [\fIoptions\fR]"
 Run a test of \fBbrew update\fR with a new repository clone\. If no options are passed, use \fBorigin/master\fR as the start commit\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This allows for updating the resources of Python formulae that include optional dependencies

Example usage:

```bash
brew update-python-resources --package-name='xonsh[ptk,pygments,proctitle]' xonsh
```

Related: Homebrew/homebrew-core#61327