### PR TITLE
tap: make `private?` return true if not tapped

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -629,6 +629,8 @@ class Tap
   private
 
   def read_or_set_private_config
+    return true unless installed?
+
     case config["private"]
     when "true" then true
     when "false" then false


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This fixes an error when installing a `.tar.gz` bottle from an untapped tap:

```
Error: No available tap seekingmeaning/tap.
/usr/local/Homebrew/Library/Homebrew/tap.rb:230:in `config'
/usr/local/Homebrew/Library/Homebrew/tap.rb:632:in `read_or_set_private_config'
/usr/local/Homebrew/Library/Homebrew/tap.rb:224:in `private?'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:410:in `install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:386:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:299:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:297:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:297:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:124:in `<main>'
```