### PR TITLE
Add missing workflow scope for Github

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -20,7 +20,8 @@ module GitHub
 
   CREATE_GIST_SCOPES = ["gist"].freeze
   CREATE_ISSUE_FORK_OR_PR_SCOPES = ["public_repo"].freeze
-  ALL_SCOPES = (CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES).freeze
+  CREATE_WORKFLOW = ["workflow"].freeze
+  ALL_SCOPES = (CREATE_GIST_SCOPES + CREATE_ISSUE_FORK_OR_PR_SCOPES + CREATE_WORKFLOW).freeze
   ALL_SCOPES_URL = Formatter.url(
     "https://github.com/settings/tokens/new?scopes=#{ALL_SCOPES.join(",")}&description=Homebrew",
   ).freeze


### PR DESCRIPTION
Github has slightly changed their scopes for application keys. I added the required field to the source, but I can't run the tests as several unrelated tests fail.

Maybe someone with a better understanding of how the brew tests work can pick up this change and make the PR a proper one? I'm sorry that I can't fulfill all points that are required for a proper PR!