### PR TITLE
env_config: delete values after loading.

### DIFF
--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -54,16 +54,16 @@ HOMEBREW_LOCKS = (HOMEBREW_PREFIX/"var/homebrew/locks").freeze
 HOMEBREW_CELLAR = Pathname(EnvVar["HOMEBREW_CELLAR"]).freeze
 
 # Where downloads (bottles, source tarballs, etc.) are cached
-HOMEBREW_CACHE = Pathname(EnvVar["HOMEBREW_CACHE"]).freeze
+HOMEBREW_CACHE = Pathname(Homebrew::EnvConfig.cache).freeze
 
 # Where brews installed via URL are cached
 HOMEBREW_CACHE_FORMULA = (HOMEBREW_CACHE/"Formula").freeze
 
 # Where build, postinstall, and test logs of formulae are written to
-HOMEBREW_LOGS = Pathname(EnvVar["HOMEBREW_LOGS"]).expand_path.freeze
+HOMEBREW_LOGS = Pathname(Homebrew::EnvConfig.logs).expand_path.freeze
 
 # Must use `/tmp` instead of `TMPDIR` because long paths break Unix domain sockets
-HOMEBREW_TEMP = Pathname(EnvVar["HOMEBREW_TEMP"]).yield_self do |tmp|
+HOMEBREW_TEMP = Pathname(Homebrew::EnvConfig.temp).yield_self do |tmp|
   tmp.mkpath unless tmp.exist?
   tmp.realpath
 end.freeze

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -77,6 +77,9 @@ HOMEBREW_RELEASES_URL_REGEX =
 
 require "fileutils"
 
+require "env_config"
+Homebrew::EnvConfig.load!
+
 require "os"
 require "os/global"
 require "messages"
@@ -116,8 +119,6 @@ module Homebrew
     end
   end
 end
-
-require "env_config"
 
 require "config"
 require "context"


### PR DESCRIPTION
This should ensure that `EnvConfig` is used as the API rather than relying on `ENV[]` to access Homebrew specific variables.