### PR TITLE
dev-cmd/update-maintainers: If there are changes, auto-update man pages

### DIFF
--- a/Library/Homebrew/dev-cmd/update-maintainers.rb
+++ b/Library/Homebrew/dev-cmd/update-maintainers.rb
@@ -3,6 +3,7 @@
 
 require "cli/parser"
 require "utils/github"
+require "dev-cmd/man"
 
 module Homebrew
   extend T::Sig
@@ -61,7 +62,8 @@ module Homebrew
     if diff.status.success?
       puts "No changes to list of maintainers."
     else
-      puts "List of maintainers updated in README."
+      Homebrew.regenerate_man_pages(preserve_date: true, quiet: true)
+      puts "List of maintainers updated in the README and the generated man pages."
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- I noticed this in a PR recently, maybe the maintainer didn't think they would have to run `brew man` for this? In that case there's an extra step after the PR is raised, red CI checks on the PR (which is demoralising) and potentially requires a reviewer to point this out.
- This runs `brew man` if the `README` file has a diff as part of this command. Then the user has to `git add .` and their PR is (probably) good.
- I thought at first to remind users to run `brew man` after the success message, but it was just as easy to run the update command automatically.
