### PR TITLE
dev-cmd/audit: only go back in git history until revision or version …

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -928,6 +928,7 @@ module Homebrew
         end
 
         break if previous_version && current_version != previous_version
+        break if previous_revision && current_revision != previous_revision
       end
 
       if current_version == previous_version &&

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -746,6 +746,17 @@ module Homebrew
           it { is_expected.to be_nil }
         end
 
+        context "should not warn when revision from previous version matches current revision" do
+          before do
+            formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
+            formula_gsub_origin_commit "revision 2", "# no revision"
+            formula_gsub_origin_commit "# no revision", "revision 1"
+            formula_gsub_origin_commit "revision 1", "revision 2"
+          end
+
+          it { is_expected.to be_nil }
+        end
+
         context "should only increment by 1 with an uncommitted version" do
           before do
             formula_gsub "foo-1.0.tar.gz", "foo-1.1.tar.gz"
@@ -776,8 +787,8 @@ module Homebrew
         context "should not decrease with a new version" do
           before do
             formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
-            formula_gsub_origin_commit "version_scheme 1", ""
             formula_gsub_origin_commit "revision 2", ""
+            formula_gsub_origin_commit "version_scheme 1", ""
           end
 
           it { is_expected.to match("version_scheme should not decrease (from 1 to 0)") }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
This PR will now only go back until the version or revision changes to audit that they've been changed properly. Previously, it would keep going until the version changed. One test needed to be slightly modified and a new test has been added which exhibits the bug in https://github.com/Homebrew/homebrew-core/pull/64452.