### PR TITLE
formulae: fix sed extended regex flag on macOS.

### DIFF
--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -5,6 +5,14 @@
 
 homebrew-formulae() {
   local formulae
+  local sed_extended_regex_flag
+
+  if [[ -n "$HOMEBREW_MACOS" ]]; then
+    sed_extended_regex_flag="-E"
+  else
+    sed_extended_regex_flag="-r"
+  fi
+
   formulae="$( \
     find "$HOMEBREW_REPOSITORY/Library/Taps" \
          -type d \( \
@@ -16,9 +24,10 @@ homebrew-formulae() {
            -name vendor \
           \) \
          -prune -false -o -name '*\.rb' | \
-    sed -r -e 's/\.rb//g' \
-           -e 's_.*/Taps/(.*)/(home|linux)brew-_\1/_' \
-           -e 's|/Formula/|/|' \
+    sed "$sed_extended_regex_flag" \
+      -e 's/\.rb//g' \
+      -e 's_.*/Taps/(.*)/(home|linux)brew-_\1/_' \
+      -e 's|/Formula/|/|' \
   )"
   local shortnames
   shortnames="$(echo "$formulae" | cut -d "/" -f 3)"


### PR DESCRIPTION
Closes #9367
Fixes #9388