### PR TITLE
untap: add missing --force switch

### DIFF
--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -14,6 +14,8 @@ module Homebrew
       description <<~EOS
         Remove a tapped formula repository.
       EOS
+      switch "-f", "--force",
+             description: "Untap even if formulae or casks from this tap are currently installed."
 
       named_args :tap, min: 1
     end

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -2047,6 +2047,7 @@ _brew_untap() {
     -*)
       __brewcomp "
       --debug
+      --force
       --help
       --quiet
       --verbose

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1406,6 +1406,7 @@ __fish_brew_complete_arg 'unpin' -a '(__fish_brew_suggest_formulae_installed)'
 
 __fish_brew_complete_cmd 'untap' 'Remove a tapped formula repository'
 __fish_brew_complete_arg 'untap' -l debug -d 'Display any debugging information'
+__fish_brew_complete_arg 'untap' -l force -d 'Untap even if formulae or casks from this tap are currently installed'
 __fish_brew_complete_arg 'untap' -l help -d 'Show this message'
 __fish_brew_complete_arg 'untap' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'untap' -l verbose -d 'Make some output more verbose'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1638,6 +1638,7 @@ _brew_unpin() {
 _brew_untap() {
   _arguments \
     '--debug[Display any debugging information]' \
+    '--force[Untap even if formulae or casks from this tap are currently installed]' \
     '--help[Show this message]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -590,9 +590,12 @@ for temporarily disabling a formula:
 Unpin *`formula`*, allowing them to be upgraded by `brew upgrade` *`formula`*.
 See also `pin`.
 
-### `untap` *`tap`* [...]
+### `untap` [*`--force`*] *`tap`* [...]
 
 Remove a tapped formula repository.
+
+* `-f`, `--force`:
+  Untap even if formulae or casks from this tap are currently installed.
 
 ### `update` [*`options`*]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -793,8 +793,12 @@ List files which would be unlinked without actually unlinking or deleting any fi
 .SS "\fBunpin\fR \fIinstalled_formula\fR [\.\.\.]"
 Unpin \fIformula\fR, allowing them to be upgraded by \fBbrew upgrade\fR \fIformula\fR\. See also \fBpin\fR\.
 .
-.SS "\fBuntap\fR \fItap\fR [\.\.\.]"
+.SS "\fBuntap\fR [\fI\-\-force\fR] \fItap\fR [\.\.\.]"
 Remove a tapped formula repository\.
+.
+.TP
+\fB\-f\fR, \fB\-\-force\fR
+Untap even if formulae or casks from this tap are currently installed\.
 .
 .SS "\fBupdate\fR [\fIoptions\fR]"
 Fetch the newest version of Homebrew and all formulae from GitHub using \fBgit\fR(1) and perform any necessary migrations\.


### PR DESCRIPTION
Functionality added in https://github.com/Homebrew/brew/pull/9489, but without the flag.
This PR fixes that.

Closes: #10511

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----