### PR TITLE
version: fix type signature

### DIFF
--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -1,6 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
+require "pkg_version"
 require "version/null"
 
 # A formula's version.
@@ -509,7 +510,7 @@ class Version
   end
   private_class_method :_parse
 
-  sig { params(val: T.any(String, Version), detected_from_url: T::Boolean).void }
+  sig { params(val: T.any(PkgVersion, String, Version), detected_from_url: T::Boolean).void }
   def initialize(val, detected_from_url: false)
     raise TypeError, "Version value must be a string; got a #{val.class} (#{val})" unless val.respond_to?(:to_str)
 


### PR DESCRIPTION
Fixes a type error encountered when running `brew cleanup`:

```console
% brew cleanup -s
Error: Parameter 'val': Expected type T.any(String, Version), got type PkgVersion with hash 2964960359647174741
Caller: /usr/local/Homebrew/Library/Homebrew/cleanup.rb:81
Definition: /usr/local/Homebrew/Library/Homebrew/version.rb:513
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6216/lib/types/configuration.rb:247:in `call_validation_error_handler_default'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6216/lib/types/configuration.rb:254:in `call_validation_error_handler'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6216/lib/types/private/methods/call_validation.rb:1125:in `report_error'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6216/lib/types/private/methods/call_validation.rb:81:in `block in validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6216/lib/types/private/methods/signature.rb:186:in `each_args_value_type'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6216/lib/types/private/methods/call_validation.rb:78:in `validate_call'
/usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.6216/lib/types/private/methods/call_validation.rb:186:in `block in create_validator_slow'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:81:in `new'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:81:in `stale_formula?'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:59:in `stale?'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:321:in `block in cleanup_cache'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:304:in `each'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:304:in `cleanup_cache'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:239:in `cleanup_formula'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:191:in `block in clean!'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:190:in `each'
/usr/local/Homebrew/Library/Homebrew/cleanup.rb:190:in `clean!'
/usr/local/Homebrew/Library/Homebrew/cmd/cleanup.rb:57:in `cleanup'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----