### PR TITLE
cmd/list: Constrain `-lrt` options to formulae

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -533,8 +533,8 @@ module Homebrew
 
     class OptionConstraintError < UsageError
       def initialize(arg1, arg2, missing: false)
-        arg1 = arg1.length > 1 ? "--#{arg1.tr("_", "-")}" : "-#{arg1.tr("_", "-")}"
-        arg2 = arg2.length > 1 ? "--#{arg2.tr("_", "-")}" : "-#{arg2.tr("_", "-")}"
+        arg1 = dashes(arg1) + arg1.tr("_", "-")
+        arg2 = dashes(arg2) + arg2.tr("_", "-")
 
         message = if missing
           "`#{arg2}` cannot be passed without `#{arg1}`."
@@ -542,6 +542,10 @@ module Homebrew
           "`#{arg1}` and `#{arg2}` should be passed together."
         end
         super message
+      end
+
+      def dashes(arg)
+        arg.length > 1 ? "--" : "-"
       end
     end
 

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -533,8 +533,8 @@ module Homebrew
 
     class OptionConstraintError < UsageError
       def initialize(arg1, arg2, missing: false)
-        arg1 = "--#{arg1.tr("_", "-")}"
-        arg2 = "--#{arg2.tr("_", "-")}"
+        arg1 = arg1.length > 1 ? "--#{arg1.tr("_", "-")}" : "-#{arg1.tr("_", "-")}"
+        arg2 = arg2.length > 1 ? "--#{arg2.tr("_", "-")}" : "-#{arg2.tr("_", "-")}"
 
         message = if missing
           "`#{arg2}` cannot be passed without `#{arg1}`."

--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -432,6 +432,10 @@ module Homebrew
         @constraints.each do |primary, secondary, constraint_type|
           primary_passed = option_passed?(primary)
           secondary_passed = option_passed?(secondary)
+
+          primary = name_to_option(primary)
+          secondary = name_to_option(secondary)
+
           if :mandatory.equal?(constraint_type) && primary_passed && !secondary_passed
             raise OptionConstraintError.new(primary, secondary)
           end
@@ -533,19 +537,12 @@ module Homebrew
 
     class OptionConstraintError < UsageError
       def initialize(arg1, arg2, missing: false)
-        arg1 = dashes(arg1) + arg1.tr("_", "-")
-        arg2 = dashes(arg2) + arg2.tr("_", "-")
-
         message = if missing
           "`#{arg2}` cannot be passed without `#{arg1}`."
         else
           "`#{arg1}` and `#{arg2}` should be passed together."
         end
         super message
-      end
-
-      def dashes(arg)
-        arg.length > 1 ? "--" : "-"
       end
     end
 

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -47,11 +47,14 @@ module Homebrew
              description: "Force output to be one entry per line. " \
                           "This is the default when output is not to a terminal."
       switch "-l",
+             depends_on:  "--formula",
              description: "List formulae in long format. If the output is to a terminal, "\
                           "a total sum for all the file sizes is printed before the long listing."
       switch "-r",
+             depends_on:  "--formula",
              description: "Reverse the order of the formulae sort to list the oldest entries first."
       switch "-t",
+             depends_on:  "--formula",
              description: "Sort formulae by time modified, listing most recently modified first."
 
       conflicts "--formula", "--cask"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- Fixes #10116 (part two).

- These are documented as only working on formulae, but users expect the same options (long format, reverse order or sort by modified time) to be passed to both formulae and casks in the default `brew list`. The output looks weird as they're not. Hence, constrain these to be `--formula`-only.

- This was added originally in 5adb76a5babdccd2c4edfb8752ac979ed14716ca, but disappeared later (I've not yet dug through and found why).

- This also fixes the CLI parser's handling of error messages for short options (assuming they're only a single character). Before, the error messages for this missing `--formula` option on `brew list -l` was `Error: Invalid usage: `--l` cannot be passed without `--formula`.`. ~I don't much like this code, but I'll revisit it later - I have to run for a 🚌 🚏 now!~
