### PR TITLE
bin/brew: Enforce use of MacOS versions of tools.

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -7,14 +7,18 @@ if ! [[ -d "$PWD" ]]; then
   exit 1
 fi
 
+# Enforce use of MacOS versions of some tools.
+DIRNAME="/usr/bin/dirname"
+READLINK="/usr/bin/readlink"
+
 quiet_cd() {
   cd "$@" >/dev/null || return
 }
 
 symlink_target_directory() {
   local target target_dirname
-  target="$(readlink "$1")"
-  target_dirname="$(dirname "$target")"
+  target="$("$READLINK" "$1")"
+  target_dirname="$("$DIRNAME" "$target")"
   local directory="$2"
   quiet_cd "$directory" && quiet_cd "$target_dirname" && pwd -P
 }


### PR DESCRIPTION
When the user uses the Homebrew installed version of coreutils (i.e. `PATH="/opt/brew/opt/coreutils/libexec/gnubin:$PATH"`), some brew commands fail:
```
╰─➤  brew bundle dump
/opt/brew/bin/brew: line 16: readlink: command not found
/opt/brew/bin/brew: line 17: dirname: command not found
/bin/bash: /opt/brew/Library/Homebrew/brew.sh: No such file or directory
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
