### PR TITLE
named_args: raise or print error if both or either formula/cask unreadable

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -78,7 +78,7 @@ module Homebrew
       end
 
       def load_formula_or_cask(name, only: nil, method: nil)
-        unreadable_errors = []
+        unreadable_error = nil
 
         if only != :cask
           begin
@@ -102,7 +102,7 @@ module Homebrew
                  TapFormulaUnreadableError, TapFormulaClassUnavailableError => e
             # Need to rescue before `FormulaUnavailableError` (superclass of this)
             # The formula was found, but there's a problem with its implementation
-            unreadable_errors << e
+            unreadable_error ||= e
           rescue NoSuchKegError, FormulaUnavailableError => e
             raise e if only == :formula
           end
@@ -114,13 +114,13 @@ module Homebrew
           rescue Cask::CaskUnreadableError => e
             # Need to rescue before `CaskUnavailableError` (superclass of this)
             # The cask was found, but there's a problem with its implementation
-            unreadable_errors << e
+            unreadable_error ||= e
           rescue Cask::CaskUnavailableError => e
             raise e if only == :cask
           end
         end
 
-        raise unreadable_errors.first if unreadable_errors.count == 1
+        raise unreadable_error if unreadable_error.present?
 
         raise FormulaOrCaskUnavailableError, name
       end

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -99,7 +99,7 @@ describe Homebrew::CLI::NamedArgs do
       end
 
       it "raises an error" do
-        expect { described_class.new("foo").to_formulae_and_casks }.to raise_error(FormulaOrCaskUnavailableError)
+        expect { described_class.new("foo").to_formulae_and_casks }.to raise_error(FormulaUnreadableError)
       end
 
       it "raises an error if loading formula only" do

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -122,6 +122,7 @@ describe Homebrew::CLI::NamedArgs do
       setup_unredable_cask "foo"
 
       expect(described_class.new("foo").to_formulae_and_casks).to eq [foo]
+      expect { described_class.new("foo").to_formulae_and_casks }.to output(/Failed to load cask: foo/).to_stderr
     end
 
     it "returns cask when formula is unreadable and cask is present" do
@@ -129,6 +130,7 @@ describe Homebrew::CLI::NamedArgs do
       stub_cask_loader foo_cask
 
       expect(described_class.new("foo").to_formulae_and_casks).to eq [foo_cask]
+      expect { described_class.new("foo").to_formulae_and_casks }.to output(/Failed to load formula: foo/).to_stderr
     end
 
     it "raises an error when formula is absent and cask is unreadable" do

--- a/Library/Homebrew/test/cmd/--cache_spec.rb
+++ b/Library/Homebrew/test/cmd/--cache_spec.rb
@@ -11,12 +11,20 @@ describe "brew --cache", :integration_test do
   it "prints all cache files for a given Formula" do
     expect { brew "--cache", testball }
       .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--testball-}o).to_stdout
+      .and output(/Treating #{Regexp.escape(testball)} as a formula/).to_stderr
+      .and be_a_success
+    expect { brew "--cache", "--formula", testball }
+      .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--testball-}o).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end
 
   it "prints the cache files for a given Cask" do
     expect { brew "--cache", cask_path("local-caffeine") }
+      .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}o).to_stdout
+      .and output(/Treating #{Regexp.escape(cask_path("local-caffeine"))} as a cask/).to_stderr
+      .and be_a_success
+    expect { brew "--cache", "--cask", cask_path("local-caffeine") }
       .to output(%r{#{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip}o).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
@@ -30,7 +38,7 @@ describe "brew --cache", :integration_test do
           #{HOMEBREW_CACHE}/downloads/[\da-f]{64}--caffeine\.zip
         }xo,
       ).to_stdout
-      .and not_to_output.to_stderr
+      .and output(/(Treating .* as a formula).*(Treating .* as a cask)/m).to_stderr
       .and be_a_success
   end
 end

--- a/Library/Homebrew/test/cmd/home_spec.rb
+++ b/Library/Homebrew/test/cmd/home_spec.rb
@@ -40,6 +40,10 @@ describe "brew home", :integration_test do
   it "opens the homepage for a given Cask" do
     expect { brew "home", local_caffeine_path, "HOMEBREW_BROWSER" => "echo" }
       .to output(/#{local_caffeine_homepage}/).to_stdout
+      .and output(/Treating #{Regexp.escape(local_caffeine_path)} as a cask/).to_stderr
+      .and be_a_success
+    expect { brew "home", "--cask", local_caffeine_path, "HOMEBREW_BROWSER" => "echo" }
+      .to output(/#{local_caffeine_homepage}/).to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end
@@ -49,7 +53,7 @@ describe "brew home", :integration_test do
 
     expect { brew "home", "testballhome", local_caffeine_path, "HOMEBREW_BROWSER" => "echo" }
       .to output(/#{testballhome_homepage} #{local_caffeine_homepage}/).to_stdout
-      .and not_to_output.to_stderr
+      .and output(/Treating #{Regexp.escape(local_caffeine_path)} as a cask/).to_stderr
       .and be_a_success
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Related: https://github.com/Homebrew/brew/pull/10405, https://github.com/Homebrew/brew/pull/10422

This PR changes how some edge cases are handled in `named_args.rb`:

- When both the formula and the cask are unreadable, raise the `FormulaUnreadableError`
- When both the formula and the cask are present and one of them is unreadable, print the error and a warning that the readable one will be used.

<details open><summary><code>brew info</code> output when both the formula and the cask are unreadable</summary>

Before:

```console
$ brew info crunch
Error: No available formula or cask with the name "crunch".
```

After:

```console
$ brew info crunch
Error: crunch: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/crunch.rb:5: syntax error, unexpected tSTRING_BEG, expecting end
  sha 256 "6a8f6c3c7410cc1930e6854d1dadc...
          ^
```

</details>

<details open><summary><code>brew info</code> output when only the formula is unreadable</summary>

Before:

```console
$ brew info crunch
crunch: 4.0.0
```

After:

```console
$ brew info crunch
Error: Failed to load formula: crunch
crunch: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/crunch.rb:5: syntax error, unexpected tSTRING_BEG, expecting end
  sha 256 "6a8f6c3c7410cc1930e6854d1dadc...
          ^
Warning: Treating crunch as a cask.
crunch: 4.0.0
...
```

</details>

<details><summary><code>brew info</code> output when only the cask is unreadable</summary>

Before:

```console
$ brew info crunch
crunch: stable 3.6 (bottled)
...
```

After:

```console
$ brew info crunch
Error: Failed to load cask: crunch
Cask 'crunch' is unreadable: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/crunch.rb:3: syntax error, unexpected tSTRING_BEG, expecting end
  sha 256 "6969fcb91e5a93b9d9e604cca2e6a...
          ^
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/crunch.rb:17: syntax error, unexpected end, expecting end-of-input
Warning: Treating crunch as a formula.
crunch: stable 3.6 (bottled)
...
```

</details>