### PR TITLE
Fix fish shell completion for upgrade

### DIFF
--- a/Library/Homebrew/completions/fish.erb
+++ b/Library/Homebrew/completions/fish.erb
@@ -119,7 +119,7 @@ function __fish_brew_suggest_formulae_installed
 end
 
 function __fish_brew_suggest_formulae_outdated -d "List of outdated formulae with the information about potential upgrade"
-    brew outdated --verbose \
+    brew outdated --formula --verbose \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end
@@ -145,7 +145,7 @@ function __fish_brew_suggest_casks_installed -d "Lists installed casks"
 end
 
 function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the information about potential upgrade"
-    brew cask outdated --verbose \
+    brew outdated --cask --verbose \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -106,7 +106,7 @@ function __fish_brew_suggest_formulae_installed
 end
 
 function __fish_brew_suggest_formulae_outdated -d "List of outdated formulae with the information about potential upgrade"
-    brew outdated --verbose \
+    brew outdated --formula --verbose \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end
@@ -132,7 +132,7 @@ function __fish_brew_suggest_casks_installed -d "Lists installed casks"
 end
 
 function __fish_brew_suggest_casks_outdated -d "Lists outdated casks with the information about potential upgrade"
-    brew cask outdated --verbose \
+    brew outdated --cask --verbose \
         # replace first space with tab to make the following a description in the completions list:
         | string replace -r '\s' '\t'
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Trying fish completion for `brew upgrade` results in:
```
brew upgrade Error: Calling `brew cask outdated` is disabled! Use brew outdated [--cask] instead.
Error: Calling `brew cask outdated` is disabled! Use brew outdated [--cask] instead.
Error: Calling `brew cask outdated` is disabled! Use brew outdated [--cask] instead.
```

This updates the deprecated command to properly generate the completion.