### PR TITLE
dev-cmd/tap-new: fix output on newer versions of Git.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -148,7 +148,9 @@ module Homebrew
 
     unless args.no_git?
       cd tap.path do
-        safe_system "git", "init"
+        # Would be nice to use --initial-branch here but it's not available in
+        # older versions of Git that we support.
+        safe_system "git", "-c", "init.defaultBranch=#{branch}", "init"
         safe_system "git", "add", "--all"
         safe_system "git", "commit", "-m", "Create #{tap} tap"
         safe_system "git", "branch", "-m", branch


### PR DESCRIPTION
Otherwise this prints to `stderr` to ask for configuration of the branch name:
https://github.com/Homebrew/brew/pull/10323/checks?check_run_id=1701105141#step:5:51