### PR TITLE
Systemcommand: Add debug option

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -74,15 +74,14 @@ class SystemCommand
       must_succeed: T::Boolean,
       print_stdout: T::Boolean,
       print_stderr: T::Boolean,
-      debug:        T::Boolean,
-      verbose:      T::Boolean,
+      debug:        T.nilable(T::Boolean),
+      verbose:      T.nilable(T::Boolean),
       secrets:      T.any(String, T::Array[String]),
       chdir:        T.any(String, Pathname),
     ).void
   end
   def initialize(executable, args: [], sudo: false, env: {}, input: [], must_succeed: false,
-                 print_stdout: false, print_stderr: true, debug: false, verbose: false, secrets: [],
-                 chdir: T.unsafe(nil))
+                 print_stdout: false, print_stderr: true, debug: nil, verbose: nil, secrets: [], chdir: T.unsafe(nil))
     require "extend/ENV"
     @executable = executable
     @args = args

--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -74,13 +74,15 @@ class SystemCommand
       must_succeed: T::Boolean,
       print_stdout: T::Boolean,
       print_stderr: T::Boolean,
+      debug:        T::Boolean,
       verbose:      T::Boolean,
       secrets:      T.any(String, T::Array[String]),
       chdir:        T.any(String, Pathname),
     ).void
   end
   def initialize(executable, args: [], sudo: false, env: {}, input: [], must_succeed: false,
-                 print_stdout: false, print_stderr: true, verbose: false, secrets: [], chdir: T.unsafe(nil))
+                 print_stdout: false, print_stderr: true, debug: false, verbose: false, secrets: [],
+                 chdir: T.unsafe(nil))
     require "extend/ENV"
     @executable = executable
     @args = args
@@ -95,6 +97,7 @@ class SystemCommand
     @must_succeed = must_succeed
     @print_stdout = print_stdout
     @print_stderr = print_stderr
+    @debug = debug
     @verbose = verbose
     @secrets = (Array(secrets) + ENV.sensitive_environment.values).uniq
     @chdir = chdir
@@ -110,6 +113,13 @@ class SystemCommand
   attr_reader :executable, :args, :input, :chdir, :env
 
   attr_predicate :sudo?, :print_stdout?, :print_stderr?, :must_succeed?
+
+  sig { returns(T::Boolean) }
+  def debug?
+    return super if @debug.nil?
+
+    @debug
+  end
 
   sig { returns(T::Boolean) }
   def verbose?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

It's sometimes necessary to control `debug` when using `SystemCommand` in certain contexts (e.g., livecheck) and this PR allows us to do this. This is also true for methods that call `system_command` internally (e.g., `Curl#curl_with_workarounds`) and we'll have to modify those to support `debug`, where appropriate.

This was originally part of #9535 but I'm pulling it out into a separate PR, as this change is necessary in #9529 for the same reasons (avoiding debug output from `curl`).  This PR also includes the commit from #9535 that updates `#curl_with_workarounds` to include a named `debug` parameter (which is passed to the `system_command` call).

This change may also allow us to migrate the `Git` livecheck strategy to `system_command`, instead of using `Open#capture3`. The technical limitations mentioned in the explanatory comment in that strategy are partly related to not being able to control `debug` when using `system_command` and this PR addresses that.

Once this is merged, I'll rebase #9535 onto `master` (dropping/editing the commits that we're handling in this PR instead). I also have the changes worked out to migrate the `Git` strategy to `system_command`, so I'll create a follow-up PR once I've properly tested everything.