### PR TITLE
Curl: Add optional debug and retry parameters

### DIFF
--- a/Library/Homebrew/test/utils/curl_spec.rb
+++ b/Library/Homebrew/test/utils/curl_spec.rb
@@ -3,25 +3,61 @@
 
 require "utils/curl"
 
-describe "curl" do
+describe "Utils::Curl" do
   describe "curl_args" do
+    let(:args) { "foo" }
+    let(:user_agent_string) { "Lorem ipsum dolor sit amet" }
+
     it "returns --disable as the first argument when HOMEBREW_CURLRC is not set" do
       # --disable must be the first argument according to "man curl"
-      expect(curl_args("foo").first).to eq("--disable")
+      expect(curl_args(*args).first).to eq("--disable")
     end
 
-    it "doesn't return --disable as the first argument when HOMEBREW_CURLRC is set" do
+    it "doesn't return `--disable` as the first argument when HOMEBREW_CURLRC is set" do
       ENV["HOMEBREW_CURLRC"] = "1"
-      expect(curl_args("foo").first).not_to eq("--disable")
+      expect(curl_args(*args).first).not_to eq("--disable")
     end
 
     it "uses `--retry 3` when HOMEBREW_CURL_RETRIES is unset" do
-      expect(curl_args("foo").join(" ")).to include("--retry 3")
+      expect(curl_args(*args).join(" ")).to include("--retry 3")
     end
 
     it "uses the given value for `--retry` when HOMEBREW_CURL_RETRIES is set" do
       ENV["HOMEBREW_CURL_RETRIES"] = "10"
-      expect(curl_args("foo").join(" ")).to include("--retry 10")
+      expect(curl_args(*args).join(" ")).to include("--retry 10")
+    end
+
+    it "doesn't use `--retry` when `:retry` == `false`" do
+      expect(curl_args(*args, retry: false).join(" ")).not_to include("--retry")
+    end
+
+    it "uses `--retry 3` when `:retry` == `true`" do
+      expect(curl_args(*args, retry: true).join(" ")).to include("--retry 3")
+    end
+
+    it "uses HOMEBREW_USER_AGENT_FAKE_SAFARI when `:user_agent` is `:browser` or `:fake`" do
+      expect(curl_args(*args, user_agent: :browser).join(" "))
+        .to include("--user-agent #{HOMEBREW_USER_AGENT_FAKE_SAFARI}")
+      expect(curl_args(*args, user_agent: :fake).join(" "))
+        .to include("--user-agent #{HOMEBREW_USER_AGENT_FAKE_SAFARI}")
+    end
+
+    it "uses HOMEBREW_USER_AGENT_CURL when `:user_agent` is `:default` or omitted" do
+      expect(curl_args(*args, user_agent: :default).join(" ")).to include("--user-agent #{HOMEBREW_USER_AGENT_CURL}")
+      expect(curl_args(*args, user_agent: nil).join(" ")).to include("--user-agent #{HOMEBREW_USER_AGENT_CURL}")
+      expect(curl_args(*args).join(" ")).to include("--user-agent #{HOMEBREW_USER_AGENT_CURL}")
+    end
+
+    it "uses provided user agent string when `:user_agent` is a `String`" do
+      expect(curl_args(*args, user_agent: user_agent_string).join(" "))
+        .to include("--user-agent #{user_agent_string}")
+    end
+
+    it "uses `--fail` unless `:show_output` is `true`" do
+      expect(curl_args(*args, show_output: false).join(" ")).to include("--fail")
+      expect(curl_args(*args, show_output: nil).join(" ")).to include("--fail")
+      expect(curl_args(*args).join(" ")).to include("--fail")
+      expect(curl_args(*args, show_output: true).join(" ")).not_to include("--fail")
     end
   end
 end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -55,12 +55,13 @@ module Utils
     end
 
     def curl_with_workarounds(
-      *args, secrets: nil, print_stdout: nil, print_stderr: nil, verbose: nil, env: {}, **options
+      *args, secrets: nil, print_stdout: nil, print_stderr: nil, debug: nil, verbose: nil, env: {}, **options
     )
       command_options = {
         secrets:      secrets,
         print_stdout: print_stdout,
         print_stderr: print_stderr,
+        debug:        debug,
         verbose:      verbose,
       }.compact
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -21,7 +21,7 @@ module Utils
       @curl
     end
 
-    def curl_args(*extra_args, show_output: false, user_agent: :default)
+    def curl_args(*extra_args, **options)
       args = []
 
       # do not load .curlrc unless requested (must be the first argument)
@@ -31,25 +31,25 @@ module Utils
 
       args << "--show-error"
 
-      args << "--user-agent" << case user_agent
+      args << "--user-agent" << case options[:user_agent]
       when :browser, :fake
         HOMEBREW_USER_AGENT_FAKE_SAFARI
-      when :default
+      when :default, nil
         HOMEBREW_USER_AGENT_CURL
-      else
-        user_agent
+      when String
+        options[:user_agent]
       end
 
       args << "--header" << "Accept-Language: en"
 
-      unless show_output
+      unless options[:show_output] == true
         args << "--fail"
         args << "--progress-bar" unless Context.current.verbose?
         args << "--verbose" if Homebrew::EnvConfig.curl_verbose?
         args << "--silent" unless $stdout.tty?
       end
 
-      args << "--retry" << Homebrew::EnvConfig.curl_retries
+      args << "--retry" << Homebrew::EnvConfig.curl_retries unless options[:retry] == false
 
       args + extra_args
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is a follow-up to #10066, primarily to add a `debug` parameter to `Curl#curl_with_workarounds` to allow us to control `debug` in `SystemCommand`.

This PR also adds a `retry_request` parameter to `#curl_with_workarounds`, so we can optionally omit the `--retry` flag from being included when it's not needed. The default value of `retry_request` is `true`, so it continues to be enabled by default.

Both of these changes have been extracted from #9535, as they're also needed in #9529.