### PR TITLE
java: fix java_home on macOS

### DIFF
--- a/Library/Homebrew/extend/os/language/java.rb
+++ b/Library/Homebrew/extend/os/language/java.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/mac/language/java" if OS.mac?

--- a/Library/Homebrew/extend/os/mac/language/java.rb
+++ b/Library/Homebrew/extend/os/mac/language/java.rb
@@ -1,0 +1,10 @@
+# typed: true
+# frozen_string_literal: true
+
+module Language
+  module Java
+    def self.java_home(version = nil)
+      find_openjdk_formula(version)&.opt_libexec&.join("openjdk.jdk/Contents/Home")
+    end
+  end
+end

--- a/Library/Homebrew/language/java.rb
+++ b/Library/Homebrew/language/java.rb
@@ -45,3 +45,5 @@ module Language
     end
   end
 end
+
+require "extend/os/language/java"

--- a/Library/Homebrew/test/language/java_spec.rb
+++ b/Library/Homebrew/test/language/java_spec.rb
@@ -18,12 +18,22 @@ describe Language::Java do
   end
 
   describe "::java_home" do
-    it "returns valid JAVA_HOME if version is specified" do
+    it "returns valid JAVA_HOME if version is specified", :needs_macos do
+      java_home = described_class.java_home("1.8+")
+      expect(java_home).to eql(f.opt_libexec/"openjdk.jdk/Contents/Home")
+    end
+
+    it "returns valid JAVA_HOME if version is not specified", :needs_macos do
+      java_home = described_class.java_home
+      expect(java_home).to eql(f.opt_libexec/"openjdk.jdk/Contents/Home")
+    end
+
+    it "returns valid JAVA_HOME if version is specified", :needs_linux do
       java_home = described_class.java_home("1.8+")
       expect(java_home).to eql(f.opt_libexec)
     end
 
-    it "returns valid JAVA_HOME if version is not specified" do
+    it "returns valid JAVA_HOME if version is not specified", :needs_linux do
       java_home = described_class.java_home
       expect(java_home).to eql(f.opt_libexec)
     end
@@ -32,24 +42,24 @@ describe Language::Java do
   describe "::java_home_env" do
     it "returns java_home path if version specified" do
       java_home_env = described_class.java_home_env("1.8+")
-      expect(java_home_env[:JAVA_HOME]).to eql(f.opt_libexec.to_s)
+      expect(java_home_env[:JAVA_HOME]).to include(f.opt_libexec.to_s)
     end
 
     it "returns java_home path if version is not specified" do
       java_home_env = described_class.java_home_env
-      expect(java_home_env[:JAVA_HOME]).to eql(f.opt_libexec.to_s)
+      expect(java_home_env[:JAVA_HOME]).to include(f.opt_libexec.to_s)
     end
   end
 
   describe "::overridable_java_home_env" do
     it "returns java_home path if version specified" do
       overridable_java_home_env = described_class.overridable_java_home_env("1.8+")
-      expect(overridable_java_home_env[:JAVA_HOME]).to eql("${JAVA_HOME:-#{f.opt_libexec}}")
+      expect(overridable_java_home_env[:JAVA_HOME]).to include(f.opt_libexec.to_s)
     end
 
     it "returns java_home path if version is not specified" do
       overridable_java_home_env = described_class.overridable_java_home_env
-      expect(overridable_java_home_env[:JAVA_HOME]).to eql("${JAVA_HOME:-#{f.opt_libexec}}")
+      expect(overridable_java_home_env[:JAVA_HOME]).to include(f.opt_libexec.to_s)
     end
   end
 end


### PR DESCRIPTION
https://github.com/Homebrew/brew/pull/10397 incorrectly changed what `java_home` pointed to on macOS. The path is correct on Linux, but on macOS, the Java home is actually in /usr/local/opt/openjdk/libexec/openjdk.jdk/Contents/Home to ensure compatibility with being linked to /Library/Java/JavaVirtualMachines per the openjdk formula caveat.

If a formula used e.g. `bin.write_jar_script` in its install block, this is what it looks like on macOS before and after this pull request.



```sh
#!/bin/bash
export JAVA_HOME="${JAVA_HOME:-/usr/local/opt/openjdk/libexec}"
exec "${JAVA_HOME}/bin/java"  -jar "/usr/local/Cellar/foo/1.0/libexec/foo.jar" "$@"
```


```sh
#!/bin/bash
export JAVA_HOME="${JAVA_HOME:-/usr/local/opt/openjdk/libexec/openjdk.jdk/Contents/Home}"
exec "${JAVA_HOME}/bin/java"  -jar "/usr/local/Cellar/foo/1.0/libexec/foo.jar" "$@"
```

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
