### PR TITLE
audit: remove python 3.9 from unstable allowlist now that it's released

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -718,7 +718,6 @@ module Homebrew
 
     # used for formulae that are unstable but need CI run without being in homebrew/core
     UNSTABLE_DEVEL_ALLOWLIST = {
-      "python@3.9" => "3.9.0rc",
     }.freeze
 
     GNOME_DEVEL_ALLOWLIST = {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Remove python 3.9 from unstable list now that it's released