### PR TITLE
pr-pull: prepare replacement for --workflow flag

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -194,7 +194,7 @@ module Homebrew
         end
       end
 
-      def flag(*names, description: nil, required_for: nil, depends_on: nil)
+      def flag(*names, description: nil, replacement: nil, required_for: nil, depends_on: nil)
         required = if names.any? { |name| name.end_with? "=" }
           OptionParser::REQUIRED_ARGUMENT
         else
@@ -202,8 +202,13 @@ module Homebrew
         end
         names.map! { |name| name.chomp "=" }
         description = option_to_description(*names) if description.nil?
-        process_option(*names, description)
+        if replacement.nil?
+          process_option(*names, description)
+        else
+          description += " (disabled#{"; replaced by #{replacement}" if replacement.present?})"
+        end
         @parser.on(*names, *wrap_option_desc(description), required) do |option_value|
+          odisabled "the `#{names.first}` flag", replacement unless replacement.nil?
           names.each do |name|
             @args[option_to_name(name)] = option_value
           end

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -51,7 +51,9 @@ module Homebrew
              description: "Message to include when autosquashing revision bumps, deletions, and rebuilds."
       flag   "--workflow=",
              description: "Retrieve artifacts from the specified workflow (default: `tests.yml`). "\
-                          "Legacy: use --workflows instead"
+                          "*Legacy:* use `--workflows` instead."
+      # TODO: enable for next major/minor release
+      #      replacement: "`--workflows`"
       flag   "--artifact=",
              description: "Download artifacts with the specified name (default: `bottles`)."
       flag   "--bintray-org=",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1141,7 +1141,7 @@ Requires write access to the repository.
 * `--message`:
   Message to include when autosquashing revision bumps, deletions, and rebuilds.
 * `--workflow`:
-  Retrieve artifacts from the specified workflow (default: `tests.yml`). Legacy: use --workflows instead
+  Retrieve artifacts from the specified workflow (default: `tests.yml`). *Legacy:* use `--workflows` instead.
 * `--artifact`:
   Download artifacts with the specified name (default: `bottles`).
 * `--bintray-org`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1589,7 +1589,7 @@ Message to include when autosquashing revision bumps, deletions, and rebuilds\.
 .
 .TP
 \fB\-\-workflow\fR
-Retrieve artifacts from the specified workflow (default: \fBtests\.yml\fR)\. Legacy: use \-\-workflows instead
+Retrieve artifacts from the specified workflow (default: \fBtests\.yml\fR)\. \fILegacy:\fR use \fB\-\-workflows\fR instead\.
 .
 .TP
 \fB\-\-artifact\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Add support for flag replacement, as was done for switches in #9316. Assuming that the disabling of the old flag should wait for the next minor release.