### PR TITLE
cmd/formulae.sh: compatibility with GNU Sed

### DIFF
--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -16,7 +16,7 @@ homebrew-formulae() {
            -name vendor \
           \) \
          -prune -false -o -name '*\.rb' | \
-    sed -E -e 's/\.rb//g' \
+    sed -r -e 's/\.rb//g' \
            -e 's_.*/Taps/(.*)/(home|linux)brew-_\1/_' \
            -e 's|/Formula/|/|' \
   )"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Make `formulae` command compatible with GNU Sed, some versions of which don't have `-E`. Luckily, BSD Sed has `-r` option which is what GNU Sed uses for extended regular expressions:

```
     -r      Same as -E for compatibility with GNU sed.
```