### PR TITLE
pr-pull: fix empty workflow check

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -419,9 +419,10 @@ module Homebrew
             )
             if args.ignore_missing_artifacts.present? &&
                args.ignore_missing_artifacts.include?(workflow) &&
-               workflow_run.empty?
+               workflow_run.first.blank?
               # Ignore that workflow as it was not executed and we specified
               # that we could skip it.
+              ohai "Ignoring workflow #{workflow} as requested by --ignore-missing-artifacts"
               next
             end
 


### PR DESCRIPTION
workflow_run is an array, which first element is the json
returned by the github API. We need to check that first element
if we want to know if the workflow exists.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
