### PR TITLE
bottle: fix adding bottle block to formulae with special license

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -536,7 +536,11 @@ module Homebrew
                     (\n^\ {3}[\S\ ]+$)*                                           # options can be in multiple lines
                   )?|
                   (homepage|desc|sha256|version|mirror|license)\ ['"][\S\ ]+['"]| # specs with a string
-                  (license)\ [^\[]+?\[[^\]]+?\]|                                  # license may contain a list
+                  license\ (
+                    [^\[]+?\[[^\]]+?\]|                                           # license may contain a list
+                    [^{]+?{[^}]+?}|                                               # license may contain a hash
+                    :\S+                                                          # license as a symbol
+                  )|
                   (revision|version_scheme)\ \d+|                                 # revision with a number
                   (stable|livecheck)\ do(\n+^\ {4}[\S\ ]+$)*\n+^\ {2}end          # components with blocks
                 )\n+                                                              # multiple empty lines


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This adds support for license symbols (e.g.`:cannot_represent`) and hashes (e.g. `"MIT" => { ... }`) to the `brew bottle` command

1. `[^\[]+?\[[^\]]+?\]` matches `any_of: ["MIT", "0BSD"]`
1. `[^{]+?{[^}]+?}` matches `"MIT" => { with: "LLVM-exception" }`
1. `:\S+` matches `:public_domain`

Related:
- #9080
- https://github.com/Homebrew/homebrew-core/pull/64303
- https://github.com/Homebrew/homebrew-core/pull/64349