### PR TITLE
utils/ast: move helper functions from `FormulaAST` to `AST`

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -574,7 +574,7 @@ module Homebrew
     end
     return [] unless args.keep_old?
 
-    old_keys = Utils::AST::FormulaAST.body_children(bottle_node.body).map(&:method_name)
+    old_keys = Utils::AST.body_children(bottle_node.body).map(&:method_name)
     old_bottle_spec = formula.bottle_specification
     mismatches, checksums = merge_bottle_spec(old_keys, old_bottle_spec, bottle_hash["bottle"])
     if mismatches.present?

--- a/Library/Homebrew/test/utils/ast/ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/ast_spec.rb
@@ -1,0 +1,50 @@
+# typed: false
+# frozen_string_literal: true
+
+require "utils/ast"
+
+describe Utils::AST do
+  describe ".stanza_text" do
+    let(:compound_license) do
+      <<~RUBY.chomp
+        license all_of: [
+          :public_domain,
+          "MIT",
+          "GPL-3.0-or-later" => { with: "Autoconf-exception-3.0" },
+        ]
+      RUBY
+    end
+
+    it "accepts existing stanza text" do
+      expect(described_class.stanza_text(:revision, "revision 1")).to eq("revision 1")
+      expect(described_class.stanza_text(:license, "license :public_domain")).to eq("license :public_domain")
+      expect(described_class.stanza_text(:license, 'license "MIT"')).to eq('license "MIT"')
+      expect(described_class.stanza_text(:license, compound_license)).to eq(compound_license)
+    end
+
+    it "accepts a number as the stanza value" do
+      expect(described_class.stanza_text(:revision, 1)).to eq("revision 1")
+    end
+
+    it "accepts a symbol as the stanza value" do
+      expect(described_class.stanza_text(:license, :public_domain)).to eq("license :public_domain")
+    end
+
+    it "accepts a string as the stanza value" do
+      expect(described_class.stanza_text(:license, "MIT")).to eq('license "MIT"')
+    end
+
+    it "adds indent to stanza text if specified" do
+      expect(described_class.stanza_text(:revision, "revision 1", indent: 2)).to eq("  revision 1")
+      expect(described_class.stanza_text(:license, 'license "MIT"', indent: 2)).to eq('  license "MIT"')
+      expect(described_class.stanza_text(:license, compound_license, indent: 2)).to eq(compound_license.indent(2))
+    end
+
+    it "does not add indent if already indented" do
+      expect(described_class.stanza_text(:revision, "  revision 1", indent: 2)).to eq("  revision 1")
+      expect(
+        described_class.stanza_text(:license, compound_license.indent(2), indent: 2),
+      ).to eq(compound_license.indent(2))
+    end
+  end
+end

--- a/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
+++ b/Library/Homebrew/test/utils/ast/formula_ast_spec.rb
@@ -46,50 +46,6 @@ describe Utils::AST::FormulaAST do
     end
   end
 
-  describe ".stanza_text" do
-    let(:compound_license) do
-      <<~RUBY.chomp
-        license all_of: [
-          :public_domain,
-          "MIT",
-          "GPL-3.0-or-later" => { with: "Autoconf-exception-3.0" },
-        ]
-      RUBY
-    end
-
-    it "accepts existing stanza text" do
-      expect(described_class.stanza_text(:revision, "revision 1")).to eq("revision 1")
-      expect(described_class.stanza_text(:license, "license :public_domain")).to eq("license :public_domain")
-      expect(described_class.stanza_text(:license, 'license "MIT"')).to eq('license "MIT"')
-      expect(described_class.stanza_text(:license, compound_license)).to eq(compound_license)
-    end
-
-    it "accepts a number as the stanza value" do
-      expect(described_class.stanza_text(:revision, 1)).to eq("revision 1")
-    end
-
-    it "accepts a symbol as the stanza value" do
-      expect(described_class.stanza_text(:license, :public_domain)).to eq("license :public_domain")
-    end
-
-    it "accepts a string as the stanza value" do
-      expect(described_class.stanza_text(:license, "MIT")).to eq('license "MIT"')
-    end
-
-    it "adds indent to stanza text if specified" do
-      expect(described_class.stanza_text(:revision, "revision 1", indent: 2)).to eq("  revision 1")
-      expect(described_class.stanza_text(:license, 'license "MIT"', indent: 2)).to eq('  license "MIT"')
-      expect(described_class.stanza_text(:license, compound_license, indent: 2)).to eq(compound_license.indent(2))
-    end
-
-    it "does not add indent if already indented" do
-      expect(described_class.stanza_text(:revision, "  revision 1", indent: 2)).to eq("  revision 1")
-      expect(
-        described_class.stanza_text(:license, compound_license.indent(2), indent: 2),
-      ).to eq(compound_license.indent(2))
-    end
-  end
-
   describe "#add_bottle_block" do
     let(:bottle_output) do
       <<~RUBY.chomp.indent(2)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow-up to #10279

This PR moves some general helper functions from `Utils::AST::FormulaAST` to `Utils::AST` and also splits `ast_spec.rb` into `ast/ast_spec.rb` and `ast/formula_ast_spec.rb`