### PR TITLE
RbConfig: fix broken MacOS SDK paths 

### DIFF
--- a/Library/Homebrew/extend/rbconfig_extension.rb
+++ b/Library/Homebrew/extend/rbconfig_extension.rb
@@ -1,0 +1,17 @@
+# typed: false
+# frozen_string_literal: true
+
+macos_version = ENV["HOMEBREW_MACOS_VERSION"][0..4]
+macos_sdk = "MacOSX#{macos_version}.sdk"
+
+# Ruby hardcodes what might end up being an incorrect SDK path in some of the
+# variables that get used in mkmf.rb.
+# This patches them up to use the correct SDK.
+RbConfig::CONFIG.each do |k, v|
+  next unless v.include?("MacOSX.sdk")
+
+  new_value = v.gsub("MacOSX.sdk", macos_sdk)
+  next unless File.exist?(new_value)
+
+  RbConfig::CONFIG[k] = new_value
+end

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -109,6 +109,15 @@ module Homebrew
     install_bundler!
 
     ENV["BUNDLE_GEMFILE"] = File.join(ENV.fetch("HOMEBREW_LIBRARY"), "Homebrew", "Gemfile")
+
+    # We can't use OS.mac? because not enough has
+    # been required yet this early in the boot process
+    if ENV["HOMEBREW_SYSTEM"] == "Macintosh"
+      # This patches up some paths used by mkmf.rb
+      extend_path = File.join(ENV.fetch("HOMEBREW_LIBRARY"), "Homebrew", "extend")
+      ENV["RUBYOPT"] = "-r#{extend_path}/rbconfig_extension"
+    end
+
     @bundle_installed ||= begin
       bundle = File.join(find_in_path("bundle"), "bundle")
       bundle_check_output = `#{bundle} check 2>&1`
@@ -125,6 +134,8 @@ module Homebrew
         true
       end
     end
+
+    ENV["RUBYOPT"] = ""
 
     setup_gem_environment!
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is ugly, but it works. 😅 

This is an alternate fix for #9410. #9442 attempted to fix this by changing the macOS versions whose Rubies we consider too old, but that didn't work: `ruby.sh` has a check for the Ruby version of the first `ruby` in the `PATH` in the case that `HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH` is unset, and that accepted the system Ruby.

That leaves us more or less two choices: updating the `brew.sh`/`ruby.sh` logic to reject the system Ruby regardless of Ruby version, or ensure that the system Ruby can install gems. This PR does the latter.

This inserts a shim to monkey-patch values in `RbConfig` before we run Bundler. The SDK paths that this alters are the same ones that I identified in #9410 as being faulty because they point to header paths that don't exist. Since this is only called on macOS, and it verifies that the new target paths exist before making the alterations, it should be basically pretty safe. I've tested this and it allows gems to be installed on macOS 10.15's system Ruby.

I'll also look at creating a smaller PR that introduces a harder force for the vendored Ruby on 10.15.