### PR TITLE
keg: check that alias_match_path exists before checking the `.realpath.

### DIFF
--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -650,7 +650,7 @@ class Keg
 
   def remove_alias_symlink(alias_symlink, alias_match_path)
     if alias_symlink.symlink? && alias_symlink.exist?
-      alias_symlink.delete if alias_symlink.realpath == alias_match_path.realpath
+      alias_symlink.delete if alias_match_path.exist? && alias_symlink.realpath == alias_match_path.realpath
     elsif alias_symlink.symlink? || alias_symlink.exist?
       alias_symlink.delete
     end


### PR DESCRIPTION
Otherwise this can be a broken symlink which will raise an exception:
https://github.com/Homebrew/homebrew-core/runs/1704569542?check_suite_focus=true#step:6:47