### PR TITLE
cmd/update-report: report outdated count & suggest `brew upgrade`

### DIFF
--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -121,6 +121,7 @@ module Kernel
   end
 
   def puts_stdout_or_stderr(*message)
+    message = "\n" if message.empty?
     if $stdout.tty?
       puts(message)
     else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

I've been wanting to do this for a while now.

This helps with the confusion people may have with the differences between `brew update` and `brew upgrade`.

With this change, `brew update` (via `update-report`) will now report how many installed formulae and casks are outdated and points the user to `brew upgrade` to update them.