### PR TITLE
pr-upload: add --no-commit flag

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -20,6 +20,8 @@ module Homebrew
                           "attempt to preserve its value in the generated DSL."
       switch "-n", "--dry-run",
              description: "Print what would be done rather than doing it."
+      switch "--no-commit",
+             description: "Do not generate a new commit before uploading."
       switch "--warn-on-upload-failure",
              description: "Warn instead of raising an error if the bottle upload fails. "\
                           "Useful for repairing bottle uploads that previously failed."
@@ -66,6 +68,7 @@ module Homebrew
     bottle_args << "--debug" if args.debug?
     bottle_args << "--keep-old" if args.keep_old?
     bottle_args << "--root-url=#{args.root_url}" if args.root_url
+    bottle_args << "--no-commit" if args.no_commit?
     bottle_args += json_files
 
     if args.dry_run?

--- a/docs/Common-Issues-for-Core-Contributors.md
+++ b/docs/Common-Issues-for-Core-Contributors.md
@@ -9,6 +9,10 @@ This is a page for maintainers to diagnose certain build errors.
 ### Bottle publishes failed but the commits are correct in the git history
 
 Follow these steps to fix this issue:
+* Download and extract the bottle artifact.
+* `brew pr-upload --no-commit` in the bottle directory.
+
+Alternative instructions using `pr-pull`:
 * `git reset --hard <SHA>` in homebrew/core to reset to the commit before before all the commits created by `brew pr-pull`.
 * `brew pr-pull <options>` to upload the right bottles. Add the `--warn-on-upload-failure` flag if the bottles have been partially uploaded and you're certain that the bottle checksums will match the checksums already present in the `bottle do` block of the formula.
 * `git reset --hard origin/master` to return to the latest commit and discard the commits made by `brew pr-pull`.

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1177,6 +1177,8 @@ Apply the bottle commit and publish bottles to Bintray or GitHub Releases.
   If the formula specifies a rebuild version, attempt to preserve its value in the generated DSL.
 * `-n`, `--dry-run`:
   Print what would be done rather than doing it.
+* `--no-commit`:
+  Do not generate a new commit before uploading.
 * `--warn-on-upload-failure`:
   Warn instead of raising an error if the bottle upload fails. Useful for repairing bottle uploads that previously failed.
 * `--bintray-org`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1674,6 +1674,10 @@ If the formula specifies a rebuild version, attempt to preserve its value in the
 Print what would be done rather than doing it\.
 .
 .TP
+\fB\-\-no\-commit\fR
+Do not generate a new commit before uploading\.
+.
+.TP
 \fB\-\-warn\-on\-upload\-failure\fR
 Warn instead of raising an error if the bottle upload fails\. Useful for repairing bottle uploads that previously failed\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Allow `pr-upload` to run without committing changes

This is useful in a few special cases (such as https://github.com/Homebrew/homebrew-core/issues/62022) where the bottle upload failed but the bottle commit made it into master. Now, running `brew pr-upload --no-commit` in the bottle directory will upload the bottles without trying to generate a new bottle commit.

The current alternative is to check out a commit before the bottle commit, run `pr-pull`, and then reset to `origin/master`. This situation is rare enough that using that workflow isn't terrible, but here's a potential quick fix to make it even easier.

CC @jonchang