### PR TITLE
SDK: allow SDK mismatches if major version matches

### DIFF
--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -52,6 +52,8 @@ module OS
         rescue NoSDKError
           latest_sdk
         end
+        return if sdk.blank?
+
         # Accept an SDK for another OS version if it shares a major version
         # with the current OS - for example, the 11.0 SDK on 11.1,
         # or vice versa.
@@ -59,11 +61,11 @@ module OS
         # or greater, given the way the versioning has changed.
         # This shortcuts the below check, since we *do* accept an older version
         # on macOS 11 or greater if the major version matches.
-        return sdk if sdk.present? && OS::Mac.version >= :big_sur && sdk.version.major == OS::Mac.version.major
+        return sdk if OS::Mac.version >= :big_sur && sdk.version.major == OS::Mac.version.major
 
         # On OSs lower than 11, or where the major versions don't match,
         # only return an SDK older than the OS version if it was specifically requested
-        return unless v || (sdk.present? && sdk.version >= OS::Mac.sdk_version)
+        return if v.blank? && sdk.version < OS::Mac.version
 
         sdk
       end

--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -52,7 +52,17 @@ module OS
         rescue NoSDKError
           latest_sdk
         end
-        # Only return an SDK older than the OS version if it was specifically requested
+        # Accept an SDK for another OS version if it shares a major version
+        # with the current OS - for example, the 11.0 SDK on 11.1,
+        # or vice versa.
+        # Note that this only applies on macOS 11
+        # or greater, given the way the versioning has changed.
+        # This shortcuts the below check, since we *do* accept an older version
+        # on macOS 11 or greater if the major version matches.
+        return sdk if sdk.present? && OS::Mac.version >= :big_sur && sdk.version.major == OS::Mac.version.major
+
+        # On OSs lower than 11, or where the major versions don't match,
+        # only return an SDK older than the OS version if it was specifically requested
         return unless v || (sdk.present? && sdk.version >= OS::Mac.sdk_version)
 
         sdk


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR complements #9327 and should be shipped alongside or after it.

@fxcoudert noticed an issue with our current SDK lookup code, described in #9324. @MikeMcQuaid wrote a fix in #9327 which resolves that bug, but leaves a new one: if the OS version and the SDK version are slightly different, Homebrew won't fetch the SDK. In the past that was unlikely, but thanks to the new naming scheme from macOS 11, it's actually quite a bit more common now.

Starting with macOS 11, Apple appears to be planning to increment the major number with every release instead of leaving us with an eternal 10 (or 11). That means that the series number, which in the past was the OS number, now indicates the version of each OS - macOS 11.1, 11.2, etc. are all updates to macOS 11. The Xcode 12.3 beta introduces a `MacOSX11.1` SDK, alongside the minor macOS 11.1 release. It looks like there's a very real chance that the SDK version and OS version will slightly diverge over time, or at least that the SDK version will lag. It's likely that users may have macOS 11.1 installed while using a `MacOSX11.0` SDK, or vice versa. As a result, we need to be able to pick SDKs with a version mismatch, *as long as the major version matches* (and as long as it's macOS 11 or greater).

This PR implements that, and I've tested it using macOS 11.1 running Xcode 12.2 (which ships an `11.0` SDK). Without this PR and with the commit from #9327, we fail to locate the 11.0 SDK:

```
$ sw_vers -productVersion
11.1
$ brew ruby -e 'puts MacOS.sdk_path'

```

With this PR and with the commit from #9327, however, we do find the correct SDK:

```
$ sw_vers -productVersion
11.1
$ brew ruby -e 'puts MacOS.sdk_path'
/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk
```

With the two of these together we should cover the weird edge cases in SDK handling. As noted by @fxcoudert, however, we have a few other edge cases outside SDK selection to patch up as well.

cc @MikeMcQuaid 