### PR TITLE
rubocop: add shim and command.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@
 
 # Unignore tests' bundle config
 !/Library/Homebrew/test/.bundle/config
+
+# Unignore vscode configuration
+!/.vscode

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "kaiwood.endwise",
+    "misogi.ruby-rubocop",
+    "rebornix.ruby",
+    "wingrunr21.vscode-ruby"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "ruby.rubocop.executePath": "/usr/local/Homebrew/Library/Homebrew/shims/gems/"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "ruby.rubocop.executePath": "/usr/local/Homebrew/Library/Homebrew/shims/gems/"
+    "ruby.rubocop.executePath": "Library/Homebrew/shims/gems/",
+    "files.trimTrailingWhitespace": true,
+    "editor.tabSize": 2,
+    "files.insertFinalNewline": true,
 }

--- a/Library/Homebrew/dev-cmd/rubocop.sh
+++ b/Library/Homebrew/dev-cmd/rubocop.sh
@@ -1,0 +1,25 @@
+#:  * `rubocop`
+#:
+#:  Installs, configures and runs Homebrew's `rubocop`.
+
+homebrew-rubocop() {
+  # Don't need shellcheck to follow this `source`.
+  # shellcheck disable=SC1090
+  source "$HOMEBREW_LIBRARY/Homebrew/utils/ruby.sh"
+  setup-ruby-path
+
+  GEM_VERSION="$("$HOMEBREW_RUBY_PATH" "$RUBY_DISABLE_OPTIONS" -rrbconfig -e 'puts RbConfig::CONFIG["ruby_version"]')"
+  GEM_HOME="$HOMEBREW_LIBRARY/Homebrew/vendor/bundle/ruby/$GEM_VERSION"
+
+  if ! [[ -f "$GEM_HOME/bin/rubocop" ]]; then
+    "$HOMEBREW_BREW_FILE" install-bundler-gems
+  fi
+
+  export GEM_HOME
+  export PATH="$GEM_HOME/bin:$PATH"
+
+  # Unconditional -W0 to avoid printing e.g.:
+  # warning: parser/current is loading parser/ruby26, which recognizes
+  # warning: 2.6.6-compliant syntax, but you are running 2.6.3.
+  exec "$HOMEBREW_RUBY_PATH" "$RUBY_DISABLE_OPTIONS" -W0 -S rubocop "$@"
+}

--- a/Library/Homebrew/shims/gems/rubocop
+++ b/Library/Homebrew/shims/gems/rubocop
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec brew rubocop "$@"

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -74,6 +74,7 @@ reinstall
 release-notes
 remove
 rm
+rubocop
 ruby
 search
 sh

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1206,6 +1206,10 @@ a warning will be shown if the latest minor release was less than one month ago.
 * `--markdown`:
   Print as a Markdown list.
 
+### `rubocop`
+
+Installs, configures and runs Homebrew's `rubocop`.
+
 ### `ruby` (`-e` *`text`*|*`file`*)
 
 Run a Ruby instance with Homebrew's libraries loaded, e.g.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1683,6 +1683,9 @@ If \fB\-\-markdown\fR and a \fIprevious_tag\fR are passed, an extra line contain
 \fB\-\-markdown\fR
 Print as a Markdown list\.
 .
+.SS "\fBrubocop\fR"
+Installs, configures and runs Homebrew\'s \fBrubocop\fR\.
+.
 .SS "\fBruby\fR (\fB\-e\fR \fItext\fR|\fIfile\fR)"
 Run a Ruby instance with Homebrew\'s libraries loaded, e\.g\. \fBbrew ruby \-e "puts :gcc\.f\.deps"\fR or \fBbrew ruby script\.rb\fR\.
 .


### PR DESCRIPTION
Add a shim and a command that can be used to easily add a single directory to your `PATH` (`Library/Homebrew/shims/gems`) and have it automatically install, configure and run `rubocop` so you can use it for in-editor integrations.

CC @Rylan12 who talked about this with me. ideally we'd/you'd add a commit to this PR with the Visual Studio Code configuration to run this `rubocop` 