### PR TITLE
cleanup: don't do stale check when passing --prune.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -141,7 +141,7 @@ module Homebrew
 
     PERIODIC_CLEAN_FILE = (HOMEBREW_CACHE/".cleaned").freeze
 
-    attr_predicate :dry_run?, :scrub?
+    attr_predicate :dry_run?, :scrub?, :prune?
     attr_reader :args, :days, :cache, :disk_cleanup_size
 
     def initialize(*args, dry_run: false, scrub: false, days: nil, cache: HOMEBREW_CACHE)
@@ -149,6 +149,7 @@ module Homebrew
       @args = args
       @dry_run = dry_run
       @scrub = scrub
+      @prune = days.present?
       @days = days || Homebrew::EnvConfig.cleanup_max_age_days.to_i
       @cache = cache
       @cleaned_up_paths = Set.new
@@ -316,7 +317,8 @@ module Homebrew
           next
         end
 
-        next cleanup_path(path) { path.unlink } if path.stale?(scrub: scrub?)
+        # If we've specifed --prune don't do the (expensive) .stale? check.
+        cleanup_path(path) { path.unlink } if !prune? && path.stale?(scrub: scrub?)
       end
 
       cleanup_unreferenced_downloads


### PR DESCRIPTION
This speeds up `--prune` fairly considerably.

Before:
```console
$ hyperfine --warmup 3 'brew cleanup --prune=365'
Benchmark #1: brew cleanup --prune=365
  Time (mean ± σ):     33.352 s ±  0.654 s    [User: 21.684 s, System: 6.458 s]
  Range (min … max):   31.901 s … 34.096 s    10 runs
```

After:
```console
$ hyperfine --warmup 3 'brew cleanup --prune=365'
Benchmark #1: brew cleanup --prune=365
  Time (mean ± σ):      6.821 s ±  0.186 s    [User: 2.225 s, System: 3.926 s]
  Range (min … max):    6.578 s …  7.178 s    10 runs
```

Closes https://github.com/Homebrew/brew/pull/10177
Fixes https://github.com/Homebrew/brew/issues/10172