### PR TITLE
workflows/triage: skip for BrewTestBot PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -133,7 +133,7 @@ jobs:
               })
 
               const { data: user } = await github.users.getAuthenticated()
-              if (pullRequest.user.login == user) {
+              if (pullRequest.user.login == user.login) {
                 core.warning('Pull request author is a bot.')
                 return
               }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

The triage workflow is supposed to skip PRs opened by @BrewTestBot. However, it does not which eventually causes problems because @BrewTestBot tries (and fails) to approve it's own PR. Seen in https://github.com/Homebrew/brew/pull/9334.

**Note: I haven't tested this PR**

Based on the [GitHub API documentation for getting the authenticated user](https://docs.github.com/en/free-pro-team@latest/rest/reference/users#get-the-authenticated-user), the `user` object that is retrieved contains an object with more metadata rather than just the username. To get the username, we can use `user.login`.

While I haven't tested this PR, I've done something similar in https://github.com/actions/stale/pull/231. There, I also used `github.users.getAuthenticated()` and then accessed the user's login via `.data.login`. Also, lower down in the workflow file, another comparison is made between `review.user.login` and `user.login` to filter only @BrewTestBot reviews. From these, I'm reasonably confident in this change.

CC: @reitermarkus