### PR TITLE
bottle: add merge_bottle_spec helper function

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -550,6 +550,9 @@ module Homebrew
       rebuild:  new_bottle_hash["rebuild"],
     }.each do |key, new_value|
       old_value = old_bottle_spec.send(key)
+      next if key == :rebuild && old_value.zero?
+      next if key == :prefix && old_value == Homebrew::DEFAULT_PREFIX
+      next if key == :cellar && old_value == Homebrew::DEFAULT_REPOSITORY
       next if key == :cellar && old_value == :any && new_value == :any_skip_relocation
       next if old_value.present? && new_value == old_value
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This pull request refactors the confusing `brew bottle --merge --keep-old` logic and extracts it out into a helper function in `Utils::Bottles`.

Notable changes:

- Use `Formulary` to read the formula from `path` and get a `Formula` instance.
  - This is used to get the formula's `bottle_specification`, which is easier to use and reason about than with regexes and string manipulation.
- Replaced some `unless` statements with their equivalent `if` statements.
- Removed support for old `sha1` checksums.

(This needs to be rebased after merging https://github.com/Homebrew/brew/pull/10097, which will allow this PR to be tested for any possible regressions.)