### PR TITLE
audit: don't require uses_from_macos in Linux formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -477,6 +477,7 @@ module Homebrew
 
           if @core_tap &&
              @new_formula &&
+             spec.requirements.none? { |req| req.is_a? LinuxRequirement } &&
              dep_f.keg_only? &&
              dep_f.keg_only_reason.provided_by_macos? &&
              dep_f.keg_only_reason.applicable? &&


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Related: Homebrew/homebrew-core#64256

```console
% brew audit onedrive --strict --new-formula
onedrive:
  * Dependency 'sqlite' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.
Error: 1 problem in 1 formula detected
```