### PR TITLE
sorbet: Start typechecking `install.rb` and `reinstall.rb`

### DIFF
--- a/Library/Homebrew/sorbet/files.yaml
+++ b/Library/Homebrew/sorbet/files.yaml
@@ -241,7 +241,6 @@ false:
   - ./formula_versions.rb
   - ./formulary.rb
   - ./global.rb
-  - ./install.rb
   - ./keg.rb
   - ./keg_relocate.rb
   - ./language/node.rb
@@ -266,7 +265,6 @@ false:
   - ./pkg_version.rb
   - ./postinstall.rb
   - ./readall.rb
-  - ./reinstall.rb
   - ./requirement.rb
   - ./requirements/arch_requirement.rb
   - ./requirements/codesign_requirement.rb
@@ -879,6 +877,7 @@ true:
   - ./formula_support.rb
   - ./hardware.rb
   - ./help.rb
+  - ./install.rb
   - ./install_renamed.rb
   - ./language/go.rb
   - ./language/java.rb
@@ -895,6 +894,7 @@ true:
   - ./os/linux.rb
   - ./os/linux/glibc.rb
   - ./os/linux/kernel.rb
+  - ./reinstall.rb
   - ./rubocops/cask/ast/cask_header.rb
   - ./rubocops/cask/ast/stanza.rb
   - ./rubocops/cask/constants/stanza.rb

--- a/Library/Homebrew/sorbet/rbi/homebrew.rbi
+++ b/Library/Homebrew/sorbet/rbi/homebrew.rbi
@@ -12,6 +12,10 @@ module Homebrew::Fetch
   def args; end
 end
 
+module Homebrew::Install
+  include Kernel
+end
+
 module Language::Perl::Shebang
   include Kernel
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- You can probably tell from the branch name that I had greater ambitions for tonight's Sorbet session than just two files. But I'm tired and it's still two files done!
- This moves `install.rb` and `reinstall.rb` to `true`.
