### PR TITLE
os/mac/diagnostic: always require dev tools on Apple Silicon

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -42,8 +42,20 @@ module Homebrew
     end
 
     class Checks
-      undef fatal_build_from_source_checks, fatal_setup_build_environment_checks,
-            supported_configuration_checks, build_from_source_checks
+      undef fatal_preinstall_checks, fatal_build_from_source_checks,
+            fatal_setup_build_environment_checks, supported_configuration_checks,
+            build_from_source_checks
+
+      def fatal_preinstall_checks
+        checks = %w[
+          check_access_directories
+        ]
+
+        # We need the developer tools for `codesign`.
+        checks << "check_for_installed_developer_tools" if Hardware::CPU.arm?
+
+        checks.freeze
+      end
 
       def fatal_build_from_source_checks
         %w[
@@ -405,6 +417,7 @@ module Homebrew
       end
 
       def check_if_supported_sdk_available
+        return unless DevelopmentTools.installed?
         return unless MacOS.sdk_root_needed?
         return if MacOS.sdk
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

We use `codesign` when pouring bottles, so the development tools now need to be installed even when only consuming bottles.

Currently, `codesign` failures are non-critical (`onoe`). So a user without development tools could peform `brew install git` or `brew upgrade git` and break their `brew` installation due to a non-functional unsigned `git` binary (or one of its dependencies).

This addresses at least one scenario leading towards #10275.