### PR TITLE
Add support for arm64 architecture requirement

### DIFF
--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -19,6 +19,7 @@ class ArchRequirement < Requirement
   satisfy(build_env: false) do
     case @arch
     when :x86_64 then Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+    when :arm64 then Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
     when :arm, :intel, :ppc then Hardware::CPU.type == @arch
     end
   end

--- a/Library/Homebrew/test/ENV_spec.rb
+++ b/Library/Homebrew/test/ENV_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "extend/ENV"
 
 shared_examples EnvActivation do

--- a/Library/Homebrew/test/os/mac/java_requirement_spec.rb
+++ b/Library/Homebrew/test/os/mac/java_requirement_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "requirements/java_requirement"
 require "fileutils"
 

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "extend/ENV"
 require "requirement"
 

--- a/Library/Homebrew/test/requirements/arch_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/arch_requirement_spec.rb
@@ -1,0 +1,14 @@
+# typed: false
+# frozen_string_literal: true
+
+require "requirements/arch_requirement"
+
+describe ArchRequirement do
+  subject(:requirement) { described_class.new([Hardware::CPU.type]) }
+
+  describe "#satisfied?" do
+    it "supports architecture symbols" do
+      expect(requirement).to be_satisfied
+    end
+  end
+end

--- a/Library/Homebrew/test/requirements/java_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/java_requirement_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "requirements/java_requirement"
 
 describe JavaRequirement do

--- a/Library/Homebrew/test/requirements/linux_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/linux_requirement_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "requirements/linux_requirement"
 
 describe LinuxRequirement do

--- a/Library/Homebrew/test/requirements/macos_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/macos_requirement_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "requirements/macos_requirement"
 
 describe MacOSRequirement do

--- a/Library/Homebrew/test/requirements/osxfuse_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/osxfuse_requirement_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "requirements/osxfuse_requirement"
 
 describe OsxfuseRequirement do

--- a/Library/Homebrew/test/requirements/x11_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/x11_requirement_spec.rb
@@ -1,7 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "cli/args"
 require "requirements/x11_requirement"
 
 describe X11Requirement do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Allow formulae to specify `depends_on arch: :arm64` for ARM-specific packages.