### PR TITLE
sh: skip reading user-level initialization files

### DIFF
--- a/Library/Homebrew/dev-cmd/sh.rb
+++ b/Library/Homebrew/dev-cmd/sh.rb
@@ -54,7 +54,9 @@ module Homebrew
       safe_system(ENV["SHELL"], args.named.first)
     else
       subshell = if ENV["SHELL"].include?("zsh")
-        "PS1='brew %B%F{green}%~%f%b$ ' #{ENV["SHELL"]} -d"
+        "PS1='brew %B%F{green}%~%f%b$ ' #{ENV["SHELL"]} -d -f"
+      elsif ENV["SHELL"].include?("bash")
+        "PS1=\"brew \\[\\033[1;32m\\]\\w\\[\\033[0m\\]$ \" #{ENV["SHELL"]} --noprofile --norc"
       else
         "PS1=\"brew \\[\\033[1;32m\\]\\w\\[\\033[0m\\]$ \" #{ENV["SHELL"]}"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Skip reading user-level initialization files to ensure a clean build environment for `bash` and `zsh` users. Has the side effect of always allowing the brew `PS1` prompt to show.