### PR TITLE
Revert "Refactor global `Cask::Config`."

### DIFF
--- a/Library/Homebrew/cask/auditor.rb
+++ b/Library/Homebrew/cask/auditor.rb
@@ -80,14 +80,11 @@ module Cask
 
     def audit_languages(languages)
       ohai "Auditing language: #{languages.map { |lang| "'#{lang}'" }.to_sentence}"
-
-      original_config = cask.config
-      localized_config = original_config.merge(Config.new(explicit: { languages: languages }))
-      cask.config = localized_config
-
-      audit_cask_instance(cask)
-    ensure
-      cask.config = original_config
+      localized_cask = CaskLoader.load(cask.sourcefile_path)
+      config = localized_cask.config
+      config.languages = languages
+      localized_cask.config = config
+      audit_cask_instance(localized_cask)
     end
 
     def audit_cask_instance(cask)

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -16,13 +16,13 @@ module Cask
     extend Searchable
     include Metadata
 
-    attr_reader :token, :sourcefile_path, :config, :default_config
+    attr_reader :token, :sourcefile_path, :config
 
     def self.each(&block)
       return to_enum unless block_given?
 
       Tap.flat_map(&:cask_files).each do |f|
-        block.call CaskLoader::FromTapPathLoader.new(f).load(config: nil)
+        block.call CaskLoader::FromTapPathLoader.new(f).load
       rescue CaskUnreadableError => e
         opoo e.message
       end
@@ -34,19 +34,12 @@ module Cask
       @tap
     end
 
-    def initialize(token, sourcefile_path: nil, tap: nil, config: nil, &block)
+    def initialize(token, sourcefile_path: nil, tap: nil, &block)
       @token = token
       @sourcefile_path = sourcefile_path
       @tap = tap
       @block = block
-
-      @default_config = config || Config.new
-
-      self.config = if config_path.exist?
-        Config.from_json(File.read(config_path))
-      else
-        @default_config
-      end
+      self.config = Config.for_cask(self)
     end
 
     def config=(config)

--- a/Library/Homebrew/cask/caskroom.rb
+++ b/Library/Homebrew/cask/caskroom.rb
@@ -29,18 +29,18 @@ module Cask
       SystemCommand.run("/usr/bin/chgrp", args: ["admin", path], sudo: sudo)
     end
 
-    def casks(config: nil)
+    def casks
       return [] unless path.exist?
 
       Pathname.glob(path.join("*")).sort.select(&:directory?).map do |path|
         token = path.basename.to_s
 
         if tap_path = CaskLoader.tap_paths(token).first
-          CaskLoader::FromTapPathLoader.new(tap_path).load(config: config)
+          CaskLoader::FromTapPathLoader.new(tap_path).load
         elsif caskroom_path = Pathname.glob(path.join(".metadata/*/*/*/*.rb")).first
-          CaskLoader::FromPathLoader.new(caskroom_path).load(config: config)
+          CaskLoader::FromPathLoader.new(caskroom_path).load
         else
-          CaskLoader.load(token, config: config)
+          CaskLoader.load(token)
         end
       end
     end

--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -236,6 +236,12 @@ module Cask
 
       args = self.class.parser.parse(argv, ignore_invalid_options: true)
 
+      Config::DEFAULT_DIRS.each_key do |name|
+        Config.global.public_send(:"#{name}=", args[name]) if args[name]
+      end
+
+      Config.global.languages = args.language if args.language
+
       Tap.default_cask_tap.install unless Tap.default_cask_tap.installed?
 
       command, argv = detect_internal_command(*argv) ||

--- a/Library/Homebrew/cask/cmd/abstract_command.rb
+++ b/Library/Homebrew/cask/cmd/abstract_command.rb
@@ -106,7 +106,8 @@ module Cask
       def casks(alternative: -> { [] })
         return @casks if defined?(@casks)
 
-        @casks = args.named.empty? ? alternative.call : args.named.to_casks
+        casks = args.named.empty? ? alternative.call : args.named
+        @casks = casks.map { |cask| CaskLoader.load(cask) }
       rescue CaskUnavailableError => e
         reason = [e.reason, *suggestion_message(e.token)].join(" ")
         raise e.class.new(e.token, reason)

--- a/Library/Homebrew/cask/cmd/audit.rb
+++ b/Library/Homebrew/cask/cmd/audit.rb
@@ -62,8 +62,8 @@ module Cask
           else
             name
           end
-        end
-        casks = casks.map { |c| CaskLoader.load(c, config: Config.from_args(args)) }
+        end.map(&CaskLoader.public_method(:load))
+
         casks = Cask.to_a if casks.empty?
 
         failed_casks = casks.reject do |cask|

--- a/Library/Homebrew/cask/cmd/list.rb
+++ b/Library/Homebrew/cask/cmd/list.rb
@@ -32,17 +32,16 @@ module Cask
           one:       args.public_send(:'1?'),
           full_name: args.full_name?,
           versions:  args.versions?,
-          args:      args,
         )
       end
 
-      def self.list_casks(*casks, args:, json: false, one: false, full_name: false, versions: false)
+      def self.list_casks(*casks, json: false, one: false, full_name: false, versions: false)
         output = if casks.any?
           casks.each do |cask|
             raise CaskNotInstalledError, cask unless cask.installed?
           end
         else
-          Caskroom.casks(config: Config.from_args(args))
+          Caskroom.casks
         end
 
         if json

--- a/Library/Homebrew/cask/cmd/outdated.rb
+++ b/Library/Homebrew/cask/cmd/outdated.rb
@@ -20,7 +20,7 @@ module Cask
       end
 
       def run
-        outdated_casks = casks(alternative: -> { Caskroom.casks(config: Config.from_args(args)) }).select do |cask|
+        outdated_casks = casks(alternative: -> { Caskroom.casks }).select do |cask|
           odebug "Checking update info of Cask #{cask}"
           cask.outdated?(greedy: args.greedy?)
         end

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -38,13 +38,11 @@ module Cask
           require_sha:    args.require_sha?,
           skip_cask_deps: args.skip_cask_deps?,
           verbose:        verbose,
-          args:           args,
         )
       end
 
       def self.upgrade_casks(
         *casks,
-        args:,
         force: false,
         greedy: false,
         dry_run: false,
@@ -58,7 +56,7 @@ module Cask
         quarantine = true if quarantine.nil?
 
         outdated_casks = if casks.empty?
-          Caskroom.casks(config: Config.from_args(args)).select do |cask|
+          Caskroom.casks.select do |cask|
             cask.outdated?(greedy: greedy)
           end
         else
@@ -120,7 +118,7 @@ module Cask
         old_cask_installer =
           Installer.new(old_cask, **old_options)
 
-        new_cask.config = new_cask.default_config.merge(old_config)
+        new_cask.config = Config.global.merge(old_config)
 
         new_options = {
           binaries:       binaries,

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -36,24 +36,20 @@ module Cask
       }.merge(DEFAULT_DIRS).freeze
     end
 
-    def self.from_args(args)
-      new(explicit: {
-        appdir:               args.appdir,
-        colorpickerdir:       args.colorpickerdir,
-        prefpanedir:          args.prefpanedir,
-        qlplugindir:          args.qlplugindir,
-        mdimporterdir:        args.mdimporterdir,
-        dictionarydir:        args.dictionarydir,
-        fontdir:              args.fontdir,
-        servicedir:           args.servicedir,
-        input_methoddir:      args.input_methoddir,
-        internet_plugindir:   args.internet_plugindir,
-        audio_unit_plugindir: args.audio_unit_plugindir,
-        vst_plugindir:        args.vst_plugindir,
-        vst3_plugindir:       args.vst3_plugindir,
-        screen_saverdir:      args.screen_saverdir,
-        languages:            args.language,
-      }.compact)
+    def self.global
+      @global ||= new
+    end
+
+    def self.clear
+      @global = nil
+    end
+
+    def self.for_cask(cask)
+      if cask.config_path.exist?
+        from_json(File.read(cask.config_path))
+      else
+        global
+      end
     end
 
     def self.from_json(json)
@@ -99,19 +95,19 @@ module Cask
 
     def env
       @env ||= self.class.canonicalize(
-        Homebrew::EnvConfig.cask_opts
-          .select { |arg| arg.include?("=") }
-          .map { |arg| arg.split("=", 2) }
-          .map do |(flag, value)|
-            key = flag.sub(/^--/, "")
+        Shellwords.shellsplit(ENV.fetch("HOMEBREW_CASK_OPTS", ""))
+                  .select { |arg| arg.include?("=") }
+                  .map { |arg| arg.split("=", 2) }
+                  .map do |(flag, value)|
+                    key = flag.sub(/^--/, "")
 
-            if key == "language"
-              key = "languages"
-              value = value.split(",")
-            end
+                    if key == "language"
+                      key = "languages"
+                      value = value.split(",")
+                    end
 
-            [key, value]
-          end,
+                    [key, value]
+                  end,
       )
     end
 

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -99,7 +99,7 @@ module Cask
       opoo "macOS's Gatekeeper has been disabled for this Cask" unless quarantine?
       stage
 
-      @cask.config = @cask.default_config.merge(old_config)
+      @cask.config = Config.global.merge(old_config)
 
       install_artifacts
 
@@ -284,11 +284,10 @@ module Cask
 
       if cask_or_formula.is_a?(Cask)
         formula_deps = cask_or_formula.depends_on.formula.map { |f| Formula[f] }
-        cask_deps = cask_or_formula.depends_on.cask.map { |c| CaskLoader.load(c, config: nil) }
+        cask_deps = cask_or_formula.depends_on.cask.map(&CaskLoader.public_method(:load))
       else
         formula_deps = cask_or_formula.deps.reject(&:build?).map(&:to_formula)
-        cask_deps = cask_or_formula.requirements.map(&:cask).compact
-                                   .map { |c| CaskLoader.load(c, config: nil) }
+        cask_deps = cask_or_formula.requirements.map(&:cask).compact.map(&CaskLoader.public_method(:load))
       end
 
       acc[cask_or_formula] ||= []

--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -20,7 +20,7 @@ module Homebrew
 
         # Can set these because they will be overwritten by freeze_named_args!
         # (whereas other values below will only be overwritten if passed).
-        self[:named_args] = NamedArgs.new(parent: self)
+        self[:named_args] = NamedArgs.new
         self[:remaining] = []
       end
 
@@ -34,7 +34,6 @@ module Homebrew
           override_spec: spec(nil),
           force_bottle:  force_bottle?,
           flags:         flags_only,
-          parent:        self,
         )
       end
 
@@ -50,7 +49,7 @@ module Homebrew
       end
 
       def named
-        named_args
+        named_args || NamedArgs.new
       end
 
       def no_named?

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-require "delegate"
-
 require "cask/cask_loader"
-require "cli/args"
+require "delegate"
 require "formulary"
 require "missing_formula"
 
@@ -13,12 +11,11 @@ module Homebrew
     #
     # @api private
     class NamedArgs < SimpleDelegator
-      def initialize(*args, parent: Args.new, override_spec: nil, force_bottle: false, flags: [])
+      def initialize(*args, override_spec: nil, force_bottle: false, flags: [])
         @args = args
         @override_spec = override_spec
         @force_bottle = force_bottle
         @flags = flags
-        @parent = parent
 
         super(@args)
       end
@@ -133,9 +130,7 @@ module Homebrew
       end
 
       def to_casks
-        @to_casks ||= downcased_unique_named
-                      .map { |name| Cask::CaskLoader.load(name, config: Cask::Config.from_args(@parent)) }
-                      .freeze
+        @to_casks ||= downcased_unique_named.map(&Cask::CaskLoader.method(:load)).freeze
       end
 
       def to_kegs
@@ -160,7 +155,7 @@ module Homebrew
             warn_if_cask_conflicts(name, "keg")
           rescue NoSuchKegError, FormulaUnavailableError
             begin
-              casks << Cask::CaskLoader.load(name, config: Cask::Config.from_args(@parent))
+              casks << Cask::CaskLoader.load(name)
             rescue Cask::CaskUnavailableError
               raise "No installed keg or cask with the name \"#{name}\""
             end

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -78,7 +78,7 @@ module Homebrew
       dependents = if args.named.present?
         sorted_dependents(args.named.to_formulae_and_casks)
       elsif args.installed?
-        sorted_dependents(Formula.installed + Cask::Caskroom.casks(config: Cask::Config.from_args(args)))
+        sorted_dependents(Formula.installed + Cask::Caskroom.casks)
       else
         raise FormulaUnspecifiedError
       end
@@ -96,8 +96,7 @@ module Homebrew
     if args.no_named?
       raise FormulaUnspecifiedError unless args.installed?
 
-      puts_deps sorted_dependents(Formula.installed + Cask::Caskroom.casks(config: Cask::Config.from_args(args))),
-                recursive: recursive, args: args
+      puts_deps sorted_dependents(Formula.installed + Cask::Caskroom.casks), recursive: recursive, args: args
       return
     end
 

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -172,7 +172,6 @@ module Homebrew
       one:       args.public_send(:'1?'),
       full_name: args.full_name?,
       versions:  args.versions?,
-      args:      args,
     )
   end
 end

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -174,9 +174,9 @@ module Homebrew
 
   def outdated_casks(args:)
     if args.named.present?
-      select_outdated(args.named.to_casks, args: args)
+      select_outdated(args.named.uniq.map(&Cask::CaskLoader.method(:load)), args: args)
     else
-      select_outdated(Cask::Caskroom.casks(config: Cask::Config.from_args(args)), args: args)
+      select_outdated(Cask::Caskroom.casks, args: args)
     end
   end
 
@@ -185,7 +185,7 @@ module Homebrew
 
     if formulae.blank? && casks.blank?
       formulae = Formula.installed
-      casks = Cask::Caskroom.casks(config: Cask::Config.from_args(args))
+      casks = Cask::Caskroom.casks
     end
 
     [select_outdated(formulae, args: args).sort, select_outdated(casks, args: args)]

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -157,7 +157,6 @@ module Homebrew
       require_sha:    EnvConfig.cask_opts_require_sha?,
       skip_cask_deps: args.skip_cask_deps?,
       verbose:        args.verbose?,
-      args:           args,
     )
   end
 end

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -78,13 +78,10 @@ module Homebrew
       used_formulae.map(&:runtime_installed_formula_dependents)
                    .reduce(&:&)
                    .select(&:any_version_installed?) +
-        select_used_dependents(
-          dependents(Cask::Caskroom.casks(config: Cask::Config.from_args(args))),
-          used_formulae, recursive, includes, ignores
-        )
+        select_used_dependents(dependents(Cask::Caskroom.casks), used_formulae, recursive, includes, ignores)
     else
       deps = if args.installed?
-        dependents(Formula.installed + Cask::Caskroom.casks(config: Cask::Config.from_args(args)))
+        dependents(Formula.installed + Cask::Caskroom.casks)
       else
         dependents(Formula.to_a + Cask::Cask.to_a)
       end

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -7,16 +7,10 @@ describe Cask::Artifact::Binary, :cask do
     end
   }
   let(:artifacts) { cask.artifacts.select { |a| a.is_a?(described_class) } }
-  let(:binarydir) { cask.config.binarydir }
-  let(:expected_path) { binarydir.join("binary") }
+  let(:expected_path) { cask.config.binarydir.join("binary") }
 
-  around do |example|
-    binarydir.mkpath
-
-    example.run
-  ensure
-    FileUtils.rm_f expected_path
-    FileUtils.rmdir binarydir
+  after do
+    FileUtils.rm expected_path if expected_path.exist?
   end
 
   context "when --no-binaries is specified" do
@@ -86,7 +80,7 @@ describe Cask::Artifact::Binary, :cask do
   end
 
   it "creates parent directory if it doesn't exist" do
-    FileUtils.rmdir binarydir
+    FileUtils.rmdir Cask::Config.global.binarydir
 
     artifacts.each do |artifact|
       artifact.install_phase(command: NeverSudoSystemCommand, force: false)

--- a/Library/Homebrew/test/cask/cask_loader/from__path_loader_spec.rb
+++ b/Library/Homebrew/test/cask/cask_loader/from__path_loader_spec.rb
@@ -13,7 +13,7 @@ describe Cask::CaskLoader::FromPathLoader do
 
       it "raises an error" do
         expect {
-          described_class.new(path).load(config: nil)
+          described_class.new(path).load
         }.to raise_error(Cask::CaskUnreadableError, /does not contain a cask/)
       end
     end
@@ -29,7 +29,7 @@ describe Cask::CaskLoader::FromPathLoader do
 
       it "raises an error" do
         expect {
-          described_class.new(path).load(config: nil)
+          described_class.new(path).load
         }.to raise_error(Cask::CaskUnreadableError, /undefined local variable or method/)
       end
     end

--- a/Library/Homebrew/test/cask/cmd/audit_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/audit_spec.rb
@@ -20,7 +20,7 @@ describe Cask::Cmd::Audit, :cask do
 
     it "audits specified Casks if tokens are given" do
       cask_token = "nice-app"
-      expect(Cask::CaskLoader).to receive(:load).with(cask_token, any_args).and_return(cask)
+      expect(Cask::CaskLoader).to receive(:load).with(cask_token).and_return(cask)
 
       expect(Cask::Auditor).to receive(:audit)
         .with(cask, quarantine: true)

--- a/Library/Homebrew/test/cask/cmd/cat_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/cat_spec.rb
@@ -23,19 +23,6 @@ describe Cask::Cmd::Cat, :cask do
         end
       RUBY
     }
-    let(:caffeine_content) {
-      <<~'RUBY'
-        cask "local-caffeine" do
-          version "1.2.3"
-          sha256 "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94"
-
-          url "file://#{TEST_FIXTURE_DIR}/cask/caffeine.zip"
-          homepage "https://brew.sh/"
-
-          app "Caffeine.app"
-        end
-      RUBY
-    }
 
     it "displays the Cask file content about the specified Cask" do
       expect {
@@ -45,8 +32,8 @@ describe Cask::Cmd::Cat, :cask do
 
     it "can display multiple Casks" do
       expect {
-        described_class.run("basic-cask", "local-caffeine")
-      }.to output(basic_cask_content + caffeine_content).to_stdout
+        described_class.run("basic-cask", "basic-cask")
+      }.to output(basic_cask_content * 2).to_stdout
     end
   end
 

--- a/Library/Homebrew/test/cask/cmd/install_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/install_spec.rb
@@ -31,50 +31,6 @@ describe Cask::Cmd::Install, :cask do
     expect(caffeine.config.appdir.join("Caffeine.app")).to be_a_directory
   end
 
-  it "recognizes the --appdir flag" do
-    appdir = mktmpdir
-
-    expect(Cask::CaskLoader).to receive(:load).with("local-caffeine", any_args)
-      .and_wrap_original { |f, *args|
-        caffeine = f.call(*args)
-        expect(caffeine.config.appdir).to eq appdir
-        caffeine
-      }
-
-    described_class.run("local-caffeine", "--appdir=#{appdir}")
-  end
-
-  it "recognizes the --appdir flag from HOMEBREW_CASK_OPTS" do
-    appdir = mktmpdir
-
-    expect(Cask::CaskLoader).to receive(:load).with("local-caffeine", any_args)
-      .and_wrap_original { |f, *args|
-        caffeine = f.call(*args)
-        expect(caffeine.config.appdir).to eq appdir
-        caffeine
-      }
-
-    ENV["HOMEBREW_CASK_OPTS"] = "--appdir=#{appdir}"
-
-    described_class.run("local-caffeine")
-  end
-
-  it "prefers an explicit --appdir flag to one from HOMEBREW_CASK_OPTS" do
-    global_appdir = mktmpdir
-    appdir = mktmpdir
-
-    expect(Cask::CaskLoader).to receive(:load).with("local-caffeine", any_args)
-      .and_wrap_original { |f, *args|
-        caffeine = f.call(*args)
-        expect(caffeine.config.appdir).to eq appdir
-        caffeine
-      }
-
-    ENV["HOMEBREW_CASK_OPTS"] = "--appdir=#{global_appdir}"
-
-    described_class.run("local-caffeine", "--appdir=#{appdir}")
-  end
-
   it "skips double install (without nuking existing installation)" do
     described_class.run("local-transmission")
     described_class.run("local-transmission")

--- a/Library/Homebrew/test/cask/cmd/style_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/style_spec.rb
@@ -30,8 +30,7 @@ describe Cask::Cmd::Style, :cask do
     subject { cli.cask_paths }
 
     before do
-      args = instance_double(Homebrew::CLI::Args, named: Homebrew::CLI::NamedArgs.new(*tokens))
-      allow(cli).to receive(:args).and_return(args)
+      allow(cli).to receive(:args).and_return(instance_double(Homebrew::CLI::Args, named: tokens))
     end
 
     context "when no cask tokens are given" do

--- a/Library/Homebrew/test/cask/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/uninstall_spec.rb
@@ -64,7 +64,7 @@ describe Cask::Cmd::Uninstall, :cask do
     Cask::Installer.new(cask).install
 
     expect(cask).to be_installed
-    expect(cask.config.appdir.join("MyFancyApp.app")).to exist
+    expect(Cask::Config.global.appdir.join("MyFancyApp.app")).to exist
 
     expect {
       described_class.run("with-uninstall-script-app")
@@ -143,8 +143,8 @@ describe Cask::Cmd::Uninstall, :cask do
     end
   end
 
-  context "when Casks in Taps have been renamed or removed" do
-    let(:app) { Cask::Config.new.appdir.join("ive-been-renamed.app") }
+  describe "when Casks in Taps have been renamed or removed" do
+    let(:app) { Cask::Config.global.appdir.join("ive-been-renamed.app") }
     let(:caskroom_path) { Cask::Caskroom.path.join("ive-been-renamed").tap(&:mkpath) }
     let(:saved_caskfile) {
       caskroom_path.join(".metadata", "latest", "timestamp", "Casks").join("ive-been-renamed.rb")
@@ -168,7 +168,7 @@ describe Cask::Cmd::Uninstall, :cask do
       RUBY
     end
 
-    it "can still uninstall them" do
+    it "can still uninstall those Casks" do
       described_class.run("ive-been-renamed")
 
       expect(app).not_to exist

--- a/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
@@ -3,16 +3,6 @@
 require_relative "shared_examples/invalid_option"
 
 describe Cask::Cmd::Upgrade, :cask do
-  let(:version_latest_path_2) { version_latest.config.appdir.join("Caffeine Pro.app") }
-  let(:version_latest_path_1) { version_latest.config.appdir.join("Caffeine Mini.app") }
-  let(:version_latest) { Cask::CaskLoader.load("version-latest") }
-  let(:auto_updates_path) { auto_updates.config.appdir.join("MyFancyApp.app") }
-  let(:auto_updates) { Cask::CaskLoader.load("auto-updates") }
-  let(:local_transmission_path) { local_transmission.config.appdir.join("Transmission.app") }
-  let(:local_transmission) { Cask::CaskLoader.load("local-transmission") }
-  let(:local_caffeine_path) { local_caffeine.config.appdir.join("Caffeine.app") }
-  let(:local_caffeine) { Cask::CaskLoader.load("local-caffeine") }
-
   it_behaves_like "a command that handles invalid options"
 
   context "successful upgrade" do
@@ -33,6 +23,11 @@ describe Cask::Cmd::Upgrade, :cask do
 
     describe 'without --greedy it ignores the Casks with "version latest" or "auto_updates true"' do
       it "updates all the installed Casks when no token is provided" do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        local_transmission = Cask::CaskLoader.load("local-transmission")
+        local_transmission_path = Cask::Config.global.appdir.join("Transmission.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -53,6 +48,11 @@ describe Cask::Cmd::Upgrade, :cask do
       end
 
       it "updates only the Casks specified in the command line" do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        local_transmission = Cask::CaskLoader.load("local-transmission")
+        local_transmission_path = Cask::Config.global.appdir.join("Transmission.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -73,6 +73,11 @@ describe Cask::Cmd::Upgrade, :cask do
       end
 
       it 'updates "auto_updates" and "latest" Casks when their tokens are provided in the command line' do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        auto_updates = Cask::CaskLoader.load("auto-updates")
+        auto_updates_path = Cask::Config.global.appdir.join("MyFancyApp.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -95,6 +100,16 @@ describe Cask::Cmd::Upgrade, :cask do
 
     describe "with --greedy it checks additional Casks" do
       it 'includes the Casks with "auto_updates true" or "version latest"' do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        auto_updates = Cask::CaskLoader.load("auto-updates")
+        auto_updates_path = Cask::Config.global.appdir.join("MyFancyApp.app")
+        local_transmission = Cask::CaskLoader.load("local-transmission")
+        local_transmission_path = Cask::Config.global.appdir.join("Transmission.app")
+        version_latest = Cask::CaskLoader.load("version-latest")
+        version_latest_path_1 = Cask::Config.global.appdir.join("Caffeine Mini.app")
+        version_latest_path_2 = Cask::Config.global.appdir.join("Caffeine Pro.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -133,21 +148,24 @@ describe Cask::Cmd::Upgrade, :cask do
       end
 
       it 'does not include the Casks with "auto_updates true" when the version did not change' do
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.57")
+        cask = Cask::CaskLoader.load("auto-updates")
+        cask_path = cask.config.appdir.join("MyFancyApp.app")
+
+        expect(cask).to be_installed
+        expect(cask_path).to be_a_directory
+        expect(cask.versions).to include("2.57")
 
         described_class.run("auto-updates", "--greedy")
 
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.61")
+        expect(cask).to be_installed
+        expect(cask_path).to be_a_directory
+        expect(cask.versions).to include("2.61")
 
         described_class.run("auto-updates", "--greedy")
 
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.61")
+        expect(cask).to be_installed
+        expect(cask_path).to be_a_directory
+        expect(cask.versions).to include("2.61")
       end
     end
   end
@@ -170,6 +188,11 @@ describe Cask::Cmd::Upgrade, :cask do
 
     describe 'without --greedy it ignores the Casks with "version latest" or "auto_updates true"' do
       it "would update all the installed Casks when no token is provided" do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        local_transmission = Cask::CaskLoader.load("local-transmission")
+        local_transmission_path = Cask::Config.global.appdir.join("Transmission.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -192,6 +215,11 @@ describe Cask::Cmd::Upgrade, :cask do
       end
 
       it "would update only the Casks specified in the command line" do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        local_transmission = Cask::CaskLoader.load("local-transmission")
+        local_transmission_path = Cask::Config.global.appdir.join("Transmission.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -214,6 +242,11 @@ describe Cask::Cmd::Upgrade, :cask do
       end
 
       it 'would update "auto_updates" and "latest" Casks when their tokens are provided in the command line' do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        auto_updates = Cask::CaskLoader.load("auto-updates")
+        auto_updates_path = Cask::Config.global.appdir.join("MyFancyApp.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -238,6 +271,16 @@ describe Cask::Cmd::Upgrade, :cask do
 
     describe "with --greedy it checks additional Casks" do
       it 'would include the Casks with "auto_updates true" or "version latest"' do
+        local_caffeine = Cask::CaskLoader.load("local-caffeine")
+        local_caffeine_path = Cask::Config.global.appdir.join("Caffeine.app")
+        auto_updates = Cask::CaskLoader.load("auto-updates")
+        auto_updates_path = Cask::Config.global.appdir.join("MyFancyApp.app")
+        local_transmission = Cask::CaskLoader.load("local-transmission")
+        local_transmission_path = Cask::Config.global.appdir.join("Transmission.app")
+        version_latest = Cask::CaskLoader.load("version-latest")
+        version_latest_path_1 = Cask::Config.global.appdir.join("Caffeine Mini.app")
+        version_latest_path_2 = Cask::Config.global.appdir.join("Caffeine Pro.app")
+
         expect(local_caffeine).to be_installed
         expect(local_caffeine_path).to be_a_directory
         expect(local_caffeine.versions).to include("1.2.2")
@@ -276,23 +319,26 @@ describe Cask::Cmd::Upgrade, :cask do
       end
 
       it 'does not include the Casks with "auto_updates true" when the version did not change' do
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.57")
+        cask = Cask::CaskLoader.load("auto-updates")
+        cask_path = cask.config.appdir.join("MyFancyApp.app")
+
+        expect(cask).to be_installed
+        expect(cask_path).to be_a_directory
+        expect(cask.versions).to include("2.57")
 
         described_class.run("--dry-run", "auto-updates", "--greedy")
 
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.57")
-        expect(auto_updates.versions).not_to include("2.61")
+        expect(cask).to be_installed
+        expect(cask_path).to be_a_directory
+        expect(cask.versions).to include("2.57")
+        expect(cask.versions).not_to include("2.61")
 
         described_class.run("--dry-run", "auto-updates", "--greedy")
 
-        expect(auto_updates).to be_installed
-        expect(auto_updates_path).to be_a_directory
-        expect(auto_updates.versions).to include("2.57")
-        expect(auto_updates.versions).not_to include("2.61")
+        expect(cask).to be_installed
+        expect(cask_path).to be_a_directory
+        expect(cask.versions).to include("2.57")
+        expect(cask.versions).not_to include("2.61")
       end
     end
   end
@@ -370,6 +416,9 @@ describe Cask::Cmd::Upgrade, :cask do
     it "will not end the upgrade process" do
       bad_checksum = Cask::CaskLoader.load("bad-checksum")
       bad_checksum_path = bad_checksum.config.appdir.join("Caffeine.app")
+
+      local_transmission = Cask::CaskLoader.load("local-transmission")
+      local_transmission_path = Cask::Config.global.appdir.join("Transmission.app")
 
       bad_checksum_2 = Cask::CaskLoader.load("bad-checksum2")
       bad_checksum_2_path = bad_checksum_2.config.appdir.join("container")

--- a/Library/Homebrew/test/cask/cmd_spec.rb
+++ b/Library/Homebrew/test/cask/cmd_spec.rb
@@ -16,6 +16,26 @@ describe Cask::Cmd, :cask do
       }.to output(/Displays information about the given cask/).to_stdout
     end
 
+    it "respects the env variable when choosing what appdir to create" do
+      allow(described_class).to receive(:lookup_command).with("noop").and_return(noop_command)
+
+      ENV["HOMEBREW_CASK_OPTS"] = "--appdir=/custom/appdir"
+
+      described_class.run("noop")
+
+      expect(Cask::Config.global.appdir).to eq(Pathname.new("/custom/appdir"))
+    end
+
+    it "overrides the env variable when passing --appdir directly" do
+      allow(described_class).to receive(:lookup_command).with("noop").and_return(noop_command)
+
+      ENV["HOMEBREW_CASK_OPTS"] = "--appdir=/custom/appdir"
+
+      described_class.run("noop", "--appdir=/even/more/custom/appdir")
+
+      expect(Cask::Config.global.appdir).to eq(Pathname.new("/even/more/custom/appdir"))
+    end
+
     it "exits with a status of 1 when something goes wrong" do
       allow(described_class).to receive(:lookup_command).and_raise(Cask::CaskError)
       command = described_class.new("noop")

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -503,15 +503,16 @@ describe Cask::DSL, :cask do
     end
 
     it "does not include a trailing slash" do
-      config = Cask::Config.new(explicit: {
-                                  appdir: "/Applications/",
-                                })
+      original_appdir = Cask::Config.global.appdir
+      Cask::Config.global.appdir = "#{original_appdir}/"
 
-      cask = Cask::Cask.new("appdir-trailing-slash", config: config) do
+      cask = Cask::Cask.new("appdir-trailing-slash") do
         binary "#{appdir}/some/path"
       end
 
-      expect(cask.artifacts.first.source).to eq(Pathname("/Applications/some/path"))
+      expect(cask.artifacts.first.source).to eq(original_appdir/"some/path")
+    ensure
+      Cask::Config.global.appdir = original_appdir
     end
   end
 

--- a/Library/Homebrew/test/cask/installer_spec.rb
+++ b/Library/Homebrew/test/cask/installer_spec.rb
@@ -195,7 +195,7 @@ describe Cask::Installer, :cask do
 
       described_class.new(nested_app).install
 
-      expect(nested_app.config.appdir.join("MyNestedApp.app")).to be_a_directory
+      expect(Cask::Config.global.appdir.join("MyNestedApp.app")).to be_a_directory
     end
 
     it "generates and finds a timestamped metadata directory for an installed Cask" do

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -37,6 +37,7 @@ RSpec.shared_context "Homebrew Cask", :needs_macos do
 
     begin
       Cask::Config::DEFAULT_DIRS_PATHNAMES.values.each(&:mkpath)
+      Cask::Config.global.binarydir.mkpath
 
       Tap.default_cask_tap.tap do |tap|
         FileUtils.mkdir_p tap.path.dirname
@@ -51,10 +52,11 @@ RSpec.shared_context "Homebrew Cask", :needs_macos do
       example.run
     ensure
       FileUtils.rm_rf Cask::Config::DEFAULT_DIRS_PATHNAMES.values
-      FileUtils.rm_rf [Cask::Config.new.binarydir, Cask::Caskroom.path, Cask::Cache.path]
+      FileUtils.rm_rf [Cask::Config.global.binarydir, Cask::Caskroom.path, Cask::Cache.path]
       Tap.default_cask_tap.path.unlink
       third_party_tap.path.unlink
       FileUtils.rm_rf third_party_tap.path.parent
+      Cask::Config.clear
     end
   end
 end


### PR DESCRIPTION
Reverts Homebrew/brew#8822

Fixes https://formulae.brew.sh generation and CI.

CC @reitermarkus 