### PR TITLE
spec_helper: fix Timeout::Error/SystemExit handling.

### DIFF
--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -189,20 +189,15 @@ RSpec.configure do |config|
       end
 
       begin
-        timeout = example.metadata.fetch(:timeout, 120)
-        inner_timeout = nil
+        timeout = example.metadata.fetch(:timeout, 60)
         Timeout.timeout(timeout) do
           example.run
-        rescue Timeout::Error => e
-          inner_timeout = e
         end
-      rescue Timeout::Error
-        raise "Example exceeded maximum runtime of #{timeout} seconds."
+      rescue Timeout::Error => e
+        example.example.set_exception(e)
       end
-
-      raise inner_timeout if inner_timeout
     rescue SystemExit => e
-      raise "Unexpected exit with status #{e.status}."
+      example.example.set_exception(e)
     ensure
       ENV.replace(@__env)
 


### PR DESCRIPTION
These need to be manually caught and set otherwise they will not be retried by `rspec-retry`. This is particularly annoying and a cause of CI failures when tests timeout but are not retried.

Also, because timeouts should be rarer now, reduce the general timeout from 120s to 60s.

~add468b is pushed temporarily (and should not be merged) to attempt to reproduce the correct behaviour on a forced timeout~ This has been removed due to reproduction in https://github.com/Homebrew/brew/pull/9004/checks?check_run_id=1326013554#step:13:38

Fixes https://github.com/Homebrew/brew/issues/8979

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
