### PR TITLE
workflows/tests: run vendored gems on macOS 11.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
             os: ubuntu-latest
             core-tap: linuxbrew-core
           - name: vendored gems (macOS)
-            os: macos-latest
+            os: macos-11.0
             core-tap: homebrew-core
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
All existing workflows using this seem to be broken.
