### PR TITLE
cmd/--prefix: ignore shared-mime-info and mactex

### DIFF
--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -88,6 +88,8 @@ module Homebrew
     share/pypy3/*
     share/info/dir
     share/man/whatis
+    share/mime/*
+    texlive/*
   ].freeze
 
   def list_unbrewed


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
    - `Cask::Config#explicit` did not expect a language `en-GB`, which caused a failure.
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

The `shared-mime-info` formula and the `mactex` cask currently install into
locations that are picked up by `brew --prefix --unbrewed`. This leads
to a very large number of files being found.

Before:
```
❯ brew --prefix --unbrewed | wc -l
206735
```

After
```
❯ brew --prefix --unbrewed | wc -l
3
```