### PR TITLE
homebrew_bootsnap: fix brew tests.

### DIFF
--- a/Library/Homebrew/homebrew_bootsnap.rb
+++ b/Library/Homebrew/homebrew_bootsnap.rb
@@ -23,12 +23,14 @@ end
 
 ENV.delete("HOMEBREW_BOOTSNAP_RETRY")
 
+tmp = ENV["HOMEBREW_TEMP"] || ENV["HOMEBREW_DEFAULT_TEMP"]
+raise "Needs HOMEBREW_TEMP or HOMEBREW_DEFAULT_TEMP!" unless tmp
+
 Bootsnap.setup(
-  cache_dir:            "#{ENV["HOMEBREW_TEMP"]}/homebrew-bootsnap",
+  cache_dir:            "#{tmp}/homebrew-bootsnap",
   development_mode:     false, # TODO: use ENV["HOMEBREW_DEVELOPER"]?,
   load_path_cache:      true,
   autoload_paths_cache: true,
-  disable_trace:        true,
   compile_cache_iseq:   true,
   compile_cache_yaml:   true,
 )


### PR DESCRIPTION
Use one of the possible temp variables and `raise` if not.