### PR TITLE
cask/audit: disallow new cask to have token in tap_migrations.json

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -48,6 +48,7 @@ module Cask
 
     def run!
       check_denylist
+      check_reverse_migration
       check_required_stanzas
       check_version
       check_sha256
@@ -680,10 +681,20 @@ module Cask
     end
 
     def check_denylist
-      return unless cask.tap&.official?
+      return unless cask.tap
+      return unless cask.tap.official?
       return unless reason = Denylist.reason(cask.token)
 
       add_error "#{cask.token} is not allowed: #{reason}"
+    end
+
+    def check_reverse_migration
+      return unless new_cask?
+      return unless cask.tap
+      return unless cask.tap.official?
+      return unless cask.tap.tap_migrations.key?(cask.token)
+
+      add_error "#{cask.token} is listed in tap_migrations.json"
     end
 
     def check_https_availability

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -37,7 +37,6 @@ describe Cask::Audit, :cask do
   let(:token_conflicts) { nil }
   let(:audit) {
     described_class.new(cask, online:          online,
-
                               strict:          strict,
                               new_cask:        new_cask,
                               token_conflicts: token_conflicts)
@@ -313,6 +312,32 @@ describe Cask::Audit, :cask do
 
         it "does not fail" do
           expect(subject).to pass
+        end
+      end
+
+      context "when cask token is in tap_migrations.json" do
+        let(:cask_token) { "token-migrated" }
+        let(:tap) { Tap.fetch("homebrew/cask") }
+
+        before do
+          allow(tap).to receive(:tap_migrations).and_return({ cask_token => "homebrew/core" })
+          allow(cask).to receive(:tap).and_return(tap)
+        end
+
+        context "and `new_cask` is true" do
+          let(:new_cask) { true }
+
+          it "fails" do
+            expect(subject).to fail_with("#{cask_token} is listed in tap_migrations.json")
+          end
+        end
+
+        context "and `new_cask` is false" do
+          let(:new_cask) { false }
+
+          it "does not fail" do
+            expect(subject).to pass
+          end
         end
       end
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This audit already exists for formulae (but not for casks): https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula_auditor.rb#L688-L699

Related: https://github.com/Homebrew/homebrew-cask/pull/98719