### PR TITLE
Remove `infrakit` from `GITHUB_PRERELEASE_ALLOWLIST` as it's deprecated

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -38,7 +38,6 @@ module SharedAudits
     "freetube"         => :all,
     "gitless"          => "0.8.8",
     "home-assistant"   => :all,
-    "infrakit"         => "0.5",
     "nuclear"          => :all,
     "pock"             => :all,
     "riff"             => "0.5.0",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] ~Have you successfully run `brew style` with your changes locally?~
- [x] ~Have you successfully run `brew tests` with your changes locally?~
- [x] ~Have you successfully run `brew man` locally and committed any changes?~

-----
