### PR TITLE
test/rubocops: improve test descriptions

### DIFF
--- a/Library/Homebrew/test/rubocops/caveats_spec.rb
+++ b/Library/Homebrew/test/rubocops/caveats_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/caveats"
 describe RuboCop::Cop::FormulaAudit::Caveats do
   subject(:cop) { described_class.new }
 
-  context "When auditing caveats" do
-    it "When there is setuid mentioned in caveats" do
+  context "when auditing `caveats`" do
+    it "reports an offense if `setuid` is mentioned" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh/foo"

--- a/Library/Homebrew/test/rubocops/checksum_spec.rb
+++ b/Library/Homebrew/test/rubocops/checksum_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/checksum"
 describe RuboCop::Cop::FormulaAudit::Checksum do
   subject(:cop) { described_class.new }
 
-  context "When auditing spec checksums" do
-    it "When the checksum is empty" do
+  context "when auditing spec checksums" do
+    it "reports an offense if a checksum is empty" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -26,7 +26,7 @@ describe RuboCop::Cop::FormulaAudit::Checksum do
       RUBY
     end
 
-    it "When the checksum is not 64 characters" do
+    it "reports an offense if a checksum is not 64 characters" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -45,7 +45,7 @@ describe RuboCop::Cop::FormulaAudit::Checksum do
       RUBY
     end
 
-    it "When the checksum has invalid chars" do
+    it "reports an offense if a checksum contains invalid characters" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -69,8 +69,8 @@ end
 describe RuboCop::Cop::FormulaAudit::ChecksumCase do
   subject(:cop) { described_class.new }
 
-  context "When auditing spec checksums" do
-    it "When the checksum has upper case characters" do
+  context "when auditing spec checksums" do
+    it "reports an offense if a checksum contains uppercase letters" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -89,7 +89,7 @@ describe RuboCop::Cop::FormulaAudit::ChecksumCase do
       RUBY
     end
 
-    it "When auditing stable blocks outside spec blocks" do
+    it "reports an offense if a checksum outside a `stable` block contains uppercase letters" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -110,10 +110,8 @@ describe RuboCop::Cop::FormulaAudit::ChecksumCase do
         end
       RUBY
     end
-  end
 
-  context "When auditing checksum with autocorrect" do
-    it "When there is uppercase sha256" do
+    it "auto-corrects checksums that contain uppercase letters" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'

--- a/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_redundancy_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/components_redundancy"
 describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula components common errors" do
-    it "When url outside stable block" do
+  context "when auditing formula components" do
+    it "reports an offense if `url` is outside `stable` block" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -23,7 +23,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
       RUBY
     end
 
-    it "When both `head` and `head do` are present" do
+    it "reports an offense if both `head` and `head do` are present" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           head "https://brew.sh/foo.git"
@@ -35,7 +35,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
       RUBY
     end
 
-    it "When both `bottle :modifier` and `bottle do` are present" do
+    it "reports an offense if both `bottle :modifier` and `bottle do` are present" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -48,7 +48,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
       RUBY
     end
 
-    it "When `stable do` is present with a `head` method" do
+    it "reports no offenses if `stable do` is present with a `head` method" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           head "https://brew.sh/foo.git"
@@ -60,7 +60,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsRedundancy do
       RUBY
     end
 
-    it "When `stable do` is present with a `head do` block" do
+    it "reports no offenses if `stable do` is present with a `head do` block" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           stable do

--- a/Library/Homebrew/test/rubocops/conflicts_spec.rb
+++ b/Library/Homebrew/test/rubocops/conflicts_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/conflicts"
 describe RuboCop::Cop::FormulaAudit::Conflicts do
   subject(:cop) { described_class.new }
 
-  context "When auditing conflicts_with" do
-    it "conflicts_with reason is capitalized" do
+  context "when auditing `conflicts_with`" do
+    it "reports an offense if reason is capitalized" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -18,7 +18,7 @@ describe RuboCop::Cop::FormulaAudit::Conflicts do
       RUBY
     end
 
-    it "conflicts_with reason ends with a period" do
+    it "reports an offense if reason ends with a period" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -28,7 +28,7 @@ describe RuboCop::Cop::FormulaAudit::Conflicts do
       RUBY
     end
 
-    it "conflicts_with in a versioned formula" do
+    it "reports an offense if it is present in a versioned formula" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo@2.0.rb")
         class FooAT20 < Formula
           url 'https://brew.sh/foo-2.0.tgz'
@@ -38,7 +38,7 @@ describe RuboCop::Cop::FormulaAudit::Conflicts do
       RUBY
     end
 
-    it "no conflicts_with" do
+    it "reports no offenses if it is not present" do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo@2.0.rb")
         class FooAT20 < Formula
           url 'https://brew.sh/foo-2.0.tgz'

--- a/Library/Homebrew/test/rubocops/dependency_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/dependency_order_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/dependency_order"
 describe RuboCop::Cop::FormulaAudit::DependencyOrder do
   subject(:cop) { described_class.new }
 
-  context "uses_from_macos" do
-    it "wrong conditional uses_from_macos order" do
+  context "when auditing `uses_from_macos`" do
+    it "reports an offense if wrong conditional order" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -19,7 +19,7 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
       RUBY
     end
 
-    it "wrong alphabetical uses_from_macos order" do
+    it "reports an offense if wrong alphabetical order" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -43,7 +43,7 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
       RUBY
     end
 
-    it "wrong conditional uses_from_macos order with block" do
+    it "reports an offense if wrong conditional order with block" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -62,7 +62,7 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
       RUBY
     end
 
-    it "correct uses_from_macos order for multiple tags" do
+    it "reports no offenses if correct order for multiple tags" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -75,8 +75,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     end
   end
 
-  context "depends_on" do
-    it "wrong conditional depends_on order" do
+  context "when auditing `depends_on`" do
+    it "reports an offense if wrong conditional order" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -88,7 +88,7 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
       RUBY
     end
 
-    it "wrong alphabetical depends_on order" do
+    it "reports an offense if wrong alphabetical order" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -112,7 +112,7 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
       RUBY
     end
 
-    it "wrong conditional depends_on order with block" do
+    it "reports an offense if wrong conditional order with block" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -131,7 +131,7 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
       RUBY
     end
 
-    it "correct depends_on order for multiple tags" do
+    it "reports no offenses if correct order for multiple tags" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -144,8 +144,8 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
     end
   end
 
-  context "autocorrect" do
-    it "wrong conditional uses_from_macos order" do
+  context "when auto-correcting" do
+    it "supports wrong conditional `uses_from_macos` order" do
       source = <<~RUBY
         class Foo < Formula
           homepage "https://brew.sh"
@@ -168,7 +168,7 @@ describe RuboCop::Cop::FormulaAudit::DependencyOrder do
       expect(corrected_source).to eq(correct_source)
     end
 
-    it "wrong conditional depends_on order" do
+    it "supports wrong conditional `depends_on` order" do
       source = <<~RUBY
         class Foo < Formula
           homepage "https://brew.sh"

--- a/Library/Homebrew/test/rubocops/deprecate_disable_spec.rb
+++ b/Library/Homebrew/test/rubocops/deprecate_disable_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/deprecate_disable"
 describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula for deprecate! date:" do
-    it "deprecation date is not ISO 8601 compliant" do
+  context "when auditing `deprecate!`" do
+    it "reports an offense if `date` is not ISO 8601 compliant" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -17,7 +17,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "deprecation date is not ISO 8601 compliant with reason" do
+    it "reports an offense if `date` is not ISO 8601 compliant (with `reason`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -27,7 +27,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "deprecation date is ISO 8601 compliant" do
+    it "reports no offenses if `date` is ISO 8601 compliant" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -36,7 +36,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "deprecation date is ISO 8601 compliant with reason" do
+    it "reports no offenses if `date` is ISO 8601 compliant (with `reason`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -45,7 +45,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "no deprecation date" do
+    it "reports no offenses if no `date` is specified" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -54,7 +54,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "no deprecation date with reason" do
+    it "reports no offenses if no `date` is specified (with `reason`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -63,7 +63,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "auto corrects to ISO 8601 format" do
+    it "auto-corrects `date` to ISO 8601 format" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -82,7 +82,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       expect(new_source).to eq(corrected_source)
     end
 
-    it "auto corrects to ISO 8601 format with reason" do
+    it "auto-corrects `date` to ISO 8601 format (with `reason`)" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -102,8 +102,8 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
     end
   end
 
-  context "When auditing formula for disable! date:" do
-    it "disable date is not ISO 8601 compliant" do
+  context "when auditing `disable!`" do
+    it "reports an offense if `date` is not ISO 8601 compliant" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -113,7 +113,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "disable date is not ISO 8601 compliant with reason" do
+    it "reports an offense if `date` is not ISO 8601 compliant (with `reason`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -123,7 +123,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "disable date is ISO 8601 compliant" do
+    it "reports no offenses if `date` is ISO 8601 compliant" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -132,7 +132,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "disable date is ISO 8601 compliant with reason" do
+    it "reports no offenses if `date` is ISO 8601 compliant (with `reason`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -141,7 +141,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "no disable date" do
+    it "reports no offenses if no `date` is specified" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -150,7 +150,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "no disable date with reason" do
+    it "reports no offenses if no `date` is specified (with `reason`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -159,7 +159,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       RUBY
     end
 
-    it "auto corrects to ISO 8601 format" do
+    it "auto-corrects `date` to ISO 8601 format" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -178,7 +178,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableDate do
       expect(new_source).to eq(corrected_source)
     end
 
-    it "auto corrects to ISO 8601 format with reason" do
+    it "auto-corrects `date` to ISO 8601 format (with `reason`)" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -202,8 +202,8 @@ end
 describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula for deprecate! because:" do
-    it "deprecation reason is acceptable" do
+  context "when auditing `deprecate!`" do
+    it "reports no offenses if `reason` is acceptable" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -212,7 +212,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason is acceptable as a symbol" do
+    it "reports no offenses if `reason` is acceptable as a symbol" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -221,7 +221,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason is acceptable with date" do
+    it "reports no offenses if `reason` is acceptable (with `date`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -230,7 +230,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason is acceptable as a symbol with date" do
+    it "reports no offenses if `reason` is acceptable as a symbol (with `date`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -239,7 +239,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason is absent" do
+    it "reports an offense if `reason` is absent" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -249,7 +249,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason is absent with date" do
+    it "reports an offense if `reason` is absent (with `date`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -259,7 +259,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason starts with `it`" do
+    it "reports an offense if `reason` starts with 'it'" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -269,7 +269,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason starts with `it` with date" do
+    it "reports an offense if `reason` starts with 'it' (with `date`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -279,7 +279,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason ends with a period" do
+    it "reports an offense if `reason` ends with a period" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -289,7 +289,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason ends with an exclamation point" do
+    it "reports an offense if `reason` ends with an exclamation point" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -299,7 +299,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason ends with a question mark" do
+    it "reports an offense if `reason` ends with a question mark" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -309,7 +309,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "deprecation reason ends with a period with date" do
+    it "reports an offense if `reason` ends with a period (with `date`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -319,7 +319,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "auto corrects to remove `it`" do
+    it "auto-corrects `reason` to remove 'it'" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -338,7 +338,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       expect(new_source).to eq(corrected_source)
     end
 
-    it "auto corrects to remove punctuation" do
+    it "auto-corrects `reason` to remove punctuation" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -358,8 +358,8 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
     end
   end
 
-  context "When auditing formula for disable! because:" do
-    it "disable reason is acceptable" do
+  context "when auditing `disable!`" do
+    it "reports no offenses if `reason` is acceptable" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -368,7 +368,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason is acceptable as a symbol" do
+    it "reports no offenses if `reason` is acceptable as a symbol" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -377,7 +377,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason is acceptable with date" do
+    it "reports no offenses if `reason` is acceptable (with `date`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -386,7 +386,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason is acceptable as a symbol with date" do
+    it "reports no offenses if `reason` is acceptable as a symbol (with `date`)" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -395,7 +395,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason is absent" do
+    it "reports an offense if `reason` is absent" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -405,7 +405,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason is absent with date" do
+    it "reports an offense if `reason` is absent (with `date`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -415,7 +415,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason starts with `it`" do
+    it "reports an offense if `reason` starts with 'it'" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -425,7 +425,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason starts with `it` with date" do
+    it "reports an offense if `reason` starts with 'it' (with `date`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -435,7 +435,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason ends with a period" do
+    it "reports an offense if `reason` ends with a period" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -445,7 +445,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason ends with an exclamation point" do
+    it "reports an offense if `reason` ends with an exclamation point" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -455,7 +455,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason ends with a question mark" do
+    it "reports an offense if `reason` ends with a question mark" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -465,7 +465,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "disable reason ends with a period with date" do
+    it "reports an offense if `reason` ends with a period (with `date`)" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -475,7 +475,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       RUBY
     end
 
-    it "auto corrects to remove `it`" do
+    it "auto-corrects to remove 'it'" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -494,7 +494,7 @@ describe RuboCop::Cop::FormulaAudit::DeprecateDisableReason do
       expect(new_source).to eq(corrected_source)
     end
 
-    it "auto corrects to remove punctuation" do
+    it "auto-corrects to remove punctuation" do
       source = <<~RUBY
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [?] Have you written new tests for your changes? [That's an interesting idea—writing tests for our tests]
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

While reviewing #10118, I noticed that a lot of `context` and `it` descriptions in `test/rubocops` are somewhat incoherent

For example:

```rb
  context "uses_from_macos" do
    it "wrong conditional uses_from_macos order" do
```

```
Failures:

  1) RuboCop::Cop::FormulaAudit::DependencyOrder uses_from_macos wrong conditional uses_from_macos order
```

This PR improves the test descriptions for the following specs:

- `test/rubocops/caveats_spec.rb`
- `test/rubocops/checksum_spec.rb`
- `test/rubocops/components_redundancy_spec.rb`
- `test/rubocops/conflicts_spec.rb`
- `test/rubocops/dependency_order_spec.rb`
- `test/rubocops/deprecate_disable_spec.rb`

Now the previous example looks like this:

```rb
  context "when auditing `uses_from_macos`" do
    it "reports an offense if wrong conditional order" do
```

```
Failures:

  1) RuboCop::Cop::FormulaAudit::DependencyOrder when auditing `uses_from_macos` reports an offense if wrong conditional order
```