### PR TITLE
bump-formula-pr: pass --formula flag when auditing a bumped formula

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -503,7 +503,7 @@ module Homebrew
   end
 
   def run_audit(formula, alias_rename, old_contents, args:)
-    audit_args = []
+    audit_args = ["--formula"]
     audit_args << "--strict" if args.strict?
     audit_args << "--online" if args.online?
     if args.dry_run?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
Explicitly pass `--formula` flag to prevent cask warning in `bump-formula-pr`.

Before:
```
$ brew bump-formula-pr whistle --url https://registry.npmjs.org/whistle/-/whistle-2.6.4.tgz --no-browse -w --force
==> Downloading https://registry.npmjs.org/whistle/-/whistle-2.6.4.tgz
######################################################################## 100.0%
Warning: Cannot verify integrity of 'b2bf9da204a4c13d7f5bd734cca8504ac08cff334022120f34a058508f2d3a99--whistle-2.6.4.tgz'.
No checksum was provided for this resource.
For your reference, the checksum is:
  sha256 "a6c7f1df6951d7c46d2d98f13448fc696788daf01f86ba33c56dd4d4821227d4"
==> replace /https:\/\/registry\.npmjs\.org\/whistle\/\-\/whistle\-2\.6\.3\.tgz/ with "https://registry.npmjs.org/whistle/-/whistle-2.6.4.tgz"
==> replace "31f11603a1bdbf5f31ff863096d8bde965f186fecc17895847a9032c3250c68d" with "a6c7f1df6951d7c46d2d98f13448fc696788daf01f86ba33c56dd4d4821227d4"
Error: Failed to load cask: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/whistle.rb
Cask 'whistle' is unreadable: wrong constant name #<Class:0x0000000137db7f30>
Warning: Treating /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/whistle.rb as a formula.
...
```

After:
```
$ brew bump-formula-pr whistle --url https://registry.npmjs.org/whistle/-/whistle-2.6.4.tgz --no-browse -w --force
==> Downloading https://registry.npmjs.org/whistle/-/whistle-2.6.4.tgz
######################################################################## 100.0%
Warning: Cannot verify integrity of 'b2bf9da204a4c13d7f5bd734cca8504ac08cff334022120f34a058508f2d3a99--whistle-2.6.4.tgz'.
No checksum was provided for this resource.
For your reference, the checksum is:
  sha256 "a6c7f1df6951d7c46d2d98f13448fc696788daf01f86ba33c56dd4d4821227d4"
==> replace /https:\/\/registry\.npmjs\.org\/whistle\/\-\/whistle\-2\.6\.3\.tgz/ with "https://registry.npmjs.org/whistle/-/whistle-2.6.4.tgz"
==> replace "31f11603a1bdbf5f31ff863096d8bde965f186fecc17895847a9032c3250c68d" with "a6c7f1df6951d7c46d2d98f13448fc696788daf01f86ba33c56dd4d4821227d4"
...
```