### PR TITLE
More bottling HOMEBREW_LIBRARY changes

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -175,6 +175,7 @@ class FormulaInstaller
 
     bottle = formula.bottle_specification
     unless bottle.compatible_locations?
+      # TODO: delete HOMEBREW_REPOSITORY reference after Homebrew 2.7.0 is released.
       if output_warning
         opoo <<~EOS
           Building #{formula.full_name} from source as the bottle needs:

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -4,14 +4,17 @@
 class Keg
   PREFIX_PLACEHOLDER = "@@HOMEBREW_PREFIX@@"
   CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@"
+  LIBRARY_PLACEHOLDER = "@@HOMEBREW_LIBRARY@@"
+
+  # TODO: delete these after Homebrew 2.7.0 is released.
   REPOSITORY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@"
+  REPOSITORY_LIBRARY_PLACEHOLDER = "#{REPOSITORY_PLACEHOLDER}/Library"
 
-  # If the location of HOMEBREW_LIBRARY changes
-  # formula_cellar_checks.rb, test/global_spec.rb, and this constant need to change.
-  LIBRARY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@/Library"
-
-  Relocation = Struct.new(:old_prefix, :old_cellar, :old_repository, :old_library,
-                          :new_prefix, :new_cellar, :new_repository, :new_library) do
+  Relocation = Struct.new(:old_prefix, :old_cellar, :old_library,
+                          :new_prefix, :new_cellar, :new_library,
+                          # TODO: delete these after Homebrew 2.7.0 is released.
+                          :old_repository, :new_repository,
+                          :old_repository_library, :new_repository_library) do
     # Use keyword args instead of positional args for initialization.
     def initialize(**kwargs)
       super(*members.map { |k| kwargs[k] })
@@ -43,12 +46,16 @@ class Keg
     relocation = Relocation.new(
       old_prefix:     HOMEBREW_PREFIX.to_s,
       old_cellar:     HOMEBREW_CELLAR.to_s,
-      old_repository: HOMEBREW_REPOSITORY.to_s,
-      old_library:    HOMEBREW_LIBRARY.to_s,
       new_prefix:     PREFIX_PLACEHOLDER,
       new_cellar:     CELLAR_PLACEHOLDER,
+      # TODO: delete these after Homebrew 2.7.0 is released.
+      old_library:    HOMEBREW_LIBRARY.to_s,
+      new_library:    REPOSITORY_LIBRARY_PLACEHOLDER,
+      old_repository: HOMEBREW_REPOSITORY.to_s,
       new_repository: REPOSITORY_PLACEHOLDER,
-      new_library:    LIBRARY_PLACEHOLDER,
+      # TODO: add these after Homebrew 2.7.0 is released.
+      # old_library:    HOMEBREW_LIBRARY.to_s,
+      # new_library:    LIBRARY_PLACEHOLDER,
     )
     relocate_dynamic_linkage(relocation)
     replace_text_in_files(relocation)
@@ -56,14 +63,17 @@ class Keg
 
   def replace_placeholders_with_locations(files, skip_linkage: false)
     relocation = Relocation.new(
-      old_prefix:     PREFIX_PLACEHOLDER,
-      old_cellar:     CELLAR_PLACEHOLDER,
-      old_repository: REPOSITORY_PLACEHOLDER,
-      old_library:    LIBRARY_PLACEHOLDER,
-      new_prefix:     HOMEBREW_PREFIX.to_s,
-      new_cellar:     HOMEBREW_CELLAR.to_s,
-      new_repository: HOMEBREW_REPOSITORY.to_s,
-      new_library:    HOMEBREW_LIBRARY.to_s,
+      old_prefix:             PREFIX_PLACEHOLDER,
+      old_cellar:             CELLAR_PLACEHOLDER,
+      old_library:            LIBRARY_PLACEHOLDER,
+      new_prefix:             HOMEBREW_PREFIX.to_s,
+      new_cellar:             HOMEBREW_CELLAR.to_s,
+      new_library:            HOMEBREW_LIBRARY.to_s,
+      # TODO: delete these after Homebrew 2.7.0 is released.
+      old_repository:         REPOSITORY_PLACEHOLDER,
+      new_repository:         HOMEBREW_REPOSITORY.to_s,
+      old_repository_library: REPOSITORY_LIBRARY_PLACEHOLDER,
+      new_repository_library: HOMEBREW_LIBRARY.to_s,
     )
     relocate_dynamic_linkage(relocation) unless skip_linkage
     replace_text_in_files(relocation, files: files)
@@ -77,16 +87,16 @@ class Keg
       s = first.open("rb", &:read)
 
       replacements = {
-        relocation.old_prefix => relocation.new_prefix,
-        relocation.old_cellar => relocation.new_cellar,
-      }
+        relocation.old_prefix             => relocation.new_prefix,
+        relocation.old_cellar             => relocation.new_cellar,
+        relocation.old_library            => relocation.new_library,
+        # TODO: delete this after Homebrew 2.7.0 is released.
+        relocation.old_repository_library => relocation.new_repository_library,
+      }.compact
       # when HOMEBREW_PREFIX == HOMEBREW_REPOSITORY we should use HOMEBREW_PREFIX for all relocations to avoid
       # being unable to differentiate between them.
-      if HOMEBREW_PREFIX == HOMEBREW_REPOSITORY
-        replacements[relocation.old_library] = relocation.new_library
-      else
-        replacements[relocation.old_repository] = relocation.new_repository
-      end
+      # TODO: delete this after Homebrew 2.7.0 is released.
+      replacements[relocation.old_repository] = relocation.new_repository if HOMEBREW_PREFIX != HOMEBREW_REPOSITORY
       changed = s.gsub!(Regexp.union(replacements.keys.sort_by(&:length).reverse), replacements)
       next unless changed
 

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -4,16 +4,15 @@
 class Keg
   PREFIX_PLACEHOLDER = "@@HOMEBREW_PREFIX@@"
   CELLAR_PLACEHOLDER = "@@HOMEBREW_CELLAR@@"
+  REPOSITORY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@"
   LIBRARY_PLACEHOLDER = "@@HOMEBREW_LIBRARY@@"
 
-  # TODO: delete these after Homebrew 2.7.0 is released.
-  REPOSITORY_PLACEHOLDER = "@@HOMEBREW_REPOSITORY@@"
+  # TODO: delete this after Homebrew 2.7.0 is released.
   REPOSITORY_LIBRARY_PLACEHOLDER = "#{REPOSITORY_PLACEHOLDER}/Library"
 
-  Relocation = Struct.new(:old_prefix, :old_cellar, :old_library,
-                          :new_prefix, :new_cellar, :new_library,
+  Relocation = Struct.new(:old_prefix, :old_cellar, :old_repository, :old_library,
+                          :new_prefix, :new_cellar, :new_repository, :new_library,
                           # TODO: delete these after Homebrew 2.7.0 is released.
-                          :old_repository, :new_repository,
                           :old_repository_library, :new_repository_library) do
     # Use keyword args instead of positional args for initialization.
     def initialize(**kwargs)
@@ -65,13 +64,13 @@ class Keg
     relocation = Relocation.new(
       old_prefix:             PREFIX_PLACEHOLDER,
       old_cellar:             CELLAR_PLACEHOLDER,
+      old_repository:         REPOSITORY_PLACEHOLDER,
       old_library:            LIBRARY_PLACEHOLDER,
       new_prefix:             HOMEBREW_PREFIX.to_s,
       new_cellar:             HOMEBREW_CELLAR.to_s,
+      new_repository:         HOMEBREW_REPOSITORY.to_s,
       new_library:            HOMEBREW_LIBRARY.to_s,
       # TODO: delete these after Homebrew 2.7.0 is released.
-      old_repository:         REPOSITORY_PLACEHOLDER,
-      new_repository:         HOMEBREW_REPOSITORY.to_s,
       old_repository_library: REPOSITORY_LIBRARY_PLACEHOLDER,
       new_repository_library: HOMEBREW_LIBRARY.to_s,
     )
@@ -95,7 +94,6 @@ class Keg
       }.compact
       # when HOMEBREW_PREFIX == HOMEBREW_REPOSITORY we should use HOMEBREW_PREFIX for all relocations to avoid
       # being unable to differentiate between them.
-      # TODO: delete this after Homebrew 2.7.0 is released.
       replacements[relocation.old_repository] = relocation.new_repository if HOMEBREW_PREFIX != HOMEBREW_REPOSITORY
       changed = s.gsub!(Regexp.union(replacements.keys.sort_by(&:length).reverse), replacements)
       next unless changed

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -389,6 +389,7 @@ class BottleSpecification
     # Only check the repository matches if the prefix is the default.
     # This is because the bottle DSL does not allow setting a custom repository
     # but does allow setting a custom prefix.
+    # TODO: delete this after Homebrew 2.7.0 is released.
     compatible_repository = if Homebrew.default_prefix?(prefix)
       repository == HOMEBREW_REPOSITORY.to_s
     else

--- a/Library/Homebrew/test/global_spec.rb
+++ b/Library/Homebrew/test/global_spec.rb
@@ -8,10 +8,4 @@ describe "brew", :integration_test do
       .and not_to_output.to_stderr
       .and be_a_success
   end
-
-  # If the location of HOMEBREW_LIBRARY changes
-  # keg_relocate.rb, formula_cellar_checks.rb, and this test need to change.
-  it "ensures that HOMEBREW_LIBRARY=HOMEBREW_REPOSITORY/Library" do
-    expect(HOMEBREW_LIBRARY.to_s).to eq("#{HOMEBREW_REPOSITORY}/Library")
-  end
 end


### PR DESCRIPTION
- Refuse to create bottles which have non-relocatable references to `HOMEBREW_LIBRARY`. This allows us to make all bottles ignore where `HOMEBREW_REPOSITORY` is (even those that aren't `cellar :any`). I cannot see any circumstances in which any bottle should link to anything within `HOMEBREW_REPOSITORY`.
- Remove audit that becomes unnecessary given the above change.
- Relocate references to `@HOMEBREW_LIBRARY@` but don't actually write any references yet. This will allow us to move to using  `@HOMEBREW_LIBRARY` and remove all relocation of `HOMEBREW_REPOSITORY` in a future release (2.7.1, most likely).

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?
