### PR TITLE
pr-automerge: don't automerge PRs with linux-only label

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -38,7 +38,7 @@ module Homebrew
   def pr_automerge
     args = pr_automerge_args.parse
 
-    without_labels = args.without_labels || ["do not merge", "new formula", "automerge-skip"]
+    without_labels = args.without_labels || ["do not merge", "new formula", "automerge-skip", "linux-only"]
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
 
     query = "is:pr is:open repo:#{tap.full_name}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Related: https://github.com/Homebrew/homebrew-core/pull/64294

> This allows us to quickly identify bump PRs as updates to Linux formulae, which for the time being, should not be updated in `homebrew-core`; see [#64175 (comment)](https://github.com/Homebrew/homebrew-core/pull/64175#issuecomment-723311040)
> 
> > I was not really expecting people to upgrade linux-only formulae here before completing the merging of both repositories. Especially as no bottles are built; and not reverse dependencies are tested. So we may introduce breakages in linuxbrew-core, which is far from ideal.