### PR TITLE
integration_test: fix indentation for test formulae

### DIFF
--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -29,6 +29,7 @@ require "active_support/core_ext/hash/deep_merge"
 require "active_support/core_ext/file/atomic"
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/string/exclude"
+require "active_support/core_ext/string/indent"
 
 I18n.backend.available_locales # Initialize locales so they can be overwritten.
 I18n.backend.store_translations :en, support: { array: { last_word_connector: " and " } }

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -171,7 +171,7 @@ RSpec.shared_context "integration test" do
     Formulary.core_path(name).tap do |formula_path|
       formula_path.write <<~RUBY
         class #{Formulary.class_s(name)} < Formula
-          #{content}
+        #{content.indent(2)}
         end
       RUBY
     end

--- a/Library/Homebrew/test/utils/bottles/bottles_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/bottles_spec.rb
@@ -17,8 +17,6 @@ describe Utils::Bottles do
 
   describe "#add_bottle_stanza!" do
     let(:bottle_output) do
-      require "active_support/core_ext/string/indent"
-
       <<~RUBY.chomp.indent(2)
         bottle do
           sha256 "f7b1fc772c79c20fddf621ccc791090bc1085fcef4da6cca03399424c66e06ca" => :sierra


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

I noticed in https://github.com/Homebrew/brew/pull/9490 that formulae returned by `setup_test_formula` have weird indentation. For example:

```rb
class Testball < Formula
  desc "Some test"
homepage "https://brew.sh/testball"
url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
# -snip-
end
```

Note how `desc` has one more level of indentation than `homepage` and `url`.
This PR fixes the indentation so that the previous example now looks like this:

```rb
class Testball < Formula
  desc "Some test"
  homepage "https://brew.sh/testball"
  url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
  # -snip-
end
```