### PR TITLE
utils/pypi: make package name comparison case-insensitive

### DIFF
--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -22,6 +22,7 @@ describe PyPI do
     let(:package_with_different_version) { described_class.new("snakemake==5.29.0") }
     let(:package_with_extra) { described_class.new("snakemake[foo]") }
     let(:package_with_extra_and_version) { described_class.new("snakemake[foo]==5.28.0") }
+    let(:package_with_different_capitalization) { described_class.new("SNAKEMAKE") }
     let(:package_from_url) { described_class.new(package_url, is_url: true) }
     let(:other_package) { described_class.new("virtualenv==20.2.0") }
 
@@ -145,6 +146,10 @@ describe PyPI do
 
       it "returns true for the same package with different versions" do
         expect(package_with_version.same_package?(package_with_different_version)).to eq true
+      end
+
+      it "returns true for the same package with different capitalization" do
+        expect(package.same_package?(package_with_different_capitalization)).to eq true
       end
     end
 

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -91,7 +91,7 @@ module PyPI
 
     sig { params(other: Package).returns(T::Boolean) }
     def same_package?(other)
-      @name.downcase.tr("_", "-") == other.name.downcase.tr("_", "-")
+      @name.tr("_", "-").casecmp(other.name.tr("_", "-")).zero?
     end
 
     # Compare only names so we can use .include? on a Package array

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -91,7 +91,7 @@ module PyPI
 
     sig { params(other: Package).returns(T::Boolean) }
     def same_package?(other)
-      @name.tr("_", "-") == other.name.tr("_", "-")
+      @name.downcase.tr("_", "-") == other.name.downcase.tr("_", "-")
     end
 
     # Compare only names so we can use .include? on a Package array
@@ -231,7 +231,7 @@ module PyPI
     end
 
     # Remove extra packages that may be included in pipgrip output
-    exclude_list = %W[#{main_package.name.downcase} argparse pip setuptools wheel wsgiref].map { |p| Package.new p }
+    exclude_list = %W[#{main_package.name} argparse pip setuptools wheel wsgiref].map { |p| Package.new p }
     found_packages.delete_if { |package| exclude_list.include? package }
 
     new_resource_blocks = ""


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to https://github.com/Homebrew/brew/pull/9337. All PyPI package name comparisons should be case-insensitive, so I moved the `.downcases` to the `Package#same_package?` method.
