### PR TITLE
utils/ruby.sh: simplify and fix Ruby-related logic

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -28,12 +28,14 @@ find_ruby() {
   fi
 }
 
-unusable_ruby() {
-  if [[ -n "$HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH" ]]
+need_vendored_ruby() {
+  if [[ -n "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
+  then
+    return 0
+  elif [[ -n "$HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH" ]]
   then
     return 1
-  elif [[ -z "$HOMEBREW_MACOS" && -n "$HOMEBREW_RUBY_PATH" && -z "$HOMEBREW_FORCE_VENDOR_RUBY" ]] &&
-       test_ruby "$HOMEBREW_RUBY_PATH"
+  elif [[ -z "$HOMEBREW_MACOS" ]] && test_ruby "$HOMEBREW_RUBY_PATH"
   then
     return 1
   else
@@ -93,7 +95,7 @@ If there's no Homebrew Portable Ruby available for your processor:
     fi
   else
     HOMEBREW_RUBY_PATH=$(find_ruby)
-    if [[ -z "$HOMEBREW_RUBY_PATH" || -n "$HOMEBREW_FORCE_VENDOR_RUBY" ]] || unusable_ruby
+    if need_vendored_ruby
     then
       brew vendor-install ruby || odie "$install_fail"
       HOMEBREW_RUBY_PATH="$vendor_ruby_path"


### PR DESCRIPTION
General:
- Rename `unusable_ruby` to `need_vendored_ruby` (due to code changes).

**`setup-ruby-path`** function:
* Move `-z "$HOMEBREW_RUBY_PATH"` and `-n "$HOMEBREW_FORCE_VENDOR_RUBY"` checks to `need_vendored_ruby`.

**`need_vendored_ruby`** function:
* Check `HOMEBREW_FORCE_VENDOR_RUBY` first so that it's respected even on Macs that are "new enough" (`HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH` is set).
* Don't check `-n $HOMEBREW_RUBY_PATH` because it is implicitly tested by `test_ruby` (and because this case is specific to Linux).
* Remove (now-) redundant `-z $HOMEBREW_FORCE_VENDOR_RUBY` check as it is tested earlier in the conditional.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
