### PR TITLE
utils/git: set HEAD from remote if needed

### DIFF
--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -126,8 +126,14 @@ module Utils
     end
 
     def origin_branch(repo)
-      Utils.popen_read(git, "-C", repo, "symbolic-ref", "-q", "--short",
-                       "refs/remotes/origin/HEAD").chomp.presence
+      origin_branch = Utils.popen_read(git, "-C", repo, "symbolic-ref", "-q", "--short",
+                                       "refs/remotes/origin/HEAD").chomp.presence
+      unless origin_branch
+        quiet_system git, "-C", repo, "remote", "set-head", "origin", "--auto"
+        origin_branch = Utils.popen_read(git, "-C", repo, "symbolic-ref", "-q", "--short",
+                                         "refs/remotes/origin/HEAD").chomp.presence
+      end
+      origin_branch
     end
 
     def current_branch(repo)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Fixes workflows like [this one](https://github.com/dawidd6/homebrew-test-tap-new/runs/1198674370?check_suite_focus=true) from getting the following error:

```
brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
Error: undefined method `split' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:385:in `block in pr_pull'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:378:in `each'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:378:in `pr_pull'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```

See also https://github.com/Homebrew/brew/pull/8762#issuecomment-702691935


cc @dawidd6