### PR TITLE
Add experimental HOMEBREW_GIT_FILTER_TREE_ZERO variable

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -209,9 +209,9 @@ else
       odie <<EOS
 The version of cURL that you provided to Homebrew using HOMEBREW_CURL_PATH is too old.
 Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}.
-Your cURL version: ${curl_name_and_version##* }.
+Your cURL version: ${curl_name_and_version##* }
 Please point Homebrew to cURL ${HOMEBREW_MINIMUM_CURL_VERSION} or newer
-or unset HOMEBREW_CURL_PATH variable.
+or unset the HOMEBREW_CURL_PATH variable.
 EOS
     fi
   fi
@@ -220,10 +220,10 @@ EOS
   # Git 2.7.4 is the version of git on Ubuntu 16.04 LTS (Xenial Xerus).
   HOMEBREW_MINIMUM_GIT_VERSION="2.7.0"
   git_version_output="$($HOMEBREW_GIT --version 2>/dev/null)"
-  # $extra is intentionally discarded.
+  # $build and $extra are intentionally discarded.
   # shellcheck disable=SC2034
   IFS=. read -r major minor micro build extra <<< "${git_version_output##* }"
-  if [[ $(numeric "$major.$minor.$micro.$build") -lt $(numeric "$HOMEBREW_MINIMUM_GIT_VERSION") ]]
+  if [[ $(numeric "$major.$minor.$micro") -lt $(numeric "$HOMEBREW_MINIMUM_GIT_VERSION") ]]
   then
     if [[ -z $HOMEBREW_GIT_PATH ]]; then
       HOMEBREW_FORCE_BREWED_GIT="1"
@@ -231,9 +231,9 @@ EOS
       odie <<EOS
 The version of Git that you provided to Homebrew using HOMEBREW_GIT_PATH is too old.
 Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}.
-Your Git version: $major.$minor.$micro.$build.
-Please point Homebrew to Git ${HOMEBREW_MINIMUM_CURL_VERSION} or newer
-or unset HOMEBREW_GIT_PATH variable.
+Your Git version: $major.$minor.$micro
+Please point Homebrew to Git ${HOMEBREW_MINIMUM_GIT_VERSION} or newer
+or unset the HOMEBREW_GIT_PATH variable.
 EOS
     fi
   fi
@@ -244,6 +244,30 @@ EOS
   HOMEBREW_DEFAULT_TEMP="/tmp"
 
   unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
+fi
+
+if [[ -n "$HOMEBREW_GIT_FILTER_TREE_ZERO" ]]
+then
+  if [[ -n "$HOMEBREW_MACOS" ]]
+  then
+    git_version_output="$($HOMEBREW_GIT --version 2>/dev/null | sed -e 's/ (Apple Git-.*)//')"
+  fi
+
+  # Ensure Git is at or newer than the minimum required version.
+  HOMEBREW_GIT_FILTER_TREE_ZERO_VERSION="2.20.0"
+  # $build and $extra are intentionally discarded.
+  # shellcheck disable=SC2034
+  IFS=. read -r major minor micro build extra <<< "${git_version_output##* }"
+  if [[ $(numeric "$major.$minor.$micro") -lt $(numeric "$HOMEBREW_GIT_FILTER_TREE_ZERO_VERSION") ]]
+  then
+    odie <<EOS
+The version of Git that you provided to Homebrew is too old for --filter=tree:0.
+Minimum required version: ${HOMEBREW_GIT_FILTER_TREE_ZERO_VERSION}
+Your Git version: $major.$minor.$micro
+Please point Homebrew to Git ${HOMEBREW_GIT_FILTER_TREE_ZERO_VERSION} or newer
+or unset the HOMEBREW_GIT_FILTER_TREE_ZERO variable.
+EOS
+  fi
 fi
 
 if [[ -n "$HOMEBREW_MACOS" || -n "$HOMEBREW_FORCE_HOMEBREW_ON_LINUX" ]]

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -59,6 +59,11 @@ git_init_if_necessary() {
     fi
     git config remote.origin.url "$HOMEBREW_CORE_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    if [[ -n "$HOMEBREW_GIT_FILTER_TREE_ZERO" ]]
+    then
+      git config extensions.partialClone "true"
+      git config remote.origin.partialclonefilter "tree:0"
+    fi
     git fetch --force origin refs/heads/master:refs/remotes/origin/master
     git remote set-head origin --auto >/dev/null
     git reset --hard origin/master
@@ -437,6 +442,11 @@ EOS
     echo "HOMEBREW_CORE_GIT_REMOTE set: using $HOMEBREW_CORE_GIT_REMOTE for Homebrew/brew Git remote."
     git remote set-url origin "$HOMEBREW_CORE_GIT_REMOTE"
     git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    if [[ -n "$HOMEBREW_GIT_FILTER_TREE_ZERO" ]]
+    then
+      git config extensions.partialClone "true"
+      git config remote.origin.partialclonefilter "tree:0"
+    fi
     git fetch --force origin refs/heads/master:refs/remotes/origin/master
   fi
 
@@ -476,6 +486,10 @@ EOS
     if [[ "$DIR" = "$HOMEBREW_REPOSITORY" && -z "$(git tag --list)" ]]
     then
       HOMEBREW_UPDATE_FORCE=1
+    elif [[ "$DIR" = "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" && -n "$HOMEBREW_GIT_FILTER_TREE_ZERO" ]]
+    then
+      git config extensions.partialClone "true"
+      git config remote.origin.partialclonefilter "tree:0"
     fi
 
     if [[ -z "$HOMEBREW_UPDATE_FORCE" ]]


### PR DESCRIPTION
This uses a `tree:0` partial clone filter for Homebrew/homebrew-core to (attempt to) improve performance.

If my personal experiments go well for this we'll:
- enable it for `HOMEBREW_DEVELOPER`
- enable it for CI
- enable it for `homebrew.devcmd`
- enable it for everyone

while conferring with GitHub about the performance impacts.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
