### PR TITLE
Linkage checker: flag unrequested dependencies in --test

### DIFF
--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -47,7 +47,7 @@ module Homebrew
 
         if args.test?
           result.display_test_output
-          Homebrew.failed = true if result.broken_library_linkage?
+          Homebrew.failed = true if result.broken_library_linkage? || result.undeclared_dependencies?
         elsif args.reverse?
           result.display_reverse_output
         else

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -78,12 +78,18 @@ class LinkageChecker
     end
 
     puts "Unexpected non-missing linkage detected" if unexpected_present_dylibs.present?
+
+    puts "Undeclared dependencies detected" if undeclared_dependencies?
   end
 
   sig { returns(T::Boolean) }
   def broken_library_linkage?
     issues = [@broken_deps, @unwanted_system_dylibs, @version_conflict_deps]
     [issues, unexpected_broken_dylibs, unexpected_present_dylibs].flatten.any?(&:present?)
+  end
+
+  def undeclared_dependencies?
+    !undeclared_deps.empty?
   end
 
   def unexpected_broken_dylibs


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

@claui noticed when running `brew test-bot` locally that we don't flag unrequested dependencies when building bottles, even though we flag broken linkage. This wasn't what we expected from `brew linkage --test`, which we thought would flag these kinds of problems. This adds unrequested dependencies to the list of things being tested by `brew linkage --test`.

For example, I have a `fish` bottle with an unrequested `gettext` dependency. Before:

```
$ brew linkage fish --test
No broken library linkage detected
$ echo $?
0
$ brew linkage fish
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libncurses.5.4.dylib
Homebrew libraries:
  /opt/homebrew/opt/gettext/lib/libintl.8.dylib (gettext)
Undeclared dependencies with linkage:
  gettext
```

After:

```
$ brew linkage fish --test
No broken library linkage detected
Undeclared dependencies detected
$ echo $?
1
```

/cc @MikeMcQuaid 