### PR TITLE
Use more reliable method to run homebrew-pypi-poet

### DIFF
--- a/docs/Python-for-Formula-Authors.md
+++ b/docs/Python-for-Formula-Authors.md
@@ -31,20 +31,19 @@ You can use `brew update-python-resources` to help you write resource stanzas. T
 If using `brew update-python-resources` doesn't work, you can use [homebrew-pypi-poet](https://pypi.python.org/pypi/homebrew-pypi-poet) to help you write resource stanzas. To use it, set up a virtualenv and install your package and all its dependencies. Then, `pip install homebrew-pypi-poet` into the same virtualenv. Running `poet some_package` will generate the necessary resource stanzas. You can do this like:
 
 ```sh
-# Install virtualenvwrapper
-brew install python
-python3 -m pip install virtualenvwrapper
-source $(brew --prefix)/bin/virtualenvwrapper.sh
+# Dependency manager that supports virtual environments
+brew reinstall pipenv
 
-# Set up a temporary virtual environment
-mktmpenv
+# Use a temporary directory for the virtual environment
+cd "$(mktemp -d)"
 
 # Install the package of interest as well as homebrew-pypi-poet
-pip3 install some_package homebrew-pypi-poet
-poet some_package
+# This will also set up a temporary virtual environment
+pipenv install some_package homebrew-pypi-poet
+pipenv run poet some_package
 
 # Destroy the temporary virtualenv you just created
-deactivate
+pipenv --rm
 ```
 
 Homebrew provides helper methods for instantiating and populating virtualenvs. You can use them by putting `include Language::Python::Virtualenv` at the top of the `Formula` class definition.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

**Update:** Replacing the old method instead of adding to it.

-----

This replaces the `virtualenvwrapper` method in the documentation with one based on the `pipenv` formula, a dependency manager that doubles as a `virtualenvwrapper` alternative.

A non-brewed installation of virtualenvwrapper is not always reliable.

For me, it fails like this:

```
$ source /Users/claudia/Library/Python/3.9/bin/virtualenvwrapper.sh
/usr/bin/python: No module named virtualenvwrapper
virtualenvwrapper.sh: There was a problem running the initialization hooks.
If Python could not import the module virtualenvwrapper.hook_loader,
check that virtualenvwrapper has been installed for
VIRTUALENVWRAPPER_PYTHON=/usr/bin/python and that PATH is
set properly.
```

~It’s therefore useful to document a working alternative based on the `pipenv` formula, which is actually a dependency manager but doubles as a `virtualenvwrapper` alternative.~

~This also adds documentation on how to use `poet` on software that is not on PyPI.~

Thanks again to @Rylan12 for technical help!