### PR TITLE
Fix ZSH FPATH handling

### DIFF
--- a/Library/Homebrew/caveats.rb
+++ b/Library/Homebrew/caveats.rb
@@ -133,7 +133,8 @@ class Caveats
         zsh #{installed.join(" and ")} have been installed to:
           #{site_functions}
       EOS
-      unless PATH.new(ENV["HOMEBREW_FPATH"]).to_a.include?(site_functions.to_s)
+      zsh = which("zsh") || which("zsh", ENV["HOMEBREW_PATH"])
+      if zsh.present? && Utils.popen_read("'#{zsh}' -ic 'echo $FPATH'").exclude?(site_functions.to_s)
         zsh_caveats << <<~EOS
 
           #{site_functions} is not in your zsh FPATH!

--- a/bin/brew
+++ b/bin/brew
@@ -62,7 +62,7 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
-for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH FPATH
+for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
Don't require it to be exported but shell out to `zsh` instead.

Fixes https://github.com/Homebrew/brew/issues/9387