### PR TITLE
pr-pull: fix logic

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -366,9 +366,9 @@ module Homebrew
     odeprecated "`brew pr-pull --workflow`", "`brew pr-pull --workflows=`" if args.workflow.presence
 
     workflows = if args.workflow.blank?
-      args.workflows.presence || ["tests.yml"]
-    else
       [args.workflow].compact.presence || ["tests.yml"]
+    else
+      args.workflows.presence || ["tests.yml"]
     end
     artifact = args.artifact || "bottles"
     bintray_org = args.bintray_org || "homebrew"


### PR DESCRIPTION
if --workflow is not blank == is set,
we want to use that value.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
