### PR TITLE
zsh: add guards to speed up completions

### DIFF
--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -49,6 +49,8 @@ __brew_completion_caching_policy() {
 }
 
 __brew_formulae() {
+  [[ -prefix '-' ]] && return 0
+
   local -a list
   local comp_cachename=brew_formulae
   if ! _retrieve_cache $comp_cachename; then
@@ -59,18 +61,24 @@ __brew_formulae() {
 }
 
 __brew_installed_formulae() {
+  [[ -prefix '-' ]] && return 0
+
   local -a formulae
   formulae=($(brew list --formula))
   _describe -t formulae 'installed formulae' formulae
 }
 
 __brew_outdated_formulae() {
+  [[ -prefix '-' ]] && return 0
+
   local -a formulae
   formulae=($(brew outdated --formula))
   _describe -t formulae 'outdated formulae' formulae
 }
 
 __brew_casks() {
+  [[ -prefix '-' ]] && return 0
+
   local -a list
   local expl
   local comp_cachename=brew_casks
@@ -84,6 +92,8 @@ __brew_casks() {
 }
 
 __brew_installed_casks() {
+  [[ -prefix '-' ]] && return 0
+
   local -a list
   local expl
   list=( $(brew list --cask) )
@@ -91,18 +101,24 @@ __brew_installed_casks() {
 }
 
 __brew_outdated_casks() {
+  [[ -prefix '-' ]] && return 0
+
   local -a casks
   casks=($(brew outdated --cask))
   _describe -t casks 'outdated casks' casks
 }
 
 __brew_installed_taps() {
+  [[ -prefix '-' ]] && return 0
+
   local -a taps
   taps=($(brew tap))
   _describe -t installed-taps 'installed taps' taps
 }
 
 __brew_any_tap() {
+  [[ -prefix '-' ]] && return 0
+
   _alternative \
     'installed-taps:installed taps:__brew_installed_taps'
 }

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -52,6 +52,8 @@ __brew_completion_caching_policy() {
 }
 
 __brew_formulae() {
+  [[ -prefix '-' ]] && return 0
+
   local -a list
   local comp_cachename=brew_formulae
   if ! _retrieve_cache $comp_cachename; then
@@ -62,18 +64,24 @@ __brew_formulae() {
 }
 
 __brew_installed_formulae() {
+  [[ -prefix '-' ]] && return 0
+
   local -a formulae
   formulae=($(brew list --formula))
   _describe -t formulae 'installed formulae' formulae
 }
 
 __brew_outdated_formulae() {
+  [[ -prefix '-' ]] && return 0
+
   local -a formulae
   formulae=($(brew outdated --formula))
   _describe -t formulae 'outdated formulae' formulae
 }
 
 __brew_casks() {
+  [[ -prefix '-' ]] && return 0
+
   local -a list
   local expl
   local comp_cachename=brew_casks
@@ -87,6 +95,8 @@ __brew_casks() {
 }
 
 __brew_installed_casks() {
+  [[ -prefix '-' ]] && return 0
+
   local -a list
   local expl
   list=( $(brew list --cask) )
@@ -94,18 +104,24 @@ __brew_installed_casks() {
 }
 
 __brew_outdated_casks() {
+  [[ -prefix '-' ]] && return 0
+
   local -a casks
   casks=($(brew outdated --cask))
   _describe -t casks 'outdated casks' casks
 }
 
 __brew_installed_taps() {
+  [[ -prefix '-' ]] && return 0
+
   local -a taps
   taps=($(brew tap))
   _describe -t installed-taps 'installed taps' taps
 }
 
 __brew_any_tap() {
+  [[ -prefix '-' ]] && return 0
+
   _alternative \
     'installed-taps:installed taps:__brew_installed_taps'
 }


### PR DESCRIPTION
If we type `brew install -<TAB>` we shouldn't try to shell out to Ruby to get a list of formulae for completions, since formulae aren't allowed to start with a hyphen.

This is especially important for commands that we can't or don't already cache, such as a list of outdated formulae or installed taps. `brew link --<TAB>` before and after this pull request is a good example to showcase the speedup, or try `brew install --<TAB>` after removing your zsh completions cache in `~/.zcomp*`.

http://zsh.sourceforge.net/Doc/Release/Completion-Widgets.html#Completion-Condition-Codes

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----