### PR TITLE
mktemp: replace '@' with '-' in temp path

### DIFF
--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -35,7 +35,7 @@ class Mktemp
   end
 
   def run
-    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix.dup.tr! "@", "-"}-", HOMEBREW_TEMP))
+    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix.tr "@", "-"}-", HOMEBREW_TEMP))
 
     # Make sure files inside the temporary directory have the same group as the
     # brew instance.

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -35,7 +35,7 @@ class Mktemp
   end
 
   def run
-    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix}-", HOMEBREW_TEMP))
+    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix.dup.tr! "@", "-"}-", HOMEBREW_TEMP))
 
     # Make sure files inside the temporary directory have the same group as the
     # brew instance.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Some formula (e.g. [gcc@10](https://github.com/Homebrew/linuxbrew-core/blob/master/Formula/gcc@10.rb)) fails to build if the temp directory contains an at sign (`@`). This pull request replace the character into a hyphen (`-`) for temp directories to avoid build failures.