### PR TITLE
dev-cmd/pr-publish: add autosquash workflow

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -14,6 +14,12 @@ module Homebrew
         Publish bottles for a pull request with GitHub Actions.
         Requires write access to the repository.
       EOS
+      switch "--autosquash",
+             description: "If supported on the target tap, automatically reformat and reword commits "\
+                          "in the pull request to our preferred format."
+      flag   "--message=",
+             depends_on:  "--autosquash",
+             description: "Message to include when autosquashing revision bumps, deletions, and rebuilds."
       flag   "--tap=",
              description: "Target tap repository (default: `homebrew/core`)."
       flag   "--workflow=",
@@ -30,6 +36,11 @@ module Homebrew
     workflow = args.workflow || "publish-commit-bottles.yml"
     ref = "master"
 
+    extra_args = []
+    extra_args << "--autosquash" if args.autosquash?
+    extra_args << "--message='#{args.message}'" if args.message.presence
+    dispatch_args = extra_args.join " "
+
     args.named.uniq.each do |arg|
       arg = "#{tap.default_remote}/pull/#{arg}" if arg.to_i.positive?
       url_match = arg.match HOMEBREW_PULL_OR_COMMIT_URL_REGEX
@@ -40,7 +51,7 @@ module Homebrew
       end
 
       ohai "Dispatching #{tap} pull request ##{issue}"
-      GitHub.workflow_dispatch_event(user, repo, workflow, ref, pull_request: issue)
+      GitHub.workflow_dispatch_event(user, repo, workflow, ref, pull_request: issue, args: dispatch_args)
     end
   end
 end

--- a/docs/Brew-Test-Bot-For-Core-Contributors.md
+++ b/docs/Brew-Test-Bot-For-Core-Contributors.md
@@ -14,5 +14,10 @@ If a pull request is correct and doesn't need any modifications to commit messag
 If a pull request needs its commits squashed or its commit messages reformatted to [follow our style](https://docs.brew.sh/Formula-Cookbook#commit):
 
 1. Ensure the job has already completed successfully.
-2. Run `brew pr-pull --autosquash 12345` where `12345` is the pull request number (or URL). For revision bumps, rebuilds, and formula deletions, you can optionally include a `--message` argument to explain the change.
+2. Run `brew pr-publish --autosquash 12345` where `12345` is the pull request number (or URL). For revision bumps, rebuilds, and formula deletions, you can optionally include a `--message` argument to explain the change.
+
+If a pull request needs its commit messages changed in a way that autosquash doesn't support:
+
+1. Ensure the job has already completed successfully.
+2. Run `brew pr-pull 12345` where `12345` is the pull request number (or URL).
 3. Amend any relevant commits if needed, then run `git push` to push the commits.

--- a/docs/Homebrew-homebrew-core-Merge-Checklist.md
+++ b/docs/Homebrew-homebrew-core-Merge-Checklist.md
@@ -55,7 +55,7 @@ Check for:
   - formula `bottle :unneeded`, you can merge it through GitHub UI
   - bottles need to be pulled, and...
     - the commits are correct and don't need changes, approve the PR to trigger an automatic merge (use `brew pr-publish $PR_ID` to trigger manually in case of a new formula)
-    - the commits need to be squashed, use `brew pr-pull --autosquash $PR_ID` and `git push`
+    - the commits need to be squashed, use `brew pr-publish --autosquash $PR_ID` and `git push`
     - the commits need to be amended, use `brew pr-pull $PR_ID`, make changes, and `git push`
 - don't forget to thank the contributor
   - celebrate the first-time contributors

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1119,6 +1119,10 @@ Find pull requests that can be automatically merged using `brew pr-publish`.
 Publish bottles for a pull request with GitHub Actions.
 Requires write access to the repository.
 
+* `--autosquash`:
+  If supported on the target tap, automatically reformat and reword commits in the pull request to our preferred format.
+* `--message`:
+  Message to include when autosquashing revision bumps, deletions, and rebuilds.
 * `--tap`:
   Target tap repository (default: `homebrew/core`).
 * `--workflow`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1576,6 +1576,14 @@ Include pull requests that have failing status checks\.
 Publish bottles for a pull request with GitHub Actions\. Requires write access to the repository\.
 .
 .TP
+\fB\-\-autosquash\fR
+If supported on the target tap, automatically reformat and reword commits in the pull request to our preferred format\.
+.
+.TP
+\fB\-\-message\fR
+Message to include when autosquashing revision bumps, deletions, and rebuilds\.
+.
+.TP
 \fB\-\-tap\fR
 Target tap repository (default: \fBhomebrew/core\fR)\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Part of https://github.com/Homebrew/brew/issues/8093.

This permits maintainers to run e.g. `brew pr-publish --autosquash 1234` to run the autosquash workflow on GitHub Actions runners, rather than their personal computers. This should greatly reduce the frequency of needing to ask contributors and maintainers to squash or reword pull request commits.