### PR TITLE
mktemp: avoid directories with @

### DIFF
--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -40,7 +40,7 @@ class Mktemp
   end
 
   def run
-    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix}-", HOMEBREW_TEMP))
+    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix.tr "@", "-"}-", HOMEBREW_TEMP))
 
     # Make sure files inside the temporary directory have the same group as the
     # brew instance.


### PR DESCRIPTION
This is a workaround for some build tools that have trouble building if the current path contains a `@`
This was originally proposed https://github.com/Homebrew/brew/pull/9007 in the context of versioned gcc formulas, but I fixed the bug upstream and we decided we didn't want to change it in brew.

Now it appears that this is also an issue with ninja (https://github.com/ninja-build/ninja/issues/1606) and it doesn't look like they're actively working on it. (They use the `@` character for another special meaning). This is currently blocking the build of `qt@5`: https://github.com/Homebrew/homebrew-core/pull/67536

Given that… I suggest we include this workaround in brew. Other that the slight effect of surprise, I don't really see a downside.