### PR TITLE
test/utils/git_spec: fix cherry pick test with older git

### DIFF
--- a/Library/Homebrew/test/utils/git_spec.rb
+++ b/Library/Homebrew/test/utils/git_spec.rb
@@ -58,6 +58,7 @@ describe Utils::Git do
     end
 
     it "aborts when cherry picking an existing hash" do
+      ENV["GIT_MERGE_VERBOSITY"] = "5" # Consistent output across git versions
       expect {
         described_class.cherry_pick!(HOMEBREW_CACHE, file_hash1)
       }.to raise_error(ErrorDuringExecution, /Merge conflict in README.md/)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

(e.g. system git on Mojave)