### PR TITLE
cmd/formulae.sh: fix sed flags

### DIFF
--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -3,6 +3,21 @@
 #:  List all locally installable formulae including short names.
 #:
 
+smart-sed() {
+  if [[ -n $(/usr/bin/sed -E 's:1::' <<< 1 2>&1) ]]
+  then
+    for arg in "$@"
+    do
+      if [[ "$arg" =~ ^-.*E ]]
+      then
+        shift
+        set -- "${arg//E/r}" "$@"
+      fi
+    done
+  fi
+  /usr/bin/sed "$@"
+}
+
 homebrew-formulae() {
   local formulae
   formulae="$( \
@@ -16,7 +31,8 @@ homebrew-formulae() {
            -name vendor \
           \) \
          -prune -false -o -name '*\.rb' | \
-    sed -r -e 's/\.rb//g' \
+    smart-sed \
+        -E -e 's/\.rb//g' \
            -e 's_.*/Taps/(.*)/(home|linux)brew-_\1/_' \
            -e 's|/Formula/|/|' \
   )"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Turns out BSD Sed that shipped with macOS 10.11 - 10.15 doesn't support `-r` flag (it does on macOS 11.0.1). I suggest dropping extended regular expressions and switching to the basic ones. This change requires prepending `\` to all special characters.

CC @EricFromCanada.

Fixes https://github.com/Homebrew/brew/issues/9388