### PR TITLE
livecheck: fix filtering of watchlist with --formulae/--casks flag

### DIFF
--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -89,11 +89,8 @@ module Homebrew
                           .reject { |line| line.start_with?("#") || line.blank? }
                           .map(&:strip)
 
-          named_args = T.unsafe(CLI::NamedArgs).new(*names)
-          named_args.to_formulae_and_casks.reject do |formula_or_cask|
-            (args.formula? && !formula_or_cask.is_a?(Formula)) ||
-              (args.cask? && !formula_or_cask.is_a?(Cask::Cask))
-          end
+          named_args = T.unsafe(CLI::NamedArgs).new(*names, parent: args)
+          named_args.to_formulae_and_casks(ignore_unavailable: true)
         rescue Errno::ENOENT => e
           onoe e
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

`~/.brew_livecheck_watchlist`:

```
appium
```

Before:

```console
$ brew livecheck --formulae
Warning: Treating appium as a formula. For the cask, use homebrew/cask/appium
appium : 1.20.2 ==> 1.20.2
```

```console
$ brew livecheck --casks
Warning: Treating appium as a formula. For the cask, use homebrew/cask/appium
Error: Invalid usage: No formulae or casks to check.
```

After:

```console
$ brew livecheck --formulae
appium : 1.20.2 ==> 1.20.2
```

```console
$ brew livecheck --casks
appium : 1.19.1 ==> 1.20.0
```