### PR TITLE
Properly handle outdated cURL

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -351,7 +351,7 @@ else
   if [[ $(numeric "${curl_name_and_version##* }") -lt $(numeric "$HOMEBREW_MINIMUM_CURL_VERSION") ]]
   then
       message="Please update your system cURL.
-Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}.
+Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}
 Your cURL version: ${curl_name_and_version##* }
 Your cURL executable: $(type -p $HOMEBREW_CURL)"
 
@@ -376,16 +376,18 @@ Your cURL executable: $(type -p $HOMEBREW_CURL)"
   IFS=. read -r major minor micro build extra <<< "${git_version_output##* }"
   if [[ $(numeric "$major.$minor.$micro.$build") -lt $(numeric "$HOMEBREW_MINIMUM_GIT_VERSION") ]]
   then
-    if [[ -z $HOMEBREW_GIT_PATH ]]; then
-      HOMEBREW_FORCE_BREWED_GIT="1"
-    else
-      odie <<EOS
-The version of Git that you provided to Homebrew using HOMEBREW_GIT_PATH is too old.
+    message="Please update your system Git.
 Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}.
-Your Git version: $major.$minor.$micro.$build.
-Please point Homebrew to Git ${HOMEBREW_MINIMUM_CURL_VERSION} or newer
-or unset HOMEBREW_GIT_PATH variable.
-EOS
+Your Git version: $major.$minor.$micro.$build
+Your Git executable: $(unset git && type -p $HOMEBREW_GIT)"
+    if [[ -z $HOMEBREW_GIT_PATH || -z $HOMEBREW_DEVELOPER ]]; then
+      HOMEBREW_FORCE_BREWED_GIT="1"
+      if [[ -z $HOMEBREW_GIT_WARNING ]]; then
+        onoe "$message"
+        HOMEBREW_GIT_WARNING=1
+      fi
+    else
+      odie "$message"
     fi
   fi
 
@@ -424,6 +426,7 @@ export HOMEBREW_CURL
 export HOMEBREW_CURL_WARNING
 export HOMEBREW_SYSTEM_CURL_TOO_OLD
 export HOMEBREW_GIT
+export HOMEBREW_GIT_WARNING
 export HOMEBREW_MINIMUM_GIT_VERSION
 export HOMEBREW_PROCESSOR
 export HOMEBREW_PRODUCT

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -350,17 +350,23 @@ else
   curl_name_and_version="${curl_version_output%% (*}"
   if [[ $(numeric "${curl_name_and_version##* }") -lt $(numeric "$HOMEBREW_MINIMUM_CURL_VERSION") ]]
   then
-    if [[ -z $HOMEBREW_CURL_PATH ]]; then
+      message="Your cURL version is too old.
+Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}
+Your cURL version: ${curl_name_and_version##* }
+Your cURL executable: $(type -p $HOMEBREW_CURL)
+To point Homebrew to cURL ${HOMEBREW_MINIMUM_CURL_VERSION} or newer,
+enable developer mode by setting HOMEBREW_DEVELOPER to 1,
+then set HOMEBREW_CURL_PATH to the location of cURL executable."
+
+    if [[ -z $HOMEBREW_CURL_PATH || -z $HOMEBREW_DEVELOPER ]]; then
       HOMEBREW_SYSTEM_CURL_TOO_OLD=1
       HOMEBREW_FORCE_BREWED_CURL=1
+      if [[ -z $HOMEBREW_CURL_WARNING ]]; then
+        onoe "$message"
+        HOMEBREW_CURL_WARNING=1
+      fi
     else
-      odie <<EOS
-The version of cURL that you provided to Homebrew using HOMEBREW_CURL_PATH is too old.
-Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}.
-Your cURL version: ${curl_name_and_version##* }.
-Please point Homebrew to cURL ${HOMEBREW_MINIMUM_CURL_VERSION} or newer
-or unset HOMEBREW_CURL_PATH variable.
-EOS
+      odie "$message"
     fi
   fi
 
@@ -418,6 +424,7 @@ export HOMEBREW_TEMP
 export HOMEBREW_CELLAR
 export HOMEBREW_SYSTEM
 export HOMEBREW_CURL
+export HOMEBREW_CURL_WARNING
 export HOMEBREW_SYSTEM_CURL_TOO_OLD
 export HOMEBREW_GIT
 export HOMEBREW_MINIMUM_GIT_VERSION

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -377,7 +377,7 @@ Your cURL executable: $(type -p $HOMEBREW_CURL)"
   if [[ $(numeric "$major.$minor.$micro.$build") -lt $(numeric "$HOMEBREW_MINIMUM_GIT_VERSION") ]]
   then
     message="Please update your system Git.
-Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}.
+Minimum required version: ${HOMEBREW_MINIMUM_GIT_VERSION}
 Your Git version: $major.$minor.$micro.$build
 Your Git executable: $(unset git && type -p $HOMEBREW_GIT)"
     if [[ -z $HOMEBREW_GIT_PATH || -z $HOMEBREW_DEVELOPER ]]; then

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -350,13 +350,10 @@ else
   curl_name_and_version="${curl_version_output%% (*}"
   if [[ $(numeric "${curl_name_and_version##* }") -lt $(numeric "$HOMEBREW_MINIMUM_CURL_VERSION") ]]
   then
-      message="Your cURL version is too old.
-Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}
+      message="Please update your system cURL.
+Minimum required version: ${HOMEBREW_MINIMUM_CURL_VERSION}.
 Your cURL version: ${curl_name_and_version##* }
-Your cURL executable: $(type -p $HOMEBREW_CURL)
-To point Homebrew to cURL ${HOMEBREW_MINIMUM_CURL_VERSION} or newer,
-enable developer mode by setting HOMEBREW_DEVELOPER to 1,
-then set HOMEBREW_CURL_PATH to the location of cURL executable."
+Your cURL executable: $(type -p $HOMEBREW_CURL)"
 
     if [[ -z $HOMEBREW_CURL_PATH || -z $HOMEBREW_DEVELOPER ]]; then
       HOMEBREW_SYSTEM_CURL_TOO_OLD=1

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -383,9 +383,7 @@ EOS
       ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
     ohai "Installing Homebrew Git"
-    [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git
-    unset GIT_EXECUTABLE
-    if ! git --version &>/dev/null
+    if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && ! brew install git
     then
       odie "Git must be installed and in your PATH!"
     fi

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -368,10 +368,11 @@ user account:
 EOS
   fi
 
+  # we may want to use a Homebrew curl
   if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
       ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
   then
-    ohai "Installing Homebrew cURL"
+    # we cannot install a Homebrew cURL if homebrew/core is unavailable.
     if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && ! brew install curl
     then
       odie "Curl must be installed and in your PATH!"
@@ -382,7 +383,7 @@ EOS
      [[ -n "$HOMEBREW_FORCE_BREWED_GIT" &&
       ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
-    ohai "Installing Homebrew Git"
+    # we cannot install a Homebrew Git if homebrew/core is unavailable.
     if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && ! brew install git
     then
       odie "Git must be installed and in your PATH!"

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -373,7 +373,7 @@ EOS
       ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
   then
     # we cannot install a Homebrew cURL if homebrew/core is unavailable.
-    if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && ! brew install curl
+    if [[ ! -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] || ! brew install curl
     then
       odie "Curl must be installed and in your PATH!"
     fi
@@ -384,7 +384,7 @@ EOS
       ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
     # we cannot install a Homebrew Git if homebrew/core is unavailable.
-    if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && ! brew install git
+    if [[ ! -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] || ! brew install git
     then
       odie "Git must be installed and in your PATH!"
     fi

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -372,7 +372,8 @@ EOS
   if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
       ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
   then
-    brew install curl
+    ohai "Installing Homebrew cURL"
+    brew install curl || odie "Failed to install cURL"
   fi
 
   if ! git --version &>/dev/null ||
@@ -380,7 +381,11 @@ EOS
       ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
     # we cannot install brewed git if homebrew/core is unavailable.
-    [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git
+    if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]]
+    then
+      ohai "Installing Homebrew Git"
+      brew install git || odie "Failed to install Git"
+    fi
     unset GIT_EXECUTABLE
     if ! git --version &>/dev/null
     then

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -368,12 +368,14 @@ user account:
 EOS
   fi
 
-  set -e
   if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
       ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
   then
     ohai "Installing Homebrew cURL"
-    brew install curl
+    if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && ! brew install curl
+    then
+      odie "Curl must be installed and in your PATH!"
+    fi
   fi
 
   if ! git --version &>/dev/null ||
@@ -381,14 +383,14 @@ EOS
       ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
     ohai "Installing Homebrew Git"
-    brew install git
+    [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]] && brew install git
     unset GIT_EXECUTABLE
     if ! git --version &>/dev/null
     then
       odie "Git must be installed and in your PATH!"
     fi
   fi
-  set +e
+
   export GIT_TERMINAL_PROMPT="0"
   export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
 

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -368,30 +368,27 @@ user account:
 EOS
   fi
 
-  # we may want to use a Homebrew curl
+  set -e
   if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
       ! -x "$HOMEBREW_PREFIX/opt/curl/bin/curl" ]]
   then
     ohai "Installing Homebrew cURL"
-    brew install curl || odie "Failed to install cURL"
+    brew install curl
   fi
 
   if ! git --version &>/dev/null ||
      [[ -n "$HOMEBREW_FORCE_BREWED_GIT" &&
       ! -x "$HOMEBREW_PREFIX/opt/git/bin/git" ]]
   then
-    # we cannot install brewed git if homebrew/core is unavailable.
-    if [[ -d "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" ]]
-    then
-      ohai "Installing Homebrew Git"
-      brew install git || odie "Failed to install Git"
-    fi
+    ohai "Installing Homebrew Git"
+    brew install git
     unset GIT_EXECUTABLE
     if ! git --version &>/dev/null
     then
       odie "Git must be installed and in your PATH!"
     fi
   fi
+  set +e
   export GIT_TERMINAL_PROMPT="0"
   export GIT_SSH_COMMAND="ssh -oBatchMode=yes"
 


### PR DESCRIPTION
`HOMEBREW_CURL_PATH` has an effect only when `HOMEBREW_DEVELOPER` is set. Currently, the part of `brew.sh` that prints a message about outdated cURL disregards the value of `HOMEBREW_DEVELOPER`, which leads to a misleadnig message telling the user that `HOMEBREW_CURL_PATH` is outdated even though another cURL was used/tested.

This PR updates the message and fixes the logic that prints the warning.

Summary of changes:

1. Display a warning message when system cURL is outdated and when either `HOMEBREW_CURL_PATH` **or `HOMEBREW_DEVELOPER`** are not set. New `HOMEBREW_CURL_WARNING` variable is set to display the above warning only once. This is necessary to prevent Homebrew from printing repeated warnings  because `brew` may call itself internally (see p2 and p3 below).
2. Display `Installing Homebrew cURL` before auto-installing cURL in `update.sh` (due to `HOMEBREW_FORCE_BREWED_CURL`) and stop/exit if this step fails.
3. Display `Installing Homebrew Git` before auto-installing Git in `update.sh` (due to `HOMEBREW_FORCE_BREWED_GIT`) and stop/exit if this step fails.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
