### PR TITLE
utils/pypi: return nil for non-pypi-packages from url

### DIFF
--- a/Library/Homebrew/test/utils/pypi_spec.rb
+++ b/Library/Homebrew/test/utils/pypi_spec.rb
@@ -172,5 +172,13 @@ describe PyPI do
     it "updates url to new version" do
       expect(described_class.update_pypi_url(old_package_url, "5.29.0")).to eq package_url
     end
+
+    it "returns nil for invalid versions" do
+      expect(described_class.update_pypi_url(old_package_url, "0.0.0")).to eq nil
+    end
+
+    it "returns nil for non-pypi urls" do
+      expect(described_class.update_pypi_url("https://brew.sh/foo-1.0.tgz", "1.1")).to eq nil
+    end
   end
 end

--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -110,8 +110,12 @@ module PyPI
   def update_pypi_url(url, version)
     package = Package.new url, is_url: true
 
+    return unless package.valid_pypi_package?
+
     _, url = package.pypi_info(version: version)
     url
+  rescue ArgumentError
+    nil
   end
 
   # Return true if resources were checked (even if no change).


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Closes #9402

Now, `PyPI.update_pypi_url` will return `nil` instead of failing when passed a non-PyPI URL or an invalid version.

Marking as `critical` because this PR fixes a bug.