### PR TITLE
[Library/Homebrew/cli/named_args.rb] `to_formulae_to_casks()`:  Reasssociate its `rescue` Block with the Correct Enclosing Scope

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -48,8 +48,8 @@ module Homebrew
         @to_formulae_and_casks ||= {}
         @to_formulae_and_casks[only] ||= downcased_unique_named.flat_map do |name|
           load_formula_or_cask(name, only: only, method: method)
-      rescue NoSuchKegError, FormulaUnavailableError, Cask::CaskUnavailableError
-        ignore_unavailable ? [] : raise
+        rescue NoSuchKegError, FormulaUnavailableError, Cask::CaskUnavailableError
+          ignore_unavailable ? [] : raise
         end.uniq.freeze
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?  
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?  
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?  (Yes, see my commit message.)  
- [ ] Have you written new tests for your changes?  [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).  
- [x] Have you successfully run `brew style` with your changes locally?  
- [ ] Have you successfully run `brew tests` with your changes locally?  (No unexpected failures or new failures related to my changes other than some test execution timeouts due to running on older hardware.)  
- [x] Have you successfully run `brew man` locally and committed any changes?  

-----

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;I noticed a small issue with PR #9398; this PR fixes it.  

CC @reitermarkus.  (Let me know if you actually meant to make the change I revert here.)  