### PR TITLE
tests: make macOS tests require a passing syntax job.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,7 @@ jobs:
 
   test-everything:
     name: test everything (macOS)
+    needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
The syntax job is quick (takes 1m) and this avoids running the long macOS job (for which we have a limited number of workers) unless it has passed.