### PR TITLE
docs/create-tap: remove nbsp

### DIFF
--- a/docs/How-to-Create-and-Maintain-a-Tap.md
+++ b/docs/How-to-Create-and-Maintain-a-Tap.md
@@ -54,7 +54,7 @@ avoid conflicts.
 ## Maintaining a tap
 
 A tap is just a Git repository so you don’t have to do anything specific when
-making modifications, apart from committing and pushing your changes.
+making modifications, apart from committing and pushing your changes.
 
 ### Updating
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
This removes the [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space) and replaces it with a normal space.