### PR TITLE
os/{mac,mac/sdk}: refactor out sdk_version

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -46,11 +46,6 @@ module OS
     end
     private :latest_sdk_version
 
-    sig { returns(::Version) }
-    def sdk_version
-      full_version.major_minor
-    end
-
     def outdated_release?
       # TODO: bump version when new macOS is released and also update
       # references in docs/Installation.md and


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
    - Looking into this, but it seems to already be tested elsewhere.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

The changes here rely on https://github.com/Homebrew/brew/pull/10129. Merge that PR before this one. (Tests will pass when that is done.)

This PR:
1. Removes `sdk_version`, as it is no longer in use (cf. https://github.com/Homebrew/brew/pull/10129#discussion_r548848473)
2. Combines the logic in https://github.com/Homebrew/brew/blob/da0d7eff9b19368735c569f5dafd8490fdd4a4c2/Library/Homebrew/os/mac/sdk.rb#L64 and https://github.com/Homebrew/brew/blob/da0d7eff9b19368735c569f5dafd8490fdd4a4c2/Library/Homebrew/os/mac/sdk.rb#L96-L101 using the behaviour of `OS::Mac.version` in Big Sur.

Since `OS::Mac.version` returns only the major version in Big Sur, we use that to populate the `sdk_paths` hash with the key-value pair `OS::Mac.version.major => /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk`.

This alleviates the concern expressed here: https://github.com/Homebrew/brew/pull/10112#issuecomment-750704692

This also allows you to request for the versioned SDK path if required:
```
❯ brew ruby -e 'puts MacOS.sdk_path_if_needed'
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
❯ brew ruby -e 'puts MacOS.sdk_path_if_needed(OS::Mac::Version.new("11.1"))'
/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk
❯ brew ruby -e 'puts MacOS.sdk_path_if_needed(OS::Mac::Version.new("10.15"))'
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk
```
Finer-grained control over the exact SDK path could prove useful when macOS 12 hits.