### PR TITLE
upgrade: fix style in help text

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -39,7 +39,7 @@ module Homebrew
              description: "Show what would be upgraded, but do not actually upgrade anything."
       [
         [:switch, "--formula", "--formulae", {
-          description: "Treat all named arguments as formulae. If no named arguments" \
+          description: "Treat all named arguments as formulae. If no named arguments " \
                        "are specified, upgrade only outdated formulae.",
         }],
         [:switch, "-s", "--build-from-source", {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -612,7 +612,7 @@ upgraded formulae or, every 30 days, for all formulae.
 * `-n`, `--dry-run`:
   Show what would be upgraded, but do not actually upgrade anything.
 * `--formula`:
-  Treat all named arguments as formulae. If no named argumentsare specified, upgrade only outdated formulae.
+  Treat all named arguments as formulae. If no named arguments are specified, upgrade only outdated formulae.
 * `-s`, `--build-from-source`:
   Compile *`formula`* from source even if a bottle is available.
 * `-i`, `--interactive`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -823,7 +823,7 @@ Show what would be upgraded, but do not actually upgrade anything\.
 .
 .TP
 \fB\-\-formula\fR
-Treat all named arguments as formulae\. If no named argumentsare specified, upgrade only outdated formulae\.
+Treat all named arguments as formulae\. If no named arguments are specified, upgrade only outdated formulae\.
 .
 .TP
 \fB\-s\fR, \fB\-\-build\-from\-source\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Fix a small spacing issue in the `upgrade` help text.

Before:

```
      --formula, --formulae        Treat all named arguments as formulae. If
                                   no named argumentsare specified, upgrade
                                   only outdated formulae.
```

After:

```
      --formula, --formulae        Treat all named arguments as formulae. If
                                   no named arguments are specified, upgrade
                                   only outdated formulae.
```
