### PR TITLE
github: check token scopes even if authorized

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -141,9 +141,8 @@ module GitHub
   def api_credentials_error_message(response_headers, needed_scopes)
     return if response_headers.empty?
 
-    unauthorized = (response_headers["http/1.1"] == "401 Unauthorized")
     scopes = response_headers["x-accepted-oauth-scopes"].to_s.split(", ")
-    return unless unauthorized && scopes.blank?
+    return if scopes.present?
 
     needed_human_scopes = needed_scopes.join(", ")
     credentials_scopes = response_headers["x-oauth-scopes"]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

A homebrew-cask user attempted to submit a bump PR but got this error because their personal access token did not have the `public_repo` scope:

```
Error: Unable to fork: Not Found!
```

This PR changes `utils/github` to check token scopes even if the token is authorized, which results in this more helpful error message:

```
Error: Your macOS keychain GitHub credentials do not have sufficient scope!
Scopes required: public_repo
Scopes present:  none
Create a personal access token:
  https://github.com/settings/tokens/new?scopes=gist,public_repo&description=Homebrew
echo 'export HOMEBREW_GITHUB_API_TOKEN=your_token_here' >> ~/.zshrc
Error: Unable to fork: Not Found!
```

The authorization check was added in https://github.com/Homebrew/brew/commit/6135da800e4f93ded3a5a331d0efa691f4822afb

Related:  https://github.com/Homebrew/homebrew-cask/issues/97297