### PR TITLE
Remove amd-power-gadget from prerelease exceptions

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -32,7 +32,6 @@ module SharedAudits
   end
 
   GITHUB_PRERELEASE_ALLOWLIST = {
-    "amd-power-gadget" => :all,
     "elm-format"       => "0.8.3",
     "extraterm"        => :all,
     "freetube"         => :all,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Cask finally has a stable release, so no longer needs an exception. See https://github.com/Homebrew/homebrew-cask/pull/93183.