### PR TITLE
Remove locked option in std_cargo_args if CPU.arch is arm64

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1412,7 +1412,11 @@ class Formula
 
   # Standard parameters for cargo builds.
   def std_cargo_args
-    ["--locked", "--root", prefix, "--path", "."]
+    if Hardware::CPU.arch == :arm64
+      ["--root", prefix, "--path", "."]
+    else
+      ["--locked", "--root", prefix, "--path", "."]
+    end
   end
 
   # Standard parameters for CMake builds.


### PR DESCRIPTION
There are lots of errors in formulae depending rust on arm64
because homebrew installs older dependent cargo packages.
It is because std_cargo_args uses locked option and Cargo.lock.
https://github.com/Homebrew/homebrew-core/pull/68089

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?(same master branch)
- [x] Have you successfully run `brew typecheck` with your changes locally?(same master branch)
- [x] Have you successfully run `brew tests` with your changes locally?(same master branch)
- [x] Have you successfully run `brew man` locally and committed any changes?(same master branch)

-----
