### PR TITLE
cask/cmd/info.rb: Fix crash when running `brew cask info --github`

### DIFF
--- a/Library/Homebrew/cask/cmd/info.rb
+++ b/Library/Homebrew/cask/cmd/info.rb
@@ -43,15 +43,15 @@ module Cask
 
       def run
         if args.json == "v1"
-          puts JSON.generate(casks.map(&:to_h))
+          puts JSON.generate(args.named.to_casks.map(&:to_h))
         elsif args.github?
           raise CaskUnspecifiedError if args.no_named?
 
-          args.named.to_formulae_and_casks.map do |cask|
+          args.named.to_casks.map do |cask|
             exec_browser(github_info(cask))
           end
         else
-          casks.each_with_index do |cask, i|
+          args.named.to_casks.each_with_index do |cask, i|
             puts unless i.zero?
             odebug "Getting info for Cask #{cask}"
             self.class.info(cask)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Fix crash when using `brew cask info --github sl` caused by formulae being passed to `Cask::Cmd::Info.github_info`

```
Error: undefined method `sourcefile_path' for #<Formulary::FormulaNamespacee3b11e986e0540a2aeccc9b89fd2c30f::Sl:0x00007f9d0d193528>
```