### PR TITLE
audit: don't error on old OS X versions

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -918,19 +918,23 @@ module Homebrew
       newest_committed_url = nil
 
       fv.rev_list("origin/master") do |rev|
-        fv.formula_at_revision(rev) do |f|
-          stable = f.stable
-          next if stable.blank?
+        begin
+          fv.formula_at_revision(rev) do |f|
+            stable = f.stable
+            next if stable.blank?
 
-          previous_version = stable.version
-          previous_checksum = stable.checksum
-          previous_version_scheme = f.version_scheme
-          previous_revision = f.revision
+            previous_version = stable.version
+            previous_checksum = stable.checksum
+            previous_version_scheme = f.version_scheme
+            previous_revision = f.revision
 
-          newest_committed_version ||= previous_version
-          newest_committed_checksum ||= previous_checksum
-          newest_committed_revision ||= previous_revision
-          newest_committed_url ||= stable.url
+            newest_committed_version ||= previous_version
+            newest_committed_checksum ||= previous_checksum
+            newest_committed_revision ||= previous_revision
+            newest_committed_url ||= stable.url
+          end
+        rescue MacOSVersionError
+          break
         end
 
         break if previous_version && current_version != previous_version


### PR DESCRIPTION
Some formulae are old enough to start taking driving lessons. Don't fail audits when the git history reaches into pre-history causing errors like:

```
==> brew audit viennacl --online --git --skip-style
==> FAILED
Error: unknown or unsupported macOS version: :snow_leopard
```

https://github.com/Homebrew/homebrew-core/runs/1401166825?check_suite_focus=true

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----