### PR TITLE
os/mac/pkgconfig: add pc files for Big Sur 11.1

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/11.1/expat.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/expat.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: expat
+Version: 2.2.8
+Description: expat XML parser
+URL: http://www.libexpat.org
+Libs: -L${libdir} -lexpat
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/libcurl.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/libcurl.pc
@@ -1,0 +1,40 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) 2001 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.haxx.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+###########################################################################
+
+# This should most probably benefit from getting a "Requires:" field added
+# dynamically by configure.
+#
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+supported_protocols="DICT FILE FTP FTPS GOPHER HTTP HTTPS IMAP IMAPS LDAP LDAPS POP3 POP3S RTSP SMB SMBS SMTP SMTPS TELNET TFTP"
+supported_features="AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO MultiSSL NTLM NTLM_WB SSL libz HTTP2 UnixSockets HTTPS-proxy"
+
+Name: libcurl
+URL: https://curl.haxx.se/
+Description: Library to transfer files with ftp, http, etc.
+Version: 7.64.1
+Libs: -L${libdir} -lcurl
+Libs.private: -lldap -lz
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/libedit.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/libedit.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libedit
+Description: command line editor library provides generic line editing, history, and tokenization functions.
+Version: 3.0
+Requires:
+Libs: -L${libdir} -ledit
+Cflags: -I${includedir}/editline

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/libexslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/libexslt.pc
@@ -1,0 +1,13 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+
+Name: libexslt
+Version: 0.8.17
+Description: EXSLT Extension library
+Requires: libxml-2.0
+Libs: -L${libdir} -lexslt -lxslt  -lxml2 -lz -lpthread -licucore -lm
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/libffi.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+toolexeclibdir=${libdir}
+includedir=${prefix}/include/ffi
+
+Name: libffi
+Description: Library supporting Foreign Function Interfaces
+Version: 3.3-rc0
+Libs: -L${toolexeclibdir} -lffi
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/libxml-2.0.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/libxml-2.0.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+modules=1
+
+Name: libXML
+Version: 2.9.4
+Description: libXML library version2.
+Requires:
+Libs: -L${libdir} -lxml2
+Libs.private: -lz -lpthread -licucore -lm
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/libxslt.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/libxslt.pc
@@ -1,0 +1,13 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+
+Name: libxslt
+Version: 1.1.29
+Description: XSLT library version 2.
+Requires: libxml-2.0
+Libs: -L${libdir} -lxslt  -lxml2 -lz -lpthread -licucore -lm
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/ncurses.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/ncurses.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+major_version=5
+version=5.7.20081102
+
+Name: ncurses
+Description: ncurses 5.7 library
+Version: ${version}
+Requires:
+Libs: -L${libdir} -lncurses
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/ncursesw.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/ncursesw.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+major_version=5
+version=5.7.20081102
+
+Name: ncursesw
+Description: ncurses 5.7 library
+Version: ${version}
+Requires:
+Libs: -L${libdir} -lncurses
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/sqlite3.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/sqlite3.pc
@@ -1,0 +1,12 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: SQLite
+Description: SQL database engine
+Version: 3.32.3
+Libs: -L${libdir} -lsqlite3
+Libs.private:
+Cflags:

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/uuid.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/uuid.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include/uuid
+
+Name: uuid
+Description: Universally unique id library
+Version: 1.0
+
+Requires:
+Libs:
+Cflags: -I${includedir}

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/zlib.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/zlib.pc
@@ -1,0 +1,14 @@
+homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
+prefix=${homebrew_sdkroot}/usr
+exec_prefix=/usr
+libdir=${exec_prefix}/lib
+sharedlibdir=${libdir}
+includedir=${prefix}/include
+
+Name: zlib
+Description: zlib compression library
+Version: 1.2.11
+
+Requires:
+Libs: -L${libdir} -L${sharedlibdir} -lz
+Cflags:


### PR DESCRIPTION
Big Sur 11.1 beta annoyingly introduced a new SDK path - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk

This broke various builds which depend on the various macOS provided pkgconfig files.

This pull request adds a new directory for 11.1, updated the paths in the pc files and checked the versions.

Not sure if that's the way you want to do it going forwards, seeing as it'll break at every macOS point release, but it fixes it for now.