### PR TITLE
style: python versions must match python dependency

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -319,6 +319,43 @@ module RuboCop
         EOS
       end
 
+      # This cop makes sure that python versions are consistent.
+      #
+      # @api private
+      class PythonVersions < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, body_node)
+          python_formula_node = find_every_method_call_by_name(body_node, :depends_on).find do |dep|
+            string_content(parameters(dep).first).start_with? "python@"
+          end
+
+          return if python_formula_node.blank?
+
+          python_version = string_content(parameters(python_formula_node).first).split("@").last
+
+          find_strings(body_node).each do |str|
+            string_content = string_content(str)
+
+            next unless match = string_content.match(/^python(@)?(\d\.\d)$/)
+            next if python_version == match[2]
+
+            @fix = if match[1]
+              "python@#{python_version}"
+            else
+              "python#{python_version}"
+            end
+
+            offending_node(str)
+            problem "References to `#{string_content}` should match the specified python dependency (`#{@fix}`)"
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node.source_range, "\"#{@fix}\"")
+          end
+        end
+      end
+
       # This cop checks for other miscellaneous style violations.
       #
       # @api private

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -335,7 +335,7 @@ module RuboCop
           find_strings(body_node).each do |str|
             string_content = string_content(str)
 
-            next unless match = string_content.match(/^python(@)?(\d\.\d)$/)
+            next unless match = string_content.match(/^python(@)?(\d\.\d+)$/)
             next if python_version == match[2]
 
             @fix = if match[1]

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -793,6 +793,30 @@ describe RuboCop::Cop::FormulaAudit::PythonVersions do
       RUBY
     end
 
+    it "allow matching versions with two digits" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.10"
+
+          def install
+            puts "python@3.10"
+          end
+        end
+      RUBY
+    end
+
+    it "allow matching versions without `@` with two digits" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.10"
+
+          def install
+            puts "python3.10"
+          end
+        end
+      RUBY
+    end
+
     it "do not allow mismatching versions" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -814,6 +838,32 @@ describe RuboCop::Cop::FormulaAudit::PythonVersions do
           def install
             puts "python3.8"
                  ^^^^^^^^^^^ References to `python3.8` should match the specified python dependency (`python3.9`)
+          end
+        end
+      RUBY
+    end
+
+    it "do not allow mismatching versions with two digits" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.11"
+
+          def install
+            puts "python@3.10"
+                 ^^^^^^^^^^^^^ References to `python@3.10` should match the specified python dependency (`python@3.11`)
+          end
+        end
+      RUBY
+    end
+
+    it "do not allow mismatching versions without `@` with two digits" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          depends_on "python@3.11"
+
+          def install
+            puts "python3.10"
+                 ^^^^^^^^^^^^ References to `python3.10` should match the specified python dependency (`python3.11`)
           end
         end
       RUBY
@@ -861,6 +911,56 @@ describe RuboCop::Cop::FormulaAudit::PythonVersions do
 
           def install
             puts "python3.9"
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "autocorrects mismatching versions with two digits" do
+      source = <<~RUBY
+        class Foo < Formula
+          depends_on "python@3.10"
+
+          def install
+            puts "python@3.9"
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          depends_on "python@3.10"
+
+          def install
+            puts "python@3.10"
+          end
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+      expect(new_source).to eq(corrected_source)
+    end
+
+    it "autocorrects mismatching versions without `@` with two digits" do
+      source = <<~RUBY
+        class Foo < Formula
+          depends_on "python@3.11"
+
+          def install
+            puts "python3.10"
+          end
+        end
+      RUBY
+
+      corrected_source = <<~RUBY
+        class Foo < Formula
+          depends_on "python@3.11"
+
+          def install
+            puts "python3.11"
           end
         end
       RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Require that all strings that match `pythonX.Y` or `python@X.Y` match versions with the specified python dependency

Partially influenced by discussion at https://github.com/Homebrew/homebrew-core/pull/62406#discussion_r502016092

This change should make the migration easier because `brew style --fix` will update python references to the new python version

CC: @iMichka and @fxcoudert
