### PR TITLE
software_spec: make bottle sorting stable.

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -392,10 +392,9 @@ class BottleSpecification
 
   def checksums
     tags = collector.keys.sort_by do |tag|
-      # Sort non-MacOS tags below MacOS tags.
-
-      OS::Mac::Version.from_symbol tag
+      "#{OS::Mac::Version.from_symbol(tag)}_#{tag}"
     rescue MacOSVersionError
+      # Sort non-MacOS tags below MacOS tags.
       "0.#{tag}"
     end
     checksums = {}


### PR DESCRIPTION
As `:arm64_big_sur` and `:big_sur` equated to the same version: their sorting was not consistent. Instead, suffix the tag and use that for sorting so `:big_sur` is always before `:arm64_big_sur`.
