### PR TITLE
formula: add deprecation_date and disable_date methods

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1165,6 +1165,12 @@ class Formula
   # @return [Boolean]
   delegate deprecated?: :"self.class"
 
+  # The date that this {Formula} was or becomes deprecated.
+  # Returns `nil` if no date is specified.
+  # @!method deprecation_date
+  # @return Date
+  delegate deprecation_date: :"self.class"
+
   # The reason this {Formula} is deprecated.
   # Returns `nil` if no reason is specified or the formula is not deprecated.
   # @!method deprecation_reason
@@ -1176,6 +1182,12 @@ class Formula
   # @!method disabled?
   # @return [Boolean]
   delegate disabled?: :"self.class"
+
+  # The date that this {Formula} was or becomes disabled.
+  # Returns `nil` if no date is specified.
+  # @!method disable_date
+  # @return Date
+  delegate disable_date: :"self.class"
 
   # The reason this {Formula} is disabled.
   # Returns `nil` if no reason is specified or the formula is not disabled.
@@ -2771,6 +2783,8 @@ class Formula
       odeprecated "`deprecate!` without a reason", "`deprecate! because: \"reason\"`" if because.blank?
       odeprecated "`deprecate!` without a date", "`deprecate! date: \"#{Date.today}\"`" if date.blank?
 
+      @deprecation_date = Date.parse(date) if date.present?
+
       return if date.present? && Date.parse(date) > Date.today
 
       @deprecation_reason = because if because.present?
@@ -2783,6 +2797,11 @@ class Formula
     def deprecated?
       @deprecated == true
     end
+
+    # The date that this {Formula} was or becomes deprecated.
+    # Returns `nil` if no date is specified.
+    # @return Date
+    attr_reader :deprecation_date
 
     # The reason for deprecation of a {Formula}.
     # @return [nil] if no reason was provided or the formula is not deprecated.
@@ -2798,7 +2817,9 @@ class Formula
       odeprecated "`disable!` without a reason", "`disable! because: \"reason\"`" if because.blank?
       odeprecated "`disable!` without a date", "`disable! date: \"#{Date.today}\"`" if date.blank?
 
-      if date.present? && Date.parse(date) > Date.today
+      @disable_date = Date.parse(date) if date.present?
+
+      if @disable_date && @disable_date > Date.today
         @deprecation_reason = because if because.present?
         @deprecated = true
         return
@@ -2814,6 +2835,11 @@ class Formula
     def disabled?
       @disabled == true
     end
+
+    # The date that this {Formula} was or becomes disabled.
+    # Returns `nil` if no date is specified.
+    # @return Date
+    attr_reader :disable_date
 
     # The reason this {Formula} is disabled.
     # Returns `nil` if no reason was provided or the formula is not disabled.

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1789,7 +1789,11 @@ class Formula
       "pinned"                   => pinned?,
       "outdated"                 => outdated?,
       "deprecated"               => deprecated?,
+      "deprecation_date"         => deprecation_date,
+      "deprecation_reason"       => deprecation_reason,
       "disabled"                 => disabled?,
+      "disable_date"             => disable_date,
+      "disable_reason"           => disable_reason,
     }
 
     if stable


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds the `Formula#deprecation_date` and `Formula#disable_date` methods. These will return the respective dates when they exist. If not, the methods return `nil`. This is needed for https://github.com/Homebrew/actions/pull/133 and https://github.com/Homebrew/homebrew-core/pull/67386.

I'm marking this as critical because it is blocking those other PRs. Since the PR is a simple change that only adds methods that aren't used in the codebase yet, I don't feel the full 24 hours are needed. However, I will wait to merge until I'm ready to move forward with the other PRs.
