### PR TITLE
brew: re-exec under native arch if requested

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -40,6 +40,16 @@ fi
 
 HOMEBREW_REPOSITORY="$HOMEBREW_PREFIX"
 
+# If we're running under macOS Rosetta 2, and it was requested by setting
+# HOMEBREW_CHANGE_ARCH_TO_ARM (for example in CI), then we re-exec this
+# same file under the native architecture
+if [[ "$HOMEBREW_CHANGE_ARCH_TO_ARM" = "1" ]] && \
+   [[ "$(uname -s)" = "Darwin" ]] && \
+   [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" = "1" ]] && \
+   [[ "$(sysctl -n sysctl.proc_translated 2>/dev/null)" = "1" ]]; then
+  exec arch -arm64e "$HOMEBREW_BREW_FILE" "$@"
+fi
+
 # Resolve the bin/brew symlink to find Homebrew's repository
 if [[ -L "$HOMEBREW_BREW_FILE" ]]
 then


### PR DESCRIPTION
We are in the process of setting up a CI runner for macOS Big Sur on ARM. However, github's action-runner is not available for macOS ARM, so at least in the short term we will run the action-runner under Rosetta 2. In that use case, we need `brew` to still run natively, even when it is launched from a Rosetta process.

This PR allows this, and will let `brew` re-exec itself natively (under ARM architecture) if:
- requested by setting an environment variable, `HOMEBREW_CHANGE_ARCH_TO_ARM=1`
- we're on darwin, with ARM hardware (`hw.optional.arm64`)
- we were invoked under Rosetta (`sysctl -n sysctl.proc_translated`)

The idea and code is borrowed from @mistydemeo's pull request to do things the other away around https://github.com/Homebrew/brew/pull/9287

----

With this patch, we have:

- native `brew`: 

```
brew@28105 bin % brew config
HOMEBREW_VERSION: 2.6.0-82-gde1afcb-dirty
ORIGIN: https://github.com/Homebrew/brew
HEAD: de1afcbfc58fb3cd5779bd8fbb6b9995700dda4c
Last commit: 4 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 597d19eb9dd526fb1dd27e7105b2926b381a8c5e
Core tap last commit: 2 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /opt/homebrew
HOMEBREW_REPOSITORY: /opt/homebrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_MAKE_JOBS: 8
Homebrew Ruby: 2.6.3 => /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
CPU: octa-core 64-bit arm_vortex_tempest
Clang: 12.0 build 1200
Git: 2.24.3 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 11.0.1-arm64
CLT: 12.2.0.0.1.1604076827
Xcode: 12.2
Rosetta 2: false
```

- once we are under Rosetta 2:

```
brew@28105 bin % arch -x86_64 zsh
brew@28105 bin % brew config
HOMEBREW_VERSION: 2.6.0-82-gde1afcb-dirty
ORIGIN: https://github.com/Homebrew/brew
HEAD: de1afcbfc58fb3cd5779bd8fbb6b9995700dda4c
Last commit: 4 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 597d19eb9dd526fb1dd27e7105b2926b381a8c5e
Core tap last commit: 2 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /opt/homebrew
HOMEBREW_REPOSITORY: /opt/homebrew
HOMEBREW_CELLAR: /opt/homebrew/Cellar
HOMEBREW_CASK_OPTS: []
HOMEBREW_MAKE_JOBS: 4
Homebrew Ruby: 2.6.3 => /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
CPU: quad-core 64-bit arrandale
Clang: 12.0 build 1200
Git: 2.24.3 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 11.0.1-x86_64
CLT: 12.2.0.0.1.1604076827
Xcode: 12.2
Rosetta 2: true
brew@28105 bin % HOMEBREW_CHANGE_ARCH_TO_ARM=1 brew config
HOMEBREW_VERSION: 2.6.0-82-gde1afcb-dirty
ORIGIN: https://github.com/Homebrew/brew
HEAD: de1afcbfc58fb3cd5779bd8fbb6b9995700dda4c
Last commit: 4 hours ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: 597d19eb9dd526fb1dd27e7105b2926b381a8c5e
Core tap last commit: 2 hours ago
Core tap branch: master
HOMEBREW_PREFIX: /opt/homebrew
HOMEBREW_REPOSITORY: /opt/homebrew
HOMEBREW_CASK_OPTS: []
HOMEBREW_MAKE_JOBS: 8
Homebrew Ruby: 2.6.3 => /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
CPU: octa-core 64-bit arm_vortex_tempest
Clang: 12.0 build 1200
Git: 2.24.3 => /Applications/Xcode.app/Contents/Developer/usr/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 11.0.1-arm64
CLT: 12.2.0.0.1.1604076827
Xcode: 12.2
Rosetta 2: false
```