### PR TITLE
Don't tap user-untapped official taps

### DIFF
--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -132,8 +132,7 @@ begin
     possible_tap = OFFICIAL_CMD_TAPS.find { |_, cmds| cmds.include?(cmd) }
     possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
-    untapped_official_taps = Homebrew::Settings.read(:untapped)&.split(";") || []
-    if !possible_tap || possible_tap.installed? || untapped_official_taps.include?(possible_tap.name)
+    if !possible_tap || possible_tap.installed? || Tap.untapped_official_taps.include?(possible_tap.name)
       odie "Unknown command: #{cmd}"
     end
 

--- a/Library/Homebrew/brew.rb
+++ b/Library/Homebrew/brew.rb
@@ -132,7 +132,10 @@ begin
     possible_tap = OFFICIAL_CMD_TAPS.find { |_, cmds| cmds.include?(cmd) }
     possible_tap = Tap.fetch(possible_tap.first) if possible_tap
 
-    odie "Unknown command: #{cmd}" if !possible_tap || possible_tap.installed?
+    untapped_official_taps = Homebrew::Settings.read(:untapped)&.split(";") || []
+    if !possible_tap || possible_tap.installed? || untapped_official_taps.include?(possible_tap.name)
+      odie "Unknown command: #{cmd}"
+    end
 
     # Unset HOMEBREW_HELP to avoid confusing the tap
     with_env HOMEBREW_HELP: nil do

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -99,8 +99,6 @@ module Homebrew
           begin
             return Cask::CaskLoader.load(name, config: Cask::Config.from_args(@parent))
           rescue Cask::CaskUnavailableError => e
-            retry if Tap.install_default_cask_tap_if_necessary
-
             raise e if only == :cask
           end
         end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -153,8 +153,14 @@ module Homebrew
       EOS
     end
 
-    formulae, casks = args.named.to_formulae_and_casks
-                          .partition { |formula_or_cask| formula_or_cask.is_a?(Formula) }
+    begin
+      formulae, casks = args.named.to_formulae_and_casks
+                            .partition { |formula_or_cask| formula_or_cask.is_a?(Formula) }
+    rescue FormulaOrCaskUnavailableError, Cask::CaskUnavailableError => e
+      retry if Tap.install_default_cask_tap_if_necessary(force: args.cask?)
+
+      raise e
+    end
 
     if casks.any?
       Cask::Cmd::Install.install_casks(

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -43,7 +43,7 @@ module Homebrew
         end
       end
 
-      tap.uninstall
+      tap.uninstall manual: true
     end
   end
 end

--- a/Library/Homebrew/extend/os/mac/tap.rb
+++ b/Library/Homebrew/extend/os/mac/tap.rb
@@ -5,8 +5,7 @@ class Tap
   def self.install_default_cask_tap_if_necessary
     return false if default_cask_tap.installed?
 
-    untapped_official_taps = Homebrew::Settings.read(:untapped)&.split(";") || []
-    return false if untapped_official_taps.include?(default_cask_tap.name)
+    return false if Tap.untapped_official_taps.include?(default_cask_tap.name)
 
     default_cask_tap.install
     true

--- a/Library/Homebrew/extend/os/mac/tap.rb
+++ b/Library/Homebrew/extend/os/mac/tap.rb
@@ -2,10 +2,10 @@
 # frozen_string_literal: true
 
 class Tap
-  def self.install_default_cask_tap_if_necessary
+  def self.install_default_cask_tap_if_necessary(force: false)
     return false if default_cask_tap.installed?
 
-    return false if Tap.untapped_official_taps.include?(default_cask_tap.name)
+    return false if !force && Tap.untapped_official_taps.include?(default_cask_tap.name)
 
     default_cask_tap.install
     true

--- a/Library/Homebrew/extend/os/mac/tap.rb
+++ b/Library/Homebrew/extend/os/mac/tap.rb
@@ -5,6 +5,9 @@ class Tap
   def self.install_default_cask_tap_if_necessary
     return false if default_cask_tap.installed?
 
+    untapped_official_taps = Homebrew::Settings.read(:untapped)&.split(";") || []
+    return false if untapped_official_taps.include?(default_cask_tap.name)
+
     default_cask_tap.install
     true
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -326,6 +326,17 @@ class Tap
                            .update_from_formula_names!(formula_names)
     end
 
+    if official?
+      untapped = Homebrew::Settings.read(:untapped)&.split(";") || []
+      untapped -= [name]
+
+      if untapped.empty?
+        Homebrew::Settings.delete :untapped
+      else
+        Homebrew::Settings.write :untapped, untapped.join(";")
+      end
+    end
+
     return if clone_target
     return unless private?
     return if quiet
@@ -374,6 +385,15 @@ class Tap
 
     Commands.rebuild_commands_completion_list
     clear_cache
+
+    return unless official?
+
+    untapped = Homebrew::Settings.read(:untapped)&.split(";") || []
+
+    return if untapped.include? name
+
+    untapped << name
+    Homebrew::Settings.write :untapped, untapped.join(";")
   end
 
   # True if the {#remote} of {Tap} is customized.

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -327,7 +327,7 @@ class Tap
     end
 
     if official?
-      untapped = Homebrew::Settings.read(:untapped)&.split(";") || []
+      untapped = self.class.untapped_official_taps
       untapped -= [name]
 
       if untapped.empty?
@@ -388,8 +388,7 @@ class Tap
 
     return unless official?
 
-    untapped = Homebrew::Settings.read(:untapped)&.split(";") || []
-
+    untapped = self.class.untapped_official_taps
     return if untapped.include? name
 
     untapped << name
@@ -642,6 +641,12 @@ class Tap
   sig { returns(T::Array[Pathname]) }
   def self.cmd_directories
     Pathname.glob TAP_DIRECTORY/"*/*/cmd"
+  end
+
+  # An array of official taps that have been manually untapped
+  sig { returns(T::Array[String]) }
+  def self.untapped_official_taps
+    Homebrew::Settings.read(:untapped)&.split(";") || []
   end
 
   # @private

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -363,7 +363,7 @@ class Tap
   end
 
   # Uninstall this {Tap}.
-  def uninstall
+  def uninstall(manual: false)
     require "descriptions"
     raise TapUnavailableError, name unless installed?
 
@@ -386,7 +386,7 @@ class Tap
     Commands.rebuild_commands_completion_list
     clear_cache
 
-    return unless official?
+    return if !manual || !official?
 
     untapped = self.class.untapped_official_taps
     return if untapped.include? name

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -67,8 +67,8 @@ class Tap
     @default_cask_tap ||= fetch("Homebrew", "cask")
   end
 
-  sig { returns(T::Boolean) }
-  def self.install_default_cask_tap_if_necessary
+  sig { params(force: T::Boolean).returns(T::Boolean) }
+  def self.install_default_cask_tap_if_necessary(force: false)
     false
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Fixes #10303

This PR modifies the logic for when to automatically tap official taps.

As a refresher, there are two times where an official tap would be automatically tapped:
1. When running the `bundle`, `test-bot`, or `services` command and the respective repo isn't tapped
2. When `args.named.to_casks` (or other similar methods that convert named args to casks) is unable to match a name to a formula or cask. This is seen mostly when running `brew install <invalid_formula_or_cask>` or `brew uninstall <invalid_formula_or_cask>`.

Now, if a user has untapped an official tap, we will remember this in the Homebrew settings. If a user does one of the above actions that would normally tap the repo, we will first check to see whether they have already untapped the repo. If so, we assume that they genuinely do not want that repo, so we don't re-tap.

A few comments:
- There is one more spot where `Tap.install_default_cask_tap_if_necessary` is used in [`Library/Homebrew/cask/cmd.rb`](https://github.com/Homebrew/brew/blob/152eac333b3cfed6801d26a30183954d8a3d5c1b/Library/Homebrew/cask/cmd.rb#L170). Should this be modified to _always_ tap the cask repo, even if the user has explicitly untapped it? I'm not sure if this file will even have a use after Homebrew 2.8.0 (where `brew cask` commands are removed).
- If there are other places where a similar thing is done that should be modified, let me know.
- I will probably refactor some of this logic out to an e.g. `Tap.untapped_official_taps` to avoid repeating the `untapped = Settings.read(:untapped) || []` line in many places. I didn't for now simply because I wanted to get this PR up for feedback.

CC: @carlocab, @fxcoudert, and @jonchang
