### PR TITLE
os/mac/sdk: parse version from SDKSettings.json

### DIFF
--- a/Library/Homebrew/os/mac/sdk.rb
+++ b/Library/Homebrew/os/mac/sdk.rb
@@ -93,10 +93,11 @@ module OS
 
             # Use unversioned SDK path on Big Sur to avoid issues such as:
             # https://github.com/Homebrew/homebrew-core/issues/67075
-            if OS::Mac.version >= :big_sur
-              sdk_path = File.join(sdk_prefix, "MacOSX.sdk")
-              version = OS::Mac.full_version
-              paths[version] = sdk_path if File.directory?(sdk_path)
+            sdk_path = File.join(sdk_prefix, "MacOSX.sdk")
+            if OS::Mac.version >= :big_sur && File.directory?(sdk_path)
+              sdk_settings = File.join(sdk_path, "SDKSettings.json")
+              version = JSON.parse(File.read(sdk_settings))["Version"] if File.exist?(sdk_settings)
+              paths[OS::Mac::Version.new(version)] = sdk_path if version.present?
             end
 
             paths


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
    - This returned an error about `Language::Java::java_home`
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This implements feedback from https://github.com/Homebrew/brew/pull/10072.

We try to use a more sensible version check for the SDK, by querying, in order of priority:
1. `sdk_prefix/MacOSX.sdk/SDKSettings.json`
2. ~`sdk_prefix/MacOSX.sdk/SDKSettings.plist`~
3. ~`OS::Mac.sdk_version`~