### PR TITLE
formula: widen type for system args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1982,7 +1982,7 @@ class Formula
   #
   # # If there is a "make install" available, please use it!
   # system "make", "install"</pre>
-  sig { params(cmd: T.any(String, Pathname), args: T.any(String, Pathname)).void }
+  sig { params(cmd: T.any(String, Pathname), args: T.any(String, Pathname, Integer)).void }
   def system(cmd, *args)
     verbose_using_dots = Homebrew::EnvConfig.verbose_using_dots?
 


### PR DESCRIPTION
We can pass Integers here too, for e.g. make flags

```
TypeError: Parameter 'args': Expected type T.any(Pathname, String), got type Integer with value 4
Caller: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/pypy.rb:68
Definition: /usr/local/Homebrew/Library/Homebrew/formula.rb:1985
```


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----