### PR TITLE
cmd/info: Add support for casks in brew info

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -38,6 +38,14 @@ module Homebrew
         end
       end
 
+      def to_formulae_casks_unknowns(method: nil)
+        downcased_unique_named.map do |name|
+          load_formula_or_cask(name, method: method)
+        rescue FormulaOrCaskUnavailableError => e
+          e
+        end.uniq.freeze
+      end
+
       def load_formula_or_cask(name, only: nil, method: nil)
         if only != :cask
           begin

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -38,8 +38,16 @@ module Homebrew
         end
       end
 
+      def to_formulae_to_casks(method: nil, only: nil)
+        @to_formulae_to_casks ||= {}
+        @to_formulae_to_casks[[method, only]] = to_formulae_and_casks(method: method, only: only)
+                                                .partition { |o| o.is_a?(Formula) }
+                                                .map(&:freeze).freeze
+      end
+
       def to_formulae_casks_unknowns(method: nil)
-        downcased_unique_named.map do |name|
+        @to_formulae_casks_unknowns ||= {}
+        @to_formulae_casks_unknowns[method] = downcased_unique_named.map do |name|
           load_formula_or_cask(name, method: method)
         rescue FormulaOrCaskUnavailableError => e
           e
@@ -88,9 +96,7 @@ module Homebrew
       end
 
       def to_resolved_formulae_to_casks(only: nil)
-        @to_resolved_formulae_to_casks ||= to_formulae_and_casks(method: :resolve, only: only)
-                                           .partition { |o| o.is_a?(Formula) }
-                                           .map(&:freeze).freeze
+        to_formulae_to_casks(method: :resolve, only: only)
       end
 
       # Convert named arguments to `Tap`, `Formula` or `Cask` objects.

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -45,7 +45,7 @@ module Homebrew
                                                 .map(&:freeze).freeze
       end
 
-      def to_formulae_casks_unknowns(method: nil)
+      def to_formulae_and_casks_and_unavailable(method: nil)
         @to_formulae_casks_unknowns ||= {}
         @to_formulae_casks_unknowns[method] = downcased_unique_named.map do |name|
           load_formula_or_cask(name, method: method)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -103,7 +103,7 @@ module Homebrew
       return
     end
 
-    args.named.to_formulae_casks_unknowns.each_with_index do |obj, i|
+    args.named.to_formulae_and_casks_and_unavailable.each_with_index do |obj, i|
       puts unless i.zero?
 
       case obj
@@ -120,7 +120,7 @@ module Homebrew
   end
 
   def print_info(args:)
-    args.named.to_formulae_casks_unknowns(method: nil).each_with_index do |obj, i|
+    args.named.to_formulae_and_casks_and_unavailable.each_with_index do |obj, i|
       puts unless i.zero?
 
       case obj

--- a/Library/Homebrew/test/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cmd/info_spec.rb
@@ -17,6 +17,15 @@ describe "brew info", :integration_test do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  it "prints as json with the --json=v2 flag" do
+    setup_test_formula "testball"
+
+    expect { brew "info", "testball", "--json=v2" }
+      .to output(a_json_string).to_stdout
+      .and not_to_output.to_stderr
+      .and be_a_success
+  end
 end
 
 describe Homebrew do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Allow references to casks in `brew info`, e.g. `brew info firefox sl`. 

 - [x] Add support for `--json` for casks

Using brew outdated as prior art: https://github.com/Homebrew/brew/pull/7927

I added `--json=v2` which outputs a json dictionary with keys for formulae and casks.

 - [ ] Deprecate `brew cask info` (any more functionality to move over besides `--json`?)