### PR TITLE
cleanup.rb: ensure cache exists before touching .cleaned

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -168,6 +168,7 @@ module Homebrew
       return false if Homebrew::EnvConfig.no_install_cleanup?
 
       unless PERIODIC_CLEAN_FILE.exist?
+        HOMEBREW_CACHE.mkpath
         FileUtils.touch PERIODIC_CLEAN_FILE
         return false
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Make sure that HOMEBREW_CACHE exists before creating the `.cleaned` file. Might fix occasional "Error: No such file or directory @ rb_sysopen - /Users/brew/Library/Caches/Homebrew/.cleaned" errors for bottle builds involving [lots of dependents](https://github.com/Homebrew/homebrew-core/pull/64718/checks?check_run_id=1396591291). (xref #5510)

One might note that in the aforelinked job, only the Mojave runner was repeatedly deciding to run `Formulae#cleanup_during!` after every dependent after a certain point, which suggests that something's awry with the free space detection on that OS or runner.