### PR TITLE
Deprecation fixes

### DIFF
--- a/Library/Homebrew/cask/cmd.rb
+++ b/Library/Homebrew/cask/cmd.rb
@@ -71,7 +71,7 @@ module Cask
       Cmd::Style     => "brew style",
       Cmd::Uninstall => "brew uninstall [--cask]",
       Cmd::Upgrade   => "brew upgrade [--cask]",
-      Cmd::Zap       => "brew upgrade --zap [--cask]",
+      Cmd::Zap       => "brew uninstall --zap [--cask]",
     }.freeze
 
     def self.parser(&block)

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -49,9 +49,9 @@ module Homebrew
              description: "Open the GitHub source page for <formula> in a browser. "\
                           "To view formula history locally: `brew log -p` <formula>"
       flag   "--json",
-             description: "Print a JSON representation of <formula>. Currently the default and only accepted "\
-                          "value for <version> is `v1`. See the docs for examples of using the JSON "\
-                          "output: <https://docs.brew.sh/Querying-Brew>"
+             description: "Print a JSON representation. Currently the default value for <version> is `v1` for "\
+                          "<formula>. For <formula> and <cask> use `v2`. See the docs for examples of using the "\
+                          "JSON output: <https://docs.brew.sh/Querying-Brew>"
       switch "--installed",
              depends_on:  "--json",
              description: "Print JSON of formulae that are currently installed."
@@ -178,6 +178,8 @@ module Homebrew
 
     json = case json_version(args.json)
     when :v1, :default
+      raise UsageError, "cannot specify --cask with --json=v1!" if args.cask?
+
       formulae = if args.all?
         Formula.sort
       elsif args.installed?

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -222,7 +222,7 @@ If a *`formula`* or *`cask`* is provided, show summary of information about it.
 * `--github`:
   Open the GitHub source page for *`formula`* in a browser. To view formula history locally: `brew log -p` *`formula`*
 * `--json`:
-  Print a JSON representation of *`formula`*. Currently the default and only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>
+  Print a JSON representation. Currently the default value for *`version`* is `v1` for *`formula`*. For *`formula`* and *`cask`* use `v2`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>
 * `--installed`:
   Print JSON of formulae that are currently installed.
 * `--all`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -274,7 +274,7 @@ Open the GitHub source page for \fIformula\fR in a browser\. To view formula his
 .
 .TP
 \fB\-\-json\fR
-Print a JSON representation of \fIformula\fR\. Currently the default and only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
+Print a JSON representation\. Currently the default value for \fIversion\fR is \fBv1\fR for \fIformula\fR\. For \fIformula\fR and \fIcask\fR use \fBv2\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
 .TP
 \fB\-\-installed\fR


### PR DESCRIPTION
- `brew uninstall --zap` replaces `brew cask zap`
- clarify how `--json` should behave

Fixes https://github.com/Homebrew/brew/issues/9296