### PR TITLE
virtualenv: use version 20 to support Python 3.9

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -145,7 +145,7 @@ module Homebrew
     check_closed_pull_requests(formula, tap_full_name, version: new_version, args: args) if new_version
 
     opoo "This formula has patches that may be resolved upstream." if formula.patchlist.present?
-    if formula.resources.present? && formula.resources.any? { |resource| resource.name != "homebrew-virtualenv" }
+    if formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") }
       opoo "This formula has resources that may need to be updated."
     end
 
@@ -339,8 +339,7 @@ module Homebrew
     run_audit(formula, alias_rename, old_contents, args: args)
 
     pr_message = "Created with `brew bump-formula-pr`."
-    if resources_checked.nil? && formula.resources.present? &&
-       formula.resources.any? { |resource| resource.name != "homebrew-virtualenv" }
+    if resources_checked.nil? && formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") }
       pr_message += <<~EOS
 
 

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -116,9 +116,28 @@ module Language
       def self.included(base)
         base.class_eval do
           resource "homebrew-virtualenv" do
-            url "https://files.pythonhosted.org/packages/11/74" \
-                "/2c151a13ef41ab9fb43b3c4ff9e788e0496ed7923b2078d42cab30622bdf/virtualenv-16.7.4.tar.gz"
-            sha256 "94a6898293d07f84a98add34c4df900f8ec64a570292279f6d91c781d37fd305"
+            url "https://files.pythonhosted.org/packages/85/3e/6c3abf78b2207f3565ebadd0b99d1945f4ff18abdc6879617a4f6d939e41/virtualenv-20.0.33.tar.gz"
+            sha256 "a5e0d253fe138097c6559c906c528647254f437d1019af9d5a477b09bfa7300f"
+          end
+
+          resource "homebrew-appdirs" do
+            url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"
+            sha256 "7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"
+          end
+
+          resource "homebrew-distlib" do
+            url "https://files.pythonhosted.org/packages/2f/83/1eba07997b8ba58d92b3e51445d5bf36f9fba9cb8166bcae99b9c3464841/distlib-0.3.1.zip"
+            sha256 "edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"
+          end
+
+          resource "homebrew-filelock" do
+            url "https://files.pythonhosted.org/packages/14/ec/6ee2168387ce0154632f856d5cc5592328e9cf93127c5c9aeca92c8c16cb/filelock-3.0.12.tar.gz"
+            sha256 "18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"
+          end
+
+          resource "homebrew-six" do
+            url "https://files.pythonhosted.org/packages/6b/34/415834bfdafca3c5f451532e8a8d9ba89a21c9743a0c59fbd0205c7f9426/six-1.15.0.tar.gz"
+            sha256 "30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"
           end
         end
       end
@@ -217,6 +236,14 @@ module Language
             old_pythonpath = ENV.delete "PYTHONPATH"
             begin
               staging = Pathname.new(stage.staging.tmpdir)
+
+              ENV.prepend_create_path "PYTHONPATH", staging/"target/vendor"/Language::Python.site_packages(@python)
+              %w[appdirs distlib filelock six].each do |virtualenv_dependency|
+                @formula.resource("homebrew-#{virtualenv_dependency}").stage do
+                  @formula.system @python, *Language::Python.setup_install_args(staging/"target/vendor")
+                end
+              end
+
               ENV.prepend_create_path "PYTHONPATH", staging/"target"/Language::Python.site_packages(@python)
               @formula.system @python, *Language::Python.setup_install_args(staging/"target")
               @formula.system @python, "-s", staging/"target/bin/virtualenv", "-p", @python, @venv_root

--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -289,7 +289,7 @@ module Language
           targets = Array(targets)
           targets.each do |t|
             if t.respond_to? :stage
-              next if t.name == "homebrew-virtualenv"
+              next if t.name.start_with? "homebrew-"
 
               t.stage { do_install Pathname.pwd }
             else

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -142,9 +142,8 @@ module PyPI
       return
     end
 
-    # Check whether resources already exist (excluding homebrew-virtualenv)
-    if formula.resources.blank? ||
-       (formula.resources.length == 1 && formula.resources.first.name == "homebrew-virtualenv")
+    # Check whether resources already exist (excluding virtualenv dependencies)
+    if formula.resources.all? { |resource| resource.name.start_with?("homebrew-") }
       # Place resources above install method
       inreplace_regex = /  def install/
       new_resource_blocks += "  def install"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

See https://github.com/Homebrew/homebrew-core/issues/62201#issuecomment-704600513 and https://github.com/Homebrew/discussions/discussions/31

Update the `homebrew-virtualenv` resource to version 20.0.33 to support virtual environments using Python 3.9. This was attempted previously in https://github.com/Homebrew/brew/pull/7941.

I tested this locally and was able to build a formula using a Python 3.9 formula locally without any problems. I'm not yet sure what the consequences are to adding the four new `homebrew-` resources.