### PR TITLE
PageMatch: Return fetched content in match_data

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -526,6 +526,7 @@ module Homebrew
           puts "URL (strategy):   #{strategy_data[:url]}" if strategy_data[:url] != url
           puts "URL (final):      #{strategy_data[:final_url]}" if strategy_data[:final_url]
           puts "Regex (strategy): #{strategy_data[:regex].inspect}" if strategy_data[:regex] != livecheck_regex
+          puts "Cached?:          Yes" if strategy_data[:cached] == true
         end
 
         match_version_map.delete_if do |_match, version|
@@ -568,6 +569,7 @@ module Homebrew
           version_info[:meta][:url][:final] = strategy_data[:final_url] if strategy_data[:final_url]
           version_info[:meta][:strategies] = strategies.map { |s| livecheck_strategy_names[s] } if strategies.present?
           version_info[:meta][:regex] = regex.inspect if regex.present?
+          version_info[:meta][:cached] = true if strategy_data[:cached] == true
         end
 
         return version_info

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -92,7 +92,7 @@ module Homebrew
             provided_content
           else
             match_data.merge!(Strategy.page_content(url))
-            match_data.delete(:content)
+            match_data[:content]
           end
           return match_data if content.blank?
 

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -88,7 +88,7 @@ module Homebrew
         def self.find_versions(url, regex, provided_content = nil, &block)
           match_data = { matches: {}, regex: regex, url: url }
 
-          content = if provided_content.present?
+          content = if provided_content.is_a?(String)
             provided_content
           else
             match_data.merge!(Strategy.page_content(url))

--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -89,6 +89,7 @@ module Homebrew
           match_data = { matches: {}, regex: regex, url: url }
 
           content = if provided_content.is_a?(String)
+            match_data[:cached] = true
             provided_content
           else
             match_data.merge!(Strategy.page_content(url))

--- a/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
+++ b/Library/Homebrew/test/livecheck/strategy/page_match_spec.rb
@@ -36,6 +36,7 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
   }
 
   let(:page_content_matches) { ["2.6.0", "2.5.0", "2.4.0", "2.3.0", "2.2.0", "2.1.0", "2.0.0", "1.9.0"] }
+
   let(:find_versions_return_hash) {
     {
       matches: {
@@ -51,6 +52,12 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
       regex:   regex,
       url:     url,
     }
+  }
+
+  let(:find_versions_cached_return_hash) {
+    return_hash = find_versions_return_hash
+    return_hash[:cached] = true
+    return_hash
   }
 
   describe "::match?" do
@@ -72,7 +79,7 @@ describe Homebrew::Livecheck::Strategy::PageMatch do
 
   describe "::find_versions?" do
     it "finds versions in provided_content" do
-      expect(page_match.find_versions(url, regex, page_content)).to eq(find_versions_return_hash)
+      expect(page_match.find_versions(url, regex, page_content)).to eq(find_versions_cached_return_hash)
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is a follow-up to #10113, which made modifications to `PageMatch` to support working with cached content, as a way of being able to modify the `Xorg` strategy to use `PageMatch` internally (like other strategies). With those changes, `PageMatch` properly works with page content that's passed to `#find_versions`.

However, the issue is that `Xorg` isn't actually able to cache page content in the current state because `PageMatch` isn't passing fetched content back to it in its return hash (`match_data`). Before #10113, I had been deleting the `:content` from `match_data` (as it wasn't necessary to keep it in the hash) and I simply forgot to modify that line when modifying `PageMatch#find_versions` to support cached content.

In general, this PR makes the following changes:

* Modify `PageMatch#find_versions` to return fetched page content in the `match_data` hash (i.e., not actively deleting it like we have been doing).
* Modify the condition where we check for `provided_content` in `PageMatch#find_versions` to ensure that `provided_content` is a string before using it.
* Set `match_data[:cached] = true` when `PageMatch#find_versions` is using `provided_content`. In this case, `Cached?: Yes` is printed in the debug output and `["meta"]["cached"]` is set to `true` in the verbose JSON output. I missed this issue before because it's sometimes hard to tell when caching is actually working, so it's a good idea to surface this information.

Though I know it's the holidays, I'm labeling this "critical" so this fix can be integrated if anyone happens to review it over the next few days.