### PR TITLE
Relocate @@HOMEBREW_REPOSITORY@@/Library

### DIFF
--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -7,6 +7,8 @@ require "utils/shell"
 #
 # @api private
 module FormulaCellarChecks
+  # If the location of HOMEBREW_LIBRARY changes
+  # keg_relocate.rb, test/global_spec.rb, and this constant need to change.
   REPOSITORY_AND_NOT_LIBRARY_REGEX = %r{#{HOMEBREW_REPOSITORY}(?!/Library/)}.freeze
 
   def check_env_path(bin)

--- a/Library/Homebrew/formula_cellar_checks.rb
+++ b/Library/Homebrew/formula_cellar_checks.rb
@@ -210,6 +210,7 @@ module FormulaCellarChecks
   end
 
   def check_repository_references(prefix)
+    return if HOMEBREW_PREFIX != HOMEBREW_REPOSITORY
     return unless prefix.directory?
 
     keg = Keg.new(prefix)

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -5,9 +5,10 @@ class Keg
   PREFIX_PLACEHOLDER = "@@HOMEBREW_PREFIX@@"
   CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@"
   REPOSITORY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@"
+  LIBRARY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@/Library"
 
-  Relocation = Struct.new(:old_prefix, :old_cellar, :old_repository,
-                          :new_prefix, :new_cellar, :new_repository) do
+  Relocation = Struct.new(:old_prefix, :old_cellar, :old_repository, :old_library,
+                          :new_prefix, :new_cellar, :new_repository, :new_library) do
     # Use keyword args instead of positional args for initialization.
     def initialize(**kwargs)
       super(*members.map { |k| kwargs[k] })
@@ -40,9 +41,11 @@ class Keg
       old_prefix:     HOMEBREW_PREFIX.to_s,
       old_cellar:     HOMEBREW_CELLAR.to_s,
       old_repository: HOMEBREW_REPOSITORY.to_s,
+      old_library:    HOMEBREW_LIBRARY.to_s,
       new_prefix:     PREFIX_PLACEHOLDER,
       new_cellar:     CELLAR_PLACEHOLDER,
       new_repository: REPOSITORY_PLACEHOLDER,
+      new_library:    LIBRARY_PLACEHOLDER,
     )
     relocate_dynamic_linkage(relocation)
     replace_text_in_files(relocation)
@@ -53,9 +56,11 @@ class Keg
       old_prefix:     PREFIX_PLACEHOLDER,
       old_cellar:     CELLAR_PLACEHOLDER,
       old_repository: REPOSITORY_PLACEHOLDER,
+      old_library:    LIBRARY_PLACEHOLDER,
       new_prefix:     HOMEBREW_PREFIX.to_s,
       new_cellar:     HOMEBREW_CELLAR.to_s,
       new_repository: HOMEBREW_REPOSITORY.to_s,
+      new_library:    HOMEBREW_LIBRARY.to_s,
     )
     relocate_dynamic_linkage(relocation) unless skip_linkage
     replace_text_in_files(relocation, files: files)
@@ -69,8 +74,9 @@ class Keg
       s = first.open("rb", &:read)
 
       replacements = {
-        relocation.old_prefix => relocation.new_prefix,
-        relocation.old_cellar => relocation.new_cellar,
+        relocation.old_prefix  => relocation.new_prefix,
+        relocation.old_cellar  => relocation.new_cellar,
+        relocation.old_library => relocation.new_library,
       }
       # when HOMEBREW_PREFIX == HOMEBREW_REPOSITORY we should use HOMEBREW_PREFIX for all relocations to avoid
       # being unable to differentiate between them.

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -74,13 +74,16 @@ class Keg
       s = first.open("rb", &:read)
 
       replacements = {
-        relocation.old_prefix  => relocation.new_prefix,
-        relocation.old_cellar  => relocation.new_cellar,
-        relocation.old_library => relocation.new_library,
+        relocation.old_prefix => relocation.new_prefix,
+        relocation.old_cellar => relocation.new_cellar,
       }
       # when HOMEBREW_PREFIX == HOMEBREW_REPOSITORY we should use HOMEBREW_PREFIX for all relocations to avoid
       # being unable to differentiate between them.
-      replacements[relocation.old_repository] = relocation.new_repository if HOMEBREW_PREFIX != HOMEBREW_REPOSITORY
+      if HOMEBREW_PREFIX == HOMEBREW_REPOSITORY
+        replacements[relocation.old_library] = relocation.new_library
+      else
+        replacements[relocation.old_repository] = relocation.new_repository
+      end
       changed = s.gsub!(Regexp.union(replacements.keys.sort_by(&:length).reverse), replacements)
       next unless changed
 

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -5,6 +5,9 @@ class Keg
   PREFIX_PLACEHOLDER = "@@HOMEBREW_PREFIX@@"
   CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@"
   REPOSITORY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@"
+
+  # If the location of HOMEBREW_LIBRARY changes
+  # formula_cellar_checks.rb, test/global_spec.rb, and this constant need to change.
   LIBRARY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@/Library"
 
   Relocation = Struct.new(:old_prefix, :old_cellar, :old_repository, :old_library,

--- a/Library/Homebrew/test/global_spec.rb
+++ b/Library/Homebrew/test/global_spec.rb
@@ -9,6 +9,8 @@ describe "brew", :integration_test do
       .and be_a_success
   end
 
+  # If the location of HOMEBREW_LIBRARY changes
+  # keg_relocate.rb, formula_cellar_checks.rb, and this test need to change.
   it "ensures that HOMEBREW_LIBRARY=HOMEBREW_REPOSITORY/Library" do
     expect(HOMEBREW_LIBRARY.to_s).to eq("#{HOMEBREW_REPOSITORY}/Library")
   end

--- a/Library/Homebrew/test/global_spec.rb
+++ b/Library/Homebrew/test/global_spec.rb
@@ -8,4 +8,8 @@ describe "brew", :integration_test do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  it "ensures that HOMEBREW_LIBRARY=HOMEBREW_REPOSITORY/Library" do
+    expect(HOMEBREW_LIBRARY.to_s).to eq("#{HOMEBREW_REPOSITORY}/Library")
+  end
 end

--- a/bin/brew
+++ b/bin/brew
@@ -58,6 +58,8 @@ then
   fi
 fi
 
+# If the location of HOMEBREW_LIBRARY changes
+# keg_relocate.rb, formula_cellar_checks.rb, and test/global_spec.rb need to change.
 HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in


### PR DESCRIPTION
Ensure that `$HOMEBREW_REPOSITORY/Library` is relocated to `@@HOMEBREW_REPOSITORY@@/Library` even when `HOMEBREW_PREFIX = HOMEBREW_REPOSITORY`.

See issue https://github.com/Homebrew/brew/issues/9453 `Bottle path substitution when HOMEBREW_REPOSITORY == HOMEBREW_PREFIX`
and related proposal https://github.com/Homebrew/brew/issues/9453#issuecomment-742252733
and related PR https://github.com/Homebrew/brew/pull/9481
and related PR https://github.com/Homebrew/brew/pull/10025

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

When bottles are built with `HOMEBREW_REPOSITORY = HOMEBREW_PREFIX`, the resulting bottles have the `@@HOMEBREW_PREFIX@@` placeholder, where bottles with  `HOMEBREW_REPOSITORY = HOMEBREW_PREFIX/Homebrew` would have instead used `@@HOMEBREW_REPOSITORY@@`.

Native ARM currently uses a CI configuration with `HOMEBREW_REPOSITORY = HOMEBREW_PREFIX`, which would make the bottles built for this one architecture different than the other two supported architectures, Homebrew on macOS for Intel, and Homebrew on Linux.

This PR makes it possible to build bottles that use `@@HOMEBREW_REPOSITORY@@` even when `HOMEBREW_REPOSITORY = HOMEBREW_PREFIX`.

The following test demonstrates
- `a`: a bottle built using `HOMEBREW_REPOSITORY=$HOMEBREW_PREFIX/Homebrew`
- `b`: a bottle built using `HOMEBREW_REPOSITORY=$HOMEBREW_PREFIX` without this PR
- `c`: a bottle built using `HOMEBREW_REPOSITORY=$HOMEBREW_PREFIX` with this PR

```console
$ git clone --reference=/usr/local/Homebrew https://github.com/Homebrew/brew ~/.homebrew
$ git clone --reference=/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core https://github.com/Homebrew/homebrew-core ~/.homebrew/Library/Taps/homebrew/homebrew-core
$ brew install --build-bottle hello
$ ~/.homebrew/bin/brew install --build-bottle hello
$ (mkdir a && cd a && brew bottle --json --no-rebuild hello)
$ (mkdir b && cd b && ~/.homebrew/bin/brew bottle --json --no-rebuild hello)
$ git -C ~/.homebrew fetch https://github.com/sjackman/brew sj/keg-relocate-library
$ git -C ~/.homebrew switch -c sj/keg-relocate-library FETCH_HEAD
$ (mkdir c && cd c && ~/.homebrew/bin/brew bottle --json --no-rebuild hello)
$ brew install jq
$ tar -xOf a/hello--2.10.catalina.bottle.tar.gz hello/2.10/INSTALL_RECEIPT.json | jq -r '.source.path'
@@HOMEBREW_REPOSITORY@@/Library/Taps/homebrew/homebrew-core/Formula/hello.rb
$ tar -xOf b/hello--2.10.catalina.bottle.tar.gz hello/2.10/INSTALL_RECEIPT.json | jq -r '.source.path'
@@HOMEBREW_PREFIX@@/Library/Taps/homebrew/homebrew-core/Formula/hello.rb
$ tar -xOf c/hello--2.10.catalina.bottle.tar.gz hello/2.10/INSTALL_RECEIPT.json | jq -r '.source.path'
@@HOMEBREW_REPOSITORY@@/Library/Taps/homebrew/homebrew-core/Formula/hello.rb
```

This fix has the advantages that
1. Bottles built for native ARM will be similar to bottles built for the other supported architectures
2. Bottles are compatible with Homebrew installations using either `HOMEBREW_REPOSITORY=HOMEBREW_PREFIX` or `HOMEBREW_REPOSITORY=HOMEBREW_PREFIX/Homebrew`
3. It futures proofs the bottles being built for native ARM, so that it would be possible to switch to `HOMEBREW_REPOSITORY=HOMEBREW_PREFIX/Homebrew` if needed

-----

Example uses of `@@HOMEBREW_REPOSITORY@@` in current bottles are…

Every bottle has a reference to `@@HOMEBREW_REPOSITORY@@` in `INSTALL_RECEIPT.json` in the key `source.path`

References to the pkg-config directory and files:
`@@HOMEBREW_REPOSITORY@@/Library/Homebrew/os/mac/pkgconfig/11.0/`
for example in the bottle for `r`

References to the shim compiler and scm scripts:
`@@HOMEBREW_REPOSITORY@@/Library/Homebrew/shims/super/cc`
`@@HOMEBREW_REPOSITORY@@/Library/Homebrew/shims/scm/git`

For newer bottles, there is now an audit to prevent this last case. See https://github.com/Homebrew/brew/issues/9453#issuecomment-742337748