### PR TITLE
docs: update for new autosquash on automerge

### DIFF
--- a/docs/Brew-Test-Bot-For-Core-Contributors.md
+++ b/docs/Brew-Test-Bot-For-Core-Contributors.md
@@ -6,17 +6,17 @@ If a build has run and passed on `brew test-bot` then it can be used to quickly 
 
 If a pull request is correct and doesn't need any modifications to commit messages or otherwise:
 
+1. Review and approve the pull request. Be sure to thank the contributor!
+2. Wait for BrewTestBot to automatically merge the pull request. This happens about once an hour. BrewTestBot will comment if there is a failure.
+
+If a pull request won't be automatically merged by Brew Test Bot (has the labels `do not merge`, `new formula`, or `automerge-skip`), but the [commit messages and commit style](Formula-Cookbook.md#commit) are correct:
+
 1. Ensure the job has already completed successfully.
 2. Run `brew pr-publish 12345` where `12345` is the pull request number (or URL).
     - Approving a PR for an existing formula will automatically publish the bottles and close the PR, taking care of this step.
 3. Watch the [actions queue](https://github.com/Homebrew/homebrew-core/actions) to ensure your job finishes. BrewTestBot will usually notify you of failures with a ping as well.
 
-If a pull request needs its commits squashed or its commit messages reformatted to [follow our style](https://docs.brew.sh/Formula-Cookbook#commit):
-
-1. Ensure the job has already completed successfully.
-2. Run `brew pr-publish --autosquash 12345` where `12345` is the pull request number (or URL). For revision bumps, rebuilds, and formula deletions, you can optionally include a `--message` argument to explain the change.
-
-If a pull request needs its commit messages changed in a way that autosquash doesn't support:
+If a pull request needs its commit messages changed in a way that autosquash doesn't support (has the label `automerge-skip`):
 
 1. Ensure the job has already completed successfully.
 2. Run `brew pr-pull 12345` where `12345` is the pull request number (or URL).

--- a/docs/Homebrew-homebrew-core-Merge-Checklist.md
+++ b/docs/Homebrew-homebrew-core-Merge-Checklist.md
@@ -54,8 +54,8 @@ Check for:
 - if CI is green and...
   - formula `bottle :unneeded`, you can merge it through GitHub UI
   - bottles need to be pulled, and...
-    - the commits are correct and don't need changes, approve the PR to trigger an automatic merge (use `brew pr-publish $PR_ID` to trigger manually in case of a new formula)
-    - the commits need to be squashed, use `brew pr-publish --autosquash $PR_ID` and `git push`
+    - the commits are correct, don't need changes, and BrewTestBot can merge it (doesn't have the label `automerge-skip`): approve the PR to trigger an automatic merge (use `brew pr-publish $PR_ID` to trigger manually in case of a new formula)
+    - the commits are correct and don't need changes, but BrewTestBot can't merge it (has the label `automerge-skip`), use `brew pr-publish $PR_ID`
     - the commits need to be amended, use `brew pr-pull $PR_ID`, make changes, and `git push`
 - don't forget to thank the contributor
   - celebrate the first-time contributors


### PR DESCRIPTION
Update the Homebrew/core maintainer guidelines to talk about the new automatic pull request squashing/amending when BrewTestBot thinks it knows how to do it.

Closes https://github.com/Homebrew/brew/issues/8093.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----