### PR TITLE
workflows/tests: set HOMEBREW_BOOTSNAP.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,6 +169,8 @@ jobs:
   test-default-formula-linux:
     name: test default formula (Linux)
     runs-on: ubuntu-latest
+    env:
+      HOMEBREW_BOOTSNAP: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -183,6 +185,8 @@ jobs:
     needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: macos-latest
+    env:
+      HOMEBREW_BOOTSNAP: 1
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/Library/Homebrew/homebrew_bootsnap.rb
+++ b/Library/Homebrew/homebrew_bootsnap.rb
@@ -14,9 +14,8 @@ if !ENV["HOMEBREW_NO_BOOTSNAP"] &&
   rescue LoadError
     raise if ENV["HOMEBREW_BOOTSNAP_RETRY"]
 
-    Dir.chdir(HOMEBREW_LIBRARY_PATH) do
-      system "bundle", "install", "--standalone"
-    end
+    require "utils/gems"
+    Homebrew.install_bundler_gems!
 
     ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"
     exec ENV["HOMEBREW_BREW_FILE"], *ARGV


### PR DESCRIPTION
Set this for the only tests with measurable, multi-minute improvements.

Also:  use `utils/gems` as this is more robust e.g. if we don't have a `bundler` already installed.
