### PR TITLE
Livecheck: Replace OpenURI#open with Curl

### DIFF
--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "open-uri"
-
 module Homebrew
   module Livecheck
     module Strategy

--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -4,6 +4,67 @@
 require "utils/curl"
 
 describe "Utils::Curl" do
+  let(:headers_ok) {
+    <<~EOS
+      HTTP/2 200\r
+      cache-control: max-age=604800\r
+      content-type: text/html; charset=UTF-8\r
+      date: Wed, 1 Jan 2020 01:23:45 GMT\r
+      expires: Wed, 31 Jan 2020 01:23:45 GMT\r
+      last-modified: Thu, 1 Jan 2019 01:23:45 GMT\r
+      content-length: 123\r
+      \r
+    EOS
+  }
+  let(:headers_ok_array) { [headers_ok.rstrip] }
+
+  let(:location_urls) {
+    %w[
+      https://example.com/example/
+      https://example.com/example1/
+      https://example.com/example2/
+      https://example.com/example3/
+    ]
+  }
+
+  let(:headers_redirection) {
+    headers_ok.sub(
+      "HTTP/2 200\r\n",
+      "HTTP/2 301\r\nlocation: #{location_urls[0]}\r\n",
+    )
+  }
+
+  let(:headers_redirection_to_ok) { "#{headers_redirection}#{headers_ok}" }
+
+  let(:headers_redirections_to_ok) {
+    "#{headers_redirection.sub(location_urls[0], location_urls[3])}" \
+      "#{headers_redirection.sub(location_urls[0], location_urls[3])}" \
+      "#{headers_redirection.sub(location_urls[0], location_urls[1])}" \
+      "#{headers_ok}"
+  }
+
+  let(:body_content) {
+    <<~EOS
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>Example</title>
+        </head>
+        <body>
+          <h1>Example</h1>
+          <p>Hello, world!</p>
+        </body>
+      </html>
+    EOS
+  }
+
+  let(:body_content_with_carriage_returns) { body_content.sub("<html>\n", "<html>\r\n\r\n") }
+
+  let(:body_content_with_http_status_line) { body_content.sub("<html>", "HTTP/2 200\r\n<html>") }
+
+  let(:headers_and_body_content) { "#{headers_ok}#{body_content}" }
+
   describe "curl_args" do
     let(:args) { "foo" }
     let(:user_agent_string) { "Lorem ipsum dolor sit amet" }
@@ -58,6 +119,88 @@ describe "Utils::Curl" do
       expect(curl_args(*args, show_output: nil).join(" ")).to include("--fail")
       expect(curl_args(*args).join(" ")).to include("--fail")
       expect(curl_args(*args, show_output: true).join(" ")).not_to include("--fail")
+    end
+  end
+
+  describe "#response_headers_and_body" do
+    it "returns [[headers], \"\"] when response contains headers and no body" do
+      expect(response_headers_and_body(headers_ok)).to eq([headers_ok_array, ""])
+    end
+
+    it "returns [[], body] when response contains body and no headers" do
+      expect(response_headers_and_body(body_content)).to eq([[], body_content])
+      expect(response_headers_and_body(body_content_with_carriage_returns))
+        .to eq([[], body_content_with_carriage_returns])
+      expect(response_headers_and_body(body_content_with_http_status_line))
+        .to eq([[], body_content_with_http_status_line])
+    end
+
+    it "returns [[headers], body] when response contains headers and body" do
+      expect(response_headers_and_body(headers_and_body_content))
+        .to eq([headers_ok_array, body_content])
+      expect(response_headers_and_body("#{headers_ok}#{body_content_with_carriage_returns}"))
+        .to eq([headers_ok_array, body_content_with_carriage_returns])
+      expect(response_headers_and_body("#{headers_ok}#{body_content_with_http_status_line}"))
+        .to eq([headers_ok_array, body_content_with_http_status_line])
+    end
+
+    it "returns [[], \"\"] when response is empty" do
+      expect(response_headers_and_body("")).to eq([[], ""])
+    end
+  end
+
+  describe "#response_status_code_and_location" do
+    it "returns [status_code, nil] with no location in headers" do
+      expect(response_status_code_and_location(headers_ok_array)).to eq(["200", nil])
+      expect(response_status_code_and_location(headers_ok)).to eq(["200", nil])
+      expect(response_status_code_and_location(headers_and_body_content)).to eq(["200", nil])
+    end
+
+    it "returns [status_code, final_location] with location header(s) present" do
+      expect(response_status_code_and_location(headers_redirection_to_ok))
+        .to eq(["200", location_urls[0]])
+      expect(response_status_code_and_location(headers_redirections_to_ok))
+        .to eq(["200", location_urls[1]])
+    end
+
+    it "returns absolute location URL with absolutize set to true" do
+      expect(response_status_code_and_location(
+               headers_redirection_to_ok.sub(
+                 location_urls[0],
+                 location_urls[0].delete_prefix("https:"),
+               ),
+               url:        location_urls[0],
+               absolutize: true,
+             )).to eq(["200", location_urls[0]])
+
+      expect(response_status_code_and_location(
+               headers_redirection_to_ok.sub(
+                 location_urls[0],
+                 location_urls[0].delete_prefix("https://www.example.com"),
+               ),
+               url:        location_urls[0],
+               absolutize: true,
+             )).to eq(["200", location_urls[0]])
+
+      expect(response_status_code_and_location(
+               headers_redirection_to_ok.sub(
+                 location_urls[0],
+                 "./subexample/",
+               ),
+               url:        location_urls[0],
+               absolutize: true,
+             )).to eq(["200", "#{location_urls[0]}subexample/"])
+    end
+
+    it "returns [nil, nil] with body content and no headers" do
+      expect(response_status_code_and_location(body_content)).to eq([nil, nil])
+    end
+
+    it "returns [nil, nil] when headers are empty" do
+      expect(response_status_code_and_location([])).to eq([nil, nil])
+      expect(response_status_code_and_location([""])).to eq([nil, nil])
+      expect(response_status_code_and_location(["", "", ""])).to eq([nil, nil])
+      expect(response_status_code_and_location("")).to eq([nil, nil])
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR migrates `brew livecheck` from `open-uri` to `Utils::Curl`, as `Curl` is used throughout Homebrew/brew for network requests and livecheck was the only place where `open-uri` was used (outside of a vendored gem).

## Notable Changes

* Replaces `open-uri` in `PageMatch` with `#curl_with_workarounds`. Most other strategies use `PageMatch#find_versions` internally, so this is one of the two strategies that used `open-uri` (the other being `Xorg`). For what it's worth, some of the code in `#page_matches`/`#page_content` was adapted from methods in `Utils::Curl` (e.g., `#curl_http_content_headers_and_checksum`).
* Adds a `user_agent` parameter to `Strategy#page_content`, so we can pass a symbol to `curl_args` to configure `curl`'s user agent. The `user_agent` parameter could be used in strategies, if we ever encounter a page that requires a different user agent string to work. Similarly, we could modify the `livecheck` DSL to allow user agent configuration but that's something we should defer until it's actually necessary for a given formula/cask's check to function. That said, I imagine these cases will be quite rare but adding this parameter (and passing it in the `curl` args) takes almost no work, so I don't see any adding it.

## Closing

This PR is currently blocked while I troubleshoot a hang that occurs on this `curl` version of livecheck. Basically, either `curl` or `SystemCommand` is hanging in a random place on longer livecheck runs (e.g., `brew livecheck --tap homebrew/core`) and I haven't yet determined the cause of the hang. This is a crucial bug that needs to be addressed before this can be merged.