### PR TITLE
formula: include versioned `*.so.*` libs for `shared_library("*")`

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -5,7 +5,12 @@ class Formula
   undef shared_library
 
   def shared_library(name, version = nil)
-    "#{name}.so#{"." unless version.nil?}#{version}"
+    suffix = if version == "*" || (name == "*" && version.blank?)
+      "{,.*}"
+    elsif version.present?
+      ".#{version}"
+    end
+    "#{name}.so#{suffix}"
   end
 
   class << self

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1470,7 +1470,14 @@ class Formula
   end
 
   def shared_library(name, version = nil)
-    "#{name}.#{version}#{"." unless version.nil?}dylib"
+    return "*.dylib" if name == "*" && (version.blank? || version == "*")
+
+    infix = if version == "*"
+      "{,.*}"
+    elsif version.present?
+      ".#{version}"
+    end
+    "#{name}#{infix}.dylib"
   end
 
   # an array of all core {Formula} names

--- a/Library/Homebrew/test/os/linux/formula_spec.rb
+++ b/Library/Homebrew/test/os/linux/formula_spec.rb
@@ -107,6 +107,12 @@ describe Formula do
       f = Testball.new
       expect(f.shared_library("foobar")).to eq("foobar.so")
       expect(f.shared_library("foobar", 2)).to eq("foobar.so.2")
+      expect(f.shared_library("foobar", nil)).to eq("foobar.so")
+      expect(f.shared_library("foobar", "*")).to eq("foobar.so{,.*}")
+      expect(f.shared_library("*")).to eq("*.so{,.*}")
+      expect(f.shared_library("*", 2)).to eq("*.so.2")
+      expect(f.shared_library("*", nil)).to eq("*.so{,.*}")
+      expect(f.shared_library("*", "*")).to eq("*.so{,.*}")
     end
   end
 end

--- a/Library/Homebrew/test/os/mac/formula_spec.rb
+++ b/Library/Homebrew/test/os/mac/formula_spec.rb
@@ -112,6 +112,12 @@ describe Formula do
       f = Testball.new
       expect(f.shared_library("foobar")).to eq("foobar.dylib")
       expect(f.shared_library("foobar", 2)).to eq("foobar.2.dylib")
+      expect(f.shared_library("foobar", nil)).to eq("foobar.dylib")
+      expect(f.shared_library("foobar", "*")).to eq("foobar{,.*}.dylib")
+      expect(f.shared_library("*")).to eq("*.dylib")
+      expect(f.shared_library("*", 2)).to eq("*.2.dylib")
+      expect(f.shared_library("*", nil)).to eq("*.dylib")
+      expect(f.shared_library("*", "*")).to eq("*.dylib")
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

`ipopt` and `libgsm` use `Formula#shared_library` to locate shared libraries:

```rb
lib.install_symlink Dir["#{libexec}/lib/#{shared_library("*")}"]
```

However, this only matches unversioned `*.so` files such as `libpord.so` but ignores versioned `*.so.*` files like `libpord.so.0`. This PR modifies `shared_library` so that it matches both.

Related:
- https://github.com/Homebrew/homebrew-core/pull/67553
- https://github.com/Homebrew/homebrew-core/search?q=shared_library
- https://github.com/Homebrew/homebrew-core/blob/master/Formula/ipopt.rb#L54-L58
- https://github.com/Homebrew/homebrew-core/blob/master/Formula/libgsm.rb#L48