### PR TITLE
diagnostic: don't complain about creatable directories that don't exist.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -341,6 +341,8 @@ module Homebrew
       alias generic_check_tmpdir_sticky_bit check_tmpdir_sticky_bit
 
       def check_exist_directories
+        return if HOMEBREW_PREFIX.writable_real?
+
         not_exist_dirs = Keg::MUST_EXIST_DIRECTORIES.reject(&:exist?)
         return if not_exist_dirs.empty?
 


### PR DESCRIPTION
If you can write to `HOMEBREW_PREFIX` (which isn't the case for `/usr/local` on newer macOSs) then don't complain about these directories not existing.
