### PR TITLE
inreplace: fix typecheck error

### DIFF
--- a/Library/Homebrew/utils/string_inreplace_extension.rb
+++ b/Library/Homebrew/utils/string_inreplace_extension.rb
@@ -42,7 +42,7 @@ class StringInreplaceExtension
   # value with "new_value", or removes the definition entirely.
   #
   # @api public
-  sig { params(flag: String, new_value: String).void }
+  sig { params(flag: String, new_value: T.any(String, Pathname)).void }
   def change_make_var!(flag, new_value)
     return if gsub!(/^#{Regexp.escape(flag)}[ \t]*[\\?+:!]?=[ \t]*((?:.*\\\n)*.*)$/, "#{flag}=#{new_value}", false)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

With runtime type checking enabled, `inreplace "foo", "bar", libexec` fails in formulae. Seen when building https://github.com/Homebrew/homebrew-core/pull/64347 from source.