### PR TITLE
Do not build from source on ARM unless explicitly requested

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -231,12 +231,21 @@ class FormulaInstaller
       raise CannotInstallFormulaError, "--force-bottle passed but #{formula.full_name} has no bottle!"
     end
 
-    if Hardware::CPU.arm? && !pour_bottle? && !formula.bottle_unneeded? && !build_from_source? && !build_bottle? && !formula.bottle_disabled?
-      # During the first stage of ARM support, we bail out unless there is a bottle or the user specifically asked to build from source
-      onoe "There is no prebuilt bottle available for #{formula.full_name} on ARM macOS yet"
-      onoe "You can try to install it from source with the --build-from-source flag (or -s)"
-      onoe "However, this means we can offer no support."
-      raise CannotInstallFormulaError, "no bottle is available for #{formula.full_name} on ARM macOS yet"
+    if Homebrew.default_prefix? && !Homebrew::EnvConfig.developer? &&
+       !build_from_source? && !build_bottle? &&
+       formula.tap&.core_tap? && !formula.bottle_unneeded? &&
+       # Integration tests override homebrew-core locations
+       ENV["HOMEBREW_TEST_TMPDIR"].nil? &&
+       !pour_bottle?
+      raise CannotInstallFormulaError, <<~EOS
+        #{formula}: no bottle available!
+        You can try to install from source with e.g.
+          brew install --build-from-source #{formula}
+        Please note building from source is unsupported. You will encounter build
+        failures with some formulae. If you experience any issues please create pull
+        requests instead of asking for help on Homebrew's GitHub, Twitter or any other
+        official channels.
+      EOS
     end
 
     type, reason = DeprecateDisable.deprecate_disable_info formula

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -231,6 +231,14 @@ class FormulaInstaller
       raise CannotInstallFormulaError, "--force-bottle passed but #{formula.full_name} has no bottle!"
     end
 
+    if Hardware::CPU.arm? && !pour_bottle? && !formula.bottle_unneeded? && !build_from_source? && !build_bottle? && !formula.bottle_disabled?
+      # During the first stage of ARM support, we bail out unless there is a bottle or the user specifically asked to build from source
+      onoe "There is no prebuilt bottle available for #{formula.full_name} on ARM macOS yet"
+      onoe "You can try to install it from source with the --build-from-source flag (or -s)"
+      onoe "However, this means we can offer no support."
+      raise CannotInstallFormulaError, "no bottle is available for #{formula.full_name} on ARM macOS yet"
+    end
+
     type, reason = DeprecateDisable.deprecate_disable_info formula
 
     if type.present?


### PR DESCRIPTION
To provide good user experience on ARM, we need to provide a way for users to know which formulas are known to work, and which formulas are unknown / not supported yet. We don't need to reinvent the wheel, we have an easy way: bottles 😄 

Formulas that have an ARM bottle have built on our CI. Formulas that don't have an ARM bottle mean we haven't been able to test them yet, or they currently fail to build. After the initial wave of bottling, the second case will be the most likely possibility. And we need to indicate that to users, so they don't do a long build-from-source for nothing.

This is my proposal: on ARM, unless a user asks for `--build-from-source` (or `--build-bottle`) specifically, if they `brew install` a formula that doesn't have a bottle, we error out (instead of saying “now building from source”). And while we error out, we tell them how to try a source build, if they want to.