### PR TITLE
livecheck: crates.io strategy

### DIFF
--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -86,6 +86,7 @@ end
 
 require_relative "strategy/apache"
 require_relative "strategy/bitbucket"
+require_relative "strategy/crates"
 require_relative "strategy/git"
 require_relative "strategy/github_latest"
 require_relative "strategy/gnome"

--- a/Library/Homebrew/livecheck/strategy/crates.rb
+++ b/Library/Homebrew/livecheck/strategy/crates.rb
@@ -1,0 +1,50 @@
+# typed: false
+# frozen_string_literal: true
+
+module Homebrew
+  module Livecheck
+    module Strategy
+      # The {Crates} strategy identifies versions of software at crates.io by
+      # checking the listed versions for a crate at docs.rs.
+      #
+      # Crates URLs take one of the following formats:
+      #
+      # * `https://crates.io/api/v1/crates/brew/1.2.3/download`
+      # * `https://static.crates.io/crates/brew/brew-1.2.3.crate`
+      #
+      # @api public
+      class Crates
+        NICE_NAME = "crates"
+
+        # The `Regexp` used to determine if the strategy applies to the URL.
+        URL_MATCH_REGEX = %r{^https?://(?:static\.)?crates\.io(?:/api/v1)?/crates/[^/]+/}i.freeze
+
+        # Whether the strategy can be applied to the provided URL.
+        #
+        # @param url [String] the URL to match against
+        # @return [Boolean]
+        def self.match?(url)
+          URL_MATCH_REGEX.match?(url)
+        end
+
+        # Generates a URL and regex (if one isn't provided) and passes them
+        # to {PageMatch.find_versions} to identify versions in the content.
+        #
+        # @param url [String] the URL of the content to check
+        # @param regex [Regexp] a regex used for matching versions in content
+        # @return [Hash]
+        def self.find_versions(url, regex = nil)
+          %r{/crates/(?<package_name>[^/]+)/}i =~ url
+
+          # docs.rs crate page containing version listing
+          page_url = "https://docs.rs/crate/#{package_name}"
+
+          # Example regex: `%r{href=.*?/crate/brew/v?(\d+(?:\.\d+)+)"}i`
+          regex ||= %r{href=.*?/crate/#{Regexp.escape(package_name)}/v?(\d+(?:\.\d+)+)"}i
+
+          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+        end
+      end
+    end
+  end
+end

--- a/Library/Homebrew/test/livecheck/strategy/crates_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/crates_spec.rb
@@ -1,0 +1,23 @@
+# typed: false
+# frozen_string_literal: true
+
+require "livecheck/strategy/crates"
+
+describe Homebrew::Livecheck::Strategy::Crates do
+  subject(:crates) { described_class }
+
+  let(:crates_api_url) { "https://crates.io/api/v1/crates/brew-1.2.3/download" }
+  let(:crates_static_url) { "https://static.crates.io/crates/brew/brew-1.2.3.crate" }
+  let(:non_crates_url) { "https://brew.sh/test" }
+
+  describe "::match?" do
+    it "returns true if the argument provided is a crates URL" do
+      expect(crates.match?(crates_api_url)).to be true
+      expect(crates.match?(crates_static_url)).to be true
+    end
+
+    it "returns false if the argument provided is not a crates URL" do
+      expect(crates.match?(non_crates_url)).to be false
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This adds a new livecheck strategy for software obtained from crates.io. Note that crates.io doesn't let bots access their data (https://crates.io/policies#crawlers) so docs.rs is used instead. 