### PR TITLE
Suggest alternative method for enabling ZSH completions

### DIFF
--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -43,7 +43,12 @@ if type brew &>/dev/null; then
 fi
 ```
 
-This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you, so this must be done before you call `oh-my-zsh.sh`.
+This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you, so this must be done before you call `oh-my-zsh.sh`. This may be done by adding the following line to your `~/.zprofile` file, instead of modifying your `~/.zshrc` as above:
+
+```diff
+  eval $(/opt/homebrew/bin/brew shellenv)
++ export FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
+```
 
 You may also need to forcibly rebuild `zcompdump`:
 

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -47,7 +47,7 @@ This must be done before `compinit` is called. Note that if you are using Oh My 
 
 ```diff
   eval $(/opt/homebrew/bin/brew shellenv)
-+ export FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
++ FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
 ```
 
 You may also need to forcibly rebuild `zcompdump`:

--- a/docs/Shell-Completion.md
+++ b/docs/Shell-Completion.md
@@ -43,11 +43,10 @@ if type brew &>/dev/null; then
 fi
 ```
 
-This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you, so this must be done before you call `oh-my-zsh.sh`. This may be done by adding the following line to your `~/.zprofile` file, instead of modifying your `~/.zshrc` as above:
+This must be done before `compinit` is called. Note that if you are using Oh My Zsh, it will call `compinit` for you, so this must be done before you call `oh-my-zsh.sh`. This may be done by appending the following line to your `~/.zprofile` after Homebrew's initialization, instead of modifying your `~/.zshrc` as above:
 
-```diff
-  eval $(/opt/homebrew/bin/brew shellenv)
-+ FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
+```sh
+FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
 ```
 
 You may also need to forcibly rebuild `zcompdump`:


### PR DESCRIPTION
This PR suggests an alternative method for enabling ZSH completions when a framework like `oh-my-zsh` already runs `compinit` without the need to run this directly.

The benefit of using this method is that only one line of code is needed, rather than 5 lines for the currently suggested method, reducing configuration maintenance for the user. I have not included an `if` block to check for existence of the `brew` command, as this line comes directly after the command to setup brew's environment.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] (n/a) Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] (n/a) Have you successfully run `brew typecheck` with your changes locally?
- [ ] (n/a) Have you successfully run `brew tests` with your changes locally?
- [ ] (n/a) Have you successfully run `brew man` locally and committed any changes?