### PR TITLE
Only select Sparkle items for macOS.

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -68,6 +68,8 @@ module Homebrew
 
             bundle_version = BundleVersion.new(short_version, version) if short_version || version
 
+            next if (os = enclosure&.attr("os")) && os != "osx"
+
             data = {
               title:          title,
               url:            url,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Apparently Sparkle appcasts can contain releases for other platforms,  we only use this strategy for casks as far as I'm aware of, so exclude other platforms if the `os` attribute is specified.

Fixes CI failure in https://github.com/Homebrew/homebrew-cask/pull/97558.