### PR TITLE
docs: add a note about the stability of python 3 formulae

### DIFF
--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -13,6 +13,12 @@ Homebrew provided a `python@2` formula until the end of 2019, at which point it 
 ## Python 3.x
 Homebrew provides a formula for Python 3.x (`python@3.x`).
 
+**Important:** Homebrew does not guarantee that Python 3, once installed, remains the same version.
+In particular, Homebrew may choose to upgrade the minor or patch version of Python 3, which may in
+turn break any custom virtual environments that use the Homebrewed Python. Python developers
+who expect virtual environment stability should consider using a Python version manager rather than
+the Homebrewed Python.
+
 The executables are organised as follows:
 
 * `python3` points to Homebrew's Python 3.x (if installed)

--- a/docs/Homebrew-and-Python.md
+++ b/docs/Homebrew-and-Python.md
@@ -13,11 +13,8 @@ Homebrew provided a `python@2` formula until the end of 2019, at which point it 
 ## Python 3.x
 Homebrew provides a formula for Python 3.x (`python@3.x`).
 
-**Important:** Homebrew does not guarantee that Python 3, once installed, remains the same version.
-In particular, Homebrew may choose to upgrade the minor or patch version of Python 3, which may in
-turn break any custom virtual environments that use the Homebrewed Python. Python developers
-who expect virtual environment stability should consider using a Python version manager rather than
-the Homebrewed Python.
+**Important**: Python may be upgraded to a newer version at any time. Consider using a version
+manager such as `pyenv` if you require stability of minor or patch versions for virtual environments.
 
 The executables are organised as follows:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

This tweaks the `Homebrew-and-Python` doc to include a note about the stability of the various Python 3 formulae: we don't have a policy of guaranteeing that `/usr/local/bin/python3` (or wherever) remains at the same minor and patchlevels between upgrades, which is a frequent source of confusion for people using the Homebrewed Python with virtual environments. I think this is reasonable behavior on our part (since it's what every other system package manager does), but making an explicit note of it will give us something easy to link to when the question comes up.