### PR TITLE
pr-pull: disable --workflow flag

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -50,10 +50,8 @@ module Homebrew
              depends_on:  "--autosquash",
              description: "Message to include when autosquashing revision bumps, deletions, and rebuilds."
       flag   "--workflow=",
-             description: "Retrieve artifacts from the specified workflow (default: `tests.yml`). "\
-                          "*Legacy:* use `--workflows` instead."
-      # TODO: enable for next major/minor release
-      #      replacement: "`--workflows`"
+             description: "Retrieve artifacts from the specified workflow (default: `tests.yml`).",
+             replacement: "`--workflows`"
       flag   "--artifact=",
              description: "Download artifacts with the specified name (default: `bottles`)."
       flag   "--bintray-org=",
@@ -66,8 +64,8 @@ module Homebrew
              description: "Use the specified Bintray repository to automatically mirror stable URLs "\
                           "defined in the formulae (default: `mirror`)."
       comma_array "--workflows=",
-                  description: "Retrieve artifacts from the specified workflow (default: `tests.yml`) "\
-                               "Comma-separated list to include multiple workflows."
+                  description: "Retrieve artifacts from the specified workflow (default: `tests.yml`). "\
+                               "Can be a comma-separated list to include multiple workflows."
       comma_array "--ignore-missing-artifacts=",
                   description: "Comma-separated list of workflows which can be ignored if they have not been run."
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1150,8 +1150,6 @@ Requires write access to the repository.
   Warn instead of raising an error if the bottle upload fails. Useful for repairing bottle uploads that previously failed.
 * `--message`:
   Message to include when autosquashing revision bumps, deletions, and rebuilds.
-* `--workflow`:
-  Retrieve artifacts from the specified workflow (default: `tests.yml`). *Legacy:* use `--workflows` instead.
 * `--artifact`:
   Download artifacts with the specified name (default: `bottles`).
 * `--bintray-org`:
@@ -1163,7 +1161,7 @@ Requires write access to the repository.
 * `--bintray-mirror`:
   Use the specified Bintray repository to automatically mirror stable URLs defined in the formulae (default: `mirror`).
 * `--workflows`:
-  Retrieve artifacts from the specified workflow (default: `tests.yml`) Comma-separated list to include multiple workflows.
+  Retrieve artifacts from the specified workflow (default: `tests.yml`). Can be a comma-separated list to include multiple workflows.
 * `--ignore-missing-artifacts`:
   Comma-separated list of workflows which can be ignored if they have not been run.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1604,10 +1604,6 @@ Warn instead of raising an error if the bottle upload fails\. Useful for repairi
 Message to include when autosquashing revision bumps, deletions, and rebuilds\.
 .
 .TP
-\fB\-\-workflow\fR
-Retrieve artifacts from the specified workflow (default: \fBtests\.yml\fR)\. \fILegacy:\fR use \fB\-\-workflows\fR instead\.
-.
-.TP
 \fB\-\-artifact\fR
 Download artifacts with the specified name (default: \fBbottles\fR)\.
 .
@@ -1629,7 +1625,7 @@ Use the specified Bintray repository to automatically mirror stable URLs defined
 .
 .TP
 \fB\-\-workflows\fR
-Retrieve artifacts from the specified workflow (default: \fBtests\.yml\fR) Comma\-separated list to include multiple workflows\.
+Retrieve artifacts from the specified workflow (default: \fBtests\.yml\fR)\. Can be a comma\-separated list to include multiple workflows\.
 .
 .TP
 \fB\-\-ignore\-missing\-artifacts\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Replaced by --workflows.
Tagging as `critical` to match Homebrew/brew#10056.