### PR TITLE
formulary: remove consts on cache clear

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -60,6 +60,7 @@ module Formulary
       mod.const_set(:BUILD_FLAGS, flags)
       mod.module_eval(contents, path)
     rescue NameError, ArgumentError, ScriptError, MethodDeprecatedError => e
+      remove_const(namespace)
       raise FormulaUnreadableError.new(name, e)
     end
     class_name = class_s(name)
@@ -71,6 +72,7 @@ module Formulary
                       .map { |const_name| mod.const_get(const_name) }
                       .select { |const| const.is_a?(Class) }
       new_exception = FormulaClassUnavailableError.new(name, path, class_name, class_list)
+      remove_const(namespace)
       raise new_exception, "", e.backtrace
     end
   end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -33,6 +33,19 @@ module Formulary
     cache.fetch(path)
   end
 
+  def self.clear_cache
+    cache.each do |key, klass|
+      next if key == :formulary_factory
+
+      namespace = klass.name.deconstantize
+      next if namespace.deconstantize != name
+
+      remove_const(namespace.demodulize)
+    end
+
+    super
+  end
+
   def self.load_formula(name, path, contents, namespace, flags:)
     raise "Formula loading disabled by HOMEBREW_DISABLE_LOAD_FORMULA!" if Homebrew::EnvConfig.disable_load_formula?
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

Fixes this `-W1` warning:

```
/usr/local/Homebrew/Library/Homebrew/formulary.rb:47: warning: already initialized constant Formulary::FormulaNamespace05bf70582f35fd2a829a4b3b42cd7164
/usr/local/Homebrew/Library/Homebrew/formulary.rb:47: warning: previous definition of FormulaNamespace05bf70582f35fd2a829a4b3b42cd7164 was here
```

Steps to reproduce:

```rb
Formula["hello"]
Formulary.clear_cache
Formula["hello"]
```