### PR TITLE
formula_installer: only require --build-from-source on macOS.

### DIFF
--- a/Library/Homebrew/cli/args.rb
+++ b/Library/Homebrew/cli/args.rb
@@ -69,7 +69,7 @@ module Homebrew
       end
 
       def build_from_source_formulae
-        if build_from_source? || build_bottle?
+        if build_from_source? || HEAD? || build_bottle?
           named.to_formulae_and_casks.select { |f| f.is_a?(Formula) }.map(&:full_name)
         else
           []

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -233,6 +233,9 @@ class FormulaInstaller
     end
 
     if Homebrew.default_prefix? && !Homebrew::EnvConfig.developer? &&
+       # TODO: re-enable this on Linux when we merge linuxbrew-core into
+       # homebrew-core and have full bottle coverage.
+       (OS.mac? || ENV["CI"]) &&
        !build_from_source? && !build_bottle? &&
        !installed_as_dependency? &&
        formula.tap&.core_tap? && !formula.bottle_unneeded? && !formula.any_version_installed? &&


### PR DESCRIPTION
There's not enough bottles on Homebrew on Linux to justify this behaviour currently.

Extract `cli/args: --HEAD implies building from source` from https://github.com/Homebrew/brew/pull/10155 (thanks @Rylan12).

Closes https://github.com/Homebrew/brew/pull/10155

