### PR TITLE
bash completion: Add remaining flags for brew outdated

### DIFF
--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -419,7 +419,7 @@ _brew_outdated() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
     -*)
-      __brewcomp "--quiet --cask --json=v1 --fetch-HEAD"
+      __brewcomp "--quiet --verbose --formula --cask --json=v1 --fetch-HEAD --greedy"
       return
       ;;
   esac


### PR DESCRIPTION
Adds `--verbose`, `--formula`, and `--greedy`

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [X] Have you successfully run `brew man` locally and committed any changes?
