### PR TITLE
completions: complete files where appropriate in bash

### DIFF
--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -35,6 +35,7 @@ module Homebrew
       installed_tap:     "__brew_complete_tapped",
       command:           "__brew_complete_commands",
       diagnostic_check:  '__brewcomp "$(brew doctor --list-checks)"',
+      file:              "__brew_complete_files",
     }.freeze
 
     sig { void }

--- a/Library/Homebrew/completions/bash.erb
+++ b/Library/Homebrew/completions/bash.erb
@@ -117,6 +117,11 @@ __brew_complete_commands() {
   COMPREPLY+=($(compgen -W "$cmds" -- "$cur"))
 }
 
+# compopt is only available in newer versions of bash
+__brew_complete_files() {
+  command -v compopt &> /dev/null && compopt -o default
+}
+
 <%= completion_functions.join("\n") %>
 
 _brew() {

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -85,7 +85,7 @@ module Homebrew
 
       conflicts "--no-rebuild", "--keep-old"
 
-      named_args :installed_formula, min: 1
+      named_args [:installed_formula, :file], min: 1
     end
   end
 

--- a/Library/Homebrew/dev-cmd/ruby.rb
+++ b/Library/Homebrew/dev-cmd/ruby.rb
@@ -20,6 +20,8 @@ module Homebrew
            description: "Load a library using `require`."
       flag "-e=",
            description: "Execute the given text string as a script."
+
+      named_args :file
     end
   end
 

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -104,6 +104,11 @@ __brew_complete_commands() {
   COMPREPLY+=($(compgen -W "$cmds" -- "$cur"))
 }
 
+# compopt is only available in newer versions of bash
+__brew_complete_files() {
+  command -v compopt &> /dev/null && compopt -o default
+}
+
 _brew___cache() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
@@ -413,6 +418,7 @@ _brew_bottle() {
       ;;
   esac
   __brew_complete_installed_formulae
+  __brew_complete_files
 }
 
 _brew_bump() {
@@ -1732,6 +1738,7 @@ _brew_ruby() {
       return
       ;;
   esac
+  __brew_complete_files
 }
 
 _brew_search() {
@@ -1776,6 +1783,7 @@ _brew_sh() {
       return
       ;;
   esac
+  __brew_complete_files
 }
 
 _brew_sponsors() {
@@ -1813,6 +1821,7 @@ _brew_style() {
       return
       ;;
   esac
+  __brew_complete_files
   __brew_complete_tapped
   __brew_complete_formulae
   __brew_complete_casks

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -794,7 +794,7 @@ non-zero status if any errors are found.
 * `--token-conflicts`:
   Audit for token conflicts
 
-### `bottle` [*`options`*] *`installed_formula`* [...]
+### `bottle` [*`options`*] *`installed_formula`*|*`file`* [...]
 
 Generate a bottle (binary package) from a formula that was installed with
 `--build-bottle`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1085,7 +1085,7 @@ Audit the appcast
 \fB\-\-token\-conflicts\fR
 Audit for token conflicts
 .
-.SS "\fBbottle\fR [\fIoptions\fR] \fIinstalled_formula\fR [\.\.\.]"
+.SS "\fBbottle\fR [\fIoptions\fR] \fIinstalled_formula\fR|\fIfile\fR [\.\.\.]"
 Generate a bottle (binary package) from a formula that was installed with \fB\-\-build\-bottle\fR\. If the formula specifies a rebuild version, it will be incremented in the generated DSL\. Passing \fB\-\-keep\-old\fR will attempt to keep it at its original value, while \fB\-\-no\-rebuild\fR will remove it\.
 .
 .TP


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is a follow-up to https://github.com/Homebrew/brew/pull/10229 which adds the ability to complete files where appropriate.

A few commands (`bottle`, `ruby`, `sh`, and `style`) accept files as named arguments. This PR will now enable automatic file completion for these commands. Note that this is only available in newer versions of `bash`, so I've added a conditional making the `__brew_complete_files` a no-op unless the `compopt` command exists. I've tested using builtin `/bin/bash` (no `compopt` command so no file completions) and Homebrew's `/usr/local/bin/bash` (with `compopt` and file completions).
