### PR TITLE
Test for `brew ruby -e 'puts "testball".f.path'`

### DIFF
--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -16,6 +16,7 @@ describe "brew ruby", :integration_test do
   end
 end
 
+# Doesn't actually need Linux but only running there as integration tests are slow.
 describe "brew ruby -e 'puts \"testball\".f.path'", :integration_test, :needs_linux do
   let!(:target) do
     target_path = setup_test_formula "testball"

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -16,7 +16,7 @@ describe "brew ruby", :integration_test do
   end
 end
 
-describe "brew ruby -e 'puts \"testball\".f.path'", :integration_test do
+describe "brew ruby -e 'puts \"testball\".f.path'", :integration_test, :needs_linux do
   let!(:target) do
     target_path = setup_test_formula "testball"
     { path: target_path }

--- a/Library/Homebrew/test/dev-cmd/ruby_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/ruby_spec.rb
@@ -15,3 +15,17 @@ describe "brew ruby", :integration_test do
       .and not_to_output.to_stderr
   end
 end
+
+describe "brew ruby -e 'puts \"testball\".f.path'", :integration_test do
+  let!(:target) do
+    target_path = setup_test_formula "testball"
+    { path: target_path }
+  end
+
+  it "prints the path of a test formula" do
+    expect { brew "ruby", "-e", "puts 'testball'.f.path" }
+      .to be_a_success
+      .and output(/^#{target[:path]}$/).to_stdout
+      .and not_to_output.to_stderr
+  end
+end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This adds a test for a command like `brew ruby -e 'puts "qt".f.path'` to avoid a regression like #9362, which was fixed very quickly in #9363 (thanks @reitermarkus!).