### PR TITLE
manpage: Recommend using ./ for local file formulae

### DIFF
--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -104,6 +104,8 @@ can take several different forms:
   * An arbitrary file:
     Homebrew can install formulae from a local path. It can point to either a
     formula file or a bottle.
+    Prefix relative paths with `./` to prevent them being interpreted as a
+    formula or tap name.
 
 ## SPECIFYING CASKS
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1610,6 +1610,8 @@ can take several different forms:
   * An arbitrary file:
     Homebrew can install formulae from a local path. It can point to either a
     formula file or a bottle.
+    Prefix relative paths with `./` to prevent them being interpreted as a
+    formula or tap name.
 
 ## SPECIFYING CASKS
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2241,7 +2241,7 @@ Sometimes a formula from a tapped repository may conflict with one in \fBhomebre
 .
 .TP
 An arbitrary file
-Homebrew can install formulae from a local path\. It can point to either a formula file or a bottle\.
+Homebrew can install formulae from a local path\. It can point to either a formula file or a bottle\. Prefix relative paths with \fB\./\fR to prevent them being interpreted as a formula or tap name\.
 .
 .SH "SPECIFYING CASKS"
 Many Homebrew Cask commands accept one or more \fIcask\fR arguments\. These can be specified the same way as the \fIformula\fR arguments described in \fBSPECIFYING FORMULAE\fR above\.


### PR DESCRIPTION
Addresses an aspect of #8966 by recommending that relative paths use `./` explicitly to avoid being misinterpreted.