### PR TITLE
cli/parser: use - instead of _ in cask args

### DIFF
--- a/Library/Homebrew/cli/parser.rb
+++ b/Library/Homebrew/cli/parser.rb
@@ -64,27 +64,27 @@ module Homebrew
             description: "Target location for Services " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:servicedir]}`).",
           }],
-          [:flag, "--input_methoddir=", {
+          [:flag, "--input-methoddir=", {
             description: "Target location for Input Methods " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:input_methoddir]}`).",
           }],
-          [:flag, "--internet_plugindir=", {
+          [:flag, "--internet-plugindir=", {
             description: "Target location for Internet Plugins " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:internet_plugindir]}`).",
           }],
-          [:flag, "--audio_unit_plugindir=", {
+          [:flag, "--audio-unit-plugindir=", {
             description: "Target location for Audio Unit Plugins " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:audio_unit_plugindir]}`).",
           }],
-          [:flag, "--vst_plugindir=", {
+          [:flag, "--vst-plugindir=", {
             description: "Target location for VST Plugins " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:vst_plugindir]}`).",
           }],
-          [:flag, "--vst3_plugindir=", {
+          [:flag, "--vst3-plugindir=", {
             description: "Target location for VST3 Plugins " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:vst3_plugindir]}`).",
           }],
-          [:flag, "--screen_saverdir=", {
+          [:flag, "--screen-saverdir=", {
             description: "Target location for Screen Savers " \
                          "(default: `#{Cask::Config::DEFAULT_DIRS[:screen_saverdir]}`).",
           }],

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -252,6 +252,42 @@ describe Homebrew::CLI::Parser do
     end
   end
 
+  describe "test inferrability of args" do
+    subject(:parser) {
+      described_class.new do
+        switch "--switch-a"
+        switch "--switch-b"
+        switch "--foo-switch"
+        flag "--flag-foo="
+        comma_array "--comma-array-foo"
+      end
+    }
+
+    it "parses a valid switch that uses `_` instead of `-`" do
+      args = parser.parse(["--switch_a"])
+      expect(args).to be_switch_a
+    end
+
+    it "parses a valid flag that uses `_` instead of `-`" do
+      args = parser.parse(["--flag_foo=foo.txt"])
+      expect(args.flag_foo).to eq "foo.txt"
+    end
+
+    it "parses a valid comma_array that uses `_` instead of `-`" do
+      args = parser.parse(["--comma_array_foo=foo.txt,bar.txt"])
+      expect(args.comma_array_foo).to eq %w[foo.txt bar.txt]
+    end
+
+    it "raises an error when option is ambiguous" do
+      expect { parser.parse(["--switch"]) }.to raise_error(RuntimeError, /ambiguous option: --switch/)
+    end
+
+    it "inferrs the option from an abbreviated name" do
+      args = parser.parse(["--foo"])
+      expect(args).to be_foo_switch
+    end
+  end
+
   describe "test argv extensions" do
     subject(:parser) {
       described_class.new do

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -799,7 +799,7 @@ _brew_cask ()
     done
 
     if [[ $i -eq $COMP_CWORD ]]; then
-        __brew_caskcomp "abv audit cat create doctor edit fetch home info install list ls outdated reinstall remove rm search style uninstall upgrade zap -S --force --verbose --appdir --colorpickerdir --prefpanedir --qlplugindir --fontdir --servicedir --input_methoddir --internet_plugindir --screen_saverdir --no-binaries --debug --version"
+        __brew_caskcomp "abv audit cat create doctor edit fetch home info install list ls outdated reinstall remove rm search style uninstall upgrade zap -S --force --verbose --appdir --colorpickerdir --prefpanedir --qlplugindir --fontdir --servicedir --input-methoddir --internet-plugindir --screen-saverdir --no-binaries --debug --version"
         return
     fi
 

--- a/completions/zsh/_brew_cask
+++ b/completions/zsh/_brew_cask
@@ -179,12 +179,12 @@ _brew_cask()
     '--dictionarydir=-:Target location for Dictionaries. The default value is ~/Library/Dictionaries.' \
     '--fontdir=-:Target location for Fonts. The default value is ~/Library/Fonts.' \
     '--servicedir=-:Target location for Services. The default value is ~/Library/Services.' \
-    '--input_methoddir=-:Target location for Input Methods. The default value is ~/Library/Input Methods.' \
-    '--internet_plugindir=-:Target location for Internet Plugins. The default value is ~/Library/Internet Plug-Ins.' \
-    '--audio_unit_plugindir=-:Target location for Audio Unit Plugins. The default value is ~/Library/Audio/Plug-Ins/Components.' \
-    '--vst_plugindir=-:Target location for VST Plugins. The default value is ~/Library/Audio/Plug-Ins/VST.' \
-    '--vst3_plugindir=-:Target location for VST3 Plugins. The default value is ~/Library/Audio/Plug-Ins/VST3.' \
-    '--screen_saverdir=-:Target location for Screen Savers. The default value is ~/Library/Screen Savers.' \
+    '--input-methoddir=-:Target location for Input Methods. The default value is ~/Library/Input Methods.' \
+    '--internet-plugindir=-:Target location for Internet Plugins. The default value is ~/Library/Internet Plug-Ins.' \
+    '--audio-unit-plugindir=-:Target location for Audio Unit Plugins. The default value is ~/Library/Audio/Plug-Ins/Components.' \
+    '--vst-plugindir=-:Target location for VST Plugins. The default value is ~/Library/Audio/Plug-Ins/VST.' \
+    '--vst3-plugindir=-:Target location for VST3 Plugins. The default value is ~/Library/Audio/Plug-Ins/VST3.' \
+    '--screen-saverdir=-:Target location for Screen Savers. The default value is ~/Library/Screen Savers.' \
     '--no-binaries:Do not link "helper" executables to /usr/local/bin.' \
     '--debug:Output debugging information of use to Cask authors and developers.' \
     ':command:->command' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1418,22 +1418,22 @@ These options are applicable to subcommands accepting a `--cask` flag and all `c
 * `--servicedir`:
   Target location for Services (default: `~/Library/Services`).
 
-* `--input_methoddir`:
+* `--input-methoddir`:
   Target location for Input Methods (default: `~/Library/Input Methods`).
 
-* `--internet_plugindir`:
+* `--internet-plugindir`:
   Target location for Internet Plugins (default: `~/Library/Internet Plug-Ins`).
 
-* `--audio_unit_plugindir`:
+* `--audio-unit-plugindir`:
   Target location for Audio Unit Plugins (default: `~/Library/Audio/Plug-Ins/Components`).
 
-* `--vst_plugindir`:
+* `--vst-plugindir`:
   Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`).
 
-* `--vst3_plugindir`:
+* `--vst3-plugindir`:
   Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`).
 
-* `--screen_saverdir`:
+* `--screen-saverdir`:
   Target location for Screen Savers (default: `~/Library/Screen Savers`).
 
 * `--language`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1972,27 +1972,27 @@ Target location for Fonts (default: \fB~/Library/Fonts\fR)\.
 Target location for Services (default: \fB~/Library/Services\fR)\.
 .
 .TP
-\fB\-\-input_methoddir\fR
+\fB\-\-input\-methoddir\fR
 Target location for Input Methods (default: \fB~/Library/Input Methods\fR)\.
 .
 .TP
-\fB\-\-internet_plugindir\fR
+\fB\-\-internet\-plugindir\fR
 Target location for Internet Plugins (default: \fB~/Library/Internet Plug\-Ins\fR)\.
 .
 .TP
-\fB\-\-audio_unit_plugindir\fR
+\fB\-\-audio\-unit\-plugindir\fR
 Target location for Audio Unit Plugins (default: \fB~/Library/Audio/Plug\-Ins/Components\fR)\.
 .
 .TP
-\fB\-\-vst_plugindir\fR
+\fB\-\-vst\-plugindir\fR
 Target location for VST Plugins (default: \fB~/Library/Audio/Plug\-Ins/VST\fR)\.
 .
 .TP
-\fB\-\-vst3_plugindir\fR
+\fB\-\-vst3\-plugindir\fR
 Target location for VST3 Plugins (default: \fB~/Library/Audio/Plug\-Ins/VST3\fR)\.
 .
 .TP
-\fB\-\-screen_saverdir\fR
+\fB\-\-screen\-saverdir\fR
 Target location for Screen Savers (default: \fB~/Library/Screen Savers\fR)\.
 .
 .TP


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Rename the default cask args to use `-` instead of `_` for consistency throughout Homebrew. This will remove the need for #10139. My understanding is that the argument parser we use treats `-` and `_` the same for all arguments, so passing `--input-methoddir` is already treated the same as `--input_methoddir` (and vice versa). Consequently, I don't believe that this really changes functionality at all. Already, a user could use the `-` args if they choose. The only difference is in the documentation and wherever argument names are printed.

CC @MikeMcQuaid and @Homebrew/cask