### PR TITLE
workflows/triage: fix handling outdated PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Review pull request
         if: >
           (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') &&
-            github.event.action != 'closed'
+            github.event.action != 'closed' && github.event.pull_request.state != 'closed'
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

I've noticed that this workflow sometimes runs on PRs when the `outdated` label is applied by the `triage-issues` workflow. See https://github.com/Homebrew/brew/pull/9300, https://github.com/Homebrew/brew/pull/9310, and https://github.com/Homebrew/brew/pull/9313 for examples.

I think that this PR will solve the issue by simply ending the run if the `outdated` label is applied.
