### PR TITLE
Use patchelf.rb unconditionally

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -372,7 +372,7 @@ else
 
   if [[ -n "$HOMEBREW_FORCE_HOMEBREW_ON_LINUX" && -n "$HOMEBREW_ON_DEBIAN7" ]]
   then
-    # Special version for our debian 7 docker container used to build patchelf and binutils
+    # Special version for our debian 7 docker container used to build binutils
     HOMEBREW_MINIMUM_CURL_VERSION="7.25.0"
   else
     # Ensure the system Curl is a version that supports modern HTTPS certificates.

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -84,18 +84,8 @@ module Homebrew
 
     return merge(args: args) if args.merge?
 
-    ensure_relocation_formulae_installed! unless args.skip_relocation?
     args.named.to_resolved_formulae.each do |f|
       bottle_formula f, args: args
-    end
-  end
-
-  def ensure_relocation_formulae_installed!
-    Keg.relocation_formulae.each do |f|
-      next if Formula[f].latest_version_installed?
-
-      ohai "Installing #{f}..."
-      safe_system HOMEBREW_BREW_FILE, "install", f
     end
   end
 

--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -8,9 +8,6 @@ class Keg
     # Patching the dynamic linker of glibc breaks it.
     return if name == "glibc"
 
-    # Patching patchelf using itself fails with "Text file busy" or SIGBUS.
-    return if name == "patchelf"
-
     elf_files.each do |file|
       file.ensure_writable do
         change_rpath(file, relocation.old_prefix, relocation.new_prefix)
@@ -79,13 +76,9 @@ class Keg
     elf_files
   end
 
-  def self.relocation_formulae
-    ["patchelf"]
-  end
-
   def self.bottle_dependencies
     @bottle_dependencies ||= begin
-      formulae = relocation_formulae
+      formulae = []
       gcc = Formulary.factory(CompilerSelector.preferred_gcc)
       if !Homebrew::EnvConfig.force_homebrew_on_linux? &&
          DevelopmentTools.non_apple_gcc_version("gcc") < gcc.version.to_i

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -630,8 +630,6 @@ class FormulaInstaller
     if pour_bottle && !Keg.bottle_dependencies.empty?
       bottle_deps = if Keg.bottle_dependencies.exclude?(formula.name)
         Keg.bottle_dependencies
-      elsif Keg.relocation_formulae.exclude?(formula.name)
-        Keg.relocation_formulae
       else
         []
       end

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -155,6 +155,3 @@ require "tap"
 require "tap_constants"
 
 require "compat" unless Homebrew::EnvConfig.no_compat?
-
-# Enables `patchelf.rb` write support.
-HOMEBREW_PATCHELF_RB_WRITE = ENV["HOMEBREW_NO_PATCHELF_RB_WRITE"].blank?.freeze

--- a/Library/Homebrew/keg_relocate.rb
+++ b/Library/Homebrew/keg_relocate.rb
@@ -199,12 +199,8 @@ class Keg
     []
   end
 
-  def self.relocation_formulae
-    []
-  end
-
   def self.bottle_dependencies
-    relocation_formulae
+    []
   end
 end
 

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -8,19 +8,6 @@ describe "brew bottle" do
   it_behaves_like "parseable arguments"
 
   it "builds a bottle for the given Formula", :integration_test do
-    # create stub patchelf
-    if OS.linux?
-      setup_test_formula "patchelf"
-      patchelf = HOMEBREW_CELLAR/"patchelf/1.0/bin/patchelf"
-      patchelf.dirname.mkpath
-      patchelf.write <<~EOS
-        #!/bin/sh
-        exit 0
-      EOS
-      FileUtils.chmod "+x", patchelf
-      FileUtils.ln_s patchelf, HOMEBREW_PREFIX/"bin/patchelf"
-    end
-
     install_test_formula "testball", build_bottle: true
 
     # `brew bottle` should not fail with dead symlink

--- a/Library/Homebrew/test/formula_installer_bottle_spec.rb
+++ b/Library/Homebrew/test/formula_installer_bottle_spec.rb
@@ -25,8 +25,6 @@ describe FormulaInstaller do
     stub_formula_loader formula
     stub_formula_loader formula("gcc") { url "gcc-1.0" }
     stub_formula_loader formula("gcc@5") { url "gcc-5.0" }
-    stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
-    allow(Formula["patchelf"]).to receive(:latest_version_installed?).and_return(true)
 
     fi = FormulaInstaller.new(formula)
     fi.fetch

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -143,8 +143,6 @@ describe Formulary do
         allow(described_class).to receive(:loader_for).and_call_original
         stub_formula_loader formula("gcc") { url "gcc-1.0" }
         stub_formula_loader formula("gcc@5") { url "gcc-5.0" }
-        stub_formula_loader formula("patchelf") { url "patchelf-1.0" }
-        allow(Formula["patchelf"]).to receive(:latest_version_installed?).and_return(true)
       end
 
       let(:installed_formula) { described_class.factory(formula_path) }

--- a/Library/Homebrew/test/os/linux/pathname_spec.rb
+++ b/Library/Homebrew/test/os/linux/pathname_spec.rb
@@ -43,11 +43,6 @@ describe Pathname do
   end
 
   describe "#patch!" do
-    # testing only patchelf.rb as HOMEBREW_PREFIX is different for tests,
-    # and DevelopmentTools.locate fails to locate patchelf
-    # TODO: use stub_const("HOMEBREW_PATCHELF_RB_WRITE", true) in tests instead.
-    HOMEBREW_PATCHELF_RB_WRITE = true
-
     let(:placeholder_prefix) { "@@HOMEBREW_PREFIX@@" }
     let(:short_prefix) { "/home/dwarf" }
     let(:standard_prefix) { "/home/linuxbrew/.linuxbrew" }

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -152,7 +152,7 @@ RSpec.shared_context "integration test" do
 
         # something here
       RUBY
-    when "foo", "patchelf"
+    when "foo"
       content = <<~RUBY
         url "https://brew.sh/#{name}-1.0"
       RUBY
@@ -163,7 +163,7 @@ RSpec.shared_context "integration test" do
       RUBY
     when "package_license"
       content = <<~RUBY
-        url "https://brew.sh/#patchelf-1.0"
+        url "https://brew.sh/#{name}-1.0"
         license "0BSD"
       RUBY
     end

--- a/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
+++ b/docs/Homebrew-linuxbrew-core-Maintainer-Guide.md
@@ -323,7 +323,6 @@ In this case deleting `cellar :any` line from the `bottle do` block is enough.
 
 There are some formulae that would fail with an error message like the one provided above, but they are crucial for users of old systems and we should restore the `cellar :any` line after pulling the bottles.
 Those formulae are:
-- `patchelf`
 - `binutils`
 - `gcc`
 - `curl`


### PR DESCRIPTION
Remove all the old code related to `patchelf` and use the `patchelf.rb` gem instead.

It may well be we're not ready for this (yet). That's fine!