### PR TITLE
unlink: unlink only keg-only versioned formulae.

### DIFF
--- a/Library/Homebrew/unlink.rb
+++ b/Library/Homebrew/unlink.rb
@@ -8,6 +8,7 @@ module Homebrew
 
     def unlink_versioned_formulae(formula, verbose: false)
       formula.versioned_formulae
+             .select(&:keg_only?)
              .select(&:linked?)
              .map(&:any_installed_keg)
              .compact


### PR DESCRIPTION
As otherwise we unlink those that don't conflict e.g. `gcc@8` and `gcc@9`.

Fixes https://github.com/Homebrew/brew/issues/9100