### PR TITLE
os/mac/pkgconfig: use ${homebrew_sdkroot}/usr/lib for libffi

### DIFF
--- a/Library/Homebrew/os/mac/pkgconfig/10.14/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.14/libffi.pc
@@ -1,6 +1,6 @@
 homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk
 prefix=${homebrew_sdkroot}/usr
-exec_prefix=/usr
+exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 toolexeclibdir=${libdir}
 includedir=${prefix}/include/ffi

--- a/Library/Homebrew/os/mac/pkgconfig/10.15/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/10.15/libffi.pc
@@ -1,6 +1,6 @@
 homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
 prefix=${homebrew_sdkroot}/usr
-exec_prefix=/usr
+exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 toolexeclibdir=${libdir}
 includedir=${prefix}/include/ffi

--- a/Library/Homebrew/os/mac/pkgconfig/11.0/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.0/libffi.pc
@@ -1,6 +1,6 @@
 homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk
 prefix=${homebrew_sdkroot}/usr
-exec_prefix=/usr
+exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 toolexeclibdir=${libdir}
 includedir=${prefix}/include/ffi

--- a/Library/Homebrew/os/mac/pkgconfig/11.1/libffi.pc
+++ b/Library/Homebrew/os/mac/pkgconfig/11.1/libffi.pc
@@ -1,6 +1,6 @@
 homebrew_sdkroot=/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
 prefix=${homebrew_sdkroot}/usr
-exec_prefix=/usr
+exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 toolexeclibdir=${libdir}
 includedir=${prefix}/include/ffi


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
  - No. Some tests are failed but they aren't related to this change. They may be caused by my environment.
  - I want to see CI result.
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

We need to use ${homebrew_sdkroot}/usr/lib/libffi.tbd not
/usr/lib/libffi.dylib to use libffi with
${homebrew_sdkroot}/usr/include/ffi/ffi.h. If we use
/usr/lib/libffi.dylib directly,
${homebrew_sdkroot}/usr/include/ffi/ffi.h and -lffi are inconsistent.

For example, ${homebrew_sdkroot}/usr/include/ffi/ffi.h for 10.14
doesn't provide ffi_prep_cif_var() but -lffi accept it.

a.c:

    #include <ffi.h>

    int
    main(void)
    {
      ffi_prep_cif_var(NULL, 0, 0, 0, 0, NULL);
      return 0;
    }

No declaration error is expected, OK:

    $ gcc $(PKG_CONFIG_PATH=$(brew --prefix)/Homebrew/Library/Homebrew/os/mac/pkgconfig/10.14 pkg-config --cflags --libs libffi) a.c
    a.c:6:3: error: implicit declaration of function 'ffi_prep_cif_var' is invalid in C99
          [-Werror,-Wimplicit-function-declaration]
      ffi_prep_cif_var(NULL, 0, 0, 0, 0, NULL);
      ^
    a.c:6:3: note: did you mean 'ffi_prep_cif'?
    /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/include/ffi/ffi.h:312:1: note: 'ffi_prep_cif' declared here
    ffi_prep_cif(
    ^
    1 error generated.

Ignoring no declaration error. It must be a link error. NG:

    $ gcc -Wno-implicit-function-declaration $(PKG_CONFIG_PATH=$(brew --prefix)/Homebrew/Library/Homebrew/os/mac/pkgconfig/10.14 pkg-config --cflags --libs libffi) a.c
    (no error, unexpected)

With this change: Ignoring no declaration error. It must be a link error. OK:

    $ gcc -Wno-implicit-function-declaration $(PKG_CONFIG_PATH=$(brew --prefix)/Homebrew/Library/Homebrew/os/mac/pkgconfig/10.14 pkg-config --cflags --libs libffi) a.c
    Undefined symbols for architecture x86_64:
      "_ffi_prep_cif_var", referenced from:
          _main in a-ae3840.o
    ld: symbol(s) not found for architecture x86_64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)

Context: https://github.com/ruby/fiddle/issues/52
