### PR TITLE
cli: fix type signature of to_kegs_to_casks

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -159,7 +159,7 @@ module Homebrew
         end
       end
 
-      sig { params(only: Symbol).returns([T::Array[Keg], T::Array[Cask::Cask]]) }
+      sig { params(only: T.nilable(Symbol)).returns([T::Array[Keg], T::Array[Cask::Cask]]) }
       def to_kegs_to_casks(only: nil)
         @to_kegs_to_casks ||= to_formulae_and_casks(only: only, method: :keg)
                               .partition { |o| o.is_a?(Keg) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Before & after:

```console
% brew rm coreutils cscope watch
Error: Parameter 'only': Expected type Symbol, got type NilClass
Caller: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:78
Definition: /usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:163
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/configuration.rb:219:in `call_validation_error_handler_default'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/configuration.rb:226:in `call_validation_error_handler'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:1125:in `report_error'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:81:in `block in validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/signature.rb:196:in `block in each_args_value_type'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/signature.rb:191:in `each'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/signature.rb:191:in `each_args_value_type'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:78:in `validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/_methods.rb:228:in `block in _on_method_added'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:67:in `uninstall'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'

% brew rm coreutils cscope watch
Uninstalling /usr/local/Cellar/coreutils/8.32... (476 files, 12.5MB)
Uninstalling /usr/local/Cellar/cscope/15.9... (11 files, 744.2KB)
Uninstalling /usr/local/Cellar/watch/3.3.16... (10 files, 135KB)
```