### PR TITLE
Make HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK default

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -212,11 +212,6 @@ module Homebrew
         description: "If set, do not use Bootsnap to speed up repeated `brew` calls.",
         boolean:     true,
       },
-      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK:     {
-        description: "If set, fail on the failure of installation from a bottle rather than " \
-                     "falling back to building from source.",
-        boolean:     true,
-      },
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: {
         description: "If set, do not check for broken dependents after installing, upgrading or reinstalling " \
                      "formulae.",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1852,9 +1852,6 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_NO_BOOTSNAP`
   <br>If set, do not use Bootsnap to speed up repeated `brew` calls.
 
-- `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK`
-  <br>If set, fail on the failure of installation from a bottle rather than falling back to building from source.
-
 - `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK`
   <br>If set, do not check for broken dependents after installing, upgrading or reinstalling formulae.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2641,12 +2641,6 @@ If set, do not automatically update before running some commands e\.g\. \fBbrew 
 If set, do not use Bootsnap to speed up repeated \fBbrew\fR calls\.
 .
 .TP
-\fBHOMEBREW_NO_BOTTLE_SOURCE_FALLBACK\fR
-.
-.br
-If set, fail on the failure of installation from a bottle rather than falling back to building from source\.
-.
-.TP
 \fBHOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK\fR
 .
 .br


### PR DESCRIPTION
- Remove `HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK` and make the behaviour the default. We mostly already do this since we added the need for the `--build-from-source` override on macOS. This allows us to delete some more code.
- Still fail and require `--build-from-source` when reinstalling or upgrading if failing on a formula-specific reason e.g. the CLT is not/no longer installed, you're using a non-default prefix.

Fixes #10623