### PR TITLE
Fix `sudo` prompt.

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -158,7 +158,7 @@ class SystemCommand
     options = {
       # Create a new process group so that we can send `SIGINT` from
       # parent to child rather than the child receiving `SIGINT` directly.
-      pgroup: true,
+      pgroup: sudo? ? nil : true,
     }
     options[:chdir] = chdir if chdir
 
@@ -174,7 +174,7 @@ class SystemCommand
 
     @status = raw_wait_thr.value
   rescue Interrupt
-    Process.kill("INT", pid) if pid
+    Process.kill("INT", pid) if pid && !sudo?
     raise Interrupt
   rescue SystemCallError => e
     @status = $CHILD_STATUS

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -55,7 +55,7 @@ describe SystemCommand do
             .to receive(:popen3)
             .with(
               an_instance_of(Hash), ["/usr/bin/sudo", "/usr/bin/sudo"], "-E", "--",
-              "/usr/bin/env", "A=1", "B=2", "C=3", "env", *env_args, pgroup: true
+              "/usr/bin/env", "A=1", "B=2", "C=3", "env", *env_args, pgroup: nil
             )
             .and_wrap_original do |original_popen3, *_, &block|
               original_popen3.call("true", &block)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

The `sudo` prompt is hidden when using another process group. Also, to interrupt a `sudo` process, we would need `sudo` again, so we would have to store the password ourselves to ensure we can actually successfully call it, so let's just not create new process groups for `sudo`.

Fixes https://github.com/Homebrew/homebrew-cask/issues/95893.