### PR TITLE
Fix eql? in Cask::Cask

### DIFF
--- a/Library/Homebrew/cask/cask.rb
+++ b/Library/Homebrew/cask/cask.rb
@@ -162,7 +162,7 @@ module Cask
     end
 
     def eql?(other)
-      token == other.token
+      instance_of?(other.class) && token == other.token
     end
     alias == eql?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

This PR fixes equality checking for Casks.

Before:
```
➜ brew livecheck volt homebrew/cask/volt
Warning: Treating volt as a formula. For the cask, use homebrew/cask/volt
Error: undefined method `token' for #<Formulary::FormulaNamespace8375643587616545a6f8955d8b01e055::Volt:0x00007ff183b86ec0>
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/cask/cask.rb:165:in `eql?'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:61:in `uniq'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:61:in `to_formulae_and_casks'
/usr/local/Homebrew/Library/Homebrew/dev-cmd/livecheck.rb:84:in `livecheck'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```

After:
```
➜ brew livecheck volt homebrew/cask/volt
Warning: Treating volt as a formula. For the cask, use homebrew/cask/volt
volt : 0.3.7 ==> 0.3.7
volt : 0.80 ==> 0.87
```