### PR TITLE
dev-cmd/audit: don't do dependency checks on Linux.

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -524,7 +524,7 @@ module Homebrew
 
       # The number of conflicts on Linux is absurd.
       # TODO: remove this and check these there too.
-      return if OS.linux? && !Homebrew::EnvConfig.force_homebrew_on_linux?
+      return if OS.linux?
 
       recursive_runtime_formulae = formula.runtime_formula_dependencies(undeclared: false)
       version_hash = {}


### PR DESCRIPTION
Alternate approach to #9091 for https://github.com/Homebrew/homebrew-core/pull/64423