### PR TITLE
unpack_strategy: add support for Cargo crates

### DIFF
--- a/Library/Homebrew/unpack_strategy.rb
+++ b/Library/Homebrew/unpack_strategy.rb
@@ -75,6 +75,7 @@ module UnpackStrategy
       Sit,
       Rar,
       Lha,
+      CargoCrate,
     ].freeze
   end
   private_class_method :strategies
@@ -173,6 +174,7 @@ require "unpack_strategy/air"
 require "unpack_strategy/bazaar"
 require "unpack_strategy/bzip2"
 require "unpack_strategy/cab"
+require "unpack_strategy/cargo_crate"
 require "unpack_strategy/compress"
 require "unpack_strategy/cvs"
 require "unpack_strategy/directory"

--- a/Library/Homebrew/unpack_strategy/cargo_crate.rb
+++ b/Library/Homebrew/unpack_strategy/cargo_crate.rb
@@ -1,0 +1,22 @@
+# typed: true
+# frozen_string_literal: true
+
+require_relative "tar"
+
+module UnpackStrategy
+  # Strategy for unpacking Cargo crates.
+  class CargoCrate < Tar
+    extend T::Sig
+
+    using Magic
+
+    sig { returns(T::Array[String]) }
+    def self.extensions
+      [".crate"].freeze
+    end
+
+    def self.can_extract?(path)
+      Tar.can_extract?(path) && path.magic_number.match?(/\.crate\b/n)
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This allows for URLs like https://static.crates.io/crates/oakc/oakc-0.6.1.crate to be used in formulae

Tested with https://github.com/Homebrew/homebrew-core/pull/66697 with `tar -xzvf` step removed