### PR TITLE
Reduce shallow clone usage

### DIFF
--- a/Library/Homebrew/cmd/tap.rb
+++ b/Library/Homebrew/cmd/tap.rb
@@ -26,7 +26,7 @@ module Homebrew
       EOS
       switch "--full",
              description: "Convert a shallow clone to a full clone without untapping. Taps are only cloned as "\
-                          "shallow clones on continuous integration, or if `--shallow` was originally passed."
+                          "shallow clones if `--shallow` was originally passed."
       switch "--shallow",
              description: "Fetch tap as a shallow clone rather than a full clone. Useful for continuous integration."
       switch "--force-auto-update",
@@ -53,8 +53,6 @@ module Homebrew
     else
       full_clone = if args.full?
         true
-      elsif !args.shallow?
-        ENV["CI"].blank?
       else
         !args.shallow?
       end

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -37,8 +37,7 @@ git_init_if_necessary() {
     fi
     git config remote.origin.url "$HOMEBREW_BREW_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    latest_tag="$(git ls-remote --tags --refs -q origin | tail -n1 | cut -f2)"
-    git fetch --force origin --shallow-since="$latest_tag"
+    git fetch --force --tags origin
     git remote set-head origin --auto >/dev/null
     git reset --hard origin/master
     SKIP_FETCH_BREW_REPOSITORY=1
@@ -60,7 +59,7 @@ git_init_if_necessary() {
     fi
     git config remote.origin.url "$HOMEBREW_CORE_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    git fetch --force --depth=1 origin refs/heads/master:refs/remotes/origin/master
+    git fetch --force origin refs/heads/master:refs/remotes/origin/master
     git remote set-head origin --auto >/dev/null
     git reset --hard origin/master
     SKIP_FETCH_CORE_REPOSITORY=1
@@ -428,12 +427,7 @@ EOS
     echo "HOMEBREW_BREW_GIT_REMOTE set: using $HOMEBREW_BREW_GIT_REMOTE for Homebrew/brew Git remote."
     git remote set-url origin "$HOMEBREW_BREW_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    latest_tag="$(git ls-remote --tags --refs -q origin |
-                  cut -d/ -f3 | 
-                  sort --numeric-sort --field-separator=. --key=1,1 --key=2,2 --key=3,3 |
-                  tail -n1)"
-    latest_ref="refs/tags/$latest_tag"
-    git fetch --force origin --shallow-since="$latest_ref"
+    git fetch --force --tags origin
   fi
 
   if [[ "$HOMEBREW_CORE_DEFAULT_GIT_REMOTE" != "$HOMEBREW_CORE_GIT_REMOTE" ]] &&
@@ -443,7 +437,7 @@ EOS
     echo "HOMEBREW_CORE_GIT_REMOTE set: using $HOMEBREW_CORE_GIT_REMOTE for Homebrew/brew Git remote."
     git remote set-url origin "$HOMEBREW_CORE_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-    git fetch --force --depth=1 origin refs/heads/master:refs/remotes/origin/master
+    git fetch --force origin refs/heads/master:refs/remotes/origin/master
   fi
 
   safe_cd "$HOMEBREW_REPOSITORY"

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -620,7 +620,10 @@ class CoreTap < Tap
     safe_system HOMEBREW_BREW_FILE, "tap", instance.name
   end
 
+  # CoreTap never allows shallow clones (on request from GitHub).
   def install(full_clone: true, quiet: false, clone_target: nil, force_auto_update: nil)
+    raise "Shallow clones are not supported for homebrew-core!" unless full_clone
+
     remote = Homebrew::EnvConfig.core_git_remote
     if remote != default_remote
       $stderr.puts "HOMEBREW_CORE_GIT_REMOTE set: using #{remote} for Homebrew/core Git remote URL."

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -556,7 +556,7 @@ assumptions, so taps can be cloned from places other than GitHub and
 using protocols other than HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
 
 * `--full`:
-  Convert a shallow clone to a full clone without untapping. Taps are only cloned as shallow clones on continuous integration, or if `--shallow` was originally passed.
+  Convert a shallow clone to a full clone without untapping. Taps are only cloned as shallow clones if `--shallow` was originally passed.
 * `--shallow`:
   Fetch tap as a shallow clone rather than a full clone. Useful for continuous integration.
 * `--force-auto-update`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -786,7 +786,7 @@ With \fIURL\fR specified, tap a formula repository from anywhere, using any tran
 .
 .TP
 \fB\-\-full\fR
-Convert a shallow clone to a full clone without untapping\. Taps are only cloned as shallow clones on continuous integration, or if \fB\-\-shallow\fR was originally passed\.
+Convert a shallow clone to a full clone without untapping\. Taps are only cloned as shallow clones if \fB\-\-shallow\fR was originally passed\.
 .
 .TP
 \fB\-\-shallow\fR


### PR DESCRIPTION
GitHub has requested we request our usage of shallow clones. As a result:

- do default to shallow clones on CI
- do not do --shallow-since when setting up new repositories in `brew update`
- do not support shallow clones of homebrew-core at all

We may consider in future unshallowing all clones unconditionally.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
