### PR TITLE
untap: add --force switch

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -36,7 +36,10 @@ module Homebrew
 
       if installed_tap_formulae.length.positive? || installed_tap_casks.length.positive?
         if args.force?
-          opoo "Untapping #{tap} even though it contains formulae or casks that are currently installed."
+          opoo <<~EOS
+            Untapping #{tap} even though it contains the following installed formulae or casks:
+            #{(installed_tap_formulae + installed_tap_casks.map(&:token)).join("\n")}
+          EOS
         else
           odie <<~EOS
             Refusing to untap #{tap} because it contains the following installed formulae or casks:

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cli/parser"
+require "formula"
 
 module Homebrew
   extend T::Sig
@@ -16,6 +17,8 @@ module Homebrew
 
         Remove a tapped formula repository.
       EOS
+      switch "-f", "--force",
+             description: "Untap even if formulae or casks from this tap are currently installed."
 
       min_named 1
     end
@@ -27,6 +30,20 @@ module Homebrew
     args.named.each do |tapname|
       tap = Tap.fetch(tapname)
       odie "Untapping #{tap} is not allowed" if tap.core_tap?
+
+      installed_tap_formulae = Formula.installed.select { |formula| formula.tap == tap }
+      installed_tap_casks = Cask::Caskroom.casks.select { |cask| cask.tap == tap }
+
+      if installed_tap_formulae.length.positive? || installed_tap_casks.length.positive?
+        if args.force?
+          opoo "Untapping #{tap} even though it contains formulae or casks that are currently installed."
+        else
+          odie <<~EOS
+            Refusing to untap #{tap} because it contains the following installed formulae or casks:
+            #{(installed_tap_formulae + installed_tap_casks.map(&:token)).join("\n")}
+          EOS
+        end
+      end
 
       tap.uninstall
     end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -572,6 +572,9 @@ See also `pin`.
 
 Remove a tapped formula repository.
 
+* `-f`, `--force`:
+  Untap even if formulae or casks from this tap are currently installed.
+
 ### `update` [*`options`*]
 
 Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1) and perform any necessary migrations.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -770,6 +770,10 @@ Unpin \fIformula\fR, allowing them to be upgraded by \fBbrew upgrade\fR \fIformu
 .SS "\fBuntap\fR \fItap\fR"
 Remove a tapped formula repository\.
 .
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Untap even if formulae or casks from this tap are currently installed\.
+.
 .SS "\fBupdate\fR [\fIoptions\fR]"
 Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1) and perform any necessary migrations\.
 .


### PR DESCRIPTION
Closes: https://github.com/Homebrew/brew/issues/9419

This PR introduces `--force` option to `brew untap`.
If there are formulae installed from specified tap and `--force` is not specified, `brew` will refuse to untap.
If `--force` is specified, then `brew` will print a warining and untap.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----