### PR TITLE
update.sh: add instruction to delete shallow file

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -396,7 +396,7 @@ EOS
   then
     odie <<EOS
 homebrew-core is a shallow clone. To \`brew update\` first run:
-  git -C "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" fetch --unshallow
+  git -C "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" fetch --unshallow && rm $HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core/.git/shallow
 EOS
   fi
 
@@ -406,7 +406,7 @@ EOS
   then
     odie <<EOS
 homebrew-cask is a shallow clone. To \`brew update\` first run:
-  git -C "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-cask" fetch --unshallow
+  git -C "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-cask" fetch --unshallow && rm $HOMEBREW_LIBRARY/Taps/homebrew/homebrew-cask/.git/shallow
 EOS
   fi
 


### PR DESCRIPTION
I was still getting the following error even after running `git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask" fetch --unshallow` and saw that the `.git/shallow` file was not removed after the git command.
```
Error: homebrew-cask is a shallow clone. To `brew update` first run:
  git -C "/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask" fetch --unshallow
```

This change adds the instruction to delete the shallow file after the repo is unshallowed.

Related PR: https://github.com/Homebrew/brew/pull/9383

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
