### PR TITLE
possible bug breaking install on wsl2 ubuntu 20.04

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -67,16 +67,19 @@ HOMEBREW_LIBRARY="$HOMEBREW_REPOSITORY/Library"
 for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH
 do
   # Skip if variable value is empty.
-  [[ -z "${!VAR}" ]] && continue
-
+  if [[ -z "${!VAR:-}" ]]; then
+    continue
+  fi 
   VAR_NEW="HOMEBREW_${VAR}"
   # Skip if existing HOMEBREW_* variable is set.
-  [[ -n "${!VAR_NEW}" ]] && continue
+  if [[ -n "${!VAR_NEW}" ]]; then
+    continue
+  fi
   export "$VAR_NEW"="${!VAR}"
 done
 
 # Use VISUAL if HOMEBREW_EDITOR and EDITOR are unset.
-if [[ -z "$HOMEBREW_EDITOR" && -n "$VISUAL" ]]
+if [[ -z "${HOMEBREW_EDITOR:-}" && -n "$VISUAL" ]]
 then
   export HOMEBREW_EDITOR="$VISUAL"
 fi


### PR DESCRIPTION
Windows 10 2004 
wsl2
Ubuntu 20.04
windows terminal preview
git --version 2.25.1
glibc --version 2.31
ruby --version 2.7.0p0
/bin/bash --version GNU bash, version 5.0.17(1)-release (x86_64-pc-linux-gnu)

I'm trying to install homebrew for the first time.

I ran `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` from my $HOME directory. 

The installation breaks at the following point after fetching tags.

```
 * [new tag]             2.7.1      -> 2.7.1
HEAD is now at 635ecbc58 Merge pull request #10178 from Rylan12/documentation-updates
/home/linuxbrew/.linuxbrew/bin/brew: line 70: !VAR: unbound variable
Failed during: /home/linuxbrew/.linuxbrew/bin/brew update --force
```
When attempting the install subsequent times, I removed the `/home/linuxbrew` directory first to have a clean-slate install.

I confirmed that the symlink made directly before the `update --force` was created.

```
if [[ "${HOMEBREW_REPOSITORY}" != "${HOMEBREW_PREFIX}" ]]; then                                                              
  execute "ln" "-sf" "${HOMEBREW_REPOSITORY}/bin/brew" "${HOMEBREW_PREFIX}/bin/brew"
fi

execute "${HOMEBREW_PREFIX}/bin/brew" "update" "--force"
```

Of the following, I only have values in EDITOR and PATH.
`BROWSER DISPLAY EDITOR NO_COLOR PATH`

I made these changes locally to get past the `line 70` issue.  `continue` wasn't skipping the remainder of the loop without placing it inside the `if..fi` block and  the second block failed to test that the `$HOMEBREW_EDITOR` had been set.

I'm not positive that this will fix the full install because re-running the install.sh wipes out the `brew` file each time.


- [ ] Have you checked to ensure there aren't other open [Pull Requests] for the same change?

I have searched for help with the error shown above and not found anything relevant or current.

