### PR TITLE
cmd/formulae.sh: columnate output, fix spaces

### DIFF
--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -22,7 +22,10 @@ homebrew-formulae() {
   )"
   local shortnames
   shortnames="$(echo "$formulae" | cut -d "/" -f 3)"
-  echo -e "$formulae \n $shortnames" | \
-    grep -v '^homebrew/core' | \
-    sort -uf
+
+  local column
+  column=$(type -p column)
+  local cmd=cat
+  [[ -t 1 && -n $column ]] && cmd=$column
+  echo -e "$formulae\n$shortnames" | grep -v '^homebrew/core' | sort -uf | $cmd
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

columnate output of `brew formulae` when the `column` command is available and the output is going to a terminal.
Also, remove spaces around `\n` so that formulae names are properly aligned.