### PR TITLE
utils/popen: add `safe` argument to `popen_read` and `popen_write`

### DIFF
--- a/Library/Homebrew/extend/git_repository.rb
+++ b/Library/Homebrew/extend/git_repository.rb
@@ -32,20 +32,21 @@ module GitRepositoryExtension
   end
 
   # Gets the full commit hash of the HEAD commit.
-  sig { returns(T.nilable(String)) }
-  def git_head
+  sig { params(safe: T::Boolean).returns(T.nilable(String)) }
+  def git_head(safe: false)
     return if !git? || !Utils::Git.available?
 
-    Utils.popen_read(Utils::Git.git, "rev-parse", "--verify", "-q", "HEAD", chdir: self).chomp.presence
+    Utils.popen_read(Utils::Git.git, "rev-parse", "--verify", "-q", "HEAD", safe: safe, chdir: self).chomp.presence
   end
 
   # Gets a short commit hash of the HEAD commit.
-  sig { params(length: T.nilable(Integer)).returns(T.nilable(String)) }
-  def git_short_head(length: nil)
+  sig { params(length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String)) }
+  def git_short_head(length: nil, safe: false)
     return if !git? || !Utils::Git.available?
 
+    git = Utils::Git.git
     short_arg = length&.to_s&.prepend("=")
-    Utils.popen_read(Utils::Git.git, "rev-parse", "--short#{short_arg}", "--verify", "-q", "HEAD", chdir: self)
+    Utils.popen_read(git, "rev-parse", "--short#{short_arg}", "--verify", "-q", "HEAD", safe: safe, chdir: self)
          .chomp.presence
   end
 

--- a/Library/Homebrew/test/utils/popen_spec.rb
+++ b/Library/Homebrew/test/utils/popen_spec.rb
@@ -72,4 +72,32 @@ describe Utils do
       EOS
     end
   end
+
+  describe "::safe_popen_read" do
+    it "does not raise an error if the command succeeds" do
+      expect(subject.safe_popen_read("sh", "-c", "true")).to eq("")
+      expect($CHILD_STATUS).to be_a_success
+    end
+
+    it "raises an error if the command fails" do
+      expect { subject.safe_popen_read("sh", "-c", "false") }.to raise_error(ErrorDuringExecution)
+      expect($CHILD_STATUS).to be_a_failure
+    end
+  end
+
+  describe "::safe_popen_write" do
+    it "does not raise an error if the command succeeds" do
+      expect(
+        subject.safe_popen_write("grep", "success") { |pipe| pipe.write "success\n" }.chomp,
+      ).to eq("success")
+      expect($CHILD_STATUS).to be_a_success
+    end
+
+    it "raises an error if the command fails" do
+      expect {
+        subject.safe_popen_write("grep", "success") { |pipe| pipe.write "failure\n" }
+      }.to raise_error(ErrorDuringExecution)
+      expect($CHILD_STATUS).to be_a_failure
+    end
+  end
 end

--- a/Library/Homebrew/utils/git_repository.rb
+++ b/Library/Homebrew/utils/git_repository.rb
@@ -4,17 +4,21 @@
 module Utils
   extend T::Sig
 
-  sig { params(repo: T.any(String, Pathname), length: T.nilable(Integer)).returns(T.nilable(String)) }
-  def self.git_head(repo, length: nil)
+  sig do
+    params(repo: T.any(String, Pathname), length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String))
+  end
+  def self.git_head(repo, length: nil, safe: true)
     return git_short_head(repo, length: length) if length.present?
 
     repo = Pathname(repo).extend(GitRepositoryExtension)
-    repo.git_head
+    repo.git_head(safe: safe)
   end
 
-  sig { params(repo: T.any(String, Pathname), length: T.nilable(Integer)).returns(T.nilable(String)) }
-  def self.git_short_head(repo, length: nil)
+  sig do
+    params(repo: T.any(String, Pathname), length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String))
+  end
+  def self.git_short_head(repo, length: nil, safe: true)
     repo = Pathname(repo).extend(GitRepositoryExtension)
-    repo.git_short_head(length: length)
+    repo.git_short_head(length: length, safe: safe)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow-up to https://github.com/Homebrew/brew/pull/10245

This PR adds a `safe` argument to `popen_read` and `popen_write` that can then be used in `Utils.git_head`

The reason for adding this is that formulae use `safe_popen_read` to get the git head, while `Utils.git_head` currently uses `popen_read`. Since `Utils.git_head` should primarily be used by formulae, this PR adds a `safe` argument to `git_head` that has a default value of `true` (whereas the default value is `false` for `popen_read`)

I also added tests for `safe_popen_read` and `safe_popen_write` which passed with the original methods as seen in the test runs for commit 40d85ec: https://github.com/Homebrew/brew/runs/1689977863