### PR TITLE
Fix type error for inreplace.

### DIFF
--- a/Library/Homebrew/utils/inreplace.rb
+++ b/Library/Homebrew/utils/inreplace.rb
@@ -34,7 +34,7 @@ module Utils
     # @api public
     sig do
       params(
-        paths:        T::Array[T.untyped],
+        paths:        T.any(T::Array[T.untyped], String),
         before:       T.nilable(T.any(Regexp, String)),
         after:        T.nilable(T.any(String, Symbol)),
         audit_result: T::Boolean,


### PR DESCRIPTION
`inreplace "file.c", "a", "b"` is a common idiom in formula install blocks.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----