### PR TITLE
prof: needs at least 1 argument

### DIFF
--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -17,7 +17,7 @@ module Homebrew
       switch "--stackprof",
              description: "Use `stackprof` instead of `ruby-prof` (the default)."
 
-      named_args :command
+      named_args :command, min: 1
     end
   end
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1207,7 +1207,7 @@ Apply the bottle commit and publish bottles to Bintray or GitHub Releases.
 * `--root-url`:
   Use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
 
-### `prof` [*`--stackprof`*] [*`command`* ...]
+### `prof` [*`--stackprof`*] *`command`* [...]
 
 Run Homebrew with a Ruby profiler. For example, `brew prof readall`.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1687,7 +1687,7 @@ Upload to the specified Bintray organisation (default: \fBhomebrew\fR)\.
 \fB\-\-root\-url\fR
 Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
 .
-.SS "\fBprof\fR [\fI\-\-stackprof\fR] [\fIcommand\fR \.\.\.]"
+.SS "\fBprof\fR [\fI\-\-stackprof\fR] \fIcommand\fR [\.\.\.]"
 Run Homebrew with a Ruby profiler\. For example, \fBbrew prof readall\fR\.
 .
 .TP


### PR DESCRIPTION
`brew prof` was incorrectly marked as having an optional argument, which is not correct as a bare `brew prof` will result in:

```console
% brew prof
Error: undefined method `extname' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/prof.rb:30:in `prof'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----