### PR TITLE
Fix type signature of StringInreplaceExtension

### DIFF
--- a/Library/Homebrew/utils/string_inreplace_extension.rb
+++ b/Library/Homebrew/utils/string_inreplace_extension.rb
@@ -18,7 +18,7 @@ class StringInreplaceExtension
   # Same as `String#sub!`, but warns if nothing was replaced.
   #
   # @api public
-  sig { params(before: String, after: String).returns(T.nilable(String)) }
+  sig { params(before: T.any(Regexp, String), after: String).returns(T.nilable(String)) }
   def sub!(before, after)
     result = inreplace_string.sub!(before, after)
     errors << "expected replacement of #{before.inspect} with #{after.inspect}" unless result


### PR DESCRIPTION
Fixes error when running `brew pr-pull` (really `brew bottle`)

```
% brew pr-pull https://github.com/Homebrew/homebrew-core/pull/61774
==> Fetching homebrew/core pull request #61774
==> Using 1 commit from #61774
==> Downloading https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/21342739/zip
==> postgresql
  bottle do
    sha256 "0c8e80038485e0e398210b87b309da03e409dab0b0f78d2b7a3be9f51a3d30c0" => :catalina
    sha256 "74499938a2f7bde3c33fb158161566eaf61a70975e69d1c59b491deff94826dd" => :mojave
    sha256 "5175c72b20e73566ef1dadc07286a68b70ae4f31eacc484ad11c4f90f39fd840" => :high_sierra
  end
Error: Parameter 'before': Expected type String, got type Regexp with value /  bottle do.+?end\n/m
Caller: /usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:524
Definition: /usr/local/Homebrew/Library/Homebrew/utils/string_inreplace_extension.rb:22
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.5944/lib/types/configuration.rb:219:in `call_validation_error_handler_default'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.5944/lib/types/configuration.rb:226:in `call_validation_error_handler'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.5944/lib/types/private/methods/call_validation.rb:1125:in `report_error'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.5944/lib/types/private/methods/call_validation.rb:81:in `block in validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.5944/lib/types/private/methods/signature.rb:182:in `each_args_value_type'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.5944/lib/types/private/methods/call_validation.rb:78:in `validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.5944/lib/types/private/methods/_methods.rb:228:in `block in _on_method_added'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:524:in `block (2 levels) in merge'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:55:in `block in inreplace'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:50:in `each'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:50:in `inreplace'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:478:in `block in merge'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:458:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:458:in `merge'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bottle.rb:89:in `bottle'
/usr/local/Homebrew/Library/Homebrew/brew.rb:120:in `<main>'
Error: Failure while executing; `/usr/local/bin/brew bottle --merge --write --debug postgresql--13.0.high_sierra.bottle.json postgresql@12--12.4.mojave.bottle.json postgresql@12--12.4.catalina.bottle.json postgresql--13.0.mojave.bottle.json postgresql@12--12.4.high_sierra.bottle.json postgresql--13.0.catalina.bottle.json` exited with 1.
/usr/local/Homebrew/Library/Homebrew/utils.rb:288:in `safe_system'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/pr-upload.rb:88:in `pr_upload'
/usr/local/Homebrew/Library/Homebrew/brew.rb:120:in `<main>'
Error: Failure while executing; `/usr/local/bin/brew pr-upload --debug --bintray-org=homebrew` exited with 1.
/usr/local/Homebrew/Library/Homebrew/utils.rb:288:in `safe_system'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:429:in `block (3 levels) in pr_pull'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/fileutils.rb:128:in `chdir'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/fileutils.rb:128:in `cd'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:395:in `block (2 levels) in pr_pull'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/tmpdir.rb:93:in `mktmpdir'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:394:in `block in pr_pull'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:380:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/pr-pull.rb:380:in `pr_pull'
/usr/local/Homebrew/Library/Homebrew/brew.rb:120:in `<main>'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----