### PR TITLE
diagnostic: fix xattr check

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -968,9 +968,9 @@ module Homebrew
         return if result.status.success?
 
         if result.stderr.include? "ImportError: No module named pkg_resources"
-          result = system_command "/usr/bin/python", "--version"
+          result = Utils.popen_read "/usr/bin/python", "--version", err: :out
 
-          if result.stdout.include? "Python 2.7"
+          if result.include? "Python 2.7"
             <<~EOS
               Your Python installation has a broken version of setuptools.
               To fix, reinstall macOS or run 'sudo /usr/bin/python -m pip install -I setuptools'.


### PR DESCRIPTION
Python emits the version on either stderr or stdout based on major version, so just to be safe let's use popen_read and combine the output streams.

Noticed in https://github.com/Homebrew/homebrew-core/issues/61357

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----