### PR TITLE
Fix running deprecated command in fish completion

### DIFF
--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -198,7 +198,7 @@ function __fish_brew_suggest_services -d "Lists available services"
 end
 
 function __fish_brew_suggest_casks_installed -d "Lists installed casks"
-    brew cask list -1
+    brew list --cask -1
 end
 
 function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the information about potential upgrade"


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

A deprecated command is used in fish completion file.

How to occur the problem \:
- Open fish shell.
- Type "brew cask uninstall " then press `Tab`.

<img width="527" alt="image" src="https://user-images.githubusercontent.com/54097100/95479257-8638aa80-09c5-11eb-852a-be20873b80e3.png">