### PR TITLE
install: tweak missing formula behaviour.

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -304,12 +304,6 @@ module Homebrew
       return
     end
 
-    ofail e.message
-    if (reason = MissingFormula.reason(e.name))
-      $stderr.puts reason
-      return
-    end
-
     ohai "Searching for similarly named formulae..."
     formulae_search_results = search_formulae(e.name)
     case formulae_search_results.length
@@ -325,10 +319,15 @@ module Homebrew
       puts "To install one of them, run (for example):\n  brew install #{formulae_search_results.first}"
     end
 
+    ofail e.message
+    if (reason = MissingFormula.reason(e.name))
+      $stderr.puts reason
+      return
+    end
+
     # Do not search taps if the formula name is qualified
     return if e.name.include?("/")
 
-    ohai "Searching taps..."
     taps_search_results = search_taps(e.name)[:formulae]
     case taps_search_results.length
     when 0


### PR DESCRIPTION
- Run `brew search` for local formulae first (as it's quickest) rather than checking Git history.
- Don't output `Searching taps...` because `Searching taps on GitHub...` is output by the called function (and because it'll say it's searching taps even when it is not if `HOMEBREW_NO_GITHUB_API` is set).

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
