### PR TITLE
Migrate license mismatch allowlist to Homebrew/core

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -165,11 +165,6 @@ module Homebrew
       "LGPL-3.0" => ["LGPL-3.0-only", "LGPL-3.0-or-later"],
     }.freeze
 
-    PERMITTED_FORMULA_LICENSE_MISMATCHES = {
-      "cmockery" => "0.1.2",
-      "scw@1"    => "1.20",
-    }.freeze
-
     def audit_license
       if formula.license.present?
         licenses, exceptions = SPDX.parse_license_expression formula.license
@@ -213,7 +208,7 @@ module Homebrew
         return unless github_license
         return if (licenses + ["NOASSERTION"]).include?(github_license)
         return if PERMITTED_LICENSE_MISMATCHES[github_license]&.any? { |license| licenses.include? license }
-        return if PERMITTED_FORMULA_LICENSE_MISMATCHES[formula.name] == formula.version
+        return if tap_audit_exception :permitted_formula_license_mismatches, formula.name
 
         problem "Formula license #{licenses} does not match GitHub license #{Array(github_license)}."
 
@@ -821,6 +816,7 @@ module Homebrew
     end
 
     def tap_audit_exception(list, formula, value = nil)
+      return false if @tap_audit_exceptions.blank?
       return false unless @tap_audit_exceptions.key? list
 
       list = @tap_audit_exceptions[list]

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -423,6 +423,23 @@ module Homebrew
           .to eq 'Formula license ["0BSD"] does not match GitHub license ["GPL-3.0"].'
       end
 
+      it "allows a formula-specified license that differes from its GitHub "\
+         "repository for formulae on the mismatched license allowlist" do
+        formula_text = <<~RUBY
+          class Cask < Formula
+            url "https://github.com/cask/cask/archive/v0.8.4.tar.gz"
+            head "https://github.com/cask/cask.git"
+            license "0BSD"
+          end
+        RUBY
+        fa = formula_auditor "cask", formula_text, spdx_license_data: spdx_license_data,
+                             online: true, core_tap: true, new_formula: true,
+                             tap_audit_exceptions: { permitted_formula_license_mismatches: ["cask"] }
+
+        fa.audit_license
+        expect(fa.problems).to be_empty
+      end
+
       it "checks online and detects that an array of license does not contain "\
         "what is indicated on its Github repository" do
         formula_text = <<~RUBY

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -423,7 +423,7 @@ module Homebrew
           .to eq 'Formula license ["0BSD"] does not match GitHub license ["GPL-3.0"].'
       end
 
-      it "allows a formula-specified license that differes from its GitHub "\
+      it "allows a formula-specified license that differs from its GitHub "\
          "repository for formulae on the mismatched license allowlist" do
         formula_text = <<~RUBY
           class Cask < Formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? (I've run the audit tests only)
- [ ] Have you successfully run `brew man` locally and committed any changes? (no changes)

-----

This PR migrates the `PERMITTED_FORMULA_LICENSE_MISMATCHES` audit allowlist to Homebrew/core.

Additionally, I added some more tests for the lists migrated in https://github.com/Homebrew/brew/pull/9039

Prompted by https://github.com/Homebrew/homebrew-core/pull/59828

Corresponding Homebrew/core PR (should be merged at the same time or before): https://github.com/Homebrew/homebrew-core/pull/65061