### PR TITLE
Add :arm_vortex_tempest as CPU family

### DIFF
--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -22,7 +22,7 @@ describe Hardware::CPU do
   describe "::family" do
     let(:cpu_families) {
       [
-        :arm,
+        :arm_vortex_tempest,
         :arrandale,
         :atom,
         :broadwell,


### PR DESCRIPTION
Since https://github.com/Homebrew/brew/commit/559d0a91a28b40e6e2c6d2dcf00b14cfdf7989d4 the CPU family for ARM processors on macOS is `:arm_vortex_tempest`. However, the relevant test was not updated at the same time, and is failing: https://github.com/Homebrew/brew/issues/9066