### PR TITLE
dev-cmd/pr-automerge: exclude draft PRs

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -44,7 +44,7 @@ module Homebrew
     without_labels = args.without_labels || ["do not merge", "new formula", "automerge-skip", "linux-only"]
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
 
-    query = "is:pr is:open repo:#{tap.full_name}"
+    query = "is:pr is:open repo:#{tap.full_name} draft:false"
     query += args.ignore_failures? ? " -status:pending" : " status:success"
     query += " review:approved" unless args.without_approval?
     query += " label:\"#{args.with_label}\"" if args.with_label


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This PR prevents draft PRs to be merged by `pr-automerge`.

By now, there are only 2 PR were automatically merged being a draft: https://github.com/Homebrew/homebrew-core/pull/61327 and https://github.com/Homebrew/homebrew-core/pull/64346 ([see query](https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+draft%3Atrue+review%3Aapproved)).

I'm not sure if we need to add a flag to override this behaviour (as we have `--without-approval`).