### PR TITLE
Improve `brew install --quiet`

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -100,7 +100,7 @@ module Homebrew
       def self.global_options
         [
           ["-d", "--debug",   "Display any debugging information."],
-          ["-q", "--quiet",   "Suppress any warnings."],
+          ["-q", "--quiet",   "Make some output more quiet."],
           ["-v", "--verbose", "Make some output more verbose."],
           ["-h", "--help",    "Show this message."],
         ]

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -204,7 +204,7 @@ module Homebrew
           EOS
         elsif args.only_dependencies?
           installed_formulae << f
-        else
+        elsif !args.quiet?
           opoo <<~EOS
             #{f.full_name} #{f.pkg_version} is already installed and up-to-date
             To reinstall #{f.pkg_version}, run `brew reinstall #{f.name}`
@@ -224,11 +224,14 @@ module Homebrew
         msg = "#{f.full_name} #{installed_version} is already installed"
         linked_not_equals_installed = f.linked_version != installed_version
         if f.linked? && linked_not_equals_installed
-          msg = <<~EOS
-            #{msg}
-            The currently linked version is #{f.linked_version}
-            You can use `brew switch #{f} #{installed_version}` to link this version.
-          EOS
+          msg = if args.quiet?
+            nil
+          else
+            <<~EOS
+              #{msg}
+              The currently linked version is #{f.linked_version}
+            EOS
+          end
         elsif !f.linked? || f.keg_only?
           msg = <<~EOS
             #{msg}, it's just not linked
@@ -238,10 +241,14 @@ module Homebrew
           msg = nil
           installed_formulae << f
         else
-          msg = <<~EOS
-            #{msg} and up-to-date
-            To reinstall #{f.pkg_version}, run `brew reinstall #{f.name}`
-          EOS
+          msg = if args.quiet?
+            nil
+          else
+            <<~EOS
+              #{msg} and up-to-date
+              To reinstall #{f.pkg_version}, run `brew reinstall #{f.name}`
+            EOS
+          end
         end
         opoo msg if msg
       elsif !f.any_version_installed? && old_formula = f.old_installed_formulae.first
@@ -251,8 +258,10 @@ module Homebrew
             #{msg}, it's just not linked.
             You can use `brew link #{old_formula.full_name}` to link this version.
           EOS
+        elsif args.quiet?
+          msg = nil
         end
-        opoo msg
+        opoo msg if msg
       elsif f.migration_needed? && !args.force?
         # Check if the formula we try to install is the same as installed
         # but not migrated one. If --force is passed then install anyway.

--- a/Library/Homebrew/dev-cmd/diy.rb
+++ b/Library/Homebrew/dev-cmd/diy.rb
@@ -31,6 +31,8 @@ module Homebrew
   def diy
     args = diy_args.parse
 
+    # odeprecated "`brew diy`"
+
     path = Pathname.getwd
 
     version = args.version || detect_version(path)

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1384,7 +1384,7 @@ These options are applicable across multiple subcommands.
   Display any debugging information.
 
 * `-q`, `--quiet`:
-  Suppress any warnings.
+  Make some output more quiet.
 
 * `-v`, `--verbose`:
   Make some output more verbose.

--- a/docs/Tips-N'-Tricks.md
+++ b/docs/Tips-N'-Tricks.md
@@ -15,15 +15,6 @@ This can be useful if a package can't build against the version of something you
 
 And of course, you can simply `brew link <formula>` again afterwards!
 
-## Activate a previously installed version of a formula
-
-```sh
-brew info <formula>
-brew switch <formula> <version>
-```
-
-Use `brew info <formula>` to check what versions are installed but not currently activated, then `brew switch <formula> <version>` to activate the desired version. This can be useful if you would like to switch between versions of a formula.
-
 ## Install into Homebrew without formulae
 
 ```sh

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1899,7 +1899,7 @@ Display any debugging information\.
 .
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
-Suppress any warnings\.
+Make some output more quiet\.
 .
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR


### PR DESCRIPTION
- Suppress (some more) warnings when doing `brew install --quiet`
- Clarify `man brew` output that we don't suppress all warnings for all commands with `--quiet`

While I was doing this I noticed references to the (soon to be deprecated) `brew switch` so:
- remove these references in `install` output
- remove a reference in the documentation
- add a comment to remind me to deprecate `brew diy`, too

Fixes #9179