### PR TITLE
Fix some type errors

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -654,7 +654,7 @@ class FormulaInstaller
     @show_header = true unless deps.empty?
   end
 
-  sig { params(dep: Formula).void }
+  sig { params(dep: Dependency).void }
   def fetch_dependency(dep)
     df = dep.to_formula
     fi = FormulaInstaller.new(
@@ -675,7 +675,7 @@ class FormulaInstaller
     fi.fetch
   end
 
-  sig { params(dep: Formula, inherited_options: Options).void }
+  sig { params(dep: Dependency, inherited_options: Options).void }
   def install_dependency(dep, inherited_options)
     df = dep.to_formula
     tab = Tab.for_formula(df)

--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -10,7 +10,7 @@ module Homebrew
 
     attr_reader :name, :path, :tap_audit_exceptions, :problems
 
-    sig { params(tap: Tap, strict: T::Boolean).void }
+    sig { params(tap: Tap, strict: T.nilable(T::Boolean)).void }
     def initialize(tap, strict:)
       @name                 = tap.name
       @path                 = tap.path


### PR DESCRIPTION
This receives a Dependency, not a Formula.

```console
% brew install hive
Error: Parameter 'dep': Expected type Formula, got type Dependency with value #<Dependency: "hadoop" []>
Caller: /usr/local/Homebrew/Library/Homebrew/formula_installer.rb:1086
Definition: /usr/local/Homebrew/Library/Homebrew/formula_installer.rb:658
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/configuration.rb:219:in `call_validation_error_handler_default'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/configuration.rb:226:in `call_validation_error_handler'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:1125:in `report_error'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:81:in `block in validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/signature.rb:186:in `each_args_value_type'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:78:in `validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/_methods.rb:228:in `block in _on_method_added'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:1086:in `block in fetch_dependencies'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:1086:in `each'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:1086:in `fetch_dependencies'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:126:in `call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:126:in `validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/_methods.rb:228:in `block in _on_method_added'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:1091:in `fetch'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:126:in `call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/call_validation.rb:126:in `validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6076/lib/types/private/methods/_methods.rb:228:in `block in _on_method_added'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:383:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:297:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:295:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:295:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----