### PR TITLE
ENV.shared: deprecate ncurses_define

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -241,6 +241,8 @@ module SharedEnvExtension
   # Currently only used by aalib in core.
   sig { void }
   def ncurses_define
+    # odeprecated "ENV.ncurses_define"
+
     append "CPPFLAGS", "-DNCURSES_OPAQUE=0"
   end
 


### PR DESCRIPTION
This was only used by 2 formuale in homebrew-core.
One formula did not need the flag anymore and the flag was removed
The other formula (rogue) still needs it, the flag was directly
added to the formula.

There is no reason for us to keep this method.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
