### PR TITLE
hide deprecated cask command

### DIFF
--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -69,6 +69,7 @@ module Cask
 
       command_lines = Cmd.command_classes
                          .select(&:visible?)
+                         .reject { |command| DEPRECATED_COMMANDS.key?(command) }
                          .map do |klass|
         "  - #{"`#{klass.command_name}`".ljust(max_command_length + 2)}  #{klass.short_description}\n"
       end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -71,9 +71,6 @@ Homebrew Cask provides a friendly CLI workflow for the administration of macOS a
 
 Commands:
 
-- `--cache`
-  <br>Display the file used to cache a *`cask`*.
-
 - `audit`
   <br>Check *`cask`* for Homebrew coding style violations.
 
@@ -82,9 +79,6 @@ Commands:
 
 - `create`
   <br>Creates the given *`cask`* and opens it in an editor.
-
-- `doctor`
-  <br>Checks for configuration issues.
 
 - `edit`
   <br>Open the given *`cask`* for editing.
@@ -95,32 +89,17 @@ Commands:
 - `help`
   <br>Print help for `cask` commands.
 
-- `home`
-  <br>Opens the homepage of the given *`cask`*.
-
 - `info`
   <br>Displays information about the given *`cask`*.
 
 - `install`
   <br>Installs the given *`cask`*.
 
-- `list`
-  <br>Lists installed casks or the casks provided in the arguments.
-
-- `outdated`
-  <br>List the outdated installed casks.
-
-- `reinstall`
-  <br>Reinstalls the given *`cask`*.
-
 - `style`
   <br>Checks style of the given *`cask`* using RuboCop.
 
 - `uninstall`
   <br>Uninstalls the given *`cask`*.
-
-- `upgrade`
-  <br>Upgrades all outdated casks or the specified casks.
 
 - `zap`
   <br>Zaps all files associated with the given *`cask`*.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -67,12 +67,6 @@ Homebrew Cask provides a friendly CLI workflow for the administration of macOS a
 Commands:
 .
 .TP
-\fB\-\-cache\fR
-.
-.br
-Display the file used to cache a \fIcask\fR\.
-.
-.TP
 \fBaudit\fR
 .
 .br
@@ -89,12 +83,6 @@ Dump raw source of a \fIcask\fR to the standard output\.
 .
 .br
 Creates the given \fIcask\fR and opens it in an editor\.
-.
-.TP
-\fBdoctor\fR
-.
-.br
-Checks for configuration issues\.
 .
 .TP
 \fBedit\fR
@@ -115,12 +103,6 @@ Downloads remote application files to local cache\.
 Print help for \fBcask\fR commands\.
 .
 .TP
-\fBhome\fR
-.
-.br
-Opens the homepage of the given \fIcask\fR\.
-.
-.TP
 \fBinfo\fR
 .
 .br
@@ -133,24 +115,6 @@ Displays information about the given \fIcask\fR\.
 Installs the given \fIcask\fR\.
 .
 .TP
-\fBlist\fR
-.
-.br
-Lists installed casks or the casks provided in the arguments\.
-.
-.TP
-\fBoutdated\fR
-.
-.br
-List the outdated installed casks\.
-.
-.TP
-\fBreinstall\fR
-.
-.br
-Reinstalls the given \fIcask\fR\.
-.
-.TP
 \fBstyle\fR
 .
 .br
@@ -161,12 +125,6 @@ Checks style of the given \fIcask\fR using RuboCop\.
 .
 .br
 Uninstalls the given \fIcask\fR\.
-.
-.TP
-\fBupgrade\fR
-.
-.br
-Upgrades all outdated casks or the specified casks\.
 .
 .TP
 \fBzap\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
hide some deprecated cask command from the document  because of https://github.com/Homebrew/brew/issues/8629