### PR TITLE
Unify and use Git username/email/GPG handling.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -549,6 +549,7 @@ module Homebrew
 
         unless args.no_commit?
           Utils::Git.set_name_email!
+          Utils::Git.setup_gpg!
 
           short_name = formula_name.split("/", -1).last
           pkg_version = bottle_hash["formula"]["pkg_version"]

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -35,10 +35,8 @@ module Homebrew
       ohai "git add vendor/bundle"
       system "git", "add", "vendor/bundle"
 
-      if Formula["gpg"].optlinked?
-        ENV["PATH"] = PATH.new(ENV["PATH"])
-                          .prepend(Formula["gpg"].opt_bin)
-      end
+      Utils::Git.set_name_email!
+      Utils::Git.setup_gpg!
 
       ohai "git commit"
       system "git", "commit", "--message", "brew vendor-gems: commit updates."

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -126,6 +126,13 @@ module Utils
       ENV["GIT_COMMITTER_EMAIL"] = Homebrew::EnvConfig.git_email if committer
     end
 
+    def setup_gpg!
+      return unless Formula["gnupg"].optlinked?
+
+      ENV["PATH"] = PATH.new(ENV["PATH"])
+                        .prepend(Formula["gnupg"].opt_bin)
+    end
+
     def origin_branch(repo)
       Utils.popen_read(git, "-C", repo, "symbolic-ref", "-q", "--short",
                        "refs/remotes/origin/HEAD").chomp.presence


### PR DESCRIPTION
We're using essentially the same logic to setup Git for committing in multiple places but the way we're doing so is inconsistent. Moved to using two shared utility methods and use them consistently.

Without this `brew pr-pull` failed consistently due to being unable to find `gpg` when it ran `brew bottle`.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
