### PR TITLE
Make Python 3.9 our main Python version

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -582,7 +582,7 @@ module Homebrew
       lua@5.1
       numpy@1.16
       openssl@1.1
-      python@3.8
+      python@3.9
     ].freeze
 
     def audit_versioned_keg_only


### PR DESCRIPTION
This will allow testing of https://github.com/Homebrew/homebrew-core/pull/63346