### PR TITLE
Prepare deprecations for the old bottle syntax

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2447,11 +2447,11 @@ class Formula
     #
     # <pre>bottle do
     #   root_url "https://example.com" # Optional root to calculate bottle URLs.
-    #   cellar "/opt/homebrew/Cellar" # Optional HOMEBREW_CELLAR in which the bottles were built.
     #   rebuild 1 # Marks the old bottle as outdated without bumping the version/revision of the formula.
-    #   sha256 "ef65c759c5097a36323fa9c77756468649e8d1980a3a4e05695c05e39568967c" => :catalina
-    #   sha256 "28f4090610946a4eb207df102d841de23ced0d06ba31cb79e040d883906dcd4f" => :mojave
-    #   sha256 "91dd0caca9bd3f38c439d5a7b6f68440c4274945615fae035ff0a369264b8a2f" => :high_sierra
+    #   # Optionally specify the HOMEBREW_CELLAR in which the bottles were built.
+    #   sha256 cellar: "/brew/Cellar", catalina:    "ef65c759c5097a36323fa9c77756468649e8d1980a3a4e05695c05e39568967c"
+    #   sha256 cellar: :any,           mojave:      "28f4090610946a4eb207df102d841de23ced0d06ba31cb79e040d883906dcd4f"
+    #   sha256                         high_sierra: "91dd0caca9bd3f38c439d5a7b6f68440c4274945615fae035ff0a369264b8a2f"
     # end</pre>
     #
     # Homebrew maintainers aim to bottle all formulae that require compilation.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -371,6 +371,14 @@ class BottleSpecification
   end
 
   def cellar(val = nil)
+    # TODO: (3.1) uncomment to deprecate the old bottle syntax
+    # if val.present?
+    #   odeprecated(
+    #     "`cellar` in a bottle block",
+    #     "`brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument",
+    #   )
+    # end
+
     return collector.dig(Utils::Bottles.tag, :cellar) || @all_tags_cellar if val.nil?
 
     @all_tags_cellar = val
@@ -422,6 +430,14 @@ class BottleSpecification
       digest, tag = hash.find do |key, value|
         key.is_a?(String) && value.is_a?(Symbol) && key.match?(sha256_regex)
       end
+
+      # TODO: (3.1) uncomment to deprecate the old bottle syntax
+      # if digest && tag
+      #   odeprecated(
+      #     '`sha256 "digest" => :tag` in a bottle block',
+      #     '`brew style --fix` on the formula to update the style or use `sha256 tag: "digest"`',
+      #   )
+      # end
     end
 
     cellar ||= all_tags_cellar


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Closes #9315 (although I can unlink so that issue isn't closed until the actual deprecations are merged)

This is the last step needed to finish #9315. It prepares the deprecations for the old bottle syntax. These deprecations are commented out for now but should be uncommented for the 3.1.0 release.

CC: @iMichka
