### PR TITLE
livecheck: skip disabled formulae

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -233,6 +233,13 @@ module Homebrew
         return
       end
 
+      if formula.disabled? && !formula.livecheckable?
+        return status_hash(formula, "disabled", args: args) if args.json?
+
+        puts "#{Tty.red}#{formula_name(formula, args: args)}#{Tty.reset} : disabled" unless args.quiet?
+        return
+      end
+
       if formula.versioned_formula? && !formula.livecheckable?
         return status_hash(formula, "versioned", args: args) if args.json?
 

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -29,6 +29,15 @@ describe Homebrew::Livecheck do
     end
   end
 
+  let(:f_disabled) do
+    formula("test_disabled") do
+      desc "Disabled test formula"
+      homepage "https://brew.sh"
+      url "https://brew.sh/test-0.0.1.tgz"
+      disable! because: :unmaintained
+    end
+  end
+
   let(:f_gist) do
     formula("test_gist") do
       desc "Gist test formula"
@@ -97,6 +106,12 @@ describe Homebrew::Livecheck do
     it "skips a deprecated formula without a livecheckable" do
       expect { livecheck.skip_conditions(f_deprecated, args: args) }
         .to output("test_deprecated : deprecated\n").to_stdout
+        .and not_to_output.to_stderr
+    end
+
+    it "skips a disabled formula without a livecheckable" do
+      expect { livecheck.skip_conditions(f_disabled, args: args) }
+        .to output("test_disabled : disabled\n").to_stdout
         .and not_to_output.to_stderr
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR modifies `brew livecheck` to automatically skip disabled formulae which don't contain a `livecheck` block. We already do this for deprecated and versioned formulae without a `livecheck` block, so this is a logical extension.