### PR TITLE
rubocops/text: improve test descriptions

### DIFF
--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -49,7 +49,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "reports an offense if veclibfort is used instead of OpenBLAS" do
+    it "reports an offense if veclibfort is used instead of OpenBLAS (in homebrew/core)" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -60,7 +60,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "repots an offense if lapack is used instead of OpenBLAS" do
+    it "reports an offense if lapack is used instead of OpenBLAS (in homebrew/core)" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -83,9 +83,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
           end
         end
       RUBY
-    end
 
-    it "reports an offense if xcodebuild is called without any args" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -280,7 +278,7 @@ end
 describe RuboCop::Cop::FormulaAuditStrict::Text do
   subject(:cop) { described_class.new }
 
-  context "when auditing formula text" do
+  context "when auditing formula text in homebrew/core" do
     it "reports an offense if `env :userpaths` is present" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -292,7 +290,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it "reports an offense if `env :std` is present" do
+    it "reports an offense if `env :std` is present in homebrew/core" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/text"
 describe RuboCop::Cop::FormulaAudit::Text do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula text" do
-    it "with `require \"formula\"` is present" do
+  context "when auditing formula text" do
+    it 'reports an offense if `require "formula"` is present' do
       expect_offense(<<~RUBY)
         require "formula"
         ^^^^^^^^^^^^^^^^^ `require "formula"` is now unnecessary
@@ -25,7 +25,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "with both openssl and libressl optional dependencies" do
+    it "reports an offense if both openssl and libressl are dependencies" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -36,9 +36,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Formulae should not depend on both OpenSSL and LibreSSL (even optionally).
         end
       RUBY
-    end
 
-    it "with both openssl and libressl dependencies" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -51,7 +49,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "when veclibfort is used instead of OpenBLAS" do
+    it "reports an offense if veclibfort is used instead of OpenBLAS" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -62,7 +60,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "when lapack is used instead of OpenBLAS" do
+    it "repots an offense if lapack is used instead of OpenBLAS" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -73,7 +71,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When xcodebuild is called without SYMROOT" do
+    it "reports an offense if xcodebuild is called without SYMROOT" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -87,7 +85,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When xcodebuild is called without any args" do
+    it "reports an offense if xcodebuild is called without any args" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -101,7 +99,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When go get is executed" do
+    it "reports an offense if `go get` is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -115,7 +113,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When xcodebuild is executed" do
+    it "reports an offense if `xcodebuild` is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -129,7 +127,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When plist_options are not defined when using a formula-defined plist", :ruby23 do
+    it "reports an offense if `plist_options` are not defined when using a formula-defined `plist`", :ruby23 do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -157,7 +155,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When language/go is require'd" do
+    it 'reports an offense if `require "language/go"` is present' do
       expect_offense(<<~RUBY)
         require "language/go"
         ^^^^^^^^^^^^^^^^^^^^^ require "language/go" is unnecessary unless using `go_resource`s
@@ -174,7 +172,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When formula uses virtualenv and also `setuptools` resource" do
+    it "reports an offense if formula uses virtualenv and also `setuptools` resource" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -193,7 +191,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When Formula.factory(name) is used" do
+    it "reports an offense if `Formula.factory(name)` is present" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -207,7 +205,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When dep ensure is used without `-vendor-only`" do
+    it "reports an offense if `dep ensure` is used without `-vendor-only`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -221,7 +219,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When cargo build is executed" do
+    it "reports an offense if `cargo build` is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -235,7 +233,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When make calls are not separated" do
+    it "reports an offense if `make` calls are not separated" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           def install
@@ -246,7 +244,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When concatenating in string interpolation" do
+    it "reports an offense if paths are concatenated in string interpolation" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           def install
@@ -257,7 +255,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "When using `prefix + \"bin\"` instead of `bin`" do
+    it 'reports an offense if `prefix + "bin"` is present' do
       expect_offense(<<~RUBY)
         class Foo < Formula
           def install
@@ -266,9 +264,7 @@ describe RuboCop::Cop::FormulaAudit::Text do
           end
         end
       RUBY
-    end
 
-    it "When using `prefix + \"bin/foo\"` instead of `bin`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           def install
@@ -284,8 +280,8 @@ end
 describe RuboCop::Cop::FormulaAuditStrict::Text do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula text" do
-    it "when deprecated `env :userpaths` is present" do
+  context "when auditing formula text" do
+    it "reports an offense if `env :userpaths` is present" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -296,7 +292,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it "when deprecated `env :std` is present in homebrew-core" do
+    it "reports an offense if `env :std` is present" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tgz"
@@ -307,7 +303,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it "when `\#{share}/foo` is used instead of `\#{pkgshare}`" do
+    it %Q(reports an offense if "\#{share}/<formula name>" is present) do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -316,9 +312,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
           end
         end
       RUBY
-    end
 
-    it "when `\#{share}/foo/bar` is used instead of `\#{pkgshare}/bar`" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -327,11 +321,9 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
           end
         end
       RUBY
-    end
 
-    it "when `\#{share}/foolibc++` is used instead of `\#{pkgshare}/foolibc++`" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foolibc++.rb")
-        class Foo < Formula
+        class Foolibcxx < Formula
           def install
             ohai "\#{share}/foolibc++"
                  ^^^^^^^^^^^^^^^^^^^^ Use `\#{pkgshare}` instead of `\#{share}/foolibc++`
@@ -340,7 +332,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it "when `share/\"foo\"` is used instead of `pkgshare`" do
+    it 'reports an offense if `share/"<formula name>"` is present' do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -349,9 +341,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
           end
         end
       RUBY
-    end
 
-    it "when `share/\"foo/bar\"` is used instead of `pkgshare`" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -360,11 +350,9 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
           end
         end
       RUBY
-    end
 
-    it "when `share/\"foolibc++\"` is used instead of `pkgshare`" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foolibc++.rb")
-        class Foo < Formula
+        class Foolibcxx < Formula
           def install
             ohai share/"foolibc++"
                  ^^^^^^^^^^^^^^^^^ Use `pkgshare` instead of `share/"foolibc++"`
@@ -373,7 +361,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it "when `\#{share}/foo-bar` doesn't match formula name" do
+    it %Q(reports no offenses if "\#{share}/<directory name>" doesn't match formula name) do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -383,7 +371,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it "when `share/foo-bar` doesn't match formula name" do
+    it 'reports no offenses if `share/"<formula name>"` is not present' do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -391,9 +379,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
           end
         end
       RUBY
-    end
 
-    it "when `share/bar` doesn't match formula name" do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -401,9 +387,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
           end
         end
       RUBY
-    end
 
-    it "when formula name appears afer `share/\"bar\"`" do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install
@@ -413,7 +397,7 @@ describe RuboCop::Cop::FormulaAuditStrict::Text do
       RUBY
     end
 
-    it "when formula name appears afer `\"\#{share}/bar\"`" do
+    it %Q(reports no offenses if formula name appears afer "\#{share}/<directory name>") do
       expect_no_offenses(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula
           def install


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Continuation of https://github.com/Homebrew/brew/pull/10124

This PR improves the test descriptions of `text_spec.rb` so that the error messages are more coherent.

Before:
``RuboCop::Cop::FormulaAudit::Text When auditing formula text with `require "formula"` is present``

After:
``RuboCop::Cop::FormulaAudit::Text when auditing formula text reports an offense if `require "formula"` is present``

(I'm not sure if my extensive use of single quotes [`'`] and percent literals [`%Q(...)`] is recommended; please tell me if it isn't)