### PR TITLE
Adjust macOS version logic

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -44,13 +44,6 @@ module OS
       Version.new "11.0"
     end
 
-    def latest_stable_version
-      # TODO: bump version when new macOS is released and also update
-      # references in docs/Installation.md and
-      # https://github.com/Homebrew/install/blob/HEAD/install.sh
-      Version.new "11.0"
-    end
-
     def outdated_release?
       # TODO: bump version when new macOS is released and also update
       # references in docs/Installation.md and
@@ -59,7 +52,10 @@ module OS
     end
 
     def prerelease?
-      version > latest_stable_version
+      # TODO: bump version when new macOS is released or announced
+      # and also update references in docs/Installation.md and
+      # https://github.com/Homebrew/install/blob/HEAD/install.sh
+      version >= "12.0"
     end
 
     def languages

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -22,7 +22,7 @@ module OS
       def latest_version
         latest_stable = "12.2"
         case MacOS.version
-        when "11.0"  then latest_stable
+        when /^11\./ then latest_stable
         when "10.15" then "12.2"
         when "10.14" then "11.3.1"
         when "10.13" then "10.1"
@@ -45,7 +45,7 @@ module OS
       sig { returns(String) }
       def minimum_version
         case MacOS.version
-        when "11.0"  then "12.2"
+        when /^11\./ then "12.2"
         when "10.15" then "11.0"
         when "10.14" then "10.2"
         when "10.13" then "9.0"
@@ -275,7 +275,7 @@ module OS
       sig { returns(String) }
       def latest_clang_version
         case MacOS.version
-        when "11.0", "10.15" then "1200.0.32.27"
+        when /^11\./, "10.15" then "1200.0.32.27"
         when "10.14" then "1100.0.33.17"
         when "10.13" then "1000.10.44.2"
         when "10.12" then "900.0.39.2"
@@ -291,7 +291,7 @@ module OS
       sig { returns(String) }
       def minimum_version
         case MacOS.version
-        when "11.0"  then "12.0.0"
+        when /^11\./ then "12.0.0"
         when "10.15" then "11.0.0"
         when "10.14" then "10.0.0"
         when "10.13" then "9.0.0"

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -11,7 +11,7 @@ it does it too. You have to confirm everything it will do before it starts.
 ## macOS Requirements
 
 * A 64-bit Intel CPU <sup>[1](#1)</sup>
-* macOS High Sierra (10.13) (or higher) <sup>[2](#2)</sup>
+* macOS Mojave (10.14) (or higher) <sup>[2](#2)</sup>
 * Command Line Tools (CLT) for Xcode: `xcode-select --install`,
   [developer.apple.com/downloads](https://developer.apple.com/downloads) or
   [Xcode](https://itunes.apple.com/us/app/xcode/id497799835) <sup>[3](#3)</sup>
@@ -52,7 +52,7 @@ Uninstallation is documented in the [FAQ](FAQ.md).
 <a name="1"><sup>1</sup></a> For 32-bit or PPC support see
 [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 
-<a name="2"><sup>2</sup></a> 10.13 or higher is recommended. 10.9–10.12 are
+<a name="2"><sup>2</sup></a> 10.14 or higher is recommended. 10.9–10.13 are
 supported on a best-effort basis. For 10.4-10.6 see
 [Tigerbrew](https://github.com/mistydemeo/tigerbrew).
 


### PR DESCRIPTION
- Adjust latest supported macOS logic for e.g. Big Sur 11.1.
- Updated latest supported version in docs to Mojave

Fixes https://github.com/Homebrew/brew/issues/9211