### PR TITLE
Update sponsor count

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Homebrew is a member of the [Software Freedom Conservancy](https://sfconservancy
 
 [![Software Freedom Conservancy](https://sfconservancy.org/img/conservancy_64x64.png)](https://sfconservancy.org)
 
-Homebrew is generously supported by [Randy Reddig](https://github.com/ydnar) and 439 users via [GitHub Sponsors](https://github.com/sponsors/Homebrew).
+Homebrew is generously supported by [Randy Reddig](https://github.com/ydnar) and 439 other users via [GitHub Sponsors](https://github.com/sponsors/Homebrew).

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Homebrew is a member of the [Software Freedom Conservancy](https://sfconservancy
 
 [![Software Freedom Conservancy](https://sfconservancy.org/img/conservancy_64x64.png)](https://sfconservancy.org)
 
-Homebrew is generously supported by [Randy Reddig](https://github.com/ydnar) and 271 users via [GitHub Sponsors](https://github.com/sponsors/Homebrew).
+Homebrew is generously supported by [Randy Reddig](https://github.com/ydnar) and 439 users via [GitHub Sponsors](https://github.com/sponsors/Homebrew).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This only changes `README.md` so do not feel bottom four tasks are applicable/relevant.

I noticed the count of GitHub sponsoring users at the bottom of README had fallen far behind the current user count. Updated to match the current count (440), according to https://github.com/sponsors/Homebrew.
