### PR TITLE
macos_requirement: fix display of versions as array

### DIFF
--- a/Library/Homebrew/requirements/macos_requirement.rb
+++ b/Library/Homebrew/requirements/macos_requirement.rb
@@ -75,9 +75,15 @@ class MacOSRequirement < Requirement
 
   sig { returns(String) }
   def display_s
-    return "macOS" unless version_specified?
-
-    "macOS #{@comparator} #{@version}"
+    if version_specified?
+      if @version.respond_to?(:to_ary)
+        "macOS #{@comparator} #{version.join(" / ")}"
+      else
+        "macOS #{@comparator} #{@version}"
+      end
+    else
+      "macOS"
+    end
   end
 
   def to_json(*args)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
`$ brew deps --include-requirements openzfs`

Before:
```
:macOS == [#<OS::Mac::Version:0x00007fd222a5b968 @version="10.11", @detected_from_url=false, @comparison_cache={}>, #<OS::Mac::Version:0x00007fd222a5b8c8 @version="10.12", @detected_from_url=false, @comparison_cache={}>, #<OS::Mac::Version:0x00007fd222a5b800 @version="10.13", @detected_from_url=false, @comparison_cache={}>, #<OS::Mac::Version:0x00007fd222a5b788 @version="10.14", @detected_from_url=false, @comparison_cache={}>, #<OS::Mac::Version:0x00007fd222a5b738 @version="10.15", @detected_from_url=false, @comparison_cache={}>]
```

After:
```
:macOS == 10.11 / 10.12 / 10.13 / 10.14 / 10.15
```

```