### PR TITLE
cli/parser: improve name_to_option for some cask args

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -232,6 +232,8 @@ module Homebrew
       def name_to_option(name)
         if name.length == 1
           "-#{name}"
+        elsif Homebrew::CLI::Parser.global_cask_options.any? { |_, option, **| name == option_to_name(option) }
+          "--#{name}"
         else
           "--#{name.tr("_", "-")}"
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to #10133

Previously (note that `--input_methoddir` is incorrectly displayed as `--input-methoddir`):

```console
$ brew install --input_methoddir=abc --formula safe-rm
[...]
Error: Invalid usage: Options --formula and --input-methoddir are mutually exclusive.
```

Now (note the correct `--input_methoddir` flag is shown):
```console
$ brew install --input_methoddir=abc --formula safe-rm
[...]
Error: Invalid usage: Options --formula and --input_methoddir are mutually exclusive.
```

CC @issyl0 and @reitermarkus