### PR TITLE
Fix `:arm64_big_sur` bottle ordering.

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -11,6 +11,14 @@ module Hardware
     INTEL_64BIT_ARCHS = [:x86_64].freeze
     PPC_32BIT_ARCHS   = [:ppc, :ppc32, :ppc7400, :ppc7450, :ppc970].freeze
     PPC_64BIT_ARCHS   = [:ppc64, :ppc64le, :ppc970].freeze
+    ARM_64BIT_ARCHS   = [:arm64].freeze
+    ALL_ARCHS = [
+      *INTEL_32BIT_ARCHS,
+      *INTEL_64BIT_ARCHS,
+      *PPC_32BIT_ARCHS,
+      *PPC_64BIT_ARCHS,
+      *ARM_64BIT_ARCHS,
+    ].freeze
 
     class << self
       extend T::Sig

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -25,7 +25,11 @@ module OS
 
       sig { params(sym: Symbol).returns(T.attached_class) }
       def self.from_symbol(sym)
-        str = SYMBOLS.fetch(sym) { raise MacOSVersionError, sym }
+        @all_archs_regex ||= /^#{Regexp.union(Hardware::CPU::ALL_ARCHS.map(&:to_s))}_/
+        sym_without_arch = sym.to_s
+                              .sub(@all_archs_regex, "")
+                              .to_sym
+        str = SYMBOLS.fetch(sym_without_arch) { raise MacOSVersionError, sym }
         new(str)
       end
 


### PR DESCRIPTION
This wasn't being parsed correctly so was being put below the Linux bottle which is less readable, less intuitive and will cause a bunch of merge conflicts.
