### PR TITLE
Improve submitted analytics data

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -313,13 +313,20 @@ then
   HOMEBREW_SYSTEM="Macintosh"
   [[ "$HOMEBREW_PROCESSOR" = "x86_64" ]] && HOMEBREW_PROCESSOR="Intel"
   HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
-  HOMEBREW_OS_VERSION="macOS $HOMEBREW_MACOS_VERSION"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X $HOMEBREW_MACOS_VERSION"
 
   # Intentionally set this variable by exploding another.
   # shellcheck disable=SC2086,SC2183
   printf -v HOMEBREW_MACOS_VERSION_NUMERIC "%02d%02d%02d" ${HOMEBREW_MACOS_VERSION//./ }
+
+  # Don't include minor versions for Big Sur and later.
+  if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -gt "110000" ]]
+  then
+    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION%.*}"
+  else
+    HOMEBREW_OS_VERSION="macOS $HOMEBREW_MACOS_VERSION"
+  fi
 
   # Refuse to run on pre-Yosemite
   if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101000" ]]

--- a/Library/Homebrew/extend/os/mac/utils/analytics.rb
+++ b/Library/Homebrew/extend/os/mac/utils/analytics.rb
@@ -5,9 +5,23 @@ module Utils
   module Analytics
     class << self
       extend T::Sig
+
       sig { returns(String) }
       def custom_prefix_label
+        return generic_custom_prefix_label if Hardware::CPU.arm?
+
         "non-/usr/local"
+      end
+
+      sig { returns(String) }
+      def arch_label
+        if Hardware::CPU.arm?
+          "ARM"
+        elsif Hardware::CPU.in_rosetta2?
+          "Rosetta"
+        else
+          ""
+        end
       end
     end
   end

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -31,7 +31,7 @@ module OS
     # This can be compared to numerics, strings, or symbols
     # using the standard Ruby Comparable methods.
     def full_version
-      @full_version ||= Version.new((ENV["HOMEBREW_MACOS_VERSION"] || ENV["HOMEBREW_OSX_VERSION"]).chomp)
+      @full_version ||= Version.new((ENV["HOMEBREW_MACOS_VERSION"]).chomp)
     end
 
     def full_version=(version)

--- a/Library/Homebrew/test/utils/analytics_spec.rb
+++ b/Library/Homebrew/test/utils/analytics_spec.rb
@@ -5,24 +5,24 @@ require "utils/analytics"
 require "formula_installer"
 
 describe Utils::Analytics do
-  describe "::os_prefix_ci" do
-    context "when os_prefix_ci is not set" do
+  describe "::os_arch_prefix_ci" do
+    context "when os_arch_prefix_ci is not set" do
       before do
-        described_class.clear_os_prefix_ci
+        described_class.clear_os_arch_prefix_ci
       end
 
       it "returns OS_VERSION and prefix when HOMEBREW_PREFIX is a custom prefix" do
         allow(Homebrew).to receive(:default_prefix?).and_return(false)
-        expect(described_class.os_prefix_ci).to include("#{OS_VERSION}, #{described_class.custom_prefix_label}")
+        expect(described_class.os_arch_prefix_ci).to include("#{OS_VERSION}, #{described_class.custom_prefix_label}")
       end
 
       it "does not include prefix when HOMEBREW_PREFIX is the default prefix" do
-        expect(described_class.os_prefix_ci).not_to include(described_class.custom_prefix_label)
+        expect(described_class.os_arch_prefix_ci).not_to include(described_class.custom_prefix_label)
       end
 
       it "includes CI when ENV['CI'] is set" do
         ENV["CI"] = "true"
-        expect(described_class.os_prefix_ci).to include("CI")
+        expect(described_class.os_arch_prefix_ci).to include("CI")
       end
     end
   end

--- a/Library/Homebrew/utils/analytics.rb
+++ b/Library/Homebrew/utils/analytics.rb
@@ -62,7 +62,7 @@ module Utils
         end
       end
 
-      def report_event(category, action, label = os_prefix_ci, value = nil)
+      def report_event(category, action, label = os_arch_prefix_ci, value = nil)
         report(:event,
                ec: category,
                ea: action,
@@ -198,19 +198,30 @@ module Utils
       def custom_prefix_label
         "custom-prefix"
       end
+      alias generic_custom_prefix_label custom_prefix_label
 
-      def clear_os_prefix_ci
-        return unless instance_variable_defined?(:@os_prefix_ci)
-
-        remove_instance_variable(:@os_prefix_ci)
+      sig { returns(String) }
+      def arch_label
+        if Hardware::CPU.arm?
+          "ARM"
+        else
+          ""
+        end
       end
 
-      def os_prefix_ci
-        @os_prefix_ci ||= begin
+      def clear_os_arch_prefix_ci
+        return unless instance_variable_defined?(:@os_arch_prefix_ci)
+
+        remove_instance_variable(:@os_arch_prefix_ci)
+      end
+
+      def os_arch_prefix_ci
+        @os_arch_prefix_ci ||= begin
           os = OS_VERSION
+          arch = ", #{arch_label}" if arch_label.present?
           prefix = ", #{custom_prefix_label}" unless Homebrew.default_prefix?
           ci = ", CI" if ENV["CI"]
-          "#{os}#{prefix}#{ci}"
+          "#{os}#{arch}#{prefix}#{ci}"
         end
       end
 


### PR DESCRIPTION
- Use default `custom-prefix` label on macOS ARM (as `/usr/local` is not the default there).
- Add architecture (or Rosetta) to analytics event label.
- Don't send minor versions on Big Sur.
- Remove defunct `HOMEBREW_OSX_VERSION` reference.