### PR TITLE
Fix basename for extracting cask downloads.

### DIFF
--- a/Library/Homebrew/cask/artifact/pkg.rb
+++ b/Library/Homebrew/cask/artifact/pkg.rb
@@ -42,7 +42,14 @@ module Cask
         ohai "Running installer for #{cask}; your password may be necessary."
         ohai "Package installers may write to any location; options such as --appdir are ignored."
         unless path.exist?
-          raise CaskError, "pkg source file not found: '#{path.relative_path_from(cask.staged_path)}'"
+          pkg = path.relative_path_from(cask.staged_path)
+          pkgs = Pathname.glob(cask.staged_path/"**"/"*.pkg").map { |path| path.relative_path_from(cask.staged_path) }
+
+          message = "Could not find PKG source file '#{pkg}'"
+          message += ", found #{pkgs.map { |path| "'#{path}'" }.to_sentence} instead" if pkgs.any?
+          message += "."
+
+          raise CaskError, message
         end
 
         args = [

--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -52,6 +52,10 @@ module Cask
       downloader.cached_location
     end
 
+    def basename
+      downloader.basename
+    end
+
     def verify_download_integrity(fn)
       if @cask.sha256 == :no_check
         opoo "No checksum defined for cask '#{@cask}', skipping verification."

--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -152,10 +152,14 @@ module Cask
       s.freeze
     end
 
+    sig { returns(Download) }
+    def downloader
+      @downloader ||= Download.new(@cask, quarantine: quarantine?)
+    end
+
     sig { returns(Pathname) }
     def download
-      @download ||= Download.new(@cask, quarantine: quarantine?)
-                            .fetch(verify_download_integrity: @verify_download_integrity)
+      @download ||= downloader.fetch(verify_download_integrity: @verify_download_integrity)
     end
 
     def verify_has_sha
@@ -180,7 +184,7 @@ module Cask
 
       odebug "Using container class #{primary_container.class} for #{primary_container.path}"
 
-      basename = CGI.unescape(File.basename(@cask.url.path))
+      basename = downloader.basename
 
       if nested_container = @cask.container&.nested
         Dir.mktmpdir do |tmpdir|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Fix workaround needed due to wrong basename being used: https://github.com/Homebrew/homebrew-cask-versions/pull/10117#discussion_r546356445