### PR TITLE
Livecheck#url: Don't convert URL symbol to string

### DIFF
--- a/Library/Homebrew/livecheck.rb
+++ b/Library/Homebrew/livecheck.rb
@@ -92,17 +92,11 @@ class Livecheck
   # @param val [String, Symbol] URL to check for version information
   # @return [String, nil]
   def url(val = nil)
-    @url = case val
+    case val
     when nil
-      return @url
-    when :url
-      @formula_or_cask.url.to_s
-    when :head, :stable
-      @formula_or_cask.send(val).url
-    when :homepage
-      @formula_or_cask.homepage
-    when String
-      val
+      @url
+    when String, :head, :homepage, :stable, :url
+      @url = val
     else
       raise TypeError, "Livecheck#url expects a String or valid Symbol"
     end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -695,7 +695,7 @@ describe Formula do
         end
       end
 
-      expect(f.livecheck.url).to eq("https://brew.sh/test")
+      expect(f.livecheck.url).to eq(:homepage)
     end
   end
 

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -6,21 +6,21 @@ require "livecheck/livecheck"
 describe Homebrew::Livecheck do
   subject(:livecheck) { described_class }
 
-  CASK_URL = "https://brew.sh/test-0.0.1.dmg"
-  HEAD_URL = "https://github.com/Homebrew/brew.git"
-  HOMEPAGE_URL = "https://brew.sh"
-  LIVECHECK_URL = "https://formulae.brew.sh/api/formula/ruby.json"
-  STABLE_URL = "https://brew.sh/test-0.0.1.tgz"
+  let(:cask_url) { "https://brew.sh/test-0.0.1.dmg" }
+  let(:head_url) { "https://github.com/Homebrew/brew.git" }
+  let(:homepage_url) { "https://brew.sh" }
+  let(:livecheck_url) { "https://formulae.brew.sh/api/formula/ruby.json" }
+  let(:stable_url) { "https://brew.sh/test-0.0.1.tgz" }
 
   let(:f) do
     formula("test") do
       desc "Test formula"
-      homepage HOMEPAGE_URL
-      url STABLE_URL
-      head HEAD_URL
+      homepage "https://brew.sh"
+      url "https://brew.sh/test-0.0.1.tgz"
+      head "https://github.com/Homebrew/brew.git"
 
       livecheck do
-        url LIVECHECK_URL
+        url "https://formulae.brew.sh/api/formula/ruby.json"
         regex(/"stable":"(\d+(?:\.\d+)+)"/i)
       end
     end
@@ -31,13 +31,13 @@ describe Homebrew::Livecheck do
       cask "test" do
         version "0.0.1,2"
 
-        url CASK_URL
+        url "https://brew.sh/test-0.0.1.dmg"
         name "Test"
         desc "Test cask"
-        homepage HOMEPAGE_URL
+        homepage "https://brew.sh"
 
         livecheck do
-          url LIVECHECK_URL
+          url "https://formulae.brew.sh/api/formula/ruby.json"
           regex(/"stable":"(\d+(?:\.\d+)+)"/i)
         end
       end
@@ -82,9 +82,9 @@ describe Homebrew::Livecheck do
     let(:f_livecheck_url) do
       formula("test_livecheck_url") do
         desc "Test Livecheck URL formula"
-        homepage HOMEPAGE_URL
-        url STABLE_URL
-        head HEAD_URL
+        homepage "https://brew.sh"
+        url "https://brew.sh/test-0.0.1.tgz"
+        head "https://github.com/Homebrew/brew.git"
       end
     end
 
@@ -93,34 +93,34 @@ describe Homebrew::Livecheck do
         cask "test_livecheck_url" do
           version "0.0.1,2"
 
-          url CASK_URL
+          url "https://brew.sh/test-0.0.1.dmg"
           name "Test"
           desc "Test Livecheck URL cask"
-          homepage HOMEPAGE_URL
+          homepage "https://brew.sh"
         end
       RUBY
     end
 
     it "returns a URL string when given a livecheck_url string" do
-      f_livecheck_url.livecheck.url(LIVECHECK_URL)
-      expect(livecheck.livecheck_url_to_string(LIVECHECK_URL, f_livecheck_url)).to eq(LIVECHECK_URL)
+      f_livecheck_url.livecheck.url(livecheck_url)
+      expect(livecheck.livecheck_url_to_string(livecheck_url, f_livecheck_url)).to eq(livecheck_url)
     end
 
     it "returns a URL symbol when given a valid livecheck_url symbol" do
       f_livecheck_url.livecheck.url(:head)
-      expect(livecheck.livecheck_url_to_string(HEAD_URL, f_livecheck_url)).to eq(HEAD_URL)
+      expect(livecheck.livecheck_url_to_string(head_url, f_livecheck_url)).to eq(head_url)
 
       f_livecheck_url.livecheck.url(:homepage)
-      expect(livecheck.livecheck_url_to_string(HOMEPAGE_URL, f_livecheck_url)).to eq(HOMEPAGE_URL)
+      expect(livecheck.livecheck_url_to_string(homepage_url, f_livecheck_url)).to eq(homepage_url)
 
       c_livecheck_url.livecheck.url(:homepage)
-      expect(livecheck.livecheck_url_to_string(HOMEPAGE_URL, c_livecheck_url)).to eq(HOMEPAGE_URL)
+      expect(livecheck.livecheck_url_to_string(homepage_url, c_livecheck_url)).to eq(homepage_url)
 
       f_livecheck_url.livecheck.url(:stable)
-      expect(livecheck.livecheck_url_to_string(STABLE_URL, f_livecheck_url)).to eq(STABLE_URL)
+      expect(livecheck.livecheck_url_to_string(stable_url, f_livecheck_url)).to eq(stable_url)
 
       c_livecheck_url.livecheck.url(:url)
-      expect(livecheck.livecheck_url_to_string(CASK_URL, c_livecheck_url)).to eq(CASK_URL)
+      expect(livecheck.livecheck_url_to_string(cask_url, c_livecheck_url)).to eq(cask_url)
     end
 
     it "returns nil when not given a string or valid symbol" do
@@ -133,8 +133,8 @@ describe Homebrew::Livecheck do
 
   describe "::checkable_urls" do
     it "returns the list of URLs to check" do
-      expect(livecheck.checkable_urls(f)).to eq([HEAD_URL, STABLE_URL, HOMEPAGE_URL])
-      expect(livecheck.checkable_urls(c)).to eq([CASK_URL, HOMEPAGE_URL])
+      expect(livecheck.checkable_urls(f)).to eq([head_url, stable_url, homepage_url])
+      expect(livecheck.checkable_urls(c)).to eq([cask_url, homepage_url])
     end
   end
 

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -8,6 +8,7 @@ describe Livecheck do
   HOMEPAGE_URL = "https://example.com/"
   STABLE_URL = "https://example.com/example-1.2.3.tar.gz"
   HEAD_URL = "https://example.com/example.git"
+  CASK_URL = "https://example.com/example-1.2.3.dmg"
 
   let(:f) do
     formula do
@@ -16,100 +17,119 @@ describe Livecheck do
       head HEAD_URL
     end
   end
-  let(:livecheckable) { described_class.new(f) }
+  let(:livecheckable_f) { described_class.new(f) }
+
+  let(:c) do
+    Cask::CaskLoader.load(+<<-RUBY)
+      cask "test" do
+        version "0.0.1,2"
+
+        url CASK_URL
+        name "Test"
+        desc "Test cask"
+        homepage HOMEPAGE_URL
+      end
+    RUBY
+  end
+  let(:livecheckable_c) { described_class.new(c) }
 
   describe "#regex" do
     it "returns nil if not set" do
-      expect(livecheckable.regex).to be nil
+      expect(livecheckable_f.regex).to be nil
     end
 
     it "returns the Regexp if set" do
-      livecheckable.regex(/foo/)
-      expect(livecheckable.regex).to eq(/foo/)
+      livecheckable_f.regex(/foo/)
+      expect(livecheckable_f.regex).to eq(/foo/)
     end
 
     it "raises a TypeError if the argument isn't a Regexp" do
       expect {
-        livecheckable.regex("foo")
+        livecheckable_f.regex("foo")
       }.to raise_error(TypeError, "Livecheck#regex expects a Regexp")
     end
   end
 
   describe "#skip" do
     it "sets @skip to true when no argument is provided" do
-      expect(livecheckable.skip).to be true
-      expect(livecheckable.instance_variable_get(:@skip)).to be true
-      expect(livecheckable.instance_variable_get(:@skip_msg)).to be nil
+      expect(livecheckable_f.skip).to be true
+      expect(livecheckable_f.instance_variable_get(:@skip)).to be true
+      expect(livecheckable_f.instance_variable_get(:@skip_msg)).to be nil
     end
 
     it "sets @skip to true and @skip_msg to the provided String" do
-      expect(livecheckable.skip("foo")).to be true
-      expect(livecheckable.instance_variable_get(:@skip)).to be true
-      expect(livecheckable.instance_variable_get(:@skip_msg)).to eq("foo")
+      expect(livecheckable_f.skip("foo")).to be true
+      expect(livecheckable_f.instance_variable_get(:@skip)).to be true
+      expect(livecheckable_f.instance_variable_get(:@skip_msg)).to eq("foo")
     end
 
     it "raises a TypeError if the argument isn't a String" do
       expect {
-        livecheckable.skip(/foo/)
+        livecheckable_f.skip(/foo/)
       }.to raise_error(TypeError, "Livecheck#skip expects a String")
     end
   end
 
   describe "#skip?" do
     it "returns the value of @skip" do
-      expect(livecheckable.skip?).to be false
+      expect(livecheckable_f.skip?).to be false
 
-      livecheckable.skip
-      expect(livecheckable.skip?).to be true
+      livecheckable_f.skip
+      expect(livecheckable_f.skip?).to be true
     end
   end
 
   describe "#strategy" do
     it "returns nil if not set" do
-      expect(livecheckable.strategy).to be nil
+      expect(livecheckable_f.strategy).to be nil
     end
 
     it "returns the Symbol if set" do
-      livecheckable.strategy(:page_match)
-      expect(livecheckable.strategy).to eq(:page_match)
+      livecheckable_f.strategy(:page_match)
+      expect(livecheckable_f.strategy).to eq(:page_match)
     end
 
     it "raises a TypeError if the argument isn't a Symbol" do
       expect {
-        livecheckable.strategy("page_match")
+        livecheckable_f.strategy("page_match")
       }.to raise_error(TypeError, "Livecheck#strategy expects a Symbol")
     end
   end
 
   describe "#url" do
     it "returns nil if not set" do
-      expect(livecheckable.url).to be nil
+      expect(livecheckable_f.url).to be nil
     end
 
-    it "returns the URL if set" do
-      livecheckable.url("foo")
-      expect(livecheckable.url).to eq("foo")
-
-      livecheckable.url(:homepage)
-      expect(livecheckable.url).to eq(HOMEPAGE_URL)
-
-      livecheckable.url(:stable)
-      expect(livecheckable.url).to eq(STABLE_URL)
-
-      livecheckable.url(:head)
-      expect(livecheckable.url).to eq(HEAD_URL)
+    it "returns a string when set to a string" do
+      livecheckable_f.url("https://brew.sh")
+      expect(livecheckable_f.url).to eq("https://brew.sh")
     end
 
-    it "raises a TypeError if the argument isn't a String or Symbol" do
+    it "returns the URL symbol if valid" do
+      livecheckable_f.url(:head)
+      expect(livecheckable_f.url).to eq(:head)
+
+      livecheckable_f.url(:homepage)
+      expect(livecheckable_f.url).to eq(:homepage)
+
+      livecheckable_f.url(:stable)
+      expect(livecheckable_f.url).to eq(:stable)
+
+      livecheckable_c.url(:url)
+      expect(livecheckable_c.url).to eq(:url)
+    end
+
+    it "raises a TypeError if the argument isn't a String or valid Symbol" do
       expect {
-        livecheckable.url(/foo/)
+        livecheckable_f.url(/foo/)
       }.to raise_error(TypeError, "Livecheck#url expects a String or valid Symbol")
     end
   end
 
   describe "#to_hash" do
     it "returns a Hash of all instance variables" do
-      expect(livecheckable.to_hash).to eq(
+      expect(livecheckable_f.to_hash).to eq(
         {
           "regex"    => nil,
           "skip"     => false,

--- a/Library/Homebrew/test/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck_spec.rb
@@ -5,16 +5,11 @@ require "formula"
 require "livecheck"
 
 describe Livecheck do
-  HOMEPAGE_URL = "https://example.com/"
-  STABLE_URL = "https://example.com/example-1.2.3.tar.gz"
-  HEAD_URL = "https://example.com/example.git"
-  CASK_URL = "https://example.com/example-1.2.3.dmg"
-
   let(:f) do
     formula do
-      homepage HOMEPAGE_URL
-      url STABLE_URL
-      head HEAD_URL
+      homepage "https://brew.sh"
+      url "https://brew.sh/test-0.0.1.tgz"
+      head "https://github.com/Homebrew/brew.git"
     end
   end
   let(:livecheckable_f) { described_class.new(f) }
@@ -24,10 +19,10 @@ describe Livecheck do
       cask "test" do
         version "0.0.1,2"
 
-        url CASK_URL
+        url "https://brew.sh/test-0.0.1.dmg"
         name "Test"
         desc "Test cask"
-        homepage HOMEPAGE_URL
+        homepage "https://brew.sh"
       end
     RUBY
   end
@@ -97,13 +92,15 @@ describe Livecheck do
   end
 
   describe "#url" do
+    let(:url_string) { "https://brew.sh" }
+
     it "returns nil if not set" do
       expect(livecheckable_f.url).to be nil
     end
 
     it "returns a string when set to a string" do
-      livecheckable_f.url("https://brew.sh")
-      expect(livecheckable_f.url).to eq("https://brew.sh")
+      livecheckable_f.url(url_string)
+      expect(livecheckable_f.url).to eq(url_string)
     end
 
     it "returns the URL symbol if valid" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

An issue that we've encountered in at least one homebrew/core formula is that `url :head` won't work in a `livecheck` block if the formula uses a `head` block. The `livecheck` block comes before the `head` block, so the `head` URL isn't defined when the `livecheck` block `#url` method is called.

In #10157, I proposed that we could resolve this issue by moving `head` blocks after `stable` blocks in formulae, so they both come before the `livecheck` block. Some Homebrew members supported this while others preferred to simply move the `livecheck` block after the `head` block. Both of these options would lead to some level of unhappiness in the end.

While discussing these options, @SeekingMeaning asked if we could modify `Livecheck#url` to simply store the symbol from the `livecheck` block and convert it to the formula URL string sometime after the formula is parsed. I had already considered doing this for other reasons (see https://github.com/Homebrew/brew/pull/10157#discussion_r555949019 for details), so I agreed that this was the most amenable solution to this particular issue.

---

With that in mind, this PR modifies `Livecheck#url` to simply store the value it's passed (a string or symbol). We do the conversion from a URL symbol to the formula/cask URL string in `#latest_version`, using a new `#livecheck_url_to_string` method.

This solution resolves the issue described above but it also allows us to surface information in the debug and JSON output about whether a URL symbol was used in the `livecheck` block. The existing `Livecheck#url` setup prevented us from being able to do this before and that was initially why I thought about pursuing this change.

Along the way, I did some minor refactoring in livecheck's tests. There's still a lot of room for improvement when it comes to tidying up these tests but that's something for a later PR.

If/when this is merged, I'll close #10157 and Homebrew/homebrew-core#67824, as they won't be necessary.