### PR TITLE
outdated/upgrade: fix upgrade alias edge case.

### DIFF
--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -97,7 +97,7 @@ module Homebrew
         if verbose?
           outdated_kegs = f.outdated_kegs(fetch_head: args.fetch_HEAD?)
 
-          current_version = if f.alias_changed?
+          current_version = if f.alias_changed? && !f.latest_formula.latest_version_installed?
             latest = f.latest_formula
             "#{latest.name} (#{latest.pkg_version})"
           elsif f.head? && outdated_kegs.any? { |k| k.version.to_s == f.pkg_version.to_s }

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -137,7 +137,14 @@ module Homebrew
 
     pinned = outdated.select(&:pinned?)
     outdated -= pinned
-    formulae_to_install = outdated.map(&:latest_formula)
+    formulae_to_install = outdated.map do |f|
+      f_latest = f.latest_formula
+      if f_latest.latest_version_installed?
+        f
+      else
+        f_latest
+      end
+    end
 
     if !pinned.empty? && !args.ignore_pinned?
       ofail "Not upgrading #{pinned.count} pinned #{"package".pluralize(pinned.count)}:"


### PR DESCRIPTION
If you're going to follow an alias to find the outdated formula then ensure that the latest one isn't already installed.

Fixes https://github.com/Homebrew/homebrew-core/issues/63971

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
