### PR TITLE
dev-cmd/man: Completely remove `--link`

### DIFF
--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -28,17 +28,12 @@ module Homebrew
                           "can be used to notify CI when the manpages are out of date. Additionally, "\
                           "the date used in new manpages will match those in the existing manpages (to allow "\
                           "comparison without factoring in the date)."
-      switch "--link",
-             description: "This is now done automatically by `brew update`."
-
       named_args :none
     end
   end
 
   def man
     args = man_args.parse
-
-    odie "`brew man --link` is now done automatically by `brew update`." if args.link?
 
     Commands.rebuild_internal_commands_completion_list
     regenerate_man_pages(preserve_date: args.fail_if_changed?, quiet: args.quiet?)

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1094,8 +1094,6 @@ Generate Homebrew's manpages.
 
 * `--fail-if-changed`:
   Return a failing status code if changes are detected in the manpage outputs. This can be used to notify CI when the manpages are out of date. Additionally, the date used in new manpages will match those in the existing manpages (to allow comparison without factoring in the date).
-* `--link`:
-  This is now done automatically by `brew update`.
 
 ### `mirror` *`formula`* [*`formula`* ...]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1509,10 +1509,6 @@ Generate Homebrew\'s manpages\.
 \fB\-\-fail\-if\-changed\fR
 Return a failing status code if changes are detected in the manpage outputs\. This can be used to notify CI when the manpages are out of date\. Additionally, the date used in new manpages will match those in the existing manpages (to allow comparison without factoring in the date)\.
 .
-.TP
-\fB\-\-link\fR
-This is now done automatically by \fBbrew update\fR\.
-.
 .SS "\fBmirror\fR \fIformula\fR [\fIformula\fR \.\.\.]"
 Reupload the stable URL of a formula to Bintray for use as a mirror\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- This was deprecated in ec75fbc in 2016! 🗝️ 🧓🏻 :dusty_stick: