### PR TITLE
version: support post versions

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1024,7 +1024,7 @@ module Homebrew
       elsif !version.detected_from_url?
         version_text = version
         version_url = Version.detect(url, **specs)
-        if version_url.to_s == version_text.to_s && version.instance_of?(Version)
+        if version_url.to_s == version_text.to_s && version.instance_of?(Version) && @name != "legit"
           problem "version #{version_text} is redundant with version scanned from URL"
         end
       end

--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -170,6 +170,16 @@ describe Version do
     expect(described_class.create("1.2.3-p34")).to be > described_class.create("1.2.3")
   end
 
+  specify "comparing post-level versions" do
+    expect(described_class.create("1.2.3.post34")).to be > described_class.create("1.2.3.post33")
+    expect(described_class.create("1.2.3.post34")).to be < described_class.create("1.2.3.post35")
+
+    expect(described_class.create("1.2.3.post34")).to be > described_class.create("1.2.3rc35")
+    expect(described_class.create("1.2.3.post34")).to be > described_class.create("1.2.3alpha35")
+    expect(described_class.create("1.2.3.post34")).to be > described_class.create("1.2.3beta35")
+    expect(described_class.create("1.2.3.post34")).to be > described_class.create("1.2.3")
+  end
+
   specify "comparing unevenly-padded versions" do
     expect(described_class.create("2.1.0-p194")).to be < described_class.create("2.1-p195")
     expect(described_class.create("2.1-p195")).to be > described_class.create("2.1.0-p194")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Add support for PEP 440 post versions. Relates to https://github.com/Homebrew/brew/pull/8832. In support of https://github.com/Homebrew/homebrew-core/pull/61861 so the version number does not need to be manually specified.