### PR TITLE
Allow --extras parameter to "brew update-python-resources"

### DIFF
--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -22,7 +22,7 @@ module Homebrew
       switch "-s", "--silent",
              description: "Suppress any output."
       comma_array "--extras",
-             description: "Include these comma-separated setuptools 'extras' in installation"
+                  description: "Include these comma-separated setuptools 'extras' in installation"
       switch "--ignore-non-pypi-packages",
              description: "Don't fail if <formula> is not a PyPI package."
       flag "--version=",

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -21,6 +21,8 @@ module Homebrew
              description: "Print the updated resource blocks instead of changing <formula>."
       switch "-s", "--silent",
              description: "Suppress any output."
+      comma_array "--extras",
+             description: "Include these comma-separated setuptools 'extras' in installation"
       switch "--ignore-non-pypi-packages",
              description: "Don't fail if <formula> is not a PyPI package."
       flag "--version=",
@@ -35,7 +37,8 @@ module Homebrew
 
     args.named.to_formulae.each do |formula|
       PyPI.update_python_resources! formula, args.version, print_only: args.print_only?, silent: args.silent?,
-                                    ignore_non_pypi_packages: args.ignore_non_pypi_packages?
+                                    ignore_non_pypi_packages: args.ignore_non_pypi_packages?,
+                                    extras: args.extras
     end
   end
 end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -96,7 +96,7 @@ module PyPI
     @pipgrip_installed ||= Formula["pipgrip"].any_version_installed?
     odie '"pipgrip" must be installed (`brew install pipgrip`)' unless @pipgrip_installed
 
-    extras_str = "[#{extras.join(',')}]" unless extras.nil?
+    extras_str = "[#{extras.join(",")}]" unless extras.nil?
     pypi_coordinates = "#{pypi_name}#{extras_str}==#{version}"
     ohai "Retrieving PyPI dependencies for \"#{pypi_coordinates}\"..." if !print_only && !silent
     pipgrip_command = [
@@ -104,7 +104,7 @@ module PyPI
       "--no-cache-dir",
       pypi_coordinates
     ]
-    pipgrip_output = Utils.popen_read *pipgrip_command
+    pipgrip_output = Utils.popen_read(*pipgrip_command)
     unless $CHILD_STATUS.success?
       odie <<~EOS
         Unable to determine dependencies for \"#{pypi_name}\" because of a failure when running

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1323,6 +1323,8 @@ Update versions for PyPI resource blocks in *`formula`*.
   Print the updated resource blocks instead of changing *`formula`*.
 * `-s`, `--silent`:
   Suppress any output.
+* `--extras`:
+  Include these comma-separated setuptools 'extras' in installation
 * `--ignore-non-pypi-packages`:
   Don't fail if *`formula`* is not a PyPI package.
 * `--version`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1842,6 +1842,10 @@ Print the updated resource blocks instead of changing \fIformula\fR\.
 Suppress any output\.
 .
 .TP
+\fB\-\-extras\fR
+Include these comma\-separated setuptools \'extras\' in installation
+.
+.TP
 \fB\-\-ignore\-non\-pypi\-packages\fR
 Don\'t fail if \fIformula\fR is not a PyPI package\.
 .


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
  (I needed this bad enough to just implement the feature and use it locally instead of going through an issue discussion first - sorry!)
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).

  I didn't see any existing tests for this module, but can cook some up if you think it's necessary.

- [ ] Have you successfully run `brew style` with your changes locally?

I've applied changes from CI and CI passes the style checks.

I tried running locally and encountered an error installing tools (in nokogiri, of course):

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby.h:33:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/ruby/ruby.h:24:10:
fatal error: 'ruby/config.h' file not found
```

If this covers things which won't be flagged by CI, please let me know and I'll pursue resolving this.

- [ ] Have you successfully run `brew tests` with your changes locally?

Same issue as above.

- [ ] Have you successfully run `brew man` locally and committed any changes?

I manually applied changes flagged by CI.

-----

Python packages can provide different transitive dependencies based on configuration you pass in - it's called a 'setuptools extra' and you can read about it here: https://packaging.python.org/tutorials/installing-packages/#installing-setuptools-extras

To be able to update Python formulas that use these extras on install, I've added a command line parameter which accepts which "extras" to use.