### PR TITLE
tab: fix nil modification time

### DIFF
--- a/.github/workflows/doctor.yml
+++ b/.github/workflows/doctor.yml
@@ -1,6 +1,6 @@
 name: brew doctor
 on:
-  push:
+  pull_request:
     paths:
       - .github/workflows/doctor.yml
       - Library/Homebrew/cmd/doctor.rb

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -324,7 +324,7 @@ class Tab < OpenStruct
   end
 
   def source_modified_time
-    Time.at(super)
+    Time.at(super || 0)
   end
 
   def to_json(options = nil)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Fixes https://github.com/Homebrew/brew/issues/8840. It's unclear why the modification time of the staged tarball could ever be nil; I suspect there's a bug in `downloader_strategy.rb`, but without the ability to reproduce locally this workaround should suffice.