### PR TITLE
utils/curl: use specs when checking http content problems

### DIFF
--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -105,7 +105,7 @@ module Homebrew
           # pull request.
           next if url.match?(%r{^https://dl.bintray.com/homebrew/mirror/})
 
-          if http_content_problem = curl_check_http_content(url)
+          if http_content_problem = curl_check_http_content(url, specs: specs)
             problem http_content_problem
           end
         elsif strategy <= GitDownloadStrategy


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

See https://github.com/Homebrew/discussions/discussions/576

Currently, specs passed to the `url` method are passed to `curl` when fetching the resource but aren't passed to `curl` when auditing the resource's url. For example, the user who opened https://github.com/Homebrew/discussions/discussions/576 needed to use the `--referrer` flag in `curl`. That meant that `brew audit --online` was failing even though the url _was_ reachable when actually running `brew install`.

This PR passes those specs on to `Utils::Curl.curl_check_http_content` to ensure that the check will pass in situations like these.