### PR TITLE
env_config: update HOMEBREW_BOOTSNAP description.

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -40,7 +40,8 @@ module Homebrew
         description: "Use this username when accessing the Bintray API (where bottles are stored).",
       },
       HOMEBREW_BOOTSNAP:                      {
-        description: "If set, use Bootsnap to speed up repeated `brew` calls.",
+        description: "If set, use Bootsnap to speed up repeated `brew` calls. "\
+                     "A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).",
         boolean:     true,
       },
       HOMEBREW_BOTTLE_DOMAIN:                 {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1708,7 +1708,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>Use this username when accessing the Bintray API (where bottles are stored).
 
 - `HOMEBREW_BOOTSNAP`
-  <br>If set, use Bootsnap to speed up repeated `brew` calls.
+  <br>If set, use Bootsnap to speed up repeated `brew` calls. A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).
 
 - `HOMEBREW_BOTTLE_DOMAIN`
   <br>Use this URL as the download mirror for bottles. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to download from the prefix `http://localhost:8080/`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2379,7 +2379,7 @@ Use this username when accessing the Bintray API (where bottles are stored)\.
 \fBHOMEBREW_BOOTSNAP\fR
 .
 .br
-If set, use Bootsnap to speed up repeated \fBbrew\fR calls\.
+If set, use Bootsnap to speed up repeated \fBbrew\fR calls\. A no\-op when using Homebrew\'s vendored, relocatable Ruby on macOS (as it doesn\'t work)\.
 .
 .TP
 \fBHOMEBREW_BOTTLE_DOMAIN\fR


### PR DESCRIPTION
Note that it is a no-op when using portable ruby.