### PR TITLE
Output full phase for Command Line Tools (CLT) in SDK error message

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -424,7 +424,7 @@ module Homebrew
         locator = MacOS.sdk_locator
 
         source = if locator.source == :clt
-          "CLT"
+          "Command Line Tools (CLT) install"
         else
           "Xcode"
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

The current SDK error message uses the initialism CLT to describe the problem:

```
Error: Your CLT does not support macOS 11.0.
It is either outdated or was modified.
Please update your CLT or delete it if no updates are available.
```

CLT stands for Command Line Tools, but I had to do a web search to find this out.  This is easily discovered through blog post articles or the title of certain web pages, but writing out the initialism in full, as this PR does, reduces the guesswork. 

The user still has to figure out how to [fix the problem](https://github.com/Homebrew/brew/issues/9128#issuecomment-726780049) but this helps those like me who know of the Command Line Tools but don't know the initialism (or actively use other phases that stand for CLT).