### PR TITLE
update-test: more improvements.

### DIFF
--- a/Library/Homebrew/dev-cmd/update-test.rb
+++ b/Library/Homebrew/dev-cmd/update-test.rb
@@ -30,12 +30,24 @@ module Homebrew
   def update_test
     args = update_test_args.parse
 
+    # Avoid `update-report.rb` tapping Homebrew/homebrew-core
     ENV["HOMEBREW_UPDATE_TEST"] = "1"
+
+    # Avoid accidentally updating when we don't expect it.
+    ENV["HOMEBREW_NO_AUTO_UPDATE"] = "1"
+
+    # Use default behaviours
+    ENV["HOMEBREW_AUTO_UPDATE_SECS"] = nil
+    ENV["HOMEBREW_DEVELOPER"] = nil
+    ENV["HOMEBREW_DEV_CMD_RUN"] = nil
+    ENV["HOMEBREW_MERGE"] = nil
+    ENV["HOMEBREW_NO_UPDATE_CLEANUP"] = nil
 
     branch = if args.to_tag?
       ENV["HOMEBREW_UPDATE_TO_TAG"] = "1"
       "stable"
     else
+      ENV["HOMEBREW_UPDATE_TO_TAG"] = nil
       "master"
     end
 
@@ -98,6 +110,7 @@ module Homebrew
       safe_system "git", "clone", "#{HOMEBREW_REPOSITORY}/.git", "remote.git",
                   "--bare", "--branch", "master", "--single-branch"
       safe_system "git", "config", "remote.origin.url", "#{curdir}/remote.git"
+      ENV["HOMEBREW_BREW_GIT_REMOTE"] = "#{curdir}/remote.git"
 
       # force push origin to end_commit
       safe_system "git", "checkout", "-B", "master", end_commit
@@ -109,9 +122,12 @@ module Homebrew
       # update ENV["PATH"]
       ENV["PATH"] = PATH.new(ENV["PATH"]).prepend(curdir/"bin")
 
+      # run brew help to install portable-ruby (if needed)
+      quiet_system "brew", "help"
+
       # run brew update
       oh1 "Running brew update..."
-      safe_system "brew", "update", "--verbose"
+      safe_system "brew", "update", "--verbose", "--debug"
       actual_end_commit = Utils.popen_read("git", "rev-parse", branch).chomp
       if actual_end_commit != end_commit
         start_log = Utils.popen_read("git", "log", "-1", "--decorate", "--oneline", start_commit).chomp


### PR DESCRIPTION
- Explain why `HOMEBREW_UPDATE_TEST` is set and what it does.
- Avoid auto-updating (this should already be not happening but let's make sure).
- Set environment variables to ensure we're testing the default update behaviour (rather than deferring to user configuration).
- Use `HOMEBREW_BREW_GIT_REMOTE` as well as setting `git config remote.origin.url` ourselves.
- Run `brew help` quietly first to hide irrelevant portable Ruby output.
- Run `brew update --verbose --debug` to get even more output on failure.

Fixes https://github.com/Homebrew/brew/issues/8979

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
