### PR TITLE
audit: deprecate requirements in core

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -665,6 +665,21 @@ module RuboCop
         end
       end
 
+      # This cop ensures that new formulae depending on Requirements are not introduced in homebrew/core.
+      class CoreRequirements < FormulaCop
+        def audit_formula(_node, _class_node, _parent_class_node, _body_node)
+          if depends_on? :java
+            problem "Formulae in homebrew/core should depend on a versioned `openjdk` instead of :java"
+          end
+
+          if depends_on? :x11
+            problem "Formulae in homebrew/core should depend on specific X libraries instead of :x11"
+          end
+
+          problem ":osxfuse is deprecated in homebrew/core" if depends_on? :osxfuse
+        end
+      end
+
       # This cop makes sure that shell command arguments are separated.
       #
       # @api private

--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -668,6 +668,8 @@ module RuboCop
       # This cop ensures that new formulae depending on Requirements are not introduced in homebrew/core.
       class CoreRequirements < FormulaCop
         def audit_formula(_node, _class_node, _parent_class_node, _body_node)
+          return if formula_tap != "homebrew-core"
+
           if depends_on? :java
             problem "Formulae in homebrew/core should depend on a versioned `openjdk` instead of :java"
           end


### PR DESCRIPTION
This strict audit ensures that new formulae that depend on Requirements like :x11, :java, and :osxfuse are not introduced into homebrew/core.

* `:java` formulae were mostly migrated over to the brewed version earlier this year. The only remaining formulae are for Java 1.8, which is being tracked here: https://github.com/Homebrew/homebrew-core/issues/63290
* `:x11` formulae can now be migrated over to e.g. `depends_on "libx11"`. https://github.com/Homebrew/homebrew-core/issues/64166
* `:osxfuse` formulae will need to be disabled or deleted, as the licensing has changed and there is no longer a way to build it from source anyway. The versions that could theoretically be built from source and distributed with Homebrew will soon not work on supported macOS versions.

cc @homebrew/core

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----