### PR TITLE
Switch most dependabot updates back to `daily`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
 
   - package-ecosystem: bundler
     directory: /docs
@@ -15,4 +15,13 @@ updates:
   - package-ecosystem: bundler
     directory: /Library/Homebrew
     schedule:
+      interval: daily
+    ignore:
+      - dependency-name: sorbet*
+
+  - package-ecosystem: bundler
+    directory: /Library/Homebrew
+    schedule:
       interval: weekly
+    allow:
+      - dependency-name: sorbet*


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Except for `sorbet`, which is updated pretty much on each commit, and non-critical updates for generating the `/docs` website.