### PR TITLE
compilers: prefer gcc 5 on linux, select brewed compiler when defined

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -111,9 +111,13 @@ class CompilerSelector
 
   private
 
+  def preferred_gcc
+    "gcc"
+  end
+
   def gnu_gcc_versions
     # prioritize gcc version provided by gcc formula.
-    v = Formulary.factory("gcc").version.to_s.slice(/\d+/)
+    v = Formulary.factory(preferred_gcc).version.to_s.slice(/\d+/)
     GNU_GCC_VERSIONS - [v] + [v] # move the version to the end of the list
   rescue FormulaUnavailableError
     GNU_GCC_VERSIONS
@@ -150,3 +154,5 @@ class CompilerSelector
     end
   end
 end
+
+require "extend/os/compilers"

--- a/Library/Homebrew/extend/os/compilers.rb
+++ b/Library/Homebrew/extend/os/compilers.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/linux/compilers" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/compilers.rb
+++ b/Library/Homebrew/extend/os/linux/compilers.rb
@@ -1,0 +1,8 @@
+# typed: strict
+# frozen_string_literal: true
+
+class CompilerSelector
+  def preferred_gcc
+    "gcc@5"
+  end
+end

--- a/Library/Homebrew/extend/os/linux/software_spec.rb
+++ b/Library/Homebrew/extend/os/linux/software_spec.rb
@@ -1,5 +1,39 @@
-# typed: strict
+# typed: true
 # frozen_string_literal: true
+
+class SoftwareSpec
+  extend T::Sig
+
+  GNU_GCC_REGEXP = /^(gcc)$|^(gcc@(4\.9|[5-9]|[10-99]))$/.freeze
+
+  sig { params(spec: T.any(String, T::Hash[T.untyped, T.untyped])).void }
+  def remove_gnu_compilers(spec)
+    spec = spec.keys.first if spec.is_a?(Hash)
+    return unless spec.is_a?(String)
+    return unless spec.match?(GNU_GCC_REGEXP)
+
+    # When a formula explicitely depends on a specific gcc compiler,
+    # remove the other compilers to avoid having to define fails_with
+    # manually for all the others compiler versions.
+    gcc_version_to_keep = Formulary.factory(spec).version.to_s.slice(/\d+/)
+
+    versions = CompilerConstants::GNU_GCC_VERSIONS
+
+    if spec == "gcc"
+      # Special case for gcc: in linuxbrew-core, gcc is currently at version 5,
+      # so when we use 'depend_on "gcc"' we do not want to remove version 5.
+      # Once https://github.com/Homebrew/linuxbrew-core/pull/21380 is merged,
+      # this line becomes useless and we can remove the whole if/else logic
+      versions -= [gcc_version_to_keep] if gcc_version_to_keep != "5"
+    else
+      versions -= [gcc_version_to_keep]
+    end
+
+    versions.each do |v|
+      fails_with("gcc-#{v}")
+    end
+  end
+end
 
 class BottleSpecification
   extend T::Sig

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -173,6 +173,7 @@ class SoftwareSpec
   end
 
   def depends_on(spec)
+    remove_gnu_compilers(spec)
     dep = dependency_collector.add(spec)
     add_dep_option(dep) if dep
   end
@@ -181,6 +182,9 @@ class SoftwareSpec
     spec = Hash[*spec.first] if spec.is_a?(Hash)
     depends_on(spec)
   end
+
+  sig { params(spec: T.any(String, T::Hash[T.untyped, T.untyped])).void }
+  def remove_gnu_compilers(spec); end
 
   def deps
     dependency_collector.deps


### PR DESCRIPTION
- Fixes #10170 by preferring gcc@5 on linux (by using the PREFERRED_GCC const)
This makes sure ENV.cc and ENV.cxx is correctly set:
  - If a formula does not depend explicitely on a brewed gcc, ENV.cc is set to gcc-5 (system gcc-5 or brewed gcc-5)
    evend if other gcc versions are installed on the system

- Use fails_with as a way to remove all other compilers from the list of available compilers.
  This avoids having to set any fails_with on linux.
  A small workaround is present for the current setup where gcc == version 5 on linuxbrew-core,
  and we do not want to remove gcc-5 from the list unless explicitely specified. That workaround
  can be removed once https://github.com/Homebrew/linuxbrew-core/pull/21380 is merged

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
