### PR TITLE
audit: migrate throttle list to Homebrew/core

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -816,7 +816,7 @@ module Homebrew
       stable_url_minor_version = stable_url_version.minor.to_i
 
       formula_suffix = stable.version.patch.to_i
-      throttled_rate = @audit_exceptions["THROTTLED_FORMULAE"][formula.name]
+      throttled_rate = audit_exception_list("THROTTLED_FORMULAE")[formula.name]
       if throttled_rate && formula_suffix.modulo(throttled_rate).nonzero?
         problem "should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
       end
@@ -1023,6 +1023,14 @@ module Homebrew
 
     def head_only?(formula)
       formula.head && formula.stable.nil?
+    end
+
+    def audit_exception_list(list)
+      if @audit_exceptions.key? list
+        @audit_exceptions[list]
+      else
+        {}
+      end
     end
   end
 

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1156,7 +1156,7 @@ module Homebrew
   end
 
   class TapAuditor
-    attr_reader :name, :path, :problems
+    attr_reader :name, :path, :tap_audit_exceptions, :problems
 
     def initialize(tap, options = {})
       @name                 = tap.name

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -127,15 +127,15 @@ module Homebrew
     audit_formulae.sort.each do |f|
       only = only_cops ? ["style"] : args.only
       options = {
-        new_formula:         new_formula,
-        strict:              strict,
-        online:              online,
-        git:                 git,
-        only:                only,
-        except:              args.except,
-        spdx_license_data:   spdx_license_data,
-        spdx_exception_data: spdx_exception_data,
-        audit_exceptions:    f.tap.audit_exceptions,
+        new_formula:          new_formula,
+        strict:               strict,
+        online:               online,
+        git:                  git,
+        only:                 only,
+        except:               args.except,
+        spdx_license_data:    spdx_license_data,
+        spdx_exception_data:  spdx_exception_data,
+        tap_audit_exceptions: f.tap.audit_exceptions,
       }
       options[:style_offenses] = style_offenses.for_path(f.path) if style_offenses
       options[:display_cop_names] = args.display_cop_names?
@@ -248,7 +248,7 @@ module Homebrew
       @specs = %w[stable head].map { |s| formula.send(s) }.compact
       @spdx_license_data = options[:spdx_license_data]
       @spdx_exception_data = options[:spdx_exception_data]
-      @audit_exceptions = options[:audit_exceptions]
+      @tap_audit_exceptions = options[:tap_audit_exceptions]
     end
 
     def audit_style
@@ -816,7 +816,7 @@ module Homebrew
       stable_url_minor_version = stable_url_version.minor.to_i
 
       formula_suffix = stable.version.patch.to_i
-      throttled_rate = audit_exception_list("THROTTLED_FORMULAE")[formula.name]
+      throttled_rate = tap_audit_exception_list(:throttled_formulae)[formula.name]
       if throttled_rate && formula_suffix.modulo(throttled_rate).nonzero?
         problem "should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
       end
@@ -1025,9 +1025,9 @@ module Homebrew
       formula.head && formula.stable.nil?
     end
 
-    def audit_exception_list(list)
-      if @audit_exceptions.key? list
-        @audit_exceptions[list]
+    def tap_audit_exception_list(list)
+      if @tap_audit_exceptions.key? list
+        @tap_audit_exceptions[list]
       else
         {}
       end

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1190,14 +1190,8 @@ module Homebrew
       audit_tap_audit_exceptions
     end
 
-    HOMEBREW_TAP_JSON_FILES = %w[
-      formula_renames.json
-      tap_migrations.json
-      audit_exceptions/*.json
-    ].freeze
-
     def audit_json_files
-      json_patterns = HOMEBREW_TAP_JSON_FILES.map { |pattern| @path/pattern }
+      json_patterns = Tap::HOMEBREW_TAP_JSON_FILES.map { |pattern| @path/pattern }
       Pathname.glob(json_patterns).each do |file|
         JSON.parse file.read
       rescue JSON::ParserError

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -1207,6 +1207,14 @@ module Homebrew
 
     def audit_tap_audit_exceptions
       @tap_audit_exceptions.each do |list_name, formula_names|
+        unless [Hash, Array].include? formula_names.class
+          problem <<~EOS
+            audit_exceptions/#{list_name}.json should contain a JSON array
+            of formula names or a JSON object mapping formula names to values
+          EOS
+          next
+        end
+
         formula_names = formula_names.keys if formula_names.is_a? Hash
 
         invalid_formulae = []

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -742,11 +742,6 @@ module Homebrew
       [user, repo]
     end
 
-    VERSIONED_HEAD_SPEC_ALLOWLIST = %w[
-      bash-completion@2
-      imagemagick@6
-    ].freeze
-
     UNSTABLE_ALLOWLIST = {
       "aalib"           => "1.4rc",
       "automysqlbackup" => "3.0-rc",
@@ -817,9 +812,9 @@ module Homebrew
 
       return unless @core_tap
 
-      if formula.head && @versioned_formula
-        head_spec_message = "Versioned formulae should not have a `HEAD` spec"
-        problem head_spec_message unless VERSIONED_HEAD_SPEC_ALLOWLIST.include?(formula.name)
+      if formula.head && @versioned_formula &&
+         !tap_audit_exception_list(:versioned_head_spec_allowlist).include?(formula.name)
+        problem "Versioned formulae should not have a `HEAD` spec"
       end
 
       stable = formula.stable

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -127,7 +127,7 @@ module Homebrew
       ta = TapAuditor.new tap, strict: args.strict?
       ta.audit
 
-      next if ta.problems.empty?
+      next if ta.problems.blank?
 
       tap_count += 1
       tap_problem_count += ta.problems.size
@@ -188,7 +188,6 @@ module Homebrew
     puts new_formula_problem_lines.map { |s| "  #{s}" }
 
     total_problems_count = problem_count + new_formula_problem_count + tap_problem_count
-
     return unless total_problems_count.positive?
 
     problem_plural = "#{total_problems_count} #{"problem".pluralize(total_problems_count)}"
@@ -1058,7 +1057,7 @@ module Homebrew
         list.include? formula
       when Hash
         return false unless list.include? formula
-        return list[formula] if value.nil?
+        return list[formula] if value.blank?
 
         list[formula] == value
       end
@@ -1191,8 +1190,15 @@ module Homebrew
       audit_tap_audit_exceptions
     end
 
+    HOMEBREW_TAP_JSON_FILES = %w[
+      formula_renames.json
+      tap_migrations.json
+      audit_exceptions/*.json
+    ].freeze
+
     def audit_json_files
-      Pathname.glob(@path/"**/*.json").each do |file|
+      json_patterns = HOMEBREW_TAP_JSON_FILES.map { |pattern| @path/pattern }
+      Pathname.glob(json_patterns).each do |file|
         JSON.parse file.read
       rescue JSON::ParserError
         problem "#{file.to_s.delete_prefix("#{@path}/")} contains invalid JSON"

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -135,6 +135,7 @@ module Homebrew
         except:              args.except,
         spdx_license_data:   spdx_license_data,
         spdx_exception_data: spdx_exception_data,
+        audit_exceptions:    f.tap.audit_exceptions,
       }
       options[:style_offenses] = style_offenses.for_path(f.path) if style_offenses
       options[:display_cop_names] = args.display_cop_names?
@@ -247,6 +248,7 @@ module Homebrew
       @specs = %w[stable head].map { |s| formula.send(s) }.compact
       @spdx_license_data = options[:spdx_license_data]
       @spdx_exception_data = options[:spdx_exception_data]
+      @audit_exceptions = options[:audit_exceptions]
     end
 
     def audit_style
@@ -730,15 +732,6 @@ module Homebrew
       imagemagick@6
     ].freeze
 
-    THROTTLED_FORMULAE = {
-      "aws-sdk-cpp" => 10,
-      "awscli@1"    => 10,
-      "balena-cli"  => 10,
-      "gatsby-cli"  => 10,
-      "quicktype"   => 10,
-      "vim"         => 50,
-    }.freeze
-
     UNSTABLE_ALLOWLIST = {
       "aalib"           => "1.4rc",
       "automysqlbackup" => "3.0-rc",
@@ -823,7 +816,7 @@ module Homebrew
       stable_url_minor_version = stable_url_version.minor.to_i
 
       formula_suffix = stable.version.patch.to_i
-      throttled_rate = THROTTLED_FORMULAE[formula.name]
+      throttled_rate = @audit_exceptions["THROTTLED_FORMULAE"][formula.name]
       if throttled_rate && formula_suffix.modulo(throttled_rate).nonzero?
         problem "should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
       end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -546,12 +546,12 @@ class Tap
   def audit_exceptions
     @audit_exceptions = {}
 
-    Dir[path/"audit_exceptions/*"].each do |exception_file|
-      list_name = File.basename(exception_file).chomp(".json").to_sym
+    Pathname.glob(path/"audit_exceptions/*").each do |exception_file|
+      list_name = exception_file.basename.to_s.chomp(".json").to_sym
       list_contents = begin
-        JSON.parse Pathname.new(exception_file).read
+        JSON.parse exception_file.read
       rescue JSON::ParserError
-        nil
+        opoo "#{exception_file} contains invalid JSON"
       end
 
       next if list_contents.nil?

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -99,6 +99,7 @@ class Tap
     @command_files = nil
     @formula_renames = nil
     @tap_migrations = nil
+    @audit_exceptions = nil
     @config = nil
     remove_instance_variable(:@private) if instance_variable_defined?(:@private)
   end
@@ -545,6 +546,17 @@ class Tap
     end
   end
 
+  # Hash with audit exceptions
+  def audit_exceptions
+    require "json"
+
+    @audit_exceptions ||= if (audit_exceptions_file = path/"audit_exceptions.json").file?
+      JSON.parse(audit_exceptions_file.read)
+    else
+      {}
+    end
+  end
+
   def ==(other)
     other = Tap.fetch(other) if other.is_a?(String)
     self.class == other.class && name == other.name
@@ -684,6 +696,14 @@ class CoreTap < Tap
   # @private
   def tap_migrations
     @tap_migrations ||= begin
+      self.class.ensure_installed!
+      super
+    end
+  end
+
+  # @private
+  def audit_exceptions
+    @audit_exceptions ||= begin
       self.class.ensure_installed!
       super
     end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -16,6 +16,16 @@ class Tap
 
   TAP_DIRECTORY = (HOMEBREW_LIBRARY/"Taps").freeze
 
+  HOMEBREW_TAP_FORMULA_RENAMES_FILE = "formula_renames.json"
+  HOMEBREW_TAP_MIGRATIONS_FILE = "tap_migrations.json"
+  HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR = "audit_exceptions"
+
+  HOMEBREW_TAP_JSON_FILES = %W[
+    #{HOMEBREW_TAP_FORMULA_RENAMES_FILE}
+    #{HOMEBREW_TAP_MIGRATIONS_FILE}
+    #{HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR}/*.json
+  ].freeze
+
   def self.fetch(*args)
     case args.length
     when 1
@@ -526,7 +536,7 @@ class Tap
 
   # Hash with tap formula renames
   def formula_renames
-    @formula_renames ||= if (rename_file = path/"formula_renames.json").file?
+    @formula_renames ||= if (rename_file = path/HOMEBREW_TAP_FORMULA_RENAMES_FILE).file?
       JSON.parse(rename_file.read)
     else
       {}
@@ -535,7 +545,7 @@ class Tap
 
   # Hash with tap migrations
   def tap_migrations
-    @tap_migrations ||= if (migration_file = path/"tap_migrations.json").file?
+    @tap_migrations ||= if (migration_file = path/HOMEBREW_TAP_MIGRATIONS_FILE).file?
       JSON.parse(migration_file.read)
     else
       {}
@@ -546,7 +556,7 @@ class Tap
   def audit_exceptions
     @audit_exceptions = {}
 
-    Pathname.glob(path/"audit_exceptions/*").each do |exception_file|
+    Pathname.glob(path/HOMEBREW_TAP_AUDIT_EXCEPTIONS_DIR/"*").each do |exception_file|
       list_name = exception_file.basename.to_s.chomp(".json").to_sym
       list_contents = begin
         JSON.parse exception_file.read

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -526,8 +526,6 @@ class Tap
 
   # Hash with tap formula renames
   def formula_renames
-    require "json"
-
     @formula_renames ||= if (rename_file = path/"formula_renames.json").file?
       JSON.parse(rename_file.read)
     else
@@ -537,8 +535,6 @@ class Tap
 
   # Hash with tap migrations
   def tap_migrations
-    require "json"
-
     @tap_migrations ||= if (migration_file = path/"tap_migrations.json").file?
       JSON.parse(migration_file.read)
     else
@@ -548,13 +544,22 @@ class Tap
 
   # Hash with audit exceptions
   def audit_exceptions
-    require "json"
+    @audit_exceptions = {}
 
-    @audit_exceptions ||= if (audit_exceptions_file = path/"audit_exceptions.json").file?
-      JSON.parse(audit_exceptions_file.read)
-    else
-      {}
+    Dir[path/"audit_exceptions/*"].each do |exception_file|
+      list_name = File.basename(exception_file).chomp(".json").to_sym
+      list_contents = begin
+        JSON.parse Pathname.new(exception_file).read
+      rescue JSON::ParserError
+        nil
+      end
+
+      next if list_contents.nil?
+
+      @audit_exceptions[list_name] = list_contents
     end
+
+    @audit_exceptions
   end
 
   def ==(other)

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -870,7 +870,6 @@ module Homebrew
     include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_ALLOWLIST
     include_examples "formulae exist", described_class::VERSIONED_HEAD_SPEC_ALLOWLIST
     include_examples "formulae exist", described_class::PROVIDED_BY_MACOS_DEPENDS_ON_ALLOWLIST
-    include_examples "formulae exist", described_class::THROTTLED_FORMULAE.keys
     include_examples "formulae exist", described_class::UNSTABLE_ALLOWLIST.keys
     include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys
   end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -868,7 +868,6 @@ module Homebrew
     end
 
     include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_ALLOWLIST
-    include_examples "formulae exist", described_class::VERSIONED_HEAD_SPEC_ALLOWLIST
     include_examples "formulae exist", described_class::PROVIDED_BY_MACOS_DEPENDS_ON_ALLOWLIST
     include_examples "formulae exist", described_class::UNSTABLE_ALLOWLIST.keys
     include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR starts moving allowlists and blocklists from the Homebrew/brew repo to the Homebrew/core repo as discussed in #8980. This PR lays the groundwork for migrating all lists to their respective taps and allows exception lists to be specified for third party taps. For now, I've chosen to migrate only one list (the `THROTTLED_FORMULAE` list) as a proof-of-concept. Assuming this is something that is desired, migrating the rest of the lists should be trivial.

Corresponding Homebrew/core PR: https://github.com/Homebrew/homebrew-core/pull/64043

-----

In my opinion, the Point Of Truth for these lists should be with the formulae themselves and the `brew` code should not be where tap-specific rules are added.

As a summary of #8980, here are [my thoughts](https://github.com/Homebrew/brew/pull/8980#issuecomment-716671650) that I expressed in #8980:

> In general, the maintainers who approve/merge PRs that change the allowlists are the Homebrew/core maintainers. In my experience, it follows the typical Homebrew/core workflow (opening a PR, waiting for an approval, merging after approved) but in a different repo. For that reason, it seems like it would make more sense to have those changes be made in the Homebrew/core PR. No need to bother non-core maintainers with PRs that they won't bother looking at.
>
> Also, shouldn't the decisions about these lists be made by the Homebrew/core mainatiners? If someone's a core maintainer but not a brew maintainer, they should still be able to approve/merge these changes as it's directly relevant to their work. Similarly, it doesn't make sense for a cask-maintainer with write access to Homebrew/brew to be able to approve/merge allowlist PRs unless they're also a core-maintainer (this is just an example and is not me pointing fingers at anyone).
>
> It seems like having these lists in Homebrew/brew is just adding unnecessary steps/complexity.

Another maintainer [expressed concerns](https://github.com/Homebrew/brew/pull/8980#issuecomment-716682984):

> I think in the "happy path" case where e.g. an item is added to a list, approved and merged the steps may be unnecessary.
> 
> The difference is: this is not what always happens. Things I've seen already happen with allow lists in Homebrew/brew that make me want to keep this process:
> 
> * a formula is added to a list by a contributor when it should not be
> * a formula is added to the wrong list (provided by macOS vs. shadows macOS)
> * multiple formulae of the same version are added to a list
> * an exception is added to an allowlist when it could be more easily fixed in the formula
> * an exception is added to an allowlist when we'd previously agreed it wouldn't be and the formula should instead be fixed/deprecated/disabled

-----

CC: @MikeMcQuaid, @fxcoudert and @Homebrew/core 