### PR TITLE
tap-new: add option for branch name

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -120,11 +120,6 @@ module Homebrew
             - name: Set up git
               uses: Homebrew/actions/git-user-config@master
 
-            - name: Checkout default branch
-              env:
-                BRANCH: ${{ github.event.pull_request.head.repo.default_branch }}
-              run: git checkout $BRANCH
-
             - name: Pull bottles
               env:
                 HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1231,6 +1231,8 @@ Generate the template files for a new tap.
   Don't initialize a git repository for the tap.
 * `--pull-label`:
   Label name for pull requests ready to be pulled (default `pr-pull`).
+* `--branch`:
+  Initialize git repository with the specified branch name (default `main`).
 
 ### `test` [*`options`*] *`formula`*
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1708,6 +1708,10 @@ Don\'t initialize a git repository for the tap\.
 \fB\-\-pull\-label\fR
 Label name for pull requests ready to be pulled (default \fBpr\-pull\fR)\.
 .
+.TP
+\fB\-\-branch\fR
+Initialize git repository with the specified branch name (default \fBmain\fR)\.
+.
 .SS "\fBtest\fR [\fIoptions\fR] \fIformula\fR"
 Run the test method provided by an installed formula\. There is no standard output or return code, but generally it should notify the user if something is wrong with the installed formula\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Allow `tap-new` to accept a `--branch` flag to specify a branch name for the new tap. Additionally, modify the CI workflows to be compatible with a custom branch name (another CI issue where the label name was missing quotes is fixed as well).

Note: I've opted to make `main` be the default branch name here instead of `master`. GitHub repositories are now created with a default branch name of `main` so I think it's fitting that we create new taps with a branch called `main` by default. This also makes uploading the new tap repository to GitHub much easier (you can just copy and paste the necessary lines if you create a new repo from the web UI) and will allow all CI to work out of the box without needing to worry about branch names changing. I think it's a good idea to start using the branch name `main` where we can. The rest of the Homebrew project still uses `master` as the default branch name, though, so I won't fight hard for this if keeping with `master` is desired.