### PR TITLE
Correct Formula Cookbook (missing ?)

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -414,7 +414,7 @@ Three commands are provided for displaying informational messages to the user:
 In particular, when a test needs to be performed before installation use `odie` to bail out gracefully. For example:
 
 ```ruby
-if build.with?("qt") && build.with("qt5")
+if build.with?("qt") && build.with?("qt5")
   odie "Options --with-qt and --with-qt5 are mutually exclusive."
 end
 system "make", "install"


### PR DESCRIPTION
Correct Messaging section:
There is a missing ? in the example code:
Currently:
```
if build.with?("qt") && build.with("qt5")
  odie "Options --with-qt and --with-qt5 are mutually exclusive."
end
```
There should be a ? in the second build.with:
`build.with?("qt5")
`
- [+] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [+] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [+] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [N/A] Have you successfully run `brew style` with your changes locally?
- [N/A] Have you successfully run `brew typecheck` with your changes locally?
- [N/A] Have you successfully run `brew tests` with your changes locally?
- [N/A] Have you successfully run `brew man` locally and committed any changes?

-----
