### PR TITLE
rubocop.yml: disable Rails/RakeEnvironment

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -201,6 +201,8 @@ Rails/Date:
   Enabled: false
 Rails/Delegate:
   Enabled: false
+Rails/RakeEnvironment:
+  Enabled: false
 Rails/SkipsModelValidations:
   Enabled: false
 Rails/Pluck:


### PR DESCRIPTION
Another rule that assumes Rails usage.