### PR TITLE
livecheck/pypi: allow post in pypi version

### DIFF
--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -49,7 +49,8 @@ module Homebrew
 
           # Example regex: `%r{href=.*?/packages.*?/example[._-]v?(\d+(?:\.\d+)*).t}i`.
           regex ||=
-            %r{href=.*?/packages.*?/#{Regexp.escape(package_name)}[._-]v?(\d+(?:\.\d+)*)#{Regexp.escape(suffix)}}i
+            %r{href=.*?/packages.*?/#{Regexp.escape(package_name)}[._-]
+               v?(\d+(?:\.\d+)*(.post\d)?)#{Regexp.escape(suffix)}}ix
 
           Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Per [PEP 440](https://www.python.org/dev/peps/pep-0440/#post-releases), PyPI version numbers can include `.postN` as part of the version number during a post-release minor bugfix. This update is in support of https://github.com/Homebrew/homebrew-core/pull/61861 whose livecheck CI step is failing.