### PR TITLE
cmd,dev-cmd: indicate multiple named args in usage banner

### DIFF
--- a/Library/Homebrew/cmd/--cache.rb
+++ b/Library/Homebrew/cmd/--cache.rb
@@ -16,7 +16,7 @@ module Homebrew
   def __cache_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `--cache` [<options>] [<formula>|<cask>]
+        `--cache` [<options>] [<formula>|<cask>] [<formula>|<cask> ...]
 
         Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 

--- a/Library/Homebrew/cmd/--caskroom.rb
+++ b/Library/Homebrew/cmd/--caskroom.rb
@@ -10,7 +10,7 @@ module Homebrew
   def __caskroom_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `--caskroom` [<cask>]
+        `--caskroom` [<cask>] [<cask> ...]
 
         Display Homebrew's Caskroom path.
 

--- a/Library/Homebrew/cmd/--cellar.rb
+++ b/Library/Homebrew/cmd/--cellar.rb
@@ -9,7 +9,7 @@ module Homebrew
   def __cellar_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `--cellar` [<formula>]
+        `--cellar` [<formula>] [<formula> ...]
 
         Display Homebrew's Cellar path. *Default:* `$(brew --prefix)/Cellar`, or if
         that directory doesn't exist, `$(brew --repository)/Cellar`.

--- a/Library/Homebrew/cmd/--env.rb
+++ b/Library/Homebrew/cmd/--env.rb
@@ -15,7 +15,7 @@ module Homebrew
   def __env_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `--env` [<options>] [<formula>]
+        `--env` [<options>] [<formula>] [<formula> ...]
 
         Summarise Homebrew's build environment as a plain list.
 

--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -12,7 +12,7 @@ module Homebrew
   def __prefix_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `--prefix` [<formula>]
+        `--prefix` [<formula>] [<formula> ...]
 
         Display Homebrew's install path. *Default:*
 

--- a/Library/Homebrew/cmd/--repository.rb
+++ b/Library/Homebrew/cmd/--repository.rb
@@ -12,7 +12,7 @@ module Homebrew
   def __repository_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `--repository`, `--repo` [<user>`/`<repo>]
+        `--repository`, `--repo` [<user>`/`<repo>] [<user>`/`<repo> ...]
 
         Display where Homebrew's `.git` directory is located.
 

--- a/Library/Homebrew/cmd/cleanup.rb
+++ b/Library/Homebrew/cmd/cleanup.rb
@@ -14,7 +14,7 @@ module Homebrew
     Homebrew::CLI::Parser.new do
       days = Homebrew::EnvConfig::ENVS[:HOMEBREW_CLEANUP_MAX_AGE_DAYS][:default]
       usage_banner <<~EOS
-        `cleanup` [<options>] [<formula>|<cask>]
+        `cleanup` [<options>] [<formula>|<cask>] [<formula>|<cask> ...]
 
         Remove stale lock files and outdated downloads for all formulae and casks,
         and remove old versions of installed formulae. If arguments are specified,

--- a/Library/Homebrew/cmd/deps.rb
+++ b/Library/Homebrew/cmd/deps.rb
@@ -18,7 +18,7 @@ module Homebrew
   def deps_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `deps` [<options>] [<formula>]
+        `deps` [<options>] [<formula>] [<formula> ...]
 
         Show dependencies for <formula>. Additional options specific to <formula>
         may be appended to the command. When given multiple formula arguments,

--- a/Library/Homebrew/cmd/desc.rb
+++ b/Library/Homebrew/cmd/desc.rb
@@ -17,7 +17,7 @@ module Homebrew
   def desc_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `desc` [<options>] (<text>|`/`<text>`/`|<formula>)
+        `desc` [<options>] <text>|`/`<text>`/`|<formula> [<text>|`/`<text>`/`|<formula> ...]
 
         Display <formula>'s name and one-line description.
         Formula descriptions are cached; the cache is created on the
@@ -35,7 +35,7 @@ module Homebrew
 
       conflicts "--search", "--name", "--description"
 
-      named_args :formula
+      named_args :formula, min: 1
     end
   end
 
@@ -51,14 +51,10 @@ module Homebrew
     end
 
     results = if search_type.nil?
-      raise FormulaUnspecifiedError if args.no_named?
-
       desc = {}
       args.named.to_formulae.each { |f| desc[f.full_name] = f.desc }
       Descriptions.new(desc)
     else
-      raise UsageError, "this command requires a search term" if args.no_named?
-
       query = args.named.join(" ")
       string_or_regex = query_regexp(query)
       CacheStoreDatabase.use(:descriptions) do |db|

--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -17,7 +17,7 @@ module Homebrew
   def fetch_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `fetch` [<options>] <formula>
+        `fetch` [<options>] <formula>|<cask> [<formula>|<cask> ...]
 
         Download a bottle (if available) or source packages for <formula>e
         and binaries for <cask>s. For files, also print SHA-256 checksums.

--- a/Library/Homebrew/cmd/home.rb
+++ b/Library/Homebrew/cmd/home.rb
@@ -13,7 +13,7 @@ module Homebrew
   def home_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `home` [<formula>|<cask>]
+        `home` [<formula>|<cask>] [<formula>|<cask> ...]
 
         Open a <formula> or <cask>'s homepage in a browser, or open
         Homebrew's own homepage if no argument is provided.

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -25,7 +25,7 @@ module Homebrew
   def info_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `info` [<options>] [<formula>|<cask>]
+        `info` [<options>] [<formula>|<cask>] [<formula>|<cask> ...]
 
         Display brief statistics for your Homebrew installation.
 

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -24,7 +24,7 @@ module Homebrew
   def install_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `install` [<options>] <formula>|<cask>
+        `install` [<options>] <formula>|<cask> [<formula>|<cask> ...]
 
         Install a <formula> or <cask>. Additional options specific to a <formula> may be
         appended to the command.

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -15,7 +15,7 @@ module Homebrew
   def link_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `link`, `ln` [<options>] <formula>
+        `link`, `ln` [<options>] <formula> [<formula> ...]
 
         Symlink all of <formula>'s installed files into Homebrew's prefix. This
         is done automatically when you install formulae but can be useful for DIY

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -15,7 +15,7 @@ module Homebrew
   def list_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `list`, `ls` [<options>] [<formula>|<cask>]
+        `list`, `ls` [<options>] [<formula>|<cask>] [<formula>|<cask> ...]
 
         List all installed formulae and casks.
 

--- a/Library/Homebrew/cmd/migrate.rb
+++ b/Library/Homebrew/cmd/migrate.rb
@@ -13,7 +13,7 @@ module Homebrew
   def migrate_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `migrate` [<options>] <formula>
+        `migrate` [<options>] <formula> [<formula> ...]
 
         Migrate renamed packages to new names, where <formula> are old names of
         packages.

--- a/Library/Homebrew/cmd/missing.rb
+++ b/Library/Homebrew/cmd/missing.rb
@@ -15,7 +15,7 @@ module Homebrew
   def missing_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `missing` [<options>] [<formula>]
+        `missing` [<options>] [<formula>] [<formula> ...]
 
         Check the given <formula> kegs for missing dependencies. If no <formula> are
         provided, check all kegs. Will exit with a non-zero status if any kegs are found

--- a/Library/Homebrew/cmd/options.rb
+++ b/Library/Homebrew/cmd/options.rb
@@ -15,7 +15,7 @@ module Homebrew
   def options_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `options` [<options>] [<formula>]
+        `options` [<options>] [<formula>] [<formula> ...]
 
         Show install options specific to <formula>.
       EOS

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -16,7 +16,7 @@ module Homebrew
   def outdated_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `outdated` [<options>] [<formula>|<cask>]
+        `outdated` [<options>] [<formula>|<cask>] [<formula>|<cask> ...]
 
         List installed casks and formulae that have an updated version available. By default, version
         information is displayed in interactive shells, and suppressed otherwise.

--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -13,7 +13,7 @@ module Homebrew
   def pin_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `pin` <formula>
+        `pin` <formula> [<formula> ...]
 
         Pin the specified <formula>, preventing them from being upgraded when
         issuing the `brew upgrade` <formula> command. See also `unpin`.

--- a/Library/Homebrew/cmd/postinstall.rb
+++ b/Library/Homebrew/cmd/postinstall.rb
@@ -14,7 +14,7 @@ module Homebrew
   def postinstall_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `postinstall` <formula>
+        `postinstall` <formula> [<formula> ...]
 
         Rerun the post-install steps for <formula>.
       EOS

--- a/Library/Homebrew/cmd/readall.rb
+++ b/Library/Homebrew/cmd/readall.rb
@@ -13,7 +13,7 @@ module Homebrew
   def readall_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `readall` [<options>] [<tap>]
+        `readall` [<options>] [<tap>] [<tap> ...]
 
         Import all items from the specified <tap>, or from all installed taps if none is provided.
         This can be useful for debugging issues across all items when making

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -22,7 +22,7 @@ module Homebrew
   def reinstall_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `reinstall` [<options>] <formula>|<cask>
+        `reinstall` [<options>] <formula>|<cask> [<formula>|<cask> ...]
 
         Uninstall and then reinstall a <formula> or <cask> using the same options it was
         originally installed with, plus any appended options specific to a <formula>.

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -31,7 +31,7 @@ module Homebrew
   def search_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `search` [<options>] [<text>|`/`<text>`/`]
+        `search` [<options>] [<text>|`/`<text>`/`] [<text>|`/`<text>`/` ...]
 
         Perform a substring search of cask tokens and formula names for <text>. If <text>
         is flanked by slashes, it is interpreted as a regular expression.

--- a/Library/Homebrew/cmd/switch.rb
+++ b/Library/Homebrew/cmd/switch.rb
@@ -19,7 +19,7 @@ module Homebrew
         Symlink all of the specified <version> of <formula>'s installation into Homebrew's prefix.
       EOS
 
-      named 2
+      named_args number: 2
       hide_from_man_page!
     end
   end

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -12,7 +12,7 @@ module Homebrew
   def tap_info_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `tap-info` [<options>] [<tap>]
+        `tap-info` [<options>] [<tap>] [<tap> ...]
 
         Show detailed information about one or more <tap>s.
 

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -19,7 +19,7 @@ module Homebrew
   def uninstall_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `uninstall`, `rm`, `remove` [<options>] <formula>|<cask>
+        `uninstall`, `rm`, `remove` [<options>] <formula>|<cask> [<formula>|<cask> ...]
 
         Uninstall a <formula> or <cask>.
       EOS

--- a/Library/Homebrew/cmd/unlink.rb
+++ b/Library/Homebrew/cmd/unlink.rb
@@ -14,7 +14,7 @@ module Homebrew
   def unlink_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `unlink` [<options>] <formula>
+        `unlink` [<options>] <formula> [<formula> ...]
 
         Remove symlinks for <formula> from Homebrew's prefix. This can be useful
         for temporarily disabling a formula:

--- a/Library/Homebrew/cmd/unpin.rb
+++ b/Library/Homebrew/cmd/unpin.rb
@@ -13,7 +13,7 @@ module Homebrew
   def unpin_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `unpin` <formula>
+        `unpin` <formula> [<formula> ...]
 
         Unpin <formula>, allowing them to be upgraded by `brew upgrade` <formula>.
         See also `pin`.

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -12,7 +12,7 @@ module Homebrew
   def untap_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `untap` <tap>
+        `untap` <tap> [<tap> ...]
 
         Remove a tapped formula repository.
       EOS

--- a/Library/Homebrew/cmd/update-reset.sh
+++ b/Library/Homebrew/cmd/update-reset.sh
@@ -1,4 +1,4 @@
-#:  * `update-reset` [<repository>]
+#:  * `update-reset` [<repository>] [<repository> ...]
 #:
 #:  Fetch and reset Homebrew and all tap repositories (or any specified <repository>) using `git`(1) to their latest `origin/master`.
 #:

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -18,7 +18,7 @@ module Homebrew
   def upgrade_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `upgrade` [<options>] [<formula>|<cask>]
+        `upgrade` [<options>] [<formula>|<cask>] [<formula>|<cask> ...]
 
         Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally
         installed with, plus any appended brew formula options. If <cask> or <formula> are specified,

--- a/Library/Homebrew/cmd/uses.rb
+++ b/Library/Homebrew/cmd/uses.rb
@@ -21,7 +21,7 @@ module Homebrew
   def uses_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `uses` [<options>] <formula>
+        `uses` [<options>] <formula> [<formula> ...]
 
         Show formulae and casks that specify <formula> as a dependency (i.e. show dependents
         of <formula>). When given multiple formula arguments, show the intersection

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -50,7 +50,7 @@ module Homebrew
   def bottle_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `bottle` [<options>] <formula>
+        `bottle` [<options>] <formula> [<formula> ...]
 
         Generate a bottle (binary package) from a formula that was installed with
         `--build-bottle`.

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -18,7 +18,7 @@ module Homebrew
   def self.bump_unversioned_casks_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `bump-unversioned-casks` [<options>] [<cask>|<tap>]
+        `bump-unversioned-casks` [<options>] <cask>|<tap> [<cask>|<tap> ...]
 
         Check all casks with unversioned URLs in a given <tap> for updates.
       EOS

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -12,7 +12,7 @@ module Homebrew
   def bump_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `bump` [<options>] [<formula>]
+        `bump` [<options>] [<formula>] [<formula> ...]
 
         Display out-of-date brew formulae and the latest version available.
         Also displays whether a pull request has been opened with the URL.

--- a/Library/Homebrew/dev-cmd/command.rb
+++ b/Library/Homebrew/dev-cmd/command.rb
@@ -13,7 +13,7 @@ module Homebrew
   def command_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `command` <cmd>
+        `command` <cmd> [<cmd> ...]
 
         Display the path to the file being used when invoking `brew` <cmd>.
       EOS

--- a/Library/Homebrew/dev-cmd/edit.rb
+++ b/Library/Homebrew/dev-cmd/edit.rb
@@ -13,7 +13,7 @@ module Homebrew
   def edit_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `edit` [<formula>|<cask>]
+        `edit` [<formula>|<cask>] [<formula>|<cask> ...]
 
         Open a <formula> or <cask> in the editor set by `EDITOR` or `HOMEBREW_EDITOR`,
         or open the Homebrew repository for editing if no formula is provided.

--- a/Library/Homebrew/dev-cmd/formula.rb
+++ b/Library/Homebrew/dev-cmd/formula.rb
@@ -13,7 +13,7 @@ module Homebrew
   def formula_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `formula` <formula>
+        `formula` <formula> [<formula> ...]
 
         Display the path where <formula> is located.
       EOS

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -34,6 +34,8 @@ module Homebrew
       switch "--pry",
              env:         :pry,
              description: "Use Pry instead of IRB. Implied if `HOMEBREW_PRY` is set."
+
+      named_args :none
     end
   end
 

--- a/Library/Homebrew/dev-cmd/irb.rb
+++ b/Library/Homebrew/dev-cmd/irb.rb
@@ -34,8 +34,6 @@ module Homebrew
       switch "--pry",
              env:         :pry,
              description: "Use Pry instead of IRB. Implied if `HOMEBREW_PRY` is set."
-
-      named_args :none
     end
   end
 

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -14,7 +14,7 @@ module Homebrew
   def linkage_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `linkage` [<options>] [<formula>]
+        `linkage` [<options>] [<formula>] [<formula> ...]
 
         Check the library links from the given <formula> kegs. If no <formula> are
         provided, check all kegs. Raises an error if run on uninstalled formulae.

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -20,7 +20,7 @@ module Homebrew
   def livecheck_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `livecheck` [<formulae>|<casks>]
+        `livecheck` [<formula>|<cask>] [<formula>|<cask> ...]
 
         Check for newer versions of formulae and/or casks from upstream.
 

--- a/Library/Homebrew/dev-cmd/mirror.rb
+++ b/Library/Homebrew/dev-cmd/mirror.rb
@@ -13,7 +13,7 @@ module Homebrew
   def mirror_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `mirror` <formula>
+        `mirror` <formula> [<formula> ...]
 
         Reupload the stable URL of a formula to Bintray for use as a mirror.
       EOS

--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -29,7 +29,7 @@ module Homebrew
       flag   "--workflow=",
              description: "Target workflow filename (default: `publish-commit-bottles.yml`)."
 
-      named_args number: 1
+      named_args min: 1
     end
   end
 

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -71,7 +71,7 @@ module Homebrew
 
       conflicts "--clean", "--autosquash"
 
-      named_args number: 1
+      named_args min: 1
     end
   end
 

--- a/Library/Homebrew/dev-cmd/style.rb
+++ b/Library/Homebrew/dev-cmd/style.rb
@@ -15,7 +15,7 @@ module Homebrew
   def style_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `style` [<options>] [<file>|<tap>|<formula>]
+        `style` [<options>] [<file>|<tap>|<formula>|<cask>] [<file>|<tap>|<formula>|<cask> ...]
 
         Check formulae or files for conformance to Homebrew style guidelines.
 

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -15,7 +15,7 @@ module Homebrew
   def test_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `test` [<options>] <formula>
+        `test` [<options>] <formula> [<formula> ...]
 
         Run the test method provided by an installed formula.
         There is no standard output or return code, but generally it should notify the

--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -13,7 +13,7 @@ module Homebrew
   def unbottled_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `unbottled` [<formula>]
+        `unbottled` [<formula>] [<formula> ...]
 
         Outputs the unbottled dependents of formulae.
       EOS

--- a/Library/Homebrew/dev-cmd/unpack.rb
+++ b/Library/Homebrew/dev-cmd/unpack.rb
@@ -14,7 +14,7 @@ module Homebrew
   def unpack_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `unpack` [<options>] <formula>
+        `unpack` [<options>] <formula> [<formula ...>]
 
         Unpack the source files for <formula> into subdirectories of the current
         working directory.

--- a/Library/Homebrew/dev-cmd/update-python-resources.rb
+++ b/Library/Homebrew/dev-cmd/update-python-resources.rb
@@ -13,7 +13,7 @@ module Homebrew
   def update_python_resources_args
     Homebrew::CLI::Parser.new do
       usage_banner <<~EOS
-        `update-python-resources` [<options>] <formula>
+        `update-python-resources` [<options>] <formula> [<formula> ...]
 
         Update versions for PyPI resource blocks in <formula>.
       EOS
@@ -34,7 +34,7 @@ module Homebrew
       comma_array "--exclude-packages=",
                   description: "Exclude these packages when finding resources."
 
-      named_args :formula, number: 1
+      named_args :formula, min: 1
     end
   end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -69,7 +69,7 @@ Uninstall formulae that were only installed as a dependency of another formula a
 
 List all locally installable casks including short names.
 
-### `cleanup` [*`options`*] [*`formula`*|*`cask`*]
+### `cleanup` [*`options`*] [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 Remove stale lock files and outdated downloads for all formulae and casks,
 and remove old versions of installed formulae. If arguments are specified,
@@ -110,7 +110,7 @@ Read more at <https://docs.brew.sh/Shell-Completion>.
 Show Homebrew and system configuration info useful for debugging. If you file
 a bug report, you will be required to provide this information.
 
-### `deps` [*`options`*] [*`formula`*]
+### `deps` [*`options`*] [*`formula`*] [*`formula`* ...]
 
 Show dependencies for *`formula`*. Additional options specific to *`formula`*
 may be appended to the command. When given multiple formula arguments,
@@ -149,7 +149,7 @@ show the intersection of dependencies for each formula.
 * `--cask`:
   Treat all named arguments as casks.
 
-### `desc` [*`options`*] (*`text`*|`/`*`text`*`/`|*`formula`*)
+### `desc` [*`options`*] *`text`*|`/`*`text`*`/`|*`formula`* [*`text`*|`/`*`text`*`/`|*`formula`* ...]
 
 Display *`formula`*'s name and one-line description.
 Formula descriptions are cached; the cache is created on the
@@ -175,7 +175,7 @@ an issue; just ignore this.
 * `-D`, `--audit-debug`:
   Enable debugging and profiling of audit methods.
 
-### `fetch` [*`options`*] *`formula`*
+### `fetch` [*`options`*] *`formula`*|*`cask`* [*`formula`*|*`cask`* ...]
 
 Download a bottle (if available) or source packages for *`formula`*e
 and binaries for *`cask`*s. For files, also print SHA-256 checksums.
@@ -219,7 +219,7 @@ error message if no logs are found.
 * `-p`, `--private`:
   The Gist will be marked private and will not appear in listings but will be accessible with its link.
 
-### `home` [*`formula`*|*`cask`*]
+### `home` [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 Open a *`formula`* or *`cask`*'s homepage in a browser, or open
 Homebrew's own homepage if no argument is provided.
@@ -229,7 +229,7 @@ Homebrew's own homepage if no argument is provided.
 * `--cask`:
   Treat all named arguments as casks.
 
-### `info` [*`options`*] [*`formula`*|*`cask`*]
+### `info` [*`options`*] [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 Display brief statistics for your Homebrew installation.
 
@@ -256,7 +256,7 @@ If a *`formula`* or *`cask`* is provided, show summary of information about it.
 * `--cask`:
   Treat all named arguments as casks.
 
-### `install` [*`options`*] *`formula`*|*`cask`*
+### `install` [*`options`*] *`formula`*|*`cask`* [*`formula`*|*`cask`* ...]
 
 Install a *`formula`* or *`cask`*. Additional options specific to a *`formula`* may be
 appended to the command.
@@ -317,7 +317,7 @@ the installed formulae or, every 30 days, for all formulae.
 
 List installed formulae that are not dependencies of another installed formula.
 
-### `link`, `ln` [*`options`*] *`formula`*
+### `link`, `ln` [*`options`*] *`formula`* [*`formula`* ...]
 
 Symlink all of *`formula`*'s installed files into Homebrew's prefix. This
 is done automatically when you install formulae but can be useful for DIY
@@ -330,7 +330,7 @@ installations.
 * `-f`, `--force`:
   Allow keg-only formulae to be linked.
 
-### `list`, `ls` [*`options`*] [*`formula`*|*`cask`*]
+### `list`, `ls` [*`options`*] [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 List all installed formulae and casks.
 
@@ -374,7 +374,7 @@ if no formula is provided.
 * `-n`, `--max-count`:
   Print only a specified number of commits.
 
-### `migrate` [*`options`*] *`formula`*
+### `migrate` [*`options`*] *`formula`* [*`formula`* ...]
 
 Migrate renamed packages to new names, where *`formula`* are old names of
 packages.
@@ -382,7 +382,7 @@ packages.
 * `-f`, `--force`:
   Treat installed *`formula`* and provided *`formula`* as if they are from the same taps and migrate them anyway.
 
-### `missing` [*`options`*] [*`formula`*]
+### `missing` [*`options`*] [*`formula`*] [*`formula`* ...]
 
 Check the given *`formula`* kegs for missing dependencies. If no *`formula`* are
 provided, check all kegs. Will exit with a non-zero status if any kegs are found
@@ -391,7 +391,7 @@ to be missing dependencies.
 * `--hide`:
   Act as if none of the specified *`hidden`* are installed. *`hidden`* should be a comma-separated list of formulae.
 
-### `options` [*`options`*] [*`formula`*]
+### `options` [*`options`*] [*`formula`*] [*`formula`* ...]
 
 Show install options specific to *`formula`*.
 
@@ -404,7 +404,7 @@ Show install options specific to *`formula`*.
 * `--command`:
   Show options for the specified *`command`*.
 
-### `outdated` [*`options`*] [*`formula`*|*`cask`*]
+### `outdated` [*`options`*] [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 List installed casks and formulae that have an updated version available. By default, version
 information is displayed in interactive shells, and suppressed otherwise.
@@ -424,16 +424,16 @@ information is displayed in interactive shells, and suppressed otherwise.
 * `--greedy`:
   Print outdated casks with `auto_updates` or `version :latest`.
 
-### `pin` *`formula`*
+### `pin` *`formula`* [*`formula`* ...]
 
 Pin the specified *`formula`*, preventing them from being upgraded when
 issuing the `brew upgrade` *`formula`* command. See also `unpin`.
 
-### `postinstall` *`formula`*
+### `postinstall` *`formula`* [*`formula`* ...]
 
 Rerun the post-install steps for *`formula`*.
 
-### `readall` [*`options`*] [*`tap`*]
+### `readall` [*`options`*] [*`tap`*] [*`tap`* ...]
 
 Import all items from the specified *`tap`*, or from all installed taps if none is provided.
 This can be useful for debugging issues across all items when making
@@ -445,7 +445,7 @@ all items or checking if any current formulae/casks have Ruby issues.
 * `--syntax`:
   Syntax-check all of Homebrew's Ruby files (if no `*`tap`*` is passed).
 
-### `reinstall` [*`options`*] *`formula`*|*`cask`*
+### `reinstall` [*`options`*] *`formula`*|*`cask`* [*`formula`*|*`cask`* ...]
 
 Uninstall and then reinstall a *`formula`* or *`cask`* using the same options it was
 originally installed with, plus any appended options specific to a *`formula`*.
@@ -482,7 +482,7 @@ reinstalled formulae or, every 30 days, for all formulae.
 * `--skip-cask-deps`:
   Skip installing cask dependencies.
 
-### `search` [*`options`*] [*`text`*|`/`*`text`*`/`]
+### `search` [*`options`*] [*`text`*|`/`*`text`*`/`] [*`text`*|`/`*`text`*`/` ...]
 
 Perform a substring search of cask tokens and formula names for *`text`*. If *`text`*
 is flanked by slashes, it is interpreted as a regular expression.
@@ -550,7 +550,7 @@ using protocols other than HTTPS, e.g. SSH, git, HTTP, FTP(S), rsync.
 * `--list-pinned`:
   List all pinned taps.
 
-### `tap-info` [*`options`*] [*`tap`*]
+### `tap-info` [*`options`*] [*`tap`*] [*`tap`* ...]
 
 Show detailed information about one or more *`tap`*s.
 
@@ -561,7 +561,7 @@ If no *`tap`* names are provided, display brief statistics for all installed tap
 * `--json`:
   Print a JSON representation of *`tap`*. Currently the default and only accepted value for *`version`* is `v1`. See the docs for examples of using the JSON output: <https://docs.brew.sh/Querying-Brew>
 
-### `uninstall`, `rm`, `remove` [*`options`*] *`formula`*|*`cask`*
+### `uninstall`, `rm`, `remove` [*`options`*] *`formula`*|*`cask`* [*`formula`*|*`cask`* ...]
 
 Uninstall a *`formula`* or *`cask`*.
 
@@ -576,7 +576,7 @@ Uninstall a *`formula`* or *`cask`*.
 * `--cask`:
   Treat all named arguments as casks.
 
-### `unlink` [*`options`*] *`formula`*
+### `unlink` [*`options`*] *`formula`* [*`formula`* ...]
 
 Remove symlinks for *`formula`* from Homebrew's prefix. This can be useful
 for temporarily disabling a formula:
@@ -585,12 +585,12 @@ for temporarily disabling a formula:
 * `-n`, `--dry-run`:
   List files which would be unlinked without actually unlinking or deleting any files.
 
-### `unpin` *`formula`*
+### `unpin` *`formula`* [*`formula`* ...]
 
 Unpin *`formula`*, allowing them to be upgraded by `brew upgrade` *`formula`*.
 See also `pin`.
 
-### `untap` *`tap`*
+### `untap` *`tap`* [*`tap`* ...]
 
 Remove a tapped formula repository.
 
@@ -605,13 +605,13 @@ Fetch the newest version of Homebrew and all formulae from GitHub using `git`(1)
 * `-f`, `--force`:
   Always do a slower, full update check (even if unnecessary).
 
-### `update-reset` [*`repository`*]
+### `update-reset` [*`repository`*] [*`repository`* ...]
 
 Fetch and reset Homebrew and all tap repositories (or any specified *`repository`*) using `git`(1) to their latest `origin/master`.
 
 *Note:* this will destroy all your uncommitted or committed changes.
 
-### `upgrade` [*`options`*] [*`formula`*|*`cask`*]
+### `upgrade` [*`options`*] [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally
 installed with, plus any appended brew formula options. If *`cask`* or *`formula`* are specified,
@@ -657,7 +657,7 @@ upgraded formulae or, every 30 days, for all formulae.
 * `--greedy`:
   Also include casks with `auto_updates true` or `version :latest`.
 
-### `uses` [*`options`*] *`formula`*
+### `uses` [*`options`*] *`formula`* [*`formula`* ...]
 
 Show formulae and casks that specify *`formula`* as a dependency (i.e. show dependents
 of *`formula`*). When given multiple formula arguments, show the intersection
@@ -681,7 +681,7 @@ specify *`formula`* as a required or recommended dependency for their stable bui
 * `--cask`:
   Include only casks.
 
-### `--cache` [*`options`*] [*`formula`*|*`cask`*]
+### `--cache` [*`options`*] [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 Display Homebrew's download cache. See also `HOMEBREW_CACHE`.
 
@@ -696,14 +696,14 @@ If *`formula`* is provided, display the file or directory used to cache *`formul
 * `--cask`:
   Only show cache files for casks.
 
-### `--caskroom` [*`cask`*]
+### `--caskroom` [*`cask`*] [*`cask`* ...]
 
 Display Homebrew's Caskroom path.
 
 If *`cask`* is provided, display the location in the Caskroom where *`cask`*
 would be installed, without any sort of versioned directory as the last path.
 
-### `--cellar` [*`formula`*]
+### `--cellar` [*`formula`*] [*`formula`* ...]
 
 Display Homebrew's Cellar path. *Default:* `$(brew --prefix)/Cellar`, or if
 that directory doesn't exist, `$(brew --repository)/Cellar`.
@@ -711,7 +711,7 @@ that directory doesn't exist, `$(brew --repository)/Cellar`.
 If *`formula`* is provided, display the location in the Cellar where *`formula`*
 would be installed, without any sort of versioned directory as the last path.
 
-### `--env` [*`options`*] [*`formula`*]
+### `--env` [*`options`*] [*`formula`*] [*`formula`* ...]
 
 Summarise Homebrew's build environment as a plain list.
 
@@ -723,7 +723,7 @@ the list is formatted for export to `bash`(1) unless `--plain` is passed.
 * `--plain`:
   Generate plain output even when piped.
 
-### `--prefix` [*`formula`*]
+### `--prefix` [*`formula`*] [*`formula`* ...]
 
 Display Homebrew's install path. *Default:*
 
@@ -737,7 +737,7 @@ is or would be installed.
 * `--unbrewed`:
   List files in Homebrew's prefix not installed by Homebrew.
 
-### `--repository`, `--repo` [*`user`*`/`*`repo`*]
+### `--repository`, `--repo` [*`user`*`/`*`repo`*] [*`user`*`/`*`repo`* ...]
 
 Display where Homebrew's `.git` directory is located.
 
@@ -794,7 +794,7 @@ non-zero status if any errors are found.
 * `--token-conflicts`:
   Audit for token conflicts
 
-### `bottle` [*`options`*] *`formula`*
+### `bottle` [*`options`*] *`formula`* [*`formula`* ...]
 
 Generate a bottle (binary package) from a formula that was installed with
 `--build-bottle`.
@@ -821,7 +821,7 @@ value, while `--no-rebuild` will remove it.
 * `--root-url`:
   Use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
 
-### `bump` [*`options`*] [*`formula`*]
+### `bump` [*`options`*] [*`formula`*] [*`formula`* ...]
 
 Display out-of-date brew formulae and the latest version available.
 Also displays whether a pull request has been opened with the URL.
@@ -925,7 +925,7 @@ present, "revision 1" will be added.
 * `--message`:
   Append *`message`* to the default commit message.
 
-### `bump-unversioned-casks` [*`options`*] [*`cask`*|*`tap`*]
+### `bump-unversioned-casks` [*`options`*] *`cask`*|*`tap`* [*`cask`*|*`tap`* ...]
 
 Check all casks with unversioned URLs in a given *`tap`* for updates.
 
@@ -945,7 +945,7 @@ Display the source of a *`formula`* or *`cask`*.
 * `--cask`:
   Treat all named arguments as casks.
 
-### `command` *`cmd`*
+### `command` *`cmd`* [*`cmd`* ...]
 
 Display the path to the file being used when invoking `brew` *`cmd`*.
 
@@ -1009,7 +1009,7 @@ Build bottles for these formulae with GitHub Actions.
 * `--upload`:
   Upload built bottles to Bintray.
 
-### `edit` [*`formula`*|*`cask`*]
+### `edit` [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 Open a *`formula`* or *`cask`* in the editor set by `EDITOR` or `HOMEBREW_EDITOR`,
 or open the Homebrew repository for editing if no formula is provided.
@@ -1032,7 +1032,7 @@ a formula from a tap that is not `homebrew/core` use its fully-qualified form of
 * `-f`, `--force`:
   Overwrite the destination formula if it already exists.
 
-### `formula` *`formula`*
+### `formula` *`formula`* [*`formula`* ...]
 
 Display the path where *`formula`* is located.
 
@@ -1049,7 +1049,7 @@ Enter the interactive Homebrew Ruby shell.
 * `--pry`:
   Use Pry instead of IRB. Implied if `HOMEBREW_PRY` is set.
 
-### `linkage` [*`options`*] [*`formula`*]
+### `linkage` [*`options`*] [*`formula`*] [*`formula`* ...]
 
 Check the library links from the given *`formula`* kegs. If no *`formula`* are
 provided, check all kegs. Raises an error if run on uninstalled formulae.
@@ -1061,7 +1061,7 @@ provided, check all kegs. Raises an error if run on uninstalled formulae.
 * `--cached`:
   Print the cached linkage values stored in `HOMEBREW_CACHE`, set by a previous `brew linkage` run.
 
-### `livecheck` [*`formulae`*|*`casks`*]
+### `livecheck` [*`formula`*|*`cask`*] [*`formula`*|*`cask`* ...]
 
 Check for newer versions of formulae and/or casks from upstream.
 
@@ -1097,7 +1097,7 @@ Generate Homebrew's manpages.
 * `--link`:
   This is now done automatically by `brew update`.
 
-### `mirror` *`formula`*
+### `mirror` *`formula`* [*`formula`* ...]
 
 Reupload the stable URL of a formula to Bintray for use as a mirror.
 
@@ -1252,7 +1252,7 @@ which build systems would not find otherwise.
 
 Print a Markdown summary of Homebrew's GitHub Sponsors, suitable for pasting into a README.
 
-### `style` [*`options`*] [*`file`*|*`tap`*|*`formula`*]
+### `style` [*`options`*] [*`file`*|*`tap`*|*`formula`*|*`cask`*] [*`file`*|*`tap`*|*`formula`*|*`cask`* ...]
 
 Check formulae or files for conformance to Homebrew style guidelines.
 
@@ -1286,7 +1286,7 @@ Generate the template files for a new tap.
 * `--branch`:
   Initialize Git repository with the specified branch name (default: `main`).
 
-### `test` [*`options`*] *`formula`*
+### `test` [*`options`*] *`formula`* [*`formula`* ...]
 
 Run the test method provided by an installed formula.
 There is no standard output or return code, but generally it should notify the
@@ -1341,7 +1341,7 @@ Check for typechecking errors using Sorbet.
 * `--ignore`:
   Ignores input files that contain the given string in their paths (relative to the input path passed to Sorbet).
 
-### `unbottled` [*`formula`*]
+### `unbottled` [*`formula`*] [*`formula`* ...]
 
 Outputs the unbottled dependents of formulae.
 
@@ -1352,7 +1352,7 @@ Outputs the unbottled dependents of formulae.
 * `--total`:
   Output the number of unbottled and total formulae.
 
-### `unpack` [*`options`*] *`formula`*
+### `unpack` [*`options`*] *`formula`* [<formula ...>]
 
 Unpack the source files for *`formula`* into subdirectories of the current
 working directory.
@@ -1373,7 +1373,7 @@ working directory.
 * `--fail-if-not-changed`:
   Return a failing status code if current license data's version is the same as the upstream. This can be used to notify CI when the SPDX license data is out of date.
 
-### `update-python-resources` [*`options`*] *`formula`*
+### `update-python-resources` [*`options`*] *`formula`* [*`formula`* ...]
 
 Update versions for PyPI resource blocks in *`formula`*.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -63,7 +63,7 @@ List what would be uninstalled, but do not actually uninstall anything\.
 .SS "\fBcasks\fR"
 List all locally installable casks including short names\.
 .
-.SS "\fBcleanup\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR]"
+.SS "\fBcleanup\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Remove stale lock files and outdated downloads for all formulae and casks, and remove old versions of installed formulae\. If arguments are specified, only do this for the given formulae and casks\. Removes all downloads more than 120 days old\. This can be adjusted with \fBHOMEBREW_CLEANUP_MAX_AGE_DAYS\fR\.
 .
 .TP
@@ -107,7 +107,7 @@ Control whether Homebrew automatically links external tap shell completion files
 .SS "\fBconfig\fR"
 Show Homebrew and system configuration info useful for debugging\. If you file a bug report, you will be required to provide this information\.
 .
-.SS "\fBdeps\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fBdeps\fR [\fIoptions\fR] [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Show dependencies for \fIformula\fR\. Additional options specific to \fIformula\fR may be appended to the command\. When given multiple formula arguments, show the intersection of dependencies for each formula\.
 .
 .TP
@@ -174,7 +174,7 @@ Treat all named arguments as formulae\.
 \fB\-\-cask\fR
 Treat all named arguments as casks\.
 .
-.SS "\fBdesc\fR [\fIoptions\fR] (\fItext\fR|\fB/\fR\fItext\fR\fB/\fR|\fIformula\fR)"
+.SS "\fBdesc\fR [\fIoptions\fR] \fItext\fR|\fB/\fR\fItext\fR\fB/\fR|\fIformula\fR [\fItext\fR|\fB/\fR\fItext\fR\fB/\fR|\fIformula\fR \.\.\.]"
 Display \fIformula\fR\'s name and one\-line description\. Formula descriptions are cached; the cache is created on the first search, making that search slower than subsequent ones\.
 .
 .TP
@@ -200,7 +200,7 @@ List all audit methods, which can be run individually if provided as arguments\.
 \fB\-D\fR, \fB\-\-audit\-debug\fR
 Enable debugging and profiling of audit methods\.
 .
-.SS "\fBfetch\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBfetch\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR [\fIformula\fR|\fIcask\fR \.\.\.]"
 Download a bottle (if available) or source packages for \fIformula\fRe and binaries for \fIcask\fRs\. For files, also print SHA\-256 checksums\.
 .
 .TP
@@ -265,7 +265,7 @@ Automatically create a new issue in the appropriate GitHub repository after crea
 \fB\-p\fR, \fB\-\-private\fR
 The Gist will be marked private and will not appear in listings but will be accessible with its link\.
 .
-.SS "\fBhome\fR [\fIformula\fR|\fIcask\fR]"
+.SS "\fBhome\fR [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Open a \fIformula\fR or \fIcask\fR\'s homepage in a browser, or open Homebrew\'s own homepage if no argument is provided\.
 .
 .TP
@@ -276,7 +276,7 @@ Treat all named arguments as formulae\.
 \fB\-\-cask\fR
 Treat all named arguments as casks\.
 .
-.SS "\fBinfo\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR]"
+.SS "\fBinfo\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Display brief statistics for your Homebrew installation\.
 .
 .P
@@ -322,7 +322,7 @@ Treat all named arguments as formulae\.
 \fB\-\-cask\fR
 Treat all named arguments as casks\.
 .
-.SS "\fBinstall\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR"
+.SS "\fBinstall\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR [\fIformula\fR|\fIcask\fR \.\.\.]"
 Install a \fIformula\fR or \fIcask\fR\. Additional options specific to a \fIformula\fR may be appended to the command\.
 .
 .P
@@ -427,7 +427,7 @@ Skip installing cask dependencies\.
 .SS "\fBleaves\fR"
 List installed formulae that are not dependencies of another installed formula\.
 .
-.SS "\fBlink\fR, \fBln\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBlink\fR, \fBln\fR [\fIoptions\fR] \fIformula\fR [\fIformula\fR \.\.\.]"
 Symlink all of \fIformula\fR\'s installed files into Homebrew\'s prefix\. This is done automatically when you install formulae but can be useful for DIY installations\.
 .
 .TP
@@ -442,7 +442,7 @@ List files which would be linked or deleted by \fBbrew link \-\-overwrite\fR wit
 \fB\-f\fR, \fB\-\-force\fR
 Allow keg\-only formulae to be linked\.
 .
-.SS "\fBlist\fR, \fBls\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR]"
+.SS "\fBlist\fR, \fBls\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 List all installed formulae and casks\.
 .
 .P
@@ -511,21 +511,21 @@ Print only one commit\.
 \fB\-n\fR, \fB\-\-max\-count\fR
 Print only a specified number of commits\.
 .
-.SS "\fBmigrate\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBmigrate\fR [\fIoptions\fR] \fIformula\fR [\fIformula\fR \.\.\.]"
 Migrate renamed packages to new names, where \fIformula\fR are old names of packages\.
 .
 .TP
 \fB\-f\fR, \fB\-\-force\fR
 Treat installed \fIformula\fR and provided \fIformula\fR as if they are from the same taps and migrate them anyway\.
 .
-.SS "\fBmissing\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fBmissing\fR [\fIoptions\fR] [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Check the given \fIformula\fR kegs for missing dependencies\. If no \fIformula\fR are provided, check all kegs\. Will exit with a non\-zero status if any kegs are found to be missing dependencies\.
 .
 .TP
 \fB\-\-hide\fR
 Act as if none of the specified \fIhidden\fR are installed\. \fIhidden\fR should be a comma\-separated list of formulae\.
 .
-.SS "\fBoptions\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fBoptions\fR [\fIoptions\fR] [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Show install options specific to \fIformula\fR\.
 .
 .TP
@@ -544,7 +544,7 @@ Show options for all available formulae\.
 \fB\-\-command\fR
 Show options for the specified \fIcommand\fR\.
 .
-.SS "\fBoutdated\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR]"
+.SS "\fBoutdated\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 List installed casks and formulae that have an updated version available\. By default, version information is displayed in interactive shells, and suppressed otherwise\.
 .
 .TP
@@ -575,13 +575,13 @@ Fetch the upstream repository to detect if the HEAD installation of the formula 
 \fB\-\-greedy\fR
 Print outdated casks with \fBauto_updates\fR or \fBversion :latest\fR\.
 .
-.SS "\fBpin\fR \fIformula\fR"
+.SS "\fBpin\fR \fIformula\fR [\fIformula\fR \.\.\.]"
 Pin the specified \fIformula\fR, preventing them from being upgraded when issuing the \fBbrew upgrade\fR \fIformula\fR command\. See also \fBunpin\fR\.
 .
-.SS "\fBpostinstall\fR \fIformula\fR"
+.SS "\fBpostinstall\fR \fIformula\fR [\fIformula\fR \.\.\.]"
 Rerun the post\-install steps for \fIformula\fR\.
 .
-.SS "\fBreadall\fR [\fIoptions\fR] [\fItap\fR]"
+.SS "\fBreadall\fR [\fIoptions\fR] [\fItap\fR] [\fItap\fR \.\.\.]"
 Import all items from the specified \fItap\fR, or from all installed taps if none is provided\. This can be useful for debugging issues across all items when making significant changes to \fBformula\.rb\fR, testing the performance of loading all items or checking if any current formulae/casks have Ruby issues\.
 .
 .TP
@@ -592,7 +592,7 @@ Verify any alias symlinks in each tap\.
 \fB\-\-syntax\fR
 Syntax\-check all of Homebrew\'s Ruby files (if no \fB<tap>\fR is passed)\.
 .
-.SS "\fBreinstall\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR"
+.SS "\fBreinstall\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR [\fIformula\fR|\fIcask\fR \.\.\.]"
 Uninstall and then reinstall a \fIformula\fR or \fIcask\fR using the same options it was originally installed with, plus any appended options specific to a \fIformula\fR\.
 .
 .P
@@ -654,7 +654,7 @@ Disable/enable quarantining of downloads (default: enabled)\.
 \fB\-\-skip\-cask\-deps\fR
 Skip installing cask dependencies\.
 .
-.SS "\fBsearch\fR [\fIoptions\fR] [\fItext\fR|\fB/\fR\fItext\fR\fB/\fR]"
+.SS "\fBsearch\fR [\fIoptions\fR] [\fItext\fR|\fB/\fR\fItext\fR\fB/\fR] [\fItext\fR|\fB/\fR\fItext\fR\fB/\fR \.\.\.]"
 Perform a substring search of cask tokens and formula names for \fItext\fR\. If \fItext\fR is flanked by slashes, it is interpreted as a regular expression\. The search for \fItext\fR is extended online to \fBhomebrew/core\fR and \fBhomebrew/cask\fR\.
 .
 .P
@@ -746,7 +746,7 @@ Migrate tapped formulae from symlink\-based to directory\-based structure\.
 \fB\-\-list\-pinned\fR
 List all pinned taps\.
 .
-.SS "\fBtap\-info\fR [\fIoptions\fR] [\fItap\fR]"
+.SS "\fBtap\-info\fR [\fIoptions\fR] [\fItap\fR] [\fItap\fR \.\.\.]"
 Show detailed information about one or more \fItap\fRs\.
 .
 .P
@@ -760,7 +760,7 @@ Show information on each installed tap\.
 \fB\-\-json\fR
 Print a JSON representation of \fItap\fR\. Currently the default and only accepted value for \fIversion\fR is \fBv1\fR\. See the docs for examples of using the JSON output: \fIhttps://docs\.brew\.sh/Querying\-Brew\fR
 .
-.SS "\fBuninstall\fR, \fBrm\fR, \fBremove\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR"
+.SS "\fBuninstall\fR, \fBrm\fR, \fBremove\fR [\fIoptions\fR] \fIformula\fR|\fIcask\fR [\fIformula\fR|\fIcask\fR \.\.\.]"
 Uninstall a \fIformula\fR or \fIcask\fR\.
 .
 .TP
@@ -783,17 +783,17 @@ Treat all named arguments as formulae\.
 \fB\-\-cask\fR
 Treat all named arguments as casks\.
 .
-.SS "\fBunlink\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBunlink\fR [\fIoptions\fR] \fIformula\fR [\fIformula\fR \.\.\.]"
 Remove symlinks for \fIformula\fR from Homebrew\'s prefix\. This can be useful for temporarily disabling a formula: \fBbrew unlink\fR \fIformula\fR \fB&&\fR \fIcommands\fR \fB&& brew link\fR \fIformula\fR
 .
 .TP
 \fB\-n\fR, \fB\-\-dry\-run\fR
 List files which would be unlinked without actually unlinking or deleting any files\.
 .
-.SS "\fBunpin\fR \fIformula\fR"
+.SS "\fBunpin\fR \fIformula\fR [\fIformula\fR \.\.\.]"
 Unpin \fIformula\fR, allowing them to be upgraded by \fBbrew upgrade\fR \fIformula\fR\. See also \fBpin\fR\.
 .
-.SS "\fBuntap\fR \fItap\fR"
+.SS "\fBuntap\fR \fItap\fR [\fItap\fR \.\.\.]"
 Remove a tapped formula repository\.
 .
 .SS "\fBupdate\fR [\fIoptions\fR]"
@@ -811,13 +811,13 @@ Run on auto\-updates (e\.g\. before \fBbrew install\fR)\. Skips some slower step
 \fB\-f\fR, \fB\-\-force\fR
 Always do a slower, full update check (even if unnecessary)\.
 .
-.SS "\fBupdate\-reset\fR [\fIrepository\fR]"
+.SS "\fBupdate\-reset\fR [\fIrepository\fR] [\fIrepository\fR \.\.\.]"
 Fetch and reset Homebrew and all tap repositories (or any specified \fIrepository\fR) using \fBgit\fR(1) to their latest \fBorigin/master\fR\.
 .
 .P
 \fINote:\fR this will destroy all your uncommitted or committed changes\.
 .
-.SS "\fBupgrade\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR]"
+.SS "\fBupgrade\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Upgrade outdated casks and outdated, unpinned formulae using the same options they were originally installed with, plus any appended brew formula options\. If \fIcask\fR or \fIformula\fR are specified, upgrade only the given \fIcask\fR or \fIformula\fR kegs (unless they are pinned; see \fBpin\fR, \fBunpin\fR)\.
 .
 .P
@@ -895,7 +895,7 @@ Skip installing cask dependencies\.
 \fB\-\-greedy\fR
 Also include casks with \fBauto_updates true\fR or \fBversion :latest\fR\.
 .
-.SS "\fBuses\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBuses\fR [\fIoptions\fR] \fIformula\fR [\fIformula\fR \.\.\.]"
 Show formulae and casks that specify \fIformula\fR as a dependency (i\.e\. show dependents of \fIformula\fR)\. When given multiple formula arguments, show the intersection of formulae that use \fIformula\fR\. By default, \fBuses\fR shows all formulae and casks that specify \fIformula\fR as a required or recommended dependency for their stable builds\.
 .
 .TP
@@ -930,7 +930,7 @@ Include only formulae\.
 \fB\-\-cask\fR
 Include only casks\.
 .
-.SS "\fB\-\-cache\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR]"
+.SS "\fB\-\-cache\fR [\fIoptions\fR] [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Display Homebrew\'s download cache\. See also \fBHOMEBREW_CACHE\fR\.
 .
 .P
@@ -952,19 +952,19 @@ Only show cache files for formulae\.
 \fB\-\-cask\fR
 Only show cache files for casks\.
 .
-.SS "\fB\-\-caskroom\fR [\fIcask\fR]"
+.SS "\fB\-\-caskroom\fR [\fIcask\fR] [\fIcask\fR \.\.\.]"
 Display Homebrew\'s Caskroom path\.
 .
 .P
 If \fIcask\fR is provided, display the location in the Caskroom where \fIcask\fR would be installed, without any sort of versioned directory as the last path\.
 .
-.SS "\fB\-\-cellar\fR [\fIformula\fR]"
+.SS "\fB\-\-cellar\fR [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Display Homebrew\'s Cellar path\. \fIDefault:\fR \fB$(brew \-\-prefix)/Cellar\fR, or if that directory doesn\'t exist, \fB$(brew \-\-repository)/Cellar\fR\.
 .
 .P
 If \fIformula\fR is provided, display the location in the Cellar where \fIformula\fR would be installed, without any sort of versioned directory as the last path\.
 .
-.SS "\fB\-\-env\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fB\-\-env\fR [\fIoptions\fR] [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Summarise Homebrew\'s build environment as a plain list\.
 .
 .P
@@ -978,7 +978,7 @@ Generate a list of environment variables for the specified shell, or \fB\-\-shel
 \fB\-\-plain\fR
 Generate plain output even when piped\.
 .
-.SS "\fB\-\-prefix\fR [\fIformula\fR]"
+.SS "\fB\-\-prefix\fR [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Display Homebrew\'s install path\. \fIDefault:\fR
 .
 .IP "\(bu" 4
@@ -999,7 +999,7 @@ If \fIformula\fR is provided, display the location in the Cellar where \fIformul
 \fB\-\-unbrewed\fR
 List files in Homebrew\'s prefix not installed by Homebrew\.
 .
-.SS "\fB\-\-repository\fR, \fB\-\-repo\fR [\fIuser\fR\fB/\fR\fIrepo\fR]"
+.SS "\fB\-\-repository\fR, \fB\-\-repo\fR [\fIuser\fR\fB/\fR\fIrepo\fR] [\fIuser\fR\fB/\fR\fIrepo\fR \.\.\.]"
 Display where Homebrew\'s \fB\.git\fR directory is located\.
 .
 .P
@@ -1085,7 +1085,7 @@ Audit the appcast
 \fB\-\-token\-conflicts\fR
 Audit for token conflicts
 .
-.SS "\fBbottle\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBbottle\fR [\fIoptions\fR] \fIformula\fR [\fIformula\fR \.\.\.]"
 Generate a bottle (binary package) from a formula that was installed with \fB\-\-build\-bottle\fR\. If the formula specifies a rebuild version, it will be incremented in the generated DSL\. Passing \fB\-\-keep\-old\fR will attempt to keep it at its original value, while \fB\-\-no\-rebuild\fR will remove it\.
 .
 .TP
@@ -1124,7 +1124,7 @@ When passed with \fB\-\-write\fR, a new commit will not generated after writing 
 \fB\-\-root\-url\fR
 Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
 .
-.SS "\fBbump\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fBbump\fR [\fIoptions\fR] [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Display out\-of\-date brew formulae and the latest version available\. Also displays whether a pull request has been opened with the URL\.
 .
 .TP
@@ -1279,7 +1279,7 @@ Print what would be done rather than doing it\.
 \fB\-\-message\fR
 Append \fImessage\fR to the default commit message\.
 .
-.SS "\fBbump\-unversioned\-casks\fR [\fIoptions\fR] [\fIcask\fR|\fItap\fR]"
+.SS "\fBbump\-unversioned\-casks\fR [\fIoptions\fR] \fIcask\fR|\fItap\fR [\fIcask\fR|\fItap\fR \.\.\.]"
 Check all casks with unversioned URLs in a given \fItap\fR for updates\.
 .
 .TP
@@ -1305,7 +1305,7 @@ Treat all named arguments as formulae\.
 \fB\-\-cask\fR
 Treat all named arguments as casks\.
 .
-.SS "\fBcommand\fR \fIcmd\fR"
+.SS "\fBcommand\fR \fIcmd\fR [\fIcmd\fR \.\.\.]"
 Display the path to the file being used when invoking \fBbrew\fR \fIcmd\fR\.
 .
 .SS "\fBcreate\fR [\fIoptions\fR] \fIURL\fR"
@@ -1406,7 +1406,7 @@ Dispatch specified workflow (default: \fBdispatch\-build\-bottle\.yml\fR)\.
 \fB\-\-upload\fR
 Upload built bottles to Bintray\.
 .
-.SS "\fBedit\fR [\fIformula\fR|\fIcask\fR]"
+.SS "\fBedit\fR [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Open a \fIformula\fR or \fIcask\fR in the editor set by \fBEDITOR\fR or \fBHOMEBREW_EDITOR\fR, or open the Homebrew repository for editing if no formula is provided\.
 .
 .TP
@@ -1428,7 +1428,7 @@ Extract the specified \fIversion\fR of \fIformula\fR instead of the most recent\
 \fB\-f\fR, \fB\-\-force\fR
 Overwrite the destination formula if it already exists\.
 .
-.SS "\fBformula\fR \fIformula\fR"
+.SS "\fBformula\fR \fIformula\fR [\fIformula\fR \.\.\.]"
 Display the path where \fIformula\fR is located\.
 .
 .SS "\fBinstall\-bundler\-gems\fR"
@@ -1445,7 +1445,7 @@ Show several examples\.
 \fB\-\-pry\fR
 Use Pry instead of IRB\. Implied if \fBHOMEBREW_PRY\fR is set\.
 .
-.SS "\fBlinkage\fR [\fIoptions\fR] [\fIformula\fR]"
+.SS "\fBlinkage\fR [\fIoptions\fR] [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Check the library links from the given \fIformula\fR kegs\. If no \fIformula\fR are provided, check all kegs\. Raises an error if run on uninstalled formulae\.
 .
 .TP
@@ -1460,7 +1460,7 @@ For every library that a keg references, print its dylib path followed by the bi
 \fB\-\-cached\fR
 Print the cached linkage values stored in \fBHOMEBREW_CACHE\fR, set by a previous \fBbrew linkage\fR run\.
 .
-.SS "\fBlivecheck\fR [\fIformulae\fR|\fIcasks\fR]"
+.SS "\fBlivecheck\fR [\fIformula\fR|\fIcask\fR] [\fIformula\fR|\fIcask\fR \.\.\.]"
 Check for newer versions of formulae and/or casks from upstream\.
 .
 .P
@@ -1513,7 +1513,7 @@ Return a failing status code if changes are detected in the manpage outputs\. Th
 \fB\-\-link\fR
 This is now done automatically by \fBbrew update\fR\.
 .
-.SS "\fBmirror\fR \fIformula\fR"
+.SS "\fBmirror\fR \fIformula\fR [\fIformula\fR \.\.\.]"
 Reupload the stable URL of a formula to Bintray for use as a mirror\.
 .
 .TP
@@ -1725,7 +1725,7 @@ Execute commands in a non\-interactive shell\.
 .SS "\fBsponsors\fR"
 Print a Markdown summary of Homebrew\'s GitHub Sponsors, suitable for pasting into a README\.
 .
-.SS "\fBstyle\fR [\fIoptions\fR] [\fIfile\fR|\fItap\fR|\fIformula\fR]"
+.SS "\fBstyle\fR [\fIoptions\fR] [\fIfile\fR|\fItap\fR|\fIformula\fR|\fIcask\fR] [\fIfile\fR|\fItap\fR|\fIformula\fR|\fIcask\fR \.\.\.]"
 Check formulae or files for conformance to Homebrew style guidelines\.
 .
 .P
@@ -1774,7 +1774,7 @@ Label name for pull requests ready to be pulled (default: \fBpr\-pull\fR)\.
 \fB\-\-branch\fR
 Initialize Git repository with the specified branch name (default: \fBmain\fR)\.
 .
-.SS "\fBtest\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBtest\fR [\fIoptions\fR] \fIformula\fR [\fIformula\fR \.\.\.]"
 Run the test method provided by an installed formula\. There is no standard output or return code, but generally it should notify the user if something is wrong with the installed formula\.
 .
 .P
@@ -1858,7 +1858,7 @@ Typecheck a single file\.
 \fB\-\-ignore\fR
 Ignores input files that contain the given string in their paths (relative to the input path passed to Sorbet)\.
 .
-.SS "\fBunbottled\fR [\fIformula\fR]"
+.SS "\fBunbottled\fR [\fIformula\fR] [\fIformula\fR \.\.\.]"
 Outputs the unbottled dependents of formulae\.
 .
 .TP
@@ -1873,7 +1873,7 @@ Don\'t get analytics data and sort by number of dependents instead\.
 \fB\-\-total\fR
 Output the number of unbottled and total formulae\.
 .
-.SS "\fBunpack\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBunpack\fR [\fIoptions\fR] \fIformula\fR [<formula \.\.\.>]</formula>"
 Unpack the source files for \fIformula\fR into subdirectories of the current working directory\.
 .
 .TP
@@ -1899,7 +1899,7 @@ Update SPDX license data in the Homebrew repository\.
 \fB\-\-fail\-if\-not\-changed\fR
 Return a failing status code if current license data\'s version is the same as the upstream\. This can be used to notify CI when the SPDX license data is out of date\.
 .
-.SS "\fBupdate\-python\-resources\fR [\fIoptions\fR] \fIformula\fR"
+.SS "\fBupdate\-python\-resources\fR [\fIoptions\fR] \fIformula\fR [\fIformula\fR \.\.\.]"
 Update versions for PyPI resource blocks in \fIformula\fR\.
 .
 .TP


### PR DESCRIPTION
Be consistent and indicate in usage banner when a command accepts multiple named args.
It was already done for a bunch of commands, this PR extends the idea to other commands.

Also fix some commands not accepting multiple named args even though they should and indeed were before.
I think some bugs was introduced in https://github.com/Homebrew/brew/pull/10288, cc @Rylan12

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----