### PR TITLE
style: re-enable bottle order cop

### DIFF
--- a/Library/Homebrew/rubocops/bottle.rb
+++ b/Library/Homebrew/rubocops/bottle.rb
@@ -167,15 +167,15 @@ module RuboCop
 
           return if sha256_order(sha256_nodes) == sha256_order(arm64_nodes + intel_nodes)
 
-          # offending_node(bottle_node)
-          # problem "ARM bottles should be listed before Intel bottles" do |corrector|
-          #   lines = ["bottle do"]
-          #   lines += non_sha256_nodes.map { |node| "    #{node.source}" }
-          #   lines += arm64_nodes.map { |node| "    #{node.source}" }
-          #   lines += intel_nodes.map { |node| "    #{node.source}" }
-          #   lines << "  end"
-          #   corrector.replace(bottle_node.source_range, lines.join("\n"))
-          # end
+          offending_node(bottle_node)
+          problem "ARM bottles should be listed before Intel bottles" do |corrector|
+            lines = ["bottle do"]
+            lines += non_sha256_nodes.map { |node| "    #{node.source}" }
+            lines += arm64_nodes.map { |node| "    #{node.source}" }
+            lines += intel_nodes.map { |node| "    #{node.source}" }
+            lines << "  end"
+            corrector.replace(bottle_node.source_range, lines.join("\n"))
+          end
         end
 
         def sha256_order(nodes)

--- a/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_order_spec.rb
@@ -116,125 +116,125 @@ describe RuboCop::Cop::FormulaAudit::BottleOrder do
     RUBY
   end
 
-  # it "reports and corrects arm bottles below intel bottles" do
-  #   expect_offense(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+  it "reports and corrects arm bottles below intel bottles" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #       ^^^^^^^^^ ARM bottles should be listed before Intel bottles
-  #         rebuild 4
-  #         sha256 big_sur: "faceb00c"
-  #         sha256 catalina: "deadbeef"
-  #         sha256 arm64_big_sur: "aaaaaaaa"
-  #       end
-  #     end
-  #   RUBY
+        bottle do
+        ^^^^^^^^^ ARM bottles should be listed before Intel bottles
+          rebuild 4
+          sha256 big_sur: "faceb00c"
+          sha256 catalina: "deadbeef"
+          sha256 arm64_big_sur: "aaaaaaaa"
+        end
+      end
+    RUBY
 
-  #   expect_correction(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #         rebuild 4
-  #         sha256 arm64_big_sur: "aaaaaaaa"
-  #         sha256 big_sur: "faceb00c"
-  #         sha256 catalina: "deadbeef"
-  #       end
-  #     end
-  #   RUBY
-  # end
+        bottle do
+          rebuild 4
+          sha256 arm64_big_sur: "aaaaaaaa"
+          sha256 big_sur: "faceb00c"
+          sha256 catalina: "deadbeef"
+        end
+      end
+    RUBY
+  end
 
-  # it "reports and corrects multiple arm bottles below intel bottles" do
-  #   expect_offense(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+  it "reports and corrects multiple arm bottles below intel bottles" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #       ^^^^^^^^^ ARM bottles should be listed before Intel bottles
-  #         rebuild 4
-  #         sha256 big_sur: "faceb00c"
-  #         sha256 arm64_catalina: "aaaaaaaa"
-  #         sha256 catalina: "deadbeef"
-  #         sha256 arm64_big_sur: "aaaaaaaa"
-  #       end
-  #     end
-  #   RUBY
+        bottle do
+        ^^^^^^^^^ ARM bottles should be listed before Intel bottles
+          rebuild 4
+          sha256 big_sur: "faceb00c"
+          sha256 arm64_catalina: "aaaaaaaa"
+          sha256 catalina: "deadbeef"
+          sha256 arm64_big_sur: "aaaaaaaa"
+        end
+      end
+    RUBY
 
-  #   expect_correction(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #         rebuild 4
-  #         sha256 arm64_catalina: "aaaaaaaa"
-  #         sha256 arm64_big_sur: "aaaaaaaa"
-  #         sha256 big_sur: "faceb00c"
-  #         sha256 catalina: "deadbeef"
-  #       end
-  #     end
-  #   RUBY
-  # end
+        bottle do
+          rebuild 4
+          sha256 arm64_catalina: "aaaaaaaa"
+          sha256 arm64_big_sur: "aaaaaaaa"
+          sha256 big_sur: "faceb00c"
+          sha256 catalina: "deadbeef"
+        end
+      end
+    RUBY
+  end
 
-  # it "reports and corrects arm bottles with cellars below intel bottles" do
-  #   expect_offense(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+  it "reports and corrects arm bottles with cellars below intel bottles" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #       ^^^^^^^^^ ARM bottles should be listed before Intel bottles
-  #         rebuild 4
-  #         sha256 cellar: "/usr/local/Cellar",  big_sur:        "faceb00c"
-  #         sha256                               catalina:       "deadbeef"
-  #         sha256 cellar: :any,                 arm64_big_sur:  "aaaaaaaa"
-  #         sha256 cellar: :any_skip_relocation, arm64_catalina: "aaaaaaaa"
-  #       end
-  #     end
-  #   RUBY
+        bottle do
+        ^^^^^^^^^ ARM bottles should be listed before Intel bottles
+          rebuild 4
+          sha256 cellar: "/usr/local/Cellar",  big_sur:        "faceb00c"
+          sha256                               catalina:       "deadbeef"
+          sha256 cellar: :any,                 arm64_big_sur:  "aaaaaaaa"
+          sha256 cellar: :any_skip_relocation, arm64_catalina: "aaaaaaaa"
+        end
+      end
+    RUBY
 
-  #   expect_correction(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #         rebuild 4
-  #         sha256 cellar: :any,                 arm64_big_sur:  "aaaaaaaa"
-  #         sha256 cellar: :any_skip_relocation, arm64_catalina: "aaaaaaaa"
-  #         sha256 cellar: "/usr/local/Cellar",  big_sur:        "faceb00c"
-  #         sha256                               catalina:       "deadbeef"
-  #       end
-  #     end
-  #   RUBY
-  # end
+        bottle do
+          rebuild 4
+          sha256 cellar: :any,                 arm64_big_sur:  "aaaaaaaa"
+          sha256 cellar: :any_skip_relocation, arm64_catalina: "aaaaaaaa"
+          sha256 cellar: "/usr/local/Cellar",  big_sur:        "faceb00c"
+          sha256                               catalina:       "deadbeef"
+        end
+      end
+    RUBY
+  end
 
-  # it "reports and corrects arm bottles below intel bottles with old bottle syntax" do
-  #   expect_offense(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+  it "reports and corrects arm bottles below intel bottles with old bottle syntax" do
+    expect_offense(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #       ^^^^^^^^^ ARM bottles should be listed before Intel bottles
-  #         cellar :any
-  #         sha256 "faceb00c" => :big_sur
-  #         sha256 "aaaaaaaa" => :arm64_big_sur
-  #         sha256 "aaaaaaaa" => :arm64_catalina
-  #         sha256 "deadbeef" => :catalina
-  #       end
-  #     end
-  #   RUBY
+        bottle do
+        ^^^^^^^^^ ARM bottles should be listed before Intel bottles
+          cellar :any
+          sha256 "faceb00c" => :big_sur
+          sha256 "aaaaaaaa" => :arm64_big_sur
+          sha256 "aaaaaaaa" => :arm64_catalina
+          sha256 "deadbeef" => :catalina
+        end
+      end
+    RUBY
 
-  #   expect_correction(<<~RUBY)
-  #     class Foo < Formula
-  #       url "https://brew.sh/foo-1.0.tgz"
+    expect_correction(<<~RUBY)
+      class Foo < Formula
+        url "https://brew.sh/foo-1.0.tgz"
 
-  #       bottle do
-  #         cellar :any
-  #         sha256 "aaaaaaaa" => :arm64_big_sur
-  #         sha256 "aaaaaaaa" => :arm64_catalina
-  #         sha256 "faceb00c" => :big_sur
-  #         sha256 "deadbeef" => :catalina
-  #       end
-  #     end
-  #   RUBY
-  # end
+        bottle do
+          cellar :any
+          sha256 "aaaaaaaa" => :arm64_big_sur
+          sha256 "aaaaaaaa" => :arm64_catalina
+          sha256 "faceb00c" => :big_sur
+          sha256 "deadbeef" => :catalina
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Follow up to https://github.com/Homebrew/brew/pull/10522.

This PR re-enables the style check to ensure the bottle lines are in the correct order.

This should not be merged until #10522 has been merged and all style issues in homebrew/core and linuxbrew/core have been resolved.
