### PR TITLE
Fix upgrading dependents on missing keg

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1477,21 +1477,10 @@ class Formula
     end
   end
 
-  # Clear cache of .racks
-  def self.clear_racks_cache
-    @racks = nil
-  end
-
-  # Clear caches of .racks and .installed.
-  def self.clear_installed_formulae_cache
-    clear_racks_cache
-    @installed = nil
-  end
-
   # An array of all racks currently installed.
   # @private
   def self.racks
-    @racks ||= if HOMEBREW_CELLAR.directory?
+    Formula.cache[:racks] ||= if HOMEBREW_CELLAR.directory?
       HOMEBREW_CELLAR.subdirs.reject do |rack|
         rack.symlink? || rack.basename.to_s.start_with?(".") || rack.subdirs.empty?
       end
@@ -1503,7 +1492,7 @@ class Formula
   # An array of all installed {Formula}
   # @private
   def self.installed
-    @installed ||= racks.flat_map do |rack|
+    Formula.cache[:installed] ||= racks.flat_map do |rack|
       Formulary.from_rack(rack)
     rescue
       []

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -854,10 +854,11 @@ class FormulaInstaller
   end
 
   def link(keg)
+    Formula.clear_cache
+
     unless link_keg
       begin
         keg.optlink(verbose: verbose?)
-        Formula.clear_cache
       rescue Keg::LinkError => e
         onoe "Failed to create #{formula.opt_prefix}"
         puts "Things that depend on #{formula.full_name} will probably not build."

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -355,7 +355,7 @@ class Tab < OpenStruct
   def write
     # If this is a new installation, the cache of installed formulae
     # will no longer be valid.
-    Formula.clear_installed_formulae_cache unless tabfile.exist?
+    Formula.clear_cache unless tabfile.exist?
 
     self.class.cache[tabfile] = self
     tabfile.atomic_write(to_json)

--- a/Library/Homebrew/test/keg_spec.rb
+++ b/Library/Homebrew/test/keg_spec.rb
@@ -36,7 +36,6 @@ describe Keg do
   end
 
   specify "::all" do
-    Formula.clear_racks_cache
     expect(described_class.all).to eq([keg])
   end
 

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -128,6 +128,7 @@ module Homebrew
                           .select do |f|
           keg = f.any_installed_keg
           next unless keg
+          next unless keg.directory?
 
           LinkageChecker.new(keg, cache_db: db)
                         .broken_library_linkage?
@@ -186,7 +187,7 @@ module Homebrew
 
       upgrade_formulae(upgradeable_dependents, args: args)
 
-      # Refresh installed formulae after upgrading
+      # Update installed formulae after upgrading
       installed_formulae = FormulaInstaller.installed.to_a
 
       # Assess the dependents tree again now we've upgraded.


### PR DESCRIPTION
Ensure that we don't try to check for broken linkage in a keg that doesn't exist. Furthermore, fix the reason we checked for the keg that doesn't exist by `Formula.clear_cache`.

While here, I noticed that there was other methods of caching at use in `Formula` so consolidate them to be consistent.

Fixes #8997

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
