### PR TITLE
upgrade: show formula caveats after casks have been updated

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -69,7 +69,7 @@ module Cask
           binaries:       T.nilable(T::Boolean),
           quarantine:     T.nilable(T::Boolean),
           require_sha:    T.nilable(T::Boolean),
-        ).void
+        ).returns(T::Boolean)
       end
       def self.upgrade_casks(
         *casks,
@@ -98,7 +98,7 @@ module Cask
           end
         end
 
-        return if outdated_casks.empty?
+        return false if outdated_casks.empty?
 
         if casks.empty? && !greedy
           ohai "Casks with `auto_updates` or `version :latest` will not be upgraded; pass `--greedy` to upgrade them."
@@ -114,7 +114,7 @@ module Cask
         puts upgradable_casks
           .map { |(old_cask, new_cask)| "#{new_cask.full_name} #{old_cask.version} -> #{new_cask.version}" }
           .join("\n")
-        return if dry_run
+        return true if dry_run
 
         upgradable_casks.each do |(old_cask, new_cask)|
           upgrade_cask(
@@ -127,7 +127,7 @@ module Cask
           next
         end
 
-        return if caught_exceptions.empty?
+        return true if caught_exceptions.empty?
         raise MultipleCaskErrors, caught_exceptions if caught_exceptions.count > 1
         raise caught_exceptions.first if caught_exceptions.count == 1
       end

--- a/Library/Homebrew/messages.rb
+++ b/Library/Homebrew/messages.rb
@@ -24,13 +24,14 @@ class Messages
     @install_times.push(formula: f.name, time: elapsed_time)
   end
 
-  def display_messages(display_times: false)
-    display_caveats
+  def display_messages(force_caveats: false, display_times: false)
+    display_caveats(force: force_caveats)
     display_install_times if display_times
   end
 
-  def display_caveats
-    return if @formula_count <= 1
+  def display_caveats(force: false)
+    return if @formula_count.zero?
+    return if @formula_count == 1 && !force
     return if @caveats.empty?
 
     oh1 "Caveats"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Hotfix for https://github.com/Homebrew/brew/issues/10290

This PR changes `upgrade_outdated_formulae` and `upgrade_outdated_casks` to return booleans, so that we can determine if and when to display formula messages (such as caveats)