### PR TITLE
All Big Sur versions are macOS 11

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -25,7 +25,14 @@ module OS
     # This can be compared to numerics, strings, or symbols
     # using the standard Ruby Comparable methods.
     def version
-      @version ||= Version.new(full_version.to_s[/^\d+\.\d+/])
+      vers = full_version.to_s.split(".")
+      @version ||= if vers[0] == "10"
+        # For 10.y.z the major version is 10.y
+        Version.new(full_version.to_s[/^\d+\.\d+/])
+      else
+        # For x.y.z with x >= 11, the major version is x
+        Version.new(vers[0])
+      end
     end
 
     # This can be compared to numerics, strings, or symbols
@@ -41,7 +48,7 @@ module OS
 
     def latest_sdk_version
       # TODO: bump version when new Xcode macOS SDK is released
-      Version.new "11.0"
+      Version.new "11"
     end
 
     def outdated_release?

--- a/Library/Homebrew/os/mac/pkgconfig/11/expat.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/expat.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/libcurl.pc
@@ -23,7 +23,7 @@
 # This should most probably benefit from getting a "Requires:" field added
 # dynamically by configure.
 #
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/libedit.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/libedit.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/libexslt.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/libffi.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/libxml-2.0.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/libxslt.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/ncurses.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/ncurses.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 major_version=5
 version=5.7.20081102
 
-Name: ncursesw
+Name: ncurses
 Description: ncurses 5.7 library
 Version: ${version}
 Requires:

--- a/Library/Homebrew/os/mac/pkgconfig/11/ncursesw.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/ncursesw.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 major_version=5
 version=5.7.20081102
 
-Name: ncurses
+Name: ncursesw
 Description: ncurses 5.7 library
 Version: ${version}
 Requires:

--- a/Library/Homebrew/os/mac/pkgconfig/11/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/sqlite3.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/uuid.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/pkgconfig/11/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11/zlib.pc
@@ -1,4 +1,4 @@
-homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
 exec_prefix=/usr
 libdir=${exec_prefix}/lib

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -11,7 +11,7 @@ module OS
     # @api private
     class Version < ::Version
       SYMBOLS = {
-        big_sur:     "11.0",
+        big_sur:     "11",
         catalina:    "10.15",
         mojave:      "10.14",
         high_sierra: "10.13",

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -22,7 +22,7 @@ module OS
       def latest_version
         latest_stable = "12.2"
         case MacOS.version
-        when /^11\./ then latest_stable
+        when "11"    then latest_stable
         when "10.15" then "12.2"
         when "10.14" then "11.3.1"
         when "10.13" then "10.1"
@@ -45,7 +45,7 @@ module OS
       sig { returns(String) }
       def minimum_version
         case MacOS.version
-        when /^11\./ then "12.2"
+        when "11"    then "12.2"
         when "10.15" then "11.0"
         when "10.14" then "10.2"
         when "10.13" then "9.0"
@@ -275,7 +275,7 @@ module OS
       sig { returns(String) }
       def latest_clang_version
         case MacOS.version
-        when /^11\./, "10.15" then "1200.0.32.27"
+        when "11", "10.15" then "1200.0.32.27"
         when "10.14" then "1100.0.33.17"
         when "10.13" then "1000.10.44.2"
         when "10.12" then "900.0.39.2"
@@ -291,7 +291,7 @@ module OS
       sig { returns(String) }
       def minimum_version
         case MacOS.version
-        when /^11\./ then "12.0.0"
+        when "11"    then "12.0.0"
         when "10.15" then "11.0.0"
         when "10.14" then "10.0.0"
         when "10.13" then "9.0.0"


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/brew/pull/9225

The semantics of `MacOS.version` is to track only major version numbers, so it should return `11` on Big Sur (not `11.x`). The current behaviour lead to breakage as 11.1 was released, and bottles are currently not being installed propertly (@SMillerDev reports).

The fix in https://github.com/Homebrew/brew/pull/9225 does not appear sufficient to me, as there are many places (including inside formulas) that assume the `MacOS.version` semantics is as stated. We should rather fix that function to return the major version, rather than fix all callers.

poke @MikeMcQuaid for thoughts