### PR TITLE
python: use built-in venv instead of virtualenv when installing formulae

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -287,7 +287,7 @@ module Language
           targets = Array(targets)
           @formula.system @venv_root/"bin/pip", "install",
                           "-v", "--no-deps", "--no-binary", ":all:",
-                          "--ignore-installed", *targets
+                          "--no-user", "--ignore-installed", *targets
         end
       end
     end

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -86,18 +86,9 @@ describe Language::Python::Virtualenv::Virtualenv do
   let(:formula) { double("formula", resource: resource, bin: formula_bin) }
 
   describe "#create" do
-    it "creates a virtual environment" do
-      expect(formula).to receive(:resource).with("homebrew-virtualenv").and_return(resource)
+    it "creates a venv" do
+      expect(formula).to receive(:system).with("python", "-m", "venv", dir)
       subject.create
-    end
-
-    specify "virtual environment creation is idempotent" do
-      expect(formula).to receive(:resource).with("homebrew-virtualenv").and_return(resource)
-      subject.create
-      FileUtils.mkdir_p dir/"bin"
-      FileUtils.touch dir/"bin/python"
-      subject.create
-      FileUtils.rm dir/"bin/python"
     end
   end
 

--- a/Library/Homebrew/test/language/python_spec.rb
+++ b/Library/Homebrew/test/language/python_spec.rb
@@ -96,7 +96,7 @@ describe Language::Python::Virtualenv::Virtualenv do
     it "accepts a string" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo")
+              "--no-binary", ":all:", "--no-user", "--ignore-installed", "foo")
         .and_return(true)
       subject.pip_install "foo"
     end
@@ -104,7 +104,7 @@ describe Language::Python::Virtualenv::Virtualenv do
     it "accepts a multi-line strings" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo", "bar")
+              "--no-binary", ":all:", "--no-user", "--ignore-installed", "foo", "bar")
         .and_return(true)
 
       subject.pip_install <<~EOS
@@ -116,12 +116,12 @@ describe Language::Python::Virtualenv::Virtualenv do
     it "accepts an array" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo")
+              "--no-binary", ":all:", "--no-user", "--ignore-installed", "foo")
         .and_return(true)
 
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "bar")
+              "--no-binary", ":all:", "--no-user", "--ignore-installed", "bar")
         .and_return(true)
 
       subject.pip_install ["foo", "bar"]
@@ -133,7 +133,7 @@ describe Language::Python::Virtualenv::Virtualenv do
       expect(res).to receive(:stage).and_yield
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", Pathname.pwd)
+              "--no-binary", ":all:", "--no-user", "--ignore-installed", Pathname.pwd)
         .and_return(true)
 
       subject.pip_install res


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
This PR uses python's built-in `venv` to install formulae instead of the external `virtualenv`, which has dependencies and needs to be bootstrapped. The dependencies could also theoretically differ based on Python version.

Current caveat: `venv` uses `ensurepip` to install `pip` and `setuptools` using the wheels that are bundled with cpython, even if a newer one is installed, which is 20.2.3 for pip and 49.2.1 for setuptools in Python 3.9.1: https://github.com/python/cpython/blob/1e5d33e9b9b8631b36f061103a30208b206fd03a/Lib/ensurepip/__init__.py#L16-L18, https://github.com/python/cpython/tree/1e5d33e9b9b8631b36f061103a30208b206fd03a/Lib/ensurepip/_bundled

Other downstream package managers patch `ensurepip` to point to their locally managed `pip` and `setuptools`: https://src.fedoraproject.org/rpms/python3.9/blob/2084e749c71fe494a9a4ed76ce9c2d149b76868c/f/00189-use-rpm-wheels.patch, so that's a possible solution to ensure the temporary installation `venv` is using the latest versions that Homebrew knows about vs either using a known outdated version or blindly using the latest available in PyPI.

Marking as a draft for now and can look into writing new tests if it's decided to go in this direction.

Follow-up to #9435.