### PR TITLE
cmd/info.rb: correctly check whether the formula is bottled

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -239,7 +239,7 @@ module Homebrew
 
     if stable = f.stable
       s = "stable #{stable.version}"
-      s += " (bottled)" if stable.bottled?
+      s += " (bottled)" if stable.bottled? && f.pour_bottle?
       specs << s
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

 I find it a little bit upsetting to see `(bottled)` in the output of `info` command and then see the formula build from source because the prefix I use is not the default one for the platform. 

Side note: `HOMEBREW_PREFIX` is currently not accessible through `Homebrew::EnvConfig` so I used `ENV[...]`.