### PR TITLE
fix(tap): set clone remote name to origin explicitly

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -296,6 +296,10 @@ class Tap
 
     $stderr.ohai "Tapping #{name}" unless quiet
     args =  %W[clone #{requested_remote} #{path}]
+
+    # Override possible user configs like:
+    #   git config --global clone.defaultRemoteName notorigin
+    args << "--origin=origin"
     args << "--depth=1" unless full_clone
     args << "-q" if quiet
 


### PR DESCRIPTION
Issue reproduction:

```shell
# Set the config value:
❯ git config --global clone.defaultRemoteName notorigin
# Add a tap:
❯ brew tap bazelbuild/tap
# Try updating and see the bug:
❯ brew update
# Remove the broken repo:
❯ brew untap bazelbuild/tap
# Apply the changes from this PR:
❯ echo "Apply change from PR"
# Add the tap again:
❯ brew tap bazelbuild/tap
# Try updating again, it works!
❯ brew update
# Clean up defaultRemoteName setting as you probably don't want it sticking around.
❯ git config --global --unset clone.defaultRemoteName
```

Output:

```console
# Set the config value:
❯ git config --global clone.defaultRemoteName notorigin

# Add a tap:
❯ brew tap bazelbuild/tap
==> Tapping bazelbuild/tap
Cloning into '/usr/local/brew/Library/Taps/bazelbuild/homebrew-tap'...
remote: Enumerating objects: 23, done.
remote: Counting objects: 100% (23/23), done.
remote: Compressing objects: 100% (17/17), done.
remote: Total 314 (delta 7), reused 11 (delta 5), pack-reused 291
Receiving objects: 100% (314/314), 59.32 KiB | 311.00 KiB/s, done.
Resolving deltas: 100% (150/150), done.
Tapped 1 formula (33 files, 110.8KB).
It looks like you tapped a private repository. To avoid entering your
credentials each time you update, you can use git HTTP credential
caching or issue the following command:
  cd /usr/local/brew/Library/Taps/bazelbuild/homebrew-tap
  git remote set-url origin git@github.com:bazelbuild/homebrew-tap.git

# Try updating and see the bug:
❯ brew update
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Error: Fetching /usr/local/brew/Library/Taps/bazelbuild/homebrew-tap failed!
fatal: invalid upstream 'origin/master'

# Remove the broken repo:
❯ brew untap bazelbuild/tap
Untapping bazelbuild/tap...
Untapped 1 formula (34 files, 110.9KB).

# Apply the changes from this PR:
❯ echo "Apply change from PR"
Apply change from PR

# Add the tap again:
❯ brew tap bazelbuild/tap
==> Tapping bazelbuild/tap
Cloning into '/usr/local/brew/Library/Taps/bazelbuild/homebrew-tap'...
remote: Enumerating objects: 23, done.
remote: Counting objects: 100% (23/23), done.
remote: Compressing objects: 100% (17/17), done.
remote: Total 314 (delta 7), reused 11 (delta 5), pack-reused 291
Receiving objects: 100% (314/314), 59.32 KiB | 421.00 KiB/s, done.
Resolving deltas: 100% (150/150), done.
Tapped 1 formula (33 files, 110.8KB).

# Try updating again, it works!
❯ brew update
Already up-to-date.

# Clean up defaultRemoteName setting as you probably don't want it sticking around.
❯ git config --global --unset clone.defaultRemoteName
```


---

#### Commits _(oldest to newest)_

0f48498ad fix(tap): set clone remote name to origin explicitly

Git now allows setting a different default remote name than `origin`
when you do a fresh clone by running:

```shell
git config --global clone.defaultRemoteName notorigin
```

This causes `brew tap <tap_name> && brew update` to fail, as it clones
with a different remote name in the `tap` and then expects the remote to
be `origin` in the `update`.

Fix this by explicitly setting the origin remote in the clone command.

<br/>