### PR TITLE
pr-pull: skip bottles for CI-syntax-only PRs

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -285,8 +285,9 @@ module Homebrew
     Utils::Git.cherry_pick!(path, "--ff", "--allow-empty", *commits, verbose: args.verbose?, resolve: args.resolve?)
   end
 
-  def formulae_need_bottles?(tap, original_commit, args:)
+  def formulae_need_bottles?(tap, original_commit, user, repo, pr, args:)
     return if args.dry_run?
+    return false if GitHub.pull_request_labels(user, repo, pr).include? "CI-syntax-only"
 
     changed_formulae(tap, original_commit).any? do |f|
       !f.bottle_unneeded? && !f.bottle_disabled?
@@ -394,7 +395,7 @@ module Homebrew
                             args: args)
           end
 
-          unless formulae_need_bottles?(tap, original_commit, args: args)
+          unless formulae_need_bottles?(tap, original_commit, user, repo, pr, args: args)
             ohai "Skipping artifacts for ##{pr} as the formulae don't need bottles"
             next
           end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -779,4 +779,9 @@ module GitHub
       end
     end
   end
+
+  def pull_request_labels(user, repo, pr)
+    pr_data = open_api(url_to("repos", user, repo, "pulls", pr))
+    pr_data["labels"].map { |label| label["name"] }
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Don't try to download bottle artifacts when merging PRs labeled as `CI-syntax-only`. This will allow `CI-syntax-only` PRs to be automerged.

Before, automerging would usually fail because `pr-pull` tried to download bottle artifacts that CI never created (see https://github.com/Homebrew/homebrew-core/pull/64740 and [the attempted merge](https://github.com/Homebrew/homebrew-core/runs/1398570519?check_suite_focus=true#step:5:151) for an example).
