### PR TITLE
global: fix `default_prefix?` definition

### DIFF
--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -88,7 +88,7 @@ module Homebrew
   class << self
     attr_writer :failed, :raise_deprecation_exceptions, :auditing
 
-    def Homebrew.default_prefix?(prefix = HOMEBREW_PREFIX)
+    def default_prefix?(prefix = HOMEBREW_PREFIX)
       prefix.to_s == DEFAULT_PREFIX
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is currently breaking all CI builds with the error:

```console
% brew typecheck
cmd/link.rb:81: Method default_prefix? does not exist on T.class_of(Homebrew) https://srb.help/7003
    81 |        if Homebrew.default_prefix? && formula.present? && formula.keg_only_reason.by_macos?
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  Did you mean:
    global.rb:91: T.class_of(Homebrew).default_prefix?
    91 |    def Homebrew.default_prefix?(prefix = HOMEBREW_PREFIX)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

cmd/link.rb:81: Method default_prefix? does not exist on T.class_of(Homebrew) https://srb.help/7003
    81 |        if Homebrew.default_prefix? && formula.present? && formula.keg_only_reason.by_macos?
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  Did you mean:
    global.rb:91: T.class_of(Homebrew).default_prefix?
    91 |    def Homebrew.default_prefix?(prefix = HOMEBREW_PREFIX)
```

It's not clear why this was defined as `Homebrew.default_prefix?` in https://github.com/Homebrew/brew/pull/4851, since the `class << self` means that all of these are class methods anyway. This appears to prevent Sorbet from figuring out where `default_prefix?` is coming from.