### PR TITLE
Remove IRC mention from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Former maintainers with significant contributions include [Jan Viljanen](https:/
 
 ## Community
 - [Homebrew/discussions (forum)](https://github.com/homebrew/discussions/discussions)
-- [freenode.net\#machomebrew (IRC)](irc://irc.freenode.net/#machomebrew)
 - [@MacHomebrew (Twitter)](https://twitter.com/MacHomebrew)
 
 ## License


### PR DESCRIPTION
Removed IRC mention (#machomebrew). This IRC channel is not being actively used by our community ( 0 active users ).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
