### PR TITLE
Add additional info for updating Command Line Tools

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -270,8 +270,10 @@ module OS
             sudo rm -rf /Library/Developer/CommandLineTools
             sudo xcode-select --install
 
-          Alternatively, manually download them from:
+          Alternatively (or if other options fail), manually download them from:
             #{Formatter.url("https://developer.apple.com/download/more/")}.
+          And refer to the following for the most recent available for your OS:
+            #{Formatter.url("https://en.wikipedia.org/wiki/Xcode#Version_comparison_table")}.
         EOS
       end
 


### PR DESCRIPTION
Add an additional note pointing users to a wiki page showing which Command Line Tool version is the latest available for their OS.

This is useful because the `softwareupdate` or `xcode-select --install` commands don’t always  manage to install the latest CLT, and a manual download and install is sometimes necessary. With a manual download, there’s no easy way to know which CLT download is the latest available & compatible one for a particular OS, which is what makes the wiki reference page very useful.

In my case, the `softwareupdate` or `xcode-select --install` did NOT update my CLT to the latest when using Mojave 10.14.6 (18G8012), and a manual download and install from Apple Developer was necessary.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
