### PR TITLE
audit: fix prerelease audit

### DIFF
--- a/Library/Homebrew/utils/shared_audits.rb
+++ b/Library/Homebrew/utils/shared_audits.rb
@@ -43,7 +43,9 @@ module SharedAudits
 
     return "#{tag} is a GitHub pre-release." if release["prerelease"] && [version, "all"].exclude?(exception)
 
-    return "#{tag} is not a GitHub pre-release but '#{name}' is in the GitHub prerelease allowlist." if exception
+    if !release["prerelease"] && exception
+      return "#{tag} is not a GitHub pre-release but '#{name}' is in the GitHub prerelease allowlist."
+    end
 
     return "#{tag} is a GitHub draft." if release["draft"]
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Fixes an issue with the GitHub prerelease audit. Previously, this would fail for prereleases that were added to the exception list. Not sure how this slipped through my testing... :facepalm:
