### PR TITLE
livecheck: raise error if no watchlist

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -97,8 +97,7 @@ module Homebrew
           onoe e
         end
       else
-        raise UsageError, "ENV['HOMEBREW_LIVECHECK_WATCHLIST'] or ~/.brew_livecheck_watchlist is required " \
-                          "if no formula or cask argument is passed"
+        raise UsageError, "A watchlist file is required when no arguments are given."
       end&.sort_by do |formula_or_cask|
         formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
       end

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -60,44 +60,45 @@ module Homebrew
       puts ENV["HOMEBREW_LIVECHECK_WATCHLIST"] if ENV["HOMEBREW_LIVECHECK_WATCHLIST"].present?
     end
 
-    formulae_and_casks_to_check = if args.tap
-      tap = Tap.fetch(args.tap)
-      formulae = args.cask? ? [] : tap.formula_files.map { |path| Formulary.factory(path) }
-      casks = args.formula? ? [] : tap.cask_files.map { |path| Cask::CaskLoader.load(path) }
-      formulae + casks
-    elsif args.installed?
-      formulae = args.cask? ? [] : Formula.installed
-      casks = args.formula? ? [] : Cask::Caskroom.casks
-      formulae + casks
-    elsif args.all?
-      formulae = args.cask? ? [] : Formula.to_a
-      casks = args.formula? ? [] : Cask::Cask.to_a
-      formulae + casks
-    elsif args.named.present?
-      if args.formula?
-        args.named.to_formulae
-      elsif args.cask?
-        args.named.to_casks
-      else
-        args.named.to_formulae_and_casks
-      end
-    elsif File.exist?(WATCHLIST_PATH)
-      begin
-        names = Pathname.new(WATCHLIST_PATH).read.lines
-                        .reject { |line| line.start_with?("#") || line.blank? }
-                        .map(&:strip)
-
-        named_args = T.unsafe(CLI::NamedArgs).new(*names)
-        named_args.to_formulae_and_casks.reject do |formula_or_cask|
-          (args.formula? && !formula_or_cask.is_a?(Formula)) ||
-            (args.cask? && !formula_or_cask.is_a?(Cask::Cask))
+    formulae_and_casks_to_check =
+      if args.tap
+        tap = Tap.fetch(args.tap)
+        formulae = args.cask? ? [] : tap.formula_files.map { |path| Formulary.factory(path) }
+        casks = args.formula? ? [] : tap.cask_files.map { |path| Cask::CaskLoader.load(path) }
+        formulae + casks
+      elsif args.installed?
+        formulae = args.cask? ? [] : Formula.installed
+        casks = args.formula? ? [] : Cask::Caskroom.casks
+        formulae + casks
+      elsif args.all?
+        formulae = args.cask? ? [] : Formula.to_a
+        casks = args.formula? ? [] : Cask::Cask.to_a
+        formulae + casks
+      elsif args.named.present?
+        if args.formula?
+          args.named.to_formulae
+        elsif args.cask?
+          args.named.to_casks
+        else
+          args.named.to_formulae_and_casks
         end
-      rescue Errno::ENOENT => e
-        onoe e
+      elsif File.exist?(WATCHLIST_PATH)
+        begin
+          names = Pathname.new(WATCHLIST_PATH).read.lines
+                          .reject { |line| line.start_with?("#") || line.blank? }
+                          .map(&:strip)
+
+          named_args = T.unsafe(CLI::NamedArgs).new(*names)
+          named_args.to_formulae_and_casks.reject do |formula_or_cask|
+            (args.formula? && !formula_or_cask.is_a?(Formula)) ||
+              (args.cask? && !formula_or_cask.is_a?(Cask::Cask))
+          end
+        rescue Errno::ENOENT => e
+          onoe e
+        end
+      end&.sort_by do |formula_or_cask|
+        formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
       end
-    end.sort_by do |formula_or_cask|
-      formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
-    end
 
     raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank?
 

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -96,6 +96,9 @@ module Homebrew
         rescue Errno::ENOENT => e
           onoe e
         end
+      else
+        raise UsageError, "ENV['HOMEBREW_LIVECHECK_WATCHLIST'] or ~/.brew_livecheck_watchlist is required " \
+                          "if no formula or cask argument is passed"
       end&.sort_by do |formula_or_cask|
         formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
       end

--- a/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/livecheck_spec.rb
@@ -21,4 +21,11 @@ describe "brew livecheck", :integration_test do
       .and not_to_output.to_stderr
       .and be_a_success
   end
+
+  it "gives an error when no arguments are given and there's no watchlist" do
+    expect { brew "livecheck" }
+      .to output(/Invalid usage: A watchlist file is required when no arguments are given\./).to_stderr
+      .and not_to_output.to_stdout
+      .and be_a_failure
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
closes https://github.com/Homebrew/brew/issues/10052
raise an error when `brew livecheck` has no args and set no `ENV['HOMEBREW_LIVECHECK_WATCHLIST'] `or `~/.brew_livecheck_watchlist`