### PR TITLE
named_args: raise error if formula/cask is found but unreadable

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -50,6 +50,12 @@ module Homebrew
         @to_formulae_and_casks ||= {}
         @to_formulae_and_casks[only] ||= downcased_unique_named.flat_map do |name|
           load_formula_or_cask(name, only: only, method: method)
+        rescue FormulaUnreadableError, FormulaClassUnavailableError,
+               TapFormulaUnreadableError, TapFormulaClassUnavailableError,
+               Cask::CaskUnreadableError
+          # Need to rescue before `*UnavailableError` (superclass of this)
+          # The formula/cask was found, but there's a problem with its implementation
+          raise
         rescue NoSuchKegError, FormulaUnavailableError, Cask::CaskUnavailableError
           ignore_unavailable ? [] : raise
         end.uniq.freeze
@@ -72,6 +78,8 @@ module Homebrew
       end
 
       def load_formula_or_cask(name, only: nil, method: nil)
+        unreadable_errors = []
+
         if only != :cask
           begin
             formula = case method
@@ -90,6 +98,11 @@ module Homebrew
 
             warn_if_cask_conflicts(name, "formula") unless only == :formula
             return formula
+          rescue FormulaUnreadableError, FormulaClassUnavailableError,
+                 TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
+            # Need to rescue before `FormulaUnavailableError` (superclass of this)
+            # The formula was found, but there's a problem with its implementation
+            unreadable_errors << e
           rescue NoSuchKegError, FormulaUnavailableError => e
             raise e if only == :formula
           end
@@ -98,10 +111,16 @@ module Homebrew
         if only != :formula
           begin
             return Cask::CaskLoader.load(name, config: Cask::Config.from_args(@parent))
+          rescue Cask::CaskUnreadableError => e
+            # Need to rescue before `CaskUnavailableError` (superclass of this)
+            # The cask was found, but there's a problem with its implementation
+            unreadable_errors << e
           rescue Cask::CaskUnavailableError => e
             raise e if only == :cask
           end
         end
+
+        raise unreadable_errors.first if unreadable_errors.count == 1
 
         raise FormulaOrCaskUnavailableError, name
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Supersedes https://github.com/Homebrew/brew/pull/10393

Commands such as `brew install` should print an error if the formula/cask is found but it is unreadable

Before:

```console
$ brew install athenason/repo/bazel@1.2.1
==> Searching for similarly named formulae...
Error: No similarly named formulae found.
Error: No available formula or cask with the name "athenason/repo/bazel@1.2.1".
```

After:

```console
$ brew install athenason/repo/bazel@1.2.1
Error: athenason/repo/bazel@1.2.1: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the athenason/repo tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/athenason/homebrew-repo/Formula/bazel@1.2.1.rb:8
```