### PR TITLE
audit: allowlist dashing's cert check

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -401,6 +401,7 @@ module Homebrew
     end
 
     CERT_ERROR_ALLOWLIST = {
+      "dashing"     => "https://ruby-doc.com/",
       "hashcat"     => "https://hashcat.net/hashcat/",
       "jinx"        => "https://www.jinx-lang.org/",
       "lmod"        => "https://www.tacc.utexas.edu/research-development/tacc-projects/lmod",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
```
$ /usr/bin/curl -v https://ruby-doc.com
* Rebuilt URL to: https://ruby-doc.com/
*   Trying 108.168.213.2...
* TCP_NODELAY set
* Connected to ruby-doc.com (108.168.213.2) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (OUT), TLS alert, Server hello (2):
* SSL certificate problem: certificate has expired
* stopped the pause stream!
* Closing connection 0
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html
```

relates to Homebrew/homebrew-core#65648
and https://github.com/Homebrew/homebrew-core/runs/1404553185
```
  * Stable resource "ruby_docs_tarball": The URL http://ruby-doc.com/downloads/ruby_2_6_5_core_rdocs.tgz should use HTTPS rather than HTTP
```