### PR TITLE
odeprecated: handle deprecated and disabled formulae.

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -188,9 +188,18 @@ module Kernel
 
     # Don't throw deprecations at all for cached, .brew or .metadata files.
     return if backtrace.any? do |line|
-      line.include?(HOMEBREW_CACHE) ||
-      line.include?("/.brew/") ||
-      line.include?("/.metadata/")
+      next true if line.include?(HOMEBREW_CACHE)
+      next true if line.include?("/.brew/")
+      next true if line.include?("/.metadata/")
+
+      next false unless line.match?(HOMEBREW_TAP_PATH_REGEX)
+
+      path = Pathname(line.split(":", 2).first)
+      next false unless path.file?
+      next false unless path.readable?
+
+      formula_contents = path.read
+      formula_contents.include?(" deprecate! ") || formula_contents.include?(" disable! ")
     end
 
     tap_message = T.let(nil, T.nilable(String))


### PR DESCRIPTION
It's not useful to spend time complaining about or fixing deprecations or disables in deprecated or disabled formulae given we already complain on install and don't run them through CI.

Needed for https://github.com/Homebrew/brew/pull/9403
