### PR TITLE
audit: avoid python symlink conflict

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -265,6 +265,20 @@ module FormulaCellarChecks
     EOS
   end
 
+  PYTHON_SYMLINK_ALLOWED_FORMULA = "python@3.8"
+
+  def check_python_symlinks(name)
+    return unless name.start_with? "python"
+    return if name == PYTHON_SYMLINK_ALLOWED_FORMULA
+
+    return if %w[pip3 wheel3].none? do |l|
+      link = HOMEBREW_PREFIX/"bin"/l
+      link.exist? && File.realpath(link).start_with?(HOMEBREW_CELLAR/name)
+    end
+
+    "Only `#{PYTHON_SYMLINK_ALLOWED_FORMULA}` should create symlinks for `pip3` and `wheel3`"
+  end
+
   def audit_installed
     @new_formula ||= false
 
@@ -282,6 +296,7 @@ module FormulaCellarChecks
     problem_if_output(check_python_packages(formula.lib, formula.deps))
     problem_if_output(check_shim_references(formula.prefix))
     problem_if_output(check_plist(formula.prefix, formula.plist))
+    problem_if_output(check_python_symlinks(formula.name))
   end
   alias generic_audit_installed audit_installed
 

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -265,18 +265,16 @@ module FormulaCellarChecks
     EOS
   end
 
-  PYTHON_SYMLINK_ALLOWED_FORMULA = "python@3.8"
-
-  def check_python_symlinks(name)
+  def check_python_symlinks(name, keg_only)
+    return unless keg_only
     return unless name.start_with? "python"
-    return if name == PYTHON_SYMLINK_ALLOWED_FORMULA
 
     return if %w[pip3 wheel3].none? do |l|
       link = HOMEBREW_PREFIX/"bin"/l
       link.exist? && File.realpath(link).start_with?(HOMEBREW_CELLAR/name)
     end
 
-    "Only `#{PYTHON_SYMLINK_ALLOWED_FORMULA}` should create symlinks for `pip3` and `wheel3`"
+    "Python formulae that are keg-only should not create `pip3` and `wheel3` symlinks"
   end
 
   def audit_installed
@@ -296,7 +294,7 @@ module FormulaCellarChecks
     problem_if_output(check_python_packages(formula.lib, formula.deps))
     problem_if_output(check_shim_references(formula.prefix))
     problem_if_output(check_plist(formula.prefix, formula.plist))
-    problem_if_output(check_python_symlinks(formula.name))
+    problem_if_output(check_python_symlinks(formula.name, formula.keg_only?))
   end
   alias generic_audit_installed audit_installed
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Resolves #8949

Only allow one python formula to create `pip3` and `wheel3` symlinks

CC: @fxcoudert, @SMillerDev and @MikeMcQuaid
