### PR TITLE
bintray: add type signatures

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -75,7 +75,7 @@ class SystemCommand
       print_stdout: T::Boolean,
       print_stderr: T::Boolean,
       verbose:      T::Boolean,
-      secrets:      T::Array[String],
+      secrets:      T.any(String, T::Array[String]),
       chdir:        T.any(String, Pathname),
     ).void
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -632,7 +632,7 @@ class Tap
     end
   end
 
-  sig { params(file: Pathname).returns(Hash) }
+  sig { params(file: Pathname).returns(T.any(T::Array[String], Hash)) }
   def read_formula_list(file)
     JSON.parse file.read
   rescue JSON::ParserError


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Add type signatures to bintray.rb. Mostly used to test out https://github.com/Homebrew/rubydoc.brew.sh/pull/125 with code I was already familiar with.