### PR TITLE
Fix description cache path in Fish completion

### DIFF
--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -93,11 +93,9 @@ function __fish_brew_suggest_formulae_all -d 'Lists all available formulae with 
     set -q __brew_cache_path
     or set -gx __brew_cache_path (brew --cache)
 
-    # TODO: Probably drop this since I think that desc_cache.json is no longer generated. Is there a different available cache?
-    if test -f "$__brew_cache_path/desc_cache.json"
-        __fish_brew_ruby_parse_json "$__brew_cache_path/desc_cache.json" \
+    if test -f "$__brew_cache_path/descriptions.json"
+        __fish_brew_ruby_parse_json "$__brew_cache_path/descriptions.json" \
             '.each{ |k, v| puts([k, v].reject(&:nil?).join("\t")) }'
-        # backup: (note that it lists only formulae names without descriptions)
     else
         brew formulae
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

The `desc_cache.json` in code is from 2 years ago, but Homebrew's description cache is now `descriptions.json`.

It seems most parts of the Fish completions are very old, I'm willing to improve it a little bit, this is the first fix.