### PR TITLE
Refresh installed list before dependency check

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -186,6 +186,9 @@ module Homebrew
 
       upgrade_formulae(upgradeable_dependents, args: args)
 
+      # Refresh installed formulae after upgrading
+      installed_formulae = FormulaInstaller.installed.to_a
+
       # Assess the dependents tree again now we've upgraded.
       oh1 "Checking for dependents of upgraded formulae..." unless args.dry_run?
       broken_dependents = check_broken_dependents(installed_formulae)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Possibly fixes #8997. I call `FormulaInstaller.installed.to_a` after upgrading dependents, in order to refresh the list of formulae before checking for broken dependents. With this change, I ran `brew upgrade x264` and both `x264` and its dependent `ffmpeg` were upgraded without errors. When I checked out master, `brew upgrade ruby` ran into errors when upgrading its dependent `cocoapods`.

I did run into one error when running `brew tests`:
```
  1) Utils::Git#cherry_pick! aborts when cherry picking an existing hash
     Failure/Error:
       expect {
         described_class.cherry_pick!(HOMEBREW_CACHE, file_hash1)
       }.to raise_error(ErrorDuringExecution, /Merge conflict in README.md/)

       expected ErrorDuringExecution with message matching /Merge conflict in README.md/, got #<ErrorDuringExecution: Failure while executing; `/usr/local/Homebrew/Library/Homebrew/shims/scm/git -C /tmp/homebrew-tests-20201026-44218-1ytlg8a/cache cherry-pick 36c62d2` exited with 0. Here's the output:
```
However, I got this exact same error when running `brew tests` on master

---
Possibly fixes https://github.com/Homebrew/homebrew-core/issues/63497 as well