### PR TITLE
update: add notice that unshallowing takes time

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -392,6 +392,14 @@ EOS
 
   [[ -f "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core/.git/shallow" ]] && HOMEBREW_CORE_SHALLOW=1
   [[ -f "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-cask/.git/shallow" ]] && HOMEBREW_CASK_SHALLOW=1
+  if [[ -n $HOMEBREW_CORE_SHALLOW && -n $HOMEBREW_CASK_SHALLOW ]]
+  then
+    SHALLOW_COMMAND_PHRASE="These commands"
+    SHALLOW_REPO_PHRASE="repositories"
+  else
+    SHALLOW_COMMAND_PHRASE="This command"
+    SHALLOW_REPO_PHRASE="repository"
+  fi
 
   if [[ -n $HOMEBREW_CORE_SHALLOW || -n $HOMEBREW_CASK_SHALLOW ]]
   then
@@ -402,6 +410,7 @@ ${HOMEBREW_CORE_SHALLOW:+
 To \`brew update\`, first run:${HOMEBREW_CORE_SHALLOW:+
   git -C "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-core" fetch --unshallow}${HOMEBREW_CASK_SHALLOW:+
   git -C "$HOMEBREW_LIBRARY/Taps/homebrew/homebrew-cask" fetch --unshallow}
+${SHALLOW_COMMAND_PHRASE} may take a few minutes to run due to the large size of the ${SHALLOW_REPO_PHRASE}.
 This restriction has been made on GitHub's request because updating shallow
 clones is an extremely expensive operation due to the tree layout and traffic of
 Homebrew/homebrew-core and Homebrew/homebrew-cask. We don't do this for you


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

I've noticed several people recently commenting that they were surprised at how long running the `git fetch --unshallow` command took (to the point where they thought it was not working). I ran a test locally and it took over 5 minutes for me to run.

This PR adds a line to the message letting users know that the command will take a while.
