### PR TITLE
cc: remove unneeded linker flag when building with GCC on Linux

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -303,6 +303,12 @@ class Cmd
   end
 
   def ldflags_linux(args)
+    # Remove $HOMEBREW_PREFIX/lib from the args because it is already provided by the GCC specs,
+    # and breaks linkage to GCC runtime libraries.
+    # Don't remove it when using clang, which does not use specs like GCC does.
+    # https://github.com/Homebrew/brew/pull/10606
+    args.pop() if tool !~ /^clang/
+
     unless mode == :ld
       wl = "-Wl,"
       args << "-B#{@opt}/glibc/lib"


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----

This pull request should fix a bug on Linux when attempting to use a newer `gcc` when the brewed `gcc@5` is installed and is linked into `$HOMEBREW_PREFIX/lib`.  The `determine_library_paths` method in `extend/ENV/super.rb` adds `$HOMEBREW_PREFIX/lib` to the list of the library paths, which results in `-L$HOMEBREW_PREFIX/lib` being add as a linker flag to the superenv.  This creates a problem when using newer of versions of `gcc`, because this flag causes the linker to use `$HOMEBREW_PREFIX/lib/libstdc++.so.6` and the other run time libraries from `gcc-5` instead of the versions of those libraries that come with newer version of `gcc` which we are trying to use.

This solution resolves this by inserting an additional linker flag for the directory which contains the runtime libraries for the newer `gcc` **before** `$HOMEBREW_PREFIX/lib`, so that the linker will always find the newer `gcc` runtime libraries before finding the older copies of those libraries in `$HOMEBREW_PREFIX/lib`.  

This fix should not be merged until `gcc` on Linux points to `gcc@10`.  Once that is completed, we will migrate all formulae which need a newer `gcc` from whatever version they are currently using to `depends_on gcc`.  In the unlikely event that we have formulae which need a `gcc` version between 5 and 10, we'd have to make equivalent changes for those versions of `gcc` as well.  This is because the directory with the run time libraries includes the `gcc` version, and therefore differs for each version.

The other solution that was mentioned was to remove `$HOMEBREW_PREFIX/lib` from the list of library paths added by `determine_library_paths`, but I don't know what kind of breakage this could create, so this solution is safer.  However feedback on this decision would be great as there may be other opinions about how best to handle this.