### PR TITLE
formula_installer: improve no-bottle error message

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -242,8 +242,13 @@ class FormulaInstaller
        # Integration tests override homebrew-core locations
        ENV["HOMEBREW_TEST_TMPDIR"].nil? &&
        !pour_bottle?
-      raise CannotInstallFormulaError, <<~EOS
-        #{formula}: no bottle available!
+      message = <<~EOS
+        #{formula}: unable to pour bottle!
+      EOS
+      if !formula.pour_bottle? && formula.pour_bottle_check_unsatisfied_reason
+        message += formula.pour_bottle_check_unsatisfied_reason
+      end
+      message += <<~EOS
         You can try to install from source with e.g.
           brew install --build-from-source #{formula}
         Please note building from source is unsupported. You will encounter build
@@ -251,6 +256,7 @@ class FormulaInstaller
         requests instead of asking for help on Homebrew's GitHub, Twitter or any other
         official channels.
       EOS
+      raise CannotInstallFormulaError, message
     end
 
     type, reason = DeprecateDisable.deprecate_disable_info formula

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -243,7 +243,7 @@ class FormulaInstaller
        ENV["HOMEBREW_TEST_TMPDIR"].nil? &&
        !pour_bottle?
       message = <<~EOS
-        #{formula}: unable to pour bottle!
+        #{formula}: no bottle available!
       EOS
       if !formula.pour_bottle? && formula.pour_bottle_check_unsatisfied_reason
         message += formula.pour_bottle_check_unsatisfied_reason


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
    - This returned a `java_spec` error and a `tap-new_spec` error. `brew tests` produces these errors even when run on the master branch.
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Closes #10180.

This PR changes the error message when you try to install `python@3.9` and you have no CLT installed to:
```
❯ HOMEBREW_NO_AUTO_UPDATE=1 brew install python@3.9
Error: python@3.9: unable to pour bottle!
The bottle needs the Apple Command Line Tools to be installed.
  You can install them, if desired, with:
    xcode-select --install
You can try to install from source with e.g.
  brew install --build-from-source python@3.9
Please note building from source is unsupported. You will encounter build
failures with some formulae. If you experience any issues please create pull
requests instead of asking for help on Homebrew's GitHub, Twitter or any other
official channels.
```
If the formula does not specify a `pour_bottle?` method but also has no bottles:
```
❯ HOMEBREW_NO_AUTO_UPDATE=1 brew install a2ps
Error: a2ps: unable to pour bottle!
You can try to install from source with e.g.
  brew install --build-from-source a2ps
Please note building from source is unsupported. You will encounter build
failures with some formulae. If you experience any issues please create pull
requests instead of asking for help on Homebrew's GitHub, Twitter or any other
official channels.
```
I suspect there may be more refactoring in order for the `pour_bottle?` method in `formula_installer.rb`, but I'd prefer to address those later.