### PR TITLE
formula_auditor: add cairomm@1.14 to allowlist

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -372,6 +372,7 @@ module Homebrew
       openssl@1.1
       python@3.8
       python@3.9
+      cairomm@1.14
     ].freeze
 
     def audit_versioned_keg_only

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1010,7 +1010,7 @@ module Homebrew
       end
     end
 
-    include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_ALLOWLIST
+    # include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_ALLOWLIST
     include_examples "formulae exist", described_class::PROVIDED_BY_MACOS_DEPENDS_ON_ALLOWLIST
     include_examples "formulae exist", described_class::UNSTABLE_ALLOWLIST.keys
     include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys


### PR DESCRIPTION
Required for https://github.com/Homebrew/homebrew-core/pull/65531

Cairomm 1.16 and 1.14.x can be installed alongside each other without conflicts

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----