### PR TITLE
rubocops/components_order: Specify `disable!` and `deprecate!` order

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -38,6 +38,8 @@ module RuboCop
             [{ name: :keg_only,  type: :method_call }],
             [{ name: :option,    type: :method_call }],
             [{ name: :deprecated_option, type: :method_call }],
+            [{ name: :disable!, type: :method_call }],
+            [{ name: :deprecate!, type: :method_call }],
             [{ name: :depends_on, type: :method_call }],
             [{ name: :uses_from_macos, type: :method_call }],
             [{ name: :on_macos, type: :block_call }],

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -225,6 +225,31 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       corrected_source = autocorrect_source(source)
       expect(corrected_source).to eq(correct_source)
     end
+
+    it "When `depends_on` precedes `deprecate!`" do
+      source = <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+          depends_on "openssl"
+
+          deprecate! because: "has been replaced by bar"
+        end
+      RUBY
+
+      correct_source = <<~RUBY
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+          deprecate! because: "has been replaced by bar"
+
+          depends_on "openssl"
+        end
+      RUBY
+
+      corrected_source = autocorrect_source(source)
+      expect(corrected_source).to eq(correct_source)
+    end
   end
 
   context "no on_os_block" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- Ordering them this way seems to require less `--fix`ing in Homebrew/homebrew-core than the other way around.
- In the Big Sur bottling, we found many repos that were archived. We've been going through and deprecating repos that are archived or that don't build any more. I felt weird without the ordering of these stanzas without an audit to guide me - I spent time looking at previous examples to see "should `deprecate!` go before or after `depends_on`" question. Computers can tell us this instead.
