### PR TITLE
compilers: prefer gcc 5 on linux

### DIFF
--- a/Library/Homebrew/compilers.rb
+++ b/Library/Homebrew/compilers.rb
@@ -78,6 +78,7 @@ end
 #
 # @api private
 class CompilerSelector
+  extend T::Sig
   include CompilerConstants
 
   Compiler = Struct.new(:name, :version)
@@ -111,9 +112,14 @@ class CompilerSelector
 
   private
 
+  sig { returns(String) }
+  def preferred_gcc
+    "gcc"
+  end
+
   def gnu_gcc_versions
     # prioritize gcc version provided by gcc formula.
-    v = Formulary.factory("gcc").version.to_s.slice(/\d+/)
+    v = Formulary.factory(preferred_gcc).version.to_s.slice(/\d+/)
     GNU_GCC_VERSIONS - [v] + [v] # move the version to the end of the list
   rescue FormulaUnavailableError
     GNU_GCC_VERSIONS
@@ -150,3 +156,5 @@ class CompilerSelector
     end
   end
 end
+
+require "extend/os/compilers"

--- a/Library/Homebrew/extend/os/compilers.rb
+++ b/Library/Homebrew/extend/os/compilers.rb
@@ -1,0 +1,4 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "extend/os/linux/compilers" if OS.linux?

--- a/Library/Homebrew/extend/os/linux/compilers.rb
+++ b/Library/Homebrew/extend/os/linux/compilers.rb
@@ -1,0 +1,11 @@
+# typed: strict
+# frozen_string_literal: true
+
+class CompilerSelector
+  sig { returns(String) }
+  def preferred_gcc
+    # gcc-5 is the lowest gcc version we support on Linux.
+    # gcc-5 is the default gcc in Ubuntu 16.04 (used for our CI)
+    "gcc@5"
+  end
+end


### PR DESCRIPTION
Fixes #10170 by preferring gcc@5 on linux
This makes sure ENV.cc and ENV.cxx is correctly set:

If a formula does not explicitely depend on a brewed gcc,
ENV.cc is set to gcc-5 (system gcc-5 or brewed gcc-5) with this change,
even if other gcc versions are installed on the system.

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
