### PR TITLE
Maintainer-Guidelines: give maintainers time to review enhancements.

### DIFF
--- a/docs/Maintainer-Guidelines.md
+++ b/docs/Maintainer-Guidelines.md
@@ -159,7 +159,7 @@ Any maintainer can revert a PR created by another maintainer after a user submit
 
 ### Give time for other maintainers to review
 
-PRs that are an "enhancement" to existing functionality i.e. not a fix to an open user issue/discussion, not a version bump, not a security fix, not a fix for CI failure, a usability improvement, a new feature etc. should wait 24h Monday - Friday before being merged. For example,
+PRs that are an "enhancement" to existing functionality i.e. not a fix to an open user issue/discussion, not a version bump, not a security fix, not a fix for CI failure, a usability improvement, a new feature, refactoring etc. should wait 24h Monday - Friday before being merged. For example,
 
 - a new feature PR submitted at 5pm on Thursday should wait until 5pm on Friday before it is merged
 - a usability fix PR submitted at 5pm on Friday should wait until 5pm on Monday before it is merged

--- a/docs/Maintainer-Guidelines.md
+++ b/docs/Maintainer-Guidelines.md
@@ -157,6 +157,16 @@ Any maintainer can merge any PR they have carefully reviewed and is passing CI t
 
 Any maintainer can revert a PR created by another maintainer after a user submitted issue or CI failure that results. The maintainer who created the original PR should be given no less than an hour to fix the issue themselves or decide to revert the PR themselves if they would rather.
 
+### Give time for other maintainers to review
+
+PRs that are an "enhancement" to existing functionality i.e. not a fix to an open user issue/discussion, not a version bump, not a security fix, not a fix for CI failure, a usability improvement, a new feature etc. should wait 24h Monday - Friday before being merged. For example,
+
+- a new feature PR submitted at 5pm on Thursday should wait until 5pm on Friday before it is merged
+- a usability fix PR submitted at 5pm on Friday should wait until 5pm on Monday before it is merged
+- a user-reported issue fix PR can be merged immediately after CI is green
+
+If a maintainer is on holiday/vacation/sick during this time and leaves comments after they are back: please treat post-merge PR comments and feedback as you would left within the time period and follow-up with another PR to address their requests (if agreed).
+
 ## Communication
 
 Maintainers have a variety of ways to communicate with each other:

--- a/docs/Maintainer-Guidelines.md
+++ b/docs/Maintainer-Guidelines.md
@@ -167,6 +167,8 @@ PRs that are an "enhancement" to existing functionality i.e. not a fix to an ope
 
 If a maintainer is on holiday/vacation/sick during this time and leaves comments after they are back: please treat post-merge PR comments and feedback as you would left within the time period and follow-up with another PR to address their requests (if agreed).
 
+The vast majority of Homebrew/homebrew-core PRs are bug fixes or version bumps so can be self-merged once CI has completed.
+
 ## Communication
 
 Maintainers have a variety of ways to communicate with each other:


### PR DESCRIPTION
Let's slow down a little on enhancement PRs to give other maintainers time to give their feedback.

This is mostly self-directed criticism after discussion with @sjackman and some other @homebrew/plc members.

@Homebrew/maintainers please provide your thoughts and feedback here. I only want to merge this if we have majority agreement on it.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
