### PR TITLE
dev-cmd: disable when broken on Apple Silicon.

### DIFF
--- a/Library/Homebrew/dev-cmd/install-bundler-gems.rb
+++ b/Library/Homebrew/dev-cmd/install-bundler-gems.rb
@@ -14,6 +14,8 @@ module Homebrew
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Install Homebrew's Bundler gems.
+
+        Not (yet) working on Apple Silicon.
       EOS
 
       named_args :none
@@ -21,6 +23,9 @@ module Homebrew
   end
 
   def install_bundler_gems
+    # TODO: update description above if removing this.
+    raise UsageError, "not (yet) working on Apple Silicon!" if Hardware::CPU.arm?
+
     install_bundler_gems_args.parse
 
     Homebrew.install_bundler_gems!

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -21,6 +21,8 @@ module Homebrew
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Generate Homebrew's manpages.
+
+        Not (yet) working on Apple Silicon.
       EOS
       switch "--fail-if-changed",
              description: "Return a failing status code if changes are detected in the manpage outputs. This "\
@@ -32,6 +34,9 @@ module Homebrew
   end
 
   def man
+    # TODO: update description above if removing this.
+    raise UsageError, "not (yet) working on Apple Silicon!" if Hardware::CPU.arm?
+
     args = man_args.parse
 
     Commands.rebuild_internal_commands_completion_list

--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -13,6 +13,8 @@ module Homebrew
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Check for typechecking errors using Sorbet.
+
+        Not (yet) working on Apple Silicon.
       EOS
       switch "--fix",
              description: "Automatically fix type errors."
@@ -42,6 +44,11 @@ module Homebrew
 
   sig { void }
   def typecheck
+    # TODO: update description above if removing this.
+    if Hardware::CPU.arm? || Hardware::CPU.in_rosetta2?
+      raise UsageError, "not (yet) working on Apple Silicon or Rosetta 2!"
+    end
+
     args = typecheck_args.parse
 
     Homebrew.install_bundler_gems!

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1040,6 +1040,8 @@ Display the path where *`formula`* is located.
 
 Install Homebrew's Bundler gems.
 
+Not (yet) working on Apple Silicon.
+
 ### `irb` [*`--examples`*] [*`--pry`*]
 
 Enter the interactive Homebrew Ruby shell.
@@ -1091,6 +1093,8 @@ casks to check is taken from `HOMEBREW_LIVECHECK_WATCHLIST` or
 ### `man` [*`--fail-if-changed`*]
 
 Generate Homebrew's manpages.
+
+Not (yet) working on Apple Silicon.
 
 * `--fail-if-changed`:
   Return a failing status code if changes are detected in the manpage outputs. This can be used to notify CI when the manpages are out of date. Additionally, the date used in new manpages will match those in the existing manpages (to allow comparison without factoring in the date).
@@ -1321,6 +1325,8 @@ Run Homebrew's unit and integration tests.
 ### `typecheck`, `tc` [*`options`*]
 
 Check for typechecking errors using Sorbet.
+
+Not (yet) working on Apple Silicon.
 
 * `--fix`:
   Automatically fix type errors.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1434,6 +1434,9 @@ Display the path where \fIformula\fR is located\.
 .SS "\fBinstall\-bundler\-gems\fR"
 Install Homebrew\'s Bundler gems\.
 .
+.P
+Not (yet) working on Apple Silicon\.
+.
 .SS "\fBirb\fR [\fI\-\-examples\fR] [\fI\-\-pry\fR]"
 Enter the interactive Homebrew Ruby shell\.
 .
@@ -1504,6 +1507,9 @@ Only check casks\.
 .
 .SS "\fBman\fR [\fI\-\-fail\-if\-changed\fR]"
 Generate Homebrew\'s manpages\.
+.
+.P
+Not (yet) working on Apple Silicon\.
 .
 .TP
 \fB\-\-fail\-if\-changed\fR
@@ -1821,6 +1827,9 @@ Randomise tests with the specified \fIvalue\fR instead of a random seed\.
 .
 .SS "\fBtypecheck\fR, \fBtc\fR [\fIoptions\fR]"
 Check for typechecking errors using Sorbet\.
+.
+.P
+Not (yet) working on Apple Silicon\.
 .
 .TP
 \fB\-\-fix\fR


### PR DESCRIPTION
This is better than users getting a weird error.

Partially addresses https://github.com/Homebrew/brew/issues/10210