### PR TITLE
github/workflows: use macos-latest.

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -7,13 +7,13 @@ on:
     branches-ignore:
       - master
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
   tapioca:
     if: github.repository == 'Homebrew/brew'
-    runs-on: macos-11.0
+    runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -181,7 +181,7 @@ jobs:
   test-everything:
     name: test everything (macOS)
     if: startsWith(github.repository, 'Homebrew/')
-    runs-on: macos-11.0
+    runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -17,7 +17,7 @@ jobs:
           contains(github.event.pull_request.title, '/Library/Homebrew')
         )
       )
-    runs-on: macos-11.0
+    runs-on: macos-latest
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
macos-11.0 capacity is too low for us at the moment.