### PR TITLE
Fix zsh completions for upgrade and reinstall

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -88,8 +88,14 @@ __brew_installed_casks() {
 
 __brew_outdated_formulae() {
   local -a formulae
-  formulae=($(brew outdated))
+  formulae=($(brew outdated --formula))
   _describe -t formulae 'outdated formulae' formulae
+}
+
+__brew_outdated_casks() {
+  local -a casks
+  casks=($(brew outdated --cask))
+  _describe -t casks 'outdated casks' casks
 }
 
 __brew_installed_taps() {
@@ -676,7 +682,7 @@ _brew_reinstall() {
       '::formula:__brew_installed_formulae' \
     - cask-install \
       '--cask[reinstall casks]' \
-      ': :__brew_all_casks' \
+      ': :__brew_installed_casks' \
 }
 
 # brew search, -S:
@@ -879,7 +885,7 @@ _brew_upgrade() {
     ': : __brew_outdated_formulae' \
   - cask-install \
     '--cask[reinstall casks]' \
-    ': :__brew_all_casks' \
+    ': : __brew_outdated_casks' \
 
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
#10410 fixed my previous issue #10409, however it also resulted in the `upgrade` completion to list *every* cask, not just the outdated or installed ones. I noticed the same behavior for `brew reinstall` as well. This fixes those completions to only show installed/outdated casks.

I think this PR might become unnecessary due to #10403, but I created this one anyway in case that one does not get merged soon.