### PR TITLE
Documentation: Fixing xcode-select --switch command line option

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -466,7 +466,7 @@ then
 Your xcode-select path is currently set to '/'.
 This causes the 'xcrun' tool to hang, and can render Homebrew unusable.
 If you are using Xcode, you should:
-  sudo xcode-select -switch /Applications/Xcode.app
+  sudo xcode-select --switch /Applications/Xcode.app
 Otherwise, you should:
   sudo rm -rf /usr/share/xcode-select
 EOS

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -241,7 +241,7 @@ module Homebrew
         <<~EOS
           Your Xcode is configured with an invalid path.
           You should change it to the correct path:
-            sudo xcode-select -switch #{path}
+            sudo xcode-select --switch #{path}
         EOS
       end
 

--- a/Library/Homebrew/shims/mac/super/xcrun
+++ b/Library/Homebrew/shims/mac/super/xcrun
@@ -61,6 +61,6 @@ Failed to execute $arg0 $@
 
 Xcode and/or the CLT appear to be misconfigured. Try one or both of the following:
   xcodebuild -license
-  sudo xcode-select -switch /path/to/Xcode.app
+  sudo xcode-select --switch /path/to/Xcode.app
 "
 exit 1


### PR DESCRIPTION
Running `man xcode-select` only lists `-s <path>` or `--switch <path>` as valid options for switch.

I'm running on Big Sur 11.1 with Xcode Version 12.3 (12C33). I noticed this after I installed the latest Xcode update and ran brew doctor.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
`3194 examples, 1 failure, 54 pendings`

Had one unrelated test failure with: `rspec ./test/language/java_spec.rb:15`
```
1) Language::Java::java_home returns valid JAVA_HOME if version is not specified
     Failure/Error: expect(java_home/"bin/java").to be_an_executable

     NoMethodError:
       undefined method `/' for nil:NilClass
     # ./test/language/java_spec.rb:17:in `block (3 levels) in <top (required)>'
     # ./test/support/helper/spec/shared_context/homebrew_cask.rb:51:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:204:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:203:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```