### PR TITLE
style: require `tag` and `revision` for git urls

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -315,6 +315,26 @@ module RuboCop
           "https://pypi.org/project/#{package_name}/#files"
         end
       end
+
+      # This cop makes sure that git urls have both a `tag` and `revision`.
+      #
+      # @api private
+      class GitUrls < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          find_method_calls_by_name(body_node, :url).each do |url|
+            next unless string_content(parameters(url).first).match?(/\.git$/)
+
+            next if url_has_tag_and_revision?(parameters(url).last)
+
+            offending_node(url)
+            problem "Specify a `tag` and `revision` for git urls"
+          end
+        end
+
+        def_node_matcher :url_has_tag_and_revision?, <<~EOS
+          (hash <(pair (sym :tag) str) (pair (sym :revision) str) ...>)
+        EOS
+      end
     end
   end
 end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -276,3 +276,123 @@ describe RuboCop::Cop::FormulaAudit::PyPiUrls do
     end
   end
 end
+
+describe RuboCop::Cop::FormulaAudit::GitUrls do
+  subject(:cop) { described_class.new }
+
+  context "when a git URL is used" do
+    it "reports no offenses with a non-git url" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://foo.com"
+        end
+      RUBY
+    end
+
+    it "reports no offenses with both a tag and a revision" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+              tag:      "v1.0.0",
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        end
+      RUBY
+    end
+
+    it "reports no offenses with both a tag, revision and `shallow` before" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+              shallow:  false,
+              tag:      "v1.0.0",
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        end
+      RUBY
+    end
+
+    it "reports no offenses with both a tag, revision and `shallow` after" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+              tag:      "v1.0.0",
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              shallow:  false
+        end
+      RUBY
+    end
+
+    it "reports an offense with no `revision`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
+              tag: "v1.0.0"
+        end
+      RUBY
+    end
+
+    it "reports an offense with no `revision` and `shallow`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
+              shallow: false,
+              tag:     "v1.0.0"
+        end
+      RUBY
+    end
+
+    it "reports an offense with no `tag`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        end
+      RUBY
+    end
+
+    it "reports an offense with no `tag` and `shallow`" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              shallow:  false
+        end
+      RUBY
+    end
+
+    it "reports no offenses with missing arguments in `head`" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://foo.com"
+          head do
+            url "https://github.com/foo/bar.git"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses with missing arguments in `devel`" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://foo.com"
+          devel do
+            url "https://github.com/foo/bar.git"
+          end
+        end
+      RUBY
+    end
+  end
+end

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -282,7 +282,7 @@ describe RuboCop::Cop::FormulaAudit::GitUrls do
 
   context "when a git URL is used" do
     it "reports no offenses with a non-git url" do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://foo.com"
@@ -291,7 +291,7 @@ describe RuboCop::Cop::FormulaAudit::GitUrls do
     end
 
     it "reports no offenses with both a tag and a revision" do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
@@ -302,7 +302,7 @@ describe RuboCop::Cop::FormulaAudit::GitUrls do
     end
 
     it "reports no offenses with both a tag, revision and `shallow` before" do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
@@ -314,7 +314,7 @@ describe RuboCop::Cop::FormulaAudit::GitUrls do
     end
 
     it "reports no offenses with both a tag, revision and `shallow` after" do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
@@ -326,45 +326,43 @@ describe RuboCop::Cop::FormulaAudit::GitUrls do
     end
 
     it "reports an offense with no `revision`" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should specify a revision for git urls
               tag: "v1.0.0"
         end
       RUBY
     end
 
     it "reports an offense with no `revision` and `shallow`" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should specify a revision for git urls
               shallow: false,
               tag:     "v1.0.0"
         end
       RUBY
     end
 
-    it "reports an offense with no `tag`" do
-      expect_offense(<<~RUBY)
+    it "reports no offenses with no `tag`" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
               revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         end
       RUBY
     end
 
-    it "reports an offense with no `tag` and `shallow`" do
-      expect_offense(<<~RUBY)
+    it "reports no offenses with no `tag` and `shallow`" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://github.com/foo/bar.git",
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Specify a `tag` and `revision` for git urls
               revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
               shallow:  false
         end
@@ -372,7 +370,7 @@ describe RuboCop::Cop::FormulaAudit::GitUrls do
     end
 
     it "reports no offenses with missing arguments in `head`" do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://foo.com"
@@ -384,13 +382,119 @@ describe RuboCop::Cop::FormulaAudit::GitUrls do
     end
 
     it "reports no offenses with missing arguments in `devel`" do
-      expect_no_offenses(<<~RUBY)
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           desc "foo"
           url "https://foo.com"
           devel do
             url "https://github.com/foo/bar.git"
           end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for non-core taps" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git"
+        end
+      RUBY
+    end
+  end
+end
+
+describe RuboCop::Cop::FormulaAuditStrict::GitUrls do
+  subject(:cop) { described_class.new }
+
+  context "when a git URL is used" do
+    it "reports no offenses with both a tag and a revision" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+              tag:      "v1.0.0",
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        end
+      RUBY
+    end
+
+    it "reports no offenses with both a tag, revision and `shallow` before" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+              shallow:  false,
+              tag:      "v1.0.0",
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        end
+      RUBY
+    end
+
+    it "reports no offenses with both a tag, revision and `shallow` after" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+              tag:      "v1.0.0",
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              shallow:  false
+        end
+      RUBY
+    end
+
+    it "reports an offense with no `tag`" do
+      expect_offense(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should specify a tag for git urls
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        end
+      RUBY
+    end
+
+    it "reports an offense with no `tag` and `shallow`" do
+      expect_offense(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git",
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core should specify a tag for git urls
+              revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              shallow:  false
+        end
+      RUBY
+    end
+
+    it "reports no offenses with missing arguments in `head`" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://foo.com"
+          head do
+            url "https://github.com/foo/bar.git"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses with missing arguments in `devel`" do
+      expect_no_offenses(<<~RUBY, "/homebrew-core/")
+        class Foo < Formula
+          desc "foo"
+          url "https://foo.com"
+          devel do
+            url "https://github.com/foo/bar.git"
+          end
+        end
+      RUBY
+    end
+
+    it "reports no offenses for non-core taps" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url "https://github.com/foo/bar.git"
         end
       RUBY
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Require a revision for git urls in homebrew/core

Require a tag as well if `--strict` is passed.

For example, this is always 👍:

```ruby
url "https://github.com/foo/bar.git",
    tag:      "v1.0.0",
    revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
```

This is 👍 unless `--strict` is passed and then 👎:

```ruby
url "https://github.com/foo/bar.git",
    tag: "v1.0.0"
```

This is always 👎:
```ruby
url "https://github.com/foo/bar.git"
```