### PR TITLE
man: allow command to run on unsupported platforms when --force is passed

### DIFF
--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -35,7 +35,9 @@ module Homebrew
 
   def man
     # TODO: update description above if removing this.
-    raise UsageError, "not (yet) working on Apple Silicon!" if Hardware::CPU.arm?
+    if !ENV["HOMEBREW_SILICON_DEVELOPER"] && Hardware::CPU.arm?
+      raise UsageError, "not (yet) working on Apple Silicon!"
+    end
 
     args = man_args.parse
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
The `brew man` command doesn't work on Apple silicon using the system ruby. However, building and using https://github.com/Homebrew/homebrew-portable-ruby does allow the `ronn` gem and therefore the `brew man` command to work. Given that this is not a supported configuration, allow the command to run on Silicon only if a user passes the `--force` flag.

Helps to address https://github.com/Homebrew/brew/issues/10210