### PR TITLE
utils/github: Provide a better error message when users don't have any GitHub credentials set

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -84,7 +84,7 @@ module GitHub
   # Error when the user has no GitHub API credentials set at all (macOS keychain or envvar).
   class MissingAuthenticationError < Error
     def initialize
-      message = +"No GitHub credentials found in Keychain or environment.\n"
+      message = +"No GitHub credentials found in macOS Keychain or environment.\n"
       message << CREATE_GITHUB_PAT_MESSAGE
       super message
     end

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -49,9 +49,8 @@ module GitHub
       @github_message = github_message
       super <<~EOS
         GitHub API Error: #{github_message}
-        Try again in #{pretty_ratelimit_reset(reset)}, or create a personal access token:
-          #{ALL_SCOPES_URL}
-        #{Utils::Shell.set_variable_in_profile("HOMEBREW_GITHUB_API_TOKEN", "your_token_here")}
+        Try again in #{pretty_ratelimit_reset(reset)}, or:
+        #{CREATE_GITHUB_PAT_MESSAGE}
       EOS
     end
 
@@ -75,9 +74,7 @@ module GitHub
           The GitHub credentials in the macOS keychain may be invalid.
           Clear them with:
             printf "protocol=https\\nhost=github.com\\n" | git credential-osxkeychain erase
-          Or create a personal access token:
-            #{ALL_SCOPES_URL}
-          #{Utils::Shell.set_variable_in_profile("HOMEBREW_GITHUB_API_TOKEN", "your_token_here")}
+          #{CREATE_GITHUB_PAT_MESSAGE}
         EOS
       end
       super message.freeze
@@ -182,9 +179,7 @@ module GitHub
       Your #{what} credentials do not have sufficient scope!
       Scopes required: #{needed_scopes}
       Scopes present:  #{credentials_scopes}
-      Create a personal access token:
-        #{ALL_SCOPES_URL}
-      #{Utils::Shell.set_variable_in_profile("HOMEBREW_GITHUB_API_TOKEN", "your_token_here")}
+      #{CREATE_GITHUB_PAT_MESSAGE}
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- When running [`brew request-bottle`](https://github.com/Homebrew/homebrew-linux-dev/blob/master/cmd/request-bottle.rb), which uses `GitHub.open_api()` from here, users who don't have credentials in the macOS keychain (ie, Linux users) or `HOMEBREW_GITHUB_API_TOKEN` receive "Error: Not Found" from the GitHub API returning a 404.
- This is cryptic and confusing for newcomers to Linux maintenance, and potentially confusing to other folks using `open_api` where credentials are expected yet unset.
- This adds a new `MissingAuthenticationError` to handle the case where the GitHub API returns 404 and there are no creds yet API scopes are required.

Before:

```
issyl0@sky:/home/linuxbrew/.linuxbrew/Homebrew$ brew request-bottle hello
==> Dispatching request to Homebrew/linuxbrew-core for hello
Error: Not Found
```

After:

```
issyl0@sky:/home/linuxbrew/.linuxbrew/Homebrew$ brew request-bottle hello
==> Dispatching request to Homebrew/linuxbrew-core for hello
Error: No GitHub credentials found in Keychain or environment.
Create a GitHub personal access token:
    https://github.com/settings/tokens/new?scopes=gist,public_repo&description=Homebrew
  echo 'export HOMEBREW_GITHUB_API_TOKEN=your_token_here' >> ~/.profile
```

----

- This is an alternative to https://github.com/Homebrew/homebrew-linux-dev/pull/192.
- I'm not 100% sure of the behaviour when a user doesn't strictly need an API token (ie, finding related issues when builds fail locally), but I think checking for `scopes` not being empty before raising this error should cover it?
