### PR TITLE
docs - remove Discourse from communication methods

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -164,7 +164,7 @@ rescue BuildError => e
   if e.formula.head? || e.formula.deprecated? || e.formula.disabled?
     $stderr.puts <<~EOS
       Please create pull requests instead of asking for help on Homebrew's GitHub,
-      Discourse, Twitter or any other official channels.
+      Twitter or any other official channels.
     EOS
   end
 

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -115,8 +115,8 @@ module Homebrew
         <<~EOS
           You will encounter build failures with some formulae.
           Please create pull requests instead of asking for help on Homebrew's GitHub,
-          Discourse, Twitter or any other official channels. You are responsible for
-          resolving any issues you experience while you are running this
+          Twitter or any other official channels. You are responsible for resolving
+          any issues you experience while you are running this
           #{what}.
         EOS
       end

--- a/docs/Adding-Software-to-Homebrew.md
+++ b/docs/Adding-Software-to-Homebrew.md
@@ -19,7 +19,7 @@ If everything checks out, you're ready to get started on a new formula!
 
 1. Try to install the formula using `brew install --build-from-source <formula>`, where \<formula\> is the name of your formula. If any errors occur, correct your formula and attempt to install it again. The formula should install without errors by the end of this step.
 
-If you're stuck, ask for help on GitHub or [Discourse](https://discourse.brew.sh). The maintainers are very happy to help but we also like to see that you've put effort into trying to find a solution first.
+If you're stuck, ask for help on GitHub or [Homebrew/discussions](https://github.com/homebrew/discussions/discussions). The maintainers are very happy to help but we also like to see that you've put effort into trying to find a solution first.
 
 ## Testing and auditing the formula
 

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -91,7 +91,7 @@ eval $(~/.linuxbrew/bin/brew shellenv)
 
 - [@HomebrewOnLinux on Twitter](https://twitter.com/HomebrewOnLinux)
 - [Homebrew/linuxbrew-core on GitHub](https://github.com/Homebrew/linuxbrew-core)
-- [Homebrew on Linux category](https://discourse.brew.sh/c/linuxbrew) of [Homebrew's Discourse](https://discourse.brew.sh)
+- [Homebrew/discussions (forum)](https://github.com/homebrew/discussions/discussions)
 
 ## Sponsors
 

--- a/docs/Maintainer-Guidelines.md
+++ b/docs/Maintainer-Guidelines.md
@@ -174,8 +174,8 @@ The vast majority of Homebrew/homebrew-core PRs are bug fixes or version bumps s
 Maintainers have a variety of ways to communicate with each other:
 
 - Homebrew's public repositories on GitHub
-- Homebrew's group communications between more than two maintainers on private channels (e.g. GitHub/Slack/Discourse)
-- Homebrew's direct 1:1 messages between two maintainers on private channels (e.g. iMessage/Slack/Discourse/IRC/carrier pigeon)
+- Homebrew's group communications between more than two maintainers on private channels (e.g. GitHub/Slack)
+- Homebrew's direct 1:1 messages between two maintainers on private channels (e.g. iMessage/Slack/carrier pigeon)
 
 All communication should ideally occur in public on GitHub. Where this is not possible or appropriate (e.g. a security disclosure, interpersonal issue between two maintainers, urgent breakage that needs to be resolved) this can move to maintainers' private group communication and, if necessary, 1:1 communication. Technical decisions should not happen in 1:1 communications but if they do (or did in the past) they must end up back as something linkable on GitHub. For example, if a technical decision was made a year ago on Slack and another maintainer/contributor/user asks about it on GitHub, that's a good chance to explain it to them and have something that can be linked to in the future.
 

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -8,7 +8,7 @@ Homebrew release:
 1. Check the [Homebrew/brew pull requests](https://github.com/homebrew/brew/pulls),
    [issues](https://github.com/homebrew/brew/issues),
    [Homebrew/core issues](https://github.com/homebrew/homebrew-core/issues) and
-   [Discourse](https://discourse.brew.sh) to see if there is
+   [Homebrew/discussions (forum)](https://github.com/homebrew/discussions/discussions) to see if there is
    anything pressing that needs to be fixed or merged before the next release.
    If so, fix and merge these changes.
 2. After no code changes have happened for at least a couple of hours (ideally 24 hours)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Removes Discourse and IRC from listed communication methods except for historical issues