### PR TITLE
fix update-python-resources for formulae not in a tap

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -130,7 +130,7 @@ module PyPI
   def update_python_resources!(formula, version: nil, package_name: nil, extra_packages: nil, exclude_packages: nil,
                                print_only: false, silent: false, ignore_non_pypi_packages: false)
 
-    auto_update_list = formula.tap.pypi_formula_mappings
+    auto_update_list = formula.tap&.pypi_formula_mappings
     if auto_update_list.present? && auto_update_list.key?(formula.full_name) &&
        package_name.blank? && extra_packages.blank? && exclude_packages.blank?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to https://github.com/Homebrew/brew/pull/9185. This fixes a bug reported in https://github.com/Homebrew/brew/pull/9185#issuecomment-733247821.

Even after being reminded of this issue by https://github.com/Homebrew/brew/pull/9249 (and noting that I would check for this), I still missed an instance where the `pypi_formula_mappings` method isn't available for formulae that aren't in a tap. Instead of calling `formula.tap.pypi_formula_mappings`, `update-python-resources` will now call `formula.tap&.pypi_formula_mappings` to simply return `nil` instead of failing when `formula.tap` is `nil`.
