### PR TITLE
homebrew_bootsnap: fail more gracefully.

### DIFF
--- a/Library/Homebrew/homebrew_bootsnap.rb
+++ b/Library/Homebrew/homebrew_bootsnap.rb
@@ -14,25 +14,29 @@ if !ENV["HOMEBREW_NO_BOOTSNAP"] &&
   begin
     require "bootsnap"
   rescue LoadError
-    raise if ENV["HOMEBREW_BOOTSNAP_RETRY"]
+    unless ENV["HOMEBREW_BOOTSNAP_RETRY"]
+      require "utils/gems"
+      Homebrew.install_bundler_gems!
 
-    require "utils/gems"
-    Homebrew.install_bundler_gems!
-
-    ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"
-    exec ENV["HOMEBREW_BREW_FILE"], *ARGV
+      ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"
+      exec ENV["HOMEBREW_BREW_FILE"], *ARGV
+    end
   end
 
   ENV.delete("HOMEBREW_BOOTSNAP_RETRY")
 
-  cache = ENV["HOMEBREW_CACHE"] || ENV["HOMEBREW_DEFAULT_CACHE"]
-  # Can't use .blank? here because we haven't required active_support yet.
-  raise "Needs HOMEBREW_CACHE or HOMEBREW_DEFAULT_CACHE!" if cache.nil? || cache.empty? # rubocop:disable Rails/Blank
+  if defined?(Bootsnap)
+    cache = ENV["HOMEBREW_CACHE"] || ENV["HOMEBREW_DEFAULT_CACHE"]
+    # Can't use .blank? here because we haven't required active_support yet.
+    raise "Needs HOMEBREW_CACHE or HOMEBREW_DEFAULT_CACHE!" if cache.nil? || cache.empty? # rubocop:disable Rails/Blank
 
-  Bootsnap.setup(
-    cache_dir:          cache,
-    load_path_cache:    true,
-    compile_cache_iseq: true,
-    compile_cache_yaml: true,
-  )
+    Bootsnap.setup(
+      cache_dir:          cache,
+      load_path_cache:    true,
+      compile_cache_iseq: true,
+      compile_cache_yaml: true,
+    )
+  else
+    $stderr.puts "Error: HOMEBREW_BOOTSNAP could not `require \"bootsnap\"`!\n\n"
+  end
 end


### PR DESCRIPTION
If `bootsnap` isn't available then print out an error message rather than failing all of Homebrew.