### PR TITLE
audit: migrate shared audits to taps

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -582,7 +582,7 @@ module Cask
 
       tag = SharedAudits.gitlab_tag_from_url(cask.url)
       tag ||= cask.version
-      error = SharedAudits.gitlab_release(user, repo, tag)
+      error = SharedAudits.gitlab_release(user, repo, tag, cask: cask)
       add_error error if error
     end
 

--- a/Library/Homebrew/tap_auditor.rb
+++ b/Library/Homebrew/tap_auditor.rb
@@ -64,16 +64,16 @@ module Homebrew
       end
 
       list = list.keys if list.is_a? Hash
-      invalid_formulae = list.select do |formula_or_cask_name|
+      invalid_formulae_casks = list.select do |formula_or_cask_name|
         @formula_names.exclude?(formula_or_cask_name) && @cask_tokens.exclude?("#{@name}/#{formula_or_cask_name}")
       end
 
-      return if invalid_formulae.empty?
+      return if invalid_formulae_casks.empty?
 
       problem <<~EOS
         #{list_file}.json references
         formulae or casks that are not found in the #{@name} tap.
-        Invalid formulae or casks: #{invalid_formulae.join(", ")}
+        Invalid formulae or casks: #{invalid_formulae_casks.join(", ")}
       EOS
     end
 

--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -31,36 +31,26 @@ module SharedAudits
     nil
   end
 
-  GITHUB_PRERELEASE_ALLOWLIST = {
-    "elm-format"       => "0.8.3",
-    "extraterm"        => :all,
-    "freetube"         => :all,
-    "gitless"          => "0.8.8",
-    "haptickey"        => :all,
-    "home-assistant"   => :all,
-    "lidarr"           => :all,
-    "nuclear"          => :all,
-    "pock"             => :all,
-    "riff"             => "0.5.0",
-    "syntax-highlight" => :all,
-    "telegram-cli"     => "1.3.1",
-    "toggl-track"      => :all,
-    "volta"            => "0.8.6",
-    "xit"              => :all,
-  }.freeze
-
   def github_release(user, repo, tag, formula: nil, cask: nil)
     release = github_release_data(user, repo, tag)
     return unless release
 
-    if cask && GITHUB_PRERELEASE_ALLOWLIST[cask.token] == :all
-      return if release["prerelease"]
-
-      return "#{tag} is not a GitHub pre-release but cask '#{cask.token}' is in GITHUB_PRERELEASE_ALLOWLIST."
+    if !release["prerelease"] && cask && tap_audit_exception(:github_prerelease_allowlist, cask.tap, cask.token)
+      return "#{tag} is not a GitHub pre-release but cask '#{cask.token}' is in the GitHub prerelease allowlist."
     end
 
     if release["prerelease"]
-      return if formula && GITHUB_PRERELEASE_ALLOWLIST[formula.name] == formula.version
+      exception = if formula
+        tap_audit_exception(:github_prerelease_allowlist, formula.tap, formula.name)
+      elsif cask
+        tap_audit_exception(:github_prerelease_allowlist, cask.tap, cask.token)
+      end
+      version = if formula
+        formula.version
+      elsif cask
+        cask.version
+      end
+      return if exception && [version, "all"].include?(exception)
 
       return "#{tag} is a GitHub pre-release."
     end
@@ -87,30 +77,33 @@ module SharedAudits
     end
   end
 
-  GITLAB_PRERELEASE_ALLOWLIST = {}.freeze
-
-  def gitlab_release(user, repo, tag, formula: nil)
+  def gitlab_release(user, repo, tag, formula: nil, cask: nil)
     release = gitlab_release_data(user, repo, tag)
     return unless release
 
     return if Date.parse(release["released_at"]) <= Date.today
-    return if formula && GITLAB_PRERELEASE_ALLOWLIST[formula.name] == formula.version
+
+    exception = if formula
+      tap_audit_exception(:gitlab_prerelease_allowlist, formula.tap, formula.name)
+    elsif cask
+      tap_audit_exception(:gitlab_prerelease_allowlist, cask.tap, cask.token)
+    end
+    version = if formula
+      formula.version
+    elsif cask
+      cask.version
+    end
+    return if exception && [version, "all"].include?(exception)
 
     "#{tag} is a GitLab pre-release."
   end
-
-  GITHUB_FORK_ALLOWLIST = %w[
-    variar/klogg
-  ].freeze
 
   def github(user, repo)
     metadata = github_repo_data(user, repo)
 
     return if metadata.nil?
 
-    if metadata["fork"] && GITHUB_FORK_ALLOWLIST.exclude?("#{user}/#{repo}")
-      return "GitHub fork (not canonical repository)"
-    end
+    return "GitHub fork (not canonical repository)" if metadata["fork"]
 
     if (metadata["forks_count"] < 30) && (metadata["subscribers_count"] < 30) &&
        (metadata["stargazers_count"] < 75)
@@ -184,5 +177,22 @@ module SharedAudits
     url.match(%r{^https://gitlab\.com/[\w-]+/[\w-]+/-/archive/([^/]+)/})
        .to_a
        .second
+  end
+
+  def tap_audit_exception(list, tap, formula_or_cask, value = nil)
+    return false if tap.audit_exceptions.blank?
+    return false unless tap.audit_exceptions.key? list
+
+    list = tap.audit_exceptions[list]
+
+    case list
+    when Array
+      list.include? formula_or_cask
+    when Hash
+      return false unless list.include? formula_or_cask
+      return list[formula_or_cask] if value.blank?
+
+      list[formula_or_cask] == value
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is the final (I think) step in the migration of formula/cask lists to their respective taps. Here are the three lists that are modified by this PR:

1. `GITHUB_PRERELEASE_ALLOWLIST` is being split and migrated to the homebrew/core and homebrew/cask taps
1. `GITLAB_PRERELEASE_ALLOWLIST` is being migrated to the homebrew/core and homebrew/cask taps. It's currently empty but I've migrated them so maintainers know it is an option. Alternatively, it can be deleted and re-added when (if) it's needed.
1. `GITHUB_FORK_ALLOWLIST` is being removed. This was only used for new formulae and casks, so it doesn't need to be in a list. If we want to allow a fork when adding new formulae/casks, I think we should just ignore the audit. It doesn't make sense to add to a list that will never be used again.

As always, there will be corresponding PRs in homebrew/core (https://github.com/Homebrew/homebrew-core/pull/67384) and homebrew/cask (https://github.com/Homebrew/homebrew-cask/pull/96469) to add these lists. Those should be merged before this PR.
