### PR TITLE
fix: launchctl list can return empty id

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_uninstall.rb
+++ b/Library/Homebrew/cask/artifact/abstract_uninstall.rb
@@ -127,7 +127,7 @@ module Cask
           .map { |line| line.chomp.split("\t") }
           .map { |pid, state, id| [pid.to_i, state.to_i, id] }
           .select do |(pid, _, id)|
-            pid.nonzero? && id.match?(/^#{Regexp.escape(bundle_id)}($|\.\d+)/)
+            pid.nonzero? && /^#{Regexp.escape(bundle_id)}($|\.\d+)/.match?(id)
           end
       end
 


### PR DESCRIPTION
causing

```
Error: undefined method `match?' for nil:NilClass
```

Seen in macOS Big Sur

```
$ brew uninstall yubico-authenticator
==> Uninstalling Cask yubico-authenticator
==> Signalling 'TERM' to application ID 'com.yubico.yubioath'
running_processes com.yubico.yubioath
Error: undefined method `match?' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:131:in `block in running_processes'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:130:in `select'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:130:in `running_processes'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:225:in `block in uninstall_signal'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:220:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:220:in `uninstall_signal'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/abstract_uninstall.rb:76:in `dispatch_uninstall_directive'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/uninstall.rb:15:in `block in uninstall_phase'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/uninstall.rb:14:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/artifact/uninstall.rb:14:in `uninstall_phase'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:461:in `block in uninstall_artifacts'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/set.rb:777:in `each'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/set.rb:777:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:458:in `uninstall_artifacts'
/usr/local/Homebrew/Library/Homebrew/cask/installer.rb:407:in `uninstall'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/uninstall.rb:61:in `block in uninstall_casks'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/uninstall.rb:49:in `each'
/usr/local/Homebrew/Library/Homebrew/cask/cmd/uninstall.rb:49:in `uninstall_casks'
/usr/local/Homebrew/Library/Homebrew/cmd/uninstall.rb:68:in `uninstall'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```

Caused by a process missing id

```
$ /bin/launchctl list  | grep 839
839	0
$ ps -fea | grep 839
  501   839     1   0 16Nov20 ??         0:45.71 /Applications/OneDrive.app/Contents/MacOS/OneDrive
```


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
