### PR TITLE
Keg: allow overwriting same-formula conflicts

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -647,6 +647,18 @@ class Keg
     dst.delete if options[:overwrite] && (dst.exist? || dst.symlink?)
     dst.make_relative_symlink(src)
   rescue Errno::EEXIST => e
+    # We're linking a different version of the same formula
+    # Note that the AlreadyLinkedError check above *should*
+    # have caught this, but there are circumstances in which
+    # we end up with symlinks for a formula even though
+    # it seems to be missing an optlink. In that case,
+    # we should be clear to blow those away and replace
+    # them.
+    if dst.symlink? && Keg.for(dst).name == name
+      dst.unlink
+      retry
+    end
+
     raise ConflictError.new(self, src.relative_path_from(path), dst, e) if dst.exist?
 
     if dst.symlink?

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -651,7 +651,7 @@ class Keg
     # formula. The `AlreadyLinkedError` above won't catch
     # this if a formula is missing an optlink. In that case,
     # delete the symlink and retry.
-    if dst.symlink? && Keg.for(dst).name == name
+    if dst.symlink? && dst.exist? && Keg.for(dst).name == name
       dst.unlink
       retry
     end

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -647,7 +647,7 @@ class Keg
     dst.delete if options[:overwrite] && (dst.exist? || dst.symlink?)
     dst.make_relative_symlink(src)
   rescue Errno::EEXIST => e
-    # Retry if we're linking a different version of the same 
+    # Retry if we're linking a different version of the same
     # formula. The `AlreadyLinkedError` above won't catch
     # this if a formula is missing an optlink. In that case,
     # delete the symlink and retry.

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -647,13 +647,10 @@ class Keg
     dst.delete if options[:overwrite] && (dst.exist? || dst.symlink?)
     dst.make_relative_symlink(src)
   rescue Errno::EEXIST => e
-    # We're linking a different version of the same formula
-    # Note that the AlreadyLinkedError check above *should*
-    # have caught this, but there are circumstances in which
-    # we end up with symlinks for a formula even though
-    # it seems to be missing an optlink. In that case,
-    # we should be clear to blow those away and replace
-    # them.
+    # Retry if we're linking a different version of the same 
+    # formula. The `AlreadyLinkedError` above won't catch
+    # this if a formula is missing an optlink. In that case,
+    # delete the symlink and retry.
     if dst.symlink? && Keg.for(dst).name == name
       dst.unlink
       retry


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is weird. We're seeing some installs where formulae have no opt prefix and no linked keg record, *but* still ended up linked into the prefix. Upgrades will blow up in this case because the old symlinks won't get deleted and Homebrew will report a nonsensical error message about not being able to link over another link from the same formula!

Since the optpath is either missing or pointing to the wrong destination at this point, the checks for conflict linking above will have failed. We should instead be safe to simply blow away these conflicting symlinks and replace them with the new targets.

Sample error:

<details>
<pre>
==> Upgrading 1 outdated package:
x264 r3027_1
==> Upgrading x264 -> r3027_1
==> Downloading https://homebrew.bintray.com/bottles/x264-r3027_1.catalina.bottle.tar.gz
Already downloaded: /Users/mistydemeo/Library/Caches/Homebrew/downloads/43fdb2169249f2616888ce651cfc6eaca82110a49ace3072aee714221b4808ba--x264-r3027_1.catalina.bottle.tar.gz
==> Pouring x264-r3027_1.catalina.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/x264
Target /usr/local/bin/x264
is a symlink belonging to x264. You can unlink it:
  brew unlink x264

To force the link and overwrite all conflicting files:
  brew link --overwrite x264

To list all files that would be deleted:
  brew link --overwrite --dry-run x264

Possible conflicting files are:
/usr/local/bin/x264 -> /usr/local/Cellar/x264/r3011/bin/x264
/usr/local/include/x264.h -> /usr/local/Cellar/x264/r3011/include/x264.h
/usr/local/include/x264_config.h -> /usr/local/Cellar/x264/r3011/include/x264_config.h
/usr/local/lib/libx264.a -> /usr/local/Cellar/x264/r3011/lib/libx264.a
/usr/local/lib/libx264.dylib -> /usr/local/Cellar/x264/r3011/lib/libx264.dylib
/usr/local/lib/pkgconfig/x264.pc -> /usr/local/Cellar/x264/r3011/lib/pkgconfig/x264.pc
==> Summary
🍺  /usr/local/Cellar/x264/r3027_1: 11 files, 5.7MB
</pre>
</details>

Fixes https://github.com/Homebrew/homebrew-core/issues/68866.