### PR TITLE
bump-formula-pr: improvements

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -138,6 +138,7 @@ module Homebrew
     raise FormulaUnspecifiedError if formula.blank?
 
     odie "This formula is disabled!" if formula.disabled?
+    odie "This formula is deprecated and does not build!" if formula.deprecation_reason == :does_not_build
     odie "This formula is not in a tap!" if formula.tap.blank?
     odie "This formula's tap is not a Git repository!" unless formula.tap.git?
 
@@ -148,7 +149,7 @@ module Homebrew
     check_open_pull_requests(formula, tap_full_name, args: args)
 
     new_version = args.version
-    check_closed_pull_requests(formula, tap_full_name, version: new_version, args: args) if new_version.present?
+    check_new_version(formula, tap_full_name, version: new_version, args: args) if new_version.present?
 
     opoo "This formula has patches that may be resolved upstream." if formula.patchlist.present?
     if formula.resources.any? { |resource| !resource.name.start_with?("homebrew-") }
@@ -172,10 +173,10 @@ module Homebrew
     old_version = old_formula_version.to_s
     forced_version = new_version.present?
     new_url_hash = if new_url.present? && new_hash.present?
-      check_closed_pull_requests(formula, tap_full_name, url: new_url, args: args) if new_version.blank?
+      check_new_version(formula, tap_full_name, url: new_url, args: args) if new_version.blank?
       true
     elsif new_tag.present? && new_revision.present?
-      check_closed_pull_requests(formula, tap_full_name, url: old_url, tag: new_tag, args: args) if new_version.blank?
+      check_new_version(formula, tap_full_name, url: old_url, tag: new_tag, args: args) if new_version.blank?
       false
     elsif old_hash.blank?
       if new_tag.blank? && new_version.blank? && new_revision.blank?
@@ -190,9 +191,7 @@ module Homebrew
             and old tag are both #{new_tag}.
           EOS
         end
-        if new_version.blank?
-          check_closed_pull_requests(formula, tap_full_name, url: old_url, tag: new_tag, args: args)
-        end
+        check_new_version(formula, tap_full_name, url: old_url, tag: new_tag, args: args) if new_version.blank?
         resource_path, forced_version = fetch_resource(formula, new_version, old_url, tag: new_tag)
         new_revision = Utils.popen_read("git -C \"#{resource_path}\" rev-parse -q --verify HEAD")
         new_revision = new_revision.strip
@@ -219,7 +218,7 @@ module Homebrew
             #{new_url}
         EOS
       end
-      check_closed_pull_requests(formula, tap_full_name, url: new_url, args: args) if new_version.blank?
+      check_new_version(formula, tap_full_name, url: new_url, args: args) if new_version.blank?
       resource_path, forced_version = fetch_resource(formula, new_version, new_url)
       Utils::Tar.validate_file(resource_path)
       new_hash = resource_path.sha256
@@ -462,17 +461,33 @@ module Homebrew
                                              args:  args)
   end
 
-  def check_closed_pull_requests(formula, tap_full_name, args:, version: nil, url: nil, tag: nil)
+  def check_new_version(formula, tap_full_name, args:, version: nil, url: nil, tag: nil)
     if version.nil?
       specs = {}
       specs[:tag] = tag if tag.present?
       version = Version.detect(url, **specs)
     end
+    check_throttle(formula, version)
+    check_closed_pull_requests(formula, tap_full_name, args: args, version: version)
+  end
+
+  def check_throttle(formula, new_version)
+    throttled_rate = formula.tap.audit_exceptions.dig(:throttled_formulae, formula.name)
+    return if throttled_rate.blank?
+
+    formula_suffix = Version.new(new_version).patch.to_i
+    return if formula_suffix.modulo(throttled_rate).zero?
+
+    odie "#{formula} should only be updated every #{throttled_rate} releases on multiples of #{throttled_rate}"
+  end
+
+  def check_closed_pull_requests(formula, tap_full_name, args:, version:)
     # if we haven't already found open requests, try for an exact match across closed requests
-    GitHub.check_for_duplicate_pull_requests("#{formula.name} #{version}", tap_full_name,
-                                             state: "closed",
-                                             file:  formula.path.relative_path_from(formula.tap.path).to_s,
-                                             args:  args)
+    GitHub.check_for_duplicate_pull_requests(formula.name, tap_full_name,
+                                             version: version,
+                                             state:   "closed",
+                                             file:    formula.path.relative_path_from(formula.tap.path).to_s,
+                                             args:    args)
   end
 
   def alias_update_pair(formula, new_formula_version)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- If the formula is deprecated because it doesn't build, raise an error.
   - For example, [`openrtsp`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/openrtsp.rb) will be [disabled on 2021-11-22](https://github.com/Homebrew/homebrew-core/pull/69307); since we have not yet reached that date, it is treated as a deprecated formula (i.e. `disabled?` returns `false`, but `deprecated?` returns `true`). We shouldn't open new bump PRs for this formula because [we've already tried updating it before](https://github.com/Homebrew/homebrew-core/pull/68149#issuecomment-762520242), and future versions will most likely continue failing to build.
- Check if the formula is throttled, and if so, check if the specified new version meets the throttle requirement.
  - For example, raise an error if attempting to bump `aws-sdk-cpp` with a version that isn't a multiple of 10.
- Improved regex for filtering duplicate PRs by title.
  - Changed `(:|\s|$)` to `(:|,|\s|$)` to include commas as delimiters. For example:
    - `brew bump-formula-pr libnetworkit`
      - Should match this open PR: [`libnetworkit, networkit 8.0`](https://github.com/Homebrew/homebrew-core/pull/67184)
      - `libnetworkit` is at the start of the title and is followed by a comma.
  - Added custom regex for checking the titles of closed PRs, which allows for PRs that bump multiple formulae to be counted as duplicate PRs. For example:
    - `brew bump-formula-pr mysql@5.7 --version=5.7.33`
      - Should match this closed PR: [`mysql@5.7 mysql-client@5.7 5.7.33`](https://github.com/Homebrew/homebrew-core/pull/69290)
      - `mysql@5.7` is at the start of the title and is followed by a space.
      - `5.7.33` is at the end of the title and is preceded by a space.
    - `brew bump-formula-pr libbtbb --version=2020-12-R1`
      - Should match this closed PR: [`libbtbb ubertooth 2020-12-R1`](https://github.com/Homebrew/homebrew-core/pull/67722)
      - `libbtbb` is at the start of the title.
      - `2020-12-R1` is at the end of the title.