### PR TITLE
doctor: disable python symlink message

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -707,20 +707,6 @@ module Homebrew
         message
       end
 
-      def check_for_bad_python_symlink
-        return unless which "python"
-
-        `python -V 2>&1` =~ /Python (\d+)\./
-        # This won't be the right warning if we matched nothing at all
-        return if Regexp.last_match(1).nil?
-        return if Regexp.last_match(1) == "2"
-
-        <<~EOS
-          python is symlinked to python#{Regexp.last_match(1)}
-          This will confuse build scripts and in general lead to subtle breakage.
-        EOS
-      end
-
       def check_for_non_prefixed_coreutils
         coreutils = Formula["coreutils"]
         return unless coreutils.any_version_installed?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

`brew doctor` will soon start to fail on `ubuntu-latest` actions runs once they migrate to Ubuntu 20.04. This has already happened to me in personal taps.

The issue is that Ubuntu 20.04 [no longer comes with Python 2](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md). Instead, the `python` executable points to Python 3.8.5.

I think there are three options:

1. Use `ubuntu-18.04` instead of `ubuntu-latest` on all our runners. This isn't a good long-term solution
1. Conditionally allow this doctor failure on CI machines to allow them to continue running
1. Disable this check (everywhere or only on Linux) (suggested to me on Slack by @sjackman)

I don't know much about Homebrew on Linux, but I think that option 3 is the best option (mainly because @sjackman suggested it :smile:). Ideally, now that Python 2 is no longer supported, we should expect to not deal with it in the future. Unfortunately, I'm not sure that's feasible on macOS (especially not yet).
