### PR TITLE
bump-formula-pr: don't warn for virtualenv resource

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -145,7 +145,9 @@ module Homebrew
     check_closed_pull_requests(formula, tap_full_name, version: new_version, args: args) if new_version
 
     opoo "This formula has patches that may be resolved upstream." if formula.patchlist.present?
-    opoo "This formula has resources that may need to be updated." if formula.resources.present?
+    if formula.resources.present? && formula.resources.any? { |resource| resource.name != "homebrew-virtualenv" }
+      opoo "This formula has resources that may need to be updated."
+    end
 
     requested_spec = :stable
     formula_spec = formula.stable


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Don't display the `This formula has resources that may need to be updated` warning if the only resource is `homebrew-virtualenv`