### PR TITLE
utils/github: paginate pull request commits API

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -78,9 +78,14 @@ describe GitHub do
   end
 
   describe "::pull_request_commits", :needs_network do
-    it "gets the correct commits hashes for a pull request" do
-      hashes = %w[188606a4a9587365d930b02c98ad6857b1d00150 25a71fe1ea1558415d6496d23834dc70778ddee5]
+    hashes = %w[188606a4a9587365d930b02c98ad6857b1d00150 25a71fe1ea1558415d6496d23834dc70778ddee5]
+
+    it "gets commit hashes for a pull request" do
       expect(subject.pull_request_commits("Homebrew", "legacy-homebrew", 50678)).to eq(hashes)
+    end
+
+    it "gets commit hashes for a paginated pull request API response" do
+      expect(subject.pull_request_commits("Homebrew", "legacy-homebrew", 50678, per_page: 1)).to eq(hashes)
     end
   end
 end


### PR DESCRIPTION
This is needed to run `brew pr-pull` on jumbo pull requests like https://github.com/Homebrew/homebrew-core/pull/62560.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----