### PR TITLE
Don't preprocess URL for `:header_match` strategy.

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -31,6 +31,7 @@ module Homebrew
     STRATEGY_SYMBOLS_TO_SKIP_PREPROCESS_URL = [
       :github_latest,
       :page_match,
+      :header_match,
       :sparkle,
     ].freeze
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

---

Fixes

```
URL:              https://central.github.com/deployments/desktop/desktop/latest/darwin
URL (processed):  https://central.github.com/deployments/desktop.git
```