### PR TITLE
docs: update external command documentation

### DIFF
--- a/docs/External-Commands.md
+++ b/docs/External-Commands.md
@@ -84,9 +84,7 @@ module Homebrew
 
   def foo_args
     Homebrew::CLI::Parser.new do
-      usage_banner <<~EOS
-        `foo` [<options>] <formula|cask>
-
+      description <<~EOS
         Do something. Place a description here.
       EOS
       switch "-f", "--force",
@@ -113,7 +111,7 @@ Using the above will generate appropriate help text:
 
 ```console
 $ brew foo --help
-Usage: brew foo [options] formula|cask
+Usage: brew foo [options] formula|cask [...]
 
 Do something. Place a description here.
 
@@ -126,6 +124,8 @@ Do something. Place a description here.
   -v, --verbose                    Make some output more verbose.
   -h, --help                       Show this message.
 ```
+
+The usage string is automatically generated based on the specified number and type of named arguments (see below for more details on specifying named arguments). The generated usage string can be overridden by passing the correct usage string to the `usage_banner` method (placed just before the `description` method). See the [`brew tap` command](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/cmd/tap.rb) for an example.
 
 Use the `named_args` method to specify the type and number of named arguments that are expected. Pass either a symbol to indicate the type of argument expected, an array of symbols to indicate that multiple types should be expected, or an array of strings to specify which specific options should be expected (see the [`brew analytics`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/cmd/analytics.rb) command for an example of this).
 

--- a/docs/External-Commands.md
+++ b/docs/External-Commands.md
@@ -13,6 +13,8 @@ External commands come in two flavours: Ruby commands and shell scripts.
 
 In both cases, the command file should be executable (`chmod +x`) and live somewhere in `PATH`.
 
+External commands can be added to a tap to allow easy distribution. See [below](#external-commands-in-taps) for more details.
+
 ### Ruby commands
 An external command `extcmd` implemented as a Ruby command should be named `brew-extcmd.rb`. The command is executed by doing a `require` on the full pathname. As the command is `require`d, it has full access to the Homebrew "environment", i.e. all global variables and modules that any internal command has access to. Be wary of using Homebrew internals; they may change at any time without warning.
 
@@ -66,3 +68,87 @@ Note they are largely untested, and as always, be careful about running untested
 Install any `gem` package into a self-contained Homebrew Cellar location: <https://github.com/sportngin/brew-gem>
 
 Note this can also be installed with `brew install brew-gem`.
+
+## External commands in taps
+External commands can be hosted in a [tap](Taps.md) to allow users to easy install and use the command. See [How to Create and Maintain a Tap](How-to-Create-and-Maintain-a-Tap.md) for more details about creating and maintaining a tap.
+
+External commands should be added to a `cmd` directory in the tap. An external command `extcmd` implemented as a Ruby command should live in `cmd/extcmd.rb` (don't forget to `chmod +x`).
+
+To easily use Homebrew's argument parser, follow the following Ruby template for external commands (replacing all instances of `foo` with the name of the command):
+
+```ruby
+# frozen_string_literal: true
+
+module Homebrew
+  module_function
+
+  def foo_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `foo` [<options>] <formula|cask>
+
+        Do something. Place a description here.
+      EOS
+      switch "-f", "--force",
+             description: "Force doing something in the command."
+      flag   "--file=",
+             description: "Specify a file to do something with in the command."
+      comma_array "--names",
+                  description: "Add a list of names to the command."
+
+      named_args [:formula, :cask], min: 1
+    end
+  end
+
+  def foo
+    args = foo_args.parse
+
+    something if args.force?
+    something_else if args.file == "file.txt"
+  end
+end
+```
+
+Using the above will generate the appropriate help text:
+
+```console
+$ brew foo --help
+Usage: brew foo [options] formula|cask
+
+Do something. Place a description here.
+
+  -f, --force                      Force doing something in the command.
+      --file                       Specify a file to do something with in the
+                                   command.
+      --names                      Add a list of names to the command.
+  -d, --debug                      Display any debugging information.
+  -q, --quiet                      Make some output more quiet.
+  -v, --verbose                    Make some output more verbose.
+  -h, --help                       Show this message.
+```
+
+Use the `named_args` method to specify the type and number of named arguments that are expected. Pass a symbol to indicate the type of argument expected. Pass an array of symbols to indicate that multiple types should be expected. Pass an array of strings to specify the specific options that should be expected (see the [`brew analytics`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/cmd/analytics.rb) command for an example of this).
+
+Pass an integer to the `number`, `min`, or `max` parameter of `named_args` to specify the number of named arguments that are expected. See the following examples:
+
+```ruby
+# Accept no named args
+named_args :none
+
+# Accept any number (including none) of formula arguments
+named_args :formula
+
+# Accept exactly one of the specified options as an argument
+named_args %w[state off on], number: 1
+
+# Accept at least one argument that is either a formula or a cask
+named_args [:formula, :cask], min: 1
+
+# Accept no more than one argument that is a tap
+named_args :tap, max: 1
+
+# Accept between one and two named args
+named_args min: 1, max: 2
+```
+
+Named arguments can be accessed by calling `args.named`. Check out the internal [commands](https://github.com/Homebrew/brew/tree/HEAD/Library/Homebrew/cmd) and [developer commands](https://github.com/Homebrew/brew/tree/HEAD/Library/Homebrew/dev-cmd) for more usage examples.

--- a/docs/External-Commands.md
+++ b/docs/External-Commands.md
@@ -70,7 +70,7 @@ Install any `gem` package into a self-contained Homebrew Cellar location: <https
 Note this can also be installed with `brew install brew-gem`.
 
 ## External commands in taps
-External commands can be hosted in a [tap](Taps.md) to allow users to easy install and use the command. See [How to Create and Maintain a Tap](How-to-Create-and-Maintain-a-Tap.md) for more details about creating and maintaining a tap.
+External commands can be hosted in a [tap](Taps.md) to allow users to easily install and use them. See [How to Create and Maintain a Tap](How-to-Create-and-Maintain-a-Tap.md) for more details about creating and maintaining a tap.
 
 External commands should be added to a `cmd` directory in the tap. An external command `extcmd` implemented as a Ruby command should live in `cmd/extcmd.rb` (don't forget to `chmod +x`).
 
@@ -109,7 +109,7 @@ module Homebrew
 end
 ```
 
-Using the above will generate the appropriate help text:
+Using the above will generate appropriate help text:
 
 ```console
 $ brew foo --help
@@ -127,7 +127,7 @@ Do something. Place a description here.
   -h, --help                       Show this message.
 ```
 
-Use the `named_args` method to specify the type and number of named arguments that are expected. Pass a symbol to indicate the type of argument expected. Pass an array of symbols to indicate that multiple types should be expected. Pass an array of strings to specify the specific options that should be expected (see the [`brew analytics`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/cmd/analytics.rb) command for an example of this).
+Use the `named_args` method to specify the type and number of named arguments that are expected. Pass either a symbol to indicate the type of argument expected, an array of symbols to indicate that multiple types should be expected, or an array of strings to specify which specific options should be expected (see the [`brew analytics`](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/cmd/analytics.rb) command for an example of this).
 
 Pass an integer to the `number`, `min`, or `max` parameter of `named_args` to specify the number of named arguments that are expected. See the following examples:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to https://github.com/Homebrew/brew/pull/10288

This PR updates the documentation around external commands and how to use the new `named_args` method.

My ultimate goal is to have completions be automatically generated based on `named_args` and to have an e.g. `brew generate-completions` command that will generate completions automatically for a tap. Given this, let me know if it's better for this PR to wait until that's ready (in order to document both at the same time).
