### PR TITLE
Try preventing sorbet error.

### DIFF
--- a/Library/Homebrew/utils/sorbet.rb
+++ b/Library/Homebrew/utils/sorbet.rb
@@ -6,5 +6,8 @@ if ENV["HOMEBREW_SORBET_RUNTIME"]
   Homebrew.install_bundler_gems!
   require "sorbet-runtime"
 else
+  # Explicitly prevent `sorbet-runtime` from being loaded.
+  ENV["GEM_SKIP"] = "sorbet-runtime"
+
   require "sorbet-runtime-stub"
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

I am only guessing that this fixes https://github.com/Homebrew/discussions/discussions/53.

When `sorbet-runtime` is installed for the system Ruby, I presume `gem "sorbet-runtime"` does not error, preventing `sorbet-runtime-stub` from begin loaded.