### PR TITLE
manpages: update from homebrew-bundle

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1512,46 +1512,46 @@ Otherwise, operate on `~/Library/LaunchAgents` (started at login).
 * `--all`:
   Run *`subcommand`* on all services.
 
-### `test-bot` [*`options`*] [*`formula`*]
+### `test-bot` [*`options`*] [*`formula`*]:
 
-Tests the full lifecycle of a Homebrew change to a tap (Git repository). For example, for a GitHub Actions pull request that changes a formula `brew test-bot` will ensure the system is cleaned and set up to test the formula, install the formula, run various tests and checks on it, bottle (package) the binaries and test formulae that depend on it to ensure they aren't broken by these changes.
+Tests the full lifecycle of a Homebrew change to a tap (Git repository). For example, for a GitHub Actions pull request that changes a formula `brew test-bot` will ensure the system is cleaned and setup to test the formula, install the formula, run various tests and checks on it, bottle (package) the binaries and test formulae that depend on it to ensure they aren't broken by these changes.
 
 Only supports GitHub Actions as a CI provider. This is because Homebrew uses GitHub Actions and it's freely available for public and private use with macOS and Linux workers.
 
 * `--dry-run`:
-  Print what would be done rather than doing it.
+  print what would be done rather than doing it.
 * `--cleanup`:
-  Clean all state from the Homebrew directory. Use with care!
+  clean all state from the Homebrew directory. Use with care!
 * `--skip-setup`:
-  Don't check if the local system is set up correctly.
+  don't check if the local system is set up correctly.
 * `--keep-old`:
-  Run `brew bottle --keep-old` to build new bottles for a single platform.
+  run `brew bottle --keep-old` to build new bottles for a single platform.
 * `--skip-relocation`:
-  Run `brew bottle --skip-relocation` to build new bottles that don't require relocation.
+  run `brew bottle --skip-relocation` to build new bottles that don't require relocation.
 * `--local`:
-  Ask Homebrew to write verbose logs under `./logs/` and set `$HOME` to `./home/`
+  ask Homebrew to write verbose logs under `./logs/` and set `$HOME` to `./home/`
 * `--tap`:
-  Use the Git repository of the given tap. Defaults to the core tap for syntax checking.
+  use the `git` repository of the given tap. Defaults to the core tap for syntax checking.
 * `--fail-fast`:
-  Immediately exit on a failing step.
+  immediately exit on a failing step.
 * `-v`, `--verbose`:
-  Print test step output in real time. Has the side effect of passing output as raw bytes instead of re-encoding in UTF-8.
+  print test step output in real time. Has the side effect of passing output as raw bytes instead of re-encoding in UTF-8.
 * `--test-default-formula`:
-  Use a default testing formula when not building a tap and no other formulae are specified.
+  use a default testing formula when not building a tap and no other formulae are specified.
 * `--bintray-org`:
-  Upload bottles to the given Bintray organisation.
+  upload to the given Bintray organisation.
 * `--root-url`:
-  Use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
+  use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
 * `--git-name`:
-  Set the Git author/committer names to the given name.
+  set the Git author/committer names to the given name.
 * `--git-email`:
-  Set the Git author/committer email to the given email.
+  set the Git author/committer email to the given email.
 * `--ci-upload`:
-  Use the Homebrew CI bottle upload options.
+  use the Homebrew CI bottle upload options.
 * `--publish`:
-  Publish the uploaded bottles.
+  publish the uploaded bottles.
 * `--skip-recursive-dependents`:
-  Only test the direct dependents.
+  only test the direct dependents.
 * `--only-cleanup-before`:
   Only run the pre-cleanup step. Needs `--cleanup`.
 * `--only-setup`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2099,79 +2099,79 @@ If \fBsudo\fR is passed, operate on \fB/Library/LaunchDaemons\fR (started at boo
 \fB\-\-all\fR
 Run \fIsubcommand\fR on all services\.
 .
-.SS "\fBtest\-bot\fR [\fIoptions\fR] [\fIformula\fR]"
-Tests the full lifecycle of a Homebrew change to a tap (Git repository)\. For example, for a GitHub Actions pull request that changes a formula \fBbrew test\-bot\fR will ensure the system is cleaned and set up to test the formula, install the formula, run various tests and checks on it, bottle (package) the binaries and test formulae that depend on it to ensure they aren\'t broken by these changes\.
+.SS "\fBtest\-bot\fR [\fIoptions\fR] [\fIformula\fR]:"
+Tests the full lifecycle of a Homebrew change to a tap (Git repository)\. For example, for a GitHub Actions pull request that changes a formula \fBbrew test\-bot\fR will ensure the system is cleaned and setup to test the formula, install the formula, run various tests and checks on it, bottle (package) the binaries and test formulae that depend on it to ensure they aren\'t broken by these changes\.
 .
 .P
 Only supports GitHub Actions as a CI provider\. This is because Homebrew uses GitHub Actions and it\'s freely available for public and private use with macOS and Linux workers\.
 .
 .TP
 \fB\-\-dry\-run\fR
-Print what would be done rather than doing it\.
+print what would be done rather than doing it\.
 .
 .TP
 \fB\-\-cleanup\fR
-Clean all state from the Homebrew directory\. Use with care!
+clean all state from the Homebrew directory\. Use with care!
 .
 .TP
 \fB\-\-skip\-setup\fR
-Don\'t check if the local system is set up correctly\.
+don\'t check if the local system is set up correctly\.
 .
 .TP
 \fB\-\-keep\-old\fR
-Run \fBbrew bottle \-\-keep\-old\fR to build new bottles for a single platform\.
+run \fBbrew bottle \-\-keep\-old\fR to build new bottles for a single platform\.
 .
 .TP
 \fB\-\-skip\-relocation\fR
-Run \fBbrew bottle \-\-skip\-relocation\fR to build new bottles that don\'t require relocation\.
+run \fBbrew bottle \-\-skip\-relocation\fR to build new bottles that don\'t require relocation\.
 .
 .TP
 \fB\-\-local\fR
-Ask Homebrew to write verbose logs under \fB\./logs/\fR and set \fB$HOME\fR to \fB\./home/\fR
+ask Homebrew to write verbose logs under \fB\./logs/\fR and set \fB$HOME\fR to \fB\./home/\fR
 .
 .TP
 \fB\-\-tap\fR
-Use the Git repository of the given tap\. Defaults to the core tap for syntax checking\.
+use the \fBgit\fR repository of the given tap\. Defaults to the core tap for syntax checking\.
 .
 .TP
 \fB\-\-fail\-fast\fR
-Immediately exit on a failing step\.
+immediately exit on a failing step\.
 .
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
-Print test step output in real time\. Has the side effect of passing output as raw bytes instead of re\-encoding in UTF\-8\.
+print test step output in real time\. Has the side effect of passing output as raw bytes instead of re\-encoding in UTF\-8\.
 .
 .TP
 \fB\-\-test\-default\-formula\fR
-Use a default testing formula when not building a tap and no other formulae are specified\.
+use a default testing formula when not building a tap and no other formulae are specified\.
 .
 .TP
 \fB\-\-bintray\-org\fR
-Upload bottles to the given Bintray organisation\.
+upload to the given Bintray organisation\.
 .
 .TP
 \fB\-\-root\-url\fR
-Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
+use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
 .
 .TP
 \fB\-\-git\-name\fR
-Set the Git author/committer names to the given name\.
+set the Git author/committer names to the given name\.
 .
 .TP
 \fB\-\-git\-email\fR
-Set the Git author/committer email to the given email\.
+set the Git author/committer email to the given email\.
 .
 .TP
 \fB\-\-ci\-upload\fR
-Use the Homebrew CI bottle upload options\.
+use the Homebrew CI bottle upload options\.
 .
 .TP
 \fB\-\-publish\fR
-Publish the uploaded bottles\.
+publish the uploaded bottles\.
 .
 .TP
 \fB\-\-skip\-recursive\-dependents\fR
-Only test the direct dependents\.
+only test the direct dependents\.
 .
 .TP
 \fB\-\-only\-cleanup\-before\fR


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Incorporates changes from https://github.com/Homebrew/homebrew-bundle/pull/813 and https://github.com/Homebrew/homebrew-bundle/pull/814.

These don't get checked during homebrew-bundle CI and PRs to brew don't seem to update the official external command taps (bundle, services, test-bot) to show that the `brew man` output has changed.

cc @EricFromCanada @Rylan12 @MikeMcQuaid 