### PR TITLE
git_extensions: refactor and delete redundant functions

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -77,8 +77,8 @@ module Homebrew
     old_hash = cask.sha256.to_s
 
     tap_full_name = cask.tap&.full_name
-    origin_branch = Utils::Git.origin_branch(cask.tap.path) if cask.tap
-    origin_branch ||= "origin/master"
+    default_remote_branch = cask.tap.path.git_origin_branch if cask.tap
+    default_remote_branch ||= "master"
     previous_branch = "-"
 
     check_open_pull_requests(cask, tap_full_name, args: args)
@@ -200,7 +200,7 @@ module Homebrew
     pr_info = {
       sourcefile_path: cask.sourcefile_path,
       old_contents:    old_contents,
-      origin_branch:   origin_branch,
+      remote_branch:   default_remote_branch,
       branch_name:     "bump-#{cask.token}-#{new_version.tr(",:", "-")}",
       commit_message:  "Update #{cask.token} from #{old_version} to #{new_version}",
       previous_branch: previous_branch,

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -385,7 +385,7 @@ module Homebrew
       _, user, repo, pr = *url_match
       odie "Not a GitHub pull request: #{arg}" unless pr
 
-      current_branch = Utils::Git.current_branch(tap.path)
+      current_branch = tap.path.git_branch
       origin_branch = Utils::Git.origin_branch(tap.path).split("/").last
 
       if current_branch != origin_branch || args.branch_okay? || args.clean?

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -89,7 +89,7 @@ module Homebrew
   end
 
   def signoff!(path, pr: nil, dry_run: false)
-    subject, body, trailers = separate_commit_message(Utils::Git.commit_message(path))
+    subject, body, trailers = separate_commit_message(path.git_commit_message)
 
     if pr
       # This is a tap pull request and approving reviewers should also sign-off.
@@ -156,7 +156,7 @@ module Homebrew
     new_formula = Utils::Git.file_at_commit(path, file, "HEAD")
 
     bump_subject = determine_bump_subject(old_formula, new_formula, formula_file, reason: reason).strip
-    subject, body, trailers = separate_commit_message(Utils::Git.commit_message(path))
+    subject, body, trailers = separate_commit_message(path.git_commit_message)
 
     if subject != bump_subject && !subject.start_with?("#{formula_name}:")
       safe_system("git", "-C", path, "commit", "--amend", "-q",
@@ -181,7 +181,7 @@ module Homebrew
     messages = []
     trailers = []
     commits.each do |commit|
-      subject, body, trailer = separate_commit_message(Utils::Git.commit_message(path, commit))
+      subject, body, trailer = separate_commit_message(path.git_commit_message(commit))
       body = body.lines.map { |line| "  #{line.strip}" }.join("\n")
       messages << "* #{subject}\n#{body}".strip
       trailers << trailer

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -385,11 +385,8 @@ module Homebrew
       _, user, repo, pr = *url_match
       odie "Not a GitHub pull request: #{arg}" unless pr
 
-      current_branch = tap.path.git_branch
-      origin_branch = Utils::Git.origin_branch(tap.path).split("/").last
-
-      if current_branch != origin_branch || args.branch_okay? || args.clean?
-        opoo "Current branch is #{current_branch}: do you need to pull inside #{origin_branch}?"
+      if !tap.path.git_default_origin_branch? || args.branch_okay? || args.clean?
+        opoo "Current branch is #{tap.path.git_branch}: do you need to pull inside #{tap.path.git_origin_branch}?"
       end
 
       ohai "Fetching #{tap} pull request ##{pr}"

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -216,7 +216,8 @@ module Homebrew
   end
 
   def autosquash!(original_commit, path: ".", reason: "", verbose: false, resolve: false)
-    original_head = Utils.safe_popen_read("git", "-C", path, "rev-parse", "HEAD").strip
+    path = Pathname(path).extend(GitRepositoryExtension)
+    original_head = path.git_head
 
     commits = Utils.safe_popen_read("git", "-C", path, "rev-list",
                                     "--reverse", "#{original_commit}..HEAD").lines.map(&:strip)
@@ -394,7 +395,7 @@ module Homebrew
       ohai "Fetching #{tap} pull request ##{pr}"
       Dir.mktmpdir pr do |dir|
         cd dir do
-          original_commit = Utils.popen_read("git", "-C", tap.path, "rev-parse", "HEAD").chomp
+          original_commit = tap.path.git_head
           cherry_pick_pr!(user, repo, pr, path: tap.path, args: args)
           if args.autosquash? && !args.dry_run?
             autosquash!(original_commit, path: tap.path,

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -572,16 +572,9 @@ module Homebrew
         return unless Utils::Git.available?
 
         commands = Tap.map do |tap|
-          next unless tap.path.git?
-          next if tap.path.git_origin.blank?
+          next if tap.path.git_default_origin_branch?
 
-          branch = tap.path.git_branch
-          next if branch.blank?
-
-          origin_branch = Utils::Git.origin_branch(tap.path)&.split("/")&.last
-          next if origin_branch == branch
-
-          "git -C $(brew --repo #{tap.name}) checkout #{origin_branch}"
+          "git -C $(brew --repo #{tap.name}) checkout #{tap.path.git_origin_branch}"
         end.compact
 
         return if commands.blank?

--- a/Library/Homebrew/extend/git_repository.rb
+++ b/Library/Homebrew/extend/git_repository.rb
@@ -63,6 +63,21 @@ module GitRepositoryExtension
     Utils.popen_read("git", "rev-parse", "--abbrev-ref", "HEAD", chdir: self).chomp.presence
   end
 
+  # Gets the name of the default origin HEAD branch.
+  sig { returns(T.nilable(String)) }
+  def git_origin_branch
+    return unless git? && Utils::Git.available?
+
+    Utils.popen_read("git", "symbolic-ref", "-q", "--short", "refs/remotes/origin/HEAD", chdir: self)
+         .chomp.presence&.split("/")&.last
+  end
+
+  # Returns true if the repository's current branch matches the default origin branch.
+  sig { returns(T.nilable(T::Boolean)) }
+  def git_default_origin_branch?
+    git_origin_branch == git_branch
+  end
+
   # Returns the date of the last commit, in YYYY-MM-DD format.
   sig { returns(T.nilable(String)) }
   def git_last_commit_date

--- a/Library/Homebrew/extend/git_repository.rb
+++ b/Library/Homebrew/extend/git_repository.rb
@@ -85,4 +85,12 @@ module GitRepositoryExtension
 
     Utils.popen_read("git", "show", "-s", "--format=%cd", "--date=short", "HEAD", chdir: self).chomp.presence
   end
+
+  # Gets the full commit message of the specified commit, or of the HEAD commit if unspecified.
+  sig { params(commit: String).returns(T.nilable(String)) }
+  def git_commit_message(commit = "HEAD")
+    return unless git? && Utils::Git.available?
+
+    Utils.popen_read("git", "log", "-1", "--pretty=%B", commit, "--", chdir: self, err: :out).strip.presence
+  end
 end

--- a/Library/Homebrew/extend/git_repository.rb
+++ b/Library/Homebrew/extend/git_repository.rb
@@ -1,50 +1,70 @@
-# typed: false
+# typed: strict
 # frozen_string_literal: true
 
 require "utils/git"
 require "utils/popen"
 
+# Extensions to {Pathname} for querying Git repository information.
+# @see Utils::Git
+# @api private
 module GitRepositoryExtension
+  extend T::Sig
+
+  sig { returns(T::Boolean) }
   def git?
     join(".git").exist?
   end
 
+  # Gets the URL of the Git origin remote.
+  sig { returns(T.nilable(String)) }
   def git_origin
     return unless git? && Utils::Git.available?
 
     Utils.popen_read("git", "config", "--get", "remote.origin.url", chdir: self).chomp.presence
   end
 
+  # Sets the URL of the Git origin remote.
+  sig { params(origin: String).returns(T.nilable(T::Boolean)) }
   def git_origin=(origin)
     return unless git? && Utils::Git.available?
 
     safe_system "git", "remote", "set-url", "origin", origin, chdir: self
   end
 
+  # Gets the full commit hash of the HEAD commit.
+  sig { returns(T.nilable(String)) }
   def git_head
     return unless git? && Utils::Git.available?
 
     Utils.popen_read("git", "rev-parse", "--verify", "-q", "HEAD", chdir: self).chomp.presence
   end
 
+  # Gets a short commit hash of the HEAD commit.
+  sig { returns(T.nilable(String)) }
   def git_short_head
     return unless git? && Utils::Git.available?
 
     Utils.popen_read("git", "rev-parse", "--short=4", "--verify", "-q", "HEAD", chdir: self).chomp.presence
   end
 
+  # Gets the relative date of the last commit, e.g. "1 hour ago"
+  sig { returns(T.nilable(String)) }
   def git_last_commit
     return unless git? && Utils::Git.available?
 
     Utils.popen_read("git", "show", "-s", "--format=%cr", "HEAD", chdir: self).chomp.presence
   end
 
+  # Gets the name of the currently checked-out branch, or HEAD if the repository is in a detached HEAD state.
+  sig { returns(T.nilable(String)) }
   def git_branch
     return unless git? && Utils::Git.available?
 
     Utils.popen_read("git", "rev-parse", "--abbrev-ref", "HEAD", chdir: self).chomp.presence
   end
 
+  # Returns the date of the last commit, in YYYY-MM-DD format.
+  sig { returns(T.nilable(String)) }
   def git_last_commit_date
     return unless git? && Utils::Git.available?
 

--- a/Library/Homebrew/extend/git_repository.rbi
+++ b/Library/Homebrew/extend/git_repository.rbi
@@ -1,0 +1,8 @@
+# typed: strict
+
+module GitRepositoryExtension
+  include Kernel
+
+  sig { params(args: T.any(String, Pathname)).returns(Pathname) }
+  def join(*args); end
+end

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -58,7 +58,7 @@ describe Homebrew do
         safe_system Utils::Git.git, "commit", formula_file, "-m", "revision"
         File.open(formula_file, "w") { |f| f.write(formula_version) }
         safe_system Utils::Git.git, "commit", formula_file, "-m", "version", "--author=#{secondary_author}"
-        described_class.autosquash!(original_hash, path: ".")
+        described_class.autosquash!(original_hash, path: path)
         expect(Utils::Git.commit_message(path)).to include("foo 2.0")
         expect(Utils::Git.commit_message(path)).to include("Co-authored-by: #{secondary_author}")
       end

--- a/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pr-pull_spec.rb
@@ -38,7 +38,7 @@ describe Homebrew do
     EOS
   end
   let(:formula_file) { path/"Formula/foo.rb" }
-  let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-foo" }
+  let(:path) { (Tap::TAP_DIRECTORY/"homebrew/homebrew-foo").extend(GitRepositoryExtension) }
 
   describe "Homebrew.pr_pull_args" do
     it_behaves_like "parseable arguments"
@@ -59,8 +59,8 @@ describe Homebrew do
         File.open(formula_file, "w") { |f| f.write(formula_version) }
         safe_system Utils::Git.git, "commit", formula_file, "-m", "version", "--author=#{secondary_author}"
         described_class.autosquash!(original_hash, path: path)
-        expect(Utils::Git.commit_message(path)).to include("foo 2.0")
-        expect(Utils::Git.commit_message(path)).to include("Co-authored-by: #{secondary_author}")
+        expect(path.git_commit_message).to include("foo 2.0")
+        expect(path.git_commit_message).to include("Co-authored-by: #{secondary_author}")
       end
     end
   end
@@ -75,7 +75,7 @@ describe Homebrew do
         safe_system Utils::Git.git, "commit", "-m", "foo 1.0 (new formula)"
       end
       described_class.signoff!(path)
-      expect(Utils::Git.commit_message(path)).to include("Signed-off-by:")
+      expect(path.git_commit_message).to include("Signed-off-by:")
     end
   end
 

--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -52,19 +52,6 @@ describe Utils::Git do
   let(:files_hash2) { [@h2[0..6], ["README.md"]] }
   let(:cherry_pick_commit) { @cherry_pick_commit[0..6] }
 
-  describe "#commit_message" do
-    it "returns the commit message" do
-      expect(described_class.commit_message(HOMEBREW_CACHE, file_hash1)).to eq("File added")
-      expect(described_class.commit_message(HOMEBREW_CACHE, file_hash2)).to eq("written to File")
-    end
-
-    it "errors when commit doesn't exist" do
-      expect {
-        described_class.commit_message(HOMEBREW_CACHE, "bad_refspec")
-      }.to raise_error(ErrorDuringExecution, /bad revision/)
-    end
-  end
-
   describe "#cherry_pick!" do
     it "can cherry pick a commit" do
       expect(described_class.cherry_pick!(HOMEBREW_CACHE, cherry_pick_commit)).to be_truthy

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -135,8 +135,8 @@ module Utils
     end
 
     def origin_branch(repo)
-      Utils.popen_read(git, "-C", repo, "symbolic-ref", "-q", "--short",
-                       "refs/remotes/origin/HEAD").chomp.presence
+      odeprecated "Utils::Git.origin_branch(repo)", "Pathname(repo).git_origin_branch"
+      Pathname(repo).extend(GitRepositoryExtension).git_origin_branch
     end
 
     def current_branch(repo)

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -140,7 +140,8 @@ module Utils
     end
 
     def current_branch(repo)
-      Utils.popen_read("git", "-C", repo, "symbolic-ref", "--short", "HEAD").chomp.presence
+      odeprecated "Utils::Git.current_branch(repo)", "Pathname(repo).git_branch"
+      Pathname(repo).extend(GitRepositoryExtension).git_branch
     end
 
     # Special case of `git cherry-pick` that permits non-verbose output and

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -89,8 +89,9 @@ module Utils
     end
 
     def commit_message(repo, commit = nil)
+      odeprecated "Utils::Git.commit_message(repo)", "Pathname(repo).git_commit_message"
       commit ||= "HEAD"
-      Utils.safe_popen_read(git, "-C", repo, "log", "-1", "--pretty=%B", commit, "--", err: :out).strip
+      Pathname(repo).extend(GitRepositoryExtension).git_commit_message(commit)
     end
 
     def ensure_installed!

--- a/Library/Homebrew/utils/git.rb
+++ b/Library/Homebrew/utils/git.rb
@@ -4,6 +4,7 @@
 module Utils
   # Helper functions for querying Git information.
   #
+  # @see GitRepositoryExtension
   # @api private
   module Git
     module_function


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

We have some duplicated functionality in utils/git.rb that should be instead in extend/git_extensions.rb which provides a much more expressive API.

This will also help ensure that our code dealing with upstream remotes is agnostic to the choice of default branch.

In general, I think features in git_extensions.rb should be things that deal directly with git repositories. So anything in utils/git.rb that takes a repository argument should instead be in git_extensions.rb. There's still a few more in there but I wanted to make these trickier migrations first since the origin_branch change is pretty invasive, but all other functions remaining only have a single consumer in the codebase.