### PR TITLE
Build from source fallback fixes

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -69,7 +69,7 @@ module Homebrew
       end
 
       def build_from_source_formulae
-        if build_from_source? || build_bottle?
+        if build_from_source? || HEAD? || build_bottle?
           named.to_formulae_and_casks.select { |f| f.is_a?(Formula) }.map(&:full_name)
         else
           []

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -203,10 +203,9 @@ module Homebrew
                      "`brew install`, `brew upgrade` or `brew tap`.",
         boolean:     true,
       },
-      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK:     {
-        description: "If set, fail on the failure of installation from a bottle rather than " \
-                     "falling back to building from source.",
-        boolean:     true,
+      HOMEBREW_BOTTLE_SOURCE_FALLBACK:        {
+        description: "If set, fall back to building from source if installation from a bottle fails.",
+        boolean:     false,
       },
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: {
         description: "If set, do not check for broken dependents after installing, upgrading or reinstalling " \

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -238,6 +238,7 @@ class FormulaInstaller
        formula.tap&.core_tap? && !formula.bottle_unneeded? && !formula.any_version_installed? &&
        # Integration tests override homebrew-core locations
        ENV["HOMEBREW_TEST_TMPDIR"].nil? &&
+       ENV["HOMEBREW_BOTTLE_SOURCE_FALLBACK"].nil? &&
        !pour_bottle?
       raise CannotInstallFormulaError, <<~EOS
         #{formula}: no bottle available!

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1808,8 +1808,8 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_NO_AUTO_UPDATE`
   <br>If set, do not automatically update before running `brew install`, `brew upgrade` or `brew tap`.
 
-- `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK`
-  <br>If set, fail on the failure of installation from a bottle rather than falling back to building from source.
+- `HOMEBREW_BOTTLE_SOURCE_FALLBACK`
+  <br>If set, fall back to building from source if installation from a bottle fails.
 
 - `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK`
   <br>If set, do not check for broken dependents after installing, upgrading or reinstalling formulae.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2589,10 +2589,10 @@ If set, do not send analytics\. For more information, see: \fIhttps://docs\.brew
 If set, do not automatically update before running \fBbrew install\fR, \fBbrew upgrade\fR or \fBbrew tap\fR\.
 .
 .TP
-\fBHOMEBREW_NO_BOTTLE_SOURCE_FALLBACK\fR
+\fBHOMEBREW_BOTTLE_SOURCE_FALLBACK\fR
 .
 .br
-If set, fail on the failure of installation from a bottle rather than falling back to building from source\.
+If set, fall back to building from source if installation from a bottle fails\.
 .
 .TP
 \fBHOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to https://github.com/Homebrew/brew/pull/9518 and relates to discussion in https://github.com/Homebrew/discussions/discussions/305.

In #9518, the default functionality changed so that bottle failures won't default to falling back and building from source. The `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK` environment variable was then rendered useless as it was the default. This PR replaces that wth `HOMEBREW_BOTTLE_SOURCE_FALLBACK` which, if set, will allow falling back to building from source.

This PR also changes `args.build_from_source_formulae` to include formulae when `--HEAD` is passed. Otherwise, `--HEAD` will fail when bottles aren't compatible when it should act as if passing `--build-from-source` (because there are never any bottles for HEAD).

---

To test this, I modified a formula with bottles so that the `bottle` block contained a non-default cellar location:

```ruby
cellar "/usr/local/Cellar/brew"
```

I then ran the following:

```console
$ export HOMEBREW_DEVELOPER=

$ brew install <formula>
Error: <formula>: no bottle available!
You can try to install from source with e.g.
  brew install --build-from-source <formula>
Please note building from source is unsupported. You will encounter build
failures with some formulae. If you experience any issues please create pull
requests instead of asking for help on Homebrew's GitHub, Twitter or any other
official channels.

$ brew install <formula> --HEAD # This would fail before this PR with the same error as the above command
[Installs HEAD version correctly from source]

$ brew uninstall <formula>
[Uninstall]

$ export HOMEBREW_BOTTLE_SOURCE_FALLBACK=1

$ brew install <formula>
Warning: Building <formula> from source as the bottle needs:
- HOMEBREW_CELLAR: /usr/local/Cellar/brew (yours is /usr/local/Cellar)
- HOMEBREW_PREFIX: /usr/local (yours is /usr/local)
- HOMEBREW_REPOSITORY: /usr/local/Homebrew (yours is /usr/local/Homebrew)
[Installs stable version correctly from source]
```