### PR TITLE
utils/ast: add `FormulaAST` class

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-revision.rb
+++ b/Library/Homebrew/dev-cmd/bump-revision.rb
@@ -52,14 +52,13 @@ module Homebrew
         Homebrew.install_bundler_gems!
         require "utils/ast"
 
-        Utils::Inreplace.inreplace(formula.path) do |s|
-          s = s.inreplace_string
-          if current_revision.zero?
-            Utils::AST.add_formula_stanza!(s, :revision, new_revision)
-          else
-            Utils::AST.replace_formula_stanza!(s, :revision, new_revision)
-          end
+        formula_ast = Utils::AST::FormulaAST.new(formula.path.read)
+        if current_revision.zero?
+          formula_ast.add_stanza(:revision, new_revision)
+        else
+          formula_ast.replace_stanza(:revision, new_revision)
         end
+        formula.path.atomic_write(formula_ast.process)
       end
 
       message = "#{formula.name}: revision bump #{args.message}"

--- a/Library/Homebrew/utils/ast.rb
+++ b/Library/Homebrew/utils/ast.rb
@@ -13,12 +13,28 @@ module Utils
     SendNode = RuboCop::AST::SendNode
     BlockNode = RuboCop::AST::BlockNode
     ProcessedSource = RuboCop::AST::ProcessedSource
+    TreeRewriter = Parser::Source::TreeRewriter
 
-    class << self
+    # Helper class for editing formulae.
+    #
+    # @api private
+    class FormulaAST
       extend T::Sig
+      extend Forwardable
+
+      delegate process: :tree_rewriter
+
+      sig { params(formula_contents: String).void }
+      def initialize(formula_contents)
+        @formula_contents = formula_contents
+        processed_source, children = process_formula
+        @processed_source = T.let(processed_source, ProcessedSource)
+        @children = T.let(children, T::Array[Node])
+        @tree_rewriter = T.let(TreeRewriter.new(processed_source.buffer), TreeRewriter)
+      end
 
       sig { params(body_node: Node).returns(T::Array[Node]) }
-      def body_children(body_node)
+      def self.body_children(body_node)
         if body_node.nil?
           []
         elsif body_node.begin_type?
@@ -28,56 +44,36 @@ module Utils
         end
       end
 
-      sig { params(formula_contents: String).returns(T.nilable(Node)) }
-      def bottle_block(formula_contents)
-        formula_stanza(formula_contents, :bottle, type: :block_call)
+      sig { returns(T.nilable(Node)) }
+      def bottle_block
+        stanza(:bottle, type: :block_call)
       end
 
-      sig { params(formula_contents: String, name: Symbol, type: T.nilable(Symbol)).returns(T.nilable(Node)) }
-      def formula_stanza(formula_contents, name, type: nil)
-        _, children = process_formula(formula_contents)
+      sig { params(name: Symbol, type: T.nilable(Symbol)).returns(T.nilable(Node)) }
+      def stanza(name, type: nil)
         children.find { |child| call_node_match?(child, name: name, type: type) }
       end
 
-      sig { params(formula_contents: String, bottle_output: String).void }
-      def replace_bottle_stanza!(formula_contents, bottle_output)
-        replace_formula_stanza!(formula_contents, :bottle, bottle_output.chomp, type: :block_call)
+      sig { params(bottle_output: String).void }
+      def replace_bottle_block(bottle_output)
+        replace_stanza(:bottle, bottle_output.chomp, type: :block_call)
       end
 
-      sig { params(formula_contents: String, bottle_output: String).void }
-      def add_bottle_stanza!(formula_contents, bottle_output)
-        add_formula_stanza!(formula_contents, :bottle, "\n#{bottle_output.chomp}", type: :block_call)
+      sig { params(bottle_output: String).void }
+      def add_bottle_block(bottle_output)
+        add_stanza(:bottle, "\n#{bottle_output.chomp}", type: :block_call)
       end
 
-      sig do
-        params(
-          formula_contents: String,
-          name:             Symbol,
-          replacement:      T.any(Numeric, String, Symbol),
-          type:             T.nilable(Symbol),
-        ).void
-      end
-      def replace_formula_stanza!(formula_contents, name, replacement, type: nil)
-        processed_source, children = process_formula(formula_contents)
+      sig { params(name: Symbol, replacement: T.any(Numeric, String, Symbol), type: T.nilable(Symbol)).void }
+      def replace_stanza(name, replacement, type: nil)
         stanza_node = children.find { |child| call_node_match?(child, name: name, type: type) }
         raise "Could not find #{name} stanza!" if stanza_node.nil?
 
-        tree_rewriter = Parser::Source::TreeRewriter.new(processed_source.buffer)
-        tree_rewriter.replace(stanza_node.source_range, stanza_text(name, replacement, indent: 2).lstrip)
-        formula_contents.replace(tree_rewriter.process)
+        tree_rewriter.replace(stanza_node.source_range, self.class.stanza_text(name, replacement, indent: 2).lstrip)
       end
 
-      sig do
-        params(
-          formula_contents: String,
-          name:             Symbol,
-          value:            T.any(Numeric, String, Symbol),
-          type:             T.nilable(Symbol),
-        ).void
-      end
-      def add_formula_stanza!(formula_contents, name, value, type: nil)
-        processed_source, children = process_formula(formula_contents)
-
+      sig { params(name: Symbol, value: T.any(Numeric, String, Symbol), type: T.nilable(Symbol)).void }
+      def add_stanza(name, value, type: nil)
         preceding_component = if children.length > 1
           children.reduce do |previous_child, current_child|
             if formula_component_before_target?(current_child,
@@ -108,13 +104,11 @@ module Utils
           end
         end
 
-        tree_rewriter = Parser::Source::TreeRewriter.new(processed_source.buffer)
-        tree_rewriter.insert_after(preceding_expr, "\n#{stanza_text(name, value, indent: 2)}")
-        formula_contents.replace(tree_rewriter.process)
+        tree_rewriter.insert_after(preceding_expr, "\n#{self.class.stanza_text(name, value, indent: 2)}")
       end
 
       sig { params(name: Symbol, value: T.any(Numeric, String, Symbol), indent: T.nilable(Integer)).returns(String) }
-      def stanza_text(name, value, indent: nil)
+      def self.stanza_text(name, value, indent: nil)
         text = if value.is_a?(String)
           _, node = process_source(value)
           value if (node.is_a?(SendNode) || node.is_a?(BlockNode)) && node.method_name == name
@@ -124,19 +118,31 @@ module Utils
         text
       end
 
-      private
-
       sig { params(source: String).returns([ProcessedSource, Node]) }
-      def process_source(source)
+      def self.process_source(source)
         ruby_version = Version.new(HOMEBREW_REQUIRED_RUBY_VERSION).major_minor.to_f
         processed_source = ProcessedSource.new(source, ruby_version)
         root_node = processed_source.ast
         [processed_source, root_node]
       end
 
-      sig { params(formula_contents: String).returns([ProcessedSource, T::Array[Node]]) }
-      def process_formula(formula_contents)
-        processed_source, root_node = process_source(formula_contents)
+      private
+
+      sig { returns(String) }
+      attr_reader :formula_contents
+
+      sig { returns(ProcessedSource) }
+      attr_reader :processed_source
+
+      sig { returns(T::Array[Node]) }
+      attr_reader :children
+
+      sig { returns(TreeRewriter) }
+      attr_reader :tree_rewriter
+
+      sig { returns([ProcessedSource, T::Array[Node]]) }
+      def process_formula
+        processed_source, root_node = self.class.process_source(formula_contents)
 
         class_node = if root_node.class_type?
           root_node
@@ -146,7 +152,7 @@ module Utils
 
         raise "Could not find formula class!" if class_node.nil?
 
-        children = body_children(class_node.body)
+        children = self.class.body_children(class_node.body)
         raise "Formula class is empty!" if children.empty?
 
         [processed_source, children]

--- a/Library/Homebrew/utils/ast.rbi
+++ b/Library/Homebrew/utils/ast.rbi
@@ -1,0 +1,7 @@
+# typed: strict
+
+module Utils
+  module AST
+    include ::Kernel
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds the class `Utils::AST::FormulaAST`, which stores the intermediate `processed_source` and `tree_rewriter` variables that are used in editing formulae. This will make it more efficient to replace and/or add multiple stanzas such as in `brew bump-formula-pr`

Note: I plan to extract out the `self.` functions in `Utils::AST::FormulaAST` as module functions in `Utils::AST` in a future PR