### PR TITLE
rubocops/homepage: don't attempt to auto-correct an empty string.

### DIFF
--- a/Library/Homebrew/rubocops/homepage.rb
+++ b/Library/Homebrew/rubocops/homepage.rb
@@ -90,6 +90,8 @@ module RuboCop
             return if node.nil?
 
             homepage = string_content(node).dup
+            return if homepage.nil? || homepage.empty?
+
             homepage.sub!("readthedocs.org", "readthedocs.io")
             homepage.delete_suffix!(".git") if homepage.start_with?("https://github.com")
             corrector.replace(node.source_range, "\"#{homepage}\"")


### PR DESCRIPTION
Fixes #10232