### PR TITLE
brew.sh: don't allow system Ruby on Catalina.

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -341,7 +341,9 @@ then
 
   # Set a variable when the macOS system Ruby is new enough to avoid spawning
   # a Ruby process unnecessarily.
-  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101500" ]]
+  # On Catalina the system Ruby is technically new enough but don't allow it:
+  # https://github.com/Homebrew/brew/issues/9410
+  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101600" ]]
   then
     unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
   else


### PR DESCRIPTION
It's (far) too broken for our purposes.

Fixes https://github.com/Homebrew/brew/issues/9410
