### PR TITLE
docs/typechecking: Remove mentions of sorbet/files.yaml

### DIFF
--- a/docs/Typechecking.md
+++ b/docs/Typechecking.md
@@ -27,8 +27,8 @@ file are always passed first (if it exists), followed by arguments provided on t
 command line. We use it ignore the `Library/Homebrew/vendor` directory, which
 contains gem definitions which we do not wish to type check.
 
-- The `files.yaml` file. It contains a list of every Ruby file in the codebase
-divided into 3 strictness levels, false, true and strict. The `false` files only
+- Every Ruby file in the codebase is divided into three strictness levels: false,
+true and strict. The `false` files only
 report errors related to the syntax, constant resolution and correctness of the
 method signatures, and not type errors. We use this file to override strictness
 on a file-by-file basis. Our longtime goal is to move all `false` files to `true`
@@ -40,11 +40,12 @@ out the resulting type errors. Read more about Sorbet's strictness levels
 ## Using `brew typecheck`
 
 When run without any arguments, `brew typecheck`, will run considering the strictness levels
-set in the `files.yaml` file. However, when typecheck is run on a specific file
-or directory, more errors may show up since Sorbet can not resolve constants defined
-outside the scope of the specified file. These problems can be solved with RBI files.
-Currently `brew typecheck` provides `quiet`, `--file`, `--dir` and `--ignore` options
-but you can explore more options with `srb tc --help` and passing them with `srb tc`.
+set in each of the individual Ruby files in the core Homebrew codebase. However, when
+typecheck is run on a specific file or directory, more errors may show up since Sorbet
+cannot resolve constants defined outside the scope of the specified file. These
+problems can be solved with RBI files. Currently `brew typecheck` provides `quiet`, `--file`,
+`--dir` and `--ignore` options but you can explore more options with `srb tc --help` and
+passing them with `srb tc`.
 
 ## Resolving Type Errors
 

--- a/docs/Typechecking.md
+++ b/docs/Typechecking.md
@@ -43,7 +43,7 @@ When run without any arguments, `brew typecheck`, will run considering the stric
 set in each of the individual Ruby files in the core Homebrew codebase. However, when
 typecheck is run on a specific file or directory, more errors may show up since Sorbet
 cannot resolve constants defined outside the scope of the specified file. These
-problems can be solved with RBI files. Currently `brew typecheck` provides `quiet`, `--file`,
+problems can be solved with RBI files. Currently `brew typecheck` provides `--quiet`, `--file`,
 `--dir` and `--ignore` options but you can explore more options with `srb tc --help` and
 passing them with `srb tc`.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- The `sorbet/files.yaml` file was removed in 4382ee9d1404baba4ff4a1734e11fbd9c7826cb7 in favour of more obvious individual type sigils in all files.
