### PR TITLE
bottle: tag specific cellars

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -553,7 +553,7 @@ module Homebrew
     return [mismatches, checksums] if old_keys.exclude? :sha256
 
     old_bottle_spec.collector.each_key do |tag|
-      old_value = old_bottle_spec.collector[tag].hexdigest
+      old_value = old_bottle_spec.collector[tag][:checksum].hexdigest
       new_value = new_bottle_hash.dig("tags", tag.to_s)
       if new_value.present?
         mismatches << "sha256 => #{tag}"

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1831,7 +1831,7 @@ class Formula
         bottle_info["files"] = {}
         bottle_spec.collector.each_key do |os|
           bottle_url = "#{bottle_spec.root_url}/#{Bottle::Filename.create(self, os, bottle_spec.rebuild).bintray}"
-          checksum = bottle_spec.collector[os]
+          checksum = bottle_spec.collector[os][:checksum]
           bottle_info["files"][os] = {
             "url"    => bottle_url,
             "sha256" => checksum.hexdigest,

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -8,6 +8,7 @@ require "tab"
 require "cmd/install"
 require "test/support/fixtures/testball"
 require "test/support/fixtures/testball_bottle"
+require "test/support/fixtures/testball_bottle_cellar"
 
 describe FormulaInstaller do
   alias_matcher :pour_bottle, :be_pour_bottle
@@ -49,26 +50,43 @@ describe FormulaInstaller do
     expect(formula).not_to be_latest_version_installed
   end
 
+  def test_basic_formula_setup(f)
+    # Test that things made it into the Keg
+    expect(f.bin).to be_a_directory
+
+    expect(f.libexec).to be_a_directory
+
+    expect(f.prefix/"main.c").not_to exist
+
+    # Test that things made it into the Cellar
+    keg = Keg.new f.prefix
+    keg.link
+
+    bin = HOMEBREW_PREFIX/"bin"
+    expect(bin).to be_a_directory
+
+    expect(f.libexec).to be_a_directory
+  end
+
   specify "basic bottle install" do
     allow(DevelopmentTools).to receive(:installed?).and_return(false)
     Homebrew.install_args.parse(["testball_bottle"])
     temporarily_install_bottle(TestballBottle.new) do |f|
-      # Copied directly from formula_installer_spec.rb
-      # as we expect the same behavior.
+      test_basic_formula_setup(f)
+    end
+  end
 
-      # Test that things made it into the Keg
-      expect(f.bin).to be_a_directory
+  specify "basic bottle install with cellar information on sha256 line" do
+    allow(DevelopmentTools).to receive(:installed?).and_return(false)
+    Homebrew.install_args.parse(["testball_bottle_cellar"])
+    temporarily_install_bottle(TestballBottleCellar.new) do |f|
+      test_basic_formula_setup(f)
 
-      expect(f.libexec).to be_a_directory
+      # skip_relocation is always false on Linux but can be true on macOS.
+      # see: extend/os/linux/software_spec.rb
+      skip_relocation = !OS.linux?
 
-      expect(f.prefix/"main.c").not_to exist
-
-      # Test that things made it into the Cellar
-      keg = Keg.new f.prefix
-      keg.link
-
-      bin = HOMEBREW_PREFIX/"bin"
-      expect(bin).to be_a_directory
+      expect(f.bottle_specification.skip_relocation?).to eq(skip_relocation)
     end
   end
 

--- a/Library/Homebrew/test/support/fixtures/testball_bottle_cellar.rb
+++ b/Library/Homebrew/test/support/fixtures/testball_bottle_cellar.rb
@@ -1,0 +1,24 @@
+# typed: true
+# frozen_string_literal: true
+
+class TestballBottleCellar < Formula
+  def initialize(name = "testball_bottle", path = Pathname.new(__FILE__).expand_path, spec = :stable,
+                 alias_path: nil, force_bottle: false)
+    self.class.instance_eval do
+      stable.url "file://#{TEST_FIXTURE_DIR}/tarballs/testball-0.1.tbz"
+      stable.sha256 TESTBALL_SHA256
+      hexdigest = "8f9aecd233463da6a4ea55f5f88fc5841718c013f3e2a7941350d6130f1dc149"
+      stable.bottle do
+        root_url "file://#{TEST_FIXTURE_DIR}/bottles"
+        sha256 hexdigest => Utils::Bottles.tag, :cellar => :any_skip_relocation
+      end
+      cxxstdlib_check :skip
+    end
+    super
+  end
+
+  def install
+    prefix.install "bin"
+    prefix.install "libexec"
+  end
+end

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -8,9 +8,9 @@ describe Utils::Bottles::Collector do
 
   describe "#fetch_checksum_for" do
     it "returns passed tags" do
-      collector[:mojave] = "foo"
-      collector[:catalina] = "bar"
-      expect(collector.fetch_checksum_for(:catalina)).to eq(["bar", :catalina])
+      collector[:mojave] = { checksum: Checksum.new("foo_checksum"), cellar: "foo_cellar" }
+      collector[:catalina] = { checksum: Checksum.new("bar_checksum"), cellar: "bar_cellar" }
+      expect(collector.fetch_checksum_for(:catalina)).to eq(["bar_checksum", :catalina, "bar_cellar"])
     end
 
     it "returns nil if empty" do

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -100,16 +100,17 @@ module Utils
 
       extend Forwardable
 
-      def_delegators :@checksums, :keys, :[], :[]=, :key?, :each_key
+      def_delegators :@checksums, :keys, :[], :[]=, :key?, :each_key, :dig
 
       sig { void }
       def initialize
         @checksums = {}
       end
 
+      sig { params(tag: Symbol).returns(T.nilable([Checksum, Symbol, T.any(Symbol, String)])) }
       def fetch_checksum_for(tag)
         tag = find_matching_tag(tag)
-        return self[tag], tag if tag
+        return self[tag][:checksum], tag, self[tag][:cellar] if tag
       end
 
       private


### PR DESCRIPTION
First draft implementation, opening the PR to show what I have already tested. I will need your help, this change is tricky.
See #9315 for discussion.

- I know that some tests are broken and the implementation is not ironed out
- I did not work on the `brew bottle --merge --keep-old` part
- I know that we will need to split this PR in two parts:
   - first the reading of the old and new syntax
   - create a brew release
   - add the writing part

Writing part (`brew bottle --merge`):
I did not modify the `bottle.json` file content. This means I need to shift the cellar information from one level to another in the bottle hash. In fact, each `bottle.json` file has it's own cellar information, but it is not stored at the right level. So I had to manually merge the bottle hash between the multiple `bottle.json` files.
We might investigate a change in the `bottle.json` file format but I think we can do this in a second step.

Reading part (BottleChecksum):
I had to introduce a new BottleChecksum class. It's and adapted version of the Checksum class. I think I need to make BottleChecksum a subclass of Checksum.
