### PR TITLE
fix `brew shellenv` on fish

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -6,7 +6,7 @@
 #:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 homebrew-shellenv() {
-  case "$(/bin/ps -p $PPID -o comm=)" in
+  case "$(/bin/ps -p ${PPID:-$fish_pid} -c -o comm=)" in
     fish|-fish)
       echo "set -gx HOMEBREW_PREFIX \"$HOMEBREW_PREFIX\";"
       echo "set -gx HOMEBREW_CELLAR \"$HOMEBREW_CELLAR\";"

--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -6,7 +6,7 @@
 #:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
 
 homebrew-shellenv() {
-  case "$(/bin/ps -p ${PPID:-$fish_pid} -c -o comm=)" in
+  case "$(/bin/ps -p $PPID -c -o comm=)" in
     fish|-fish)
       echo "set -gx HOMEBREW_PREFIX \"$HOMEBREW_PREFIX\";"
       echo "set -gx HOMEBREW_CELLAR \"$HOMEBREW_CELLAR\";"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? **No. The following (unrelated?) tests failed:**
    - Language::Java::java_home returns valid JAVA_HOME if version is specified
    - Language::Java::java_home returns valid JAVA_HOME if version is not specified
    - brew livecheck gives an error when no arguments are given and there's no watchlist
- [x] Have you successfully run `brew man` locally ~~and committed any changes~~? **No changes.**

-----

`brew shellenv` is currently broken on fish, where it outputs the default syntax for bash/zsh, which includes constructs like `${PATH+:$PATH}` that fish doesn't support.

```
> status fish-path
/usr/local/bin/fish

> eval (brew shellenv)
fish: ${ is not a valid variable in fish.
```

~~The first problem this PR fixes is that the call to `ps` on [line 9 of `shellenv.sh`][L9] ends up using an empty variable.~~

[L9]: https://github.com/Homebrew/brew/blob/8869208/Library/Homebrew/cmd/shellenv.sh#L9

The ~~second~~ problem (potentially also affecting csh & tcsh) is that the `case` statement can never find the bare name of *any* shell (or -name for login shells), because `-o comm=` without `-c` outputs the full path to the command:

```
> /bin/ps -p $fish_pid -o comm=
-/usr/local/bin/fish

> /bin/ps -p $fish_pid -o comm= -c
fish
```

With the change~~s~~ from this PR in place, `brew shellenv` works as expected in fish:

```
> brew shellenv
set -gx HOMEBREW_PREFIX "/usr/local";
set -gx HOMEBREW_CELLAR "/usr/local/Cellar";
set -gx HOMEBREW_REPOSITORY "/usr/local/Homebrew";
set -q PATH; or set PATH ''; set -gx PATH "/usr/local/bin" "/usr/local/sbin" $PATH;
set -q MANPATH; or set MANPATH ''; set -gx MANPATH "/usr/local/share/man" $MANPATH;
set -q INFOPATH; or set INFOPATH ''; set -gx INFOPATH "/usr/local/share/info" $INFOPATH;
```
