### PR TITLE
hardware: optimize Big Sur bottles for Ivy Bridge

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -7,6 +7,8 @@ module Hardware
   def self.oldest_cpu(version = MacOS.version)
     if CPU.arch == :arm64
       :arm_vortex_tempest
+    elsif version >= :big_sur
+      :ivybridge
     elsif version >= :mojave
       :nehalem
     else

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -26,8 +26,9 @@ module Hardware
       def optimization_flags
         @optimization_flags ||= {
           native:             arch_flag("native"),
-          nehalem:            "-march=nehalem",
+          ivybridge:          "-march=ivybridge",
           sandybridge:        "-march=sandybridge",
+          nehalem:            "-march=nehalem",
           core2:              "-march=core2",
           core:               "-march=prescott",
           arm_vortex_tempest: "",


### PR DESCRIPTION
The oldest Apple supported hardware for Big Sur is as follows:

* MacBookAir6,1 - Haswell
* MacBookPro11,1 - Haswell
* MacPro6,1 - Ivy Bridge EP
* iMac14,4 - Haswell
* Macmini7,1 - Haswell
* MacBook8,1 - Broadwell

~~We could probably get away with specifying Ivy Bridge, but Ivy Bridge EP is the Intel Xeon version of Ivy Bridge and is actually based on the Sandy Bridge architecture. It's unclear how much this would affect compiler behavior but it's probably better to be safer here.~~

The most significant change is that bottles can now use AVX instructions.

References:

* https://support.apple.com/en-us/HT211238
* https://en.wikipedia.org/wiki/List_of_Macintosh_models_grouped_by_CPU_type#Sandy_Bridge
* https://en.wikipedia.org/wiki/Ivy_Bridge_(microarchitecture)#Ivy_Bridge-E/EN/EP/EX_features
* https://everymac.com/mac-answers/macos-11-big-sur-faq/macos-big-sur-macos-11-compatbility-list-system-requirements.html
* https://dortania.github.io/hackintosh/updates/2020/11/12/bigsur-new.html#dropped-hardware

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----