### PR TITLE
cleanup: go faster on CI

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -316,7 +316,8 @@ module Homebrew
           next
         end
 
-        next cleanup_path(path) { path.unlink } if path.stale?(scrub: scrub?)
+        # `stale` is expensive, so skip it on CI where we have many files in cache
+        next cleanup_path(path) { path.unlink } if !ENV["CI"] && path.stale?(scrub: scrub?)
       end
 
       cleanup_unreferenced_downloads


### PR DESCRIPTION
Proposal to fix #10172

`stale` is quite slow, on CI we have a lot (thousands) of cached files, and we run that code twice per workflow (before and after). Since cached files are going to be removed after 3 days anyway, it's not as important to remove stale formulas as on a user system, which has less space.

In the current situation of our Intel CI runners, that should save about 3 to 5 minutes per job. The downside is potentially larger cache, we'll see if we run out of space and revert if necessary.