### PR TITLE
FAQ: Default installation prefix on Linux

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -104,7 +104,7 @@ It is not always straightforward to tell `gem` to look in non-standard directori
 
 ## Why does Homebrew on Linux recommend that I install to `/home/linuxbrew/.linuxbrew`?
 
-Homebrew's pre-built binary packages of most software can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Building from source can take a long time, is error-prone and isn't as well supported as using our binaries. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use our pre-built binary packages (known as bottles) for formulae. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
+Homebrew's pre-built binary packages, called bottles, of most software can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use our pre-built binary packages. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
 
 + https://docs.brew.sh/FAQ.html#why-do-you-compile-everything
 + https://docs.brew.sh/Installation.html#alternative-installs

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -104,7 +104,7 @@ It is not always straightforward to tell `gem` to look in non-standard directori
 
 ## Why does Homebrew on Linux recommend that I install to `/home/linuxbrew/.linuxbrew`?
 
-Homebrew's pre-built binary packages, called bottles, of most software can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use our pre-built binary packages. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`. The prefix `/home/linuxbrew/.linuxbrew` was chosen so that users without admin access can ask an admin to create a `linuxbrew` role account and still benefit from precompiled binaries.
+The prefix `/home/linuxbrew/.linuxbrew` was chosen so that users without admin access can ask an admin to create a `linuxbrew` role account and still benefit from precompiled binaries. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`. 
 
 + https://docs.brew.sh/FAQ.html#why-do-you-compile-everything
 + https://docs.brew.sh/Installation.html#alternative-installs

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -104,7 +104,7 @@ It is not always straightforward to tell `gem` to look in non-standard directori
 
 ## Why does Homebrew on Linux recommend that I install to `/home/linuxbrew/.linuxbrew`?
 
-The precompiled binary bottles of non-relocatable bottles can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use precompiled binary packages (known as bottles) for non-relocatable formula. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
+Homebrew's pre-built binary packages of most software can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Building from source can take a long time, is error-prone and isn't as well supported as using our binaries. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use our pre-built binary packages (known as bottles) for formulae. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
 
 + https://docs.brew.sh/FAQ.html#why-do-you-compile-everything
 + https://docs.brew.sh/Installation.html#alternative-installs

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -87,7 +87,7 @@ hub pull someone_else
 
 ## Why should I install Homebrew in the default location?
 
-Homebrew's pre-built binary packages, called [bottles](Bottles.md), of many packages can only be used if you install in the default installation prefix, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Do yourself a favour and install to the default prefix so that you can use our pre-built binary packages. The default prefix is `/usr/local` for macOS on Intel, `opt/homebrew` for macOS on ARM, and `/home/linuxbrew/.linuxbrew` for Linux. *Pick another prefix at your peril!*
+Homebrew's pre-built binary packages, called [bottles](Bottles.md), of many packages can only be used if you install in the default installation prefix, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Do yourself a favour and install to the default prefix so that you can use our pre-built binary packages. The default prefix is `/usr/local` for macOS on Intel, `/opt/homebrew` for macOS on ARM, and `/home/linuxbrew/.linuxbrew` for Linux. *Pick another prefix at your peril!*
 
 ## Why does Homebrew prefer I install to `/usr/local`?
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -85,6 +85,10 @@ cd $(brew --repository)
 hub pull someone_else
 ```
 
+## Why should I install Homebrew in the default location?
+
+Homebrew's pre-built binary packages, called [bottles](Bottles.md), of many packages can only be used if you install in the default installation prefix, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Do yourself a favour and install to the default prefix so that you can use our pre-built binary packages. The default prefix is `/usr/local` for macOS on Intel, `opt/homebrew` for macOS on ARM, and `/home/linuxbrew/.linuxbrew` for Linux. *Pick another prefix at your peril!*
+
 ## Why does Homebrew prefer I install to `/usr/local`?
 
 1.  **It’s easier**<br>`/usr/local/bin` is already in your
@@ -102,13 +106,9 @@ hub pull someone_else
 
 It is not always straightforward to tell `gem` to look in non-standard directories for headers and libraries. If you choose `/usr/local`, many things will "just work".
 
-## Why does Homebrew on Linux recommend that I install to `/home/linuxbrew/.linuxbrew`?
+## Why is the default installation prefix `/home/linuxbrew/.linuxbrew` on Linux?
 
-The prefix `/home/linuxbrew/.linuxbrew` was chosen so that users without admin access can ask an admin to create a `linuxbrew` role account and still benefit from precompiled binaries. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`. 
-
-+ https://docs.brew.sh/FAQ.html#why-do-you-compile-everything
-+ https://docs.brew.sh/Installation.html#alternative-installs
-+ https://docs.brew.sh/Bottles.html#cellar-cellar
+The prefix `/home/linuxbrew/.linuxbrew` was chosen so that users without admin access can ask an admin to create a `linuxbrew` role account and still benefit from precompiled binaries. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
 
 ## Why does Homebrew say sudo is bad?
 **tl;dr** Sudo is dangerous, and you installed TextMate.app without sudo

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -104,7 +104,7 @@ It is not always straightforward to tell `gem` to look in non-standard directori
 
 ## Why does Homebrew on Linux recommend that I install to `/home/linuxbrew/.linuxbrew`?
 
-Homebrew's pre-built binary packages, called bottles, of most software can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use our pre-built binary packages. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
+Homebrew's pre-built binary packages, called bottles, of most software can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use our pre-built binary packages. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`. The prefix `/home/linuxbrew/.linuxbrew` was chosen so that users without admin access can ask an admin to create a `linuxbrew` role account and still benefit from precompiled binaries.
 
 + https://docs.brew.sh/FAQ.html#why-do-you-compile-everything
 + https://docs.brew.sh/Installation.html#alternative-installs

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -102,6 +102,14 @@ hub pull someone_else
 
 It is not always straightforward to tell `gem` to look in non-standard directories for headers and libraries. If you choose `/usr/local`, many things will "just work".
 
+## Why does Homebrew on Linux recommend that I install to `/home/linuxbrew/.linuxbrew`?
+
+The precompiled binary bottles of non-relocatable bottles can only be used if you install in `/home/linuxbrew/.linuxbrew`, otherwise they have to be built from source. Install Homebrew on Linux in `/home/linuxbrew/.linuxbrew/` if possible so that you can use precompiled binary packages (known as bottles) for non-relocatable formula. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
+
++ https://docs.brew.sh/FAQ.html#why-do-you-compile-everything
++ https://docs.brew.sh/Installation.html#alternative-installs
++ https://docs.brew.sh/Bottles.html#cellar-cellar
+
 ## Why does Homebrew say sudo is bad?
 **tl;dr** Sudo is dangerous, and you installed TextMate.app without sudo
 anyway.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -87,7 +87,7 @@ hub pull someone_else
 
 ## Why should I install Homebrew in the default location?
 
-Homebrew's pre-built binary packages, called [bottles](Bottles.md), of many packages can only be used if you install in the default installation prefix, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Do yourself a favour and install to the default prefix so that you can use our pre-built binary packages. The default prefix is `/usr/local` for macOS on Intel, `/opt/homebrew` for macOS on ARM, and `/home/linuxbrew/.linuxbrew` for Linux. *Pick another prefix at your peril!*
+Homebrew's pre-built binary packages (known as [bottles](Bottles.md)) of many packages can only be used if you install in the default installation prefix, otherwise they have to be built from source. Building from source takes a long time, is prone to fail, and is not supported. Do yourself a favour and install to the default prefix so that you can use our pre-built binary packages. The default prefix is `/usr/local` for macOS on Intel, `/opt/homebrew` for macOS on ARM, and `/home/linuxbrew/.linuxbrew` for Linux. *Pick another prefix at your peril!*
 
 ## Why does Homebrew prefer I install to `/usr/local`?
 

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -26,6 +26,8 @@ Instructions for a supported install of Homebrew on Linux are on the [homepage](
 
 The installation script installs Homebrew to `/home/linuxbrew/.linuxbrew` using *sudo* if possible and in your home directory at `~/.linuxbrew` otherwise. Homebrew does not use *sudo* after installation. Using `/home/linuxbrew/.linuxbrew` allows the use of more binary packages (bottles) than installing in your personal home directory.
 
+The prefix `/home/linuxbrew/.linuxbrew` was chosen so that users without admin access can ask an admin to create a `linuxbrew` role account and still benefit from precompiled binaries. If you do not yourself have admin privileges, consider asking your admin staff to create a `linuxbrew` role account for you with home directory `/home/linuxbrew`.
+
 Follow the *Next steps* instructions to add Homebrew to your `PATH` and to your bash shell profile script, either `~/.profile` on Debian/Ubuntu or `~/.bash_profile` on CentOS/Fedora/Red Hat.
 
 ```sh


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Why does Homebrew on Linux recommend that I install to `/home/linuxbrew/.linuxbrew`?
