### PR TITLE
software_spec: deprecate `prefix` for bottles.

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -356,6 +356,15 @@ class BottleSpecification
     @root_url_specs = {}
   end
 
+  def prefix=(prefix)
+    if [HOMEBREW_DEFAULT_PREFIX,
+        HOMEBREW_MACOS_ARM_DEFAULT_PREFIX,
+        HOMEBREW_LINUX_DEFAULT_PREFIX].exclude?(prefix)
+      odeprecated "setting `prefix` for bottles"
+    end
+    @prefix = prefix
+  end
+
   def root_url(var = nil, specs = {})
     if var.nil?
       @root_url ||= "#{Homebrew::EnvConfig.bottle_domain}/#{Utils::Bottles::Bintray.repository(tap)}"


### PR DESCRIPTION
Turns out we weren't actually using/checking this value at all (so I'd be very surprised if anyone is actually using it).

Don't merge this until we're ready to tag Homebrew 2.7.0
