### PR TITLE
shared_audits: add extraterm to GITHUB_PRERELEASE_ALLOWLIST

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -34,6 +34,7 @@ module SharedAudits
   GITHUB_PRERELEASE_ALLOWLIST = {
     "amd-power-gadget" => :all,
     "elm-format"       => "0.8.3",
+    "extraterm"        => :all,
     "freetube"         => :all,
     "gitless"          => "0.8.8",
     "home-assistant"   => :all,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Required for https://github.com/Homebrew/homebrew-cask/pull/91047 to pass `audit`.