### PR TITLE
Improve ZSH completions handling

### DIFF
--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -188,6 +188,8 @@ describe Caveats do
       before do
         allow_any_instance_of(Pathname).to receive(:children).and_return([Pathname.new("child")])
         allow_any_instance_of(Object).to receive(:which).with(any_args).and_return(Pathname.new("shell"))
+        allow(Utils::Shell).to receive(:preferred).and_return(nil)
+        allow(Utils::Shell).to receive(:parent).and_return(nil)
       end
 
       it "gives dir where bash completions have been installed" do

--- a/bin/brew
+++ b/bin/brew
@@ -62,7 +62,7 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
-for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH
+for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH FPATH
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
- Only display the completions caveats from the current shell (assuming it's one of Bash, ZSH or Fish)
- If the completions location isn't in the ZSH `FPATH` then link to the documentation explaining how to do so.

Fixes https://github.com/Homebrew/brew/issues/8984