### PR TITLE
docs: update homebrew-pypi-poet instructions

### DIFF
--- a/docs/Python-for-Formula-Authors.md
+++ b/docs/Python-for-Formula-Authors.md
@@ -31,20 +31,20 @@ You can use `brew update-python-resources` to help you write resource stanzas. T
 If using `brew update-python-resources` doesn't work, you can use [homebrew-pypi-poet](https://pypi.python.org/pypi/homebrew-pypi-poet) to help you write resource stanzas. To use it, set up a virtualenv and install your package and all its dependencies. Then, `pip install homebrew-pypi-poet` into the same virtualenv. Running `poet some_package` will generate the necessary resource stanzas. You can do this like:
 
 ```sh
-# Install virtualenvwrapper
-brew install python
-python3 -m pip install virtualenvwrapper
-source $(brew --prefix)/bin/virtualenvwrapper.sh
+# Use a temporary directory for the virtual environment
+cd "$(mktemp -d)"
 
-# Set up a temporary virtual environment
-mktmpenv
+# Create and source a new virtual environment in the venv/ directory
+python3 -m venv venv
+source venv/bin/activate
 
 # Install the package of interest as well as homebrew-pypi-poet
-pip3 install some_package homebrew-pypi-poet
+pip install some_package homebrew-pypi-poet
 poet some_package
 
-# Destroy the temporary virtualenv you just created
+# Destroy the virtual environment
 deactivate
+rm -rf venv
 ```
 
 Homebrew provides helper methods for instantiating and populating virtualenvs. You can use them by putting `include Language::Python::Virtualenv` at the top of the `Formula` class definition.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Replaces up to https://github.com/Homebrew/brew/pull/9391

This PR modifies the instructions for python resource generation using `homebrew-pypi-poet` so installing `virtualenvwrapper` or `virtualenv` isn't necessary.

Instead, we can use the builtin venv module via `python3 -m venv` to more easily and reliably find resources.

CC: @claui, @dtrodrigues, and @MikeMcQuaid 