### PR TITLE
style: allow license exceptions to be on one line

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -305,14 +305,18 @@ module RuboCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           license_node = find_node_method_by_name(body_node, :license)
           return unless license_node
+          return if license_node.source.include?("\n")
 
-          license = parameters(license_node).first
-          return unless license.hash_type?
-          return unless license.each_descendant(:hash).count.positive?
-          return if license.source.include?("\n")
+          parameters(license_node).first.each_descendant(:hash).each do |license_hash|
+            next if license_exception? license_hash
 
-          problem "Split nested license declarations onto multiple lines"
+            problem "Split nested license declarations onto multiple lines"
+          end
         end
+
+        def_node_matcher :license_exception?, <<~EOS
+          (hash (pair (sym :with) str))
+        EOS
       end
 
       # This cop checks for other miscellaneous style violations.

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -681,6 +681,16 @@ describe RuboCop::Cop::FormulaAudit::Licenses do
       RUBY
     end
 
+    it "allow license exceptions" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+          license "MIT" => { with: "LLVM-exception" }
+        end
+      RUBY
+    end
+
     it "allow multiline nested license hashes" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
@@ -689,6 +699,20 @@ describe RuboCop::Cop::FormulaAudit::Licenses do
           license any_of: [
             "MIT",
             all_of: ["0BSD", "Zlib"],
+          ]
+        end
+      RUBY
+    end
+
+    it "allow multiline nested license hashes with exceptions" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          desc "foo"
+          url 'https://brew.sh/foo-1.0.tgz'
+          license any_of: [
+            "MIT",
+            all_of: ["0BSD", "Zlib"],
+            "GPL-2.0-only" => { with: "LLVM-exception" },
           ]
         end
       RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Allow license declarations like (must have missed this case when the style check was introduced):

```ruby
license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
```

See https://github.com/Homebrew/homebrew-core/pull/62105