### PR TITLE
cmd/list: Use `du -sh` to show Cellar size on `brew list -l`

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -117,6 +117,7 @@ module Homebrew
       if !$stdout.tty? && !args.formula? && !args.cask?
         odisabled "`brew list` to only list formulae", "`brew list --formula`"
       else
+        safe_system "du", "-sh", HOMEBREW_CELLAR if args.l?
         safe_system "ls", *ls_args, HOMEBREW_CELLAR unless args.cask?
         list_casks(args: args) unless args.formula?
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- Fixes #10116 (part one).

- The help text for `brew list -l` states:

  > List formulae in long format. If the output is to a terminal, a total
  > sum for all the file sizes is printed before the long listing.

- This `total` was 0 when running `ls -l` on HOMEBREW_CELLAR, despite all the files listed having size data and existing. Maybe it's a quirk of how `ls` works (though it works fine if I do `ls -l` on my home directory), but this probably wasn't the intention.

- Instead, use `du -sh HOMEBREW_CELLAR` to show a human-readable "how much space is my Homebrew Cellar taking up" when the `-l` option is passed.

Before:

```
➜ brew list -l
total 0
[list of files]
```

After:

```
➜ brew list -l
2.8G	/usr/local/Cellar
total 0
[list of files]
```
