### PR TITLE
Installer: ensure ad-hoc codesigning is applied

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -716,6 +716,8 @@ class FormulaInstaller
 
     fix_dynamic_linkage(keg) unless @poured_bottle && formula.bottle_specification.skip_relocation?
 
+    codesign_mach_o_files(keg)
+
     if build_bottle?
       ohai "Not running post_install as we're building a bottle"
       puts "You can run it manually using `brew postinstall #{formula.full_name}`"
@@ -958,6 +960,16 @@ class FormulaInstaller
     onoe "Failed to fix install linkage"
     puts "The formula built, but you may encounter issues using it or linking other"
     puts "formulae against it."
+    odebug e, e.backtrace
+    Homebrew.failed = true
+    @show_summary_heading = true
+  end
+
+  def codesign_mach_o_files(keg)
+    keg.codesign_mach_o_files
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    onoe "Failed to apply an ad-hoc signature"
+    puts "The formula built, but it may not run."
     odebug e, e.backtrace
     Homebrew.failed = true
     @show_summary_heading = true

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -34,6 +34,8 @@ class Keg
     []
   end
 
+  def codesign_mach_o_files; end
+
   def replace_locations_with_placeholders
     relocation = Relocation.new(
       old_prefix:     HOMEBREW_PREFIX.to_s,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Some form of codesigning is required to run apps on Big Sur on Apple Silicon, but an ad-hoc signature (`-s -`) is sufficient. The compiler toolchain is meant to apply that, but that doesn't fully work at thus time - tools like `strip`, `install_name_tool`, etc. break the code signature and don't apply a new valid signature of their own. That will probably be fixed later, but in the meantime for Homebrew to fully work on the latest betas we need to ensure we're codesigning all Mach-O files ourselves. This will ensure that we can keep testing Homebrew on Apple Silicon with the latest macOS betas.

cc @claui, @fxcoudert 