### PR TITLE
cmd/formulae.sh: fix spaces

### DIFF
--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -22,7 +22,7 @@ homebrew-formulae() {
   )"
   local shortnames
   shortnames="$(echo "$formulae" | cut -d "/" -f 3)"
-  echo -e "$formulae \n $shortnames" | \
+  echo -e "$formulae\n$shortnames" | \
     grep -v '^homebrew/core' | \
     sort -uf
 }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Fix two issues with spaces in the output of `brew formulae`. The space in front of a formula name is easy to visualize (see below), the other one is more subtle as it appears at the end of one formula name.

Before:
```sh
$ brew formulae | head -n 5
 xctool
a2ps
a52dec
aacgain
aalib
```

After:
```sh
$ brew formulae | head -n 5
a2ps
a52dec
aacgain
aalib
aamath
```