### PR TITLE
bug fix: add missing header param to url class

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -10,7 +10,7 @@ class URL
   attr_reader :uri, :specs,
               :using,
               :tag, :branch, :revisions, :revision,
-              :trust_cert, :cookies, :referer, :user_agent,
+              :trust_cert, :cookies, :referer, :header, :user_agent,
               :data
 
   extend Forwardable
@@ -27,6 +27,7 @@ class URL
       trust_cert: T.nilable(T::Boolean),
       cookies:    T.nilable(T::Hash[String, String]),
       referer:    T.nilable(T.any(URI::Generic, String)),
+      header:     T.nilable(String),
       user_agent: T.nilable(T.any(Symbol, String)),
       data:       T.nilable(T::Hash[String, String]),
     ).returns(T.untyped)
@@ -41,6 +42,7 @@ class URL
     trust_cert: nil,
     cookies: nil,
     referer: nil,
+    header: nil,
     user_agent: nil,
     data: nil
   )
@@ -55,6 +57,7 @@ class URL
     specs[:trust_cert] = @trust_cert = trust_cert
     specs[:cookies]    = @cookies    = cookies
     specs[:referer]    = @referer    = referer
+    specs[:header]     = @header     = header
     specs[:user_agent] = @user_agent = user_agent || :default
     specs[:data]       = @data       = data
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
The *header* param was missing from the URL class. 

I got an error while trying to use the *header* param according to the docs: https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md

This fixed the error for me.

I didn't write any tests since I couldn't find an existing spec file for this.
