### PR TITLE
Strategy: Manually handle redirections

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -524,6 +524,7 @@ module Homebrew
 
         if debug
           puts "URL (strategy):   #{strategy_data[:url]}" if strategy_data[:url] != url
+          puts "URL (final):   #{strategy_data[:final_url]}" if strategy_data[:final_url]
           puts "Regex (strategy): #{strategy_data[:regex].inspect}" if strategy_data[:regex] != livecheck_regex
         end
 
@@ -564,6 +565,7 @@ module Homebrew
           }
           version_info[:meta][:url][:processed] = url if url != original_url
           version_info[:meta][:url][:strategy] = strategy_data[:url] if strategy_data[:url] != url
+          version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data[:final_url]
           version_info[:meta][:strategies] = strategies.map { |s| livecheck_strategy_names[s] } if strategies.present?
           version_info[:meta][:regex] = regex.inspect if regex.present?
         end

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -6,11 +6,50 @@ require "livecheck/strategy/page_match"
 describe Homebrew::Livecheck::Strategy::PageMatch do
   subject(:page_match) { described_class }
 
-  let(:url) { "http://api.github.com/Homebrew/brew/releases/latest" }
+  let(:url) { "https://brew.sh/blog/" }
+  let(:regex) { %r{href=.*?/homebrew[._-]v?(\d+(?:\.\d+)+)/?["' >]}i }
+
+  let(:page_content) {
+    <<~EOS
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <meta charset="utf-8">
+          <title>Homebrew — Homebrew</title>
+        </head>
+        <body>
+          <ul class="posts">
+            <li><a href="/2020/12/01/homebrew-2.6.0/" title="2.6.0"><h2>2.6.0</h2><h3>01 Dec 2020</h3></a></li>
+            <li><a href="/2020/11/18/homebrew-tap-with-bottles-uploaded-to-github-releases/" title="Homebrew tap with bottles uploaded to GitHub Releases"><h2>Homebrew tap with bottles uploaded to GitHub Releases</h2><h3>18 Nov 2020</h3></a></li>
+            <li><a href="/2020/09/08/homebrew-2.5.0/" title="2.5.0"><h2>2.5.0</h2><h3>08 Sep 2020</h3></a></li>
+            <li><a href="/2020/06/11/homebrew-2.4.0/" title="2.4.0"><h2>2.4.0</h2><h3>11 Jun 2020</h3></a></li>
+            <li><a href="/2020/05/29/homebrew-2.3.0/" title="2.3.0"><h2>2.3.0</h2><h3>29 May 2020</h3></a></li>
+            <li><a href="/2019/11/27/homebrew-2.2.0/" title="2.2.0"><h2>2.2.0</h2><h3>27 Nov 2019</h3></a></li>
+            <li><a href="/2019/06/14/homebrew-maintainer-meeting/" title="Homebrew Maintainer Meeting"><h2>Homebrew Maintainer Meeting</h2><h3>14 Jun 2019</h3></a></li>
+            <li><a href="/2019/04/04/homebrew-2.1.0/" title="2.1.0"><h2>2.1.0</h2><h3>04 Apr 2019</h3></a></li>
+            <li><a href="/2019/02/02/homebrew-2.0.0/" title="2.0.0"><h2>2.0.0</h2><h3>02 Feb 2019</h3></a></li>
+            <li><a href="/2019/01/09/homebrew-1.9.0/" title="1.9.0"><h2>1.9.0</h2><h3>09 Jan 2019</h3></a></li>
+          </ul>
+        </body>
+      </html>
+    EOS
+  }
+  let(:page_content_matches) { ["2.6.0", "2.5.0", "2.4.0", "2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.9.0"] }
 
   describe "::match?" do
     it "returns true for any URL" do
       expect(page_match.match?(url)).to be true
+    end
+  end
+
+  describe "::page_matches" do
+    it "finds matching text in page content using a regex" do
+      expect(page_match.page_matches(page_content, regex)).to eq(page_content_matches)
+    end
+
+    it "finds matching text in page content using a strategy block" do
+      expect(page_match.page_matches(page_content, regex) { |content| content.scan(regex).map(&:first).uniq })
+        .to eq(page_content_matches)
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

These are the original changes seen in #9535 and they are intended to fix the issue that we've been dealing with where `open-uri` will give an error when an HTTPS URL redirects to an HTTP URL. This is primarily affecting the `Gnome` strategy (as they recently added an HTTP mirror, so the URL in the strategy frequently redirects from HTTPS to HTTP) and that's causing problems for related formulae on homebrew/core CI.

Though #9535 addresses the same issue by switching from `open-uri` to `Curl`, that PR is currently blocked while I investigate what's causing a hang in the middle of longer runs. I won't be able to return to that PR for at least a few days, so I think we should incorporate this fix to the current `open-uri` version in the interim time.

I've tried to keep the changes here as simple as possible and I've labeled this "critical", as I would like to see this merged ASAP to unblock some work that's being done in homebrew/core (and allow the Linux folks to re-enable running livecheck on CI).

[Most of the explanatory information below has been copied from #9535 and I'll update that PR accordingly if/when this is merged. Merging this will also help to simplify #9535 a bit, so this seems like a good idea all around.]

## Background

`Strategy#page_content` quietly follows redirections but it will error on HTTPS to HTTP redirections. This is a limitation of `OpenURI#open`, which forbids following HTTPS to HTTP redirections. This issue can affect any strategy that uses `PageMatch#find_versions` internally as well (since it calls `Strategy#page_content`).

Though we should work to minimize HTTPS to HTTP redirections wherever possible, there are situations where we don't have any choice:

* The `Gnome` strategy can intermittently fail at the moment, as the `cache.json` URL redirects to mirrors and there's at least one that is HTTP instead of HTTPS. The check fails with the `redirection forbidden` error when we happen to get the HTTP mirror, which is pretty frequently in my experience.
* Some formulae use an HTTPS sourceforge.io URL that redirects to an HTTP sourceforge.net page (e.g., bcrypt: `https://bcrypt.sourceforge.io/` -> `http://bcrypt.sourceforge.net/`). I was told in the past that we prefer the HTTPS sourceforge.io URL, despite the HTTPS to HTTP redirection. Up to this point, I've been avoiding these particular redirections by using the HTTP sourceforge.net URL in the `livecheck` blocks of related formulae. This PR allows us to simply use `url :homepage` instead.

There are likely additional situations but those are the ones at the top of my list and this is merely to say that following HTTPS to HTTP redirections is necessary at times.

## Notable Changes

* `Strategy#page_content` returns the final URL when redirections are followed. This information is surfaced in the debug and verbose JSON output (see below).
* The call to `Strategy#page_content` (which fetches the page content from a URL) has been moved out of `PageMatch#page_matches` and into `PageMatch#find_versions`. The page content is now passed into `#page_matches` (instead of a URL) to do the matching. This setup is intended to make it easier to integrate the values in the hash returned from `#page_content` (containing the content and final URL) into the `matches` hash in `#find_versions`.

## Output Examples

As mentioned above, the debug information will make redirections clear and the verbose JSON output will be useful when doing broader analysis (e.g., easily identifying livecheck redirections for an entire tap).

Example debug output showing the final URL information:

```
Formula:          glib
Livecheckable?:   Yes

URL:              https://download.gnome.org/sources/glib/2.66/glib-2.66.4.tar.xz
Strategy:         Gnome
URL (strategy):   https://download.gnome.org/sources/glib/cache.json
URL (final):   https://mirror.umd.edu/gnome/sources/glib/cache.json
Regex (strategy): /glib-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i

Matched Versions:
[Omitted for the sake of brevity]
glib : 2.66.4 ==> 2.66.4
```

Example verbose JSON output (after prettifying) showing `["meta"]["url"]["final"]`:

```json
[
  {
    "formula": "glib",
    "version": {
      "current": "2.66.2",
      "latest": "2.66.3",
      "outdated": true,
      "newer_than_upstream": false
    },
    "meta": {
      "livecheckable": true,
      "url": {
        "original": "https://download.gnome.org/sources/glib/2.66/glib-2.66.2.tar.xz",
        "strategy": "https://download.gnome.org/sources/glib/cache.json",
        "final": "http://ftp.cse.buffalo.edu/pub/Gnome/sources/glib/cache.json"
      },
      "strategy": "Gnome",
      "strategies": [
        "Gnome"
      ],
      "regex": "/glib-(\\d+\\.([0-8]\\d*?)?[02468](?:\\.\\d+)*?)\\.t/i"
    }
  }
]
```

## Closing

I did livecheck runs across homebrew/core for a before/after comparison of these changes and I didn't see anything unexpected. The output differences confirmed that this fixes the `Gnome` strategy.
