### PR TITLE
shared_audits: fix conditional in Bitbucket notability check

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -168,7 +168,7 @@ module SharedAudits
     watcher_metadata = JSON.parse(watcher_out)
     return if watcher_metadata.nil?
 
-    return if (forks_metadata["size"] < 30) && (watcher_metadata["size"] < 75)
+    return if forks_metadata["size"] >= 30 || watcher_metadata["size"] >= 75
 
     "Bitbucket repository not notable enough (<30 forks and <75 watchers)"
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
This check currently returns an error for repositories that are notable enough (and passes on repositories that are not notable enough).