### PR TITLE
bin/brew: re-exec self under Rosetta if needed

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -58,6 +58,16 @@ then
   fi
 fi
 
+# If we're in /usr/local, which is the prefix we've set aside for Intel under Rosetta 2,
+# and this is an arm64 machine not running under Rosetta, then re-exec this same file
+# within Rosetta with all arguments passed to it.
+if [[ "$(uname -s)" = "Darwin" ]] && \
+   [[ "$HOMEBREW_PREFIX" = "/usr/local" ]] && \
+   [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]] && \
+   [[ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "0" ]]; then
+  exec arch -x86_64 "$HOMEBREW_BREW_FILE" "$@"
+fi
+
 HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

As discussed in #9177, we've reserved `/usr/local` as the prefix to use on Apple Silicon Macs for an Intel installation of Homebrew to be run under Rosetta.

If a user has a `/usr/local` installation on an Apple Silicon Mac, and executes `/usr/local/bin/brew`, we should make sure we're running that copy of `brew` as Intel under emulation in order to avoid confusion. This makes that change.

cc #9126

cc @claui, @MikeMcQuaid 