### PR TITLE
Keg: apply ad-hoc signature on 10.15 or later

### DIFF
--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -8,6 +8,7 @@ class Keg
     @require_relocation = true
     odebug "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}"
     MachO::Tools.change_dylib_id(file, id, strict: false)
+    apply_ad_hoc_signature(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing dylib ID of #{file}
@@ -23,6 +24,7 @@ class Keg
     @require_relocation = true
     odebug "Changing install name in #{file}\n  from #{old}\n    to #{new}"
     MachO::Tools.change_install_name(file, old, new, strict: false)
+    apply_ad_hoc_signature(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing install name in #{file}
@@ -30,5 +32,19 @@ class Keg
           to #{new}
     EOS
     raise
+  end
+
+  def apply_ad_hoc_signature(file)
+    return if MacOS.version < :catalina
+
+    # Use quiet_system to squash notifications about resigning binaries
+    # which already have valid signatures.
+    unless quiet_system("codesign", "--sign", "-", "--force",
+                        "--preserve-metadata=entitlements,requirements,flags,runtime",
+                        file)
+      onoe <<~EOS
+        Failed applying an ad-hoc signature to #{file}
+      EOS
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is an alternative to #9040. In that case, we rely on ruby-macho to apply code signatures after changing ID or install_name. Here, we instead do that ourselves so that we can choose what OS to apply it on. Like in that PR, we swallow any failures so that we don't inadvertently break more exotic packages like OpenJDK (which caused issues in #8922).

cc @MikeMcQuaid, who had suggested this as an alternate to the other path.