### PR TITLE
version: enable Sorbet type checking

### DIFF
--- a/Library/Homebrew/os/linux/glibc.rb
+++ b/Library/Homebrew/os/linux/glibc.rb
@@ -22,7 +22,7 @@ module OS
 
       sig { returns(Version) }
       def minimum_version
-        Version.new ENV["HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION"]
+        Version.new(ENV.fetch("HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION"))
       end
 
       def below_minimum_version?

--- a/Library/Homebrew/os/mac/version.rbi
+++ b/Library/Homebrew/os/mac/version.rbi
@@ -1,0 +1,10 @@
+# typed: strict
+
+module OS
+  module Mac
+    class Version
+      sig { returns(Token) }
+      def major; end
+    end
+  end
+end

--- a/Library/Homebrew/version.rbi
+++ b/Library/Homebrew/version.rbi
@@ -1,0 +1,10 @@
+# typed: strict
+
+class Version
+  # For `alias eql? ==`
+  # See discussions:
+  #  - https://github.com/sorbet/sorbet/pull/1443
+  #  - https://github.com/sorbet/sorbet/issues/2378
+  sig { params(other: T.untyped).returns(T::Boolean) }
+  def ==(other); end
+end

--- a/Library/Homebrew/version/null.rb
+++ b/Library/Homebrew/version/null.rb
@@ -1,17 +1,24 @@
 # typed: true
 # frozen_string_literal: true
 
+require "singleton"
+
 class Version
-  # Represents the absence of a version.
-  NULL = Class.new do
+  # A pseudo-version representing the absence of a version.
+  #
+  # @api private
+  class NullVersion < Version
     extend T::Sig
 
     include Comparable
+    include Singleton
 
+    sig { override.params(_other: T.untyped).returns(Integer) }
     def <=>(_other)
       -1
     end
 
+    sig { override.params(_other: T.untyped).returns(T::Boolean) }
     def eql?(_other)
       # Makes sure that the same instance of Version::NULL
       # will never equal itself; normally Comparable#==
@@ -20,17 +27,17 @@ class Version
       false
     end
 
-    sig { returns(T::Boolean) }
+    sig { override.returns(T::Boolean) }
     def detected_from_url?
       false
     end
 
-    sig { returns(T::Boolean) }
+    sig { override.returns(T::Boolean) }
     def head?
       false
     end
 
-    sig { returns(T::Boolean) }
+    sig { override.returns(T::Boolean) }
     def null?
       true
     end
@@ -40,52 +47,59 @@ class Version
     def requires_nehalem_cpu?
       false
     end
-    alias_method :requires_sse4?, :requires_nehalem_cpu?
-    alias_method :requires_sse41?, :requires_nehalem_cpu?
-    alias_method :requires_sse42?, :requires_nehalem_cpu?
-    alias_method :requires_popcnt?, :requires_nehalem_cpu?
+    alias requires_sse4? requires_nehalem_cpu?
+    alias requires_sse41? requires_nehalem_cpu?
+    alias requires_sse42? requires_nehalem_cpu?
+    alias requires_popcnt? requires_nehalem_cpu?
 
+    sig { override.returns(Token) }
     def major
       NULL_TOKEN
     end
 
+    sig { override.returns(Token) }
     def minor
       NULL_TOKEN
     end
 
+    sig { override.returns(Token) }
     def patch
       NULL_TOKEN
     end
 
-    sig { returns(Version) }
+    sig { override.returns(Version) }
     def major_minor
       self
     end
 
-    sig { returns(Version) }
+    sig { override.returns(Version) }
     def major_minor_patch
       self
     end
 
-    sig { returns(Float) }
+    sig { override.returns(Float) }
     def to_f
       Float::NAN
     end
 
-    sig { returns(Integer) }
+    sig { override.returns(Integer) }
     def to_i
       0
     end
 
-    sig { returns(String) }
+    sig { override.returns(String) }
     def to_s
       ""
     end
-    alias_method :to_str, :to_s
+    alias to_str to_s
 
-    sig { returns(String) }
+    sig { override.returns(String) }
     def inspect
       "#<Version::NULL>"
     end
-  end.new.freeze
+  end
+  private_constant :NullVersion
+
+  # Represents the absence of a version.
+  NULL = NullVersion.instance.freeze
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Notable changes:

- Added a `NullVersion` singleton class that extends `Version`
- Changed `Version::Token` to be an abstract class
- Added `version.rbi` to work around Sorbet limitation with aliases

There are a lot of `T.untyped` but this is a start, at least