### PR TITLE
bump-*-pr: check existing PRs for exact file match

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -200,13 +200,10 @@ module Homebrew
   end
 
   def check_open_pull_requests(cask, tap_full_name, args:)
-    GitHub.check_for_duplicate_pull_requests(cask.token, tap_full_name, state: "open", args: args)
-  end
-
-  def check_closed_pull_requests(cask, tap_full_name, version:, args:)
-    # if we haven't already found open requests, try for an exact match across closed requests
-    pr_title = "Update #{cask.token} from #{cask.version} to #{version}"
-    GitHub.check_for_duplicate_pull_requests(pr_title, tap_full_name, state: "closed", args: args)
+    GitHub.check_for_duplicate_pull_requests(cask.token, tap_full_name,
+                                             state: "open",
+                                             file:  cask.sourcefile_path.relative_path_from(cask.tap.path).to_s,
+                                             args:  args)
   end
 
   def run_cask_audit(cask, old_contents, args:)

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -460,7 +460,10 @@ args: args)
   end
 
   def check_open_pull_requests(formula, tap_full_name, args:)
-    GitHub.check_for_duplicate_pull_requests(formula.name, tap_full_name, state: "open", args: args)
+    GitHub.check_for_duplicate_pull_requests(formula.name, tap_full_name,
+                                             state: "open",
+                                             file:  formula.path.relative_path_from(formula.tap.path).to_s,
+                                             args:  args)
   end
 
   def check_closed_pull_requests(formula, tap_full_name, args:, version: nil, url: nil, tag: nil)
@@ -470,7 +473,10 @@ args: args)
       version = Version.detect(url, **specs)
     end
     # if we haven't already found open requests, try for an exact match across closed requests
-    GitHub.check_for_duplicate_pull_requests("#{formula.name} #{version}", tap_full_name, state: "closed", args: args)
+    GitHub.check_for_duplicate_pull_requests("#{formula.name} #{version}", tap_full_name,
+                                             state: "closed",
+                                             file:  formula.path.relative_path_from(formula.tap.path).to_s,
+                                             args:  args)
   end
 
   def alias_update_pair(formula, new_formula_version)

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -84,9 +84,9 @@ module Homebrew
   end
 
   def use_correct_linux_tap(formula, args:)
-    default_origin_branch = formula.tap.path.git_origin_branch if formula.tap
+    default_origin_branch = formula.tap.path.git_origin_branch
 
-    return formula.tap&.full_name, "origin", default_origin_branch, "-" if !OS.linux? || !formula.tap.core_tap?
+    return formula.tap.full_name, "origin", default_origin_branch, "-" if !OS.linux? || !formula.tap.core_tap?
 
     tap_full_name = formula.tap.full_name.gsub("linuxbrew", "homebrew")
     homebrew_core_url = "https://github.com/#{tap_full_name}"
@@ -139,6 +139,8 @@ module Homebrew
     raise FormulaUnspecifiedError if formula.blank?
 
     odie "This formula is disabled!" if formula.disabled?
+    odie "This formula is not in a tap!" if formula.tap.blank?
+    odie "This formula's tap is not a Git repository!" unless formula.tap.git?
 
     tap_full_name, remote, remote_branch, previous_branch = use_correct_linux_tap(formula, args: args)
     check_open_pull_requests(formula, tap_full_name, args: args)

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -671,16 +671,16 @@ module GitHub
   end
 
   def create_bump_pr(info, args:)
+    tap = info[:tap]
     sourcefile_path = info[:sourcefile_path]
     old_contents = info[:old_contents]
     additional_files = info[:additional_files] || []
     remote = info[:remote] || "origin"
-    remote_branch = info[:remote_branch]
+    remote_branch = info[:remote_branch] || tap.path.git_origin_branch
     branch = info[:branch_name]
     commit_message = info[:commit_message]
-    previous_branch = info[:previous_branch]
-    tap = info[:tap]
-    tap_full_name = info[:tap_full_name]
+    previous_branch = info[:previous_branch] || "-"
+    tap_full_name = info[:tap_full_name] || tap.full_name
     pr_message = info[:pr_message]
 
     sourcefile_path.parent.cd do

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -628,8 +628,12 @@ module GitHub
     []
   end
 
-  def check_for_duplicate_pull_requests(query, tap_full_name, state:, args:)
+  def check_for_duplicate_pull_requests(query, tap_full_name, state:, file:, args:)
     pull_requests = fetch_pull_requests(query, tap_full_name, state: state)
+    pull_requests.select! do |pr|
+      pr_files = open_api(url_to("repos", tap_full_name, "pulls", pr["number"], "files"))
+      pr_files.any? { |f| f["filename"] == file }
+    end
     return if pull_requests.blank?
 
     duplicates_message = <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Related: https://github.com/Homebrew/brew/issues/9269

This PR changes the `bump-formula-pr`/`bump-cask-pr` commands to check duplicate PRs for the exact formula/cask being bumped (i.e. check if `Formula/<formula>.rb` is modified). For example, this would prevent `ansible: migrate to python@3.9` from preventing `python@3.9` bumps.