### PR TITLE
cask/audit: error if `verified` does not match, regardless of `url`

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -433,9 +433,8 @@ module Cask
     end
 
     def check_no_match
-      return if url_match_homepage?
       return unless verified_present?
-      return if !url_match_homepage? && verified_matches_url?
+      return if verified_matches_url?
 
       add_error "Verified URL #{url_from_verified} does not match URL #{strip_url_scheme(cask.url.to_s)}. " \
                 "See https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-verified"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR changes `brew audit --cask` such that an error is raised if the `verified` parameter is present for a `url` but does not match. For example, this should give an audit error:

```rb
  url "https://shining.softorino.com/shine_uploads/waltr#{version.major}mac_#{version}.dmg",
      verified: "dl.devmate.com/com.softorino.waltr2/"
```

Related:
- https://github.com/Homebrew/homebrew-cask/pull/98995
- https://github.com/Homebrew/homebrew-cask/pull/98996
- https://github.com/Homebrew/homebrew-cask/pull/98997
- https://github.com/Homebrew/homebrew-cask/pull/98998
- https://github.com/Homebrew/homebrew-cask/pull/98999
- https://github.com/Homebrew/homebrew-cask/pull/99000
- https://github.com/Homebrew/homebrew-cask/pull/99001
- https://github.com/Homebrew/homebrew-cask/pull/99002
- https://github.com/Homebrew/homebrew-cask-drivers/pull/2025