### PR TITLE
formula: enable Git repository extension for buildpath/testpath

### DIFF
--- a/Library/Homebrew/extend/git_repository.rb
+++ b/Library/Homebrew/extend/git_repository.rb
@@ -40,11 +40,12 @@ module GitRepositoryExtension
   end
 
   # Gets a short commit hash of the HEAD commit.
-  sig { returns(T.nilable(String)) }
-  def git_short_head
+  sig { params(length: T.nilable(Integer)).returns(T.nilable(String)) }
+  def git_short_head(length: nil)
     return unless git? && Utils::Git.available?
 
-    Utils.popen_read("git", "rev-parse", "--short=4", "--verify", "-q", "HEAD", chdir: self).chomp.presence
+    Utils.popen_read("git", "rev-parse", "--short#{"=" if length.present?}#{length}",
+                     "--verify", "-q", "HEAD", chdir: self).chomp.presence
   end
 
   # Gets the relative date of the last commit, e.g. "1 hour ago"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1891,7 +1891,7 @@ class Formula
 
     mktemp("#{name}-test") do |staging|
       staging.retain! if keep_tmp
-      @testpath = staging.tmpdir
+      @testpath = staging.tmpdir.extend(GitRepositoryExtension)
       test_env[:HOME] = @testpath
       setup_home @testpath
       begin
@@ -2224,7 +2224,7 @@ class Formula
   def stage(interactive: false)
     active_spec.stage do |staging|
       @source_modified_time = active_spec.source_modified_time
-      @buildpath = Pathname.pwd
+      @buildpath = Pathname.pwd.extend(GitRepositoryExtension)
       env_home = buildpath/".brew_home"
       mkdir_p env_home
 

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -172,7 +172,7 @@ class Tap
   def git_short_head
     raise TapUnavailableError, name unless installed?
 
-    path.git_short_head
+    path.git_short_head(length: 4)
   end
 
   # Time since last git commit for this {Tap}.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This will allow instances of `git rev-parse HEAD` to be replaced with `buildpath.git_head` or `testpath.git_head`

Note: derived paths such as `buildpath.parent.git_head` or `(testpath/"foobar").git_head` won't work as `GitRepositoryExtension` is only enabled for `buildpath` and `testpath` specifically.

References to `rev-parse` in homebrew-core: https://github.com/Homebrew/homebrew-core/search?q=rev-parse