### PR TITLE
workflows/tests: split out jobs.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
         include:
           - name: tap syntax (Linux)
             os: ubuntu-latest
-            core-tap: "linuxbrew-core"
+            core-tap: linuxbrew-core
           - name: tap syntax (macOS)
             os: macos-11.0
-            core-tap: "homebrew-core"
+            core-tap: homebrew-core
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -130,10 +130,10 @@ jobs:
         include:
           - name: vendored gems (Linux)
             os: ubuntu-latest
-            core-tap: "linuxbrew-core"
+            core-tap: linuxbrew-core
           - name: vendored gems (macOS)
             os: macos-11.0
-            core-tap: "homebrew-core"
+            core-tap: homebrew-core
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -184,10 +184,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "tests (no-compatibility mode)"
+          - name: tests (no-compatibility mode)
             os: ubuntu-latest
             test-flags: --no-compat --online --coverage
-          - name: "tests (generic OS)"
+          - name: tests (generic OS)
             os: ubuntu-latest
             test-flags: --generic --online --coverage
           - name: tests (Linux)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,13 +153,13 @@ jobs:
         include:
           - name: 'tests (no-compatibility mode)'
             os: ubuntu-latest
-            test-flags: --no-compat --online
+            test-flags: --no-compat --online --coverage
           - name: 'tests (generic OS)'
             os: ubuntu-latest
-            test-flags: --generic --online
+            test-flags: --generic --online --coverage
           - name: tests (Linux)
             os: ubuntu-latest
-            test-flags: --online
+            test-flags: --online --coverage
           - name: tests (macOS)
             os: macos-11.0
             test-flags: --online --coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,169 +1,238 @@
-name: GitHub Actions CI
+name: CI
 on:
   push:
-    branches: master
+    branches:
+      - master
   pull_request:
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
 jobs:
-  tests:
+  syntax:
     if: github.repository == 'Homebrew/brew'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - run: brew install-bundler-gems
+
+      - run: brew style --display-cop-names
+
+      - run: brew man --fail-if-changed
+
+      - run: brew typecheck
+
+      - name: Run vale for docs linting
+        run: |
+          brew install vale
+          vale docs/
+
+      - name: Lint Dockerfile
+        run: |
+          brew install hadolint
+          hadolint Dockerfile
+
+  brew-tests:
+    needs: syntax
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - test-flags: --no-compat --online
+          - test-flags: --generic --online
+          - test-flags: --online
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - run: brew install-bundler-gems
+
+      - name: Run brew tests
+        run: |
+          # brew tests doesn't like world writable directories
+          sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew
+
+          brew tests ${{ matrix.test_flags }}
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  brew-tests-coverage:
+    needs: syntax
+    runs-on: macos-11.0
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Set up Xcode
+        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
+
+      - name: Install brew tests dependencies
+        run: |
+          brew install subversion
+          Library/Homebrew/shims/scm/svn --homebrew=print-path
+          which svn
+          which svnadmin
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - run: brew install-bundler-gems
+
+      - run: brew tests --online --coverage
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # set variables for coverage reporting
+          HOMEBREW_CODECOV_TOKEN: 3ea0364c-80ce-47a3-9fba-93a940d4b5d7
+
+          # These cannot be queried at the macOS level on GitHub Actions.
+          HOMEBREW_LANGUAGES: en-GB
+
+  more-tests-and-syntax:
+    needs: syntax
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, macOS-11.0]
+        os:
+          - ubuntu-latest
+          - macos-11.0
         include:
           - os: ubuntu-latest
-            core-tap: 'linuxbrew-core'
-          - os: macOS-latest
-            core-tap: 'homebrew-core'
-          - os: macOS-11.0
-            core-tap: 'homebrew-core'
+            core-tap: "linuxbrew-core"
+          - os: macos-11.0
+            core-tap: "homebrew-core"
     steps:
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
-    - name: Configure Git user
-      uses: Homebrew/actions/git-user-config@master
-      with:
-        username: BrewTestBot
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
 
-    - run: brew test-bot --only-cleanup-before
+      - run: brew test-bot --only-cleanup-before
 
-    - name: Set up Xcode
-      if: matrix.os == 'macOS-11.0'
-      run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
+      - name: Set up Xcode
+        if: matrix.os == 'macos-11.0'
+        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
 
-    - run: brew config
+      - run: brew config
 
-    # Can't cache this because we need to check that it doesn't fail the
-    # "uncommitted RubyGems" step with a cold cache.
-    - name: Install Bundler RubyGems
-      run: brew install-bundler-gems
+      # Can't cache this because we need to check that it doesn't fail the
+      # "uncommitted RubyGems" step with a cold cache.
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems
 
-    - name: Check for uncommitted RubyGems
-      run: git diff --stat --exit-code Library/Homebrew/vendor/bundle/ruby
+      - name: Check for uncommitted RubyGems
+        run: git diff --stat --exit-code Library/Homebrew/vendor/bundle/ruby
 
-    - run: brew doctor
+      - run: brew doctor
 
-    - name: Set up Homebrew official command taps
-      run: |
-        # Setup taps needed for 'brew tests' and 'brew man'
-        cd "$(brew --repo)"
+      - name: Run brew update-tests
+        if: github.event_name == 'pull_request'
+        run: |
+          brew update-test
+          brew update-test --to-tag
+          brew update-test --commit=HEAD
 
-        if [ "$RUNNER_OS" = "macOS" ]; then
+      - name: Set up all Homebrew taps
+        if: runner.os == 'macOS'
+        run: |
           brew update-reset Library/Taps/homebrew/homebrew-bundle \
                             Library/Taps/homebrew/homebrew-cask \
-                            Library/Taps/homebrew/homebrew-cask-versions \
                             Library/Taps/homebrew/homebrew-services
-        else
-          brew update-reset Library/Taps/homebrew/homebrew-services
-        fi
+          brew tap homebrew/cask
+          brew tap homebrew/cask-drivers
+          brew tap homebrew/cask-fonts
+          brew tap homebrew/cask-versions
 
-    - name: Run brew style on Homebrew/brew
-      run: brew style --display-cop-names
+      - name: Run brew readall on all taps
+        run: brew readall --aliases
 
-    - name: Run brew man
-      run: brew man --fail-if-changed
+      - name: Run brew style on ${{ matrix.core-tap }}
+        run: brew style --display-cop-names homebrew/core
 
-    - name: Install brew tests dependencies
-      if: matrix.os != 'ubuntu-latest'
-      run: |
-        brew install subversion
-        Library/Homebrew/shims/scm/svn --homebrew=print-path
-        which svn
-        which svnadmin
+      - name: Run brew style on official taps
+        if: runner.os == 'macOS'
+        run: |
+          brew style --display-cop-names homebrew/bundle \
+                                         homebrew/services \
+                                         homebrew/test-bot
 
-    - name: Run brew tests
-      run: |
-        # brew tests doesn't like world writable directories
-        if [[ "$RUNNER_OS" = "Linux" ]]; then
-            sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew
-        fi
+      - name: Run brew style on cask taps
+        if: runner.os == 'macOS'
+        run: |
+          brew style --display-cop-names homebrew/cask \
+                                         homebrew/cask-drivers \
+                                         homebrew/cask-fonts \
+                                         homebrew/cask-versions
 
-        # don't bother running all tests on both platforms (for speed)
-        if [ "$RUNNER_OS" = "Linux" ]; then
-          brew tests --no-compat --online
-          brew tests --generic --online
-          brew tests --online
-        else
-          brew tests --online --coverage
-        fi
-      env:
-        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run brew audit --skip-style on all taps
+        run: brew audit --skip-style
 
-        # set variables for coverage reporting
-        HOMEBREW_CODECOV_TOKEN: 3ea0364c-80ce-47a3-9fba-93a940d4b5d7
+  docker:
+    needs: syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
-        # These cannot be queried at the macOS level on GitHub Actions.
-        HOMEBREW_LANGUAGES: en-GB
+      - name: Build Docker image
+        run: docker build -t brew --build-arg=version=16.04 .
 
-    - name: Run brew update-tests
-      run: |
-        brew update-test
-        brew update-test --to-tag
-        brew update-test --commit=HEAD
-      if: github.event_name == 'pull_request'
+      - name: Deploy the Docker image to GitHub Packages and Docker Hub
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo ${{secrets.HOMEBREW_GITHUB_PACKAGES_API_TOKEN}} | \
+            docker login ghcr.io -u BrewTestBot --password-stdin
+          docker tag brew "ghcr.io/homebrew/ubuntu16.04:master"
+          docker push "ghcr.io/homebrew/ubuntu16.04:master"
+          echo ${{secrets.DOCKER_TOKEN}} | \
+            docker login -u brewtestbot --password-stdin
+          docker tag brew "homebrew/ubuntu16.04:master"
+          docker push "homebrew/ubuntu16.04:master"
 
-    - name: Run brew readall on all taps
-      run: brew readall --aliases
+  test-bot-default-formula:
+    needs: syntax
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-11.0
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
-    - name: Run brew style on ${{ matrix.core-tap }}
-      run: brew style --display-cop-names homebrew/core
+      - name: Set up Xcode
+        if: matrix.os == 'macos-11.0'
+        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
 
-    - name: Run brew style on official taps
-      run: brew style --display-cop-names homebrew/bundle homebrew/services homebrew/test-bot
+      - run: brew test-bot --only-cleanup-before
 
-    - name: Run brew style on cask taps
-      if: matrix.os != 'ubuntu-latest'
-      run: |
-        brew tap homebrew/cask
-        brew tap homebrew/cask-drivers
-        brew tap homebrew/cask-fonts
-        brew tap homebrew/cask-versions
-
-        brew style --display-cop-names \
-          homebrew/cask \
-          homebrew/cask-drivers \
-          homebrew/cask-fonts \
-          homebrew/cask-versions
-
-    - name: Run brew audit --skip-style on all taps
-      run: brew audit --skip-style
-
-    - run: brew typecheck
-
-    - name: Run vale for docs linting
-      run: |
-        brew install vale
-        vale docs/
-
-    - name: Lint Dockerfile
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        brew install hadolint
-        hadolint Dockerfile
-
-    - name: Build Docker image
-      if: matrix.os == 'ubuntu-latest'
-      run: docker build -t brew --build-arg=version=16.04 .
-
-    - name: Run brew test-bot --only-formulae --test-default-formula
-      run: |
-        if [ "$RUNNER_OS" = "Linux" ]; then
-          docker run --rm brew brew test-bot --only-formulae --test-default-formula
-        else
-          brew test-bot --only-formulae --test-default-formula
-        fi
-
-    - name: Deploy the Docker image to GitHub Packages and Docker Hub
-      if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/master'
-      run: |
-        echo ${{secrets.HOMEBREW_GITHUB_PACKAGES_API_TOKEN}} | docker login ghcr.io -u BrewTestBot --password-stdin
-        docker tag brew "ghcr.io/homebrew/ubuntu16.04:master"
-        docker push "ghcr.io/homebrew/ubuntu16.04:master"
-        echo ${{secrets.DOCKER_TOKEN}} | docker login -u brewtestbot --password-stdin
-        docker tag brew "homebrew/ubuntu16.04:master"
-        docker push "homebrew/ubuntu16.04:master"
+      - run: brew test-bot --only-formulae --test-default-formula

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -271,6 +271,7 @@ jobs:
     needs:
       - syntax
       - tap-syntax
+      - vendored-gems
       - tests
       - docker
       - test-default-formula

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,11 +197,13 @@ jobs:
           fi
 
           if ${{ runner.os == 'macOS' }}; then
-            # Set variables for coverage reporting.
-            export HOMEBREW_CODECOV_TOKEN='3ea0364c-80ce-47a3-9fba-93a940d4b5d7'
-
             # These cannot be queried at the macOS level on GitHub Actions.
             export HOMEBREW_LANGUAGES='en-GB'
+          fi
+
+          if ${{ contains(matrix.test-flags, '--coverage') }}; then
+            # Set variables for coverage reporting.
+            export HOMEBREW_CODECOV_TOKEN='3ea0364c-80ce-47a3-9fba-93a940d4b5d7'
           fi
 
           brew tests ${{ matrix.test-flags }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,69 +41,6 @@ jobs:
           brew install hadolint
           hadolint Dockerfile
 
-  tests:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - name: 'tests (no compatibility)'
-            os: ubuntu-latest
-            test-flags: --no-compat --online
-          - name: 'tests (generic OS)'
-            os: ubuntu-latest
-            test-flags: --generic --online
-          - name: tests (Linux)
-            os: ubuntu-latest
-            test-flags: --online
-          - name: tests (macOS)
-            os: macos-11.0
-            test-flags: --online --coverage
-    steps:
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Set up Xcode
-        if: matrix.os == 'macos-11.0'
-        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
-
-      - name: Install brew tests dependencies
-        if: runner.os == 'macOS'
-        run: |
-          brew install subversion
-          Library/Homebrew/shims/scm/svn --homebrew=print-path
-          which svn
-          which svnadmin
-
-      - name: Cache Bundler RubyGems
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
-      - run: brew install-bundler-gems
-
-      - name: Run brew tests
-        run: |
-          if ${{ runner.os == 'Linux' }}; then
-            # brew tests doesn't like world writable directories
-            sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew
-          fi
-
-          if ${{ runner.os == 'macOS' }}; then
-            # Set variables for coverage reporting.
-            export HOMEBREW_CODECOV_TOKEN='3ea0364c-80ce-47a3-9fba-93a940d4b5d7'
-
-            # These cannot be queried at the macOS level on GitHub Actions.
-            export HOMEBREW_LANGUAGES='en-GB'
-          fi
-
-          brew tests ${{ matrix.test-flags }}
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   tap-syntax:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -207,6 +144,69 @@ jobs:
             docker login -u brewtestbot --password-stdin
           docker tag brew "homebrew/ubuntu16.04:master"
           docker push "homebrew/ubuntu16.04:master"
+
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: 'tests (no compatibility)'
+            os: ubuntu-latest
+            test-flags: --no-compat --online
+          - name: 'tests (generic OS)'
+            os: ubuntu-latest
+            test-flags: --generic --online
+          - name: tests (Linux)
+            os: ubuntu-latest
+            test-flags: --online
+          - name: tests (macOS)
+            os: macos-11.0
+            test-flags: --online --coverage
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Set up Xcode
+        if: matrix.os == 'macos-11.0'
+        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
+
+      - name: Install brew tests dependencies
+        if: runner.os == 'macOS'
+        run: |
+          brew install subversion
+          Library/Homebrew/shims/scm/svn --homebrew=print-path
+          which svn
+          which svnadmin
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - run: brew install-bundler-gems
+
+      - name: Run brew tests
+        run: |
+          if ${{ runner.os == 'Linux' }}; then
+            # brew tests doesn't like world writable directories
+            sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew
+          fi
+
+          if ${{ runner.os == 'macOS' }}; then
+            # Set variables for coverage reporting.
+            export HOMEBREW_CODECOV_TOKEN='3ea0364c-80ce-47a3-9fba-93a940d4b5d7'
+
+            # These cannot be queried at the macOS level on GitHub Actions.
+            export HOMEBREW_LANGUAGES='en-GB'
+          fi
+
+          brew tests ${{ matrix.test-flags }}
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-default-formula:
     name: ${{ matrix.name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -184,10 +184,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'tests (no-compatibility mode)'
+          - name: "tests (no-compatibility mode)"
             os: ubuntu-latest
             test-flags: --no-compat --online --coverage
-          - name: 'tests (generic OS)'
+          - name: "tests (generic OS)"
             os: ubuntu-latest
             test-flags: --generic --online --coverage
           - name: tests (Linux)
@@ -228,9 +228,7 @@ jobs:
           if ${{ runner.os == 'Linux' }}; then
             # brew tests doesn't like world writable directories
             sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew
-          fi
-
-          if ${{ runner.os == 'macOS' }}; then
+          elif ${{ runner.os == 'macOS' }}; then
             # These cannot be queried at the macOS level on GitHub Actions.
             export HOMEBREW_LANGUAGES='en-GB'
           fi
@@ -266,24 +264,3 @@ jobs:
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-formulae --test-default-formula
-
-  conclusion:
-    needs:
-      - syntax
-      - tap-syntax
-      - vendored-gems
-      - tests
-      - docker
-      - test-default-formula
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - run: >
-          ${{
-            needs.syntax.result == 'success' &&
-            needs.tap-syntax.result == 'success' &&
-            needs.vendored-gems.result == 'success' &&
-            needs.docker.result == 'success' &&
-            needs.tests.result == 'success' &&
-            needs.test-default-formula.result == 'success'
-          }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,5 +241,13 @@ jobs:
       - docker
       - test-default-formula
     runs-on: ubuntu-latest
+    if: always()
     steps:
-      - run: true
+      - run: >
+          ${{
+            needs.syntax.result == 'success' &&
+            needs.tap-syntax.result == 'success' &&
+            needs.docker.result == 'success' &&
+            needs.tests.result == 'success' &&
+            needs.test-default-formula.result == 'success'
+          }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'tests (no compatibility)'
+          - name: 'tests (no-compatibility mode)'
             os: ubuntu-latest
             test-flags: --no-compat --online
           - name: 'tests (generic OS)'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
             os: ubuntu-latest
             core-tap: linuxbrew-core
           - name: tap syntax (macOS)
-            os: macos-11.0
+            os: macos-latest
             core-tap: homebrew-core
     steps:
       - name: Set up Homebrew
@@ -132,7 +132,7 @@ jobs:
             os: ubuntu-latest
             core-tap: linuxbrew-core
           - name: vendored gems (macOS)
-            os: macos-11.0
+            os: macos-latest
             core-tap: homebrew-core
     steps:
       - name: Set up Homebrew
@@ -251,7 +251,7 @@ jobs:
           - name: test default formula (Linux)
             os: ubuntu-latest
           - name: test default formula (macOS)
-            os: macos-11.0
+            os: macos-latest
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,50 +41,36 @@ jobs:
           brew install hadolint
           hadolint Dockerfile
 
-  brew-tests:
+  tests:
+    name: ${{ matrix.name }}
     needs: syntax
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - test-flags: --no-compat --online
-          - test-flags: --generic --online
-          - test-flags: --online
-    steps:
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Cache Bundler RubyGems
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ runner.os }}-rubygems-
-
-      - run: brew install-bundler-gems
-
-      - name: Run brew tests
-        run: |
-          # brew tests doesn't like world writable directories
-          sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew
-
-          brew tests ${{ matrix.test_flags }}
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  brew-tests-coverage:
-    needs: syntax
-    runs-on: macos-11.0
+          - name: 'tests (no compatibility)'
+            os: ubuntu-latest
+            test-flags: --no-compat --online
+          - name: 'tests (generic OS)'
+            os: ubuntu-latest
+            test-flags: --generic --online
+          - name: tests (Linux)
+            os: ubuntu-latest
+            test-flags: --online
+          - name: tests (macOS)
+            os: macos-11.0
+            test-flags: --online --coverage
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Set up Xcode
+        if: matrix.os == 'macos-11.0'
         run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
 
       - name: Install brew tests dependencies
+        if: runner.os == 'macOS'
         run: |
           brew install subversion
           Library/Homebrew/shims/scm/svn --homebrew=print-path
@@ -100,24 +86,30 @@ jobs:
 
       - run: brew install-bundler-gems
 
-      - run: brew tests --online --coverage
+      - name: Run brew tests
+        run: |
+          if ${{ runner.os == 'Linux' }}; then
+            # brew tests doesn't like world writable directories
+            sudo chmod -R g-w,o-w /home/linuxbrew/.linuxbrew/Homebrew
+          fi
+
+          if ${{ runner.os == 'macOS' }}; then
+            # Set variables for coverage reporting.
+            export HOMEBREW_CODECOV_TOKEN='3ea0364c-80ce-47a3-9fba-93a940d4b5d7'
+
+            # These cannot be queried at the macOS level on GitHub Actions.
+            export HOMEBREW_LANGUAGES='en-GB'
+          fi
+
+          brew tests ${{ matrix.test-flags }}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          # set variables for coverage reporting
-          HOMEBREW_CODECOV_TOKEN: 3ea0364c-80ce-47a3-9fba-93a940d4b5d7
-
-          # These cannot be queried at the macOS level on GitHub Actions.
-          HOMEBREW_LANGUAGES: en-GB
 
   more-tests-and-syntax:
     needs: syntax
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-11.0
         include:
           - os: ubuntu-latest
             core-tap: "linuxbrew-core"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
 
   tests:
     name: ${{ matrix.name }}
-    needs: syntax
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -107,7 +106,6 @@ jobs:
 
   tap-syntax:
     name: ${{ matrix.name }}
-    needs: syntax
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -189,7 +187,6 @@ jobs:
         run: brew audit --skip-style
 
   docker:
-    needs: syntax
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew
@@ -213,7 +210,6 @@ jobs:
 
   test-default-formula:
     name: ${{ matrix.name }}
-    needs: syntax
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,15 +105,18 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  more-tests-and-syntax:
+  tap-syntax:
+    name: ${{ matrix.name }}
     needs: syntax
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - name: tap syntax (Linux)
+            os: ubuntu-latest
             core-tap: "linuxbrew-core"
-          - os: macos-11.0
+          - name: tap syntax (macOS)
+            os: macos-11.0
             core-tap: "homebrew-core"
     steps:
       - name: Set up Homebrew
@@ -208,14 +211,17 @@ jobs:
           docker tag brew "homebrew/ubuntu16.04:master"
           docker push "homebrew/ubuntu16.04:master"
 
-  test-bot-default-formula:
+  test-default-formula:
+    name: ${{ matrix.name }}
     needs: syntax
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-11.0
+        include:
+          - name: test default formula (Linux)
+            os: ubuntu-latest
+          - name: test default formula (macOS)
+            os: macos-11.0
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -228,3 +234,14 @@ jobs:
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-formulae --test-default-formula
+
+  conclusion:
+    needs:
+      - syntax
+      - tap-syntax
+      - tests
+      - docker
+      - test-default-formula
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,8 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
-      - run: brew install-bundler-gems
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems
 
       - run: brew style --display-cop-names
 
@@ -58,11 +59,6 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Configure Git user
-        uses: Homebrew/actions/git-user-config@master
-        with:
-          username: BrewTestBot
-
       - run: brew test-bot --only-cleanup-before
 
       - name: Set up Xcode
@@ -71,13 +67,15 @@ jobs:
 
       - run: brew config
 
-      # Can't cache this because we need to check that it doesn't fail the
-      # "uncommitted RubyGems" step with a cold cache.
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
       - name: Install Bundler RubyGems
         run: brew install-bundler-gems
-
-      - name: Check for uncommitted RubyGems
-        run: git diff --stat --exit-code Library/Homebrew/vendor/bundle/ruby
 
       - run: brew doctor
 
@@ -91,13 +89,14 @@ jobs:
       - name: Set up all Homebrew taps
         if: runner.os == 'macOS'
         run: |
-          brew update-reset Library/Taps/homebrew/homebrew-bundle \
-                            Library/Taps/homebrew/homebrew-cask \
-                            Library/Taps/homebrew/homebrew-services
           brew tap homebrew/cask
           brew tap homebrew/cask-drivers
           brew tap homebrew/cask-fonts
           brew tap homebrew/cask-versions
+          brew update-reset Library/Taps/homebrew/homebrew-bundle \
+                            Library/Taps/homebrew/homebrew-cask \
+                            Library/Taps/homebrew/homebrew-cask-versions \
+                            Library/Taps/homebrew/homebrew-services
 
       - name: Run brew readall on all taps
         run: brew readall --aliases
@@ -122,6 +121,40 @@ jobs:
 
       - name: Run brew audit --skip-style on all taps
         run: brew audit --skip-style
+
+  vendored-gems:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: vendored gems (Linux)
+            os: ubuntu-latest
+            core-tap: "linuxbrew-core"
+          - name: vendored gems (macOS)
+            os: macos-11.0
+            core-tap: "homebrew-core"
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Set up Xcode
+        if: matrix.os == 'macos-11.0'
+        run: sudo xcode-select --switch /Applications/Xcode_12.2.app/Contents/Developer
+
+      - name: Configure Git user
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
+
+      # Can't cache this because we need to check that it doesn't fail the
+      # "uncommitted RubyGems" step with a cold cache.
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems
+
+      - name: Check for uncommitted RubyGems
+        run: git diff --stat --exit-code Library/Homebrew/vendor/bundle/ruby
 
   docker:
     runs-on: ubuntu-latest
@@ -187,7 +220,8 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
-      - run: brew install-bundler-gems
+      - name: Install Bundler RubyGems
+        run: brew install-bundler-gems
 
       - name: Run brew tests
         run: |
@@ -247,6 +281,7 @@ jobs:
           ${{
             needs.syntax.result == 'success' &&
             needs.tap-syntax.result == 'success' &&
+            needs.vendored-gems.result == 'success' &&
             needs.docker.result == 'success' &&
             needs.tests.result == 'success' &&
             needs.test-default-formula.result == 'success'

--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -29,8 +29,7 @@ SimpleCov.start do
     # be quiet, the parent process will be in charge of output and checking coverage totals
     SimpleCov.print_error_status = false
 
-    at_exit do
-      exit_code = $ERROR_INFO.nil? ? 0 : $ERROR_INFO.status
+    SimpleCov.at_exit do
       $stdout.reopen("/dev/null")
 
       # Just save result, but don't write formatted output.
@@ -40,7 +39,7 @@ SimpleCov.start do
       simplecov_result = SimpleCov::Result.new(coverage_result)
       SimpleCov::ResultMerger.store_result(simplecov_result)
 
-      exit! exit_code
+      exit! SimpleCov.exit_status_from_exception || 0
     end
   else
     command_name "#{command_name} (#{$PROCESS_ID})"

--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -30,8 +30,6 @@ SimpleCov.start do
     SimpleCov.print_error_status = false
 
     SimpleCov.at_exit do
-      $stdout.reopen("/dev/null")
-
       # Just save result, but don't write formatted output.
       coverage_result = Coverage.result
       # TODO: this method is private, find a better way.
@@ -39,7 +37,10 @@ SimpleCov.start do
       simplecov_result = SimpleCov::Result.new(coverage_result)
       SimpleCov::ResultMerger.store_result(simplecov_result)
 
-      exit! SimpleCov.exit_status_from_exception || 0
+      # If an integration test raises a `SystemExit` exception on exit,
+      # exit immediately using the same status code to avoid reporting
+      # an error when expecting a non-successful exit status.
+      raise if $ERROR_INFO.is_a?(SystemExit)
     end
   else
     command_name "#{command_name} (#{$PROCESS_ID})"

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -42,7 +42,6 @@ module Homebrew
     args = tests_args.parse
 
     Homebrew.install_bundler_gems!
-    gem_user_dir = Gem.user_dir
 
     require "byebug" if args.byebug?
 
@@ -137,6 +136,9 @@ module Homebrew
       end
 
       puts "Randomized with seed #{seed}"
+
+      # Let tests find `bundle` in the actual location.
+      ENV["HOMEBREW_TESTS_GEM_USER_DIR"] = gem_user_dir
 
       # Let `bundle` in PATH find its gem.
       ENV["GEM_PATH"] = "#{ENV["GEM_PATH"]}:#{gem_user_dir}"

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -6,6 +6,7 @@ describe "brew", :integration_test do
     it "prints help for a documented Ruby command" do
       expect { brew "help", "cat" }
         .to output(/^Usage: brew cat/).to_stdout
+        .and not_to_output.to_stderr
         .and be_a_success
     end
   end

--- a/Library/Homebrew/test/cmd/help_spec.rb
+++ b/Library/Homebrew/test/cmd/help_spec.rb
@@ -14,6 +14,7 @@ describe "brew", :integration_test do
     it "prints help when no argument is given" do
       expect { brew "cat" }
         .to output(/^Usage: brew cat/).to_stderr
+        .and not_to_output.to_stdout
         .and be_a_failure
     end
   end

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -80,7 +80,11 @@ RSpec.configure do |config|
   if ENV["CI"]
     config.verbose_retry = true
     config.display_try_failure_messages = true
-    config.default_retry_count = 2
+
+    config.around(:each, :integration_test) do |example|
+      example.metadata[:timeout] ||= 120
+      example.run
+    end
 
     config.around(:each, :needs_network) do |example|
       example.metadata[:timeout] ||= 120

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -13,7 +13,8 @@ RSpec.shared_context "integration test" do
   matcher :be_a_success do
     match do |actual|
       status = actual.is_a?(Proc) ? actual.call : actual
-      status.respond_to?(:success?) && status.success?
+      expect(status).to respond_to(:success?)
+      status.success?
     end
 
     def supports_block_expectations?

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -17,9 +17,13 @@ module Homebrew
     "#{RbConfig::CONFIG["prefix"]}/bin"
   end
 
+  def gem_user_dir
+    ENV["HOMEBREW_TESTS_GEM_USER_DIR"] || Gem.user_dir
+  end
+
   def gem_user_bindir
     require "rubygems"
-    "#{Gem.user_dir}/bin"
+    "#{gem_user_dir}/bin"
   end
 
   def ohai_if_defined(message)
@@ -55,7 +59,7 @@ module Homebrew
     Gem.clear_paths
     Gem::Specification.reset
 
-    # Add necessary Ruby and Gem binary directories to PATH.
+    # Add necessary Ruby and Gem binary directories to `PATH`.
     gem_bindir ||= Gem.bindir
     paths = ENV.fetch("PATH").split(":")
     paths.unshift(gem_bindir) unless paths.include?(gem_bindir)
@@ -92,7 +96,7 @@ module Homebrew
 
   def install_bundler!
     require "rubygems"
-    setup_gem_environment!(gem_home: Gem.user_dir, gem_bindir: gem_user_bindir)
+    setup_gem_environment!(gem_home: gem_user_dir, gem_bindir: gem_user_bindir)
     install_gem_setup_path!(
       "bundler",
       version:               HOMEBREW_BUNDLER_VERSION,

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -24,9 +24,9 @@ module Homebrew
 
   def ohai_if_defined(message)
     if defined?(ohai)
-      ohai message
+      $stderr.ohai message
     else
-      puts "==> #{message}"
+      $stderr.puts "==> #{message}"
     end
   end
 


### PR DESCRIPTION
Separate out the slow parts of tests into jobs that can be run in parallel.

Also:
- don't build on `macOS-latest` now that Big Sur is the latest stable release.
- Use `runner.os` when it improves readability over `matrix.os`.
