### PR TITLE
utils/ast: Loose the check for Formula class node

### DIFF
--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -138,10 +138,14 @@ module Utils
       def process_formula(formula_contents)
         processed_source, root_node = process_source(formula_contents)
 
-        class_node = if root_node.class_type?
-          root_node
-        elsif root_node.begin_type?
-          root_node.children.find { |n| n.class_type? && n.parent_class&.const_name == "Formula" }
+        class_node = root_node if root_node.class_type?
+        if root_node.begin_type?
+          nodes = root_node.children.select(&:class_type?)
+          class_node = if nodes.count > 1
+            nodes.find { |n| n.parent_class&.const_name == "Formula" }
+          else
+            nodes.first
+          end
         end
 
         raise "Could not find formula class!" if class_node.nil?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Allows single class files with side-effects that load other classes that inherit `Formula`.

My [tap](https://github.com/kabel/homebrew-pecl) uses a `Formula` [subclass](https://github.com/kabel/homebrew-pecl/blob/main/lib/php_pecl_formula.rb) to reduce copy/paste. The `brew bottle --merge` command is failing for my bottles because the AST cannot find the class. This relaxes the constraint that a file that has a begin node (for loading my subclass) can only have a class that directly extends `Formula`. Now if the file starts with a begin node, the formula is either the only (first) class or the first that directly extends `Formula`.