### PR TITLE
Better check for Rosetta 2

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/mac/hardware/cpu.rb
@@ -69,7 +69,7 @@ module Hardware
       # conflict between what `uname` reports and the underlying `sysctl` flags,
       # since the `sysctl` flags don't change behaviour under Rosetta 2.
       def in_rosetta2?
-        intel? && physical_cpu_arm64?
+        sysctl_bool("sysctl.proc_translated")
       end
 
       def features


### PR DESCRIPTION
This uses the `syctl.proc_translated` sysctl, which is the Apple documented way to check for Rosetta 2 environment.

Behaviour can also be tested using the shell:

```shell
% arch -arm64 sysctl sysctl.proc_translated
sysctl.proc_translated: 0
% arch -x86_64 sysctl sysctl.proc_translated
sysctl.proc_translated: 1
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
