### PR TITLE
superenv: filter out /usr/local on ARM if necessary

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -249,6 +249,11 @@ class Cmd
     elsif path.start_with?("/opt/local", "/opt/boxen/homebrew", "/opt/X11", "/sw", "/usr/X11")
       # ignore MacPorts, Boxen's Homebrew, X11, fink
       false
+    elsif prefix != "/usr/local" && path.start_with?("/usr/local")
+      # ignore things in /usr/local if Homebrew is in another prefix;
+      # on macOS, this probably means that the user is on ARM and has an Intel
+      # Homebrew in /usr/local
+      false
     elsif mac?
       true
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This improves superenv's build handling on systems which have both an Intel and an Apple Silicon installation of Homebrew side-by-side.

Homebrew has a hardcoded list of paths to reject from build flags like `-I` and `-L`, set to various prefixes which are known to interfere with Homebrew builds (MacPorts, Boxen Homebrew, etc.). On Apple Silicon, we currently recommend two different prefixes: `/usr/local` for Intel, and `/opt/homebrew` for Apple Silicon. Users who have two Homebrew installations will see interference between them, specifically when building things using their `/opt/homebrew` installation. Many packages' buildsystems throw `-I/usr/local/include` and `-L/usr/local/lib` to the compiler willy-nilly, even if it's not strictly necessary, and this can end up instructing them to try to link against Homebrew-installed x86_64 libraries in `/usr/local` over the ARM-native versions in `/opt/homebrew`.

This PR updates the path filtering logic to add a new case after the hardcoded paths. If the system is a) macOS, and b) running in a non-`/usr/local`, it will filter out `/usr/local` paths from flags just like with `/opt/local` and other similar paths. I've left the behaviour on Linux untouched, under the assumption that if this hasn't come up so far, it either doesn't affect Linux users or it's actually seen as desirable.

I've tested one package (qemu) and this fixes a build error on Apple Silicon. I expect this to come up a lot, especially in the period where not all packages have bottles yet.

/cc @sjackman for Linuxbrew opinions