### PR TITLE
test: don't try to use Xcode SDK for build requirement

### DIFF
--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 module Stdenv
-  def setup_build_environment(**options)
-    generic_setup_build_environment(**options)
+  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
+    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
 
     prepend_path "CPATH", HOMEBREW_PREFIX/"include"
     prepend_path "LIBRARY_PATH", HOMEBREW_PREFIX/"lib"

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -10,8 +10,8 @@ module Superenv
   end
 
   # @private
-  def setup_build_environment(**options)
-    generic_setup_build_environment(**options)
+  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
+    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
     self["HOMEBREW_OPTIMIZATION_LEVEL"] = "O2"
     self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path
     self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(@formula)

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -10,8 +10,8 @@ module Stdenv
     ["#{HOMEBREW_LIBRARY}/Homebrew/os/mac/pkgconfig/#{MacOS.sdk_version}"]
   end
 
-  def setup_build_environment(**options)
-    generic_setup_build_environment(**options)
+  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
+    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
 
     # sed is strict, and errors out when it encounters files with
     # mixed character sets
@@ -19,7 +19,7 @@ module Stdenv
     self["LC_CTYPE"] = "C"
 
     # Add lib and include etc. from the current macosxsdk to compiler flags:
-    macosxsdk(formula: @formula)
+    macosxsdk(formula: @formula, testing_formula: testing_formula)
 
     return unless MacOS::Xcode.without_clt?
 
@@ -50,7 +50,7 @@ module Stdenv
     remove "CMAKE_FRAMEWORK_PATH", "#{sdk}/System/Library/Frameworks"
   end
 
-  def macosxsdk(version = nil, formula: nil)
+  def macosxsdk(version = nil, formula: nil, testing_formula: false)
     # Sets all needed lib and include dirs to CFLAGS, CPPFLAGS, LDFLAGS.
     remove_macosxsdk
     min_version = version || MacOS.version
@@ -58,7 +58,11 @@ module Stdenv
     self["CPATH"] = "#{HOMEBREW_PREFIX}/include"
     prepend "LDFLAGS", "-L#{HOMEBREW_PREFIX}/lib"
 
-    sdk = formula ? MacOS.sdk_for_formula(formula, version) : MacOS.sdk(version)
+    sdk = if formula
+      MacOS.sdk_for_formula(formula, version, check_only_runtime_requirements: testing_formula)
+    else
+      MacOS.sdk(version)
+    end
     return if !MacOS.sdk_root_needed? && sdk&.source != :xcode
 
     Homebrew::Diagnostic.checks(:fatal_setup_build_environment_checks)

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -106,8 +106,7 @@ module Superenv
   end
 
   # @private
-  def setup_build_environment(**options)
-    formula = options[:formula]
+  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
     sdk = formula ? MacOS.sdk_for_formula(formula) : MacOS.sdk
     if MacOS.sdk_root_needed? || sdk&.source == :xcode
       Homebrew::Diagnostic.checks(:fatal_setup_build_environment_checks)
@@ -122,7 +121,7 @@ module Superenv
       self["HOMEBREW_SDKROOT"] = nil
       self["HOMEBREW_DEVELOPER_DIR"] = nil
     end
-    generic_setup_build_environment(**options)
+    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -120,9 +120,16 @@ module OS
       sdk_locator.sdk_if_applicable(v)
     end
 
-    def sdk_for_formula(f, v = nil)
+    def sdk_for_formula(f, v = nil, check_only_runtime_requirements: false)
       # If the formula requires Xcode, don't return the CLT SDK
-      return Xcode.sdk if f.requirements.any? { |req| req.is_a? XcodeRequirement }
+      # If check_only_runtime_requirements is true, don't necessarily return the
+      # Xcode SDK if the XcodeRequirement is only a build or test requirment.
+      return Xcode.sdk if f.requirements.any? do |req|
+        next false unless req.is_a? XcodeRequirement
+        next false if check_only_runtime_requirements && req.build? && !req.test?
+
+        true
+      end
 
       sdk(v)
     end

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -36,7 +36,7 @@ begin
   formula.extend(Debrew::Formula) if args.debug?
 
   ENV.extend(Stdenv)
-  T.cast(ENV, Stdenv).setup_build_environment(formula: formula)
+  T.cast(ENV, Stdenv).setup_build_environment(formula: formula, testing_formula: true)
 
   # tests can also return false to indicate failure
   Timeout.timeout TEST_TIMEOUT_SECONDS do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Previously, running `brew test` failed if the formula had an Xcode build requirement but the user did not have Xcode installed. `brew` would see the Xcode requirement and default to the Xcode SDK. However, for formula that only need Xcode to build, this check is unnecessary when simply testing the formula. I ran into this in https://github.com/Homebrew/homebrew-core/pull/67043 with [`deno`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/deno.rb):

```console
$ brew test deno
==> Testing deno
Error: deno: failed
An exception occurred within a child process:
  NoMethodError: undefined method `path' for nil:NilClass
Did you mean?  paths
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/extend/ENV/std.rb:88:in `macosxsdk'
/usr/local/Homebrew/Library/Homebrew/extend/os/mac/extend/ENV/std.rb:45:in `setup_build_environment'
/usr/local/Homebrew/Library/Homebrew/test.rb:39:in `<main>'
```

I don't have code installed, so `Xcode.sdk.path` failed (`Xcode.sdk` is `nil`).

My solution is to, when testing, pass a flag to the `macosxsdk` method to determine whether to check only runtime requirements. When this is false (the default), any Xcode requirement will require the use of the Xcode SDK. When set to true (only in `brew test`), build-only Xcode requirements will not necessarily require the Xcode SDK.

I'm marking this PR as `critical` because I believe it fixes a bug. However, I'm not familiar at all with the files that I'm changing so it's entirely possible that this change will have unintended consequences. I will not merge until I have approvals from other maintainers who are more familiar with this code.