### PR TITLE
Add diagnostic for `pip.conf`

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -853,6 +853,26 @@ module Homebrew
         EOS
       end
 
+      def check_for_pip_conf
+        # https://pip.pypa.io/en/stable/user_guide/
+        dirs_to_check = [
+          "/Library/Application Support/pip",
+          "#{ENV["HOME"]}/.pip",
+          "#{ENV["HOME"]}/.config/pip",
+          "#{ENV["HOME"]}/Library/Application Support/pip",
+        ]
+        pip_confs_found = dirs_to_check
+                          .map { |dir| Pathname("#{dir}/pip.conf") }
+                          .select(&:exist?)
+                          .map(&method(:user_tilde))
+        return if pip_confs_found.blank?
+
+        inject_file_list pip_confs_found, <<~EOS
+          Customizing `pip` may break the `python` formula.
+          Consider deleting the following #{"file".pluralize(pip_confs_found.count)}:
+        EOS
+      end
+
       def check_cask_software_versions
         add_info "Homebrew Version", HOMEBREW_VERSION
         add_info "macOS", MacOS.full_version


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **All failing tests are unrelated, see also #9170.**
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Customizing `pip` may break the `python` formula and cause all sorts of mayhem.

Specifically, it may break the formula’s postinstall (which relies on `pip install`) and any [other established workflow](https://github.com/Homebrew/brew/pull/9391#issuecomment-753218100) where `pip install` is involved.

The new diagnostic detects the presence of Pip configuration files at [known locations](https://pip.pypa.io/en/stable/user_guide/) and prints a warning.

Thanks @sjackman for suggesting this PR. Also thanks to @Rylan12, @dtrodrigues and @alebcay for helping figure out the problem.
