### PR TITLE
Fix HOMEBREW_BOOTSNAP setup

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -370,7 +370,7 @@ Sorbet/FalseSigil:
     - "/**/{Formula,Casks}/*.rb"
     - "**/{Formula,Casks}/*.rb"
     - "Homebrew/test/**/Casks/**/*.rb"
-    - "Homebrew/bootsnap.rb"
+    - "Homebrew/homebrew_bootsnap.rb"
 
 Sorbet/StrictSigil:
   Enabled: true

--- a/Library/Homebrew/homebrew_bootsnap.rb
+++ b/Library/Homebrew/homebrew_bootsnap.rb
@@ -7,7 +7,21 @@
 raise "Needs HOMEBREW_BOOTSNAP!" unless ENV["HOMEBREW_BOOTSNAP"]
 
 require "rubygems"
-require "bootsnap"
+
+begin
+  require "bootsnap"
+rescue LoadError
+  raise if ENV["HOMEBREW_BOOTSNAP_RETRY"]
+
+  Dir.chdir(HOMEBREW_LIBRARY_PATH) do
+    system "bundle", "install", "--standalone"
+  end
+
+  ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"
+  exec ENV["HOMEBREW_BREW_FILE"], *ARGV
+end
+
+ENV.delete("HOMEBREW_BOOTSNAP_RETRY")
 
 Bootsnap.setup(
   cache_dir:            "#{ENV["HOMEBREW_TEMP"]}/homebrew-bootsnap",

--- a/Library/Homebrew/load_path.rb
+++ b/Library/Homebrew/load_path.rb
@@ -10,7 +10,7 @@ $LOAD_PATH.push HOMEBREW_LIBRARY_PATH.to_s
 require "vendor/bundle/bundler/setup"
 
 if ENV["HOMEBREW_BOOTSNAP"]
-  require "bootsnap"
+  require "homebrew_bootsnap"
 else
   $LOAD_PATH.select! { |d| Pathname(d).directory? }
   $LOAD_PATH.uniq!


### PR DESCRIPTION
- rename to `homebrew_bootsnap.rb` to avoid conflicting with the `bootsnap.rb` we need to `require`
- if the `require` fails: run bundler (until we vendor this gem)