### PR TITLE
Don't add headers to content in `curl_http_content_headers_and_checksum`.

### DIFF
--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -236,7 +236,7 @@ module Utils
 
       max_time = hash_needed ? "600" : "25"
       output, = curl_output(
-        "--dump-header", "-", "--output", file.path, "--include", "--location",
+        "--dump-header", "-", "--output", file.path, "--location",
         "--connect-timeout", "15", "--max-time", max_time, url,
         user_agent: user_agent
       )


### PR DESCRIPTION

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Headers are already output to `stdout`, so don't also include them in the file output.