### PR TITLE
Run `brew style` on all cask taps instead of running `brew cask style`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Run brew style on official taps
       run: brew style --display-cop-names homebrew/bundle homebrew/services homebrew/test-bot
 
-    - name: Run brew cask style on all taps
+    - name: Run brew style on cask taps
       if: matrix.os != 'ubuntu-latest'
       run: |
         brew tap homebrew/cask
@@ -122,7 +122,11 @@ jobs:
         brew tap homebrew/cask-fonts
         brew tap homebrew/cask-versions
 
-        brew cask style
+        brew style --display-cop-names \
+          homebrew/cask \
+          homebrew/cask-drivers \
+          homebrew/cask-fonts \
+          homebrew/cask-versions
 
     - name: Run brew audit --skip-style on all taps
       run: brew audit --skip-style


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Should prevent CI failures caused by new RuboCops. See https://github.com/Homebrew/homebrew-cask/pull/92322.