### PR TITLE
Utils: fix *_stdout_or_stderr helpers

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -111,15 +111,16 @@ module Kernel
     puts sput
   end
 
-  def ohai_stdout_or_stderr(message)
+  def ohai_stdout_or_stderr(message, *sput)
     if $stdout.tty?
-      ohai(message)
+      ohai(message, *sput)
     else
       $stderr.puts(ohai_title(message))
+      $stderr.puts(sput)
     end
   end
 
-  def puts_stdout_or_stderr(message)
+  def puts_stdout_or_stderr(*message)
     if $stdout.tty?
       puts(message)
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Several calls to `ohai` and `puts` were directly changed into calls to these new functions, but they don't share arity or an API. The base functions allow arbitrary number of arguments, allowing for multiline printing that covers both a title and a longer message.

Sample error:
```
Updated 1 tap (homebrew/core).
Error: wrong number of arguments (given 2, expected 1)
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/utils.rb:114:in `ohai_stdout_or_stderr'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:489:in `dump'
/usr/local/Homebrew/Library/Homebrew/cmd/update-report.rb:132:in `update_report'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```

The bug was introduced in https://github.com/Homebrew/brew/commit/dbf65770aff73b4d3af26f71214f228a8180e92b.

Here's a sample pair of lines that use the multiple-argument syntax which is broken: https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/update-report.rb#L501-L502