### PR TITLE
uses: add --formula and --casks flags

### DIFF
--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -82,21 +82,17 @@ module Homebrew
 
   def intersection_of_dependents(use_runtime_dependents, used_formulae, args:)
     recursive = args.recursive?
-    only = if args.formula?
-      :formula
-    elsif args.cask?
-      :cask
-    end
+    show_formulae_and_casks = !args.formula? && !args.cask?
     includes, ignores = args_includes_ignores(args)
 
     deps = []
     if use_runtime_dependents
-      unless only == :cask
+      if show_formulae_and_casks || args.formula?
         deps += used_formulae.map(&:runtime_installed_formula_dependents)
                              .reduce(&:&)
                              .select(&:any_version_installed?)
       end
-      unless only == :formula
+      if show_formulae_and_casks || args.cask?
         deps += select_used_dependents(
           dependents(Cask::Caskroom.casks(config: Cask::Config.from_args(args))),
           used_formulae, recursive, includes, ignores
@@ -105,10 +101,10 @@ module Homebrew
 
       deps
     else
-      unless only == :cask
+      if show_formulae_and_casks || args.formula?
         deps += args.installed? ? Formula.installed : Formula.to_a
       end
-      unless only == :formula
+      if show_formulae_and_casks || args.cask?
         deps += args.installed? ? Cask::Caskroom.casks(config: Cask::Config.from_args(args)) : Cask::Cask.to_a
       end
 

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -23,15 +23,15 @@ module Homebrew
       usage_banner <<~EOS
         `uses` [<options>] <formula>
 
-        Show formulae that specify <formula> as a dependency (i.e. show dependents
+        Show formulae and casks that specify <formula> as a dependency (i.e. show dependents
         of <formula>). When given multiple formula arguments, show the intersection
-        of formulae that use <formula>. By default, `uses` shows all formulae that
+        of formulae that use <formula>. By default, `uses` shows all formulae and casks that
         specify <formula> as a required or recommended dependency for their stable builds.
       EOS
       switch "--recursive",
              description: "Resolve more than one level of dependencies."
       switch "--installed",
-             description: "Only list formulae that are currently installed."
+             description: "Only list formulae and casks that are currently installed."
       switch "--include-build",
              description: "Include all formulae that specify <formula> as `:build` type dependency."
       switch "--include-test",
@@ -40,7 +40,12 @@ module Homebrew
              description: "Include all formulae that specify <formula> as `:optional` type dependency."
       switch "--skip-recommended",
              description: "Skip all formulae that specify <formula> as `:recommended` type dependency."
+      switch "--formula", "--formulae",
+             description: "Include only formulae."
+      switch "--cask", "--casks",
+             description: "Include only casks."
 
+      conflicts "--formula", "--cask"
       min_named :formula
     end
   end
@@ -77,24 +82,35 @@ module Homebrew
 
   def intersection_of_dependents(use_runtime_dependents, used_formulae, args:)
     recursive = args.recursive?
+    include_formulae, include_casks = if !args.formula? && !args.cask?
+      [true, true]
+    else
+      [args.formula?, args.cask?]
+    end
     includes, ignores = args_includes_ignores(args)
 
+    deps = []
     if use_runtime_dependents
-      used_formulae.map(&:runtime_installed_formula_dependents)
-                   .reduce(&:&)
-                   .select(&:any_version_installed?) +
-        select_used_dependents(
+      if include_formulae
+        deps += used_formulae.map(&:runtime_installed_formula_dependents)
+                             .reduce(&:&)
+                             .select(&:any_version_installed?)
+      end
+      if include_casks
+        deps += select_used_dependents(
           dependents(Cask::Caskroom.casks(config: Cask::Config.from_args(args))),
           used_formulae, recursive, includes, ignores
         )
-    else
-      deps = if args.installed?
-        dependents(Formula.installed + Cask::Caskroom.casks(config: Cask::Config.from_args(args)))
-      else
-        dependents(Formula.to_a + Cask::Cask.to_a)
       end
 
-      select_used_dependents(deps, used_formulae, recursive, includes, ignores)
+      deps
+    else
+      deps += args.installed? ? Formula.installed : Formula.to_a if include_formulae
+      if include_casks
+        deps += args.installed? ? Cask::Caskroom.casks(config: Cask::Config.from_args(args)) : Cask::Cask.to_a
+      end
+
+      select_used_dependents(dependents(deps), used_formulae, recursive, includes, ignores)
     end
   end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -637,15 +637,15 @@ upgraded formulae or, every 30 days, for all formulae.
 
 ### `uses` [*`options`*] *`formula`*
 
-Show formulae that specify *`formula`* as a dependency (i.e. show dependents
+Show formulae and casks that specify *`formula`* as a dependency (i.e. show dependents
 of *`formula`*). When given multiple formula arguments, show the intersection
-of formulae that use *`formula`*. By default, `uses` shows all formulae that
+of formulae that use *`formula`*. By default, `uses` shows all formulae and casks that
 specify *`formula`* as a required or recommended dependency for their stable builds.
 
 * `--recursive`:
   Resolve more than one level of dependencies.
 * `--installed`:
-  Only list formulae that are currently installed.
+  Only list formulae and casks that are currently installed.
 * `--include-build`:
   Include all formulae that specify *`formula`* as `:build` type dependency.
 * `--include-test`:
@@ -654,6 +654,10 @@ specify *`formula`* as a required or recommended dependency for their stable bui
   Include all formulae that specify *`formula`* as `:optional` type dependency.
 * `--skip-recommended`:
   Skip all formulae that specify *`formula`* as `:recommended` type dependency.
+* `--formula`:
+  Include only formulae.
+* `--cask`:
+  Include only casks.
 
 ### `--cache` [*`options`*] [*`formula`*|*`cask`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -870,7 +870,7 @@ Skip installing cask dependencies\.
 Also include casks with \fBauto_updates true\fR or \fBversion :latest\fR\.
 .
 .SS "\fBuses\fR [\fIoptions\fR] \fIformula\fR"
-Show formulae that specify \fIformula\fR as a dependency (i\.e\. show dependents of \fIformula\fR)\. When given multiple formula arguments, show the intersection of formulae that use \fIformula\fR\. By default, \fBuses\fR shows all formulae that specify \fIformula\fR as a required or recommended dependency for their stable builds\.
+Show formulae and casks that specify \fIformula\fR as a dependency (i\.e\. show dependents of \fIformula\fR)\. When given multiple formula arguments, show the intersection of formulae that use \fIformula\fR\. By default, \fBuses\fR shows all formulae and casks that specify \fIformula\fR as a required or recommended dependency for their stable builds\.
 .
 .TP
 \fB\-\-recursive\fR
@@ -878,7 +878,7 @@ Resolve more than one level of dependencies\.
 .
 .TP
 \fB\-\-installed\fR
-Only list formulae that are currently installed\.
+Only list formulae and casks that are currently installed\.
 .
 .TP
 \fB\-\-include\-build\fR
@@ -895,6 +895,14 @@ Include all formulae that specify \fIformula\fR as \fB:optional\fR type dependen
 .TP
 \fB\-\-skip\-recommended\fR
 Skip all formulae that specify \fIformula\fR as \fB:recommended\fR type dependency\.
+.
+.TP
+\fB\-\-formula\fR
+Include only formulae\.
+.
+.TP
+\fB\-\-cask\fR
+Include only casks\.
 .
 .SS "\fB\-\-cache\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR]"
 Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds `--formula` and `--cask` flags to `brew uses` to filter results by only formulae or casks.

I'm marking this as `critical` because it is causing issues with our CI in homebrew/core for a few formulae (see https://github.com/Homebrew/homebrew-core/pull/66268)

CC: @fxcoudert