### PR TITLE
Remove basic authentication support for GitHub.

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -343,15 +343,10 @@ module Homebrew
   end
 
   def download_artifact(url, dir, pr)
-    token, username = GitHub.api_credentials
-    case GitHub.api_credentials_type
-    when :env_username_password, :keychain_username_password
-      curl_args = ["--user", "#{username}:#{token}"]
-    when :env_token
-      curl_args = ["--header", "Authorization: token #{token}"]
-    when :none
-      raise "Credentials must be set to access the Artifacts API"
-    end
+    raise "Credentials must be set to access the Artifacts API" if GitHub.api_credentials_type == :none
+
+    token = GitHub.api_credentials
+    curl_args = ["--header", "Authorization: token #{token}"]
 
     # Download the artifact as a zip file and unpack it into `dir`. This is
     # preferred over system `curl` and `tar` as this leverages the Homebrew


### PR DESCRIPTION
Since we (and GitHub) no longer support password authentication using non-token passwords, always set the Authorization header, rather than needlessly checking for a (possibly incorrect) username. This also simplifies the code.

Fixes issue identified in https://github.com/Homebrew/discussions/discussions/273#discussioncomment-200900.

Tested on `brew pr-pull --verbose` and confirmed that it behaves as expected (not passing `--user foo:***` and instead passing `--header Authorization: token ***` to curl)

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----