### PR TITLE
Add more license symbol functionality

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1139,7 +1139,7 @@ class FormulaInstaller
   end
 
   def forbidden_license_check
-    forbidden_licenses = Homebrew::EnvConfig.forbidden_licenses.dup
+    forbidden_licenses = Homebrew::EnvConfig.forbidden_licenses.to_s.dup
     SPDX::ALLOWED_LICENSE_SYMBOLS.each do |s|
       pattern = /#{s.to_s.tr("_", " ")}/i
       forbidden_licenses.sub!(pattern, s.to_s)

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1139,11 +1139,12 @@ class FormulaInstaller
   end
 
   def forbidden_license_check
-    forbidden_licenses = Homebrew::EnvConfig.forbidden_licenses
-                                            .to_s
-                                            .sub("Public Domain", "public_domain")
-                                            .split(" ")
-                                            .to_h do |license|
+    forbidden_licenses = Homebrew::EnvConfig.forbidden_licenses.to_s
+    SPDX::ALLOWED_LICENSE_SYMBOLS.each do |s|
+      pattern = /#{s.to_s.tr("_", " ")}/i
+      forbidden_licenses = forbidden_licenses.sub(pattern, s.to_s)
+    end
+    forbidden_licenses = forbidden_licenses.split(" ").to_h do |license|
       [license, SPDX.license_version_info(license)]
     end
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1139,10 +1139,10 @@ class FormulaInstaller
   end
 
   def forbidden_license_check
-    forbidden_licenses = Homebrew::EnvConfig.forbidden_licenses.to_s
+    forbidden_licenses = Homebrew::EnvConfig.forbidden_licenses.dup
     SPDX::ALLOWED_LICENSE_SYMBOLS.each do |s|
       pattern = /#{s.to_s.tr("_", " ")}/i
-      forbidden_licenses = forbidden_licenses.sub(pattern, s.to_s)
+      forbidden_licenses.sub!(pattern, s.to_s)
     end
     forbidden_licenses = forbidden_licenses.split(" ").to_h do |license|
       [license, SPDX.license_version_info(license)]

--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -91,6 +91,10 @@ describe SPDX do
     it "returns :public_domain" do
       expect(described_class.parse_license_expression(:public_domain).first).to eq [:public_domain]
     end
+
+    it "returns :cannot_represent" do
+      expect(described_class.parse_license_expression(:cannot_represent).first).to eq [:cannot_represent]
+    end
   end
 
   describe ".valid_license?" do
@@ -113,6 +117,14 @@ describe SPDX do
     it "returns true for :public_domain" do
       expect(described_class.valid_license?(:public_domain)).to eq true
     end
+
+    it "returns true for :cannot_represent" do
+      expect(described_class.valid_license?(:cannot_represent)).to eq true
+    end
+
+    it "returns false for invalid symbol" do
+      expect(described_class.valid_license?(:invalid_symbol)).to eq false
+    end
   end
 
   describe ".deprecated_license?" do
@@ -130,6 +142,10 @@ describe SPDX do
 
     it "returns false for :public_domain" do
       expect(described_class.deprecated_license?(:public_domain)).to eq false
+    end
+
+    it "returns false for :cannot_represent" do
+      expect(described_class.deprecated_license?(:cannot_represent)).to eq false
     end
   end
 
@@ -187,9 +203,13 @@ describe SPDX do
     it "returns :public_domain" do
       expect(described_class.license_expression_to_string(:public_domain)).to eq "Public Domain"
     end
+
+    it "returns :cannot_represent" do
+      expect(described_class.license_expression_to_string(:cannot_represent)).to eq "Cannot Represent"
+    end
   end
 
-  describe ".license_version_info_info" do
+  describe ".license_version_info" do
     it "returns license without version" do
       expect(described_class.license_version_info("MIT")).to eq ["MIT"]
     end

--- a/docs/License-Guidelines.md
+++ b/docs/License-Guidelines.md
@@ -18,6 +18,12 @@ The public domain can be indicated using a symbol:
 license :public_domain
 ```
 
+If the license for a formula cannot be represented using an SPDX expression:
+
+```ruby
+license :cannot_represent
+```
+
 ## Complex SPDX License Expressions
 
 Some formulae have multiple licenses that need to be combined in different ways. In these cases, a more complex license expression can be used. These expressions are based on the [SPDX License Expression Guidelines](https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Modify some license functionality to allow for more license symbols to be added as needed. Specifically, this adds the `:cannot_represent` symbol as discussed in https://github.com/Homebrew/homebrew-core/pull/63226#issuecomment-714477383.

In the future, adding the symbol to the `ALLOWED_LICENSE_SYMBOLS` allow list should be the only change necessary to allow for more license symbols.
