### PR TITLE
Fix `curl_http_content_headers_and_checksum`.

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -249,7 +249,7 @@ module Utils
         final_url = location.chomp if location
       end
 
-      output_hash = Digest::SHA256.file(file.path) if hash_needed
+      file_hash = Digest::SHA256.file(file.path) if hash_needed
 
       final_url ||= url
 
@@ -260,8 +260,8 @@ module Utils
         etag:           headers[%r{ETag: ([wW]/)?"(([^"]|\\")*)"}, 2],
         content_length: headers[/Content-Length: (\d+)/, 1],
         headers:        headers,
-        file_hash:      output_hash,
-        file:           output,
+        file_hash:      file_hash,
+        file:           File.read(file.path),
       }
     ensure
       file.unlink


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Appcast checks on Cask CI are failing due to this method being used now.

This bug was introduced in https://github.com/Homebrew/brew/pull/6655, so essentially we have been checking an empty string instead of the actual content for over a year. 😭 