### PR TITLE
cmd/list: Remove help text about `-l` displaying file sizes

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -48,8 +48,7 @@ module Homebrew
                           "This is the default when output is not to a terminal."
       switch "-l",
              depends_on:  "--formula",
-             description: "List formulae in long format. If the output is to a terminal, "\
-                          "a total sum for all the file sizes is printed before the long listing."
+             description: "List formulae in long format."
       switch "-r",
              depends_on:  "--formula",
              description: "Reverse the order of the formulae sort to list the oldest entries first."

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -339,7 +339,7 @@ If *`cask`* is provided, list its artifacts.
 * `-1`:
   Force output to be one entry per line. This is the default when output is not to a terminal.
 * `-l`:
-  List formulae in long format. If the output is to a terminal, a total sum for all the file sizes is printed before the long listing.
+  List formulae in long format.
 * `-r`:
   Reverse the order of the formulae sort to list the oldest entries first.
 * `-t`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -468,7 +468,7 @@ Force output to be one entry per line\. This is the default when output is not t
 .
 .TP
 \fB\-l\fR
-List formulae in long format\. If the output is to a terminal, a total sum for all the file sizes is printed before the long listing\.
+List formulae in long format\.
 .
 .TP
 \fB\-r\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- It doesn't work on the `HOMEBREW_CELLAR` dir for some reason, and using `du -sh` instead (https://github.com/Homebrew/brew/pull/10131) was an extra call that we don't need.
- (I had to edit the man page manually as `brew man` gives me "Broken pipe" errors.)
