### PR TITLE
cmd/*: print warning if formula fails to load

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -137,7 +137,7 @@ module Homebrew
 
   sig { params(args: CLI::Args).void }
   def print_info(args:)
-    args.named.to_formulae_and_casks_and_unavailable.each_with_index do |obj, i|
+    args.named.to_formulae_and_casks_and_unavailable(quiet: args.quiet?).each_with_index do |obj, i|
       puts unless i.zero?
 
       case obj

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -323,7 +323,7 @@ module Homebrew
     end
 
     ohai "Searching for similarly named formulae..."
-    formulae_search_results = search_formulae(e.name)
+    formulae_search_results = search_formulae(e.name, quiet: args.quiet?)
     case formulae_search_results.length
     when 0
       ofail "No similarly named formulae found."

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -85,7 +85,7 @@ module Homebrew
 
     Install.perform_preinstall_checks
 
-    formulae, casks = args.named.to_formulae_and_casks(method: :resolve)
+    formulae, casks = args.named.to_formulae_and_casks(method: :resolve, quiet: args.quiet?)
                           .partition { |o| o.is_a?(Formula) }
 
     formulae.each do |f|

--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -108,7 +108,7 @@ module Homebrew
     else
       remote_results = search_taps(query, silent: true)
 
-      local_formulae = search_formulae(string_or_regex)
+      local_formulae = search_formulae(string_or_regex, quiet: args.quiet?)
       remote_formulae = remote_results[:formulae]
       all_formulae = local_formulae + remote_formulae
 

--- a/Library/Homebrew/search.rb
+++ b/Library/Homebrew/search.rb
@@ -72,10 +72,10 @@ module Homebrew
       results
     end
 
-    def search_formulae(string_or_regex)
+    def search_formulae(string_or_regex, quiet: true)
       if string_or_regex.is_a?(String) && string_or_regex.match?(HOMEBREW_TAP_FORMULA_REGEX)
         return begin
-          [Formulary.factory(string_or_regex).name]
+          [Formulary.factory(string_or_regex, quiet: quiet).name]
         rescue FormulaUnavailableError
           []
         end
@@ -89,7 +89,7 @@ module Homebrew
 
       results.map do |name|
         formula, canonical_full_name = begin
-          f = Formulary.factory(name)
+          f = Formulary.factory(name, quiet: quiet)
           [f, f.full_name]
         rescue
           [nil, name]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

Commands updated so far:

- `brew info`
- `brew install`
- `brew reinstall`
- `brew search`

Before:

```console
$ brew install athenason/repo/bazel@1.2.1
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
Error: No available formula or cask with the name "athenason/repo/bazel@1.2.1".
```

After:

```console
$ brew install athenason/repo/bazel@1.2.1
==> Searching for similarly named formulae...
Warning: Failed to load formula: athenason/repo/bazel@1.2.1
athenason/repo/bazel@1.2.1: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the athenason/repo tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/athenason/homebrew-repo/Formula/bazel@1.2.1.rb:8

Error: No similarly named formulae found.
Error: No available formula or cask with the name "athenason/repo/bazel@1.2.1".
```

<details><summary>Old PR description</summary>

This PR changes the `search_formulae` method to print a warning for each formula that fails to load. This is helpful for users in understanding why e.g. `brew install` failed for a formula that they do not know is invalid, such as in #10392. On several occasions in the recent past, I too have had to manually figure out why a formula was failing to load as the `brew` output did not say why.

Before this PR, running `brew install` on an invalid formula resulted in this output:

```console
$ brew install athenason/repo/bazel@1.2.1
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
Error: No available formula or cask with the name "athenason/repo/bazel@1.2.1".
```

```console
$ brew search /bazel/                    
==> Formulae
athenason/repo/bazel@1.2.1              bazel ✔                                 bazelisk
```

Here is the output after this PR:

```console
$ brew install athenason/repo/bazel@1.2.1
==> Searching for similarly named formulae...
Warning: Failed to load formula: athenason/repo/bazel@1.2.1
athenason/repo/bazel@1.2.1: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the athenason/repo tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/athenason/homebrew-repo/Formula/bazel@1.2.1.rb:8

Error: No similarly named formulae found.
Error: No available formula or cask with the name "athenason/repo/bazel@1.2.1".
```

```console
$ brew search /bazel/      
Warning: Failed to load formula: athenason/repo/bazel@1.2.1
athenason/repo/bazel@1.2.1: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the athenason/repo tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/athenason/homebrew-repo/Formula/bazel@1.2.1.rb:8

==> Formulae
athenason/repo/bazel@1.2.1              bazel ✔                                 bazelisk
```

(Does this count as `critical`?)

</details>