### PR TITLE
cask/config: new method for cask.config.explicit as string

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -127,7 +127,7 @@ module Cask
           .map { |arg| T.cast(arg.split("=", 2), [String, String]) }
           .map do |(flag, value)|
             key = flag.sub(/^--/, "")
-
+            # converts --language flag to :languages config key
             if key == "language"
               key = "languages"
               value = value.split(",")
@@ -180,6 +180,18 @@ module Cask
     sig { params(other: Config).returns(T.self_type) }
     def merge(other)
       self.class.new(explicit: other.explicit.merge(explicit))
+    end
+
+    sig { returns(String) }
+    def explicit_s
+      explicit.map do |key, value|
+        # inverse of #env - converts :languages config key back to --language flag
+        if key == :languages
+          key = "language"
+          value = languages.join(",")
+        end
+        "#{key}: \"#{value.to_s.sub(/^#{ENV['HOME']}/, "~")}\""
+      end.join(", ")
     end
 
     sig { params(options: T.untyped).returns(String) }

--- a/Library/Homebrew/test/cask/config_spec.rb
+++ b/Library/Homebrew/test/cask/config_spec.rb
@@ -60,10 +60,21 @@ describe Cask::Config, :cask do
   end
 
   describe "#explicit" do
-    let(:config) { described_class.new(explicit: { appdir: "/explicit/path/to/apps" }) }
+    let(:config) {
+      described_class.new(explicit: { appdir:    "/explicit/path/to/apps",
+                                      languages: ["zh-TW", "en"] })
+    }
 
     it "returns directories explicitly given as arguments" do
       expect(config.explicit[:appdir]).to eq(Pathname("/explicit/path/to/apps"))
+    end
+
+    it "returns array of preferred languages" do
+      expect(config.explicit[:languages]).to eq(["zh-TW", "en"])
+    end
+
+    it "returns string of explicit config keys and values" do
+      expect(config.explicit_s).to eq('appdir: "/explicit/path/to/apps", language: "zh-TW,en"')
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
Export a Cask object's explicit config as string for homebrew-bundle, as suggested in Homebrew/homebrew-bundle#892 for forthcoming homebrew-bundle PR. CC @Homebrew/cask for opinions.