### PR TITLE
docs/vale-styles: Bump all style violations to "error" level so they fail CI

### DIFF
--- a/docs/Typechecking.md
+++ b/docs/Typechecking.md
@@ -1,4 +1,4 @@
-# Type Checking with Sorbet
+# Type Checking With Sorbet
 
 The majority of the code in Homebrew is written in Ruby which is a dynamic
 language. To avail the benefits of static type checking, we have set up Sorbet in

--- a/docs/vale-styles/Homebrew/Abbreviations.yml
+++ b/docs/vale-styles/Homebrew/Abbreviations.yml
@@ -2,7 +2,7 @@
 extends: substitution
 message: Use '%s'
 ignorecase: false
-link: 'https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#style-and-usage'
+link: "https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#style-and-usage"
 level: error
 nonword: true
 swap:

--- a/docs/vale-styles/Homebrew/OxfordComma.yml
+++ b/docs/vale-styles/Homebrew/OxfordComma.yml
@@ -1,8 +1,8 @@
 ---
 extends: existence
-message: 'No Oxford commas!'
-link: 'https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#typographical-conventions'
+message: "No Oxford commas!"
+link: "https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#typographical-conventions"
 scope: sentence
-level: warning
+level: error
 tokens:
   - '(?:[^,]+,){1,}\s\w+,\sand'

--- a/docs/vale-styles/Homebrew/Pronouns.yml
+++ b/docs/vale-styles/Homebrew/Pronouns.yml
@@ -1,8 +1,8 @@
 ---
 extends: existence
 message: Avoid gender-specific language when not necessary.
-link: 'https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#personal-pronouns'
-level: warning
+link: "https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#personal-pronouns"
+level: error
 ignorecase: true
 tokens:
   - him

--- a/docs/vale-styles/Homebrew/Spacing.yml
+++ b/docs/vale-styles/Homebrew/Spacing.yml
@@ -1,9 +1,9 @@
 ---
 extends: existence
 message: "'%s' should have one space."
-link: 'https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#typographical-conventions'
+link: "https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#typographical-conventions"
 level: error
 nonword: true
 tokens:
-  - '[a-z][.?!][A-Z]'
-  - '[.?!] {2,}[A-Z]'
+  - "[a-z][.?!][A-Z]"
+  - "[.?!] {2,}[A-Z]"

--- a/docs/vale-styles/Homebrew/Terms.yml
+++ b/docs/vale-styles/Homebrew/Terms.yml
@@ -1,7 +1,7 @@
 ---
 extends: substitution
 message: Use '%s' instead of '%s'.
-link: 'https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#terminology-words-and-word-styling'
+link: "https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#terminology-words-and-word-styling"
 level: error
 scope: $paragraph
 swap:

--- a/docs/vale-styles/Homebrew/Titles.yml
+++ b/docs/vale-styles/Homebrew/Titles.yml
@@ -6,5 +6,6 @@ match: $title
 style: AP
 exceptions:
   - brew(1)
+  - macOS
   - Homebrew/homebrew-core
   - Homebrew/linuxbrew-core

--- a/docs/vale-styles/Homebrew/Titles.yml
+++ b/docs/vale-styles/Homebrew/Titles.yml
@@ -1,6 +1,6 @@
 extends: capitalization
 message: "'%s' should be in title case"
-level: warning
+level: error
 scope: heading.h1
 match: $title
 style: AP

--- a/docs/vale-styles/Homebrew/Trademarks.yml
+++ b/docs/vale-styles/Homebrew/Trademarks.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 message: 'No "TM", ™, SM, ©, ®, or other explicit indicators of rights ownership or trademarks'
-link: 'https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#typographical-conventions'
+link: "https://github.com/Homebrew/brew/blob/HEAD/docs/Prose-Style-Guidelines.md#typographical-conventions"
 level: error
 nonword: true
 tokens:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- I added these all the way back in December 2019 in #6826, but only today (thanks to my Sorbet PR) realised that things have been failing unnoticeably because "warning" level exits with status code 0, so doesn't fail CI.
- Upgrading to "error" level will enable us to see the style errors in our docs in every CI run and fix them faster.
- My editor also auto-formatted the YAML to have double quotes instead of single. And I fixed all the remaining style failures, now I can see them!