### PR TITLE
Enable HOMEBREW_PATCHELF_RB_WRITE by default

### DIFF
--- a/Library/Homebrew/os/linux/global.rb
+++ b/Library/Homebrew/os/linux/global.rb
@@ -3,11 +3,8 @@
 
 require "env_config"
 
-# Enables experimental `patchelf.rb` write support.
-HOMEBREW_PATCHELF_RB_WRITE = (
-  ENV["HOMEBREW_NO_PATCHELF_RB_WRITE"].blank? &&
-  (ENV["HOMEBREW_PATCHELF_RB_WRITE"].present? || ENV["CI"].present? || ENV["HOMEBREW_DEV_CMD_RUN"].present?)
-).freeze
+# Enables `patchelf.rb` write support.
+HOMEBREW_PATCHELF_RB_WRITE = ENV["HOMEBREW_NO_PATCHELF_RB_WRITE"].blank?.freeze
 
 module Homebrew
   if EnvConfig.force_homebrew_on_linux?


### PR DESCRIPTION
It may be disabled using HOMEBREW_NO_PATCHELF_RB_WRITE.

It is currently disabled in brew test-bot when building bottles.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
