### PR TITLE
manpage: test-bot: add --build-from-source.

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1564,6 +1564,8 @@ Only supports GitHub Actions as a CI provider. This is because Homebrew uses Git
   Clean all state from the Homebrew directory. Use with care!
 * `--skip-setup`:
   Don't check if the local system is set up correctly.
+* `--build-from-source`:
+  Build from source rather than building bottles.
 * `--keep-old`:
   Run `brew bottle --keep-old` to build new bottles for a single platform.
 * `--skip-relocation`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2181,6 +2181,10 @@ Clean all state from the Homebrew directory\. Use with care!
 Don\'t check if the local system is set up correctly\.
 .
 .TP
+\fB\-\-build\-from\-source\fR
+Build from source rather than building bottles\.
+.
+.TP
 \fB\-\-keep\-old\fR
 Run \fBbrew bottle \-\-keep\-old\fR to build new bottles for a single platform\.
 .


### PR DESCRIPTION
Needed due to https://github.com/Homebrew/homebrew-test-bot/pull/538
