### PR TITLE
formula: activate env extensions for postinstall

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1049,6 +1049,7 @@ class Formula
 
       with_env(new_env) do
         ENV.clear_sensitive_environment!
+        ENV.activate_extensions!
 
         etc_var_dirs = [bottle_prefix/"etc", bottle_prefix/"var"]
         T.unsafe(Find).find(*etc_var_dirs.select(&:directory?)) do |path|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This allows `ENV.prepend_path` calls during `postinstall`

Another way to do this would be:

```rb
ENV.extend SharedEnvExtension
```

Related: https://github.com/Homebrew/homebrew-core/pull/66722, https://github.com/Homebrew/homebrew-core/pull/66910