### PR TITLE
os/mac: updates for Xcode 12 on Catalina

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -1,6 +1,6 @@
 name: brew doctor
 on:
-  pull_request:
+  push:
     paths:
       - .github/workflows/doctor.yml
       - Library/Homebrew/cmd/doctor.rb

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -16,9 +16,9 @@ module OS
       # CI systems have been updated.
       # This may be a beta version for a beta macOS.
       def latest_version
-        latest_stable = "11.5"
+        latest_stable = "12.0.1"
         case MacOS.version
-        when "11.0"  then "12.0"
+        when "11.0"  then "12.0.1"
         when "10.15" then latest_stable
         when "10.14" then "11.3.1"
         when "10.13" then "10.1"
@@ -180,10 +180,10 @@ module OS
         # installed CLT version. This is useful as they are packaged
         # simultaneously so workarounds need to apply to both based on their
         # comparable version.
-        latest_stable = "11.5"
+        latest_stable = "12.0"
         case (DevelopmentTools.clang_version.to_f * 10).to_i
-        when 120     then "12.0"
-        when 110     then latest_stable
+        when 120     then latest_stable
+        when 110     then "11.5"
         when 100     then "10.3"
         when 91      then "9.4"
         when 90      then "9.2"
@@ -263,8 +263,8 @@ module OS
       # and our CI systems have been updated.
       def latest_clang_version
         case MacOS.version
-        when "11.0" then "1200.0.22.7"
-        when "10.15" then "1103.0.32.59"
+        when "11.0" then "1200.0.32.2"
+        when "10.15" then "1200.0.32.2"
         when "10.14" then "1001.0.46.4"
         when "10.13" then "1000.10.44.2"
         when "10.12" then "900.0.39.2"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Forgot to do this when I updated the CI runners. Hopefully this should help contributors diagnose build issues with AppleClang 11 vs 12.

Here's what our CI says for `brew config`:

```
Homebrew Ruby: 2.6.3 => /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
CPU: hexa-core 64-bit penryn
Clang: 12.0 build 1200
Git: 2.24.3 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
Java: 14.0.1, 1.8.0_252
macOS: 10.15.7-x86_64
CLT: 12.0.32.2
Xcode: 12.0.1
XQuartz: 2.7.11 => /opt/X11

Apple clang version 12.0.0 (clang-1200.0.32.2)
Target: x86_64-apple-darwin19.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```