### PR TITLE
Fix test for ARM

### DIFF
--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -5,9 +5,13 @@ require "utils/bottles"
 
 describe Utils::Bottles do
   describe "#tag", :needs_macos do
-    it "returns :catalina on Catalina" do
-      allow(MacOS).to receive(:version).and_return(MacOS::Version.new("10.15"))
-      expect(described_class.tag).to eq(:catalina)
+    it "returns :big_sur or :arm64_big_sur on Big Sur" do
+      allow(MacOS).to receive(:version).and_return(MacOS::Version.new("11.0"))
+      if Hardware::CPU.intel?
+        expect(described_class.tag).to eq(:big_sur)
+      else
+        expect(described_class.tag).to eq(:arm64_big_sur)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes the following failure (https://github.com/Homebrew/brew/issues/9066) on ARM Big Sur:

```
  1) Utils::Bottles#tag returns :catalina on Catalina
     Failure/Error: expect(described_class.tag).to eq(:catalina)
     
       expected: :catalina
            got: :arm64_catalina
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -:catalina
       +:arm64_catalina
       
     # ./test/utils/bottles/bottles_spec.rb:10:in `block (3 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/homebrew_cask.rb:52:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:194:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:193:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```

The test was somehow not updated when the tag for bottles was in https://github.com/Homebrew/brew/pull/7942