### PR TITLE
cpu.rb: drop field name and a colon from flags

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -69,8 +69,9 @@ module Hardware
         end
       end
 
+      # Supported CPU instructions
       def flags
-        @flags ||= cpuinfo[/^(flags|Features).*/, 0]&.split
+        @flags ||= cpuinfo[/^(?:flags|Features)\s*: (.*)/, 1]&.split
         @flags ||= []
       end
 


### PR DESCRIPTION
Before this change:

```sh
$ brew ruby -e 'p Hardware::CPU.flags'
["flags", ":", "fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr", "pge", "mca", "cmov", "pat", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "ht", "syscall", "nx", "mmxext", "fxsr_opt", "pdpe1gb", "rdtscp", "lm", "3dnowext", "3dnow", "constant_tsc", "rep_good", "nopl", "nonstop_tsc", "extd_apicid", "pni", "monitor", "cx16", "popcnt", "lahf_lm", "cmp_legacy", "svm", "extapic", "cr8_legacy", "abm", "sse4a", "misalignsse", "3dnowprefetch", "osvw", "ibs", "skinit", "wdt", "npt", "lbrv", "svm_lock", "nrip_save", "pausefilter"]
# ^^^^^^^^^^^^
```

After the change:

```sh
$ brew ruby -e 'p Hardware::CPU.flags'
["fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr", "pge", "mca", "cmov", "pat", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "ht", "syscall", "nx", "mmxext", "fxsr_opt", "pdpe1gb", "rdtscp", "lm", "3dnowext", "3dnow", "constant_tsc", "rep_good", "nopl", "nonstop_tsc", "extd_apicid", "pni", "monitor", "cx16", "popcnt", "lahf_lm", "cmp_legacy", "svm", "extapic", "cr8_legacy", "abm", "sse4a", "misalignsse", "3dnowprefetch", "osvw", "ibs", "skinit", "wdt", "npt", "lbrv", "svm_lock", "nrip_save", "pausefilter"]
```
-----

Based on the output I saw for Arm processors ([here](https://www.cnx-software.com/2018/02/14/human-readable-decoding-of-proc-cpuinfo-for-arm-processors/)), "Features" line has the same format and we can drop the first two elements of the array.
Alternative solution is to reject "flags", "Features" and ":" elements using 
```
.reject { |f| ["flags", "Features", ":"].include? f }
```
CC @sjackman 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
