### PR TITLE
patch: delete legacy code

### DIFF
--- a/Library/Homebrew/patch.rb
+++ b/Library/Homebrew/patch.rb
@@ -29,25 +29,6 @@ module Patch
       raise ArgumentError, "unexpected value #{strip.inspect} for strip"
     end
   end
-
-  def self.normalize_legacy_patches(list)
-    patches = []
-
-    case list
-    when Hash
-      list
-    when Array, String, :DATA
-      { p1: list }
-    else
-      {}
-    end.each_pair do |strip, urls|
-      Array(urls).each do
-        patches << DATAPatch.new(strip)
-      end
-    end
-
-    patches
-  end
 end
 
 # An abstract class representing a patch embedded into a formula.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -227,13 +227,6 @@ class SoftwareSpec
     end
   end
 
-  # TODO: ?
-  def add_legacy_patches(list)
-    list = Patch.normalize_legacy_patches(list)
-    list.each { |p| p.owner = self }
-    patches.concat(list)
-  end
-
   def add_dep_option(dep)
     dep.option_names.each do |name|
       if dep.optional? && !option_defined?("with-#{name}")


### PR DESCRIPTION
`SoftwareSpec#add_legacy_patches` and `Patch#normalize_legacy_patches` were added almost 6 years ago; let's delete them

See commit 665b14c4a44c272b46b8559836e9fdbeee5d8a46

```console
$ grep -r 'normalize_legacy_patches' Library/Homebrew
./software_spec.rb:    list = Patch.normalize_legacy_patches(list)
./patch.rb:  def self.normalize_legacy_patches(list)
```

```console
$ grep -r 'add_legacy_patches' Library/Homebrew
./software_spec.rb:  def add_legacy_patches(list)
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
