### PR TITLE
cellars: write tag specific cellars

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -353,6 +353,7 @@ Layout/LineLength:
       ' name "',
       ' pkg "',
       ' pkgutil: "',
+      '    sha256 "',
       "#{language}",
       "#{version.",
       ' "/Library/Application Support/',

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -442,8 +442,9 @@ class BottleSpecification
     end
     tags.reverse.map do |tag|
       {
-        collector[tag][:checksum] => tag,
-        cellar: collector[tag][:cellar],
+        "tag"    => tag,
+        "digest" => collector[tag][:checksum],
+        "cellar" => collector[tag][:cellar],
       }
     end
   end

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -263,7 +263,7 @@ describe Homebrew do
   end
 end
 
-describe "brew bottle --merge", :integration_test, :needs_linux do
+describe "brew bottle --merge", :integration_test do
   let(:core_tap) { CoreTap.new }
   let(:tarball) do
     if OS.linux?

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -228,7 +228,7 @@ describe Homebrew do
     end
   end
 
-  describe "::generate_sha256_line", :needs_linux do
+  describe "::generate_sha256_line" do
     it "generates a string without cellar" do
       expect(homebrew.generate_sha256_line(:catalina, "deadbeef", nil)).to eq(
         <<~RUBY.chomp,

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -216,10 +216,10 @@ describe Homebrew do
 
     it "checks for conflicting checksums" do
       old_spec = BottleSpecification.new
-      old_spec.sha256("109c0cb581a7b5d84da36d84b221fb9dd0f8a927b3044d82611791c9907e202e" => :catalina)
-      old_spec.sha256("7571772bf7a0c9fe193e70e521318b53993bee6f351976c9b6e01e00d13d6c3f" => :mojave)
+      old_spec.sha256(catalina: "109c0cb581a7b5d84da36d84b221fb9dd0f8a927b3044d82611791c9907e202e")
+      old_spec.sha256(mojave: "7571772bf7a0c9fe193e70e521318b53993bee6f351976c9b6e01e00d13d6c3f")
       new_hash = { "tags" => { "catalina" => "ec6d7f08412468f28dee2be17ad8cd8b883b16b34329efcecce019b8c9736428" } }
-      expected_checksum_hash = { "7571772bf7a0c9fe193e70e521318b53993bee6f351976c9b6e01e00d13d6c3f" => :mojave }
+      expected_checksum_hash = { mojave: "7571772bf7a0c9fe193e70e521318b53993bee6f351976c9b6e01e00d13d6c3f" }
       expected_checksum_hash[:cellar] = Homebrew::DEFAULT_CELLAR
       expect(homebrew.merge_bottle_spec([:sha256], old_spec, new_hash)).to eq [
         ["sha256 => catalina"],
@@ -232,7 +232,7 @@ describe Homebrew do
     it "generates a string without cellar" do
       expect(homebrew.generate_sha256_line(:catalina, "deadbeef", nil)).to eq(
         <<~RUBY.chomp,
-          sha256 "deadbeef" => :catalina
+          sha256 catalina: "deadbeef"
         RUBY
       )
     end
@@ -240,7 +240,7 @@ describe Homebrew do
     it "generates a string with cellar symbol" do
       expect(homebrew.generate_sha256_line(:catalina, "deadbeef", :any)).to eq(
         <<~RUBY.chomp,
-          sha256 "deadbeef" => :catalina, :cellar => :any
+          sha256 cellar: :any, catalina: "deadbeef"
         RUBY
       )
     end
@@ -248,7 +248,7 @@ describe Homebrew do
     it "generates a string with default cellar path" do
       expect(homebrew.generate_sha256_line(:catalina, "deadbeef", Homebrew::DEFAULT_LINUX_CELLAR)).to eq(
         <<~RUBY.chomp,
-          sha256 "deadbeef" => :catalina
+          sha256 catalina: "deadbeef"
         RUBY
       )
     end
@@ -256,7 +256,7 @@ describe Homebrew do
     it "generates a string with non-default cellar path" do
       expect(homebrew.generate_sha256_line(:catalina, "deadbeef", "/home/test")).to eq(
         <<~RUBY.chomp,
-          sha256 "deadbeef" => :catalina, :cellar => "/home/test"
+          sha256 cellar: "/home/test", catalina: "deadbeef"
         RUBY
       )
     end
@@ -320,8 +320,8 @@ describe "brew bottle --merge", :integration_test do
       ==> testball
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
+          sha256 cellar: :any_skip_relocation, big_sur: "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f"
+          sha256 cellar: :any_skip_relocation, catalina: "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac"
         end
     EOS
 
@@ -334,8 +334,8 @@ describe "brew bottle --merge", :integration_test do
 
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
+          sha256 cellar: :any_skip_relocation, big_sur: "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f"
+          sha256 cellar: :any_skip_relocation, catalina: "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac"
         end
 
         option "with-foo", "Build with foo"
@@ -365,8 +365,8 @@ describe "brew bottle --merge", :integration_test do
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
           cellar :any_skip_relocation
-          sha256 "6b276491297d4052538bd2fd22d5129389f27d90a98f831987236a5b90511b98" => :big_sur
-          sha256 "16cf230afdfcb6306c208d169549cf8773c831c8653d2c852315a048960d7e72" => :catalina
+          sha256 big_sur: "6b276491297d4052538bd2fd22d5129389f27d90a98f831987236a5b90511b98"
+          sha256 catalina: "16cf230afdfcb6306c208d169549cf8773c831c8653d2c852315a048960d7e72"
         end
       EOS
       system "git", "add", "--all"
@@ -383,8 +383,8 @@ describe "brew bottle --merge", :integration_test do
       ==> testball
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
+          sha256 cellar: :any_skip_relocation, big_sur: "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f"
+          sha256 cellar: :any_skip_relocation, catalina: "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac"
         end
     EOS
 
@@ -399,8 +399,8 @@ describe "brew bottle --merge", :integration_test do
 
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
+          sha256 cellar: :any_skip_relocation, big_sur: "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f"
+          sha256 cellar: :any_skip_relocation, catalina: "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac"
         end
 
         def install
@@ -464,9 +464,9 @@ describe "brew bottle --merge", :integration_test do
       ==> testball
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
-          sha256 "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059" => :high_sierra, :cellar => :any
+          sha256 cellar: :any_skip_relocation, big_sur: "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f"
+          sha256 cellar: :any_skip_relocation, catalina: "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac"
+          sha256 cellar: :any, high_sierra: "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059"
         end
     EOS
 
@@ -481,9 +481,9 @@ describe "brew bottle --merge", :integration_test do
 
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
-          sha256 "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059" => :high_sierra, :cellar => :any
+          sha256 cellar: :any_skip_relocation, big_sur: "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f"
+          sha256 cellar: :any_skip_relocation, catalina: "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac"
+          sha256 cellar: :any, high_sierra: "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059"
         end
 
         def install

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -149,24 +149,26 @@ describe Homebrew do
     )
 
     hello_hash = bottles_hash["hello"]
-    expect(hello_hash["bottle"]["cellar"]).to eq("any_skip_relocation")
+    expect(hello_hash["bottle"]["tags"]["big_sur"]["cellar"]).to eq("any_skip_relocation")
     expect(hello_hash["bottle"]["tags"]["big_sur"]["filename"]).to eq("hello-1.0.big_sur.bottle.tar.gz")
     expect(hello_hash["bottle"]["tags"]["big_sur"]["local_filename"]).to eq("hello--1.0.big_sur.bottle.tar.gz")
     expect(hello_hash["bottle"]["tags"]["big_sur"]["sha256"]).to eq(
       "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f",
     )
+    expect(hello_hash["bottle"]["tags"]["catalina"]["cellar"]).to eq("any_skip_relocation")
     expect(hello_hash["bottle"]["tags"]["catalina"]["filename"]).to eq("hello-1.0.catalina.bottle.tar.gz")
     expect(hello_hash["bottle"]["tags"]["catalina"]["local_filename"]).to eq("hello--1.0.catalina.bottle.tar.gz")
     expect(hello_hash["bottle"]["tags"]["catalina"]["sha256"]).to eq(
       "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac",
     )
     unzip_hash = bottles_hash["unzip"]
-    expect(unzip_hash["bottle"]["cellar"]).to eq("any")
+    expect(unzip_hash["bottle"]["tags"]["big_sur"]["cellar"]).to eq("any_skip_relocation")
     expect(unzip_hash["bottle"]["tags"]["big_sur"]["filename"]).to eq("unzip-2.0.big_sur.bottle.tar.gz")
     expect(unzip_hash["bottle"]["tags"]["big_sur"]["local_filename"]).to eq("unzip--2.0.big_sur.bottle.tar.gz")
     expect(unzip_hash["bottle"]["tags"]["big_sur"]["sha256"]).to eq(
       "16cf230afdfcb6306c208d169549cf8773c831c8653d2c852315a048960d7e72",
     )
+    expect(unzip_hash["bottle"]["tags"]["catalina"]["cellar"]).to eq("any")
     expect(unzip_hash["bottle"]["tags"]["catalina"]["filename"]).to eq("unzip-2.0.catalina.bottle.tar.gz")
     expect(unzip_hash["bottle"]["tags"]["catalina"]["local_filename"]).to eq("unzip--2.0.catalina.bottle.tar.gz")
     expect(unzip_hash["bottle"]["tags"]["catalina"]["sha256"]).to eq(
@@ -202,16 +204,6 @@ describe Homebrew do
       ]
     end
 
-    it "checks for conflicting cellar" do
-      old_spec = BottleSpecification.new
-      old_spec.cellar("/opt/failbrew/Cellar")
-      new_hash = { "cellar" => "/opt/testbrew/Cellar" }
-      expect(homebrew.merge_bottle_spec([:cellar], old_spec, new_hash)).to eq [
-        ['cellar: old: "/opt/failbrew/Cellar", new: "/opt/testbrew/Cellar"'],
-        [],
-      ]
-    end
-
     it "checks for conflicting rebuild number" do
       old_spec = BottleSpecification.new
       old_spec.rebuild(1)
@@ -227,10 +219,46 @@ describe Homebrew do
       old_spec.sha256("109c0cb581a7b5d84da36d84b221fb9dd0f8a927b3044d82611791c9907e202e" => :catalina)
       old_spec.sha256("7571772bf7a0c9fe193e70e521318b53993bee6f351976c9b6e01e00d13d6c3f" => :mojave)
       new_hash = { "tags" => { "catalina" => "ec6d7f08412468f28dee2be17ad8cd8b883b16b34329efcecce019b8c9736428" } }
+      expected_checksum_hash = { "7571772bf7a0c9fe193e70e521318b53993bee6f351976c9b6e01e00d13d6c3f" => :mojave }
+      expected_checksum_hash[:cellar] = Homebrew::DEFAULT_CELLAR
       expect(homebrew.merge_bottle_spec([:sha256], old_spec, new_hash)).to eq [
         ["sha256 => catalina"],
-        [{ "7571772bf7a0c9fe193e70e521318b53993bee6f351976c9b6e01e00d13d6c3f" => :mojave }],
+        [expected_checksum_hash],
       ]
+    end
+  end
+
+  describe "::generate_sha256_line", :needs_linux do
+    it "generates a string without cellar" do
+      expect(homebrew.generate_sha256_line(:catalina, "deadbeef", nil)).to eq(
+        <<~RUBY.chomp,
+          sha256 "deadbeef" => :catalina
+        RUBY
+      )
+    end
+
+    it "generates a string with cellar symbol" do
+      expect(homebrew.generate_sha256_line(:catalina, "deadbeef", :any)).to eq(
+        <<~RUBY.chomp,
+          sha256 "deadbeef" => :catalina, :cellar => :any
+        RUBY
+      )
+    end
+
+    it "generates a string with default cellar path" do
+      expect(homebrew.generate_sha256_line(:catalina, "deadbeef", Homebrew::DEFAULT_LINUX_CELLAR)).to eq(
+        <<~RUBY.chomp,
+          sha256 "deadbeef" => :catalina
+        RUBY
+      )
+    end
+
+    it "generates a string with non-default cellar path" do
+      expect(homebrew.generate_sha256_line(:catalina, "deadbeef", "/home/test")).to eq(
+        <<~RUBY.chomp,
+          sha256 "deadbeef" => :catalina, :cellar => "/home/test"
+        RUBY
+      )
     end
   end
 end
@@ -292,9 +320,8 @@ describe "brew bottle --merge", :integration_test, :needs_linux do
       ==> testball
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          cellar :any_skip_relocation
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina
+          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
+          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
         end
     EOS
 
@@ -307,9 +334,8 @@ describe "brew bottle --merge", :integration_test, :needs_linux do
 
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          cellar :any_skip_relocation
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina
+          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
+          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
         end
 
         option "with-foo", "Build with foo"
@@ -357,9 +383,8 @@ describe "brew bottle --merge", :integration_test, :needs_linux do
       ==> testball
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          cellar :any_skip_relocation
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina
+          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
+          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
         end
     EOS
 
@@ -374,9 +399,8 @@ describe "brew bottle --merge", :integration_test, :needs_linux do
 
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          cellar :any_skip_relocation
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina
+          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
+          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
         end
 
         def install
@@ -421,7 +445,7 @@ describe "brew bottle --merge", :integration_test, :needs_linux do
 
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          cellar :any_skip_relocation
+          cellar :any
           sha256 "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059" => :high_sierra
         end
       EOS
@@ -440,10 +464,9 @@ describe "brew bottle --merge", :integration_test, :needs_linux do
       ==> testball
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          cellar :any_skip_relocation
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina
-          sha256 "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059" => :high_sierra
+          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
+          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
+          sha256 "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059" => :high_sierra, :cellar => :any
         end
     EOS
 
@@ -458,10 +481,9 @@ describe "brew bottle --merge", :integration_test, :needs_linux do
 
         bottle do
           root_url "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}"
-          cellar :any_skip_relocation
-          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur
-          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina
-          sha256 "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059" => :high_sierra
+          sha256 "a0af7dcbb5c83f6f3f7ecd507c2d352c1a018f894d51ad241ce8492fa598010f" => :big_sur, :cellar => :any_skip_relocation
+          sha256 "5334dd344986e46b2aa4f0471cac7b0914bd7de7cb890a34415771788d03f2ac" => :catalina, :cellar => :any_skip_relocation
+          sha256 "6971b6eebf4c00eaaed72a1104a49be63861eabc95d679a0c84040398e320059" => :high_sierra, :cellar => :any
         end
 
         def install


### PR DESCRIPTION
With #10186 now merged, the tag specific cellar information is being read by brew.
This PR (once merged) will start adding the cellar information for each tag instead
of having a single cellar line on the top of the bottle block.

Each new CI build in homebrew-core will slowly start migrating the cellar lines to
the right place. If keep-old is used, the old "all tag" cellar line is removed and
added to each tag.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
