### PR TITLE
Update HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK description

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -204,8 +204,8 @@ module Homebrew
         boolean:     true,
       },
       HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK:     {
-        description: "If set, fail on the failure of installation from a bottle rather than " \
-                     "falling back to building from source.",
+        description: "If set, bottle installation failures due to pouring issues will fail " \
+                     "and not fall back to building from source. This is the default on macOS.",
         boolean:     true,
       },
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1813,7 +1813,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set, do not automatically update before running `brew install`, `brew upgrade` or `brew tap`.
 
 - `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK`
-  <br>If set, fail on the failure of installation from a bottle rather than falling back to building from source.
+  <br>If set, bottle installation failures due to pouring issues will fail and not fall back to building from source. This is the default on macOS.
 
 - `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK`
   <br>If set, do not check for broken dependents after installing, upgrading or reinstalling formulae.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2600,7 +2600,7 @@ If set, do not automatically update before running \fBbrew install\fR, \fBbrew u
 \fBHOMEBREW_NO_BOTTLE_SOURCE_FALLBACK\fR
 .
 .br
-If set, fail on the failure of installation from a bottle rather than falling back to building from source\.
+If set, bottle installation failures due to pouring issues will fail and not fall back to building from source\. This is the default on macOS\.
 .
 .TP
 \fBHOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR is a remake of https://github.com/Homebrew/brew/pull/10155 (but without the HEAD change):

Follow up to https://github.com/Homebrew/brew/pull/9518 and relates to discussion in https://github.com/Homebrew/discussions/discussions/305.

In #9518, the default functionality changed so that bottle failures won't default to falling back and building from source. The `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK` environment variable was then rendered useless as it was the default. This PR replaces that wth `HOMEBREW_BOTTLE_SOURCE_FALLBACK` which, if set, will allow falling back to building from source.

---

To test this, I modified a formula with bottles so that the `bottle` block contained a non-default cellar location:

```ruby
cellar "/usr/local/Cellar/brew"
```

I then ran the following:

```console
$ export HOMEBREW_DEVELOPER=

$ brew install <formula>
Error: <formula>: no bottle available!
You can try to install from source with e.g.
  brew install --build-from-source <formula>
Please note building from source is unsupported. You will encounter build
failures with some formulae. If you experience any issues please create pull
requests instead of asking for help on Homebrew's GitHub, Twitter or any other
official channels.

$ export HOMEBREW_BOTTLE_SOURCE_FALLBACK=1

$ brew install <formula>
Warning: Building <formula> from source as the bottle needs:
- HOMEBREW_CELLAR: /usr/local/Cellar/brew (yours is /usr/local/Cellar)
- HOMEBREW_PREFIX: /usr/local (yours is /usr/local)
- HOMEBREW_REPOSITORY: /usr/local/Homebrew (yours is /usr/local/Homebrew)
[Installs stable version correctly from source]
```