### PR TITLE
create: allow creating casks in a specified tap

### DIFF
--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -68,7 +68,6 @@ module Homebrew
                 "--perl", "--python", "--ruby", "--rust", "--cask"
       conflicts "--cask", "--HEAD"
       conflicts "--cask", "--set-license"
-      conflicts "--cask", "--tap"
 
       named 1
     end
@@ -94,7 +93,11 @@ module Homebrew
       raise UsageError, "The `--set-name` flag is required for creating casks."
     end
 
-    cask_path = Cask::CaskLoader.path(token)
+    cask_tap = Tap.fetch(args.tap || "homebrew/cask")
+    raise TapUnavailableError, args.tap unless cask_tap.installed?
+
+    cask_path = Cask::CaskLoader.path("#{cask_tap}/#{token}")
+    cask_path.dirname.mkpath unless cask_path.dirname.exist?
     raise Cask::CaskAlreadyCreatedError, token if cask_path.exist?
 
     version = if args.set_version
@@ -142,7 +145,7 @@ module Homebrew
     fc.version = args.set_version
     fc.license = args.set_license
     fc.tap = Tap.fetch(args.tap || "homebrew/core")
-    raise TapUnavailableError, tap unless fc.tap.installed?
+    raise TapUnavailableError, args.tap unless fc.tap.installed?
 
     fc.url = args.named.first # Pull the first (and only) url from ARGV
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Allow `brew create` to place a new cask in any installed tap, creating the `Casks` folder if necessary. Also fixes an error that would occur if the specified tap did not exist.