### PR TITLE
livecheck: remove redundant preprocessing exceptions

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -16,15 +16,6 @@ module Homebrew
     GITHUB_SPECIAL_CASES = %w[
       api.github.com
       /latest
-      mednafen
-      camlp5
-      kotlin
-      osrm-backend
-      prometheus
-      pyenv-virtualenv
-      sysdig
-      shairport-sync
-      yuicompressor
     ].freeze
 
     UNSTABLE_VERSION_KEYWORDS = %w[


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR removed all formula names listed in the `GITHUB_SPECIAL_CASES` list in the `livecheck` module. I was going through and moving lists with formula names to homebrew/core and realized that these formulae don't need to be part of the list anymore. I've checked all of them by running each formula's URL through `preprocess_url` with and without being in the special cases list. There were no differences in any of the formulae. For most of them, this is because the `/latest` part of the URL is also in the special cases list which means that listing the formulae name as well is redundant. One formula had a URL that didn't contain `github.com` which means that the special cases list was never even checked.
