### PR TITLE
utils/ruby: silence `which` errors when finding ruby

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -17,7 +17,7 @@ find_ruby() {
     echo "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
   else
     IFS=$'\n' # Do word splitting on new lines only
-    for ruby_exec in $(which -a ruby) $(PATH=$HOMEBREW_PATH which -a ruby)
+    for ruby_exec in $(which -a ruby 2>/dev/null) $(PATH=$HOMEBREW_PATH which -a ruby 2>/dev/null)
     do
       if test_ruby "$ruby_exec"; then
         echo "$ruby_exec"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

The `which` command is used to find `ruby` on systems where `portable-ruby` doesn't work. In my case, my WSL instance of Fedora 33 was missing one or more libraries that `portable-ruby` requires.

This pull request redirects stderr to `/dev/null` so that nothing is printed if `ruby` is not found in the usual places (`/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`).

Before:

```console
$ brew help
which: no ruby in (/usr/bin:/bin:/usr/sbin:/sbin)
Example usage:
  brew search [TEXT|/REGEX/]
...
```

After:

```console
$ brew help
Example usage:
  brew search [TEXT|/REGEX/]
...
```