### PR TITLE
doc/Homebrew-on-Linux: mention SSSE3 recommendation

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -50,7 +50,7 @@ If you're using an older distribution of Linux, installing your first package wi
 + **GCC** 4.7.0 or newer
 + **Linux** 2.6.32 or newer
 + **Glibc** 2.13 or newer
-+ **64-bit x86_64** CPU
++ **64-bit x86_64** CPU; SSSE3 recommended
 
 Paste at a terminal prompt:
 


### PR DESCRIPTION
Without SSSE3 bottled formulae fail with illegal instruction (see various linuxbrew issues and a very poorly toned Homebrew/brew#10347). I am putting it as a "recommendation" because the real check should still be in the unbottle.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
  * What tests?
- [ ] Have you successfully run `brew style` with your changes locally? 
  * What code?
- [ ] Have you successfully run `brew typecheck` with your changes locally? **No change to code**
- [ ] Have you successfully run `brew tests` with your changes locally? **No change to code**
- [ ] Have you successfully run `brew man` locally and committed any changes?
  * No change to CLI.

-----
