### PR TITLE
tests: ignore parser warnings

### DIFF
--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -9,6 +9,8 @@ module Homebrew
 
   module_function
 
+  RSPEC = (HOMEBREW_LIBRARY_PATH/"utils/rspec.rb").freeze
+
   sig { returns(CLI::Parser) }
   def tests_args
     Homebrew::CLI::Parser.new do
@@ -144,9 +146,13 @@ module Homebrew
       ENV["GEM_PATH"] = "#{ENV["GEM_PATH"]}:#{gem_user_dir}"
 
       if parallel
-        system "bundle", "exec", "parallel_rspec", *parallel_args, "--", *bundle_args, "--", *files
+        require "parallel_tests"
+
+        ENV["PARALLEL_TESTS_EXECUTABLE"] = "bundle exec #{RSPEC}"
+
+        ParallelTests::CLI.new.run(["--type", "rspec", *parallel_args, "--", *bundle_args, "--", *files])
       else
-        system "bundle", "exec", "rspec", *bundle_args, "--", *files
+        system "bundle", "exec", RSPEC, *bundle_args, "--", *files
       end
 
       return if $CHILD_STATUS.success?

--- a/Library/Homebrew/utils/rspec.rb
+++ b/Library/Homebrew/utils/rspec.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# typed: false
+# frozen_string_literal: true
+
+require "warning"
+
+warnings = [
+  %r{warning: parser/current is loading parser/ruby\d+, which recognizes},
+  /warning: \d+\.\d+\.\d+-compliant syntax, but you are running \d+\.\d+\.\d+\./,
+  %r{warning: please see https://github\.com/whitequark/parser#compatibility-with-ruby-mri\.},
+]
+
+warnings.each do |warning|
+  Warning.ignore warning
+end
+
+require "rspec/core"
+
+RSpec::Core::Runner.invoke

--- a/Library/Homebrew/utils/rspec.rb
+++ b/Library/Homebrew/utils/rspec.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "warning"

--- a/Library/Homebrew/utils/rubocop.rb
+++ b/Library/Homebrew/utils/rubocop.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# typed: false
+# typed: true
 # frozen_string_literal: true
 
 require "warning"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Closes #10505

This PR makes changes similar to #10583 to `brew tests` to remove the parser warning.

I created a `utils/rspec.rb` script in mimics the `utils/rubocop.rb` script. It, essentially, ignored the necessary warnings and then calls `RSpec::Core::Runner.invoke` directly.

For parallel tests, I needed a slightly different approach. By default, `ParallelTests::CLI.new.run` uses `bundle exec rspec` to run the tests. This can be overridden with the `PARALLEL_TESTS_EXECUTABLE` environment variable, so I set that to point to the `utils/rspec.rb` script and called `ParallelTests::CLI.new.run` directly in `dev-cmd/tests.rb`
