### PR TITLE
on_macos/on_linux block: fix rubocop for special cases

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -137,11 +137,13 @@ module RuboCop
         def check_on_os_block_content(component_precedence_list, on_os_block)
           _, offensive_node = check_order(component_precedence_list, on_os_block.body)
           component_problem(*offensive_node) if offensive_node
-          on_os_block.body.child_nodes.each do |child|
+          child_nodes = on_os_block.body.begin_type? ? on_os_block.body.child_nodes : [on_os_block.body]
+          child_nodes.each do |child|
             valid_node = depends_on_node?(child)
-            # Check for RuboCop::AST::SendNode instances only, as we are checking the
-            # method_name for patches and resources.
-            next unless child.instance_of? RuboCop::AST::SendNode
+            # Check for RuboCop::AST::SendNode and RuboCop::AST::BlockNode instances
+            # only, as we are checking the method_name for `patch`, `resource`, etc.
+            method_type = child.send_type? || child.block_type?
+            next unless method_type
 
             valid_node ||= child.method_name.to_s == "patch"
             valid_node ||= child.method_name.to_s == "resource"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

These should not be allowed:

* Single `SendNode` that isn't `depends_on`/`patch`/`resource`/etc.

```rb
on_macos do
  desc "Collection of Linux utilities"
end
```

* `BlockNode` that isn't `depends_on`/`patch`/`resource`/etc.

```rb
on_macos do
  bottle do
    cellar :any
  end

  depends_on "libcap"
end
```

Before:

```console
% brew style util-linux

1 file inspected, no offenses detected
```

After:

```console
% brew style util-linux
Library/Taps/homebrew/homebrew-core/Formula/util-linux.rb:19:3: C: on_macos can only include depends_on, patch and resource nodes.
  on_macos do ...
  ^^^^^^^^^^^

1 file inspected, 1 offense detected, 1 offense auto-correctable
```