### PR TITLE
java: only disable java version ranges on Big Sur

### DIFF
--- a/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
+++ b/Library/Homebrew/extend/os/mac/requirements/java_requirement.rb
@@ -27,11 +27,13 @@ class JavaRequirement < Requirement
 
   def java_home_cmd
     # TODO: enable for all macOS versions and Linux on next minor release
-    #       but --version is broken on Big Sur today.
-    if @version && MacOS.version >= :big_sur
-      odisabled "depends_on :java",
-                '"depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk"'
+    #       but --version with ranges is broken on Big Sur today.
+    if MacOS.version >= :big_sur && @version&.end_with?("+")
+      odisabled %Q(depends_on java: "#{@version}"),
+                'depends_on "openjdk@11", depends_on "openjdk@8" or depends_on "openjdk"'
     end
+    # odeprecated "depends_on :java",
+    #             'depends_on "openjdk@11", depends_on "openjdk@8" or depends_on "openjdk"'
 
     return unless File.executable?("/usr/libexec/java_home")
 


### PR DESCRIPTION
https://github.com/Homebrew/brew/pull/9208

Only `+` versions in conjunction with `--failfast` are broken using the built-in `/usr/libexec/java_home` on Big Sur. Only disable this specific invocation on Big Sur, so we can provide our standard deprecation for pinned java versions using the Requirement.

```console
% /usr/libexec/java_home --version 1.8 --failfast
/usr/local/Cellar/openjdk@8/1.8.0+275/libexec/openjdk.jdk/Contents/Home

% /usr/libexec/java_home --version 1.8+ --failfast
The operation couldn’t be completed. Unable to locate a Java Runtime that supports (null).
Please visit http://www.java.com for information on installing Java.
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----