### PR TITLE
keg: don't fix ids of dylibs rooted in the build directory

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -61,7 +61,11 @@ class Keg
   def fix_dynamic_linkage
     mach_o_files.each do |file|
       file.ensure_writable do
-        change_dylib_id(dylib_id_for(file), file) if file.dylib?
+        # Don't fix the id of dylibs rooted in the build directory
+        change_dylib_id(dylib_id_for(file), file) if file.dylib? &&
+                                                     file.dylib_id.start_with?("/") &&
+                                                     !file.dylib_id.start_with?(HOMEBREW_TEMP.to_s) &&
+                                                     !file.dylib_id.start_with?(HOMEBREW_TEMP.realpath.to_s)
 
         each_install_name_for(file) do |bad_name|
           # Don't fix absolute paths unless they are rooted in the build directory


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Fix for #9526, where emacs's native-compiled elisp modules, which are compiled from elisp to `*.eln` dylibs during the emacs build, were having their dylib IDs changed after being installed. Which resulted in the references from emacs/libgccjit to the compiled functions being broken, resulting in a fatal error when starting emacs:

```
emacs: can't find function "F656c646f632d646f63756d656e746174696f6e2d64656661756c74_eldoc_documentation_default_0" in compilation unit /usr/local/Cellar/emacs-head@28/28.0.50_1/Emacs.app/Contents/MacOS/../native-lisp/28.0.50-x86_64-apple-darwin19.6.0-280c4c724fff373c5b7192112ad4147c/eldoc-d20a5fe96630926dde4deb5e10fdceb0-660cfdc64f0992e89ba750c634991e2c.eln
```

This PR changes the logic so that dylib IDs that are rooted in the temp directory after install are not updated. The fix is based on the assumption that normal dylibs will have IDs rooted in the cellar. That seems to hold true for a few libs that I've spot-checked, but I could do with a second opinion on that as I'm really not too familiar with how library linkage works on macos.