### PR TITLE
completions: delete brew-cask check

### DIFF
--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -129,8 +129,6 @@ module Homebrew
 
     sig { params(command: String).returns(T::Boolean) }
     def command_gets_completions?(command)
-      return false if command.start_with? "cask " # TODO: (2.8) remove when `brew cask` commands are removed
-
       command_options(command).any?
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----
delete the check whether the command is `brew cask` or not  in `completions.rb`