### PR TITLE
cask/config: fix `explicit_s`

### DIFF
--- a/Library/Homebrew/cask/config.rb
+++ b/Library/Homebrew/cask/config.rb
@@ -188,7 +188,7 @@ module Cask
         # inverse of #env - converts :languages config key back to --language flag
         if key == :languages
           key = "language"
-          value = languages.join(",")
+          value = T.cast(explicit.fetch(:languages, []), T::Array[String]).join(",")
         end
         "#{key}: \"#{value.to_s.sub(/^#{ENV['HOME']}/, "~")}\""
       end.join(", ")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

As pointed out in [#10462 (comment)](https://github.com/Homebrew/brew/pull/10462#issuecomment-771939871), tests failed locally when languages other than `en` were enabled (sample output in #10490).

This PR fixes the `explicit_s` method to output only the languages passed as `explicit` config.

CC @EricFromCanada