### PR TITLE
Keg.for: handle non-existent path.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -183,13 +183,15 @@ class Keg
 
   # if path is a file in a keg then this will return the containing Keg object
   def self.for(path)
-    path = path.realpath
-    until path.root?
-      return Keg.new(path) if path.parent.parent == HOMEBREW_CELLAR.realpath
+    original_path = path
+    if original_path.exist? && (path = original_path.realpath)
+      until path.root?
+        return Keg.new(path) if path.parent.parent == HOMEBREW_CELLAR.realpath
 
-      path = path.parent.realpath # realpath() prevents root? failing
+        path = path.parent.realpath # realpath() prevents root? failing
+      end
     end
-    raise NotAKegError, "#{path} is not inside a keg"
+    raise NotAKegError, "#{original_path} is not inside a keg"
   end
 
   def self.all


### PR DESCRIPTION
Otherwise `path.realpath` will raise `Errno::ENOENT` rather than the expected `NotAKegError`.

Fixes https://github.com/Homebrew/brew/issues/9015

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
