### PR TITLE
deprecated livecheckables will be skipped

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -221,7 +221,7 @@ module Homebrew
     # for doing so, else it returns false.
     # @return [Hash, nil, Boolean]
     def skip_conditions(formula, args:)
-      if formula.deprecated? && !formula.livecheckable?
+      if formula.deprecated?
         return status_hash(formula, "deprecated", args: args) if args.json?
 
         puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : deprecated" unless args.quiet?


### PR DESCRIPTION
- [ x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
If a formula is livecheckable and deprecated, it will still be displayed by `brew livecheck` without any warning. This doesn't seem like it should be the case. An example of this behavior is the formula `akka`.

Once I can confirm the intended behavior, i'll update this pull request with unit tests if a change in needed. 