### PR TITLE
dev-cmd/audit: allow checksums to change when switching to/from a PyPI url

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -5,6 +5,7 @@ require "formula"
 require "formula_versions"
 require "utils/curl"
 require "utils/github/actions"
+require "utils/pypi"
 require "utils/shared_audits"
 require "utils/spdx"
 require "extend/ENV"
@@ -918,11 +919,10 @@ module Homebrew
         break if previous_version && current_version != previous_version
       end
 
-      pypi_prefix = "https://files.pythonhosted.org/packages/"
-
       if current_version == previous_version &&
          current_checksum != newest_committed_checksum &&
-         (newest_committed_url.start_with?(pypi_prefix) == current_url.start_with?(pypi_prefix))
+         (newest_committed_url.start_with?(PyPI::PYTHONHOSTED_URL_PREFIX) ==
+          current_url.start_with?(PyPI::PYTHONHOSTED_URL_PREFIX))
         problem(
           "stable sha256 changed without the version also changing; " \
           "please create an issue upstream to rule out malicious " \

--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -888,6 +888,7 @@ module Homebrew
       current_checksum = formula.stable.checksum
       current_version_scheme = formula.version_scheme
       current_revision = formula.revision
+      current_url = formula.stable.url
 
       previous_version = nil
       previous_version_scheme = nil
@@ -896,6 +897,7 @@ module Homebrew
       newest_committed_version = nil
       newest_committed_checksum = nil
       newest_committed_revision = nil
+      newest_committed_url = nil
 
       fv.rev_list("origin/master") do |rev|
         fv.formula_at_revision(rev) do |f|
@@ -910,13 +912,17 @@ module Homebrew
           newest_committed_version ||= previous_version
           newest_committed_checksum ||= previous_checksum
           newest_committed_revision ||= previous_revision
+          newest_committed_url ||= stable.url
         end
 
         break if previous_version && current_version != previous_version
       end
 
+      pypi_prefix = "https://files.pythonhosted.org/packages/"
+
       if current_version == previous_version &&
-         current_checksum != newest_committed_checksum
+         current_checksum != newest_committed_checksum &&
+         (newest_committed_url.start_with?(pypi_prefix) == current_url.start_with?(pypi_prefix))
         problem(
           "stable sha256 changed without the version also changing; " \
           "please create an issue upstream to rule out malicious " \

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -685,6 +685,18 @@ module Homebrew
           it { is_expected.to match("stable sha256 changed without the version also changing") }
         end
 
+        context "can change if switching to/from a PyPI url" do
+          before do
+            formula_gsub(
+              'sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"',
+              'sha256 "3622d2a53236ed9ca62de0616a7e80fd477a9a3f862ba09d503da188f53ca523"',
+            )
+            formula_gsub "https://brew.sh/foo-1.0.tar.gz", "https://files.pythonhosted.org/packages/foo-1.0.tar.gz"
+          end
+
+          it { is_expected.to be_nil }
+        end
+
         context "can change with the different version" do
           before do
             formula_gsub_origin_commit(

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -8,7 +8,6 @@ module PyPI
   module_function
 
   PYTHONHOSTED_URL_PREFIX = "https://files.pythonhosted.org/packages/"
-  private_constant :PYTHONHOSTED_URL_PREFIX
 
   AUTOMATIC_RESOURCE_UPDATE_BLOCKLIST = %w[
     ansible


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
When possible for Python packages, it's preferable to use the PyPI url vs GitHub/other urls to allow for automatic resource bumps. However, in general, the checksum of the GitHub archive will not match the checksum of the PyPI source package. This means that the audit will complain that the sha256 changed without changing the version if a PR is created which only switches the URL to/from PyPI. 

Supports https://github.com/Homebrew/homebrew-core/pull/64243