### PR TITLE
Expand Livecheck#preprocess_url tests

### DIFF
--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -139,11 +139,51 @@ describe Homebrew::Livecheck do
   end
 
   describe "::preprocess_url" do
-    let(:url) { "https://github.s3.amazonaws.com/downloads/Homebrew/brew/1.0.0.tar.gz" }
+    let(:github_git_url_with_extension) { "https://github.com/Homebrew/brew.git" }
 
-    it "returns the preprocessed URL for livecheck to use" do
-      expect(livecheck.preprocess_url(url))
-        .to eq("https://github.com/Homebrew/brew.git")
+    it "returns the unmodified URL for a GitHub URL ending in .git" do
+      expect(livecheck.preprocess_url(github_git_url_with_extension))
+        .to eq(github_git_url_with_extension)
+    end
+
+    it "returns the Git repository URL for a GitHub URL not ending in .git" do
+      expect(livecheck.preprocess_url("https://github.com/Homebrew/brew"))
+        .to eq(github_git_url_with_extension)
+    end
+
+    it "returns the unmodified URL for a GitHub /releases/latest URL" do
+      expect(livecheck.preprocess_url("https://github.com/Homebrew/brew/releases/latest"))
+        .to eq("https://github.com/Homebrew/brew/releases/latest")
+    end
+
+    it "returns the Git repository URL for a GitHub AWS URL" do
+      expect(livecheck.preprocess_url("https://github.s3.amazonaws.com/downloads/Homebrew/brew/1.0.0.tar.gz"))
+        .to eq(github_git_url_with_extension)
+    end
+
+    it "returns the Git repository URL for a github.com/downloads/... URL" do
+      expect(livecheck.preprocess_url("https://github.com/downloads/Homebrew/brew/1.0.0.tar.gz"))
+        .to eq(github_git_url_with_extension)
+    end
+
+    it "returns the Git repository URL for a GitHub tag archive URL" do
+      expect(livecheck.preprocess_url("https://github.com/Homebrew/brew/archive/1.0.0.tar.gz"))
+        .to eq(github_git_url_with_extension)
+    end
+
+    it "returns the Git repository URL for a GitHub release archive URL" do
+      expect(livecheck.preprocess_url("https://github.com/Homebrew/brew/releases/download/1.0.0/brew-1.0.0.tar.gz"))
+        .to eq(github_git_url_with_extension)
+    end
+
+    it "returns the Git repository URL for a gitlab.com archive URL" do
+      expect(livecheck.preprocess_url("https://gitlab.com/Homebrew/brew/-/archive/1.0.0/brew-1.0.0.tar.gz"))
+        .to eq("https://gitlab.com/Homebrew/brew.git")
+    end
+
+    it "returns the Git repository URL for a self-hosted GitLab archive URL" do
+      expect(livecheck.preprocess_url("https://brew.sh/Homebrew/brew/-/archive/1.0.0/brew-1.0.0.tar.gz"))
+        .to eq("https://brew.sh/Homebrew/brew.git")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

The existing test for `Livecheck#preprocess_url` didn't exercise all the existing functionality of this method. This PR expands the test cases to cover the current usage of this method. However, the test cases will need to be expanded again with respect to #9074, as it adds support for additional URL types. We can handle it here, in #9074, or in a follow-up PR, whichever makes the most sense.

The main impetus behind this PR was that #9074 refactors the `#preprocess_url` method and it originally didn't replicate all of the existing functionality but the issues weren't surfaced by CI. I identified the issues myself but this test should have made this readily apparent. The updated test here clearly points out these issues when run on that PR's original code, so I think it's a good improvement.