### PR TITLE
python: allow multi-digit minor versions

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -7,7 +7,7 @@ module Language
   # @api public
   module Python
     def self.major_minor_version(python)
-      version = /\d\.\d/.match `#{python} --version 2>&1`
+      version = /\d\.\d+/.match `#{python} --version 2>&1`
       return unless version
 
       Version.create(version.to_s)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
The current regex expects the python minor version to be a single digit, which won't work for Python 3.10 and later. In particular, the `virtualenv` module gets installed into `target/lib/python3.10/site-packages/` but when trying to install the target formula, the PYTHONPATH has `target/lib/python3.1/site-packages` in it due to `major_minor_version` returning only the first minor digit, so `virtualenv` is not found.