### PR TITLE
style: handle line too long for new bottle blocks

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -353,7 +353,7 @@ Layout/LineLength:
       ' name "',
       ' pkg "',
       ' pkgutil: "',
-      '    sha256 "',
+      '    sha256 cellar: ',
       "#{language}",
       "#{version.",
       ' "/Library/Application Support/',


### PR DESCRIPTION
The " was for a previous syntax we had, but we dropped that and changed our minds.
This PR fixes the style check for the current implementation of the new bottle blocks.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
