### PR TITLE
rubocops: point to offending OS-specific block in resource blocks

### DIFF
--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -614,8 +614,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_macos` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
+              ^^^^^^^^^^^ `on_macos` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
                 url "https://brew.sh/resource2.tar.gz"
               end
@@ -681,8 +681,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_macos` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
+              ^^^^^^^^^^^ `on_macos` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 if foo == :bar
                   url "https://brew.sh/resource2.tar.gz"
                   sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
@@ -707,13 +707,13 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
 
               on_linux do
+              ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
                 url "https://brew.sh/resource2.tar.gz"
               end
@@ -753,13 +753,13 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
             url "https://brew.sh/foo-1.0.tgz"
 
             resource do
-            ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `mirror` and at most `url`, `mirror`, `version`, `sha256` (in order).
               on_macos do
                 url "https://brew.sh/resource2.tar.gz"
                 sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
               end
 
               on_linux do
+              ^^^^^^^^^^^ `on_linux` blocks within `resource` blocks must contain at least `url` and `sha256` and at most `url`, `mirror`, `version` and `sha256` (in order).
                 if foo == :bar
                   url "https://brew.sh/resource2.tar.gz"
                   sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow-up to #10320

> Refactor this to point to the actual offending methods rather than the entire block.

Also, this PR fixes the error message in that `url` and `sha256` are the minimum requirement, not `url` and `mirror`