### PR TITLE
Update `sorbet` and `sorbet-runtime` together.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     directory: /Library/Homebrew
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: sorbet-runtime

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -27,26 +27,29 @@ jobs:
         with:
           username: BrewTestBot
       - name: Check out pull request
-        id: checkout_pull_request
+        id: checkout
         run: |
           gh pr checkout '${{ github.event.pull_request.number || github.event.inputs.pull_request }}'
-        env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-      - name: Vendor Gems
-        id: vendor
-        run: |
-          brew vendor-gems
-      - name: Update RBI files
-        id: update
-        run: |
+
           branch="$(git branch --show-current)"
           echo "::set-output name=branch::${branch}"
 
+          gem_name="$(echo "${branch}" | sed -E 's|.*/||;s|(.*)-.*$|\1|')"
+          echo "::set-output name=gem_name::${gem_name}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+      - name: Vendor Gems
+        run: |
+          if [[ '${{ steps.checkout.outputs.gem_name }}' == 'sorbet' ]]; then
+            brew vendor-gems --update sorbet,sorbet-runtime
+          else
+            brew vendor-gems
+          fi
+      - name: Update RBI files
+        run: |
           if brew typecheck --update --fail-if-not-changed; then
-            gem_name="$(echo "${branch}" | sed -E 's|.*/||;s|(.*)-.*$|\1|')"
-
             if git add Library/Homebrew/sorbet; then
-              git commit -m "Update RBI files for ${gem_name}."
+              git commit -m "Update RBI files for ${{ steps.checkout.outputs.gem_name }}."
             fi
 
             git reset --hard
@@ -55,5 +58,5 @@ jobs:
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-          branch: ${{ steps.update.outputs.branch }}
+          branch: ${{ steps.checkout.outputs.branch }}
           force: true

--- a/Library/Homebrew/dev-cmd/vendor-gems.rb
+++ b/Library/Homebrew/dev-cmd/vendor-gems.rb
@@ -18,13 +18,14 @@ module Homebrew
         Install and commit Homebrew's vendored gems.
       EOS
 
-      switch "--update",
-             description: "Update all vendored Gems to the latest version."
+      comma_array "--update",
+                  description: "Update all vendored Gems to the latest version."
 
       max_named 0
     end
   end
 
+  sig { void }
   def vendor_gems
     args = vendor_gems_args.parse
 
@@ -32,9 +33,9 @@ module Homebrew
 
     ohai "cd #{HOMEBREW_LIBRARY_PATH}"
     HOMEBREW_LIBRARY_PATH.cd do
-      if args.update?
+      if args.update
         ohai "bundle update"
-        safe_system "bundle", "update"
+        safe_system "bundle", "update", *args.update
 
         ohai "git add Gemfile.lock"
         system "git", "add", "Gemfile.lock"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

---

`sorbet` and `sorbet-runtime` are always released together, so disable Dependabot for `sorbet-runtime` and update both using the `vendor-gems` workflow when `sorbet` is updated.