### PR TITLE
on_macos/on_linux block: improve rubocop message

### DIFF
--- a/Library/Homebrew/rubocops.rb
+++ b/Library/Homebrew/rubocops.rb
@@ -3,6 +3,8 @@
 
 require_relative "load_path"
 
+require "active_support/core_ext/array/conversions"
+
 require "utils/sorbet"
 
 require "rubocop-performance"

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -390,9 +390,9 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
         on_macos do
-        ^^^^^^^^^^^ `on_macos` can only include `depends_on`, `patch` and `resource` nodes.
           depends_on "readline"
           uses_from_macos "ncurses"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ `on_macos` cannot include `uses_from_macos`. [...]
         end
       end
     RUBY
@@ -403,9 +403,9 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"
         on_linux do
-        ^^^^^^^^^^^ `on_linux` can only include `depends_on`, `patch` and `resource` nodes.
           depends_on "readline"
           uses_from_macos "ncurses"
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ `on_linux` cannot include `uses_from_macos`. [...]
         end
       end
     RUBY


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Related: https://github.com/Homebrew/brew/pull/9470#issuecomment-741182322

Changes:

* Include the name and line number of the method that isn't allowed
* Print the list of all allowed methods

Before:

```console
% brew style util-linux
Library/Taps/homebrew/homebrew-core/Formula/util-linux.rb:19:3: C: on_macos can only include depends_on, patch and resource nodes.
  on_macos do ...
  ^^^^^^^^^^^
```

After:

```console
% brew style util-linux
Library/Taps/homebrew/homebrew-core/Formula/util-linux.rb:20:5: C: on_macos cannot include keg_only.
Only these are allowed: depends_on, patch, resource, deprecate!, disable!
    keg_only "macOS provides the uuid.h header"
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```