### PR TITLE
requirements/java_requirement: delete adoptopenjdk condition

### DIFF
--- a/Library/Homebrew/requirements/java_requirement.rb
+++ b/Library/Homebrew/requirements/java_requirement.rb
@@ -117,12 +117,6 @@ class JavaRequirement < Requirement
   def possible_javas
     javas = []
     javas << Pathname.new(ENV["JAVA_HOME"])/"bin/java" if ENV["JAVA_HOME"]
-    jdk = begin
-      Formula["adoptopenjdk"]
-    rescue FormulaUnavailableError
-      nil
-    end
-    javas << jdk.bin/"java" if jdk&.latest_version_installed?
     javas << which("java")
     javas
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
delete the check `Formula["adoptopenjdk"]` is `latest_version_installed?` because `adoptopenjdk` is a cask and `Formula["adoptopenjdk"]` always raises `FormulaUnavailableError`