### PR TITLE
upgrade: show upgradeable dependents during dry run

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -289,7 +289,7 @@ module Homebrew
       Cleanup.install_formula_clean!(f)
     end
 
-    Upgrade.check_installed_dependents(args: args)
+    Upgrade.check_installed_dependents(installed_formulae, args: args)
 
     Homebrew.messages.display_messages(display_times: args.display_times?)
   rescue FormulaUnreadableError, FormulaClassUnavailableError,

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -102,7 +102,7 @@ module Homebrew
       Cleanup.install_formula_clean!(f)
     end
 
-    Upgrade.check_installed_dependents(args: args)
+    Upgrade.check_installed_dependents(formulae, args: args)
 
     if casks.any?
       Cask::Cmd::Reinstall.reinstall_casks(

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -172,7 +172,7 @@ module Homebrew
 
     Upgrade.upgrade_formulae(formulae_to_install, args: args)
 
-    Upgrade.check_installed_dependents(args: args)
+    Upgrade.check_installed_dependents(formulae_to_install, args: args)
 
     Homebrew.messages.display_messages(display_times: args.display_times?)
   end

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -134,10 +134,10 @@ module Homebrew
       end
     end
 
-    def check_installed_dependents(args:)
+    def check_installed_dependents(formulae, args:)
       return if Homebrew::EnvConfig.no_installed_dependents_check?
 
-      installed_formulae = FormulaInstaller.installed.to_a
+      installed_formulae = args.dry_run? ? formulae : FormulaInstaller.installed.to_a
       return if installed_formulae.empty?
 
       already_broken_dependents = check_broken_dependents(installed_formulae)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
`$ brew upgrade --dry-run libtiff`

Before:
```
==> Would upgrade 1 outdated package:
libtiff 4.1.0 -> 4.1.0_1
```

After:
```
==> Would upgrade 1 outdated package:
libtiff 4.1.0 -> 4.1.0_1
==> Would upgrade 4 dependents:
gdk-pixbuf 2.38.0 -> 2.42.0, librsvg 2.42.2_2 -> 2.50.1, webp 1.0.3 -> 1.1.0, wxmac 3.0.5 -> 3.0.5.1_1
==> No currently broken dependents found!
Warning: If they are broken by the upgrade they will also be upgraded or reinstalled.
```

Note that `install` and `reinstall` do not currently support `--dry-run`, but they may at some point.