### PR TITLE
audit: bypass artifact check for vifm-osx-0.11

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -22,7 +22,7 @@ module RuboCop
           https://osxbook.com/book/bonus/chapter8/core/download/gcore
           https://naif.jpl.nasa.gov/pub/naif/toolkit/C/MacIntel_OSX_AppleC_64bit/packages/
           https://artifacts.videolan.org/x264/release-macos/
-          https://github.com/vifm/vifm/releases/download
+          https://github.com/vifm/vifm/releases/download/v0.11/vifm-osx-0.11.tar.bz2
         ].freeze
 
         # These are formulae that, sadly, require an upstream binary to bootstrap.

--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -22,6 +22,7 @@ module RuboCop
           https://osxbook.com/book/bonus/chapter8/core/download/gcore
           https://naif.jpl.nasa.gov/pub/naif/toolkit/C/MacIntel_OSX_AppleC_64bit/packages/
           https://artifacts.videolan.org/x264/release-macos/
+          https://github.com/vifm/vifm/releases/download
         ].freeze
 
         # These are formulae that, sadly, require an upstream binary to bootstrap.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

```
==> FAILED
Formula/vifm.rb:4:3: C: https://github.com/vifm/vifm/releases/download/v0.11/vifm-osx-0.11.tar.bz2 looks like a binary package, not a source archive; homebrew/core is source-only.
  url "https://github.com/vifm/vifm/releases/download/v0.11/vifm-osx-0.11.tar.bz2"
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

relates to https://github.com/Homebrew/homebrew-core/pull/63061