### PR TITLE
dev-cmd/release: output blog post release notes.

### DIFF
--- a/Library/Homebrew/dev-cmd/release.rb
+++ b/Library/Homebrew/dev-cmd/release.rb
@@ -67,6 +67,17 @@ module Homebrew
       Version.new "#{latest_version.major}.#{latest_version.minor}.#{latest_version.patch.to_i + 1}"
     end.to_s
 
+    if args.major? || args.minor?
+      latest_major_minor_version = "#{latest_version.major}.#{latest_version.minor.to_i}.0"
+      ohai "Release notes since #{latest_major_minor_version} for #{new_version} blog post:"
+      # release notes without username suffix or dependabot bumps
+      puts ReleaseNotes.generate_release_notes(latest_major_minor_version, "origin/HEAD", markdown: true)
+                       .lines
+                       .reject { |l| l.include?(" (@Homebrew)") }
+                       .map { |l| l.gsub(/ \(@[\w-]+\)$/, "") }
+                       .sort
+    end
+
     ohai "Creating draft release for version #{new_version}"
 
     release_notes = if args.major? || args.minor?


### PR DESCRIPTION
I forgot until I started to work on the 3.0.0 release that there was an added step I would do for a major/minor release:

```
brew release-notes --markdown 2.7.0 | pbcopy
```

This would generate for 3.0.0/2.8.0 the release notes since 2.7.0 for editing down into a blog post.

Add this behaviour to `brew release` and, because we're doing it programmatically anyway, take this chance to also reject Dependabot lines and sort them for easier grouping by pull request subject.

Thanks again to @Rylan12 for creating this command, this was surprisingly easy to do 🎉 

Marking as `critical` so this makes it into 3.0.0 (meta, right?).