### PR TITLE
style: fix on_macos/on_linux resource block checks

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -106,9 +106,12 @@ module RuboCop
             if on_macos_blocks.length == 1
               on_macos_block = on_macos_blocks.first
               child_nodes = on_macos_block.body.child_nodes
-              if child_nodes[0].method_name.to_s != "url" && child_nodes[1].method_name.to_s != "sha256"
-                problem "only an url and a sha256 (in the right order) are allowed in a `on_macos` " \
-                        "block within a resource block."
+              unless child_nodes[0].method?("url") && (
+                  child_nodes[1].method?("sha256") ||
+                  (child_nodes[1].method?("version") && child_nodes[2].method?("sha256"))
+                )
+                problem "`on_macos` blocks within resource blocks must contain only a " \
+                        "url and sha256 or a url, version, and sha256 (in those orders)."
                 next
               end
             end
@@ -116,9 +119,13 @@ module RuboCop
             if on_linux_blocks.length == 1
               on_linux_block = on_linux_blocks.first
               child_nodes = on_linux_block.body.child_nodes
-              if child_nodes[0].method_name.to_s != "url" && child_nodes[1].method_name.to_s != "sha256"
-                problem "only an url and a sha256 (in the right order) are allowed in a `on_linux` " \
-                        "block within a resource block."
+              unless child_nodes[0].method?("url") && (
+                child_nodes[1].method?("sha256") ||
+                (child_nodes[1].method?("version") && child_nodes[2].method?("sha256"))
+              )
+                problem "`on_linux` blocks within resource blocks must contain only a " \
+                        "url and sha256 or a url, version, and sha256 (in those orders)."
+                next
               end
             end
 

--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -103,30 +103,37 @@ module RuboCop
 
             next if on_macos_blocks.length.zero? && on_linux_blocks.length.zero?
 
-            if on_macos_blocks.length == 1
-              on_macos_block = on_macos_blocks.first
-              child_nodes = on_macos_block.body.child_nodes
-              unless child_nodes[0].method?("url") && (
-                  child_nodes[1].method?("sha256") ||
-                  (child_nodes[1].method?("version") && child_nodes[2].method?("sha256"))
-                )
-                problem "`on_macos` blocks within resource blocks must contain only a " \
-                        "url and sha256 or a url, version, and sha256 (in those orders)."
-                next
+            on_os_bodies = []
+
+            (on_macos_blocks + on_linux_blocks).each do |on_os_block|
+              on_os_body = on_os_block.body
+              if on_os_body.if_type?
+                on_os_bodies += on_os_body.branches.map { |branch| [on_os_block.method_name, branch] }
+              else
+                on_os_bodies << [on_os_block.method_name, on_os_body]
               end
             end
 
-            if on_linux_blocks.length == 1
-              on_linux_block = on_linux_blocks.first
-              child_nodes = on_linux_block.body.child_nodes
-              unless child_nodes[0].method?("url") && (
-                child_nodes[1].method?("sha256") ||
-                (child_nodes[1].method?("version") && child_nodes[2].method?("sha256"))
-              )
-                problem "`on_linux` blocks within resource blocks must contain only a " \
-                        "url and sha256 or a url, version, and sha256 (in those orders)."
-                next
+            message = nil
+            allowed_methods = [
+              [:url, :sha256],
+              [:url, :version, :sha256],
+            ]
+
+            on_os_bodies.each do |method_name, on_os_body|
+              child_nodes = on_os_body.begin_type? ? on_os_body.child_nodes : [on_os_body]
+              if child_nodes.all? { |n| n.send_type? || n.block_type? }
+                method_names = child_nodes.map(&:method_name)
+                next if allowed_methods.include? method_names
               end
+              message = "`#{method_name}` blocks within resource blocks must contain only a " \
+                        "url and sha256 or a url, version, and sha256 (in those orders)."
+              break
+            end
+
+            if message.present?
+              problem message
+              next
             end
 
             if on_macos_blocks.length > 1

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -432,6 +432,28 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    it "correctly uses an on_macos and on_linux block with versions" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          homepage "https://brew.sh"
+
+          resource do
+            on_macos do
+              url "https://brew.sh/resource1.tar.gz"
+              version "1.2.3"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+
+            on_linux do
+              url "https://brew.sh/resource2.tar.gz"
+              version "1.2.3"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+          end
+        end
+      RUBY
+    end
+
     it "there are two on_macos blocks, which is not allowed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -508,10 +530,36 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           url "https://brew.sh/foo-1.0.tgz"
 
           resource do
-          ^^^^^^^^^^^ only an url and a sha256 (in the right order) are allowed in a `on_macos` block within a resource block.
+          ^^^^^^^^^^^ `on_macos` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
             on_macos do
               sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               url "https://brew.sh/resource2.tar.gz"
+            end
+
+            on_linux do
+              url "https://brew.sh/resource2.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "the content of the on_macos block is wrong and not a method" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+          resource do
+          ^^^^^^^^^^^ `on_macos` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
+            on_macos do
+              if foo == :bar
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              else
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
             end
 
             on_linux do
@@ -529,7 +577,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
           url "https://brew.sh/foo-1.0.tgz"
 
           resource do
-          ^^^^^^^^^^^ only an url and a sha256 (in the right order) are allowed in a `on_linux` block within a resource block.
+          ^^^^^^^^^^^ `on_linux` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
             on_macos do
               url "https://brew.sh/resource2.tar.gz"
               sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -538,6 +586,32 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             on_linux do
               sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               url "https://brew.sh/resource2.tar.gz"
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "the content of the on_linux block is wrong and not a method" do
+      expect_offense(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+          resource do
+          ^^^^^^^^^^^ `on_linux` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
+            on_macos do
+              url "https://brew.sh/resource2.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+
+            on_linux do
+              if foo == :bar
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              else
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
             end
           end
         end

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -545,6 +545,31 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    it "reports no offenses if the on_macos block has if-else branches and they are properly formatted" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+          resource do
+            on_macos do
+              if foo == :bar
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              else
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+
+            on_linux do
+              url "https://brew.sh/resource2.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+          end
+        end
+      RUBY
+    end
+
     it "the content of the on_macos block is wrong and not a method" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -557,8 +582,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               else
-                url "https://brew.sh/resource1.tar.gz"
                 sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+                url "https://brew.sh/resource1.tar.gz"
               end
             end
 
@@ -592,6 +617,31 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
+    it "reports no offenses if the on_linux block has if-else branches and they are properly formatted" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < Formula
+          url "https://brew.sh/foo-1.0.tgz"
+
+          resource do
+            on_macos do
+              url "https://brew.sh/resource2.tar.gz"
+              sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+            end
+
+            on_linux do
+              if foo == :bar
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              else
+                url "https://brew.sh/resource1.tar.gz"
+                sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
     it "the content of the on_linux block is wrong and not a method" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -609,8 +659,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               else
-                url "https://brew.sh/resource1.tar.gz"
                 sha256 "686372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+                url "https://brew.sh/resource1.tar.gz"
               end
             end
           end

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -411,8 +411,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     RUBY
   end
 
-  context "resource" do
-    it "correctly uses an on_macos and on_linux block" do
+  context "in a resource block" do
+    it "reports no offenses for a valid on_macos and on_linux block" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -432,7 +432,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "correctly uses an on_macos and on_linux block with versions" do
+    it "reports no offenses for a valid on_macos and on_linux block with versions" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -454,7 +454,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "there are two on_macos blocks, which is not allowed" do
+    it "reports an offense if there are two on_macos blocks" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -475,7 +475,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "there are two on_linux blocks, which is not allowed" do
+    it "reports an offense if there are two on_linux blocks" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -496,7 +496,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "there is a on_macos block but no on_linux block" do
+    it "reports no offenses if there is an on_macos block but no on_linux block" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -510,7 +510,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "there is a on_linux block but no on_macos block" do
+    it "reports no offenses if there is an on_linux block but no on_macos block" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -524,7 +524,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "the content of the on_macos block is wrong in a resource block" do
+    it "reports an offense if the content of an on_macos block is improperly formatted" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -545,7 +545,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "reports no offenses if the on_macos block has if-else branches and they are properly formatted" do
+    it "reports no offenses if an on_macos block has if-else branches that are properly formatted" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -570,7 +570,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "the content of the on_macos block is wrong and not a method" do
+    it "reports an offense if an on_macos block has if-else branches that aren't properly formatted" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -596,7 +596,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "the content of the on_linux block is wrong in a resource block" do
+    it "reports an offense if the content of an on_linux block is improperly formatted" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -617,7 +617,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "reports no offenses if the on_linux block has if-else branches and they are properly formatted" do
+    it "reports no offenses if an on_linux block has if-else branches that are properly formatted" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -642,7 +642,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    it "the content of the on_linux block is wrong and not a method" do
+    it "reports an offense if an on_linux block has if-else branches that aren't properly formatted" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR fixes a `brew style` bug for the `on_macos` and `on_linux` checks with resource blocks.

Previously, the following would cause an error that broke `brew style` (this example is from https://github.com/Homebrew/homebrew-core/pull/67535):

```ruby
resource "cargobootstrap" do
  on_macos do
    if Hardware::CPU.arch == :arm64
      url "https://static.rust-lang.org/dist/2020-12-23/cargo-beta-aarch64-apple-darwin.tar.gz"
      sha256 "efbc0e72533d4ca7def9a985feef4b3e43d24f1f6792815bdba9125af1f8ecdf"
    else
      url "https://static.rust-lang.org/dist/2020-11-19/cargo-1.48.0-x86_64-apple-darwin.tar.gz"
      sha256 "ce00d796cf5a9ac8d88d9df94c408e5d7ccd3541932a829eae833cc8e57efb15"
    end
  end
end
```

Now, this will trigger the style issue and give the following message:

```
only a url and a sha256 (in the right order) are allowed in a `on_macos` block within a resource block.
```

---

Edit: this is now allowed. The check will still verify that only url and sha256 or url, version, and sha256 methods are used in on_macos/on_linux blocks in resource blocks (even if they are nested in if statements)