### PR TITLE
Ignore invalid keys when reading existing `Cask::Config`.

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -71,6 +71,10 @@ Layout/HeredocIndentation:
 Metrics/ParameterLists:
   CountKeywordArgs: false
 
+# Allow dashes in filenames.
+Naming/FileName:
+  Regex: !ruby/regexp /^[\w\@\-\+\.]+(\.rb)?$/
+
 # Implicitly allow EOS as we use it everywhere.
 Naming/HeredocDelimiterNaming:
   ForbiddenDelimiters:
@@ -79,10 +83,6 @@ Naming/HeredocDelimiterNaming:
 Naming/MethodName:
   IgnoredPatterns:
     - '\A(fetch_)?HEAD\?\Z'
-
-# Allow dashes in filenames.
-Naming/FileName:
-  Regex: !ruby/regexp /^[\w\@\-\+\.]+(\.rb)?$/
 
 # Both styles are used depending on context,
 # e.g. `sha256` and `something_countable_1`.

--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -43,7 +43,10 @@ Metrics/ModuleLength:
 
 Naming/PredicateName:
   # Can't rename these.
-  AllowedMethods: is_32_bit?, is_64_bit?
+  AllowedMethods:
+    - is_a?
+    - is_32_bit?
+    - is_64_bit?
 
 Style/HashAsLastArrayItem:
   Exclude:

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -46,7 +46,7 @@ module Cask
       @default_config = config || Config.new
 
       self.config = if config_path.exist?
-        Config.from_json(File.read(config_path))
+        Config.from_json(File.read(config_path), ignore_invalid_keys: true)
       else
         @default_config
       end

--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -226,6 +226,48 @@ module Homebrew
 
       sig { returns(T.nilable(T::Boolean)) }
       def s?; end
+
+      sig { returns(T.nilable(String)) }
+      def appdir; end
+
+      sig { returns(T.nilable(String)) }
+      def fontdir; end
+
+      sig { returns(T.nilable(String)) }
+      def colorpickerdir; end
+
+      sig { returns(T.nilable(String)) }
+      def prefpanedir; end
+
+      sig { returns(T.nilable(String)) }
+      def qlplugindir; end
+
+      sig { returns(T.nilable(String)) }
+      def dictionarydir; end
+
+      sig { returns(T.nilable(String)) }
+      def servicedir; end
+
+      sig { returns(T.nilable(String)) }
+      def input_methoddir; end
+
+      sig { returns(T.nilable(String)) }
+      def mdimporterdir; end
+
+      sig { returns(T.nilable(String)) }
+      def internet_plugindir; end
+
+      sig { returns(T.nilable(String)) }
+      def audio_unit_plugindir; end
+
+      sig { returns(T.nilable(String)) }
+      def vst_plugindir; end
+
+      sig { returns(T.nilable(String)) }
+      def vst3_plugindir; end
+
+      sig { returns(T.nilable(String)) }
+      def screen_saverdir; end
     end
   end
 end

--- a/Library/Homebrew/lazy_object.rb
+++ b/Library/Homebrew/lazy_object.rb
@@ -18,4 +18,9 @@ class LazyObject < Delegator
   def __setobj__(callable)
     @__callable__ = callable
   end
+
+  # Forward to the inner object to make lazy objects type-checkable.
+  def is_a?(klass)
+    __getobj__.is_a?(klass) || super
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Ignore and remove invalid keys when loading an existing config from a path. Also add type signatures.

Fixes https://github.com/Homebrew/homebrew-cask/issues/97992.