### PR TITLE
rubocops/*: improve test descriptions

### DIFF
--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -6,7 +6,7 @@ require "rubocops/components_order"
 describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula components order" do
+  context "when auditing formula components order" do
     it "reports and corrects an offense when `uses_from_macos` precedes `depends_on`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -337,8 +337,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     RUBY
   end
 
-  context "no on_os_block" do
-    it "does not fail when there is no on_os block" do
+  context "when formula has no OS-specific blocks" do
+    it "reports no offenses" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -352,8 +352,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
     end
   end
 
-  context "on_os_block" do
-    it "correctly uses on_macos and on_linux blocks" do
+  context "when formula has OS-specific block(s)" do
+    it "reports no offenses when `on_macos` and `on_linux` are used correctly" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -400,10 +400,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         end
       RUBY
     end
-  end
 
-  context "on_macos_block" do
-    it "correctly uses as single on_macos block" do
+    it "reports no offenses when `on_macos` is used correctly" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -418,10 +416,8 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         end
       RUBY
     end
-  end
 
-  context "on_linux_block" do
-    it "correctly uses as single on_linux block" do
+    it "reports no offenses when `on_linux` is used correctly" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           homepage "https://brew.sh"
@@ -516,7 +512,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
         RUBY
       end
 
-      it "reports no offenses for a valid `on_macos` and `on_linux` block with versions" do
+      it "reports no offenses for a valid `on_macos` and `on_linux` block (with `version`)" do
         expect_no_offenses(<<~RUBY)
           class Foo < Formula
             homepage "https://brew.sh"

--- a/Library/Homebrew/test/rubocops/files_spec.rb
+++ b/Library/Homebrew/test/rubocops/files_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/files"
 describe RuboCop::Cop::FormulaAudit::Files do
   subject(:cop) { described_class.new }
 
-  context "When auditing files" do
-    it "when the permissions are invalid" do
+  context "when auditing files" do
+    it "reports an offense when the permissions are invalid" do
       filename = Formulary.core_path("test_formula")
       File.open(filename, "w") do |file|
         FileUtils.chmod "-rwx", filename

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -6,7 +6,7 @@ require "rubocops/homepage"
 describe RuboCop::Cop::FormulaAudit::Homepage do
   subject(:cop) { described_class.new }
 
-  context "When auditing homepage" do
+  context "when auditing homepage" do
     it "reports an offense when there is no homepage" do
       expect_offense(<<~RUBY)
         class Foo < Formula

--- a/Library/Homebrew/test/rubocops/lines_spec.rb
+++ b/Library/Homebrew/test/rubocops/lines_spec.rb
@@ -62,7 +62,7 @@ end
 describe RuboCop::Cop::FormulaAudit::ClassInheritance do
   subject(:cop) { described_class.new }
 
-  context "auditing formula class inheritance" do
+  context "when auditing formula class inheritance" do
     it "reports an offense when not using spaces for class inheritance" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo<Formula
@@ -78,7 +78,7 @@ end
 describe RuboCop::Cop::FormulaAudit::Comments do
   subject(:cop) { described_class.new }
 
-  context "auditing comment text" do
+  context "when auditing comment text" do
     it "reports an offense when commented cmake calls exist" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -132,7 +132,7 @@ end
 describe RuboCop::Cop::FormulaAudit::AssertStatements do
   subject(:cop) { described_class.new }
 
-  context "auditing formula assertions" do
+  context "when auditing formula assertions" do
     it "reports an offense when assert ... include is used" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -182,7 +182,7 @@ end
 describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
   subject(:cop) { described_class.new }
 
-  context "auditing options" do
+  context "when auditing options" do
     it "reports an offense when `build.without?` is used in homebrew/core" do
       expect_offense(<<~RUBY, "/homebrew-core/")
         class Foo < Formula
@@ -417,7 +417,7 @@ end
 describe RuboCop::Cop::FormulaAudit::ShellVariables do
   subject(:cop) { described_class.new }
 
-  context "When auditing shell variables" do
+  context "when auditing shell variables" do
     it "reports and corrects unexpanded shell variables in `Utils.popen`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -499,7 +499,7 @@ end
 describe RuboCop::Cop::FormulaAudit::LicenseArrays do
   subject(:cop) { described_class.new }
 
-  context "When auditing license arrays" do
+  context "when auditing license arrays" do
     it "reports no offenses for license strings" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
@@ -554,7 +554,7 @@ end
 describe RuboCop::Cop::FormulaAudit::Licenses do
   subject(:cop) { described_class.new }
 
-  context "When auditing licenses" do
+  context "when auditing licenses" do
     it "reports no offenses for license strings" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
@@ -638,7 +638,7 @@ end
 describe RuboCop::Cop::FormulaAudit::PythonVersions do
   subject(:cop) { described_class.new }
 
-  context "When auditing Python versions" do
+  context "when auditing Python versions" do
     it "reports no offenses for Python with no dependency" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
@@ -685,7 +685,7 @@ describe RuboCop::Cop::FormulaAudit::PythonVersions do
       RUBY
     end
 
-    it "reports no offenses when a Pytohn reference matches its dependency without `@`" do
+    it "reports no offenses when a Python reference matches its dependency without `@`" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           depends_on "python@3.9"
@@ -818,7 +818,7 @@ end
 describe RuboCop::Cop::FormulaAudit::Miscellaneous do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula miscellany" do
+  context "when auditing formula miscellany" do
     it "reports an offense for unneeded `FileUtils` usage" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -1339,7 +1339,7 @@ end
 describe RuboCop::Cop::FormulaAuditStrict::ShellCommands do
   subject(:cop) { described_class.new }
 
-  context "When auditing shell commands" do
+  context "when auditing shell commands" do
     it "reports and corrects an offense when `system` arguments should be separated" do
       expect_offense(<<~RUBY)
         class Foo < Formula

--- a/Library/Homebrew/test/rubocops/options_spec.rb
+++ b/Library/Homebrew/test/rubocops/options_spec.rb
@@ -6,7 +6,7 @@ require "rubocops/options"
 describe RuboCop::Cop::FormulaAudit::Options do
   subject(:cop) { described_class.new }
 
-  context "When auditing options" do
+  context "when auditing options" do
     it "reports an offense when using the 32-bit option" do
       expect_offense(<<~RUBY)
         class Foo < Formula

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/patches"
 describe RuboCop::Cop::FormulaAudit::Patches do
   subject(:cop) { described_class.new }
 
-  context "When auditing legacy patches" do
-    it "reports no offenses when there is no legacy patch" do
+  context "when auditing legacy patches" do
+    it "reports no offenses if there is no legacy patch" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -155,7 +155,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
     end
   end
 
-  context "When auditing inline patches" do
+  context "when auditing inline patches" do
     it "reports no offenses for valid inline patches" do
       expect_no_offenses(<<~RUBY)
         class Foo < Formula
@@ -202,7 +202,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
     end
   end
 
-  context "When auditing external patches" do
+  context "when auditing external patches" do
     it "reports an offense for various patch URLs" do
       patch_urls = [
         "https://raw.github.com/mogaal/sendemail",

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -183,8 +183,8 @@ describe RuboCop::Cop::FormulaAudit::Urls do
     }]
   }
 
-  context "When auditing urls" do
-    it "with offenses" do
+  context "when auditing URLs" do
+    it "reports any offenses" do
       formulae.each do |formula|
         allow_any_instance_of(RuboCop::Cop::FormulaCop).to receive(:formula_tap)
                                                        .and_return(formula["formula_tap"])
@@ -211,7 +211,7 @@ describe RuboCop::Cop::FormulaAudit::Urls do
       end
     end
 
-    it "with offenses in stable/head block" do
+    it "reports an offense for GitHub repositories with git:// prefix" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"
@@ -228,7 +228,7 @@ describe RuboCop::Cop::FormulaAudit::Urls do
       RUBY
     end
 
-    it "with duplicate mirror" do
+    it "reports an offense if `url` is the same as `mirror`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           desc "foo"

--- a/Library/Homebrew/test/rubocops/urls_spec.rb
+++ b/Library/Homebrew/test/rubocops/urls_spec.rb
@@ -6,7 +6,7 @@ require "rubocops/urls"
 describe RuboCop::Cop::FormulaAudit::Urls do
   subject(:cop) { described_class.new }
 
-  let(:formulae) {
+  let(:offense_list) {
     [{
       "url" => "https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz",
       "msg" => 'Please use "https://ftp.gnu.org/gnu/lightning/lightning-2.1.0.tar.gz" instead of https://ftpmirror.gnu.org/lightning/lightning-2.1.0.tar.gz.',
@@ -184,20 +184,20 @@ describe RuboCop::Cop::FormulaAudit::Urls do
   }
 
   context "when auditing URLs" do
-    it "reports any offenses" do
-      formulae.each do |formula|
+    it "reports all offenses in `offense_list`" do
+      offense_list.each do |offense_info|
         allow_any_instance_of(RuboCop::Cop::FormulaCop).to receive(:formula_tap)
-                                                       .and_return(formula["formula_tap"])
+                                                       .and_return(offense_info["formula_tap"])
         source = <<~RUBY
           class Foo < Formula
             desc "foo"
-            url "#{formula["url"]}"
+            url "#{offense_info["url"]}"
           end
         RUBY
-        expected_offenses = [{ message:  formula["msg"],
+        expected_offenses = [{ message:  offense_info["msg"],
                                severity: :convention,
                                line:     3,
-                               column:   formula["col"],
+                               column:   offense_info["col"],
                                source:   source }]
 
         offenses = inspect_source(source)

--- a/Library/Homebrew/test/rubocops/version_spec.rb
+++ b/Library/Homebrew/test/rubocops/version_spec.rb
@@ -6,8 +6,8 @@ require "rubocops/version"
 describe RuboCop::Cop::FormulaAudit::Version do
   subject(:cop) { described_class.new }
 
-  context "When auditing version" do
-    it "version should not be an empty string" do
+  context "when auditing version" do
+    it "reports an offense if `version` is an empty string" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -17,7 +17,7 @@ describe RuboCop::Cop::FormulaAudit::Version do
       RUBY
     end
 
-    it "version should not have a leading 'v'" do
+    it "reports an offense if `version` has a leading 'v'" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'
@@ -27,7 +27,7 @@ describe RuboCop::Cop::FormulaAudit::Version do
       RUBY
     end
 
-    it "version should not end with underline and number" do
+    it "reports an offense if `version` ends with an underline and a number" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           url 'https://brew.sh/foo-1.0.tgz'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Continuation of https://github.com/Homebrew/brew/pull/10124

This PR improves some test descriptions so that the error messages are more coherent

Before:
`RuboCop::Cop::FormulaAudit::ComponentsOrder no on_os_block does not fail when there is no on_os block`

After:
`RuboCop::Cop::FormulaAudit::ComponentsOrder when formula has no OS-specific blocks reports no offenses`