### PR TITLE
Remove `:appcast` and rename `:cask_url` to `:url`.

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -87,16 +87,14 @@ class Livecheck
   # Sets the `@url` instance variable to the provided argument or returns the
   # `@url` instance variable when no argument is provided. The argument can be
   # a `String` (a URL) or a supported `Symbol` corresponding to a URL in the
-  # formula/cask (e.g. `:stable`, `:homepage`, `:head`, `:cask_url`, `:appcast`).
+  # formula/cask (e.g. `:stable`, `:homepage`, `:head`, `:url`).
   # @param val [String, Symbol] URL to check for version information
   # @return [String, nil]
   def url(val = nil)
     @url = case val
     when nil
       return @url
-    when :appcast
-      @formula_or_cask.appcast.to_s
-    when :cask_url
+    when :url
       @formula_or_cask.url.to_s
     when :head, :stable
       @formula_or_cask.send(val).url


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

---

`livecheck` is a replacement for `appcast`, so `:appcast` should never be needed. The `:cask_url` naming is weird, since the `url` is always the cask url. `url :url` may look weird, but at least is consistent with `url :homepage`.