### PR TITLE
show cask info on browser

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -86,7 +86,7 @@ module Homebrew
     elsif args.github?
       raise FormulaUnspecifiedError if args.no_named?
 
-      exec_browser(*args.named.to_formulae.map { |f| github_info(f) })
+      exec_browser(*args.named.to_formulae_and_casks.map { |f| github_info(f) })
     else
       print_info(args: args)
     end
@@ -148,7 +148,11 @@ module Homebrew
   def github_info(f)
     if f.tap
       if remote = f.tap.remote
-        path = f.path.relative_path_from(f.tap.path)
+        path = if f.class.superclass == Formula
+          f.path.relative_path_from(f.tap.path)
+        elsif f.is_a?(Cask::Cask)
+          f.sourcefile_path.relative_path_from(f.tap.path)
+        end
         github_remote_path(remote, path)
       else
         f.path


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
add an option `--github` to `brew cask info [Cask]` to show a cask's GitHub source Page like `brew info [formula] --github`
