### PR TITLE
cleanup: raise failures and handle later.

### DIFF
--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -249,7 +249,7 @@ module Homebrew
     end
 
     def cleanup_keg(keg)
-      cleanup_path(keg) { keg.uninstall }
+      cleanup_path(keg) { keg.uninstall(raise_failures: true) }
     rescue Errno::EACCES => e
       opoo e.message
       unremovable_kegs << keg

--- a/Library/Homebrew/keg.rb
+++ b/Library/Homebrew/keg.rb
@@ -319,7 +319,7 @@ class Keg
     opt_record.parent.rmdir_if_possible
   end
 
-  def uninstall
+  def uninstall(raise_failures: false)
     CacheStoreDatabase.use(:linkage) do |db|
       break unless db.created?
 
@@ -333,6 +333,8 @@ class Keg
     remove_old_aliases
     remove_oldname_opt_record
   rescue Errno::EACCES, Errno::ENOTEMPTY
+    raise if raise_failures
+
     odie <<~EOS
       Could not remove #{name} keg! Do so manually:
         sudo rm -rf #{path}


### PR DESCRIPTION
These are already handled and outputted as a group in `cmd/cleanup.rb`.

Fixes https://github.com/Homebrew/brew/issues/10379