### PR TITLE
Fix broken network-facing cask test

### DIFF
--- a/Library/Homebrew/test/cask/cmd/info_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/info_spec.rb
@@ -156,4 +156,49 @@ describe Cask::Cmd::Info, :cask do
       Caffeine.app (App)
     EOS
   end
+
+  it "can run be run with a url twice and returns analytics", :needs_network do
+    analytics = {
+      "analytics" => {
+        "install" => {
+          "30d" => { "docker" => 1000 }, "90d" => { "docker" => 2000 }, "365d" => { "docker" => 3000 }
+        },
+      },
+    }
+    expect(Utils::Analytics).to receive(:formulae_brew_sh_json).twice.with("cask/docker.json")
+    .and_return(analytics)
+    expect {
+      described_class.run("https://raw.githubusercontent.com/Homebrew/homebrew-cask" \
+                          "/d0b2c58652ae5eff20a7a4ac93292a08b250912b/Casks/docker.rb")
+      described_class.run("https://raw.githubusercontent.com/Homebrew/homebrew-cask" \
+                          "/d0b2c58652ae5eff20a7a4ac93292a08b250912b/Casks/docker.rb")
+    }.to output(<<~EOS).to_stdout
+      ==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-cask/d0b2c58652ae5eff20a7a4ac93292a08b250912b/Casks/docker.rb.
+      docker: 2.0.0.2-ce-mac81,30215 (auto_updates)
+      https://www.docker.com/community-edition
+      Not installed
+      ==> Names
+      Docker Community Edition
+      Docker CE
+      ==> Description
+      None
+      ==> Artifacts
+      Docker.app (App)
+      ==> Analytics
+      install: 1,000 (30 days), 2,000 (90 days), 3,000 (365 days)
+      ==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-cask/d0b2c58652ae5eff20a7a4ac93292a08b250912b/Casks/docker.rb.
+      docker: 2.0.0.2-ce-mac81,30215 (auto_updates)
+      https://www.docker.com/community-edition
+      Not installed
+      ==> Names
+      Docker Community Edition
+      Docker CE
+      ==> Description
+      None
+      ==> Artifacts
+      Docker.app (App)
+      ==> Analytics
+      install: 1,000 (30 days), 2,000 (90 days), 3,000 (365 days)
+    EOS
+  end
 end

--- a/Library/Homebrew/test/download_strategies_spec.rb
+++ b/Library/Homebrew/test/download_strategies_spec.rb
@@ -171,7 +171,6 @@ describe CurlDownloadStrategy do
       expect(subject).to receive(:curl).with(
         "--location",
         "--remote-time",
-        "--continue-at", "0",
         "--output", an_instance_of(Pathname),
         url,
         an_instance_of(Hash)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -118,18 +118,10 @@ module Utils
            destination.size == %r{^.*Content-Range: bytes \d+-\d+/(\d+)\r\n.*$}m.match(headers)&.[](1)&.to_i
           return # We've already downloaded all the bytes
         end
-      else
-        supports_partial_download = false
-      end
-
-      continue_at = if destination.exist? && supports_partial_download
-        "-"
-      else
-        0
       end
 
       curl(
-        "--location", "--remote-time", "--continue-at", continue_at.to_s, "--output", destination, *args, **options
+        "--location", "--remote-time", "--output", destination, *args, **options
       )
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This fixes a test we deleted in #10315. That test had suddenly started going red, with the problem coming down to a network issue fetching code files from `github.com`. After some investigation, I determined that the issue was the `--continue-at -` flag we're passing to `curl`. It appears that `curl` is doing something technically wrong here that most servers will tolerate but a few will blow up at. It's easiest simply to remove that flag at this point, and it does fix this test.