### PR TITLE
dev-cmd/unbottled: Fail nicely if `HOMEBREW_NO_ANALYTICS` is set

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -86,6 +86,13 @@ module Homebrew
 
       ohai "Getting analytics data..."
       analytics = Utils::Analytics.formulae_brew_sh_json("analytics/install/90d.json")
+
+      if analytics.blank?
+        raise UsageError,
+              "default sort by analytics data requires " \
+              "`HOMEBREW_NO_GITHUB_API` and `HOMEBREW_NO_ANALYTICS` to be unset"
+      end
+
       formulae = analytics["items"].map do |i|
         f = i["formula"].split.first
         next if f.include?("/")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- When testing `brew unbottled` this crashed because I, as a maintainer, have `HOMEBREW_NO_ANALYTICS` set on all my machines to avoid polluting the analytics with test installs.

```
❯ brew unbottled
==> Getting formulae...
==> Getting analytics data...
Error: undefined method `[]' for nil:NilClass
/usr/local/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:89:in `formulae_all_sort_installs_from_args'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/unbottled.rb:49:in `unbottled'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```

