### PR TITLE
cmd/update-report: fix to show new tag

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -96,7 +96,7 @@ module Homebrew
       end
 
       new_tag = Utils.popen_read(
-        "git", "-C", HOMEBREW_REPOSITORY, "tag", "--list", "--sort=-version:refname"
+        "git", "-C", HOMEBREW_REPOSITORY, "tag", "--list", "--sort=-version:refname", "*.*"
       ).lines.first.chomp
 
       if new_tag != old_tag

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "December 2020" "Homebrew" "brew"
+.TH "BREW" "1" "January 2021" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
fix `cmd/update-report` to show new correct tag. When I executed `brew update`,  `new_tag` was `backup/remove-popen-read-20-00-21`,  but I expected it was `2.7.1`.

<details><summary>git -C /usr/local/Homebrew tag --list --sort=-version:refname "*.*"</summary><div>

```bash
 $ git -C /usr/local/Homebrew tag --list --sort=-version:refname "*.*"
2.7.1
2.7.0
2.6.2
2.6.1
2.6.0
2.5.12
--< omit >--
```
</div></details>

<details><summary>git -C /usr/local/Homebrew tag --list --sort=-version:refname</summary><div>

```bash
$ git -C /usr/local/Homebrew tag --list --sort=-version:refname
backup/remove-popen-read-20-00-21
backup/remove-popen-read-19-56-50
backup/gpg-verification-01-53-16
backup/days-19-30-23
backup/days-03-02-59
backup/days-03-02-52
backup/create-cache-00-29-47
backup/brew-cask-style-14-54-55
backup/activesupport-23-38-09
2.7.1
2.7.0
--< omit >--
```
</div></details>