### PR TITLE
sdk: use unversioned SDK path on Big Sur

### DIFF
--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -91,6 +91,14 @@ module OS
               paths[OS::Mac::Version.new(version)] = sdk_path if version.present?
             end
 
+            # Use unversioned SDK path on Big Sur to avoid issues such as:
+            # https://github.com/Homebrew/homebrew-core/issues/67075
+            if OS::Mac.version >= :big_sur
+              sdk_path = File.join(sdk_prefix, "MacOSX.sdk")
+              version = OS::Mac.full_version
+              paths[version] = sdk_path if File.directory?(sdk_path)
+            end
+
             paths
           else
             {}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? 
  - This returned an error regarding `Language::Java::java_home`
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Partial fix to https://github.com/Homebrew/homebrew-core/issues/67075.

This implements @fxcoudert's [suggestion](https://github.com/Homebrew/homebrew-core/issues/67075#issuecomment-748506292) in the issue linked above:

>If Apple is going to make SDKs depend on minor macOS version, then it could make sense for us to use `MacOSX.sdk` as `MacOS.sdk_path_if_needed`.

Before:
```
❯ brew ruby -e 'puts MacOS.sdk_path_if_needed'
/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
```

After:
```
❯ brew ruby -e 'puts MacOS.sdk_path_if_needed'
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
```