### PR TITLE
dev-cmd/extract: Improve the usage instructions

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -83,6 +83,7 @@ module Homebrew
   sig { returns(CLI::Parser) }
   def extract_args
     Homebrew::CLI::Parser.new do
+      usage_banner "`extract` [<--version>`=`] [<--force>] <formula> <tap>"
       description <<~EOS
         Look through repository history to find the most recent version of <formula> and
         create a copy in <tap>`/Formula/`<formula>`@`<version>`.rb`. If the tap is not
@@ -95,7 +96,7 @@ module Homebrew
       switch "-f", "--force",
              description: "Overwrite the destination formula if it already exists."
 
-      named_args :formula, number: 2
+      named_args number: 2
     end
   end
 

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -96,7 +96,7 @@ module Homebrew
       switch "-f", "--force",
              description: "Overwrite the destination formula if it already exists."
 
-      named_args number: 2
+      named_args [:formula, :tap], number: 2
     end
   end
 

--- a/Library/Homebrew/test/cask/cmd/create_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/create_spec.rb
@@ -47,7 +47,7 @@ describe Cask::Cmd::Create, :cask do
   it "raises an exception when more than one Cask is given" do
     expect {
       described_class.run("additional-cask", "another-cask")
-    }.to raise_error(UsageError, /Only one cask can be created at a time\./)
+    }.to raise_error(Homebrew::CLI::NumberOfNamedArgumentsError)
   end
 
   it "raises an exception when the Cask already exists" do

--- a/Library/Homebrew/test/cask/cmd/edit_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/edit_spec.rb
@@ -21,7 +21,7 @@ describe Cask::Cmd::Edit, :cask do
   it "raises an error when given more than one argument" do
     expect {
       described_class.new("local-caffeine", "local-transmission")
-    }.to raise_error(UsageError, /Only one cask can be edited at a time\./)
+    }.to raise_error(Homebrew::CLI::NumberOfNamedArgumentsError)
   end
 
   it "raises an exception when the Cask doesn't exist" do

--- a/Library/Homebrew/test/cask/cmd/shared_examples/requires_cask_token.rb
+++ b/Library/Homebrew/test/cask/cmd/shared_examples/requires_cask_token.rb
@@ -6,7 +6,7 @@ shared_examples "a command that requires a Cask token" do
     it "raises an exception " do
       expect {
         described_class.run
-      }.to raise_error(UsageError, /this command requires a .*cask.* argument/)
+      }.to raise_error(UsageError, /This command requires .*cask.* argument/)
     end
   end
 end

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -455,11 +455,11 @@ describe Homebrew::CLI::Parser do
     end
 
     it "doesn't accept fewer than the passed number of arguments" do
-      expect { parser_number.parse([]) }.to raise_error(Homebrew::CLI::MinNamedArgumentsError)
+      expect { parser_number.parse([]) }.to raise_error(Homebrew::CLI::NumberOfNamedArgumentsError)
     end
 
     it "doesn't accept more than the passed number of arguments" do
-      expect { parser_number.parse(["foo", "bar"]) }.to raise_error(Homebrew::CLI::MaxNamedArgumentsError)
+      expect { parser_number.parse(["foo", "bar"]) }.to raise_error(Homebrew::CLI::NumberOfNamedArgumentsError)
     end
 
     it "accepts the passed number of arguments" do
@@ -489,7 +489,7 @@ describe Homebrew::CLI::Parser do
         named_args number: 2
       end
       expect { parser.parse([]) }.to raise_error(
-        Homebrew::CLI::MinNamedArgumentsError, /This command requires exactly 2 named arguments/
+        Homebrew::CLI::NumberOfNamedArgumentsError, /This command requires exactly 2 named arguments/
       )
     end
 
@@ -507,7 +507,7 @@ describe Homebrew::CLI::Parser do
         named_args %w[on off], number: 1
       end
       expect { parser.parse([]) }.to raise_error(
-        Homebrew::CLI::MinNamedArgumentsError, /This command requires exactly 1 subcommand/
+        Homebrew::CLI::NumberOfNamedArgumentsError, /This command requires exactly 1 subcommand/
       )
     end
 
@@ -542,7 +542,7 @@ describe Homebrew::CLI::Parser do
     end
 
     it "doesn't allow less than the specified number of arguments" do
-      expect { parser.parse([]) }.to raise_error(Homebrew::CLI::MinNamedArgumentsError)
+      expect { parser.parse([]) }.to raise_error(Homebrew::CLI::NumberOfNamedArgumentsError)
     end
 
     it "treats a symbol as a single argument of the specified type" do
@@ -550,12 +550,12 @@ describe Homebrew::CLI::Parser do
         named :formula
       end
       expect { formula_parser.parse([]) }.to raise_error(
-        Homebrew::CLI::MinNamedArgumentsError, /This command requires exactly 1 formula argument/
+        Homebrew::CLI::NumberOfNamedArgumentsError, /This command requires exactly 1 formula argument/
       )
     end
 
     it "doesn't allow more than the specified number of arguments" do
-      expect { parser.parse(["foo", "bar"]) }.to raise_error(Homebrew::CLI::MaxNamedArgumentsError)
+      expect { parser.parse(["foo", "bar"]) }.to raise_error(Homebrew::CLI::NumberOfNamedArgumentsError)
     end
   end
 

--- a/Library/Homebrew/test/cli/parser_spec.rb
+++ b/Library/Homebrew/test/cli/parser_spec.rb
@@ -475,18 +475,58 @@ describe Homebrew::CLI::Parser do
       expect { parser_none.parse([]) }.not_to raise_error
     end
 
+    it "displays the correct error message with no arg types and min" do
+      parser = described_class.new do
+        named_args min: 2
+      end
+      expect { parser.parse([]) }.to raise_error(
+        Homebrew::CLI::MinNamedArgumentsError, /This command requires at least 2 named arguments/
+      )
+    end
+
+    it "displays the correct error message with no arg types and number" do
+      parser = described_class.new do
+        named_args number: 2
+      end
+      expect { parser.parse([]) }.to raise_error(
+        Homebrew::CLI::MinNamedArgumentsError, /This command requires exactly 2 named arguments/
+      )
+    end
+
+    it "displays the correct error message with no arg types and max" do
+      parser = described_class.new do
+        named_args max: 1
+      end
+      expect { parser.parse(%w[foo bar]) }.to raise_error(
+        Homebrew::CLI::MaxNamedArgumentsError, /This command does not take more than 1 named argument/
+      )
+    end
+
     it "displays the correct error message with an array of strings" do
       parser = described_class.new do
-        named_args %w[on off], min: 1
+        named_args %w[on off], number: 1
       end
-      expect { parser.parse([]) }.to raise_error(Homebrew::CLI::MinNamedArgumentsError)
+      expect { parser.parse([]) }.to raise_error(
+        Homebrew::CLI::MinNamedArgumentsError, /This command requires exactly 1 subcommand/
+      )
     end
 
     it "displays the correct error message with an array of symbols" do
       parser = described_class.new do
         named_args [:formula, :cask], min: 1
       end
-      expect { parser.parse([]) }.to raise_error(UsageError, /this command requires a formula or cask argument/)
+      expect { parser.parse([]) }.to raise_error(
+        Homebrew::CLI::MinNamedArgumentsError, /This command requires at least 1 formula or cask argument/
+      )
+    end
+
+    it "displays the correct error message with an array of symbols and max" do
+      parser = described_class.new do
+        named_args [:formula, :cask], max: 1
+      end
+      expect { parser.parse(%w[foo bar]) }.to raise_error(
+        Homebrew::CLI::MaxNamedArgumentsError, /This command does not take more than 1 formula or cask argument/
+      )
     end
   end
 
@@ -509,7 +549,9 @@ describe Homebrew::CLI::Parser do
       formula_parser = described_class.new do
         named :formula
       end
-      expect { formula_parser.parse([]) }.to raise_error(UsageError, /this command requires a formula argument/)
+      expect { formula_parser.parse([]) }.to raise_error(
+        Homebrew::CLI::MinNamedArgumentsError, /This command requires exactly 1 formula argument/
+      )
     end
 
     it "doesn't allow more than the specified number of arguments" do

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -898,6 +898,8 @@ _brew_extract() {
       return
       ;;
   esac
+  __brew_complete_formulae
+  __brew_complete_tapped
 }
 
 _brew_fetch() {

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -898,7 +898,6 @@ _brew_extract() {
       return
       ;;
   esac
-  __brew_complete_formulae
 }
 
 _brew_fetch() {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1019,7 +1019,7 @@ or open the Homebrew repository for editing if no formula is provided.
 * `--cask`:
   Treat all named arguments as casks.
 
-### `extract` [*`--version`*`=`] [*`--force`*] *`formula`* ...
+### `extract` [*`--version`*`=`] [*`--force`*] *`formula`* *`tap`*
 
 Look through repository history to find the most recent version of *`formula`* and
 create a copy in *`tap`*`/Formula/`*`formula`*`@`*`version`*`.rb`. If the tap is not

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1417,7 +1417,7 @@ Treat all named arguments as formulae\.
 \fB\-\-cask\fR
 Treat all named arguments as casks\.
 .
-.SS "\fBextract\fR [\fI\-\-version\fR\fB=\fR] [\fI\-\-force\fR] \fIformula\fR \.\.\."
+.SS "\fBextract\fR [\fI\-\-version\fR\fB=\fR] [\fI\-\-force\fR] \fIformula\fR \fItap\fR"
 Look through repository history to find the most recent version of \fIformula\fR and create a copy in \fItap\fR\fB/Formula/\fR\fIformula\fR\fB@\fR\fIversion\fR\fB\.rb\fR\. If the tap is not installed yet, attempt to install/clone the tap before continuing\. To extract a formula from a tap that is not \fBhomebrew/core\fR use its fully\-qualified form of \fIuser\fR\fB/\fR\fIrepo\fR\fB/\fR\fIformula\fR\.
 .
 .TP


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

- A friend got an error message when trying to use `brew extract` and it wasn't immediately obvious to me why. The usage banner only mentioned the "formula" argument, which they'd provided. This improves the error message when there aren't enough arguments so that others have a chance of figuring out how to use this command without having to look at the code for `extract_args`.

Before:

```
➜ brew extract --version='1.4' libftdi
Usage: brew extract [--version=] [--force] formula ...
[...]
Error: Invalid usage: this command requires a formula argument
```

After:

```
➜ brew extract --version='1.4' libftdi
Usage: brew extract [options] formula destination_tap
[...]
Error: Invalid usage: This command requires at least 2 named arguments.
```

- I don't like the "at least 2" phrasing here but that's a dive into the arg parsing code that I don't have time for right now. An alternative was `named_args [:formula, :destination_tap]`, but that gave the error message "requires formula or destination_tap" which wasn't great either. I also tried `min: 2, max: 2` and that was the same "at least 2" message.

----

I still cannot run `brew man` locally because something in my gems is messed up and `ronn` doesn't exist, so I'm going to try to re-learn enough manpage syntax to edit them by hand.