### PR TITLE
tests: cleanup user configuration.

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -44,17 +44,17 @@ module Homebrew
     require "byebug" if args.byebug?
 
     HOMEBREW_LIBRARY_PATH.cd do
-      ENV.delete("HOMEBREW_COLOR")
-      ENV.delete("HOMEBREW_NO_COLOR")
-      ENV.delete("HOMEBREW_VERBOSE")
-      ENV.delete("HOMEBREW_DEBUG")
-      ENV.delete("HOMEBREW_CASK_OPTS")
-      ENV.delete("HOMEBREW_TEMP")
-      ENV.delete("HOMEBREW_NO_GITHUB_API")
-      ENV.delete("HOMEBREW_NO_EMOJI")
-      ENV.delete("HOMEBREW_DEVELOPER")
-      ENV.delete("HOMEBREW_PRY")
-      ENV.delete("HOMEBREW_BAT")
+      # Cleanup any unwanted user configuration.
+      allowed_test_env = [
+        "HOMEBREW_GITHUB_API_TOKEN",
+        "HOMEBREW_TEMP",
+      ]
+      Homebrew::EnvConfig::ENVS.keys.map(&:to_s).each do |env|
+        next if allowed_test_env.include?(env)
+
+        ENV.delete(env)
+      end
+
       ENV["HOMEBREW_NO_ANALYTICS_THIS_RUN"] = "1"
       ENV["HOMEBREW_NO_COMPAT"] = "1" if args.no_compat?
       ENV["HOMEBREW_TEST_GENERIC_OS"] = "1" if args.generic?

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -199,8 +199,11 @@ describe Homebrew::Cleanup do
   describe "::cleanup_logs" do
     let(:path) { (HOMEBREW_LOGS/"delete_me") }
 
-    it "cleans all logs if prune is 0" do
+    before do
       path.mkpath
+    end
+
+    it "cleans all logs if prune is 0" do
       described_class.new(days: 0).cleanup_logs
       expect(path).not_to exist
     end
@@ -208,7 +211,6 @@ describe Homebrew::Cleanup do
     it "cleans up logs if older than 30 days" do
       allow_any_instance_of(Pathname).to receive(:ctime).and_return(31.days.ago)
       allow_any_instance_of(Pathname).to receive(:mtime).and_return(31.days.ago)
-      path.mkpath
       subject.cleanup_logs
       expect(path).not_to exist
     end
@@ -216,7 +218,6 @@ describe Homebrew::Cleanup do
     it "does not clean up logs less than 30 days old" do
       allow_any_instance_of(Pathname).to receive(:ctime).and_return(15.days.ago)
       allow_any_instance_of(Pathname).to receive(:mtime).and_return(15.days.ago)
-      path.mkpath
       subject.cleanup_logs
       expect(path).to exist
     end


### PR DESCRIPTION
I suspect this may be part of the cause of the flaky `cleanup` spec.

Also, while we're working on that, revert 3724c739f880945ec76a16ef8b9209c6440f0035 because it didn't make any different to the cleanup spec.