### PR TITLE
os/mac/version: use named captures in regex

### DIFF
--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -37,13 +37,17 @@ module OS
       def self.version_arch(value)
         @all_archs_regex ||= begin
           all_archs = Hardware::CPU::ALL_ARCHS.map(&:to_s)
-          /^((#{Regexp.union(all_archs)})_)?([\w.]+)(-(#{Regexp.union(all_archs)}))?$/
+          /
+            ^((?<prefix_arch>#{Regexp.union(all_archs)})_)?
+            (?<version>[\w.]+)
+            (-(?<suffix_arch>#{Regexp.union(all_archs)}))?$
+          /x
         end
         match = @all_archs_regex.match(value)
         return [] unless match
 
-        version = match[3]
-        arch = match[2] || match[5]
+        version = match[:version]
+        arch = match[:prefix_arch] || match[:suffix_arch]
         [version, arch]
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This makes it more intuitive to retrieve captures since we can use symbols instead of numbered indexes