### PR TITLE
Add CPU family for M1, remove Intel Arrandale

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -22,33 +22,10 @@ module Hardware
       end
 
       def family
-        case sysctl_int("hw.cpufamily")
-        when 0x73d67300 # Yonah: Core Solo/Duo
-          :core
-        when 0x426f69ef # Merom: Core 2 Duo
-          :core2
-        when 0x78ea4fbc # Penryn
-          :penryn
-        when 0x6b5a4cd2 # Nehalem
-          :nehalem
-        when 0x573B5EEC # Arrandale
-          :arrandale
-        when 0x5490B78C # Sandy Bridge
-          :sandybridge
-        when 0x1F65E835 # Ivy Bridge
-          :ivybridge
-        when 0x10B282DC # Haswell
-          :haswell
-        when 0x582ed09c # Broadwell
-          :broadwell
-        when 0x37fc219f # Skylake
-          :skylake
-        when 0x0f817246 # Kaby Lake
-          :kabylake
-        when 0x38435547 # Ice Lake
-          :icelake
-        when 0x07d34b9f # ARMv8.3-A (Vortex, Tempest)
-          :arm_vortex_tempest
+        if arm?
+          arm_family
+        elsif intel?
+          intel_family
         else
           :dunno
         end
@@ -123,6 +100,48 @@ module Hardware
       end
 
       private
+
+      def arm_family
+        case sysctl_int("hw.cpufamily")
+        when 0x07d34b9f             # ARMv8.3-A (Vortex, Tempest)
+          :arm_vortex_tempest
+        when 0x573b5eec, 0x1b588bb3 # ARMv8.4-A (Firestorm, Icestorm)
+          :arm_firestorm_icestorm
+        else
+          :dunno
+        end
+      end
+
+      def intel_family
+        case sysctl_int("hw.cpufamily")
+        when 0x73d67300 # Yonah: Core Solo/Duo
+          :core
+        when 0x426f69ef # Merom: Core 2 Duo
+          :core2
+        when 0x78ea4fbc # Penryn
+          :penryn
+        when 0x6b5a4cd2 # Nehalem
+          :nehalem
+        when 0x573b5eec # Arrandale
+          :arrandale
+        when 0x5490b78c # Sandy Bridge
+          :sandybridge
+        when 0x1f65e835 # Ivy Bridge
+          :ivybridge
+        when 0x10b282dc # Haswell
+          :haswell
+        when 0x582ed09c # Broadwell
+          :broadwell
+        when 0x37fc219f # Skylake
+          :skylake
+        when 0x0f817246 # Kaby Lake
+          :kabylake
+        when 0x38435547 # Ice Lake
+          :icelake
+        else
+          :dunno
+        end
+      end
 
       def sysctl_bool(key)
         sysctl_int(key) == 1

--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -103,8 +103,18 @@ module Hardware
 
       def arm_family
         case sysctl_int("hw.cpufamily")
+        when 0x2c91a47e             # ARMv8.0-A (Typhoon)
+          :arm_typhoon
+        when 0x92fb37c8             # ARMv8.0-A (Twister)
+          :arm_twister
+        when 0x67ceee93             # ARMv8.1-A (Hurricane, Zephyr)
+          :arm_hurricane_zephyr
+        when 0xe81e7ef6             # ARMv8.2-A (Monsoon, Mistral)
+          :arm_monsoon_mistral
         when 0x07d34b9f             # ARMv8.3-A (Vortex, Tempest)
           :arm_vortex_tempest
+        when 0x462504d2             # ARMv8.4-A (Lightning, Thunder)
+          :arm_lightning_thunder
         when 0x573b5eec, 0x1b588bb3 # ARMv8.4-A (Firestorm, Icestorm)
           :arm_firestorm_icestorm
         else
@@ -122,8 +132,8 @@ module Hardware
           :penryn
         when 0x6b5a4cd2 # Nehalem
           :nehalem
-        when 0x573b5eec # Arrandale
-          :arrandale
+        when 0x573b5eec # Westmere
+          :westmere
         when 0x5490b78c # Sandy Bridge
           :sandybridge
         when 0x1f65e835 # Ivy Bridge

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -22,6 +22,7 @@ describe Hardware::CPU do
   describe "::family" do
     let(:cpu_families) {
       [
+        :arm_firestorm_icestorm,
         :arm_vortex_tempest,
         :arrandale,
         :atom,
@@ -47,6 +48,29 @@ describe Hardware::CPU do
 
     it "returns the current CPU's family name as a symbol, or :dunno if it cannot be detected" do
       expect(cpu_families).to include described_class.family
+    end
+
+    context "when hw.cpufamily is 0x573b5eec on a Mac", :needs_macos do
+      before do
+        allow(described_class)
+          .to receive(:sysctl_int)
+          .with("hw.cpufamily")
+          .and_return(0x573b5eec)
+      end
+
+      it "returns :arm_firestorm_icestorm on ARM" do
+        allow(described_class).to receive(:arm?).and_return(true)
+        allow(described_class).to receive(:intel?).and_return(false)
+
+        expect(described_class.family).to eq(:arm_firestorm_icestorm)
+      end
+
+      it "returns :westmere on Intel" do
+        allow(described_class).to receive(:arm?).and_return(false)
+        allow(described_class).to receive(:intel?).and_return(true)
+
+        expect(described_class.family).to eq(:westmere)
+      end
     end
   end
 end

--- a/Library/Homebrew/test/hardware/cpu_spec.rb
+++ b/Library/Homebrew/test/hardware/cpu_spec.rb
@@ -23,8 +23,12 @@ describe Hardware::CPU do
     let(:cpu_families) {
       [
         :arm_firestorm_icestorm,
+        :arm_hurricane_zephyr,
+        :arm_lightning_thunder,
+        :arm_monsoon_mistral,
+        :arm_twister,
+        :arm_typhoon,
         :arm_vortex_tempest,
-        :arrandale,
         :atom,
         :broadwell,
         :core,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **Massive amount of test failures on my Intel Mac but all of them due to flaky tests.** See #9170.
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

**Update:** Re-added detection of the Arrandale CPU family. Also added tests, renamed Arrandale to Westmere (as in machine.h) and added all ARM-based CPU families the current macOS 11.0 release kernel supports.

-----

According to reports, XNU’s CPU family identifier previously used for the Westmere family (which Homebrew mislabels as the Arrandale family) is now being reused for one of Apple’s M1 SoC models.
    
Resolving the conflict by splitting the list of CPU families and adding a microarchitecture check.

Sources for the values:

- https://github.com/Homebrew/brew/issues/7857#issuecomment-728739049
- https://en.wikipedia.org/wiki/Comparison_of_ARMv8-A_cores
- Direct messages
