### PR TITLE
rubocops: permit `mirror` in OS-specific resources

### DIFF
--- a/Library/Homebrew/rubocops/components_order.rb
+++ b/Library/Homebrew/rubocops/components_order.rb
@@ -75,17 +75,20 @@ module RuboCop
             message = nil
             allowed_methods = [
               [:url, :sha256],
+              [:url, :mirror, :sha256],
               [:url, :version, :sha256],
+              [:url, :mirror, :version, :sha256],
             ]
 
+            # TODO: Refactor this to point to the actual offending methods rather than the entire block.
             on_os_bodies.each do |method_name, on_os_body|
               child_nodes = on_os_body.begin_type? ? on_os_body.child_nodes : [on_os_body]
               if child_nodes.all? { |n| n.send_type? || n.block_type? }
                 method_names = child_nodes.map(&:method_name)
                 next if allowed_methods.include? method_names
               end
-              message = "`#{method_name}` blocks within resource blocks must contain only a " \
-                        "url and sha256 or a url, version, and sha256 (in those orders)."
+              message = "`#{method_name}` blocks within `resource` blocks must contain at least "\
+                        "`url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order)."
               break
             end
 

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -614,10 +614,31 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_macos` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
+            ^^^^^^^^^^^ `on_macos` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
                 url "https://brew.sh/resource2.tar.gz"
+              end
+
+              on_linux do
+                url "https://brew.sh/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+              end
+            end
+          end
+        RUBY
+      end
+
+      it "reports no offenses if the content of an `on_macos` block in a resource contains a mirror" do
+        expect_no_offenses(<<~RUBY)
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+
+            resource do
+              on_macos do
+                url "https://brew.sh/resource2.tar.gz"
+                mirror "https://brew.sh/mirror/resource2.tar.gz"
+                sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
 
               on_linux do
@@ -660,7 +681,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_macos` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
+            ^^^^^^^^^^^ `on_macos` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
                 if foo == :bar
                   url "https://brew.sh/resource2.tar.gz"
@@ -686,7 +707,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_linux` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
+            ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -732,7 +753,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_linux` blocks within resource blocks must contain only a url and sha256 or a url, version, and sha256 (in those orders).
+            ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"


### PR DESCRIPTION
In support of https://github.com/Homebrew/homebrew-core/pull/68946. This rubocop needs a bit of a refactor but this is a quick fix to ensure that we can get openjdk working on ARM.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
