### PR TITLE
formula_auditor: do not allow depending on aliases

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -235,8 +235,7 @@ module Homebrew
             problem "Dependency '#{dep.name}' was renamed; use new name '#{dep_f.name}'."
           end
 
-          if self.class.aliases.include?(dep.name) &&
-             dep_f.core_formula? && !dep_f.versioned_formula?
+          if self.class.aliases.include?(dep.name) && dep_f.core_formula?
             problem "Dependency '#{dep.name}' from homebrew/core is an alias; " \
             "use the canonical name '#{dep.to_formula.full_name}'."
           end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -235,11 +235,6 @@ module Homebrew
             problem "Dependency '#{dep.name}' was renamed; use new name '#{dep_f.name}'."
           end
 
-          if self.class.aliases.include?(dep.name) && dep_f.core_formula?
-            problem "Dependency '#{dep.name}' from homebrew/core is an alias; " \
-            "use the canonical name '#{dep.to_formula.full_name}'."
-          end
-
           if @core_tap &&
              @new_formula &&
              dep_f.keg_only? &&
@@ -271,6 +266,10 @@ module Homebrew
           problem "Dependency '#{dep.name}' is marked as :run. Remove :run; it is a no-op." if dep.tags.include?(:run)
 
           next unless @core_tap
+
+          if self.class.aliases.include?(dep.name)
+            problem "Dependency '#{dep.name}' is an alias; use the canonical name '#{dep.to_formula.full_name}'."
+          end
 
           if dep.tags.include?(:recommended) || dep.tags.include?(:optional)
             problem "Formulae in homebrew/core should not have optional or recommended dependencies"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This PR makes dependency audit more strict and prohibits using aliases (at all) in `depends_on` in homebrew-core:

```ruby
  # Before both of these options were allowed (`openjdk@15` is an alias to `openjdk`:)
  depends_on "openjdk@15"
  depends_on "openjdk"
  
  # After it allows only:
  depends_on "openjdk"
```

Motivation:
- We'd like formulae to use the latest version of dependencies (when possible). When a new version of the formula appears we'd like all the depending on it formulae to start using it. So having `openjdk@15` as a dependency will not allow us making this switch (to the next `openjdk@16`) automatically and will require manual formula tuning. Also, we don't have such kind of examples in homebrew-core;
- Currently, dependency audit doesn't work for `openssl@1.1` and `python@3.9` (these are special cases when an unversioned formula is an alias to versioned one). And it was easier to make this audit more strict than add tuning for these special cases 🙂 

Existing violations fixed:
- in https://github.com/Homebrew/homebrew-core/pull/67521 
- in https://github.com/Homebrew/linuxbrew-core/pull/21926