### PR TITLE
bottle: new formula license may be a list, not just a string

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -535,6 +535,7 @@ module Homebrew
                     (\n^\ {3}[\S\ ]+$)*                                           # options can be in multiple lines
                   )?|
                   (homepage|desc|sha256|version|mirror|license)\ ['"][\S\ ]+['"]| # specs with a string
+                  (license)\ [^\[]+?\[[^\]]+?\]|                                  # license may contain a list
                   (revision|version_scheme)\ \d+|                                 # revision with a number
                   (stable|livecheck)\ do(\n+^\ {4}[\S\ ]+$)*\n+^\ {2}end          # components with blocks
                 )\n+                                                              # multiple empty lines


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Previously, the logic to add a bottle block for a new formula assumed that the `license` was a string, but this is no longer the case. A formula was added with a list of licenses and the new bottle block (https://github.com/Homebrew/homebrew-core/commit/2a73560f670d271d24364fd04419e4b87b9f2f7e) got added in the wrong place which broke CI for a bit until it was manually fixed: https://github.com/Homebrew/homebrew-core/pull/61551. 

cc @chenrui333 