### PR TITLE
utils/ruby.sh: various tweaks

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -1,3 +1,5 @@
+# shellcheck disable=SC2039
+
 export HOMEBREW_REQUIRED_RUBY_VERSION=2.6.3
 
 test_ruby () {
@@ -11,24 +13,26 @@ test_ruby () {
     "$HOMEBREW_REQUIRED_RUBY_VERSION" 2>/dev/null
 }
 
-find_ruby() {
+find_usable_ruby () {
   if [[ -n "$HOMEBREW_MACOS" ]]
   then
-    echo "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
+    HOMEBREW_RUBY_PATH="/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
   else
-    IFS=$'\n' # Do word splitting on new lines only
+    local ruby_exec
+    local IFS=$'\n' # Do word splitting on new lines only
+    HOMEBREW_RUBY_PATH=
     for ruby_exec in $(which -a ruby) $(PATH=$HOMEBREW_PATH which -a ruby)
     do
-      if test_ruby "$ruby_exec"; then
-        echo "$ruby_exec"
+      if test_ruby "$ruby_exec"
+      then
+        HOMEBREW_RUBY_PATH=$ruby_exec
         break
       fi
     done
-    IFS=$' \t\n' # Restore IFS to its default value
   fi
 }
 
-need_vendored_ruby() {
+need_vendored_ruby () {
   if [[ -n "$HOMEBREW_FORCE_VENDOR_RUBY" ]]
   then
     return 0
@@ -52,23 +56,24 @@ setup-ruby-path() {
   local vendor_ruby_current_version
   # When bumping check if HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH (in brew.sh)
   # also needs to be changed.
-  local ruby_exec
   local upgrade_fail
   local install_fail
 
+  upgrade_fail="Failed to upgrade Homebrew Portable Ruby!${HOMEBREW_FORCE_VENDOR_RUBY:+"
+HOMEBREW_FORCE_VENDOR_RUBY variable is currently set.
+It prevents Homebrew from using other Ruby that might be available on your system.
+If Ruby $HOMEBREW_REQUIRED_RUBY_VERSION is available on your system, you may safely unset HOMEBREW_FORCE_VENDOR_RUBY."}"
+
   if [[ -n $HOMEBREW_MACOS ]]
   then
-    upgrade_fail="Failed to upgrade Homebrew Portable Ruby!"
     install_fail="Failed to install Homebrew Portable Ruby (and your system version is too old)!"
   else
-    local advice="
+    install_fail="Failed to install Homebrew Portable Ruby and cannot find another Ruby $HOMEBREW_REQUIRED_RUBY_VERSION!
 If there's no Homebrew Portable Ruby available for your processor:
 - install Ruby $HOMEBREW_REQUIRED_RUBY_VERSION with your system package manager (or rbenv/ruby-build)
 - make it first in your PATH
 - try again
 "
-    upgrade_fail="Failed to upgrade Homebrew Portable Ruby!$advice"
-    install_fail="Failed to install Homebrew Portable Ruby and cannot find another Ruby $HOMEBREW_REQUIRED_RUBY_VERSION!$advice"
   fi
 
   vendor_dir="$HOMEBREW_LIBRARY/Homebrew/vendor"
@@ -80,26 +85,25 @@ If there's no Homebrew Portable Ruby available for your processor:
 
   unset HOMEBREW_RUBY_PATH
 
-  if [[ "$HOMEBREW_COMMAND" == "vendor-install" ]]
-  then
-    return 0
-  fi
-
+  # Prefer portable Ruby if/when it's available
   if [[ -x "$vendor_ruby_path" ]]
   then
-    HOMEBREW_RUBY_PATH="$vendor_ruby_path"
-    TERMINFO_DIRS="$vendor_ruby_terminfo"
-    if [[ $vendor_ruby_current_version != "$vendor_ruby_latest_version" ]]
+    HOMEBREW_RUBY_PATH=$vendor_ruby_path
+    TERMINFO_DIRS=$vendor_ruby_terminfo
+    if [[ $vendor_ruby_current_version != "$vendor_ruby_latest_version" ]] && ! brew vendor-install ruby
     then
-      brew vendor-install ruby || odie "$upgrade_fail"
+      onoe "$upgrade_fail"
+      unset TERMINFO_DIRS
+      find_usable_ruby
+      need_vendored_ruby && exit 1
     fi
   else
-    HOMEBREW_RUBY_PATH=$(find_ruby)
+    find_usable_ruby
     if need_vendored_ruby
     then
       brew vendor-install ruby || odie "$install_fail"
-      HOMEBREW_RUBY_PATH="$vendor_ruby_path"
-      TERMINFO_DIRS="$vendor_ruby_terminfo"
+      HOMEBREW_RUBY_PATH=$vendor_ruby_path
+      TERMINFO_DIRS=$vendor_ruby_terminfo
     fi
   fi
 


### PR DESCRIPTION
1. Disable SC2039 check ("In POSIX sh, ___ is undefined.")
2. `find_ruby`:
    * set `HOMEBREW_RUBY_PATH` instead of echo-ing its location to stdout. To avoid using a subshell.
    * Make `ruby_exec` and `IFS` variables local.
3. `setup-ruby-path`:
    * `upgrade_fail`:
        + Unify the message for macOS and Linux.
        + Remove Linux-specific comment as it doesn't apply to the 'upgrade' step
        + Add a clarifying note if HOMEBREW_FORCE_VENDOR_RUBY is set
    * On Linux: move `advice` note to `install_fail`
    * Remove conditional block that (I believe) is never executed. `setup-ruby-path` is called for non-Bash commands (see `brew.sh`). When Homebrew calls `vendor-install`, it doesn't source `utils/ruby.sh` nor it calls `setup-ruby-path`.
      ```sh
      # removed block
      if [[ "$HOMEBREW_COMMAND" == "vendor-install" ]]
      then
        return 0
      fi
      ```
  * Check if system Ruby can be used when Homebrew fails to upgrade portable Ruby.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
