### PR TITLE
dev-cmd/audit: Fix "undefined method audit_exceptions"

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -180,7 +180,7 @@ module Homebrew
         except:               args.except,
         spdx_license_data:    spdx_license_data,
         spdx_exception_data:  spdx_exception_data,
-        tap_audit_exceptions: f.tap.audit_exceptions,
+        tap_audit_exceptions: f.tap&.audit_exceptions,
         style_offenses:       style_offenses ? style_offenses.for_path(f.path) : nil,
         display_cop_names:    args.display_cop_names?,
         build_stable:         args.build_stable?,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- When running `brew audit` on formulae that aren't in a Homebrew tap location (ie, in a directory outside of
  `/usr/local/Homebrew/Library/Taps`), `brew audit` falls over because it can't determine which tap a formula is in.

```
issyl0 in ophiuchus in ~/repos/homebrew-edge on master
➜ brew audit ./Formula/apg.rb
Error: undefined method `audit_exceptions' for nil:NilClass
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:183:in `block in audit'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:172:in `each'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/audit.rb:172:in `audit'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```
- Fixes #9244.
