### PR TITLE
linux/hardware/cpu: make non-ssse3 x86_64 a separate arch

### DIFF
--- a/Library/Homebrew/extend/os/linux/hardware/cpu.rb
+++ b/Library/Homebrew/extend/os/linux/hardware/cpu.rb
@@ -122,6 +122,27 @@ module Hardware
         flags.include? "sse4_1"
       end
 
+      sig { returns(Symbol) }
+      def arch_64_bit
+        # FIXME: don't duplicate so much code
+        if arm?
+          :arm64
+        elsif intel?
+          # Split the arch into SSSE3-having and not to prevent bottle match
+          if ssse3?
+            :x86_64
+          else
+            :x86_64_no_ssse3
+          end
+        elsif ppc64le?
+          :ppc64le
+        elsif ppc64?
+          :ppc64
+        else
+          :dunno
+        end
+      end
+
       private
 
       def cpuinfo


### PR DESCRIPTION
Homebrew bottle currently defines x86_64 as core2. Reflect the definition in
HW test to block older x86_64 CPUs from loading a bottle.

We could alternatively dial back on the oldest_cpu thing, but rebuilding
all bottles to be slower just for 13-year-old machines is a bit... urgh.
I would rather go Apple on this and say they are simply outdated.

(Or maybe write a whole system of features and architectual compatibility. Not doing it for 13-year-old stuff, again.)

This follows #10354.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
   * It's hard to mock cleanly. I can add one to say ::arch is a symbol if you want it, but not one specifically for ssse3.
   * (More specifically, I don't think qemu-user fakes `cpuinfo`, and you don't want a five-minute test consisting of installing a new linux system.)
- [ ] Have you successfully run `brew style` with your changes locally?
  * gem's slow.
- [ ] Have you successfully run `brew typecheck` with your changes locally?
  * Changed file is untyped. Also, gem's stuck on my end.
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?
  * No change to CLI.
-----
