### PR TITLE
style: allow long lines for bottle digests

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -356,6 +356,7 @@ Layout/LineLength:
       ' pkg "',
       ' pkgutil: "',
       "    sha256 cellar: ",
+      "    sha256  ",
       "#{language}",
       "#{version.",
       ' "/Library/Application Support/',


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Needed for https://github.com/Homebrew/homebrew-core/pull/70283#issuecomment-772534602

Disable the line length check for bottle digests that don't specify a cellar. This is a continuation of https://github.com/Homebrew/brew/pull/10452 where it was decided not to allow all instances of `    sha265 `. Indeed, this would allow line length violations on non-bottle lines (which would probably be fine given that these lines are likely to contain only a 64-character digest). Instead, I added a second space to make `    sha256  `. This will only exclude bottle lines that have indented tags and no cellar (which is already covered).

Here's an example of a bottle block that failed the line-length check before but now passes:

```ruby
  bottle do
    sha256                               arm64_big_sur: "164272fc6509d724c6fcc877ee988b6b6a3c9e1ab572fab6e93cf91fed432042"
    sha256 cellar: :any_skip_relocation, big_sur:       "8720c16da6eaadeb2e8155adfa302b7621137e8cc74344344dab680f4d9d6266"
    sha256 cellar: :any_skip_relocation, catalina:      "a665da560eb8a7dfa18b563e3991de9b0a24bc8f2e5f24d02106ae5e4a0a86ba"
    sha256 cellar: :any_skip_relocation, mojave:        "b3a2587705ce4863ec6f1fdcdc2857d7017f4b913c30840f36b8161ccc2a8900"
  end
```

I'm marking as critical because this is needed for https://github.com/Homebrew/homebrew-core/pull/70283 and https://github.com/Homebrew/brew/pull/10453 to move forward (which is planned for later today)