### PR TITLE
livecheck: add GithubLatest strategy

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -393,7 +393,11 @@ module Homebrew
           preprocess_url(original_url)
         end
 
-        strategies = Strategy.from_url(url, livecheck_regex.present?)
+        strategies = Strategy.from_url(
+          url,
+          livecheck_strategy: livecheck_strategy,
+          regex_provided:     livecheck_regex.present?,
+        )
         strategy = Strategy.from_symbol(livecheck_strategy)
         strategy ||= strategies.first
         strategy_name = @livecheck_strategy_names[strategy]

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -25,6 +25,11 @@ module Homebrew
       lolg.it
     ].freeze
 
+    STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL = [
+      :github_latest,
+      :page_match,
+    ].freeze
+
     UNSTABLE_VERSION_KEYWORDS = %w[
       alpha
       beta
@@ -381,8 +386,8 @@ module Homebrew
           next
         end
 
-        # Do not preprocess the URL when livecheck.strategy is set to :page_match
-        url = if livecheck_strategy == :page_match
+        # Only preprocess the URL when it's appropriate
+        url = if STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL.include?(livecheck_strategy)
           original_url
         else
           preprocess_url(original_url)

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -78,6 +78,7 @@ end
 require_relative "strategy/apache"
 require_relative "strategy/bitbucket"
 require_relative "strategy/git"
+require_relative "strategy/github_latest"
 require_relative "strategy/gnome"
 require_relative "strategy/gnu"
 require_relative "strategy/hackage"

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -1,0 +1,59 @@
+# typed: false
+# frozen_string_literal: true
+
+module Homebrew
+  module Livecheck
+    module Strategy
+      # The {GithubLatest} strategy identifies versions of software at
+      # github.com by checking a repository's latest release page.
+      #
+      # GitHub URLs take a few differemt formats:
+      #
+      # * `https://github.com/example/example/releases/download/1.2.3/example-1.2.3.zip`
+      # * `https://github.com/example/example/archive/v1.2.3.tar.gz`
+      #
+      # This strategy is used when latest releases are marked for software hosted
+      # on GitHub. It is necessary to use `strategy :github_latest` in a `livecheck`
+      # block for Livecheck to use this strategy.
+      #
+      # The default regex identifies versions from `href` attributes containing the
+      # tag name.
+      #
+      # @api public
+      class GithubLatest
+        NICE_NAME = "GitHub Latest"
+
+        # The `Regexp` used to determine if the strategy applies to the URL.
+        URL_MATCH_REGEX = /github.com/i.freeze
+
+        # Whether the strategy can be applied to the provided URL.
+        #
+        # @param url [String] the URL to match against
+        # @return [Boolean]
+        def self.match?(url)
+          URL_MATCH_REGEX.match?(url)
+        end
+
+        # Generates a URL and regex (if one isn't provided) and passes them
+        # to {PageMatch.find_versions} to identify versions in the content.
+        #
+        # @param url [String] the URL of the content to check
+        # @param regex [Regexp] a regex used for matching versions in content
+        # @return [Hash]
+        def self.find_versions(url, regex = nil)
+          %r{github\.com/(?<username>[\da-z\-]+)/(?<repository>[\da-z_\-]+)}i =~ url
+
+          # The page containing the latest release
+          page_url = "https://github.com/#{username}/#{repository}/releases/latest"
+
+          # The default regex applies to most repositories, but may have to be
+          # replaced with a specific regex when the tag names contain the package
+          # name or other characters apart from the version.
+          regex ||= %r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i
+
+          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -7,10 +7,11 @@ module Homebrew
       # The {GithubLatest} strategy identifies versions of software at
       # github.com by checking a repository's latest release page.
       #
-      # GitHub URLs take a few differemt formats:
+      # GitHub URLs take a few different formats:
       #
-      # * `https://github.com/example/example/releases/download/1.2.3/example-1.2.3.zip`
+      # * `https://github.com/example/example/releases/download/1.2.3/example-1.2.3.tar.gz`
       # * `https://github.com/example/example/archive/v1.2.3.tar.gz`
+      # * `https://github.com/downloads/example/example/example-1.2.3.tar.gz`
       #
       # This strategy is used when latest releases are marked for software hosted
       # on GitHub. It is necessary to use `strategy :github_latest` in a `livecheck`
@@ -21,10 +22,12 @@ module Homebrew
       #
       # @api public
       class GithubLatest
-        NICE_NAME = "GitHub Latest"
+        NICE_NAME = "GitHub - Latest"
+
+        PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
-        URL_MATCH_REGEX = /github.com/i.freeze
+        URL_MATCH_REGEX = %r{//github\.com(?:/downloads)?(?:/[^/]+){2}}i.freeze
 
         # Whether the strategy can be applied to the provided URL.
         #
@@ -41,7 +44,7 @@ module Homebrew
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
         def self.find_versions(url, regex = nil)
-          %r{github\.com/(?<username>[\da-z\-]+)/(?<repository>[\da-z_\-]+)}i =~ url
+          %r{github\.com/(?:downloads/)?(?<username>[^/]+)/(?<repository>[^/]+)}i =~ url.sub(/\.git$/i, "")
 
           # The page containing the latest release
           page_url = "https://github.com/#{username}/#{repository}/releases/latest"

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -5,7 +5,7 @@ module Homebrew
   module Livecheck
     module Strategy
       # The {GithubLatest} strategy identifies versions of software at
-      # github.com by checking a repository's latest release page.
+      # github.com by checking a repository's "latest" release page.
       #
       # GitHub URLs take a few different formats:
       #
@@ -13,17 +13,30 @@ module Homebrew
       # * `https://github.com/example/example/archive/v1.2.3.tar.gz`
       # * `https://github.com/downloads/example/example/example-1.2.3.tar.gz`
       #
-      # This strategy is used when latest releases are marked for software hosted
-      # on GitHub. It is necessary to use `strategy :github_latest` in a `livecheck`
-      # block for Livecheck to use this strategy.
+      # A repository's `/releases/latest` URL normally redirects to a release
+      # tag (e.g., `/releases/tag/1.2.3`). When there isn't a "latest" release,
+      # it will redirect to the `/releases` page.
       #
-      # The default regex identifies versions from `href` attributes containing the
-      # tag name.
+      # This strategy should only be used when we know the upstream repository
+      # has a "latest" release and the tagged release is appropriate to use
+      # (e.g., "latest" isn't wrongly pointing to an unstable version, not
+      # picking up the actual latest version, etc.). The strategy can only be
+      # applied by using `strategy :github_latest` in a `livecheck` block.
+      #
+      # The default regex identifies versions like `1.2.3`/`v1.2.3` in `href`
+      # attributes containing the tag URL (e.g.,
+      # `/example/example/releases/tag/v1.2.3`). This is a common tag format
+      # but a modified regex can be provided in a `livecheck` block to override
+      # the default if a repository uses a different format (e.g.,
+      # `example-1.2.3`, `1.2.3d`, `1.2.3-4`, etc.).
       #
       # @api public
       class GithubLatest
         NICE_NAME = "GitHub - Latest"
 
+        # A priority of zero causes livecheck to skip the strategy. We do this
+        # for {GithubLatest} so we can selectively apply the strategy using
+        # `strategy :github_latest` in a `livecheck` block.
         PRIORITY = 0
 
         # The `Regexp` used to determine if the strategy applies to the URL.
@@ -46,12 +59,10 @@ module Homebrew
         def self.find_versions(url, regex = nil)
           %r{github\.com/(?:downloads/)?(?<username>[^/]+)/(?<repository>[^/]+)}i =~ url.sub(/\.git$/i, "")
 
-          # The page containing the latest release
+          # Example URL: `https://github.com/example/example/releases/latest`
           page_url = "https://github.com/#{username}/#{repository}/releases/latest"
 
-          # The default regex applies to most repositories, but may have to be
-          # replaced with a specific regex when the tag names contain the package
-          # name or other characters apart from the version.
+          # The default regex is the same for all URLs using this strategy
           regex ||= %r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i
 
           Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -7,7 +7,7 @@ describe Homebrew::Livecheck::Strategy::GithubLatest do
   subject(:github_latest) { described_class }
 
   let(:github_release_artifact_url) {
-    "https://github.com/example/example/releases/download/1.2.3/example-1.2.3.zip"
+    "https://github.com/example/example/releases/download/1.2.3/example-1.2.3.tar.gz"
   }
   let(:github_tag_archive_url) { "https://github.com/example/example/archive/v1.2.3.tar.gz" }
   let(:github_repository_upload_url) { "https://github.com/downloads/example/example/example-1.2.3.tar.gz" }

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -1,0 +1,26 @@
+# typed: false
+# frozen_string_literal: true
+
+require "livecheck/strategy/github_latest"
+
+describe Homebrew::Livecheck::Strategy::GithubLatest do
+  subject(:github_latest) { described_class }
+
+  let(:github_download_url) { "https://github.com/example/example/releases/download/1.2.3/example-1.2.3.zip" }
+  let(:github_archive_url) { "https://github.com/example/example/archive/v1.2.3.tar.gz" }
+  let(:non_github_url) { "https://brew.sh/test" }
+
+  describe "::match?" do
+    it "returns true if the argument provided is a GitHub Download URL" do
+      expect(github_latest.match?(github_download_url)).to be true
+    end
+
+    it "returns true if the argument provided is a GitHub Archive URL" do
+      expect(github_latest.match?(github_archive_url)).to be true
+    end
+
+    it "returns false if the argument provided is not a GitHub URL" do
+      expect(github_latest.match?(non_github_url)).to be false
+    end
+  end
+end

--- a/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/github_latest_spec.rb
@@ -6,17 +6,24 @@ require "livecheck/strategy/github_latest"
 describe Homebrew::Livecheck::Strategy::GithubLatest do
   subject(:github_latest) { described_class }
 
-  let(:github_download_url) { "https://github.com/example/example/releases/download/1.2.3/example-1.2.3.zip" }
-  let(:github_archive_url) { "https://github.com/example/example/archive/v1.2.3.tar.gz" }
+  let(:github_release_artifact_url) {
+    "https://github.com/example/example/releases/download/1.2.3/example-1.2.3.zip"
+  }
+  let(:github_tag_archive_url) { "https://github.com/example/example/archive/v1.2.3.tar.gz" }
+  let(:github_repository_upload_url) { "https://github.com/downloads/example/example/example-1.2.3.tar.gz" }
   let(:non_github_url) { "https://brew.sh/test" }
 
   describe "::match?" do
-    it "returns true if the argument provided is a GitHub Download URL" do
-      expect(github_latest.match?(github_download_url)).to be true
+    it "returns true if the argument provided is a GitHub release artifact URL" do
+      expect(github_latest.match?(github_release_artifact_url)).to be true
     end
 
-    it "returns true if the argument provided is a GitHub Archive URL" do
-      expect(github_latest.match?(github_archive_url)).to be true
+    it "returns true if the argument provided is a GitHub tag archive URL" do
+      expect(github_latest.match?(github_tag_archive_url)).to be true
+    end
+
+    it "returns true if the argument provided is a GitHub repository upload URL" do
+      expect(github_latest.match?(github_repository_upload_url)).to be true
     end
 
     it "returns false if the argument provided is not a GitHub URL" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds a `GithubLatest` strategy for Livecheck, to check the latest release marked on a project's GitHub repository.

If my `grep`ing was right, there are about 214 Formulae with `livecheck` blocks to check the latest release, so this strategy would reduce replication of standard URL formats and regexes across multiple Formulae.

There aren't too many exceptions to the default regex (eg: when the tag name contains the Formula name, non-version characters or version numbers separated by `-` or `_`) – I was unsure whether to factor in those cases as well.