### PR TITLE
bump-formula-pr: handle additional edge cases

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -889,7 +889,7 @@ nor vice versa. It must use whichever style specification the formula already us
 * `--tag`:
   Specify the new git commit *`tag`* for the formula.
 * `--revision`:
-  Specify the new git commit *`revision`* corresponding to the specified *`tag`*.
+  Specify the new commit *`revision`* corresponding to the specified git *`tag`* or specified *`version`*.
 * `-f`, `--force`:
   Ignore duplicate open PRs. Remove all mirrors if `--mirror` was not specified.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1236,7 +1236,7 @@ Specify the new git commit \fItag\fR for the formula\.
 .
 .TP
 \fB\-\-revision\fR
-Specify the new git commit \fIrevision\fR corresponding to the specified \fItag\fR\.
+Specify the new commit \fIrevision\fR corresponding to the specified git \fItag\fR or specified \fIversion\fR\.
 .
 .TP
 \fB\-f\fR, \fB\-\-force\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Allow `bump-formula-pr` to work with formulae that:

- use a URL that specifies only a `revision`, and a `version` (e.g. [acme](https://formulae.brew.sh/formula/acme), [colortail](https://formulae.brew.sh/formula/colortail), [pytouhou](https://formulae.brew.sh/formula/pytouhou))
  `brew bump-formula-pr -f -n acme --version=0.98 --revision=277`
- use a repository URL providing an autodetected version (e.g. [smpeg](https://formulae.brew.sh/formula/smpeg))
  `brew bump-formula-pr -f -n smpeg --url=svn://svn.icculus.org/smpeg/tags/release_0_4_6/ --revision=400`

Fixes #9462.

Currently exposes an issue with formulae that specify the `revision` as an integer rather than a string, i.e. [fuego](https://formulae.brew.sh/formula/fuego), [netpbm](https://formulae.brew.sh/formula/netpbm), [spim](https://formulae.brew.sh/formula/spim). (Update: addressed in Homebrew/homebrew-core#66558)
```
$ brew bump-formula-pr -f -n spim --version=9.2 --revision=800
==> replace 732 with "800"
Error: wrong argument type Integer (expected Regexp)
/usr/local/Homebrew/Library/Homebrew/utils/string_inreplace_extension.rb:36:in `gsub!'
/usr/local/Homebrew/Library/Homebrew/utils/string_inreplace_extension.rb:36:in `gsub!'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:78:in `block in inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:71:in `each'
/usr/local/Homebrew/Library/Homebrew/utils/inreplace.rb:71:in `inreplace_pairs'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:332:in `bump_formula_pr'
/usr/local/Homebrew/Library/Homebrew/brew.rb:119:in `<main>'
```