### PR TITLE
uses_from_macos: fix force_homebrew_on_linux behaviour.

### DIFF
--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+# The Library/Homebrew/extend/os/software_spec.rb conditional logic will need to be more nuanced
+# if this file ever includes more than `uses_from_macos`.
 class SoftwareSpec
   undef uses_from_macos
 

--- a/Library/Homebrew/extend/os/software_spec.rb
+++ b/Library/Homebrew/extend/os/software_spec.rb
@@ -1,8 +1,9 @@
 # typed: strict
 # frozen_string_literal: true
 
-if OS.linux?
-  require "extend/os/linux/software_spec"
-elsif OS.mac?
+# This logic will need to be more nuanced if this file includes more than `uses_from_macos`.
+if OS.mac? || Homebrew::EnvConfig.force_homebrew_on_linux?
   require "extend/os/mac/software_spec"
+elsif OS.linux?
+  require "extend/os/linux/software_spec"
 end


### PR DESCRIPTION
Otherwise the dependencies are read incorrectly on Linux when we're trying to analyse Homebrew.

Needed for https://github.com/Homebrew/homebrew-core/pull/64423