### PR TITLE
cask: add `cpu` stanza to cask DSL

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -60,7 +60,6 @@ module Cask
 
       @dsl.instance_eval(&@block)
       @dsl.language_eval
-      @dsl.cpu_eval
     end
 
     DSL::DSL_METHODS.each do |method_name|

--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -60,6 +60,7 @@ module Cask
 
       @dsl.instance_eval(&@block)
       @dsl.language_eval
+      @dsl.cpu_eval
     end
 
     DSL::DSL_METHODS.each do |method_name|

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -36,6 +36,7 @@ module Cask
     def self.defaults
       {
         languages: LazyObject.new { MacOS.languages },
+        cpu_type: LazyObject.new { Hardware::CPU.type.to_s },
       }.merge(DEFAULT_DIRS).freeze
     end
 
@@ -57,6 +58,7 @@ module Cask
         vst3_plugindir:       args.vst3_plugindir,
         screen_saverdir:      args.screen_saverdir,
         languages:            args.language,
+        cpu_type:             args.cpu_type,
       }.compact)
     end
 
@@ -165,6 +167,16 @@ module Cask
 
     def languages=(languages)
       explicit[:languages] = languages
+    end
+
+    sig { returns(Symbol) }
+    def cpu_type
+      (explicit[:cpu_type] || env[:cpu_type] || default[:cpu_type]).to_sym
+    end
+
+    sig { params(cpu_type: Symbol).void }
+    def cpu_type=(cpu_type)
+      explicit[:cpu_type] = cpu_type.to_s
     end
 
     DEFAULT_DIRS.each_key do |dir|

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -58,7 +58,6 @@ module Cask
         vst3_plugindir:       args.vst3_plugindir,
         screen_saverdir:      args.screen_saverdir,
         languages:            args.language,
-        cpu_type:             args.cpu_type,
       }.compact)
     end
 
@@ -171,7 +170,7 @@ module Cask
 
     sig { returns(Symbol) }
     def cpu_type
-      (explicit[:cpu_type] || env[:cpu_type] || default[:cpu_type]).to_sym
+      T.cast(explicit[:cpu_type] || env[:cpu_type] || default[:cpu_type], String).to_sym
     end
 
     sig { params(cpu_type: Symbol).void }

--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -36,7 +36,7 @@ module Cask
     def self.defaults
       {
         languages: LazyObject.new { MacOS.languages },
-        cpu_type: LazyObject.new { Hardware::CPU.type.to_s },
+        cpu_type:  LazyObject.new { Hardware::CPU.type.to_s },
       }.merge(DEFAULT_DIRS).freeze
     end
 

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -179,26 +179,17 @@ module Cask
     end
 
     def cpu(arg = nil, &block)
-      return cpu_eval if arg.nil?
+      return @cpu if arg.nil?
+
       raise CaskInvalidError.new(cask, "No block given to cpu stanza.") if block.nil?
 
-      @cpu_blocks ||= {}
-      @cpu_blocks[arg] = block
+      cpus << arg
 
-      cpu_eval if arg == Hardware::CPU.type
-    end
-
-    def cpu_eval
-      return @cpu_eval if defined?(@cpu_eval)
-      return @cpu_eval = nil if @cpu_blocks.blank?
-
-      @cpu_eval = @cpu_blocks[Hardware::CPU.type]&.call
+      @cpu = yield if arg == Hardware::CPU.type
     end
 
     def cpus
-      return [] if @cpu_blocks.nil?
-
-      @cpu_blocks.keys
+      @cpus ||= []
     end
 
     def url(*args, **options)

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -184,6 +184,8 @@ module Cask
 
       @cpu_blocks ||= {}
       @cpu_blocks[arg] = block
+
+      cpu_eval if arg == Hardware::CPU.type
     end
 
     def cpu_eval

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -75,6 +75,8 @@ module Cask
                             :homepage,
                             :language,
                             :languages,
+                            :cpu,
+                            :cpus,
                             :name,
                             :sha256,
                             :staged_path,
@@ -174,6 +176,27 @@ module Cask
       return [] if @language_blocks.nil?
 
       @language_blocks.keys.flatten
+    end
+
+    def cpu(arg = nil, &block)
+      return cpu_eval if arg.nil?
+      raise CaskInvalidError.new(cask, "No block given to cpu stanza.") if block.nil?
+
+      @cpu_blocks ||= {}
+      @cpu_blocks[arg] = block
+    end
+
+    def cpu_eval
+      return @cpu_eval if defined?(@cpu_eval)
+      return @cpu_eval = nil if @cpu_blocks.blank?
+
+      @cpu_eval = @cpu_blocks[Hardware::CPU.type]&.call
+    end
+
+    def cpus
+      return [] if @cpu_blocks.nil?
+
+      @cpu_blocks.keys
     end
 
     def url(*args, **options)

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -185,7 +185,7 @@ module Cask
 
       cpus << arg
 
-      @cpu = yield if arg == Hardware::CPU.type
+      @cpu = yield if arg == cask.config.cpu_type
     end
 
     def cpus

--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -76,7 +76,7 @@ module Cask
                             :language,
                             :languages,
                             :cpu,
-                            :cpus,
+                            :cpu_types,
                             :name,
                             :sha256,
                             :staged_path,
@@ -183,13 +183,13 @@ module Cask
 
       raise CaskInvalidError.new(cask, "No block given to cpu stanza.") if block.nil?
 
-      cpus << arg
+      cpu_types << arg
 
       @cpu = yield if arg == cask.config.cpu_type
     end
 
-    def cpus
-      @cpus ||= []
+    def cpu_types
+      @cpu_types ||= []
     end
 
     def url(*args, **options)

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -117,7 +117,7 @@ module Homebrew
       if new_version.latest?
         opoo "Ignoring specified --sha256= argument." if new_hash.present?
         new_hash = :no_check
-      elsif new_hash.nil? || cask.languages.present? || cask.cpus.present?
+      elsif new_hash.nil? || cask.languages.present? || cask.cpu_types.present?
         tmp_contents = Utils::Inreplace.inreplace_pairs(cask.sourcefile_path,
                                                         replacement_pairs.uniq.compact,
                                                         read_only_run: true,
@@ -152,10 +152,10 @@ module Homebrew
           ]
         end
 
-        cask.cpus.each do |cpu|
-          next if cpu == cask.cpu
+        cask.cpu_types.each do |cpu_type|
+          next if cpu_type == cask.cpu
 
-          cpu_config = tmp_config.merge(Cask::Config.new(explicit: { cpu_type: cpu.to_s }))
+          cpu_config = tmp_config.merge(Cask::Config.new(explicit: { cpu_type: cpu_type.to_s }))
           cpu_cask = Cask::CaskLoader.load(tmp_contents)
           cpu_cask.config = cpu_config
           cpu_url = cpu_cask.url.to_s

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -131,7 +131,7 @@ describe Cask::DSL, :cask do
   describe "language stanza" do
     context "when language is set explicitly" do
       subject(:cask) {
-        Cask::Cask.new("cask-with-apps") do
+        Cask::Cask.new("cask-with-languages") do
           language "zh" do
             sha256 "abc123"
             "zh-CN"
@@ -207,7 +207,7 @@ describe Cask::DSL, :cask do
 
     it "returns an empty array if no languages are specified" do
       cask = lambda do
-        Cask::Cask.new("cask-with-apps") do
+        Cask::Cask.new("cask-without-languages") do
           url "https://example.org/file.zip"
         end
       end
@@ -217,7 +217,7 @@ describe Cask::DSL, :cask do
 
     it "returns an array of available languages" do
       cask = lambda do
-        Cask::Cask.new("cask-with-apps") do
+        Cask::Cask.new("cask-with-languages") do
           language "zh" do
             sha256 "abc123"
             "zh-CN"
@@ -275,7 +275,7 @@ describe Cask::DSL, :cask do
 
     context "if no CPUs are specified" do
       subject(:cask) {
-        Cask::Cask.new("cask-with-cpus") do
+        Cask::Cask.new("cask-without-cpus") do
           url "https://example.org/file.zip"
         end
       }

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -255,14 +255,20 @@ describe Cask::DSL, :cask do
       }
 
       it "uses the Intel version when CPU is Intel" do
-        allow(Hardware::CPU).to receive(:type).and_return(:intel)
+        config = cask.config
+        config.cpu_type = :intel
+        cask.config = config
+
         expect(cask.cpu).to eq("x64")
         expect(cask.sha256).to eq("abc123")
         expect(cask.url.to_s).to eq("https://example.org/x64.zip")
       end
 
       it "uses the ARM version when CPU is ARM" do
-        allow(Hardware::CPU).to receive(:type).and_return(:arm)
+        config = cask.config
+        config.cpu_type = :arm
+        cask.config = config
+
         expect(cask.cpu).to eq("arm64")
         expect(cask.sha256).to eq("xyz789")
         expect(cask.url.to_s).to eq("https://example.org/arm64.zip")

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -236,6 +236,56 @@ describe Cask::DSL, :cask do
     end
   end
 
+  describe "cpu stanza" do
+    context "if CPUs are specified" do
+      subject(:cask) {
+        Cask::Cask.new("cask-with-cpus") do
+          cpu :intel do
+            sha256 "abc123"
+            "x64"
+          end
+
+          cpu :arm do
+            sha256 "xyz789"
+            "arm64"
+          end
+
+          url "https://example.org/#{cpu}.zip"
+        end
+      }
+
+      it "uses the Intel version when CPU is Intel" do
+        allow(Hardware::CPU).to receive(:type).and_return(:intel)
+        expect(cask.cpu).to eq("x64")
+        expect(cask.sha256).to eq("abc123")
+        expect(cask.url.to_s).to eq("https://example.org/x64.zip")
+      end
+
+      it "uses the ARM version when CPU is ARM" do
+        allow(Hardware::CPU).to receive(:type).and_return(:arm)
+        expect(cask.cpu).to eq("arm64")
+        expect(cask.sha256).to eq("xyz789")
+        expect(cask.url.to_s).to eq("https://example.org/arm64.zip")
+      end
+
+      it "returns an array of supported CPUs" do
+        expect(cask.cpus).to eq([:intel, :arm])
+      end
+    end
+
+    context "if no CPUs are specified" do
+      subject(:cask) {
+        Cask::Cask.new("cask-with-cpus") do
+          url "https://example.org/file.zip"
+        end
+      }
+
+      it "returns an empty array" do
+        expect(cask.cpus).to be_empty
+      end
+    end
+  end
+
   describe "app stanza" do
     it "allows you to specify app stanzas" do
       cask = Cask::Cask.new("cask-with-apps") do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -236,24 +236,24 @@ describe Cask::DSL, :cask do
     end
   end
 
-  describe "cpu stanza" do
-    context "if CPUs are specified" do
-      subject(:cask) {
-        Cask::Cask.new("cask-with-cpus") do
-          cpu :intel do
-            sha256 "abc123"
-            "x64"
-          end
-
-          cpu :arm do
-            sha256 "xyz789"
-            "arm64"
-          end
-
-          url "https://example.org/#{cpu}.zip"
+  context "if CPUs are specified" do
+    subject(:cask) {
+      Cask::Cask.new("cask-with-cpus") do
+        cpu :intel do
+          sha256 "abc123"
+          "x64"
         end
-      }
 
+        cpu :arm do
+          sha256 "xyz789"
+          "arm64"
+        end
+
+        url "https://example.org/#{cpu}.zip"
+      end
+    }
+
+    describe "#cpu" do
       it "uses the Intel version when CPU is Intel" do
         config = cask.config
         config.cpu_type = :intel
@@ -273,21 +273,31 @@ describe Cask::DSL, :cask do
         expect(cask.sha256).to eq("xyz789")
         expect(cask.url.to_s).to eq("https://example.org/arm64.zip")
       end
+    end
 
+    describe "#cpu_types" do
       it "returns an array of supported CPUs" do
-        expect(cask.cpus).to eq([:intel, :arm])
+        expect(cask.cpu_types).to eq([:intel, :arm])
+      end
+    end
+  end
+
+  context "if no CPUs are specified" do
+    subject(:cask) {
+      Cask::Cask.new("cask-without-cpus") do
+        url "https://example.org/file.zip"
+      end
+    }
+
+    describe "#cpu" do
+      it "returns nil" do
+        expect(cask.cpu).to eq(nil)
       end
     end
 
-    context "if no CPUs are specified" do
-      subject(:cask) {
-        Cask::Cask.new("cask-without-cpus") do
-          url "https://example.org/file.zip"
-        end
-      }
-
+    describe "#cpu_types" do
       it "returns an empty array" do
-        expect(cask.cpus).to be_empty
+        expect(cask.cpu_types).to be_empty
       end
     end
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -853,7 +853,7 @@ supplied by the user.
 * `--no-fork`:
   Don't try to fork the repository.
 * `--version`:
-  Specify the new *`version`* for the cask.
+  Specify the new *`version`* for the cask. If *`version`* is a semicolon-separated list of versions, the corresponding versions will be replaced.
 * `--message`:
   Append *`message`* to the default pull request message.
 * `--url`:

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1171,7 +1171,7 @@ Don\'t try to fork the repository\.
 .
 .TP
 \fB\-\-version\fR
-Specify the new \fIversion\fR for the cask\.
+Specify the new \fIversion\fR for the cask\. If \fIversion\fR is a semicolon\-separated list of versions, the corresponding versions will be replaced\.
 .
 .TP
 \fB\-\-message\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds a new DSL for casks to specify supported CPUs (Intel, ARM, PowerPC), which is useful for `brew bump-cask-pr` in determining new SHA-256 checksums for not just the user's CPU but _all CPUs_

Question: Which term is more accurate (or preferable) for this? "CPU" or "architecture"?

Todo:
- Add audit for valid CPU symbols (`:intel`, `:arm`, `:ppc`)
- Add list of CPUs supported by cask to `brew info` text

(Let me know if I should include any or all of these todos in this PR)

[`macintoshjs`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/macintoshjs.rb) cask converted to use new DSL:

```rb
cask "macintoshjs" do
  version "1.1.0"

  cpu :intel do
    sha256 "4ca41517f15c594e718da622074a2160754cb8f1293cb1fad908f6d0ae585384"
    "x64"
  end

  cpu :arm do
    sha256 "0af95bbcc075f939d6c3e1fdcdab0d8da2760e5546aecfbc82767e326640740c"
    "arm64"
  end

  url "https://github.com/felixrieseberg/macintosh.js/releases/download/v#{version}/macintosh.js-darwin-#{cpu}-#{version}.zip"
  # ...
end
```

[`dosbox-x`](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/dosbox-x.rb) converted to use new DSL:

```rb
cask "dosbox-x" do
  cpu :intel do
    version "0.83.9,20201231203002"
    sha256 "af55d06fb9277c62708b1b8f22bba3d3555744eab759700d0e5e4cd0d439abe5"
    "x86_64"
  end

  cpu :arm do
    version "0.83.9,20201231202930"
    sha256 "cd56080debf70543b030bbe8131fd009caf37c970624be35da76c0ad4d7fca99"
    "arm64"
  end

  url "https://github.com/joncampbell123/dosbox-x/releases/download/dosbox-x-v#{version.before_comma}/dosbox-x-macosx-#{cpu}-#{version.after_comma}.zip",
      verified: "github.com/joncampbell123/dosbox-x/"
  # ...
end
```

Related:
- https://github.com/Homebrew/homebrew-cask-versions/pull/10205#issuecomment-761610485
- https://github.com/Homebrew/discussions/discussions/561