### PR TITLE
dev-cmd/bump: increase test coverage

### DIFF
--- a/Library/Homebrew/test/dev-cmd/bump_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bump_spec.rb
@@ -27,5 +27,19 @@ describe "brew bump" do
         .and not_to_output.to_stderr
         .and be_a_success
     end
+
+    it "returns no data and prints a message for HEAD-only formulae" do
+      content = <<~RUBY
+        desc "HEAD-only test formula"
+        homepage "https://brew.sh"
+        head "https://github.com/Homebrew/brew.git"
+      RUBY
+      setup_test_formula("headonly", content)
+
+      expect { brew "bump", "headonly" }
+        .to output(/Formula is HEAD-only./).to_stdout
+        .and not_to_output.to_stderr
+        .and be_a_success
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This is a follow-up PR to increase `brew bump`'s test coverage after the refactoring PR (#10285).

Summary of changes:
* Combined repetitive logic into a single method, `retrieve_and_display_info`.
* Added a test for HEAD-only formulae.

In hindsight, I shouldn't have removed the `do not merge` label from the refactoring PR, I didn't notice the decrease in coverage until Sam mentioned it. Sorry! 😅

CC @samford