### PR TITLE
pypi: downcase main package name

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -231,7 +231,7 @@ module PyPI
     end
 
     # Remove extra packages that may be included in pipgrip output
-    exclude_list = %W[#{main_package.name} argparse pip setuptools wheel wsgiref].map { |p| Package.new p }
+    exclude_list = %W[#{main_package.name.downcase} argparse pip setuptools wheel wsgiref].map { |p| Package.new p }
     found_packages.delete_if { |package| exclude_list.include? package }
 
     new_resource_blocks = ""


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
If the main package name has capital letters, the pipgrip output will not match it and it will be added as a resource block. This occurred during https://github.com/Homebrew/homebrew-core/pull/65881 and can be replicated with
` brew bump-formula-pr rbtools --url https://files.pythonhosted.org/packages/10/1f/bd60d2fd57b626b3ed44daabb6392ee8e1a9d9cb35fc637d9056c4b9d318/RBTools-2.0.tar.gz -w --force`