### PR TITLE
Add more links to the changelog and blog

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -89,8 +89,7 @@ module Homebrew
       puts "Updated Homebrew from #{shorten_revision(initial_revision)} to #{shorten_revision(current_revision)}."
       updated = true
 
-      tag = Utils.safe_popen_read("git", "tag", "--points-at", "HEAD")
-      new_repository_version = tag.chomp if tag.present?
+      new_repository_version = Utils.safe_popen_read("git", "tag", "--points-at", "HEAD").chomp.presence
     end
 
     Homebrew.failed = true if ENV["HOMEBREW_UPDATE_FAILED"]
@@ -144,17 +143,17 @@ module Homebrew
     return if new_repository_version.blank?
 
     ohai "Homebrew was updated to version #{new_repository_version}"
-    puts <<~EOS
-      The changelog can be found at:
-        #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_repository_version}")}
-    EOS
-
-    return unless new_repository_version.split(".").last == "0"
-
-    puts <<~EOS
-      More detailed release notes are available on the Homebrew Blog:
-        #{Formatter.url("https://brew.sh/blog/")}
-    EOS
+    if new_repository_version.split(".").last == "0"
+      puts <<~EOS
+        More detailed release notes are available on the Homebrew Blog:
+          #{Formatter.url("https://brew.sh/blog/")}
+      EOS
+    else
+      puts <<~EOS
+        The changelog can be found at:
+          #{Formatter.url("https://github.com/Homebrew/brew/releases/tag/#{new_repository_version}")}
+      EOS
+    end
   end
 
   def shorten_revision(revision)

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -160,7 +160,7 @@ module Homebrew
     if new_repository_version.split(".").last == "0"
       puts <<~EOS
         More detailed release notes are available on the Homebrew Blog:
-          #{Formatter.url("https://brew.sh/blog/")}
+          #{Formatter.url("https://brew.sh/blog/#{new_repository_version}")}
       EOS
     else
       puts <<~EOS

--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -17,6 +17,10 @@ module Homebrew
         Print the merged pull requests on Homebrew/brew between two Git refs.
         If no <previous_tag> is provided it defaults to the latest tag.
         If no <end_ref> is provided it defaults to `origin/master`.
+
+        If `--markdown` and a <previous_tag> are passed, an extra line containg
+        a link to the Homebrew blog will be adding to the output. Additionally,
+        a warning will be shown if the latest minor release was less than one month ago.
       EOS
       switch "--markdown",
              description: "Print as a Markdown list."
@@ -29,6 +33,15 @@ module Homebrew
     args = release_notes_args.parse
 
     previous_tag = args.named.first
+
+    if previous_tag.present?
+
+      previous_tag_date = Date.parse Utils.popen_read(
+        "git", "-C", HOMEBREW_REPOSITORY, "log", "-1", "--format=%aI", previous_tag.sub(/\d+$/, "0")
+      )
+      opoo "The latest major/minor release was less than one month ago." if previous_tag_date > (Date.today << 1)
+    end
+
     previous_tag ||= Utils.popen_read(
       "git", "-C", HOMEBREW_REPOSITORY, "tag", "--list", "--sort=-version:refname"
     ).lines.first.chomp

--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -18,7 +18,7 @@ module Homebrew
         If no <previous_tag> is provided it defaults to the latest tag.
         If no <end_ref> is provided it defaults to `origin/master`.
 
-        If `--markdown` and a <previous_tag> are passed, an extra line containg
+        If `--markdown` and a <previous_tag> are passed, an extra line containing
         a link to the Homebrew blog will be adding to the output. Additionally,
         a warning will be shown if the latest minor release was less than one month ago.
       EOS
@@ -35,11 +35,12 @@ module Homebrew
     previous_tag = args.named.first
 
     if previous_tag.present?
-
+      most_recent_major_minor_tag = previous_tag.sub(/\d+$/, "0")
+      one_month_ago = Date.today << 1
       previous_tag_date = Date.parse Utils.popen_read(
-        "git", "-C", HOMEBREW_REPOSITORY, "log", "-1", "--format=%aI", previous_tag.sub(/\d+$/, "0")
+        "git", "-C", HOMEBREW_REPOSITORY, "log", "-1", "--format=%aI", most_recent_major_minor_tag
       )
-      opoo "The latest major/minor release was less than one month ago." if previous_tag_date > (Date.today << 1)
+      opoo "The latest major/minor release was less than one month ago." if previous_tag_date > one_month_ago
     end
 
     previous_tag ||= Utils.popen_read(

--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -58,6 +58,7 @@ module Homebrew
     end
 
     $stderr.puts "Release notes between #{previous_tag} and #{end_ref}:"
+    puts "Release notes for major and minor releases can be found in the [Homebrew blog](https://brew.sh/blog/)."
     puts output
   end
 end

--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -58,7 +58,9 @@ module Homebrew
     end
 
     $stderr.puts "Release notes between #{previous_tag} and #{end_ref}:"
-    puts "Release notes for major and minor releases can be found in the [Homebrew blog](https://brew.sh/blog/)."
+    if args.markdown? && args.named.first
+      puts "Release notes for major and minor releases can be found in the [Homebrew blog](https://brew.sh/blog/)."
+    end
     puts output
   end
 end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1197,7 +1197,7 @@ Print the merged pull requests on Homebrew/brew between two Git refs.
 If no *`previous_tag`* is provided it defaults to the latest tag.
 If no *`end_ref`* is provided it defaults to `origin/master`.
 
-If `--markdown` and a *`previous_tag`* are passed, an extra line containg
+If `--markdown` and a *`previous_tag`* are passed, an extra line containing
 a link to the Homebrew blog will be adding to the output. Additionally,
 a warning will be shown if the latest minor release was less than one month ago.
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1197,6 +1197,10 @@ Print the merged pull requests on Homebrew/brew between two Git refs.
 If no *`previous_tag`* is provided it defaults to the latest tag.
 If no *`end_ref`* is provided it defaults to `origin/master`.
 
+If `--markdown` and a *`previous_tag`* are passed, an extra line containg
+a link to the Homebrew blog will be adding to the output. Additionally,
+a warning will be shown if the latest minor release was less than one month ago.
+
 * `--markdown`:
   Print as a Markdown list.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1673,7 +1673,7 @@ Use \fBstackprof\fR instead of \fBruby\-prof\fR (the default)\.
 Print the merged pull requests on Homebrew/brew between two Git refs\. If no \fIprevious_tag\fR is provided it defaults to the latest tag\. If no \fIend_ref\fR is provided it defaults to \fBorigin/master\fR\.
 .
 .P
-If \fB\-\-markdown\fR and a \fIprevious_tag\fR are passed, an extra line containg a link to the Homebrew blog will be adding to the output\. Additionally, a warning will be shown if the latest minor release was less than one month ago\.
+If \fB\-\-markdown\fR and a \fIprevious_tag\fR are passed, an extra line containing a link to the Homebrew blog will be adding to the output\. Additionally, a warning will be shown if the latest minor release was less than one month ago\.
 .
 .TP
 \fB\-\-markdown\fR

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1672,6 +1672,9 @@ Use \fBstackprof\fR instead of \fBruby\-prof\fR (the default)\.
 .SS "\fBrelease\-notes\fR [\fIoptions\fR] [\fIprevious_tag\fR] [\fIend_ref\fR]"
 Print the merged pull requests on Homebrew/brew between two Git refs\. If no \fIprevious_tag\fR is provided it defaults to the latest tag\. If no \fIend_ref\fR is provided it defaults to \fBorigin/master\fR\.
 .
+.P
+If \fB\-\-markdown\fR and a \fIprevious_tag\fR are passed, an extra line containg a link to the Homebrew blog will be adding to the output\. Additionally, a warning will be shown if the latest minor release was less than one month ago\.
+.
 .TP
 \fB\-\-markdown\fR
 Print as a Markdown list\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

We've received some blowback due to the short turn around time between Homebrew 2.6.0 and 2.7.0. 2.7.0 was the release that disabled `brew cask` commands, so 20 days didn't seem to be quite long enough for the entire community to adapt (namely, some ansible modules weren't updated in time which is causing breakage).

My personal opinion is that 20 days was a tad short for such a major change, but that's irrelevant to this PR (to be clear, not trying to blame any one person for this, it's simply a product of the way we do releases). Regardless of that, I think there are a few places where we could do some work to increase visibility for these releases.

This PR attempts to increase visibility in two ways:

1. Add a link to the Homebrew Blog to the release notes. It's easy for a user to come across the brew repo and, therefore, the release notes. Only the dedicated users who are really trying will be able to find the blog, though. I think we should add a link to the top of our release notes that links directly to the blog (this already exists in our unused `CHANGELOG.md` file). For now, I added this to all invocations of `brew release-notes`. I can, if desired, add an e.g. `--major-minor` flag to only add this line on major or minor releases (alternatively, there can be some autodetection done on the `end_ref` if it's passes).
1. Add links and clearer output to `brew update`. This PR will now display a message at the very bottom of the `brew update` output if Homebrew was updated to a new tag. This output will include a link to the release notes. If it's a major or minor release, a link to the blog will be added as well.
