### PR TITLE
workflows/tests: update-reset homebrew-cask-versions.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,10 @@ jobs:
         cd "$(brew --repo)"
 
         if [ "$RUNNER_OS" = "macOS" ]; then
-          brew update-reset Library/Taps/homebrew/homebrew-bundle Library/Taps/homebrew/homebrew-cask Library/Taps/homebrew/homebrew-services
+          brew update-reset Library/Taps/homebrew/homebrew-bundle \
+                            Library/Taps/homebrew/homebrew-cask \
+                            Library/Taps/homebrew/homebrew-cask-versions \
+                            Library/Taps/homebrew/homebrew-services
         else
           brew update-reset Library/Taps/homebrew/homebrew-services
         fi


### PR DESCRIPTION
Needed after https://github.com/Homebrew/homebrew-test-bot/pull/526.