### PR TITLE
Partial revert of #10092

### DIFF
--- a/Library/Homebrew/extend/os/mac/hardware.rb
+++ b/Library/Homebrew/extend/os/mac/hardware.rb
@@ -7,8 +7,6 @@ module Hardware
   def self.oldest_cpu(version = MacOS.version)
     if CPU.arch == :arm64
       :arm_vortex_tempest
-    elsif version >= :big_sur
-      :ivybridge
     elsif version >= :mojave
       :nehalem
     else


### PR DESCRIPTION
Partial revert of https://github.com/Homebrew/brew/pull/10092

Because newly generated bottles for Big Sur include AVX instructions, which are not allowed under Rosetta 2 https://github.com/Homebrew/homebrew-core/issues/67713