### PR TITLE
workflows:  Prevent Running Additional CI Jobs on User Forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
       - published
 jobs:
   ubuntu:
+    if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
 
   tap-syntax:
     name: tap syntax (Linux)
+    if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,6 +177,7 @@ jobs:
 
   test-everything:
     name: test everything (macOS)
+    if: startsWith(github.repository, 'Homebrew/')
     runs-on: macos-11.0
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?  
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?  
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?  
- [ ] Have you written new tests for your changes?  [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).  
- [x] Have you successfully run `brew style` with your changes locally?  
- [ ] Have you successfully run `brew tests` with your changes locally?  (No unexpected failures or new ones introduced by my changes.)  
- [x] Have you successfully run `brew man` locally and committed any changes?  

-----

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Similarly to Homebrew/homebrew-cask#89714 and Homebrew/homebrew-core#65917, I also caught:  

 - The 'ubuntu' job in '`.github/workflows/docker.yml'`.'  
 - These jobs in '`…/tests.yml`:'  
    - 'tap syntax (Linux)'
    - 'test everything (macOS)'

running on my personal Homebrew fork.  (I likely won't catch any more of these, however; I found that the relevant toggles in repository settings now work in my browser soon afterward.)  