### PR TITLE
cask audit: do not require description for fonts

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -325,6 +325,9 @@ module Cask
     def check_desc
       return if cask.desc.present?
 
+      # Fonts seldom benefit from descriptions and requiring them disproportionately increases the maintenance burden
+      return if cask.tap == "homebrew/cask-fonts"
+
       add_warning "Cask should have a description. Please add a `desc` stanza."
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

We have a script which auto-adds/fixes fonts from Google Fonts to [homebrew/cask-fonts](https://github.com/Homebrew/homebrew-cask-fonts/). But those may fail `audit` due to missing `desc` stanzas, [sometimes an absurd amount](https://github.com/Homebrew/homebrew-cask-fonts/pull/3414#issuecomment-761709999). Realistically, font casks do not require descriptions, and we shouldn’t make it a requirement for them.