### PR TITLE
pr-pull: copy bottles to working directory.

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -377,6 +377,8 @@ module Homebrew
 
     setup_git_environment!
 
+    pwd = Dir.pwd
+
     args.named.uniq.each do |arg|
       arg = "#{tap.default_remote}/pull/#{arg}" if arg.to_i.positive?
       url_match = arg.match HOMEBREW_PULL_OR_COMMIT_URL_REGEX
@@ -414,6 +416,9 @@ module Homebrew
 
           url = GitHub.get_artifact_url(user, repo, pr, workflow_id: workflow, artifact_name: artifact)
           download_artifact(url, dir, pr)
+          if (bottles = Dir.glob("*.bottle.tar.gz").presence)
+            FileUtils.cp bottles, pwd
+          end
 
           next if args.no_upload?
 


### PR DESCRIPTION
This is useful when testing bottles locally without rebuilding them.

I'm unsure if this is desirable and maybe should be conditional on another flag or `--no-upload`. An alternative approach would be something like:
https://github.com/Homebrew/homebrew-test-bot/blob/c5d64d10f5b407b32760faf4bf8c55b335c56ad4/lib/tests/formulae.rb#L455-L459

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
