### PR TITLE
utils/github: set default args to search_code

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -7,7 +7,7 @@ describe GitHub do
   describe "::search_code", :needs_network do
     it "queries GitHub code with the passed parameters" do
       results = described_class.search_code(repo: "Homebrew/brew", path: "/",
-                                            filename: "readme", language: "markdown")
+                                            filename: "readme", extension: "md")
 
       expect(results.count).to eq(1)
       expect(results.first["name"]).to eq("README.md")

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -52,8 +52,8 @@ module GitHub
     API.open_rest(url_to("repos", user, repo))
   end
 
-  def search_code(**qualifiers)
-    matches = search("code", **qualifiers)
+  def search_code(repo: nil, user: "Homebrew", path: ["Formula", "Casks", "."], filename: nil, extension: "rb")
+    matches = search("code", user: user, path: path, filename: filename, extension: extension, repo: repo)
     return matches if matches.blank?
 
     matches.map do |match|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
set default args to `def search_code` in `utils/github`