### PR TITLE
bugfix: Add args and options to lazy url block

### DIFF
--- a/Library/Homebrew/cask/dsl.rb
+++ b/Library/Homebrew/cask/dsl.rb
@@ -181,7 +181,11 @@ module Cask
 
       set_unique_stanza(:url, args.empty? && options.empty? && !block_given?) do
         if block_given?
-          LazyObject.new { URL.new(*yield, from_block: true, caller_location: caller_location) }
+          LazyObject.new do
+            *args = yield
+            options = args.last.is_a?(Hash) ? args.pop : {}
+            URL.new(*args, **options, from_block: true, caller_location: caller_location)
+          end
         else
           URL.new(*args, **options, caller_location: caller_location)
         end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -981,5 +981,35 @@ describe Cask::Audit, :cask do
 
       it { is_expected.to fail_with(/a homepage stanza is required/) }
     end
+
+    context "when url is lazy" do
+      let(:strict) { true }
+      let(:cask_token) { "with-lazy" }
+      let(:cask) do
+        tmp_cask cask_token.to_s, <<~RUBY
+          cask '#{cask_token}' do
+            version '1.8.0_72,8.13.0.5'
+            sha256 '8dd95daa037ac02455435446ec7bc737b34567afe9156af7d20b2a83805c1d8a'
+            url do
+              ['https://brew.sh/foo.zip', {referer: 'https://example.com', cookies: {'foo' => 'bar'}}]
+            end
+            name 'Audit'
+            desc 'Audit Description'
+            homepage 'https://brew.sh'
+            app 'Audit.app'
+          end
+        RUBY
+      end
+
+      it { is_expected.to pass }
+
+      it "receives a referer" do
+        expect(audit.cask.url.referer).to eq "https://example.com"
+      end
+
+      it "receives cookies" do
+        expect(audit.cask.url.cookies).to eq "foo" => "bar"
+      end
+    end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

See discussion: https://github.com/Homebrew/discussions/discussions/718

tl;dr: `url do...end` blocks currently can't handle options such as `:referrer` or `:cookies`