### PR TITLE
Add support for npm 7

### DIFF
--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -44,6 +44,9 @@ module Language
 
       pack = pack_for_installation
 
+      # npm 7 requires that these dirs exist before install
+      (libexec/"lib").mkpath
+
       # npm install args for global style module format installed into libexec
       args = %W[
         -ddd

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -25,7 +25,7 @@ describe Language::Node do
   end
 
   describe "#std_npm_install_args" do
-    npm_install_arg = "libexec"
+    npm_install_arg = Pathname("libexec")
     npm_pack_cmd = "npm pack --ignore-scripts"
 
     it "raises error with non zero exitstatus" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?
-----
After upgrading `npm` to `7`, the `npm install` started to fail because the dirs `libexec/lib` doesn't exist. On https://github.com/Homebrew/homebrew-core/pull/63170 I added the `mkdir_p libexec/"lib"` to 2 formulas, but probably this will be necessary again for other formulas.

[These lines](https://github.com/Homebrew/homebrew-core/blob/ef3393a691b308b3a4cc44c559116a60186c6fc0/Formula/bcoin.rb#L22-L23) should be removed later.