### PR TITLE
install: add workaround for rosetta2 path error to msg

### DIFF
--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -35,7 +35,7 @@ module Homebrew
         if Hardware::CPU.in_rosetta2?
           odie <<~EOS
             Cannot install under Rosetta 2 in ARM default prefix (#{HOMEBREW_PREFIX})!
-            To rerun under ARM use: 
+            To rerun under ARM use:
                 arch -arm64 brew install ...
             To install under x86_64, install Homebrew into #{HOMEBREW_DEFAULT_PREFIX}.
           EOS

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -32,12 +32,16 @@ module Homebrew
     def check_prefix
       if (Hardware::CPU.intel? || Hardware::CPU.in_rosetta2?) &&
          HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX
-        configuration = if Hardware::CPU.in_rosetta2?
-          "under Rosetta 2"
+        if Hardware::CPU.in_rosetta2?
+          configuration = "under Rosetta 2"
+          odie <<~EOS
+            Cannot install in Homebrew #{configuration} in ARM default prefix (#{HOMEBREW_PREFIX})!
+            Try `arch -arm64 brew install ...`
+          EOS
         else
-          "on Intel processor"
+          configuration = "on Intel processor"
+          odie "Cannot install in Homebrew #{configuration} in ARM default prefix (#{HOMEBREW_PREFIX})!"
         end
-        odie "Cannot install in Homebrew #{configuration} in ARM default prefix (#{HOMEBREW_PREFIX})!"
       elsif Hardware::CPU.arm? && HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX
         odie <<~EOS
           Cannot install in Homebrew on ARM processor in Intel default prefix (#{HOMEBREW_PREFIX})!

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -34,15 +34,10 @@ module Homebrew
          HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX
         if Hardware::CPU.in_rosetta2?
           odie <<~EOS
-                   This invocation of Homebrew is being translated by Rosetta2 however it is
-            installed in the ARM default prefix (#{HOMEBREW_PREFIX})! Are you are using an
-            x86_64 build of your terminal emulator? All invocations of this Homebrew
-            installation must be native arm64.
-            Use:
+            Cannot install under Rosetta 2 in ARM default prefix (#{HOMEBREW_PREFIX})!
+            To rerun under ARM use: 
                 arch -arm64 brew install ...
-
-            to invoke Homebrew natively. Alternatively, if indeed you want x86_64 packages,
-            setup a separate x86_64 Homebrew installation and invoke that one.
+            To install under x86_64, install Homebrew into #{HOMEBREW_DEFAULT_PREFIX}.
           EOS
         else
           odie "Cannot install on Intel processor in ARM default prefix (#{HOMEBREW_PREFIX})!"

--- a/Library/Homebrew/install.rb
+++ b/Library/Homebrew/install.rb
@@ -33,14 +33,19 @@ module Homebrew
       if (Hardware::CPU.intel? || Hardware::CPU.in_rosetta2?) &&
          HOMEBREW_PREFIX.to_s == HOMEBREW_MACOS_ARM_DEFAULT_PREFIX
         if Hardware::CPU.in_rosetta2?
-          configuration = "under Rosetta 2"
           odie <<~EOS
-            Cannot install in Homebrew #{configuration} in ARM default prefix (#{HOMEBREW_PREFIX})!
-            Try `arch -arm64 brew install ...`
+                   This invocation of Homebrew is being translated by Rosetta2 however it is
+            installed in the ARM default prefix (#{HOMEBREW_PREFIX})! Are you are using an
+            x86_64 build of your terminal emulator? All invocations of this Homebrew
+            installation must be native arm64.
+            Use:
+                arch -arm64 brew install ...
+
+            to invoke Homebrew natively. Alternatively, if indeed you want x86_64 packages,
+            setup a separate x86_64 Homebrew installation and invoke that one.
           EOS
         else
-          configuration = "on Intel processor"
-          odie "Cannot install in Homebrew #{configuration} in ARM default prefix (#{HOMEBREW_PREFIX})!"
+          odie "Cannot install on Intel processor in ARM default prefix (#{HOMEBREW_PREFIX})!"
         end
       elsif Hardware::CPU.arm? && HOMEBREW_PREFIX.to_s == HOMEBREW_DEFAULT_PREFIX
         odie <<~EOS


### PR DESCRIPTION
It's possible the user's terminal emulator is running under rosetta2.
Consequently, the i86_64 version of the ruby interpreter will be used.
Likely, the right thing to do is simply install the arm64 version of the
requested package. This can be accomplished using: arch -arm64 brew ...

Fixes: #10313 

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
  > There were numerous failures...
- [x] Have you successfully run `brew man` locally and committed any changes?
  > Failure: Broken pipe
-----

Please help direct me to the right tests (if necessary). Also, I'm unable to test this because it does no appear that brew cares about the prefix when it's not in /opt or /usr. When I run `arch -x86_64 brew install ...` it completes successfully and does not complain. Is there a way to instruct brew to care so I can hit the codepath? 

