### PR TITLE
style: require parentheses around regex arguments

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -261,14 +261,6 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - "Homebrew/lazy_object.rb"
 
-# so many of these in formulae and can't be autocorrected
-# TODO: fix these as `ruby -w` complains about them.
-Lint/AmbiguousRegexpLiteral:
-  Exclude:
-    - "Taps/*/*/*.rb"
-    - "/**/Formula/*.rb"
-    - "**/Formula/*.rb"
-
 # useful for metaprogramming in RSpec
 Lint/ConstantDefinitionInBlock:
   Exclude:


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Using non-parenthesized regex arguments is a ruby warning with `-W2`. Adding parentheses was marked as a to-do item, so I figured I'd take care of it while working on reducing warnings.

I'm opening a homebrew/core PR to make the necessary changes there, and once that's merged through this should be good.
