### PR TITLE
dependabot: allow indirect dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,14 @@ updates:
     directory: /docs
     schedule:
       interval: weekly
+    allow:
+      - dependency-type: all
 
   - package-ecosystem: bundler
     directory: /Library/Homebrew
     schedule:
       interval: daily
+    allow:
+      - dependency-type: all
     ignore:
       - dependency-name: sorbet-runtime


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Old dependabot-preview used to do this. I think it's better for security reasons.