### PR TITLE
Improve handling of SIGINT.

### DIFF
--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -32,14 +32,10 @@ module Homebrew
     ruby_sys_args << "-e #{args.e}" if args.e
     ruby_sys_args += args.named
 
-    begin
-      safe_system RUBY_PATH,
-                  ENV["HOMEBREW_RUBY_WARNINGS"],
-                  "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
-                  "-rglobal", "-rdev-cmd/irb",
-                  *ruby_sys_args
-    rescue ErrorDuringExecution => e
-      exit e.status.exitstatus
-    end
+    exec RUBY_PATH,
+         ENV["HOMEBREW_RUBY_WARNINGS"],
+         "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
+         "-rglobal", "-rdev-cmd/irb",
+         *ruby_sys_args
   end
 end

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -578,14 +578,24 @@ class ErrorDuringExecution < RuntimeError
     @status = status
     @output = output
 
-    exitstatus = if status.respond_to?(:exitstatus)
-      status.exitstatus
-    else
+    exitstatus = case status
+    when Integer
       status
+    else
+      status.exitstatus
     end
 
     redacted_cmd = redact_secrets(cmd.shelljoin.gsub('\=', "="), secrets)
-    s = +"Failure while executing; `#{redacted_cmd}` exited with #{exitstatus}."
+
+    reason = if exitstatus
+      "exited with #{exitstatus}"
+    elsif (uncaught_signal = status.termsig)
+      "was terminated by uncaught signal #{Signal.signame(uncaught_signal)}"
+    else
+      raise ArgumentError, "Status does neither have `exitstatus` nor `termsig`."
+    end
+
+    s = +"Failure while executing; `#{redacted_cmd}` #{reason}."
 
     if Array(output).present?
       format_output_line = lambda do |type_line|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

1. Make `ignore_interrupts` raise an `Interrupt` exception afterwards if there was an an attempt to interrupt it. 
    
    If I press <kbd>CTRL</kbd>-<kbd>C</kbd>, I expect `brew` to exit after the “One sec, cleaning up...” message and not continue running until I happen to find a “correct” position where pressing <kbd>CTRL</kbd>-<kbd>C</kbd> actually works.

2. Change `SystemCommand` to spawn processes in another process group, so that the parent process can send `SIGINT` to the child rather than the child receiving it directly. We want to raise an `Interrupt` exception rather than the child exiting with a `Process::Status` containing only a signal but no actual exit status.