### PR TITLE
Identify AMD CPUs on Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -26,18 +26,16 @@ module Hardware
         unknown = :"unknown_0x#{cpu_family.to_s(16)}_0x#{cpu_model.to_s(16)}"
         case vendor_id
         when "GenuineIntel"
-          intel_family(cpu_family, cpu_model) || unknown
+          intel_family(cpu_family, cpu_model)
         when "AuthenticAMD"
-          amd_family(cpu_family) || unknown
-        else
-          unknown
-        end
+          amd_family(cpu_family)
+        end || unknown
       end
 
-      def intel_family(family, model)
+      def intel_family(family, cpu_model)
         case family
         when 0x06
-          case model
+          case cpu_model
           when 0x3a, 0x3e
             :ivybridge
           when 0x2a, 0x2d
@@ -66,7 +64,7 @@ module Hardware
             :icelake
           end
         when 0x0f
-          case model
+          case cpu_model
           when 0x06
             :presler
           when 0x03, 0x04

--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -20,12 +20,24 @@ module Hardware
         # See https://software.intel.com/en-us/articles/intel-architecture-and-processor-identification-with-cpuid-model-and-family-numbers
         # and https://github.com/llvm-mirror/llvm/blob/HEAD/lib/Support/Host.cpp
         # and https://en.wikipedia.org/wiki/List_of_Intel_CPU_microarchitectures#Roadmap
+        vendor_id = cpuinfo[/^vendor_id\s*: (.*)/, 1]
         cpu_family = cpuinfo[/^cpu family\s*: ([0-9]+)/, 1].to_i
         cpu_model = cpuinfo[/^model\s*: ([0-9]+)/, 1].to_i
         unknown = :"unknown_0x#{cpu_family.to_s(16)}_0x#{cpu_model.to_s(16)}"
-        case cpu_family
+        case vendor_id
+        when "GenuineIntel"
+          intel_family(cpu_family, cpu_model) || unknown
+        when "AuthenticAMD"
+          amd_family(cpu_family) || unknown
+        else
+          unknown
+        end
+      end
+
+      def intel_family(family, model)
+        case family
         when 0x06
-          case cpu_model
+          case model
           when 0x3a, 0x3e
             :ivybridge
           when 0x2a, 0x2d
@@ -52,20 +64,39 @@ module Hardware
             :cannonlake
           when 0x6a, 0x6c, 0x7d, 0x7e
             :icelake
-          else
-            unknown
           end
         when 0x0f
-          case cpu_model
+          case model
           when 0x06
             :presler
           when 0x03, 0x04
             :prescott
-          else
-            unknown
           end
-        else
-          unknown
+        end
+      end
+
+      def amd_family(family)
+        case family
+        when 0x06
+          :amd_k7
+        when 0x0f
+          :amd_k8
+        when 0x10
+          :amd_k10
+        when 0x11
+          :amd_k8_k10_hybrid
+        when 0x12
+          :amd_k12
+        when 0x14
+          :bobcat
+        when 0x15
+          :bulldozer
+        when 0x16
+          :jaguar
+        when 0x17
+          :zen
+        when 0x19
+          :zen3
         end
       end
 


### PR DESCRIPTION
Basic support for (that is, identify) AMD CPUs. This support requires using `vendor_id` because Intel and AMD CPU families can have identical numbers (e.g., 0x06). I used [this list from Wikipedia](https://en.wikipedia.org/wiki/List_of_AMD_CPU_microarchitectures#Nomenclature) as a basis. Processors based on a single microarchitecture can have (lots of) different names (e.g. processors based on K10 microarchitecture can be called  Sempron, Athlon, Opteron, Phenom, Turion), so I opted out for a simple `amd_kX` naming scheme for most of the architectures.

Two ` || unknown` were added to avoid multiple `else unknown` in the Intel/AMD case blocks.


-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
