### PR TITLE
uninstall: delete references to unused `--binaries` flag

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -146,7 +146,7 @@ module Cask
       installed_cask = installed_caskfile.exist? ? CaskLoader.load(installed_caskfile) : @cask
 
       # Always force uninstallation, ignore method parameter
-      Installer.new(installed_cask, binaries: binaries?, verbose: verbose?, force: true, upgrade: upgrade?).uninstall
+      Installer.new(installed_cask, verbose: verbose?, force: true, upgrade: upgrade?).uninstall
     end
 
     sig { returns(String) }

--- a/Library/Homebrew/cmd/uninstall.rb
+++ b/Library/Homebrew/cmd/uninstall.rb
@@ -69,9 +69,8 @@ module Homebrew
     else
       T.unsafe(Cask::Cmd::Uninstall).uninstall_casks(
         *casks,
-        binaries: EnvConfig.cask_opts_binaries?,
-        verbose:  args.verbose?,
-        force:    args.force?,
+        verbose: args.verbose?,
+        force:   args.force?,
       )
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

~~Similar to https://github.com/Homebrew/brew/pull/10284 and https://github.com/Homebrew/brew/pull/10398, this PR replaces `EnvConfig.cask_opts_` with `args.`~~

Delete references to unused `--binaries` flag