### PR TITLE
Xorg: Use PageMatch#find_versions

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -524,7 +524,7 @@ module Homebrew
 
         if debug
           puts "URL (strategy):   #{strategy_data[:url]}" if strategy_data[:url] != url
-          puts "URL (final):   #{strategy_data[:final_url]}" if strategy_data[:final_url]
+          puts "URL (final):      #{strategy_data[:final_url]}" if strategy_data[:final_url]
           puts "Regex (strategy): #{strategy_data[:regex].inspect}" if strategy_data[:regex] != livecheck_regex
         end
 

--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -59,7 +59,7 @@ module Homebrew
           # * `/href=["']?example-v?(\d+(?:\.\d+)+)-bin\.zip/i`
           regex ||= /href=["']?#{Regexp.escape(prefix)}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -71,7 +71,7 @@ module Homebrew
           # * `/href=.*?example-v?(\d+(?:\.\d+)+)\.t/i`
           regex ||= /href=.*?#{Regexp.escape(match[:prefix])}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -54,7 +54,7 @@ module Homebrew
           # Example regex: `/href=.*?Brew[._-]v?(\d+(?:\.\d+)*)\.t/i`
           regex ||= /href=.*?#{prefix}[._-]v?(\d+(?:\.\d+)*)#{Regexp.escape(suffix)}/i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -65,7 +65,7 @@ module Homebrew
           # The default regex is the same for all URLs using this strategy
           regex ||= %r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -53,7 +53,7 @@ module Homebrew
           # Example regex: `/example-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i`
           regex ||= /#{Regexp.escape(package_name)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -89,7 +89,7 @@ module Homebrew
           # Example regex: `%r{href=.*?example[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i`
           regex ||= %r{href=.*?#{project_name}[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -43,7 +43,7 @@ module Homebrew
           # Example regex: `%r{<h3>example-(.*?)/?</h3>}i`
           regex ||= %r{<h3>#{Regexp.escape(package_name)}-(.*?)/?</h3>}i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -49,7 +49,7 @@ module Homebrew
           # The default regex is the same for all URLs using this strategy
           regex ||= %r{class="[^"]*version[^"]*"[^>]*>\s*Latest version is (.+)\s*</}
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -46,7 +46,7 @@ module Homebrew
           # * `%r{href=.*?/package/@example/example/v/(\d+(?:\.\d+)+)"}i`
           regex ||= %r{href=.*?/package/#{Regexp.escape(package_name)}/v/(\d+(?:\.\d+)+)"}i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -55,7 +55,7 @@ module Homebrew
             %r{href=.*?/packages.*?/#{Regexp.escape(package_name)}[._-]
                v?(\d+(?:\.\d+)*(.post\d+)?)#{Regexp.escape(suffix)}}ix
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -66,7 +66,7 @@ module Homebrew
           # create something that works for most URLs.
           regex ||= %r{url=.*?/#{Regexp.escape(project_name)}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
 
-          Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -84,7 +84,7 @@ module Homebrew
 
           # Use the cached page content to avoid duplicate fetches
           cached_content = @page_data[page_url]
-          match_data = Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex, cached_content)
+          match_data = PageMatch.find_versions(page_url, regex, cached_content)
 
           # Cache any new page content
           @page_data[page_url] = match_data[:content] if match_data[:content].present?

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -1,8 +1,6 @@
 # typed: false
 # frozen_string_literal: true
 
-require "open-uri"
-
 module Homebrew
   module Livecheck
     module Strategy
@@ -74,7 +72,6 @@ module Homebrew
         # @return [Hash]
         def self.find_versions(url, regex)
           file_name = File.basename(url)
-
           /^(?<module_name>.+)-\d+/i =~ file_name
 
           # /pub/ URLs redirect to the same URL with /archive/, so we replace
@@ -82,17 +79,15 @@ module Homebrew
           # the URL gives us the relevant directory listing page.
           page_url = url.sub("x.org/pub/", "x.org/archive/").delete_suffix(file_name)
 
+          # Example regex: /href=.*?example[._-]v?(\d+(?:\.\d+)+)\.t/i
           regex ||= /href=.*?#{Regexp.escape(module_name)}[._-]v?(\d+(?:\.\d+)+)\.t/i
 
-          match_data = { matches: {}, regex: regex, url: page_url }
+          # Use the cached page content to avoid duplicate fetches
+          cached_content = @page_data[page_url]
+          match_data = Homebrew::Livecheck::Strategy::PageMatch.find_versions(page_url, regex, cached_content)
 
-          # Cache responses to avoid unnecessary duplicate fetches
-          @page_data[page_url] = URI.parse(page_url).open.read unless @page_data.key?(page_url)
-
-          matches = @page_data[page_url].scan(regex)
-          matches.map(&:first).uniq.each do |match|
-            match_data[:matches][match] = Version.new(match)
-          end
+          # Cache any new page content
+          @page_data[page_url] = match_data[:content] if match_data[:content].present?
 
           match_data
         end

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -34,7 +34,24 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
       </html>
     EOS
   }
+
   let(:page_content_matches) { ["2.6.0", "2.5.0", "2.4.0", "2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.9.0"] }
+  let(:find_versions_return_hash) {
+    {
+      matches: {
+        "2.6.0" => Version.new("2.6.0"),
+        "2.5.0" => Version.new("2.5.0"),
+        "2.4.0" => Version.new("2.4.0"),
+        "2.3.0" => Version.new("2.3.0"),
+        "2.2.0" => Version.new("2.2.0"),
+        "2.1.0" => Version.new("2.1.0"),
+        "2.0.0" => Version.new("2.0.0"),
+        "1.9.0" => Version.new("1.9.0"),
+      },
+      regex:   regex,
+      url:     url,
+    }
+  }
 
   describe "::match?" do
     it "returns true for any URL" do
@@ -50,6 +67,12 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
     it "finds matching text in page content using a strategy block" do
       expect(page_match.page_matches(page_content, regex) { |content| content.scan(regex).map(&:first).uniq })
         .to eq(page_content_matches)
+    end
+  end
+
+  describe "::find_versions?" do
+    it "finds versions in provided_content" do
+      expect(page_match.find_versions(url, regex, page_content)).to eq(find_versions_return_hash)
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

I'm working on extracting changes in #9535 that aren't specifically related to the migration from `open-uri` to `curl` into separate, topical PRs. This will help to minimize the number of changes in that PR, which certainly won't hurt when it comes to troubleshooting the hang we're seeing when using `curl`.

This PR modifies `PageMatch#find_versions` to accept an optional `provided_content` parameter, which allows the method to work with cached page content. When page content is provided, we don't fetch the content at the `url` (using `Strategy#page_content`).

Since the `Xorg` strategy tends to check the same x.org pages over and over for related formulae, we implemented a simple caching system to minimize the number of times we fetch these pages. As a result, `Xorg#find_versions` duplicates some of the logic found in `PageMatch`, simply to be able to work with cached page content. The previously-mentioned change to `PageMatch` allows us to modify `Xorg#find_versions` to simply use `PageMatch#find_versions` internally, like many other strategies.

Outside of bringing `Xorg` more in line with the other strategies, allowing `PageMatch#find_versions` to work with a content string is a first step towards enabling page caching throughout livecheck.