### PR TITLE
formula_creator: update hash syntax

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -193,7 +193,7 @@ module Homebrew
             # end
 
             bin.install name
-            bin.env_script_all_files(libexec/"bin", :PERL5LIB => ENV["PERL5LIB"])
+            bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
         <% elsif mode == :python %>
             virtualenv_install_with_resources
         <% elsif mode == :ruby %>
@@ -201,7 +201,7 @@ module Homebrew
             system "gem", "build", "\#{name}.gemspec"
             system "gem", "install", "\#{name}-\#{version}.gem"
             bin.install libexec/"bin/\#{name}"
-            bin.env_script_all_files(libexec/"bin", :GEM_HOME => ENV["GEM_HOME"])
+            bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
         <% elsif mode == :rust %>
             system "cargo", "install", *std_cargo_args
         <% else %>


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This fixes a style error in formulae that are generated by `brew create`

- `:PERL5LIB => ENV["PERL5LIB"]` &rarr; `PERL5LIB: ENV["PERL5LIB"]`
- `:GEM_HOME => ENV["GEM_HOME"]` &rarr; `GEM_HOME: ENV["GEM_HOME"]`
