### PR TITLE
Remove style exceptions for ProvidedByMacos and UsesFromMacos

### DIFF
--- a/Library/Homebrew/rubocops/lines.rb
+++ b/Library/Homebrew/rubocops/lines.rb
@@ -443,7 +443,7 @@ module RuboCop
             next if key.nil? || value.nil?
             next unless match = regex_match_group(value, /^(lua|perl|python|ruby)(\d*)/)
 
-            problem "#{match[1]} modules should be vendored rather than use deprecated #{method.source}`"
+            problem "#{match[1]} modules should be vendored rather than use deprecated `#{method.source}`"
           end
 
           find_every_method_call_by_name(body_node, :system).each do |method|

--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -50,6 +50,7 @@ module RuboCop
           texinfo
           unifdef
           unzip
+          whois
           zip
           zlib
         ].freeze
@@ -57,17 +58,9 @@ module RuboCop
         def audit_formula(_node, _class_node, _parent_class_node, body_node)
           find_method_with_args(body_node, :keg_only, :provided_by_macos) do
             return if PROVIDED_BY_MACOS_FORMULAE.include? @formula_name
-            return if tap_style_exception? :provided_by_macos_formulae
 
-            message = if formula_tap == "homebrew-core"
-              "Formulae in homebrew/core that are `keg_only :provided_by_macos` should be "\
-              "added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repo)"
-            else
-              "Formulae that are `keg_only :provided_by_macos` should be added to "\
-              "`style_exceptions/provided_by_macos_formulae.json`"
-            end
-
-            problem message
+            problem "Formulae that are `keg_only :provided_by_macos` should be "\
+                    "added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repo)"
           end
         end
       end
@@ -106,8 +99,6 @@ module RuboCop
             dep_name = string_content(dep)
             next if ALLOWED_USES_FROM_MACOS_DEPS.include? dep_name
             next if ProvidedByMacos::PROVIDED_BY_MACOS_FORMULAE.include? dep_name
-            next if tap_style_exception? :provided_by_macos_formulae, dep_name
-            next if tap_style_exception? :non_keg_only_provided_by_macos_formulae, dep_name
 
             problem "`uses_from_macos` should only be used for macOS dependencies, not #{dep_name}."
           end

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -1339,7 +1339,7 @@ describe RuboCop::Cop::FormulaAudit::Miscellaneous do
           desc "foo"
           url 'https://brew.sh/foo-1.0.tgz'
           depends_on "lpeg" => :lua51
-                                ^^^^^ lua modules should be vendored rather than use deprecated depends_on \"lpeg\" => :lua51`
+                                ^^^^^ lua modules should be vendored rather than use deprecated `depends_on \"lpeg\" => :lua51`
         end
       RUBY
     end
@@ -1469,13 +1469,40 @@ end
 describe RuboCop::Cop::FormulaAuditStrict::MakeCheck do
   subject(:cop) { described_class.new }
 
+  let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-core" }
+
+  before do
+    path.mkpath
+    (path/"style_exceptions").mkpath
+  end
+
+  def setup_style_exceptions
+    (path/"style_exceptions/make_check_allowlist.json").write <<~JSON
+      [ "bar" ]
+    JSON
+  end
+
   it "build-time checks in homebrew/core" do
-    expect_offense(<<~RUBY, "/homebrew-core/")
+    setup_style_exceptions
+
+    expect_offense(<<~RUBY, "#{path}/Formula/foo.rb")
       class Foo < Formula
         desc "foo"
         url 'https://brew.sh/foo-1.0.tgz'
         system "make", "-j1", "test"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
+      end
+    RUBY
+  end
+
+  it "build-time checks in homebrew/core in allowlist" do
+    setup_style_exceptions
+
+    expect_no_offenses(<<~RUBY, "#{path}/Formula/bar.rb")
+      class Bar < Formula
+        desc "bar"
+        url 'https://brew.sh/bar-1.0.tgz'
+        system "make", "-j1", "test"
       end
     RUBY
   end

--- a/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
+++ b/Library/Homebrew/test/rubocops/provided_by_macos_spec.rb
@@ -6,51 +6,22 @@ require "rubocops/uses_from_macos"
 describe RuboCop::Cop::FormulaAudit::ProvidedByMacos do
   subject(:cop) { described_class.new }
 
-  let(:path) { Tap::TAP_DIRECTORY/"homebrew/homebrew-foo" }
-
-  before do
-    path.mkpath
-    (path/"style_exceptions").mkpath
-  end
-
-  def setup_style_exceptions
-    (path/"style_exceptions/provided_by_macos_formulae.json").write <<~JSON
-      [ "foo", "bar" ]
-    JSON
-  end
-
-  it "fails for formulae not in provided_by_macos_formulae list" do
-    setup_style_exceptions
-
-    expect_offense(<<~RUBY, "#{path}/Formula/baz.rb")
+  it "fails for formulae not in PROVIDED_BY_MACOS_FORMULAE list" do
+    expect_offense(<<~RUBY)
       class Baz < Formula
         url "https://brew.sh/baz-1.0.tgz"
         homepage "https://brew.sh"
 
         keg_only :provided_by_macos
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae that are `keg_only :provided_by_macos` should be added to `style_exceptions/provided_by_macos_formulae.json`
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae that are `keg_only :provided_by_macos` should be added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repo)
       end
     RUBY
   end
 
-  it "fails for homebrew-core formulae not in provided_by_macos_formulae list" do
-    expect_offense(<<~RUBY, "/homebrew-core/")
-      class Baz < Formula
-        url "https://brew.sh/baz-1.0.tgz"
-        homepage "https://brew.sh"
-
-        keg_only :provided_by_macos
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae in homebrew/core that are `keg_only :provided_by_macos` should be added to the `PROVIDED_BY_MACOS_FORMULAE` list (in the Homebrew/brew repo)
-      end
-    RUBY
-  end
-
-  it "succeeds for formulae in provided_by_macos_formulae list" do
-    setup_style_exceptions
-
-    expect_no_offenses(<<~RUBY, "#{path}/Formula/foo.rb")
-      class Foo < Formula
-        url "https://brew.sh/foo-1.0.tgz"
+  it "succeeds for formulae in PROVIDED_BY_MACOS_FORMULAE list" do
+    expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/apr.rb")
+      class Apr < Formula
+        url "https://brew.sh/apr-1.0.tgz"
         homepage "https://brew.sh"
 
         keg_only :provided_by_macos
@@ -59,10 +30,8 @@ describe RuboCop::Cop::FormulaAudit::ProvidedByMacos do
   end
 
   it "succeeds for formulae that are keg_only for a different reason" do
-    setup_style_exceptions
-
-    expect_no_offenses(<<~RUBY, "#{path}/Formula/foo.rb")
-      class Baz < Formula
+    expect_no_offenses(<<~RUBY)
+      class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
         homepage "https://brew.sh"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to https://github.com/Homebrew/brew/pull/9397

This PR removes the ability for third-party taps to define their own lists for the `ProvidedByMacos` and `UsesFromMacos` cops. These should be controlled by this repo.

CC: @MikeMcQuaid
