### PR TITLE
unpack_strategy: Move `Dmg` to above `Xz` and `Lzma`

### DIFF
--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -47,6 +47,7 @@ module UnpackStrategy
       Tar, # Needs to be before Bzip2/Gzip/Xz/Lzma.
       Pax,
       Gzip,
+      Dmg, # Needs to be before Bzip2/Xz/Lzma.
       Lzma,
       Xz,
       Lzip,
@@ -66,7 +67,6 @@ module UnpackStrategy
       SelfExtractingExecutable, # Needs to be before `Cab`.
       Cab,
       Executable,
-      Dmg, # Needs to be before `Bzip2`.
       Bzip2,
       Fossil,
       Bazaar,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Updating `unpack_strategy.rb` to move `Dmg` to above `Xz` - This has been done in order to fix the issue raised at https://github.com/Homebrew/homebrew-cask/issues/92674

Have run through `brew style`, `brew man` and `brew tests`, the last of which appears to show a number of failures. Again, advise on this would be greatly appreciated!

I'm certainly not a Ruby expert and my previous contributions to homebrew have been, in general, formula/cask creations/bumps and so any and all advise would be appreciated as to what testing would need to be done, in order to validate this PR.

Also, just to highlight, the scope of my testing of this fix has been on a single machine, running macOS Big Sur.

Leaving PR as draft for now, so that it can be sanity-checked! 👍🏻 

Thanks!