### PR TITLE
utils/git_repository: use `Pathname.pwd` if no `repo` specified

### DIFF
--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -20,6 +20,10 @@ describe Utils do
     it "returns the revision at HEAD" do
       expect(described_class.git_head(HOMEBREW_CACHE)).to eq(head_revision)
       expect(described_class.git_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
+      HOMEBREW_CACHE.cd do
+        expect(described_class.git_head).to eq(head_revision)
+        expect(described_class.git_head(length: 5)).to eq(head_revision[0...5])
+      end
     end
   end
 
@@ -27,6 +31,10 @@ describe Utils do
     it "returns the short revision at HEAD" do
       expect(described_class.git_short_head(HOMEBREW_CACHE)).to eq(short_head_revision)
       expect(described_class.git_short_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
+      HOMEBREW_CACHE.cd do
+        expect(described_class.git_short_head).to eq(short_head_revision)
+        expect(described_class.git_short_head(length: 5)).to eq(head_revision[0...5])
+      end
     end
   end
 end

--- a/Library/Homebrew/utils/git_repository.rb
+++ b/Library/Homebrew/utils/git_repository.rb
@@ -7,7 +7,7 @@ module Utils
   sig do
     params(repo: T.any(String, Pathname), length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String))
   end
-  def self.git_head(repo, length: nil, safe: true)
+  def self.git_head(repo = Pathname.pwd, length: nil, safe: true)
     return git_short_head(repo, length: length) if length.present?
 
     repo = Pathname(repo).extend(GitRepositoryExtension)
@@ -17,7 +17,7 @@ module Utils
   sig do
     params(repo: T.any(String, Pathname), length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String))
   end
-  def self.git_short_head(repo, length: nil, safe: true)
+  def self.git_short_head(repo = Pathname.pwd, length: nil, safe: true)
     repo = Pathname(repo).extend(GitRepositoryExtension)
     repo.git_short_head(length: length, safe: safe)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This will allow formulae to do `Utils.git_head` instead of `Utils.git_head(buildpath)`
This is useful for `cd` blocks such as:

```rb
cd "resource-cloned-from-git" do
  resource_commit = Utils.git_head
  # ...
end
```