### PR TITLE
linkage: correctly detect missing kegs.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -193,7 +193,9 @@ class Keg
   # @param path if this is a file in a keg, returns the containing {Keg} object.
   def self.for(path)
     original_path = path
-    if original_path.exist? && (path = original_path.realpath)
+    raise Errno::ENOENT, original_path.to_s unless original_path.exist?
+
+    if (path = original_path.realpath)
       until path.root?
         return Keg.new(path) if path.parent.parent == HOMEBREW_CELLAR.realpath
 

--- a/Library/Homebrew/linkage_checker.rb
+++ b/Library/Homebrew/linkage_checker.rb
@@ -68,16 +68,6 @@ class LinkageChecker
     display_items "Broken dependencies", @broken_deps, puts_output: puts_output
     display_items "Unwanted system libraries", @unwanted_system_dylibs, puts_output: puts_output
     display_items "Conflicting libraries", @version_conflict_deps, puts_output: puts_output
-
-    if @broken_dylibs.empty?
-      puts "No broken library linkage detected"
-    elsif unexpected_broken_dylibs.empty?
-      puts "No unexpected broken library linkage detected."
-    else
-      puts "Unexpected missing library linkage detected"
-    end
-
-    puts "Unexpected non-missing linkage detected" if unexpected_present_dylibs.present?
   end
 
   sig { returns(T::Boolean) }


### PR DESCRIPTION
- manually `raise Errno::ENOENT` to ensure that a keg that doesn't exist isn't flagged as a system dependency.
- remove the inconsistent and incorrect summary messaging.

Fixes https://github.com/Homebrew/brew/issues/9321