### PR TITLE
Fix unbottled dependency handling

### DIFF
--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -488,17 +488,18 @@ class BuildError < RuntimeError
   end
 end
 
-# Raised by {FormulaInstaller#check_dependencies_bottled} and
-# {FormulaInstaller#install} if the formula or its dependencies are not bottled
-# and are being installed on a system without necessary build tools.
-class BuildToolsError < RuntimeError
+# Raised if the formula or its dependencies are not bottled and are being
+# installed in a situation where a bottle is required.
+class UnbottledError < RuntimeError
   def initialize(formulae)
-    super <<~EOS
-      The following #{"formula".pluralize(formulae.count)}
+    msg = +<<~EOS
+      The following #{"formula".pluralize(formulae.count)} cannot be installed from #{"bottle".pluralize(formulae.count)} and must be
+      built from source.
         #{formulae.to_sentence}
-      cannot be installed as #{"binary package".pluralize(formulae.count)} and must be built from source.
-      #{DevelopmentTools.installation_instructions}
     EOS
+    msg += "#{DevelopmentTools.installation_instructions}\n" unless DevelopmentTools.installed?
+    msg.freeze
+    super(msg)
   end
 end
 

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -83,7 +83,7 @@ describe FormulaInstaller do
 
     expect {
       described_class.new(formula).install
-    }.to raise_error(BuildToolsError)
+    }.to raise_error(UnbottledError)
 
     expect(formula).not_to be_latest_version_installed
   end


### PR DESCRIPTION
- Rename `BuildToolsError` to `UnbottledError` to better reflect what it does (particularly now)
- Improve the `UnbottledError` messaging
- Raise the `UnbottledError` for dependencies also when building bottles (so that we don't try and build bottles against things that have been built from source).
