### PR TITLE
os/linux.rb: don't show codename when it's n/a

### DIFF
--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -11,13 +11,14 @@ module OS
     sig { returns(String) }
     def os_version
       if which("lsb_release")
-        description = Utils.popen_read("lsb_release -d")
-                           .chomp
-                           .sub("Description:\t", "")
-        codename = Utils.popen_read("lsb_release -c")
-                        .chomp
-                        .sub("Codename:\t", "")
-        "#{description} (#{codename})"
+        lsb_info = Utils.popen_read("lsb_release -a")
+        description = lsb_info[/^Description:\s*(.*)$/, 1]
+        codename = lsb_info[/^Codename:\s*(.*)$/, 1]
+        if codename == "n/a"
+          description
+        else
+          "#{description} (#{codename})"
+        end
       elsif (redhat_release = Pathname.new("/etc/redhat-release")).readable?
         redhat_release.read.chomp
       else

--- a/Library/Homebrew/os/linux.rb
+++ b/Library/Homebrew/os/linux.rb
@@ -14,7 +14,7 @@ module OS
         lsb_info = Utils.popen_read("lsb_release -a")
         description = lsb_info[/^Description:\s*(.*)$/, 1]
         codename = lsb_info[/^Codename:\s*(.*)$/, 1]
-        if codename == "n/a"
+        if codename.blank? || (codename == "n/a")
           description
         else
           "#{description} (#{codename})"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Some Linux distros don't have codenames, so `lsb_release -c` returns `n/a`. `brew config` shows the OS that Homebrew detects and adds OS codename in parentheses. It can be somewhat confusing when codename is equal to `n/a`:

```
OS: SUSE Linux Enterprise Server 11 (x86_64) (n/a)
```

Here I'm changing the output of `os_version` function so that we don't show codename when it's `n/a`. Also, instead of using outputs of `lsb_release -d` and `lsb_release -c` separately, I'm calling `lsb_release` with `-a` flag to get all the information in one step and then parse the output to obtain the required information.