### PR TITLE
Migrate remaining audit exceptions to homebrew/core

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -477,10 +477,6 @@ module Homebrew
       [user, repo]
     end
 
-    # Used for formulae that are unstable but need CI run without being in homebrew/core
-    UNSTABLE_DEVEL_ALLOWLIST = {
-    }.freeze
-
     GNOME_DEVEL_ALLOWLIST = {
       "libart"              => "2.3",
       "gtk-mac-integration" => "2.1",
@@ -553,7 +549,7 @@ module Homebrew
         matched = Regexp.last_match(1)
         version_prefix = stable_version_string.sub(/\d+$/, "")
         return if tap_audit_exception :unstable_allowlist, formula.name, version_prefix
-        return if UNSTABLE_DEVEL_ALLOWLIST[formula.name] == version_prefix
+        return if tap_audit_exception :unstable_devel_allowlist, formula.name, version_prefix
 
         problem "Stable version URLs should not contain #{matched}"
       when %r{download\.gnome\.org/sources}, %r{ftp\.gnome\.org/pub/GNOME/sources}i

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -150,14 +150,6 @@ module Homebrew
       problem "Formula name conflicts with existing core formula."
     end
 
-    PROVIDED_BY_MACOS_DEPENDS_ON_ALLOWLIST = %w[
-      apr
-      apr-util
-      libressl
-      openblas
-      openssl@1.1
-    ].freeze
-
     PERMITTED_LICENSE_MISMATCHES = {
       "AGPL-3.0" => ["AGPL-3.0-only", "AGPL-3.0-or-later"],
       "GPL-2.0"  => ["GPL-2.0-only",  "GPL-2.0-or-later"],
@@ -265,7 +257,7 @@ module Homebrew
              dep_f.keg_only? &&
              dep_f.keg_only_reason.provided_by_macos? &&
              dep_f.keg_only_reason.applicable? &&
-             !PROVIDED_BY_MACOS_DEPENDS_ON_ALLOWLIST.include?(dep.name)
+             !tap_audit_exception(:provided_by_macos_depends_on_allowlist, dep.name)
             new_formula_problem(
               "Dependency '#{dep.name}' is provided by macOS; " \
               "please replace 'depends_on' with 'uses_from_macos'.",

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -360,8 +360,6 @@ module Homebrew
       end
 
       return if tap_audit_exception :versioned_keg_only_allowlist, formula.name
-      return if formula.name.start_with?("adoptopenjdk@")
-      return if formula.name.start_with?("gcc@")
 
       problem "Versioned formulae in homebrew/core should use `keg_only :versioned_formula`"
     end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -477,24 +477,6 @@ module Homebrew
       [user, repo]
     end
 
-    UNSTABLE_ALLOWLIST = {
-      "aalib"           => "1.4rc",
-      "automysqlbackup" => "3.0-rc",
-      "aview"           => "1.3.0rc",
-      "elm-format"      => "0.6.0-alpha",
-      "ftgl"            => "2.1.3-rc",
-      "hidapi"          => "0.8.0-rc",
-      "libcaca"         => "0.99b",
-      "premake"         => "4.4-beta",
-      "pwnat"           => "0.3-beta",
-      "recode"          => "3.7-beta",
-      "speexdsp"        => "1.2rc",
-      "sqoop"           => "1.4.",
-      "tcptraceroute"   => "1.5beta",
-      "tiny-fugue"      => "5.0b",
-      "vbindiff"        => "3.0_beta",
-    }.freeze
-
     # Used for formulae that are unstable but need CI run without being in homebrew/core
     UNSTABLE_DEVEL_ALLOWLIST = {
     }.freeze
@@ -570,7 +552,7 @@ module Homebrew
       when /[\d._-](alpha|beta|rc\d)/
         matched = Regexp.last_match(1)
         version_prefix = stable_version_string.sub(/\d+$/, "")
-        return if UNSTABLE_ALLOWLIST[formula.name] == version_prefix
+        return if tap_audit_exception :unstable_allowlist, formula.name, version_prefix
         return if UNSTABLE_DEVEL_ALLOWLIST[formula.name] == version_prefix
 
         problem "Stable version URLs should not contain #{matched}"

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -477,14 +477,6 @@ module Homebrew
       [user, repo]
     end
 
-    GNOME_DEVEL_ALLOWLIST = {
-      "libart"              => "2.3",
-      "gtk-mac-integration" => "2.1",
-      "gtk-doc"             => "1.31",
-      "gcab"                => "1.3",
-      "libepoxy"            => "1.5",
-    }.freeze
-
     def audit_specs
       problem "Head-only (no stable download)" if head_only?(formula)
 
@@ -554,7 +546,7 @@ module Homebrew
         problem "Stable version URLs should not contain #{matched}"
       when %r{download\.gnome\.org/sources}, %r{ftp\.gnome\.org/pub/GNOME/sources}i
         version_prefix = stable.version.major_minor
-        return if GNOME_DEVEL_ALLOWLIST[formula.name] == version_prefix
+        return if tap_audit_exception :gnome_devel_allowlist, formula.name, version_prefix
         return if stable_url_version < Version.create("1.0")
         return if stable_url_minor_version.even?
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -347,21 +347,6 @@ module Homebrew
       end
     end
 
-    # openssl@1.1 only needed for Linux
-    VERSIONED_KEG_ONLY_ALLOWLIST = %w[
-      autoconf@2.13
-      bash-completion@2
-      clang-format@8
-      gnupg@1.4
-      libsigc++@2
-      lua@5.1
-      numpy@1.16
-      openssl@1.1
-      python@3.8
-      python@3.9
-      cairomm@1.14
-    ].freeze
-
     def audit_versioned_keg_only
       return unless @versioned_formula
       return unless @core_tap
@@ -374,7 +359,7 @@ module Homebrew
         end
       end
 
-      return if VERSIONED_KEG_ONLY_ALLOWLIST.include?(formula.name)
+      return if tap_audit_exception :versioned_keg_only_allowlist, formula.name
       return if formula.name.start_with?("adoptopenjdk@")
       return if formula.name.start_with?("gcc@")
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -210,17 +210,6 @@ module Homebrew
       end
     end
 
-    # TODO: try to remove these, it's not a good user experience
-    VERSIONED_DEPENDENCIES_CONFLICTS_ALLOWLIST = %w[
-      agda
-      anjuta
-      fdroidserver
-      gradio
-      predictionio
-      sqoop
-      visp
-    ].freeze
-
     def audit_deps
       @specs.each do |spec|
         # Check for things we don't like to depend on.
@@ -297,7 +286,7 @@ module Homebrew
       end
 
       return unless @core_tap
-      return if VERSIONED_DEPENDENCIES_CONFLICTS_ALLOWLIST.include?(formula.name)
+      return if tap_audit_exception :versioned_dependencies_conflicts_allowlist, formula.name
 
       # The number of conflicts on Linux is absurd.
       # TODO: remove this and check these there too.

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -366,14 +366,6 @@ module Homebrew
       problem "Versioned formulae in homebrew/core should use `keg_only :versioned_formula`"
     end
 
-    CERT_ERROR_ALLOWLIST = {
-      "hashcat"     => "https://hashcat.net/hashcat/",
-      "jinx"        => "https://www.jinx-lang.org/",
-      "lmod"        => "https://www.tacc.utexas.edu/research-development/tacc-projects/lmod",
-      "micropython" => "https://www.micropython.org/",
-      "monero"      => "https://www.getmonero.org/",
-    }.freeze
-
     def audit_homepage
       homepage = formula.homepage
 
@@ -381,7 +373,7 @@ module Homebrew
 
       return unless @online
 
-      return if CERT_ERROR_ALLOWLIST[formula.name] == homepage
+      return if tap_audit_exception :cert_error_allowlist, formula.name, homepage
 
       return unless DevelopmentTools.curl_handles_most_https_certificates?
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1009,7 +1009,5 @@ module Homebrew
         expect(fa.problems).to be_empty
       end
     end
-
-    include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys
   end
 end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1011,7 +1011,6 @@ module Homebrew
     end
 
     # include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_ALLOWLIST
-    include_examples "formulae exist", described_class::PROVIDED_BY_MACOS_DEPENDS_ON_ALLOWLIST
     include_examples "formulae exist", described_class::UNSTABLE_ALLOWLIST.keys
     include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys
   end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1010,7 +1010,6 @@ module Homebrew
       end
     end
 
-    # include_examples "formulae exist", described_class::VERSIONED_KEG_ONLY_ALLOWLIST
     include_examples "formulae exist", described_class::UNSTABLE_ALLOWLIST.keys
     include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys
   end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1010,7 +1010,6 @@ module Homebrew
       end
     end
 
-    include_examples "formulae exist", described_class::UNSTABLE_ALLOWLIST.keys
     include_examples "formulae exist", described_class::GNOME_DEVEL_ALLOWLIST.keys
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR migrates the remaining audit exceptions to homebrew/core.

This is pretty straight forward, on this end, but there will be a few additional notes in the corresponding homebrew/core PR: https://github.com/Homebrew/homebrew-core/pull/65712

Note that it is expected that CI will fail until https://github.com/Homebrew/homebrew-core/pull/65712 has been merged into homebrew/core and linuxbrew/core.
