### PR TITLE
dispatch-build-bottle: support linux too

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -25,8 +25,14 @@ module Homebrew
              description: "Version of macOS the bottle should be built for."
       flag   "--workflow=",
              description: "Dispatch specified workflow (default: `dispatch-build-bottle.yml`)."
+      switch "--linux",
+             description: "Build a Linux bottle."
+      switch "--linux-self-hosted",
+             description: "Build a Linux bottle on a self hosted runner."
       switch "--upload",
              description: "Upload built bottles to Bintray."
+
+      conflicts "--macos", "--linux", "--linux-self-hosted"
 
       min_named :formula
     end
@@ -35,12 +41,18 @@ module Homebrew
   def dispatch_build_bottle
     args = dispatch_build_bottle_args.parse
 
-    odie "Must specify --macos option" unless args.macos
-
-    macos = begin
-      MacOS::Version.from_symbol(args.macos.to_sym)
-    rescue MacOSVersionError
-      MacOS::Version.new(args.macos)
+    os = if args.macos
+      begin
+        MacOS::Version.from_symbol(args.macos.to_sym)
+      rescue MacOSVersionError
+        MacOS::Version.new(args.macos)
+      end
+    elsif args.linux?
+      "ubuntu-latest"
+    elsif args.linux_self_hosted?
+      "ubuntu-self-hosted"
+    else
+      odie "Must specify either --macos or --linux or --linux-self-hosted flag"
     end
 
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
@@ -53,7 +65,7 @@ module Homebrew
       # Required inputs
       inputs = {
         formula: formula.name,
-        macos:   macos.to_s,
+        os:      os.to_s,
       }
 
       # Optional inputs
@@ -61,7 +73,7 @@ module Homebrew
       inputs[:issue] = args.issue if args.issue
       inputs[:upload] = args.upload?.to_s if args.upload?
 
-      ohai "Dispatching #{tap} bottling request of formula \"#{formula.name}\" for macOS #{macos}"
+      ohai "Dispatching #{tap} bottling request of formula \"#{formula.name}\" for #{os}"
       GitHub.workflow_dispatch_event(user, repo, workflow, ref, inputs)
     end
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -999,6 +999,10 @@ Build bottles for these formulae with GitHub Actions.
   Version of macOS the bottle should be built for.
 * `--workflow`:
   Dispatch specified workflow (default: `dispatch-build-bottle.yml`).
+* `--linux`:
+  Build a Linux bottle.
+* `--linux-self-hosted`:
+  Build a Linux bottle on a self hosted runner.
 * `--upload`:
   Upload built bottles to Bintray.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1406,6 +1406,14 @@ Version of macOS the bottle should be built for\.
 Dispatch specified workflow (default: \fBdispatch\-build\-bottle\.yml\fR)\.
 .
 .TP
+\fB\-\-linux\fR
+Build a Linux bottle\.
+.
+.TP
+\fB\-\-linux\-self\-hosted\fR
+Build a Linux bottle on a self hosted runner\.
+.
+.TP
 \fB\-\-upload\fR
 Upload built bottles to Bintray\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds support for specyfing Linux in `dispatch-build-bottle` dev command.
It will become handy when we will be ready to build Linux bottles in homebrew-core.

**Can wait with merging after Big Sur mass bottling is complete, so it won't break anything.**