### PR TITLE
missing_formula: fix cask installation advice on tap migration

### DIFF
--- a/Library/Homebrew/missing_formula.rb
+++ b/Library/Homebrew/missing_formula.rb
@@ -109,7 +109,7 @@ module Homebrew
           break if new_tap_name == CoreTap.instance.name
 
           install_cmd = if new_tap_name.start_with?("homebrew/cask")
-            "cask install"
+            "install --cask"
           else
             "install"
           end


### PR DESCRIPTION
When an installed formula is missing and its source has migrated
to a new tap, Homebrew warns the user about this, saying:

	You can access it again by running:
	  brew tap new-name
	And then you can install it by running:
	  brew cask install new-name

Unfortunately, the "brew cask install" incantation is deprecated
and the advice won't work:

	Error: Calling brew cask install is disabled! Use brew install [--cask] instead.

This alters the advice to use the new "brew install --cask" notation,
fixing the advice presented to the user.

<hr>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?