### PR TITLE
Only deprecate "brew list" without arguments

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -103,7 +103,8 @@ module Homebrew
         ls_args << "-t" if args.t?
 
         if !$stdout.tty? && !args.formula?
-          odisabled "`brew list` to only list formulae", "`brew list --formula`"
+          odeprecated "`brew list` to only list formulae", "`brew list --formula`"
+          safe_system "ls", *ls_args, HOMEBREW_CELLAR
         else
           safe_system "ls", *ls_args, HOMEBREW_CELLAR
           list_casks(args: args) unless args.formula?


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?
- [X] Have you successfully run `brew man` locally and committed any changes?

-----

Calling `brew list` without `--formula` or `--cask` was deprecated in #8851 and released in 2.5.7 as part of the effort to deprecate `brew cask` commands (see https://github.com/Homebrew/brew/issues/8668), but it was also disabled in #9209. I think we can leave it as deprecated in 2.6.0 along with the `brew cask` commands and disable it in 2.7.0, but please correct me if I am incorrect here.

I believe this has conflicts with #9316.