### PR TITLE
Deprecate GitHub basic authentication.

### DIFF
--- a/Library/Homebrew/cmd/gist-logs.rb
+++ b/Library/Homebrew/cmd/gist-logs.rb
@@ -60,6 +60,7 @@ module Homebrew
         #{Utils::Shell.set_variable_in_profile("HOMEBREW_GITHUB_API_TOKEN", "your_token_here")}
 
       EOS
+      odeprecated "`brew gist-logs` with a password", "HOMEBREW_GITHUB_API_TOKEN"
       login!
     end
 

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -148,7 +148,7 @@ module Homebrew
       },
       HOMEBREW_GITHUB_API_PASSWORD:          {
         description: "Use this password for authentication with the GitHub API, for features " \
-                     "such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.",
+                     "such as `brew search`. This is deprecated in favour of using `HOMEBREW_GITHUB_API_TOKEN`.",
       },
       HOMEBREW_GITHUB_API_TOKEN:             {
         description: "Use this personal access token for the GitHub API, for features such as " \
@@ -160,7 +160,7 @@ module Homebrew
       },
       HOMEBREW_GITHUB_API_USERNAME:          {
         description: "Use this username for authentication with the GitHub API, for features " \
-                     "such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.",
+                     "such as `brew search`. This is deprecated in favour of using `HOMEBREW_GITHUB_API_TOKEN`.",
       },
       HOMEBREW_GIT_EMAIL:                    {
         description: "Set the Git author and committer name to this value.",

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -91,6 +91,8 @@ module GitHub
     return unless Homebrew::EnvConfig.github_api_username
     return unless Homebrew::EnvConfig.github_api_password
 
+    odeprecated "the GitHub API with HOMEBREW_GITHUB_API_PASSWORD", "HOMEBREW_GITHUB_API_TOKEN"
+
     [Homebrew::EnvConfig.github_api_password, Homebrew::EnvConfig.github_api_username]
   end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1672,7 +1672,7 @@ For example, you might add something like the following to your ~/.profile, ~/.b
     If set, always use Homebrew's vendored, relocatable Ruby version even if the system version of Ruby is new enough.
 
   * `HOMEBREW_GITHUB_API_PASSWORD`:
-    Use this password for authentication with the GitHub API, for features such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.
+    Use this password for authentication with the GitHub API, for features such as `brew search`. This is deprecated in favour of using `HOMEBREW_GITHUB_API_TOKEN`.
 
   * `HOMEBREW_GITHUB_API_TOKEN`:
     Use this personal access token for the GitHub API, for features such as `brew search`. You can create one at <https://github.com/settings/tokens>. If set, GitHub will allow you a greater number of API requests. For more information, see: <https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting>.
@@ -1680,7 +1680,7 @@ For example, you might add something like the following to your ~/.profile, ~/.b
     *Note:* Homebrew doesn't require permissions for any of the scopes, but some developer commands may require additional permissions.
 
   * `HOMEBREW_GITHUB_API_USERNAME`:
-    Use this username for authentication with the GitHub API, for features such as `brew search`. We strongly recommend using `HOMEBREW_GITHUB_API_TOKEN` instead.
+    Use this username for authentication with the GitHub API, for features such as `brew search`. This is deprecated in favour of using `HOMEBREW_GITHUB_API_TOKEN`.
 
   * `HOMEBREW_GIT_EMAIL`:
     Set the Git author and committer name to this value.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "September 2020" "Homebrew" "brew"
+.TH "BREW" "1" "October 2020" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS
@@ -2336,7 +2336,7 @@ If set, always use Homebrew\'s vendored, relocatable Ruby version even if the sy
 .
 .TP
 \fBHOMEBREW_GITHUB_API_PASSWORD\fR
-Use this password for authentication with the GitHub API, for features such as \fBbrew search\fR\. We strongly recommend using \fBHOMEBREW_GITHUB_API_TOKEN\fR instead\.
+Use this password for authentication with the GitHub API, for features such as \fBbrew search\fR\. This is deprecated in favour of using \fBHOMEBREW_GITHUB_API_TOKEN\fR\.
 .
 .TP
 \fBHOMEBREW_GITHUB_API_TOKEN\fR
@@ -2347,7 +2347,7 @@ Use this personal access token for the GitHub API, for features such as \fBbrew 
 .
 .TP
 \fBHOMEBREW_GITHUB_API_USERNAME\fR
-Use this username for authentication with the GitHub API, for features such as \fBbrew search\fR\. We strongly recommend using \fBHOMEBREW_GITHUB_API_TOKEN\fR instead\.
+Use this username for authentication with the GitHub API, for features such as \fBbrew search\fR\. This is deprecated in favour of using \fBHOMEBREW_GITHUB_API_TOKEN\fR\.
 .
 .TP
 \fBHOMEBREW_GIT_EMAIL\fR


### PR DESCRIPTION
This API authentication path will be disabled on Nov 13 2020. See https://developer.github.com/changes/2020-02-14-deprecating-password-auth/ for details.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----