### PR TITLE
audit: only flag if checksum changes when full url and version stay the same

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -903,6 +903,7 @@ module Homebrew
       current_checksum = formula.stable.checksum
       current_version_scheme = formula.version_scheme
       current_revision = formula.revision
+      current_url = formula.stable.url
 
       previous_version = nil
       previous_version_scheme = nil
@@ -911,6 +912,7 @@ module Homebrew
       newest_committed_version = nil
       newest_committed_checksum = nil
       newest_committed_revision = nil
+      newest_committed_url = nil
 
       fv.rev_list("origin/master") do |rev|
         fv.formula_at_revision(rev) do |f|
@@ -925,6 +927,7 @@ module Homebrew
           newest_committed_version ||= previous_version
           newest_committed_checksum ||= previous_checksum
           newest_committed_revision ||= previous_revision
+          newest_committed_url ||= stable.url
         end
 
         break if previous_version && current_version != previous_version
@@ -932,9 +935,10 @@ module Homebrew
       end
 
       if current_version == newest_committed_version &&
+         current_url == newest_committed_url &&
          current_checksum != newest_committed_checksum
         problem(
-          "stable sha256 changed without the version also changing; " \
+          "stable sha256 changed without the url/version also changing; " \
           "please create an issue upstream to rule out malicious " \
           "circumstances and to find out why the file changed.",
         )

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -682,7 +682,7 @@ module Homebrew
             )
           end
 
-          it { is_expected.to match("stable sha256 changed without the version also changing") }
+          it { is_expected.to match("stable sha256 changed without the url/version also changing") }
         end
 
         context "should not change with the same version when not the first commit" do
@@ -699,7 +699,7 @@ module Homebrew
             )
           end
 
-          it { is_expected.to match("stable sha256 changed without the version also changing") }
+          it { is_expected.to match("stable sha256 changed without the url/version also changing") }
         end
 
         context "can change with the different version" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
This changes the audit to only warn if the url stays the same but the checksum changes. Previously, the audit would trigger if the version is the same but the checksum changed, which may be too restrictive since it's not unexpected for the checksum to change if a different URL is being used. Previous discussion: #9071.