### PR TITLE
pr-pull: clean up review signoff trailer code

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -104,9 +104,10 @@ module Homebrew
     if pr
       # This is a tap pull request and approving reviewers should also sign-off.
       tap = Tap.from_path(path)
-      trailers += GitHub.approved_reviews(tap.user, tap.full_name.split("/").last, pr).map do |r|
+      review_trailers = GitHub.approved_reviews(tap.user, tap.full_name.split("/").last, pr).map do |r|
         "Signed-off-by: #{r["name"]} <#{r["email"]}>"
-      end.join("\n")
+      end
+      trailers = trailers.lines.concat(review_trailers).map(&:strip).uniq.join("\n")
 
       # Append the close message as well, unless the commit body already includes it.
       close_message = "Closes ##{pr}."


### PR DESCRIPTION
This should avoid situations that mangle the trailers when trailers already exist but we want to add review signoff trailers. After this pull request, the commit messages look like:

https://github.com/Homebrew/homebrew-core/commit/c6a0ed89fcc6310aa8b7d48fc748c35e9e612fa9


```text
r 4.0.3

* r 4.0.3
* r: update license

Closes #62704.

Co-authored-by: chenrui <chenrui333@gmail.com>
Signed-off-by: FX Coudert <fxcoudert@gmail.com>
Signed-off-by: Jonathan Chang <me@jonathanchang.org>
```

https://github.com/Homebrew/homebrew-core/commit/7db0bc2ba7ccce7fa5814c9c7bc423a73c299714

    conan 1.30.1
    
    Closes #62710.
    
    Signed-off-by: Rui Chen <rui@meetup.com>
    Signed-off-by: FX Coudert <fxcoudert@gmail.com>
    Signed-off-by: BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----