### PR TITLE
Deprecate additional arch functions

### DIFF
--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -80,6 +80,8 @@ module Hardware
       end
 
       def universal_archs
+        odeprecated "Hardware::CPU.universal_archs"
+
         [arch].extend ArchitectureListExtension
       end
 

--- a/Library/Homebrew/os/mac/architecture_list.rb
+++ b/Library/Homebrew/os/mac/architecture_list.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+# TODO: (3.2) remove this module when the linked deprecated functions are removed.
+
 require "hardware"
 
 module ArchitectureListExtension

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -67,6 +67,7 @@ module MachOShim
   end
 
   def archs
+    # TODO: (3.2) remove ArchitectureListExtension
     mach_data.map { |m| m.fetch :arch }.extend(ArchitectureListExtension)
   end
 

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -384,6 +384,8 @@ module Kernel
 
   # Returns array of architectures that the given command or library is built for.
   def archs_for_command(cmd)
+    odeprecated "archs_for_command"
+
     cmd = which(cmd) unless Pathname.new(cmd).absolute?
     Pathname.new(cmd).archs
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
(a few pre-existing failures)
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

The eventual goal is phasing out `ArchitectureListExtension` which only supports Intel. The extension is used in:

* `Hardware::CPU.universal_archs`. Only used in other disabled functions and not in homebrew-core so can be deprecated.
* In the `Pathname` extension method `archs`. This is private API and is macOS-only but the result is exposed in the public method `arch_for_command`, which is no longer used anywhere.