### PR TITLE
Set default ruby warning level to -W1

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -576,7 +576,7 @@ fi
 
 if [[ -z "$HOMEBREW_RUBY_WARNINGS" ]]
 then
-  export HOMEBREW_RUBY_WARNINGS="-W0"
+  export HOMEBREW_RUBY_WARNINGS="-W1"
 fi
 
 if [[ -z "$HOMEBREW_BOTTLE_DOMAIN" ]]

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -114,14 +114,15 @@ class Resource
   # A target or a block must be given, but not both.
   def unpack(target = nil)
     mktemp(download_name) do |staging|
-      downloader.stage
-      @source_modified_time = downloader.source_modified_time
-      apply_patches
-      if block_given?
-        yield ResourceStageContext.new(self, staging)
-      elsif target
-        target = Pathname(target)
-        target.install Pathname.pwd.children
+      downloader.stage do
+        @source_modified_time = downloader.source_modified_time
+        apply_patches
+        if block_given?
+          yield ResourceStageContext.new(self, staging)
+        elsif target
+          target = Pathname(target)
+          target.install Pathname.pwd.children
+        end
       end
     end
   end

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -78,7 +78,13 @@ module Homebrew
                     fix: false, except_cops: nil, only_cops: nil, display_cop_names: false, reset_cache: false,
                     debug: false, verbose: false)
       Homebrew.install_bundler_gems!
-      require "rubocop"
+
+      require "warnings"
+
+      Warnings.ignore :parser_syntax do
+        require "rubocop"
+      end
+
       require "rubocops"
 
       args = %w[

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -23,12 +23,17 @@ if ENV["HOMEBREW_TESTS_COVERAGE"]
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(formatters)
 end
 
+require_relative "../warnings"
+
+Warnings.ignore :parser_syntax do
+  require "rubocop"
+end
+
 require "rspec/its"
 require "rspec/github"
 require "rspec/wait"
 require "rspec/retry"
 require "rspec/sorbet"
-require "rubocop"
 require "rubocop/rspec/support"
 require "find"
 require "byebug"

--- a/Library/Homebrew/utils/rubocop.rb
+++ b/Library/Homebrew/utils/rubocop.rb
@@ -2,18 +2,10 @@
 # typed: false
 # frozen_string_literal: true
 
-require "warning"
+require_relative "../warnings"
 
-warnings = [
-  %r{warning: parser/current is loading parser/ruby\d+, which recognizes},
-  /warning: \d+\.\d+\.\d+-compliant syntax, but you are running \d+\.\d+\.\d+\./,
-  %r{warning: please see https://github\.com/whitequark/parser#compatibility-with-ruby-mri\.},
-]
-
-warnings.each do |warning|
-  Warning.ignore warning
+Warnings.ignore :parser_syntax do
+  require "rubocop"
 end
-
-require "rubocop"
 
 exit RuboCop::CLI.new.run

--- a/Library/Homebrew/warnings.rb
+++ b/Library/Homebrew/warnings.rb
@@ -1,0 +1,36 @@
+# typed: true
+# frozen_string_literal: true
+
+require "warning"
+
+# Helper module for handling warnings.
+#
+# @api private
+module Warnings
+  module_function
+
+  COMMON_WARNINGS = {
+    parser_syntax: [
+      %r{warning: parser/current is loading parser/ruby\d+, which recognizes},
+      /warning: \d+\.\d+\.\d+-compliant syntax, but you are running \d+\.\d+\.\d+\./,
+      %r{warning: please see https://github\.com/whitequark/parser#compatibility-with-ruby-mri\.},
+    ],
+  }.freeze
+
+  def ignore(*warnings)
+    warnings.map! do |warning|
+      next warning if !warning.is_a?(Symbol) || !COMMON_WARNINGS.key?(warning)
+
+      COMMON_WARNINGS[warning]
+    end
+
+    warnings.flatten.each do |warning|
+      Warning.ignore warning
+    end
+    return unless block_given?
+
+    result = yield
+    Warning.clear
+    result
+  end
+end

--- a/Library/Homebrew/warnings.rbi
+++ b/Library/Homebrew/warnings.rbi
@@ -1,0 +1,5 @@
+# typed: strict
+
+module Warnings
+  include Kernel
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

See https://github.com/Homebrew/brew/issues/10593

Increase the default warning level to `-W1`. I've played with this a little locally, and I don't see any issues so far. My understanding is that `-W1` means that the only warnings that will be shown are those thrown using the `#warn` method. We don't use this method anywhere in Homebrew (it would likely be a bug if we did since it was being silenced), so the only potential warnings that could be shown are from other gems (e.g. `rubocop` or `rspec`). I've looked through the main commands that I think might have new warnings (including `style`, `man`, `prof`, `bump`, `tests`) and I don't detect any new warnings (the `parser/current` warning on `brew tests` is still present but is not new).

Homebrew developers can still set `HOMEBREW_RUBY_WARNINGS` to show more or less warnings if desired.
