### PR TITLE
bump-cask-pr: fix for casks that have multiple languages

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -140,6 +140,7 @@ module Homebrew
                                                       silent:        true)
 
       tmp_cask = Cask::CaskLoader.load(tmp_contents)
+      tmp_config = cask.config
       tmp_url = tmp_cask.url.to_s
 
       if new_hash.nil?
@@ -151,9 +152,9 @@ module Homebrew
       cask.languages.each do |language|
         next if language == cask.language
 
-        tmp_cask.config.languages = [language]
-
+        lang_config = tmp_config.merge(Cask::Config.new(explicit: { languages: [language] }))
         lang_cask = Cask::CaskLoader.load(tmp_contents)
+        lang_cask.config = lang_config
         lang_url = lang_cask.url.to_s
         lang_old_hash = lang_cask.sha256
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

I tried updating the cask `openoffice` to the latest version but `bump-cask-pr` was only downloading the file for `en-US`

This pull request fixes the issue by basically replacing this:

```rb
cask.config.languages = [language]
```

with this:

```rb
cask.config = config.merge(Cask::Config.new(explicit: { languages: [language] }))
```

Related: #8822