### PR TITLE
Add brew release command

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -172,7 +172,7 @@ update-preinstall() {
 
   if [[ "$HOMEBREW_COMMAND" = "install" || "$HOMEBREW_COMMAND" = "upgrade" ||
         "$HOMEBREW_COMMAND" = "bump-formula-pr" || "$HOMEBREW_COMMAND" = "bump-cask-pr" ||
-        "$HOMEBREW_COMMAND" = "bundle" ||
+        "$HOMEBREW_COMMAND" = "bundle" || "$HOMEBREW_COMMAND" = "release" ||
         "$HOMEBREW_COMMAND" = "tap" && $HOMEBREW_ARG_COUNT -gt 1 ||
         "$HOMEBREW_CASK_COMMAND" = "install" || "$HOMEBREW_CASK_COMMAND" = "upgrade" ]]
   then

--- a/Library/Homebrew/cli/args.rbi
+++ b/Library/Homebrew/cli/args.rbi
@@ -138,6 +138,12 @@ module Homebrew
       sig { returns(T.nilable(T::Boolean)) }
       def reset_cache?; end
 
+      sig { returns(T.nilable(T::Boolean)) }
+      def major?; end
+
+      sig { returns(T.nilable(T::Boolean)) }
+      def minor?; end
+
       sig { returns(T.nilable(String)) }
       def tag; end
 

--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -32,6 +32,9 @@ module Homebrew
   def release_notes
     args = release_notes_args.parse
 
+    # TODO: (2.8) Deprecate this command now that the `brew release` command exists.
+    # odeprecated "`brew release-notes`"
+
     previous_tag = args.named.first
 
     if previous_tag.present?
@@ -56,7 +59,7 @@ module Homebrew
       odie "Ref #{ref} does not exist!"
     end
 
-    release_notes = ReleaseNotes.generate_release_notes previous_tag, end_ref, markdown: T.must(args.markdown?)
+    release_notes = ReleaseNotes.generate_release_notes previous_tag, end_ref, markdown: args.markdown?
 
     $stderr.puts "Release notes between #{previous_tag} and #{end_ref}:"
     puts release_notes

--- a/Library/Homebrew/dev-cmd/release-notes.rb
+++ b/Library/Homebrew/dev-cmd/release-notes.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require "cli/parser"
+require "release_notes"
 
 module Homebrew
   extend T::Sig
@@ -55,25 +56,9 @@ module Homebrew
       odie "Ref #{ref} does not exist!"
     end
 
-    output = Utils.popen_read(
-      "git", "-C", HOMEBREW_REPOSITORY, "log", "--pretty=format:'%s >> - %b%n'", "#{previous_tag}..#{end_ref}"
-    ).lines.grep(/Merge pull request/)
-
-    output.map! do |s|
-      s.gsub(%r{.*Merge pull request #(\d+) from ([^/]+)/[^>]*(>>)*},
-             "https://github.com/Homebrew/brew/pull/\\1 (@\\2)")
-    end
-    if args.markdown?
-      output.map! do |s|
-        /(.*\d)+ \(@(.+)\) - (.*)/ =~ s
-        "- [#{Regexp.last_match(3)}](#{Regexp.last_match(1)}) (@#{Regexp.last_match(2)})"
-      end
-    end
+    release_notes = ReleaseNotes.generate_release_notes previous_tag, end_ref, markdown: T.must(args.markdown?)
 
     $stderr.puts "Release notes between #{previous_tag} and #{end_ref}:"
-    if args.markdown? && args.named.first
-      puts "Release notes for major and minor releases can be found in the [Homebrew blog](https://brew.sh/blog/)."
-    end
-    puts output
+    puts release_notes
   end
 end

--- a/Library/Homebrew/dev-cmd/release.rb
+++ b/Library/Homebrew/dev-cmd/release.rb
@@ -1,0 +1,94 @@
+# typed: true
+# frozen_string_literal: true
+
+require "cli/parser"
+
+module Homebrew
+  extend T::Sig
+
+  module_function
+
+  sig { returns(CLI::Parser) }
+  def release_args
+    Homebrew::CLI::Parser.new do
+      description <<~EOS
+        Create a new draft Homebrew/brew release with the appropriate version number and release notes.
+
+        By default, `brew release` will bump the patch version number. Pass
+        `--major` or `--minor` to bump the major or minor version numbers, respectively.
+        The command will fail if the previous major or minor release was made less than
+        one month ago.
+
+        Requires write access to the Homebrew/brew repository.
+      EOS
+      switch "--major",
+             description: "Create a major release."
+      switch "--minor",
+             description: "Create a minor release."
+      conflicts "--major", "--minor"
+
+      named_args :none
+    end
+  end
+
+  def release
+    args = release_args.parse
+
+    safe_system "git", "-C", HOMEBREW_REPOSITORY, "fetch", "origin" if Homebrew::EnvConfig.no_auto_update?
+
+    begin
+      latest_release = GitHub.get_latest_release "Homebrew", "brew"
+    rescue GitHub::HTTPNotFoundError
+      odie "No existing releases found!"
+    end
+    latest_version = Version.new latest_release["tag_name"]
+
+    if args.major? || args.minor?
+      one_month_ago = Date.today << 1
+      latest_major_minor_release = begin
+        GitHub.get_release "Homebrew", "brew", "#{latest_version.major_minor}.0"
+      rescue GitHub::HTTPNotFoundError
+        nil
+      end
+
+      if latest_major_minor_release.blank?
+        opoo "Unable to determine the release date of the latest major/minor release."
+      elsif Date.parse(latest_major_minor_release["published_at"]) > one_month_ago
+        odie "The latest major/minor release was less than one month ago."
+      end
+    end
+
+    new_version = if args.major?
+      Version.new [latest_version.major.to_i + 1, 0, 0].join(".")
+    elsif args.minor?
+      Version.new [latest_version.major, latest_version.minor.to_i + 1, 0].join(".")
+    else
+      Version.new [latest_version.major, latest_version.minor, latest_version.patch.to_i + 1].join(".")
+    end.to_s
+
+    ohai "Creating draft release for version #{new_version}"
+    release_notes = if args.major? || args.minor?
+      ["Release notes for this release can be found on the [Homebrew blog](https://brew.sh/blog/#{new_version})."]
+    else
+      []
+    end
+    release_notes += Utils.popen_read(
+      "git", "-C", HOMEBREW_REPOSITORY, "log", "--pretty=format:'%s >> - %b%n'", "#{latest_version}..origin/HEAD"
+    ).lines.grep(/Merge pull request/).map! do |s|
+      pr = s.gsub(%r{.*Merge pull request #(\d+) from ([^/]+)/[^>]*(>>)*},
+                  "https://github.com/Homebrew/brew/pull/\\1 (@\\2)")
+      /(.*\d)+ \(@(.+)\) - (.*)/ =~ pr
+      "- [#{Regexp.last_match(3)}](#{Regexp.last_match(1)}) (@#{Regexp.last_match(2)})"
+    end
+
+    begin
+      release = GitHub.create_or_update_release "Homebrew", "brew", new_version,
+                                                body: release_notes.join("\n"), draft: true
+    rescue *GitHub::API_ERRORS => e
+      odie "Unable to create release: #{e.message}!"
+    end
+
+    puts release["html_url"]
+    exec_browser release["html_url"]
+  end
+end

--- a/Library/Homebrew/release_notes.rb
+++ b/Library/Homebrew/release_notes.rb
@@ -10,7 +10,7 @@ module ReleaseNotes
   module_function
 
   sig {
-    params(start_ref: T.any(String, Version), end_ref: T.any(String, Version), markdown: T::Boolean)
+    params(start_ref: T.any(String, Version), end_ref: T.any(String, Version), markdown: T.nilable(T::Boolean))
       .returns(String)
   }
   def generate_release_notes(start_ref, end_ref, markdown: false)

--- a/Library/Homebrew/release_notes.rb
+++ b/Library/Homebrew/release_notes.rb
@@ -1,0 +1,35 @@
+# typed: true
+# frozen_string_literal: true
+
+# Helper functions for generating release notes.
+#
+# @api private
+module ReleaseNotes
+  extend T::Sig
+
+  module_function
+
+  sig {
+    params(start_ref: T.any(String, Version), end_ref: T.any(String, Version), markdown: T::Boolean)
+      .returns(String)
+  }
+  def generate_release_notes(start_ref, end_ref, markdown: false)
+    log_output = Utils.popen_read(
+      "git", "-C", HOMEBREW_REPOSITORY, "log", "--pretty=format:'%s >> - %b%n'", "#{start_ref}..#{end_ref}"
+    ).lines.grep(/Merge pull request/)
+
+    log_output.map! do |s|
+      s.gsub(%r{.*Merge pull request #(\d+) from ([^/]+)/[^>]*(>>)*},
+             "https://github.com/Homebrew/brew/pull/\\1 (@\\2)")
+    end
+
+    if markdown
+      log_output.map! do |s|
+        /(.*\d)+ \(@(.+)\) - (.*)/ =~ s
+        "- [#{Regexp.last_match(3)}](#{Regexp.last_match(1)}) (@#{Regexp.last_match(2)})\n"
+      end
+    end
+
+    log_output.join
+  end
+end

--- a/Library/Homebrew/test/dev-cmd/release_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/release_spec.rb
@@ -1,0 +1,8 @@
+# typed: false
+# frozen_string_literal: true
+
+require "cmd/shared_examples/args_parse"
+
+describe "Homebrew.release_args" do
+  it_behaves_like "parseable arguments"
+end

--- a/Library/Homebrew/test/release_notes_spec.rb
+++ b/Library/Homebrew/test/release_notes_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+# frozen_string_literal: true
+
+require "release_notes"
+
+describe ReleaseNotes do
+  before do
+    HOMEBREW_REPOSITORY.cd do
+      system "git", "init"
+      system "git", "commit", "--allow-empty", "-m", "Initial commit"
+      system "git", "tag", "release-notes-testing"
+      system "git", "commit", "--allow-empty", "-m", "Merge pull request #1 from Homebrew/fix", "-m", "Do something"
+      system "git", "commit", "--allow-empty", "-m", "make a change"
+      system "git", "commit", "--allow-empty", "-m", "Merge pull request #2 from User/fix", "-m", "Do something else"
+    end
+  end
+
+  describe ".generate_release_notes" do
+    it "generates release notes" do
+      expect(described_class.generate_release_notes("release-notes-testing", "HEAD")).to eq <<~NOTES
+        https://github.com/Homebrew/brew/pull/2 (@User) - Do something else
+        https://github.com/Homebrew/brew/pull/1 (@Homebrew) - Do something
+      NOTES
+    end
+
+    it "generates markdown release notes" do
+      expect(described_class.generate_release_notes("release-notes-testing", "HEAD", markdown: true)).to eq <<~NOTES
+        - [Do something else](https://github.com/Homebrew/brew/pull/2) (@User)
+        - [Do something](https://github.com/Homebrew/brew/pull/1) (@Homebrew)
+      NOTES
+    end
+  end
+end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -482,7 +482,12 @@ module GitHub
     open_api(url, request_method: :GET)
   end
 
-  def create_or_update_release(user, repo, tag, id: nil, name: nil, draft: false)
+  def get_latest_release(user, repo)
+    url = "#{API_URL}/repos/#{user}/#{repo}/releases/latest"
+    open_api(url, request_method: :GET)
+  end
+
+  def create_or_update_release(user, repo, tag, id: nil, name: nil, body: nil, draft: false)
     url = "#{API_URL}/repos/#{user}/#{repo}/releases"
     method = if id
       url += "/#{id}"
@@ -495,6 +500,7 @@ module GitHub
       name:     name || tag,
       draft:    draft,
     }
+    data[:body] = body if body.present?
     open_api(url, data: data, request_method: method, scopes: CREATE_ISSUE_FORK_OR_PR_SCOPES)
   end
 

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -1663,6 +1663,23 @@ _brew_reinstall() {
   __brew_complete_casks
 }
 
+_brew_release() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  case "$cur" in
+    -*)
+      __brewcomp "
+      --debug
+      --help
+      --major
+      --minor
+      --quiet
+      --verbose
+      "
+      return
+      ;;
+  esac
+}
+
 _brew_release_notes() {
   local cur="${COMP_WORDS[COMP_CWORD]}"
   case "$cur" in
@@ -2418,6 +2435,7 @@ _brew() {
     prof) _brew_prof ;;
     readall) _brew_readall ;;
     reinstall) _brew_reinstall ;;
+    release) _brew_release ;;
     release-notes) _brew_release_notes ;;
     remove) _brew_remove ;;
     rm) _brew_rm ;;

--- a/completions/internal_commands_list.txt
+++ b/completions/internal_commands_list.txt
@@ -72,6 +72,7 @@ pr-upload
 prof
 readall
 reinstall
+release
 release-notes
 remove
 rm

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1208,6 +1208,22 @@ Run Homebrew with a Ruby profiler, e.g. `brew prof readall`.
 * `--stackprof`:
   Use `stackprof` instead of `ruby-prof` (the default).
 
+### `release` [*`--major`*] [*`--minor`*]
+
+Create a new draft Homebrew/brew release with the appropriate version number and release notes.
+
+By default, `brew release` will bump the patch version number. Pass
+`--major` or `--minor` to bump the major or minor version numbers, respectively.
+The command will fail if the previous major or minor release was made less than
+one month ago.
+
+Requires write access to the Homebrew/brew repository.
+
+* `--major`:
+  Create a major release.
+* `--minor`:
+  Create a minor release.
+
 ### `release-notes` [*`options`*] [*`previous_tag`*] [*`end_ref`*]
 
 Print the merged pull requests on Homebrew/brew between two Git refs.

--- a/docs/Releases.md
+++ b/docs/Releases.md
@@ -11,16 +11,12 @@ Homebrew release:
    [Homebrew/discussions (forum)](https://github.com/homebrew/discussions/discussions) to see if there is
    anything pressing that needs to be fixed or merged before the next release.
    If so, fix and merge these changes.
-2. After no code changes have happened for at least a couple of hours (ideally 24 hours)
-   and you are confident there's no major regressions on the current `master`
-   branch you can create a new Git tag. Ideally this should be signed with your
-   GPG key. This can then be pushed to GitHub.
-3. Use `brew release-notes --markdown $PREVIOUS_TAG` to generate the release
-   notes for the release.
-4. [Create a new release on GitHub](https://github.com/Homebrew/brew/releases/new)
-   based on the new tag.
-
-You can watch a video of the above process [on YouTube](https://youtu.be/dQCpLaXOf6k)
+2. Ensure that no code changes have happened for at least a couple of hours (ideally 24 hours)
+   and that you are confident there are no major regressions on the current `master`
+   branch.
+3. Run `brew release` to create a new draft release. For major or minor version bumps,
+   pass `--major` or `--minor`, respectively.
+4. Publish the draft release on [GitHub](https://github.com/Homebrew/brew/releases).
 
 If this is a major or minor release (e.g. X.0.0 or X.Y.0) then there are a few more steps:
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1686,6 +1686,23 @@ Run Homebrew with a Ruby profiler, e\.g\. \fBbrew prof readall\fR\.
 \fB\-\-stackprof\fR
 Use \fBstackprof\fR instead of \fBruby\-prof\fR (the default)\.
 .
+.SS "\fBrelease\fR [\fI\-\-major\fR] [\fI\-\-minor\fR]"
+Create a new draft Homebrew/brew release with the appropriate version number and release notes\.
+.
+.P
+By default, \fBbrew release\fR will bump the patch version number\. Pass \fB\-\-major\fR or \fB\-\-minor\fR to bump the major or minor version numbers, respectively\. The command will fail if the previous major or minor release was made less than one month ago\.
+.
+.P
+Requires write access to the Homebrew/brew repository\.
+.
+.TP
+\fB\-\-major\fR
+Create a major release\.
+.
+.TP
+\fB\-\-minor\fR
+Create a minor release\.
+.
 .SS "\fBrelease\-notes\fR [\fIoptions\fR] [\fIprevious_tag\fR] [\fIend_ref\fR]"
 Print the merged pull requests on Homebrew/brew between two Git refs\. If no \fIprevious_tag\fR is provided it defaults to the latest tag\. If no \fIend_ref\fR is provided it defaults to \fBorigin/master\fR\.
 .


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This PR adds a new `brew release` developer command to automate the release process. The command, by default, will simply bump the patch version number. If `--major` or `--minor` is passed, the command will bump the major and minor version numbers respectively (and reset other numbers to 0 as needed).

This PR is still _extremely_ rough (hence being marked as a draft). I'm going to immediately cancel CI because I know there are issues that I haven't yet fixed locally. However, I have a few general questions, so I figured I'd open this to track my progress.

I also plan on updating the [Release docs](https://docs.brew.sh/Releases) in this PR in the future.

Additionally, there's some overlap between this command and `brew release-notes` that I plan on extracting to a new module.

-----

## Questions

1. Should there be any interactivity in this command? At the moment, the whole thing runs in about 5 seconds so there isn't really any time for a frantic control-c if someone realizes they messed up. I wonder if we should make this require an additional confirmation before pushing the tags and creating the release. I know we generally like to avoid interactivity, but I don't think this command should even be used in a script so I'm not super worried about that. I'm open to other options here as well.
2. What is the best way to determine the "current tag." At the moment, I'm simply running a `git fetch origin` (although I'm now realizing I probably want `git fetch --tags origin`) before the command starts and then simply taking the highest version number from `git tag --list --sort=-version:refname *.*.*`. Is there a way to determine the latest _upstream_ tag rather than relying on local tags? I guess an alternative would be to query GitHub for the latest release and then use that as the base. An extension question would be: is it okay to assume that those who will run this command will be in a reasonable repository state?
3. How should non-tip-of-the-master-branch releases be handled? I know that there's debate about this in #9331 so I don't need to duplicate that here. For the moment, I think I'm going to assume the following: the `brew release` command will be designed for creating releases _only_ at the tip of the master branch. If a non-tip-of-the-master-branch release is desired, this command should not be used. Is that acceptable? If so, I'll probably either call `brew update` within the command or simply fail if the brew repo isn't up to date (or, to be more precise, I'll check that `git rev-parse HEAD` matched `git rev-parse origin/HEAD`).
4. I think we should sign tags when possible. Should we run `git tag --sign` by default? If not, should we add a `--sign` flag to `brew release` to control this? I have `tag.gpgSign` enabled in my `~/.gitconfig` so my tags would be signed either way, but I'm sure tha not all maintainers do.
5. More specifically, how do I handle the scopes for the GitHub API call? I'm a little confused with what needs to be specified here. [`GitHub.open_api`](https://github.com/Homebrew/brew/blob/7242cd64743635d13d5f69fa3ae0718b2170e7da/Library/Homebrew/utils/github.rb#L179-L243) takes an optional `scopes` argument. In [`GitHub.create_pull_request`](https://github.com/Homebrew/brew/blob/7242cd64743635d13d5f69fa3ae0718b2170e7da/Library/Homebrew/utils/github.rb#L393-L398), the [`GitHub.CREATE_ISSUE_FORK_OR_PR_SCOPES`](https://github.com/Homebrew/brew/blob/7242cd64743635d13d5f69fa3ae0718b2170e7da/Library/Homebrew/utils/github.rb#L22) constant which is set to `public_repo` is passed. What (if any) scope needs to be used for creating a release? Obviously, some write access to the repo is needed. Just not totally sure what to do here and hoping someone can guide me through it :)

-----

## Quick Summary

Based on my answers to the questions above, here is what I'm picturing (at the moment) will happen when this command is run:

1. `git fetch --tags origin` is run in the background.
2. If `git rev-parse HEAD` doesn't match `git rev-parse origin/HEAD`, fail
3. Find the most recent tag using `git tag --list --sort=-version:refname *.*.*`
4. Generate the new tag based on `args.major?` and `args.minor?`
5. If creating a major/minor release, check to make sure the latest release was less than a month ago. If so, fail unless `--force` is passed (which should change the failure into a warning that's still displayed)
5. Create the new tag locally using `git tag` and maybe `--sign`
6. Generate the release notes
7. Asking for a final confirmation before pushing the tag and creating the release
8. Run `git push origin <tag>` to push the tag
9. Create a new release using the GitHub API
10. Print the url to the release
10. Open the url in a browser unless `--no-browse` is passed.

CC @MikeMcQuaid 