### PR TITLE
pr-automerge: enable --autosquash argument

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -19,11 +19,15 @@ module Homebrew
       flag   "--with-label=",
              description: "Pull requests must have this label."
       comma_array "--without-labels=",
-                  description: "Pull requests must not have these labels (default: `do not merge`, `new formula`)."
+                  description: "Pull requests must not have these labels "\
+                               "(default: `do not merge`, `new formula`, `automerge-skip`)."
       switch "--without-approval",
              description: "Pull requests do not require approval to be merged."
       switch "--publish",
              description: "Run `brew pr-publish` on matching pull requests."
+      switch "--autosquash",
+             description: "Instruct `brew pr-publish` to automatically reformat and reword commits "\
+                          "in the pull request to our preferred format."
       switch "--ignore-failures",
              description: "Include pull requests that have failing status checks."
 
@@ -34,7 +38,7 @@ module Homebrew
   def pr_automerge
     args = pr_automerge_args.parse
 
-    without_labels = args.without_labels || ["do not merge", "new formula"]
+    without_labels = args.without_labels || ["do not merge", "new formula", "automerge-skip"]
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
 
     query = "is:pr is:open repo:#{tap.full_name}"
@@ -57,12 +61,13 @@ module Homebrew
       pr_urls << pr["html_url"]
     end
 
+    publish_args = ["pr-publish"]
+    publish_args << "--tap=#{tap}" if tap
+    publish_args << "--autosquash" if args.autosquash?
     if args.publish?
-      publish_args = ["pr-publish"]
-      publish_args << "--tap=#{tap}" if tap
       safe_system HOMEBREW_BREW_FILE, *publish_args, *pr_urls
     else
-      ohai "Now run:", "  brew pr-publish \\\n    #{pr_urls.join " \\\n    "}"
+      ohai "Now run:", "  brew #{publish_args.join " "} \\\n    #{pr_urls.join " \\\n    "}"
     end
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1081,11 +1081,13 @@ Find pull requests that can be automatically merged using `brew pr-publish`.
 * `--with-label`:
   Pull requests must have this label.
 * `--without-labels`:
-  Pull requests must not have these labels (default: `do not merge`, `new formula`).
+  Pull requests must not have these labels (default: `do not merge`, `new formula`, `automerge-skip`).
 * `--without-approval`:
   Pull requests do not require approval to be merged.
 * `--publish`:
   Run `brew pr-publish` on matching pull requests.
+* `--autosquash`:
+  Instruct `brew pr-publish` to automatically reformat and reword commits in the pull request to our preferred format.
 * `--ignore-failures`:
   Include pull requests that have failing status checks.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1501,7 +1501,7 @@ Pull requests must have this label\.
 .
 .TP
 \fB\-\-without\-labels\fR
-Pull requests must not have these labels (default: \fBdo not merge\fR, \fBnew formula\fR)\.
+Pull requests must not have these labels (default: \fBdo not merge\fR, \fBnew formula\fR, \fBautomerge\-skip\fR)\.
 .
 .TP
 \fB\-\-without\-approval\fR
@@ -1510,6 +1510,10 @@ Pull requests do not require approval to be merged\.
 .TP
 \fB\-\-publish\fR
 Run \fBbrew pr\-publish\fR on matching pull requests\.
+.
+.TP
+\fB\-\-autosquash\fR
+Instruct \fBbrew pr\-publish\fR to automatically reformat and reword commits in the pull request to our preferred format\.
 .
 .TP
 \fB\-\-ignore\-failures\fR


### PR DESCRIPTION
One of the last few steps we need to enable automatic commit rewording on approved pull requests in Homebrew/homebrew-core.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----