### PR TITLE
Permit installation of googletest

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -36,14 +36,6 @@ module Homebrew
           lzma is now part of the xz formula:
             brew install xz
         EOS
-        when "gtest", "googletest", "google-test" then <<~EOS
-          Installing gtest system-wide is not recommended; it should be vendored
-          in your projects that use it.
-        EOS
-        when "gmock", "googlemock", "google-mock" then <<~EOS
-          Installing gmock system-wide is not recommended; it should be vendored
-          in your projects that use it.
-        EOS
         when "sshpass" then <<~EOS
           We won't add sshpass because it makes it too easy for novice SSH users to
           ruin SSH's security.

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -23,8 +23,6 @@ describe Homebrew::MissingFormula do
     it { is_expected.to disallow("pil") }
     it { is_expected.to disallow("macruby") }
     it { is_expected.to disallow("lzma") }
-    it { is_expected.to disallow("gtest") }
-    it { is_expected.to disallow("gmock") }
     it { is_expected.to disallow("sshpass") }
     it { is_expected.to disallow("gsutil") }
     it { is_expected.to disallow("gfortran") }


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?
- [X] Have you successfully run `brew man` locally and committed any changes?

-----

Closes: #8935

Please see #8935 for a full description of the change.  This PR removes the exclusions for gtest and gmock so that it will be possible to install google test in the future.  The prohibition upon installing these systemwide is no longer in place, as detailed in the issue description.

