### PR TITLE
pypi: allow packages in global exclude list if explicitly requested

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -182,6 +182,9 @@ module PyPI
 
     extra_packages = (extra_packages || []).map { |p| Package.new p }
     exclude_packages = (exclude_packages || []).map { |p| Package.new p }
+    exclude_packages += %W[#{main_package.name} argparse pip setuptools wheel wsgiref].map { |p| Package.new p }
+    # remove packages from the exclude list if we've explicitly requested them as an extra package
+    exclude_packages.delete_if { |package| extra_packages.include?(package) }
 
     input_packages = [main_package]
     extra_packages.each do |extra_package|
@@ -222,10 +225,6 @@ module PyPI
     found_packages = JSON.parse(pipgrip_output).to_h.map do |new_name, new_version|
       Package.new("#{new_name}==#{new_version}")
     end
-
-    # Remove extra packages that may be included in pipgrip output
-    exclude_list = %W[#{main_package.name} argparse pip setuptools wheel wsgiref].map { |p| Package.new p }
-    found_packages.delete_if { |package| exclude_list.include? package }
 
     new_resource_blocks = ""
     found_packages.sort.each do |package|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
Some python formulae may require packages that are in the global exclude list to function. Allow them to be added if they're explicitly requested.
