### PR TITLE
unpack_strategy/dmg: remove deprecated IDME attach flag

### DIFF
--- a/Library/Homebrew/unpack_strategy/dmg.rb
+++ b/Library/Homebrew/unpack_strategy/dmg.rb
@@ -132,7 +132,7 @@ module UnpackStrategy
         without_eula = system_command(
           "hdiutil",
           args:         [
-            "attach", "-plist", "-nobrowse", "-readonly", "-noidme",
+            "attach", "-plist", "-nobrowse", "-readonly",
             "-mountrandom", mount_dir, path
           ],
           input:        "qn\n",
@@ -159,7 +159,7 @@ module UnpackStrategy
           with_eula = system_command!(
             "hdiutil",
             args:    [
-              "attach", "-plist", "-nobrowse", "-readonly", "-noidme",
+              "attach", "-plist", "-nobrowse", "-readonly",
               "-mountrandom", mount_dir, cdr_path
             ],
             verbose: verbose,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

On Catalina the IDME attach flag has been removed -- according to `man hdiutil`:

> Removed the deprecated "hdiutil internet-enable" command and the IDME attach flags.

and when installing a Cask that used a `.dmg` the following message is printed:
```
hdiutil: attach: WARNING: ignoring IDME options (obsolete)
```

Thank you.