### PR TITLE
test: make pgrep call portable

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -46,7 +46,7 @@ rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.close
 ensure
   pid = Process.pid.to_s
-  if which("pgrep") && which("pkill") && system("pgrep", "-P", pid, out: :close)
+  if which("pgrep") && which("pkill") && system("pgrep", "-P", pid, :out => File::NULL)
     $stderr.puts "Killing child processes..."
     system "pkill", "-P", pid
     sleep 1

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -46,7 +46,7 @@ rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.close
 ensure
   pid = Process.pid.to_s
-  if which("pgrep") && which("pkill") && system("pgrep", "-P", pid, :out => File::NULL)
+  if which("pgrep") && which("pkill") && system("pgrep", "-P", pid, out: File::NULL)
     $stderr.puts "Killing child processes..."
     system "pkill", "-P", pid
     sleep 1


### PR DESCRIPTION
Fixes (on linux), for example for the ninja formula test:

```
pgrep
-P
83252
{out: :close}}
Invalid preceding regular expressionpgrep: write error: Bad file descriptor
Error: ninja: failed
An exception occurred within a child process:
  BuildError: Failed executing: pgrep -P 83252 {out: :close}
```

Using File:NULL is more portable.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
