### PR TITLE
language/node: remove unneeded scripts prior to installation

### DIFF
--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -16,6 +16,17 @@ module Language
       # fed to `npm install` only symlinks are created linking back to that
       # directory, consequently breaking that assumption. We require a tarball
       # because npm install creates a "real" installation when fed a tarball.
+      if (package = Pathname("package.json")) && package.exist?
+        begin
+          pkg_json = JSON.parse(package.read)
+        rescue JSON::ParserError
+          $stderr.puts "Could not parse package.json"
+          raise
+        end
+        prepare_removed = pkg_json["scripts"]&.delete("prepare")
+        prepack_removed = pkg_json["scripts"]&.delete("prepack")
+        package.atomic_write(JSON.pretty_generate(pkg_json)) if prepare_removed || prepack_removed
+      end
       output = Utils.popen_read("npm pack --ignore-scripts")
       raise "npm failed to pack #{Dir.pwd}" if !$CHILD_STATUS.exitstatus.zero? || output.lines.empty?
 

--- a/Library/Homebrew/language/node.rb
+++ b/Library/Homebrew/language/node.rb
@@ -20,7 +20,7 @@ module Language
         begin
           pkg_json = JSON.parse(package.read)
         rescue JSON::ParserError
-          $stderr.puts "Could not parse package.json"
+          opoo "Could not parse package.json!"
           raise
         end
         prepare_removed = pkg_json["scripts"]&.delete("prepare")

--- a/Library/Homebrew/test/language/node_spec.rb
+++ b/Library/Homebrew/test/language/node_spec.rb
@@ -24,6 +24,20 @@ describe Language::Node do
     end
   end
 
+  describe "#std_pack_for_installation" do
+    npm_pack_cmd = "npm pack --ignore-scripts"
+
+    it "removes prepare and prepack scripts" do
+      path = Pathname("package.json")
+      path.atomic_write("{\"scripts\":{\"prepare\": \"ls\", \"prepack\": \"ls\", \"test\": \"ls\"}}")
+      allow(Utils).to receive(:popen_read).with(npm_pack_cmd).and_return(`echo pack.tgz`)
+      subject.pack_for_installation
+      expect(path.read).not_to include("prepare")
+      expect(path.read).not_to include("prepack")
+      expect(path.read).to include("test")
+    end
+  end
+
   describe "#std_npm_install_args" do
     npm_install_arg = Pathname("libexec")
     npm_pack_cmd = "npm pack --ignore-scripts"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Based on discussion in https://github.com/Homebrew/homebrew-core/issues/63798, this removes the `prepare` and `prepack` scripts from `package.json` prior to calling `npm pack`. 

Resolves https://github.com/Homebrew/homebrew-core/issues/63798.

The linked failed Homebrew/core PRs successfully install after this change.

cc @chrmoritz @zachauten 