### PR TITLE
formula_installer: tweak bottle error message

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -242,14 +242,18 @@ class FormulaInstaller
        # Integration tests override homebrew-core locations
        ENV["HOMEBREW_TEST_TMPDIR"].nil? &&
        !pour_bottle?
-      message = <<~EOS
-        #{formula}: no bottle available!
-      EOS
-      if !formula.pour_bottle? && formula.pour_bottle_check_unsatisfied_reason
-        message += formula.pour_bottle_check_unsatisfied_reason
+      message = if !formula.pour_bottle? && formula.pour_bottle_check_unsatisfied_reason
+        formula_message = formula.pour_bottle_check_unsatisfied_reason
+        formula_message[0] = formula_message[0].downcase
+
+        "#{formula}: #{formula_message}"
+      else
+        <<~EOS
+          #{formula}: no bottle available!
+        EOS
       end
       message += <<~EOS
-        You can try to install from source with e.g.
+        You can try to install from source with:
           brew install --build-from-source #{formula}
         Please note building from source is unsupported. You will encounter build
         failures with some formulae. If you experience any issues please create pull


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
    - Failures: `Language::Java::java_home`, `Cask::Cmd::Upgrade`, `brew tap-new` 
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to #10183.

This improves the error message displayed when `formula.pour_bottle?` is
false.

<details><summary>Before</summary>
<p>

    ❯ brew install python@3.8
    Error: python@3.8: no bottle available!
    The bottle needs the Apple Command Line Tools to be installed.
      You can install them, if desired, with:
        xcode-select --install
    You can try to install from source with e.g.
      brew install --build-from-source python@3.8
    Please note building from source is unsupported. You will encounter build
    failures with some formulae. If you experience any issues please create pull
    requests instead of asking for help on Homebrew's GitHub, Twitter or any other
    official channels.

</p>
</details>
<details><summary>After</summary>
<p>

    ❯ brew install python@3.8
    Error: The bottle needs the Apple Command Line Tools to be installed.
      You can install them, if desired, with:
        xcode-select --install
    You can try to install from source with e.g.
      brew install --build-from-source python@3.8
    Please note building from source is unsupported. You will encounter build
    failures with some formulae. If you experience any issues please create pull
    requests instead of asking for help on Homebrew's GitHub, Twitter or any other
    official channels.

</p>
</details>

When a formula has no bottles available, the error message is unchanged.