### PR TITLE
keg: add codesigning

### DIFF
--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -8,6 +8,7 @@ class Keg
     @require_relocation = true
     odebug "Changing dylib ID of #{file}\n  from #{file.dylib_id}\n    to #{id}"
     MachO::Tools.change_dylib_id(file, id, strict: false)
+    apply_ad_hoc_signature(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing dylib ID of #{file}
@@ -23,6 +24,7 @@ class Keg
     @require_relocation = true
     odebug "Changing install name in #{file}\n  from #{old}\n    to #{new}"
     MachO::Tools.change_install_name(file, old, new, strict: false)
+    apply_ad_hoc_signature(file)
   rescue MachO::MachOError
     onoe <<~EOS
       Failed changing install name in #{file}
@@ -30,5 +32,38 @@ class Keg
           to #{new}
     EOS
     raise
+  end
+
+  def apply_ad_hoc_signature(file)
+    return if MacOS.version < :big_sur
+    return unless Hardware::CPU.arm?
+
+    odebug "Codesigning #{file}"
+    # Use quiet_system to squash notifications about resigning binaries
+    # which already have valid signatures.
+    return if quiet_system("codesign", "--sign", "-", "--force",
+                           "--preserve-metadata=entitlements,requirements,flags,runtime",
+                           file)
+
+    # If the codesigning fails, it may be a bug in Apple's codesign utility
+    # A known workaround is to copy the file to another inode, then move it back
+    # erasing the previous file. Then sign again.
+    #
+    # TODO: remove this once the bug in Apple's codesign utility is fixed
+    Dir::Tmpname.create("workaround") do |tmppath|
+      FileUtils.cp file, tmppath
+      FileUtils.mv tmppath, file, force: true
+    end
+
+    # Try signing again
+    odebug "Codesigning (2nd try) #{file}"
+    return if quiet_system("codesign", "--sign", "-", "--force",
+                           "--preserve-metadata=entitlements,requirements,flags,runtime",
+                           file)
+
+    # If it fails again, error out
+    onoe <<~EOS
+      Failed applying an ad-hoc signature to #{file}
+    EOS
   end
 end


### PR DESCRIPTION
I tried to propose an implementation of the discussion in https://github.com/Homebrew/brew/issues/9082
by building on @mistydemeo's https://github.com/Homebrew/brew/pull/9041

- Only codesign on Big Sur
- Apply the known workaround if `codesign` fails the first time

Testing shows that this allows to build and install formulas on ARM, including the ones that trigger the codesign bug (like `gettext` and `nettle`).

----

Possible improvements:
- only codesign if the macho file was previously signed? I don't know how we detect this
- only codesign on ARM? I don't know if developer tools on Intel Big Sur codesign or not by default