### PR TITLE
rubocop: disallow and/or in favor of &&/||

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -89,6 +89,11 @@ Naming/MethodName:
 Naming/VariableNumber:
   Enabled: false
 
+# Require &&/|| instead of and/or
+Style/AndOr:
+  Enabled: true
+  EnforcedStyle: always
+
 # Avoid leaking resources.
 Style/AutoResourceCleanup:
   Enabled: true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
This enforces usage of `&&` and `||` always.