### PR TITLE
MacOS::Version architecture handling

### DIFF
--- a/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
+++ b/Library/Homebrew/dev-cmd/dispatch-build-bottle.rb
@@ -36,13 +36,8 @@ module Homebrew
     args = dispatch_build_bottle_args.parse
 
     # Fixup version for ARM/Apple Silicon
-    arm_regex = Regexp.union(/^arm64_/, /-arm$/)
-    arm_label = if arm_regex.match?(args.macos)
-      args.macos&.gsub!(arm_regex, "")
-      true
-    else
-      false
-    end
+    # TODO: fix label name to be 11-arm64 instead and remove this.
+    args.macos&.gsub!(/^11-arm$/, "11-arm64")
 
     macos = args.macos&.yield_self do |s|
       MacOS::Version.from_symbol(s.to_sym)
@@ -53,7 +48,8 @@ module Homebrew
     raise UsageError, "Must specify --macos option" if macos.blank?
 
     # Fixup label for ARM/Apple Silicon
-    macos_label = if arm_label
+    macos_label = if macos.arch == :arm64
+      # TODO: fix label name to be 11-arm64 instead.
       "#{macos}-arm"
     else
       macos.to_s

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -42,7 +42,10 @@ module Utils
         return if tag_version.blank?
 
         keys.find do |key|
-          MacOS::Version.from_symbol(key) <= tag_version
+          key_version = MacOS::Version.from_symbol(key)
+          next if key_version.arch != tag_version.arch
+
+          key_version <= tag_version
         rescue MacOSVersionError
           false
         end

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -11,6 +11,14 @@ module Hardware
     INTEL_64BIT_ARCHS = [:x86_64].freeze
     PPC_32BIT_ARCHS   = [:ppc, :ppc32, :ppc7400, :ppc7450, :ppc970].freeze
     PPC_64BIT_ARCHS   = [:ppc64, :ppc64le, :ppc970].freeze
+    ARM_64BIT_ARCHS   = [:arm64].freeze
+    ALL_ARCHS = [
+      *INTEL_32BIT_ARCHS,
+      *INTEL_64BIT_ARCHS,
+      *PPC_32BIT_ARCHS,
+      *PPC_64BIT_ARCHS,
+      *ARM_64BIT_ARCHS,
+    ].freeze
 
     class << self
       extend T::Sig

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -25,7 +25,11 @@ module OS
 
       sig { params(sym: Symbol).returns(T.attached_class) }
       def self.from_symbol(sym)
-        str = SYMBOLS.fetch(sym) { raise MacOSVersionError, sym }
+        @all_archs_regex ||= /^#{Regexp.union(Hardware::CPU::ALL_ARCHS.map(&:to_s))}_/
+        sym_without_arch = sym.to_s
+                              .sub(@all_archs_regex, "")
+                              .to_sym
+        str = SYMBOLS.fetch(sym_without_arch) { raise MacOSVersionError, sym }
         new(str)
       end
 

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -13,6 +13,8 @@ module OS
     class Version < ::Version
       extend T::Sig
 
+      attr_reader :arch
+
       SYMBOLS = {
         big_sur:     "11",
         catalina:    "10.15",
@@ -25,20 +27,37 @@ module OS
 
       sig { params(sym: Symbol).returns(T.attached_class) }
       def self.from_symbol(sym)
-        @all_archs_regex ||= /^#{Regexp.union(Hardware::CPU::ALL_ARCHS.map(&:to_s))}_/
-        sym_without_arch = sym.to_s
-                              .sub(@all_archs_regex, "")
-                              .to_sym
-        str = SYMBOLS.fetch(sym_without_arch) { raise MacOSVersionError, sym }
-        new(str)
+        version, arch = version_arch(sym)
+        version ||= sym
+        str = SYMBOLS.fetch(version.to_sym) { raise MacOSVersionError, sym }
+        new(str, arch: arch)
       end
 
-      sig { params(value: T.nilable(String)).void }
-      def initialize(value)
-        raise MacOSVersionError, value unless /\A1\d+(?:\.\d+){0,2}\Z/.match?(value)
+      sig { params(value: T.any(String, Symbol)).returns(T::Array[String]) }
+      def self.version_arch(value)
+        @all_archs_regex ||= begin
+          all_archs = Hardware::CPU::ALL_ARCHS.map(&:to_s)
+          /^((#{Regexp.union(all_archs)})_)?([\w.]+)(-(#{Regexp.union(all_archs)}))?$/
+        end
+        match = @all_archs_regex.match(value)
+        return [] unless match
 
-        super(value)
+        version = match[3]
+        arch = match[2] || match[5]
+        [version, arch]
+      end
 
+      sig { params(value: T.nilable(String), arch: T.nilable(String)).void }
+      def initialize(value, arch: nil)
+        version, arch = Version.version_arch(value) if value.present? && arch.nil?
+        version ||= value
+        arch    ||= "intel"
+
+        raise MacOSVersionError, version unless /\A1\d+(?:\.\d+){0,2}\Z/.match?(version)
+
+        super(version)
+
+        @arch = arch.to_sym
         @comparison_cache = {}
       end
 

--- a/Library/Homebrew/test/os/mac/version_spec.rb
+++ b/Library/Homebrew/test/os/mac/version_spec.rb
@@ -62,12 +62,44 @@ describe OS::Mac::Version do
         described_class.new("1.2")
       }.to raise_error(MacOSVersionError, 'unknown or unsupported macOS version: "1.2"')
     end
+
+    it "creates a new version from a valid macOS version" do
+      string_version = described_class.new("11")
+      expect(string_version).to eq(:big_sur)
+      expect(string_version.arch).to eq(:intel)
+    end
+
+    it "creates a new version from a valid macOS version with architecture" do
+      string_version = described_class.new("11-arm64")
+      expect(string_version).to eq(:big_sur)
+      expect(string_version.arch).to eq(:arm64)
+    end
+
+    it "creates a new version from a valid macOS version and architecture" do
+      string_version = described_class.new("11", arch: "arm64")
+      expect(string_version).to eq(:big_sur)
+      expect(string_version.arch).to eq(:arm64)
+    end
   end
 
-  specify "#from_symbol" do
-    expect(described_class.from_symbol(:mojave)).to eq(version)
-    expect { described_class.from_symbol(:foo) }
-      .to raise_error(MacOSVersionError, "unknown or unsupported macOS version: :foo")
+  describe "#from_symbol" do
+    it "raises an error if the symbol is not a valid macOS version" do
+      expect {
+        described_class.from_symbol(:foo)
+      }.to raise_error(MacOSVersionError, "unknown or unsupported macOS version: :foo")
+    end
+
+    it "creates a new version from a valid macOS version" do
+      symbol_version = described_class.from_symbol(:mojave)
+      expect(symbol_version).to eq(version)
+      expect(symbol_version.arch).to eq(:intel)
+    end
+
+    it "creates a new version from a valid macOS version with architecture" do
+      symbol_version = described_class.from_symbol(:arm64_big_sur)
+      expect(symbol_version).to eq(:big_sur)
+      expect(symbol_version.arch).to eq(:arm64)
+    end
   end
 
   specify "#pretty_name" do


### PR DESCRIPTION
Reverts #9461 and provides an alternate fix to https://github.com/Homebrew/brew/issues/9449.

This makes `OS::Mac::Version` architecture aware and uses this logic to decide on which bottle to pour and which label to use for `brew dispatch-build-bottle`.
