### PR TITLE
livecheck: check stable before head by default

### DIFF
--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -352,11 +352,11 @@ module Homebrew
 
       case formula_or_cask
       when Formula
-        urls << formula_or_cask.head.url if formula_or_cask.head
         if formula_or_cask.stable
           urls << formula_or_cask.stable.url
           urls.concat(formula_or_cask.stable.mirrors)
         end
+        urls << formula_or_cask.head.url if formula_or_cask.head
         urls << formula_or_cask.homepage if formula_or_cask.homepage
       when Cask::Cask
         urls << formula_or_cask.appcast.to_s if formula_or_cask.appcast

--- a/Library/Homebrew/test/livecheck/livecheck_spec.rb
+++ b/Library/Homebrew/test/livecheck/livecheck_spec.rb
@@ -133,7 +133,7 @@ describe Homebrew::Livecheck do
 
   describe "::checkable_urls" do
     it "returns the list of URLs to check" do
-      expect(livecheck.checkable_urls(f)).to eq([head_url, stable_url, homepage_url])
+      expect(livecheck.checkable_urls(f)).to eq([stable_url, head_url, homepage_url])
       expect(livecheck.checkable_urls(c)).to eq([cask_url, homepage_url])
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

When a formula doesn't have a `livecheck` block, the `Livecheck#checkable_urls` method organizes URLs to check in order of: `head`, `stable`, and `homepage`. Checking Git tags is generally pretty reliable, so it was a good way to identify versions for as many formulae as possible without requiring manual labor early on.

Nowadays, livecheck has strategies to handle a variety of sources and we prefer to align the check with the `stable` source whenever possible. However, checking `head` first can prevent livecheck from using a checkable `stable` URL. There have been times where a formula was successfully checking `stable` by default and then a `head` URL was added to the formula, which switched the livecheck source and strategy. In these cases, we've had to add a `livecheck` block with `url :stable` to override this behavior.

Moving `stable` before `head` in `#checkable_urls` aligns with our current livecheck guidelines and would allow us to avoid having to create `livecheck` blocks that only contain `url :stable`. [We already have some of these in homebrew/core, so I'll go through and remove the unnecessary ones if/when this PR is merged.]

---

With this in mind, I compared livecheck's behavior across homebrew/core with `head` first (the current scenario) and with `stable` first.

Of the 958 formulae affected, 932 didn't involve a change in strategy. In these cases, the `stable` URL was simply converted to the `head` URL via `#preprocess_url`, so the source and strategy remained the same.

Only 26 involved a change in strategy and these were all desirable changes. That is to say, the `head` URL was at a different source and the `#checkable_urls` modification ensured the check was aligned with the `stable` source. In all of these cases, the `latest` version reported by livecheck was unchanged (meaning that the `stable` source returns the correct latest version).

The rest of the formulae were unaffected by this change. For any formulae where `stable` isn't checkable, livecheck simply moves on to the `head` URL. However, if `stable` becomes checkable in the future (e.g., a new strategy is added), then `stable` would be checked instead, which is desirable behavior.

Overall, there are clear benefits to this change and I don't see any detriments.