### PR TITLE
Update livecheck strategies to avoid unnecessary redirections

### DIFF
--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -38,7 +38,7 @@ module Homebrew
           /^(?<package_name>.+?)-\d+/i =~ File.basename(url)
 
           # A page containing a directory listing of the latest source tarball
-          page_url = "https://hackage.haskell.org/package/#{package_name}/src"
+          page_url = "https://hackage.haskell.org/package/#{package_name}/src/"
 
           # Example regex: `%r{<h3>example-(.*?)/?</h3>}i`
           regex ||= %r{<h3>#{Regexp.escape(package_name)}-(.*?)/?</h3>}i

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -48,7 +48,7 @@ module Homebrew
 
           # It's not technically necessary to have the `#files` fragment at the
           # end of the URL but it makes the debug output a bit more useful.
-          page_url = "https://pypi.org/project/#{package_name.gsub(/%20|_/, "-")}#files"
+          page_url = "https://pypi.org/project/#{package_name.gsub(/%20|_/, "-")}/#files"
 
           # Example regex: `%r{href=.*?/packages.*?/example[._-]v?(\d+(?:\.\d+)*).t}i`.
           regex ||=


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This updates the `page_url` variables in the `Hackage` and `Pypi` livecheck strategies to avoid unnecessary redirections. The URLs are currently redirecting as follows:

* `https://hackage.haskell.org/package/Agda/src` -> `https://hackage.haskell.org/package/Agda/src/`
* `https://pypi.org/project/Airshare#files` -> `https://pypi.org/project/Airshare/`

`page_url` was missing the trailing forward slash in both of these cases. The `Pypi` `page_url` also includes the `#files` fragment but it's the missing forward slash, not the fragment, that causes the redirection.

These strategies currently function fine but #9535 made these redirections more apparent and it's always nice to avoid unnecessary redirections when we can.