### PR TITLE
upgrade: allow to specify build environment

### DIFF
--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -45,6 +45,10 @@ module Homebrew
         [:switch, "-s", "--build-from-source", {
           description: "Compile <formula> from source even if a bottle is available.",
         }],
+        [:flag, "--env=", {
+          description: "If `std` is passed, use the standard build environment instead of superenv. If `super` is " \
+                       "passed, use superenv even if the formula specifies the standard build environment.",
+        }],
         [:switch, "-i", "--interactive", {
           description: "Download and patch <formula>, then open a shell. This allows the user to "\
                        "run `./configure --help` and otherwise determine how to turn the software "\

--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -77,6 +77,7 @@ module Homebrew
           build_bottle:               args.build_bottle? || tab&.built_bottle?,
           force_bottle:               args.force_bottle?,
           build_from_source_formulae: args.build_from_source_formulae,
+          env:                        args.env,
           keep_tmp:                   args.keep_tmp?,
           force:                      args.force?,
           debug:                      args.debug?,

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -830,6 +830,10 @@ Treat all named arguments as formulae\. If no named arguments are specified, upg
 Compile \fIformula\fR from source even if a bottle is available\.
 .
 .TP
+\fB\-\-env\fR
+If \fBstd\fR is passed, use the standard build environment instead of superenv\. If \fBsuper\fR is passed, use superenv even if the formula specifies the standard build environment\.
+.
+.TP
 \fB\-i\fR, \fB\-\-interactive\fR
 Download and patch \fIformula\fR, then open a shell\. This allows the user to run \fB\./configure \-\-help\fR and otherwise determine how to turn the software package into a Homebrew package\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Allow to use --env option to specify which build environment to use to build a formula (like in the install command).
