### PR TITLE
audit: fix checksum audit

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -915,7 +915,7 @@ module Homebrew
         break if previous_version && current_version != previous_version
       end
 
-      if current_version == previous_version &&
+      if current_version == newest_committed_version &&
          current_checksum != newest_committed_checksum
         problem(
           "stable sha256 changed without the version also changing; " \

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -685,6 +685,23 @@ module Homebrew
           it { is_expected.to match("stable sha256 changed without the version also changing") }
         end
 
+        context "should not change with the same version when not the first commit" do
+          before do
+            formula_gsub_origin_commit(
+              'sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"',
+              'sha256 "3622d2a53236ed9ca62de0616a7e80fd477a9a3f862ba09d503da188f53ca523"',
+            )
+            formula_gsub_origin_commit "revision 2"
+            formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
+            formula_gsub(
+              'sha256 "3622d2a53236ed9ca62de0616a7e80fd477a9a3f862ba09d503da188f53ca523"',
+              'sha256 "e048c5e6144f5932d8672c2fade81d9073d5b3ca1517b84df006de3d25414fc1"',
+            )
+          end
+
+          it { is_expected.to match("stable sha256 changed without the version also changing") }
+        end
+
         context "can change with the different version" do
           before do
             formula_gsub_origin_commit(


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Fixes #9083

The issue is that the condition starts with: 

```ruby
if current_version == previous_version &&
```

`current_version` and `previous_version` will _only_ be the same if the `current_version` is also the first version available in Homebrew/core. This means that the audit is rarely triggered. It was triggered in https://github.com/Homebrew/homebrew-core/pull/64243 because the version of `vint` was the first version. Otherwise, in cases like https://github.com/Homebrew/homebrew-core/pull/64385, the audit isn't triggered when it should be.

The check should really be:

```ruby
if current_version == newest_committed_version &&
```

This will check whether the current version has changed from the version in the last commit. I've tested this with both https://github.com/Homebrew/homebrew-core/pull/64243 and https://github.com/Homebrew/homebrew-core/pull/64385 locally and both work as exptected