### PR TITLE
Allow casks to depend on ARM

### DIFF
--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -24,7 +24,7 @@ module Cask
         intel:  { type: :intel, bits: 64 },
         # specific
         x86_64: { type: :intel, bits: 64 },
-        arm64: { type: :arm, bits: 64 },
+        arm64:  { type: :arm, bits: 64 },
       }.freeze
 
       attr_accessor :java

--- a/Library/Homebrew/cask/dsl/depends_on.rb
+++ b/Library/Homebrew/cask/dsl/depends_on.rb
@@ -24,6 +24,7 @@ module Cask
         intel:  { type: :intel, bits: 64 },
         # specific
         x86_64: { type: :intel, bits: 64 },
+        arm64: { type: :arm, bits: 64 },
       }.freeze
 
       attr_accessor :java

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-depends-on-arch.rb
@@ -6,7 +6,7 @@ cask "with-depends-on-arch" do
   homepage "https://brew.sh/with-depends-on-arch"
 
   # covers all known hardware; always succeeds
-  depends_on arch: :intel
+  depends_on arch: [:intel, :arm64]
 
   app "Caffeine.app"
 end


### PR DESCRIPTION
Fix a second failure on Big Sur ARM (https://github.com/Homebrew/brew/issues/9066):

```
  2) Satisfy Dependencies and Requirements depends_on arch when satisfied does not raise an error
     Failure/Error: expect { install }.not_to raise_error
     
       expected no Exception, got #<Cask::CaskError: Cask with-depends-on-arch depends on hardware architecture being one of [{:type=>:intel, :bits=>64}], but you are running {:type=>:arm, :bits=>64}> with backtrace:
         # ./cask/installer.rb:272:in `arch_dependencies'
         # ./cask/installer.rb:251:in `satisfy_dependencies'
         # ./cask/installer.rb:66:in `fetch'
         # ./cask/installer.rb:94:in `install'
         # ./test/cask/depends_on_spec.rb:8:in `block (2 levels) in <top (required)>'
         # ./test/cask/depends_on_spec.rb:73:in `block (5 levels) in <top (required)>'
         # ./test/cask/depends_on_spec.rb:73:in `block (4 levels) in <top (required)>'
         # ./test/support/helper/spec/shared_context/homebrew_cask.rb:52:in `block (2 levels) in <top (required)>'
         # ./test/spec_helper.rb:194:in `block (3 levels) in <top (required)>'
         # ./test/spec_helper.rb:193:in `block (2 levels) in <top (required)>'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
     # ./test/cask/depends_on_spec.rb:73:in `block (4 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/homebrew_cask.rb:52:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:194:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:193:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```
