### PR TITLE
info: restore printing of statistics with `brew info`

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -90,20 +90,23 @@ module Homebrew
       raise FormulaOrCaskUnspecifiedError if args.no_named?
 
       exec_browser(*args.named.to_formulae_and_casks.map { |f| github_info(f) })
+    elsif args.no_named?
+      print_statistics
     else
       print_info(args: args)
     end
   end
 
+  def print_statistics
+    return unless HOMEBREW_CELLAR.exist?
+
+    count = Formula.racks.length
+    puts "#{count} #{"keg".pluralize(count)}, #{HOMEBREW_CELLAR.dup.abv}"
+  end
+
   def print_analytics(args:)
     if args.no_named?
-      if args.analytics?
-        Utils::Analytics.output(args: args)
-      elsif HOMEBREW_CELLAR.exist?
-        count = Formula.racks.length
-        puts "#{count} #{"keg".pluralize(count)}, #{HOMEBREW_CELLAR.dup.abv}"
-      end
-
+      Utils::Analytics.output(args: args)
       return
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Restore printing of installation statistics with `brew info`. (xref #8893)