### PR TITLE
Keg: fix alias and versioned symlink handling.

### DIFF
--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -58,7 +58,12 @@ class Tab < OpenStruct
   # Returns the {Tab} for an install receipt at `path`.
   # Results are cached.
   def self.from_file(path)
-    cache.fetch(path) { |p| cache[p] = from_file_content(File.read(p), p) }
+    cache.fetch(path) do |p|
+      content = File.read(p)
+      return empty if content.blank?
+
+      cache[p] = from_file_content(content, p)
+    end
   end
 
   # Like {from_file}, but bypass the cache.


### PR DESCRIPTION
Previously, `brew upgrade gcc@10` could get overzealous and remove the `LinkedKeg` record for `gcc@9`. This is bad because we then think `gcc@9` is unlinked when it is not and it causes a tonne of conflicts when trying to link `gcc@9` again.

Instead, fix up the alias and versioned alias cleanup to be more precise and only delete the symlinks that point to the current `rack`,`opt_record` or `linked_keg_record` and unify the logic so it's performed consistently.

While we're here:
- don't `remove_old_aliases` every time we try to unlink a directory but just perform it once per `unlink` operation
- remove the linked keg record on `uninstall`

Fixes https://github.com/Homebrew/homebrew-core/issues/68866
Replaces https://github.com/Homebrew/brew/pull/10312