### PR TITLE
git_repository: raise error instead of returning nil if `safe`

### DIFF
--- a/Library/Homebrew/test/utils/git_repository_spec.rb
+++ b/Library/Homebrew/test/utils/git_repository_spec.rb
@@ -17,23 +17,81 @@ describe Utils do
   let(:short_head_revision) { HOMEBREW_CACHE.cd { `git rev-parse --short HEAD`.chomp } }
 
   describe ".git_head" do
-    it "returns the revision at HEAD" do
+    it "returns the revision at HEAD if repo parameter is specified" do
       expect(described_class.git_head(HOMEBREW_CACHE)).to eq(head_revision)
       expect(described_class.git_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
+    end
+
+    it "returns the revision at HEAD if repo parameter is omitted" do
       HOMEBREW_CACHE.cd do
         expect(described_class.git_head).to eq(head_revision)
         expect(described_class.git_head(length: 5)).to eq(head_revision[0...5])
       end
     end
+
+    context "when directory is not a Git repository" do
+      it "returns nil if `safe` parameter is `false`" do
+        expect(described_class.git_head(TEST_TMPDIR, safe: false)).to eq(nil)
+      end
+
+      it "raises an error if `safe` parameter is `true`" do
+        expect { described_class.git_head(TEST_TMPDIR, safe: true) }
+          .to raise_error("Not a Git repository: #{TEST_TMPDIR}")
+      end
+    end
+
+    context "when Git is unavailable" do
+      before do
+        allow(Utils::Git).to receive(:available?).and_return(false)
+      end
+
+      it "returns nil if `safe` parameter is `false`" do
+        expect(described_class.git_head(HOMEBREW_CACHE, safe: false)).to eq(nil)
+      end
+
+      it "raises an error if `safe` parameter is `true`" do
+        expect { described_class.git_head(HOMEBREW_CACHE, safe: true) }
+          .to raise_error("Git is unavailable")
+      end
+    end
   end
 
   describe ".git_short_head" do
-    it "returns the short revision at HEAD" do
+    it "returns the short revision at HEAD if repo parameter is specified" do
       expect(described_class.git_short_head(HOMEBREW_CACHE)).to eq(short_head_revision)
       expect(described_class.git_short_head(HOMEBREW_CACHE, length: 5)).to eq(head_revision[0...5])
+    end
+
+    it "returns the short revision at HEAD if repo parameter is omitted" do
       HOMEBREW_CACHE.cd do
         expect(described_class.git_short_head).to eq(short_head_revision)
         expect(described_class.git_short_head(length: 5)).to eq(head_revision[0...5])
+      end
+    end
+
+    context "when directory is not a Git repository" do
+      it "returns nil if `safe` parameter is `false`" do
+        expect(described_class.git_short_head(TEST_TMPDIR, safe: false)).to eq(nil)
+      end
+
+      it "raises an error if `safe` parameter is `true`" do
+        expect { described_class.git_short_head(TEST_TMPDIR, safe: true) }
+          .to raise_error("Not a Git repository: #{TEST_TMPDIR}")
+      end
+    end
+
+    context "when Git is unavailable" do
+      before do
+        allow(Utils::Git).to receive(:available?).and_return(false)
+      end
+
+      it "returns nil if `safe` parameter is `false`" do
+        expect(described_class.git_short_head(HOMEBREW_CACHE, safe: false)).to eq(nil)
+      end
+
+      it "raises an error if `safe` parameter is `true`" do
+        expect { described_class.git_short_head(HOMEBREW_CACHE, safe: true) }
+          .to raise_error("Git is unavailable")
       end
     end
   end

--- a/Library/Homebrew/utils/git_repository.rb
+++ b/Library/Homebrew/utils/git_repository.rb
@@ -5,7 +5,11 @@ module Utils
   extend T::Sig
 
   sig do
-    params(repo: T.any(String, Pathname), length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String))
+    params(
+      repo:   T.any(String, Pathname),
+      length: T.nilable(Integer),
+      safe:   T::Boolean,
+    ).returns(T.nilable(String))
   end
   def self.git_head(repo = Pathname.pwd, length: nil, safe: true)
     return git_short_head(repo, length: length) if length.present?
@@ -15,7 +19,11 @@ module Utils
   end
 
   sig do
-    params(repo: T.any(String, Pathname), length: T.nilable(Integer), safe: T::Boolean).returns(T.nilable(String))
+    params(
+      repo:   T.any(String, Pathname),
+      length: T.nilable(Integer),
+      safe:   T::Boolean,
+    ).returns(T.nilable(String))
   end
   def self.git_short_head(repo = Pathname.pwd, length: nil, safe: true)
     repo = Pathname(repo).extend(GitRepositoryExtension)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

To imitate `safe_popen_read`, calling `git_head` with a `safe` parameter of `true` should raise an error if the directory is not a Git repository or Git is unavailable