### PR TITLE
audit: allow checksum to be added/removed when changing download scheme

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -943,7 +943,8 @@ module Homebrew
 
       if current_version == newest_committed_version &&
          current_url == newest_committed_url &&
-         current_checksum != newest_committed_checksum
+         current_checksum != newest_committed_checksum &&
+         current_checksum.present? && newest_committed_checksum.present?
         problem(
           "stable sha256 changed without the url/version also changing; " \
           "please create an issue upstream to rule out malicious " \

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -717,6 +717,19 @@ module Homebrew
 
           it { is_expected.to be_nil }
         end
+
+        context "can be removed when switching schemes" do
+          before do
+            formula_gsub_origin_commit(
+              'url "https://brew.sh/foo-1.0.tar.gz"',
+              'url "https://foo.com/brew/bar.git", tag: "1.0", revision: "f5e00e485e7aa4c5baa20355b27e3b84a6912790"',
+            )
+            formula_gsub_origin_commit('sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"',
+                                       "")
+          end
+
+          it { is_expected.to be_nil }
+        end
       end
 
       context "revisions" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
When changing from url/checksum to or from git/tag, the checksum for one will be present and the other will be nil. This should not be an audit failure, and this PR ensures both checksums are non-nil prior to flagging.

Fixes https://github.com/Homebrew/homebrew-core/pull/64925