### PR TITLE
Undeprecate ENV.O1/ENV.O0

### DIFF
--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -238,7 +238,6 @@ module SharedEnvExtension
 
   # Snow Leopard defines an NCURSES value the opposite of most distros.
   # @see https://bugs.python.org/issue6848
-  # Currently only used by aalib in core.
   sig { void }
   def ncurses_define
     odeprecated "ENV.ncurses_define"

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -97,10 +97,17 @@ module Stdenv
     old
   end
 
-  %w[O3 O2 O1 O0 Os].each do |opt|
+  %w[O3 O2 Os].each do |opt|
     define_method opt do
       odisabled "ENV.#{opt}"
 
+      send(:remove_from_cflags, /-O./)
+      send(:append_to_cflags, "-#{opt}")
+    end
+  end
+
+  %w[O1 O0].each do |opt|
+    define_method opt do
       send(:remove_from_cflags, /-O./)
       send(:append_to_cflags, "-#{opt}")
     end

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -344,10 +344,16 @@ module Superenv
     append_to_cccfg "O"
   end
 
-  %w[O3 O2 O1 O0 Os].each do |opt|
+  %w[O3 O2 Os].each do |opt|
     define_method opt do
       odisabled "ENV.#{opt}"
 
+      send(:[]=, "HOMEBREW_OPTIMIZATION_LEVEL", opt)
+    end
+  end
+
+  %w[O1 O0].each do |opt|
+    define_method opt do
       send(:[]=, "HOMEBREW_OPTIMIZATION_LEVEL", opt)
     end
   end


### PR DESCRIPTION
These are still used in Homebrew/homebrew-core. The others are either
- default (Os on macOS, O2 on Linux)
- less reliable than the default (O3)

While we're here, also remove an outdated `ncurses_define` comment.