### PR TITLE
bump-cask-pr: ignore closed duplicate PRs

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -88,10 +88,6 @@ module Homebrew
 
     check_open_pull_requests(cask, tap_full_name, args: args)
 
-    if new_version.present? && !new_version.latest?
-      check_closed_pull_requests(cask, tap_full_name, version: new_version, args: args)
-    end
-
     old_contents = File.read(cask.sourcefile_path)
 
     replacement_pairs = []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds the `--ignore-closed-prs` switch that allows a bump PR to be opened regardless of whether or not the same PR has already been opened before. See https://github.com/Homebrew/homebrew-cask/issues/93014

> the version numbers of casks change a lot, not only up, sometimes down and up again too. there are examples each day. also some contributors close perfectly fine PRs. this means the same PR cannot be sent again although it needs to be sent. i have a system that downloads each cask with a static download URL every 4 hours and the PRs it generates are guaranteed to be 100% accurate. however they often fail to send because of limitations in 'brew bump-cask-pr'. 

Resolves #9466