### PR TITLE
livecheck: refactor url preprocessing

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -1225,7 +1225,8 @@ class DownloadStrategyDetector
     when %r{^https?://github\.com/[^/]+/[^/]+\.git$}
       GitHubGitDownloadStrategy
     when %r{^https?://.+\.git$},
-         %r{^git://}
+         %r{^git://},
+         %r{^https?://git\.sr\.ht/[^/]+/[^/]+$}
       GitDownloadStrategy
     when %r{^https?://www\.apache\.org/dyn/closer\.cgi},
          %r{^https?://www\.apache\.org/dyn/closer\.lua}

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -324,21 +324,21 @@ module Homebrew
       path = uri.path.delete_prefix("/").delete_suffix(".git")
       scheme = uri.scheme
 
-      if host == "github.com"
+      if host.end_with?("github.com")
         return url if path.match? %r{/releases/latest/?$}
 
         owner, repo = path.delete_prefix("downloads/").split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}.git"
-      elsif GITEA_INSTANCES.include? host
+      elsif host.end_with?(*GITEA_INSTANCES)
         return url if path.match? %r{/releases/latest/?$}
 
         owner, repo = path.split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}.git"
-      elsif GOGS_INSTANCES.include? host
+      elsif host.end_with?(*GOGS_INSTANCES)
         owner, repo = path.split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}.git"
       # sourcehut
-      elsif host == "git.sr.ht"
+      elsif host.end_with?("git.sr.ht")
         owner, repo = path.split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}"
       # gitlab

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -341,7 +341,7 @@ module Homebrew
       elsif host.end_with?("git.sr.ht")
         owner, repo = path.split("/")
         url = "#{scheme}://#{host}/#{owner}/#{repo}"
-      # gitlab
+      # GitLab (gitlab.com or self-hosted)
       elsif path.include?("/-/archive/")
         url = url.sub(%r{/-/archive/.*$}i, ".git")
       end

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -314,7 +314,12 @@ module Homebrew
     # Preprocesses and returns the URL used by livecheck.
     # @return [String]
     def preprocess_url(url)
-      uri = URI.parse url
+      begin
+        uri = URI.parse url
+      rescue URI::InvalidURIError
+        return url
+      end
+
       host = uri.host == "github.s3.amazonaws.com" ? "github.com" : uri.host
       path = uri.path.delete_prefix("/").delete_suffix(".git")
       scheme = uri.scheme

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -156,6 +156,12 @@ describe Homebrew::Livecheck do
   describe "::preprocess_url" do
     let(:github_git_url_with_extension) { "https://github.com/Homebrew/brew.git" }
 
+    it "returns the unmodified URL for an unparseable URL" do
+      # Modeled after the `head` URL in the `ncp` formula
+      expect(livecheck.preprocess_url(":something:cvs:@cvs.brew.sh:/cvs"))
+        .to eq(":something:cvs:@cvs.brew.sh:/cvs")
+    end
+
     it "returns the unmodified URL for a GitHub URL ending in .git" do
       expect(livecheck.preprocess_url(github_git_url_with_extension))
         .to eq(github_git_url_with_extension)
@@ -224,6 +230,11 @@ describe Homebrew::Livecheck do
     it "returns the Git repository URL for a LOL Git archive URL" do
       expect(livecheck.preprocess_url("https://lolg.it/Homebrew/brew/archive/brew-1.0.0.tar.gz"))
         .to eq("https://lolg.it/Homebrew/brew.git")
+    end
+
+    it "returns the Git repository URL for a sourcehut archive URL" do
+      expect(livecheck.preprocess_url("https://git.sr.ht/~Homebrew/brew/archive/1.0.0.tar.gz"))
+        .to eq("https://git.sr.ht/~Homebrew/brew")
     end
   end
 end

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -200,5 +200,30 @@ describe Homebrew::Livecheck do
       expect(livecheck.preprocess_url("https://brew.sh/Homebrew/brew/-/archive/1.0.0/brew-1.0.0.tar.gz"))
         .to eq("https://brew.sh/Homebrew/brew.git")
     end
+
+    it "returns the Git repository URL for a Codeberg archive URL" do
+      expect(livecheck.preprocess_url("https://codeberg.org/Homebrew/brew/archive/brew-1.0.0.tar.gz"))
+        .to eq("https://codeberg.org/Homebrew/brew.git")
+    end
+
+    it "returns the Git repository URL for a Gitea archive URL" do
+      expect(livecheck.preprocess_url("https://gitea.com/Homebrew/brew/archive/brew-1.0.0.tar.gz"))
+        .to eq("https://gitea.com/Homebrew/brew.git")
+    end
+
+    it "returns the Git repository URL for an Opendev archive URL" do
+      expect(livecheck.preprocess_url("https://opendev.org/Homebrew/brew/archive/brew-1.0.0.tar.gz"))
+        .to eq("https://opendev.org/Homebrew/brew.git")
+    end
+
+    it "returns the Git repository URL for a tildegit archive URL" do
+      expect(livecheck.preprocess_url("https://tildegit.org/Homebrew/brew/archive/brew-1.0.0.tar.gz"))
+        .to eq("https://tildegit.org/Homebrew/brew.git")
+    end
+
+    it "returns the Git repository URL for a LOL Git archive URL" do
+      expect(livecheck.preprocess_url("https://lolg.it/Homebrew/brew/archive/brew-1.0.0.tar.gz"))
+        .to eq("https://lolg.it/Homebrew/brew.git")
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Working with `URI` instances instead of `Strings` makes code much shorter and more readable. Special cases handling isn't needed anymore because matching is done on a host(name) level, paths ending with `/releases/latest` do not get altered and all those listed formulas already have formula specific livecheck blocks.
Added goodies are introducing support for [tildegit.org](https://tildegit.org) (which follows Github's routing patterns) and [sourcehut](https://git.sr.ht) 🎉 