### PR TITLE
Livecheck: Extend strategy block support

### DIFF
--- a/Library/Homebrew/livecheck/strategy/apache.rb
+++ b/Library/Homebrew/livecheck/strategy/apache.rb
@@ -38,7 +38,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           %r{
             path=
             (?<path>.+?)/ # Path to directory of files or version directories
@@ -59,7 +59,7 @@ module Homebrew
           # * `/href=["']?example-v?(\d+(?:\.\d+)+)-bin\.zip/i`
           regex ||= /href=["']?#{Regexp.escape(prefix)}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/bitbucket.rb
+++ b/Library/Homebrew/livecheck/strategy/bitbucket.rb
@@ -52,7 +52,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           match = url.match(URL_MATCH_REGEX)
 
           # Use `\.t` instead of specific tarball extensions (e.g. .tar.gz)
@@ -71,7 +71,7 @@ module Homebrew
           # * `/href=.*?example-v?(\d+(?:\.\d+)+)\.t/i`
           regex ||= /href=.*?#{Regexp.escape(match[:prefix])}v?(\d+(?:\.\d+)+)#{Regexp.escape(suffix)}/i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/cpan.rb
+++ b/Library/Homebrew/livecheck/strategy/cpan.rb
@@ -37,7 +37,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           %r{
             (?<path>/authors/id(?:/[^/]+){3,}/) # Path before the filename
             (?<prefix>[^/]+) # Filename text before the version
@@ -54,7 +54,7 @@ module Homebrew
           # Example regex: `/href=.*?Brew[._-]v?(\d+(?:\.\d+)*)\.t/i`
           regex ||= /href=.*?#{prefix}[._-]v?(\d+(?:\.\d+)*)#{Regexp.escape(suffix)}/i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/git.rb
+++ b/Library/Homebrew/livecheck/strategy/git.rb
@@ -87,7 +87,7 @@ module Homebrew
           tags_only_debian = tags_data[:tags].all? { |tag| tag.start_with?("debian/") }
 
           if block
-            case (value = block.call(tags_data[:tags]))
+            case (value = block.call(tags_data[:tags], regex))
             when String
               match_data[:matches][value] = Version.new(value)
             when Array

--- a/Library/Homebrew/livecheck/strategy/github_latest.rb
+++ b/Library/Homebrew/livecheck/strategy/github_latest.rb
@@ -56,7 +56,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           %r{github\.com/(?:downloads/)?(?<username>[^/]+)/(?<repository>[^/]+)}i =~ url.sub(/\.git$/i, "")
 
           # Example URL: `https://github.com/example/example/releases/latest`
@@ -65,7 +65,7 @@ module Homebrew
           # The default regex is the same for all URLs using this strategy
           regex ||= %r{href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -36,7 +36,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           %r{/sources/(?<package_name>.*?)/}i =~ url
 
           page_url = "https://download.gnome.org/sources/#{package_name}/cache.json"
@@ -53,7 +53,7 @@ module Homebrew
           # Example regex: `/example-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i`
           regex ||= /#{Regexp.escape(package_name)}-(\d+\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/gnu.rb
+++ b/Library/Homebrew/livecheck/strategy/gnu.rb
@@ -59,7 +59,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           project_names = PROJECT_NAME_REGEXES.map do |project_name_regex|
             m = url.match(project_name_regex)
             m["project_name"] if m
@@ -89,7 +89,7 @@ module Homebrew
           # Example regex: `%r{href=.*?example[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i`
           regex ||= %r{href=.*?#{project_name}[._-]v?(\d+(?:\.\d+)*)(?:\.[a-z]+|/)}i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/hackage.rb
+++ b/Library/Homebrew/livecheck/strategy/hackage.rb
@@ -34,7 +34,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           /^(?<package_name>.+?)-\d+/i =~ File.basename(url)
 
           # A page containing a directory listing of the latest source tarball
@@ -43,7 +43,7 @@ module Homebrew
           # Example regex: `%r{<h3>example-(.*?)/?</h3>}i`
           regex ||= %r{<h3>#{Regexp.escape(package_name)}-(.*?)/?</h3>}i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/header_match.rb
+++ b/Library/Homebrew/livecheck/strategy/header_match.rb
@@ -45,7 +45,7 @@ module Homebrew
           merged_headers = headers.reduce(&:merge)
 
           if block
-            match = block.call(merged_headers)
+            match = block.call(merged_headers, regex)
           else
             match = nil
 

--- a/Library/Homebrew/livecheck/strategy/launchpad.rb
+++ b/Library/Homebrew/livecheck/strategy/launchpad.rb
@@ -40,7 +40,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           %r{launchpad\.net/(?<project_name>[^/]+)}i =~ url
 
           # The main page for the project on Launchpad
@@ -49,7 +49,7 @@ module Homebrew
           # The default regex is the same for all URLs using this strategy
           regex ||= %r{class="[^"]*version[^"]*"[^>]*>\s*Latest version is (.+)\s*</}
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/npm.rb
+++ b/Library/Homebrew/livecheck/strategy/npm.rb
@@ -36,7 +36,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           %r{registry\.npmjs\.org/(?<package_name>.+)/-/}i =~ url
 
           page_url = "https://www.npmjs.com/package/#{package_name}?activeTab=versions"
@@ -46,7 +46,7 @@ module Homebrew
           # * `%r{href=.*?/package/@example/example/v/(\d+(?:\.\d+)+)"}i`
           regex ||= %r{href=.*?/package/#{Regexp.escape(package_name)}/v/(\d+(?:\.\d+)+)"}i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -49,7 +49,7 @@ module Homebrew
         # @return [Array]
         def self.page_matches(content, regex, &block)
           if block
-            case (value = block.call(content))
+            case (value = block.call(content, regex))
             when String
               return [value]
             when Array

--- a/Library/Homebrew/livecheck/strategy/pypi.rb
+++ b/Library/Homebrew/livecheck/strategy/pypi.rb
@@ -36,7 +36,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           /
             (?<package_name>.+)- # The package name followed by a hyphen
             .*? # The version string
@@ -55,7 +55,7 @@ module Homebrew
             %r{href=.*?/packages.*?/#{Regexp.escape(package_name)}[._-]
                v?(\d+(?:\.\d+)*(.post\d+)?)#{Regexp.escape(suffix)}}ix
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/sourceforge.rb
+++ b/Library/Homebrew/livecheck/strategy/sourceforge.rb
@@ -50,7 +50,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex = nil)
+        def self.find_versions(url, regex = nil, &block)
           if url.include?("/project")
             %r{/projects?/(?<project_name>[^/]+)/}i =~ url
           elsif url.include?(".net/p/")
@@ -66,7 +66,7 @@ module Homebrew
           # create something that works for most URLs.
           regex ||= %r{url=.*?/#{Regexp.escape(project_name)}/files/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i
 
-          PageMatch.find_versions(page_url, regex)
+          PageMatch.find_versions(page_url, regex, &block)
         end
       end
     end

--- a/Library/Homebrew/livecheck/strategy/xorg.rb
+++ b/Library/Homebrew/livecheck/strategy/xorg.rb
@@ -70,7 +70,7 @@ module Homebrew
         # @param url [String] the URL of the content to check
         # @param regex [Regexp] a regex used for matching versions in content
         # @return [Hash]
-        def self.find_versions(url, regex)
+        def self.find_versions(url, regex = nil, &block)
           file_name = File.basename(url)
           /^(?<module_name>.+)-\d+/i =~ file_name
 
@@ -84,7 +84,7 @@ module Homebrew
 
           # Use the cached page content to avoid duplicate fetches
           cached_content = @page_data[page_url]
-          match_data = PageMatch.find_versions(page_url, regex, cached_content)
+          match_data = PageMatch.find_versions(page_url, regex, cached_content, &block)
 
           # Cache any new page content
           @page_data[page_url] = match_data[:content] if match_data[:content].present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

We recently added support for a `strategy` block in `livecheck` blocks as part of expanding support for casks. Originally, this support was only added to `HeaderMatch`, `Sparkle` and `PageMatch`.

This builds on that work by adding support for `strategy` blocks to the strategies that use `PageMatch#find_versions` internally (i.e., `Apache`, `Bitbucket`, `Cpan`, `GithubLatest`, `Gnome`, `Gnu`, `Hackage`, `Npm`, `Pypi`, and `Sourceforge`). I will be updating this PR to update `Xorg` in the same fashion after #10113 is merged.

Besides those strategies, this also adds support to the `Git` strategy. I've borrowed some related code from `PageMatch#page_matches` and adapted it to the context of `Git#find_versions`. There may be room for improvement in how this is handled but this is a straightforward first draft.

---

This also modifies the related instances of `block.call` (in `HeaderMatch`, `PageMatch`, and `Git`) to pass in a regex alongside the content (e.g., page content, tags, etc.). This allows us to access a regex generated within the strategy or defined in the `livecheck` block from within the `strategy` block.

Some early `strategy` blocks have been creating a regex within the `strategy` block but unfortunately this prevents us from getting at this information in the debug and verbose JSON output. When a `strategy` block only uses one regex for matching (and the matching is done in a manner that's similar to what the strategy normally does), it's arguably better to define the regex in the `livecheck` block instead.