### PR TITLE
utils/shared_audits.rb: check version :all for non-cask formulae in the prerelease allowlist

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -59,7 +59,8 @@ module SharedAudits
     end
 
     if release["prerelease"]
-      return if formula && GITHUB_PRERELEASE_ALLOWLIST[formula.name] == formula.version
+      return if formula && (GITHUB_PRERELEASE_ALLOWLIST[formula.name] == formula.version ||
+                            GITHUB_PRERELEASE_ALLOWLIST[formula.name] == :all)
 
       return "#{tag} is a GitHub pre-release."
     end

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -36,6 +36,7 @@ module SharedAudits
     "extraterm"        => :all,
     "freetube"         => :all,
     "gitless"          => "0.8.8",
+    "gron"             => :all,
     "haptickey"        => :all,
     "home-assistant"   => :all,
     "lidarr"           => :all,

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -66,6 +66,11 @@ module SharedAudits
       return "#{tag} is a GitHub pre-release."
     end
 
+    if !release["prerelease"] && ((formula && GITHUB_PRERELEASE_ALLOWLIST.key?(formula.name)) ||
+        (cask && GITHUB_PRERELEASE_ALLOWLIST[cask.token]))
+      return "#{tag} is not a GitHub pre-release but is expected to be."
+    end
+
     return "#{tag} is a GitHub draft." if release["draft"]
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

All `gron` releases are pre-releases: https://github.com/tomnomnom/gron/releases

While adding this formula to the prerelease allowlist, I spotted that `:all` version was only used for casks.