### PR TITLE
bump-formula-pr: use livecheck to determine new version

### DIFF
--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -860,8 +860,12 @@ If a *`tag`* is specified, the Git commit *`revision`* corresponding to that tag
 should also be specified. A best effort to determine the *`revision`* will be made
 if the value is not supplied by the user.
 
-If a *`version`* is specified, a best effort to determine the *`URL`* and *`SHA-256`* or
-the *`tag`* and *`revision`* will be made if both values are not supplied by the user.
+If a *`version`* is specified, a best effort will be made to determine either (the
+*`URL`* and *`SHA-256`*) or (the *`tag`* and *`revision`*) if the pair of values is not
+supplied by the user.
+
+If a *`formula`* is specified and no other values are supplied by the user, a best
+effort will be made to determine the latest *`version`*.
 
 *Note:* this command cannot be used to transition a formula from a
 URL-and-SHA-256 style specification into a tag-and-revision style specification,

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1185,7 +1185,10 @@ If a \fIURL\fR is specified, the \fISHA\-256\fR checksum of the new download sho
 If a \fItag\fR is specified, the Git commit \fIrevision\fR corresponding to that tag should also be specified\. A best effort to determine the \fIrevision\fR will be made if the value is not supplied by the user\.
 .
 .P
-If a \fIversion\fR is specified, a best effort to determine the \fIURL\fR and \fISHA\-256\fR or the \fItag\fR and \fIrevision\fR will be made if both values are not supplied by the user\.
+If a \fIversion\fR is specified, a best effort will be made to determine either (the \fIURL\fR and \fISHA\-256\fR) or (the \fItag\fR and \fIrevision\fR) if the pair of values is not supplied by the user\.
+.
+.P
+If a \fIformula\fR is specified and no other values are supplied by the user, a best effort will be made to determine the latest \fIversion\fR\.
 .
 .P
 \fINote:\fR this command cannot be used to transition a formula from a URL\-and\-SHA\-256 style specification into a tag\-and\-revision style specification, nor vice versa\. It must use whichever style specification the formula already uses\.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This allows for `brew bump-formula-pr <formula>` without any additional arguments

I also did a bit of general cleanup of `bump-formula-pr.rb`:

- Deleted `requested_spec` variable since its value is always `:stable`
- Deleted `hash_type` variable since its value is always `:sha256` (if the formula has a checksum)