### PR TITLE
cmd/vendor-install.sh: fail on systems with old Glibc

### DIFF
--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -32,6 +32,24 @@ then
   esac
 fi
 
+if [[ -n "$HOMEBREW_LINUX" ]]
+then
+  LDD_VERSION_OUTPUT=$(/usr/bin/ldd --version)
+  if [[ $LDD_VERSION_OUTPUT =~ \ [0-9]\.[0-9]+ ]]
+  then
+    LDD_VERSION=${BASH_REMATCH[0]}
+    LDD_VERSION_MAJOR=${LDD_VERSION%.*}
+    LDD_VERSION_MINOR=${LDD_VERSION#*.}
+    if (( LDD_VERSION_MAJOR < 2 || LDD_VERSION_MINOR < 13 ))
+    then
+      odie "Vendored tools require system Glibc 2.13 or later"
+    fi
+  else
+    odie "Failed to detect system Glibc version"
+  fi
+  unset LDD_VERSION_OUTPUT LDD_VERSION LDD_VERSION_MAJOR LDD_VERSION_MINOR
+fi
+
 # Execute the specified command, and suppress stderr unless HOMEBREW_STDERR is set.
 quiet_stderr() {
   if [[ -z "$HOMEBREW_STDERR" ]]; then

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -32,23 +32,24 @@ then
   esac
 fi
 
-if [[ -n "$HOMEBREW_LINUX" ]]
-then
-  LDD_VERSION_OUTPUT=$(/usr/bin/ldd --version)
-  if [[ $LDD_VERSION_OUTPUT =~ \ [0-9]\.[0-9]+ ]]
+check_ldd_version() {
+  local ldd_version
+  local ldd_version_major
+  local ldd_version_minor
+
+  if [[ $(/usr/bin/ldd --version) =~ \ [0-9]\.[0-9]+ ]]
   then
-    LDD_VERSION=${BASH_REMATCH[0]}
-    LDD_VERSION_MAJOR=${LDD_VERSION%.*}
-    LDD_VERSION_MINOR=${LDD_VERSION#*.}
-    if (( LDD_VERSION_MAJOR < 2 || LDD_VERSION_MINOR < 13 ))
+    ldd_version=${BASH_REMATCH[0]// /}
+    ldd_version_major=${ldd_version%.*}
+    ldd_version_minor=${ldd_version#*.}
+    if (( ldd_version_major < 2 || ldd_version_minor < 13 ))
     then
-      odie "Vendored tools require system Glibc 2.13 or later"
+      odie "Vendored tools require system Glibc 2.13 or later."
     fi
   else
-    odie "Failed to detect system Glibc version"
+    odie "Failed to detect system Glibc version."
   fi
-  unset LDD_VERSION_OUTPUT LDD_VERSION LDD_VERSION_MAJOR LDD_VERSION_MINOR
-fi
+}
 
 # Execute the specified command, and suppress stderr unless HOMEBREW_STDERR is set.
 quiet_stderr() {
@@ -238,6 +239,7 @@ homebrew-vendor-install() {
 
   [[ -z "$VENDOR_NAME" ]] && odie "This command requires a vendor target!"
   [[ -n "$HOMEBREW_DEBUG" ]] && set -x
+  [[ -n "$HOMEBREW_LINUX" ]] && check_ldd_version
 
   url_var="${VENDOR_NAME}_URL"
   url2_var="${VENDOR_NAME}_URL2"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Prevent ~myself~ Homebrew from trying to install portable Ruby on systems with Glibc older than 2.13.
Supersedes #8658

```sh
$ brew vendor-install ruby
Error: Vendored tools require system Glibc 2.13 or later
```