### PR TITLE
livecheck and bump: formula/cask disambiguation

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -38,13 +38,16 @@ module Homebrew
       raise UsageError, "`--limit` must be used with either `--formula` or `--cask`."
     end
 
-    formulae_and_casks = if args.formula?
-      args.named.to_formulae.presence
-    elsif args.cask?
-      args.named.to_casks.presence
-    else
-      args.named.to_formulae_and_casks.presence
-    end
+    formulae_and_casks =
+      if args.formula?
+        args.named.to_formulae
+      elsif args.cask?
+        args.named.to_casks
+      else
+        args.named.to_formulae_and_casks
+      end&.sort_by do |formula_or_cask|
+        formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
+      end
 
     limit = args.limit.to_i if args.limit.present?
 

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -161,18 +161,17 @@ module Homebrew
     livecheck_latest = livecheck_result(formula_or_cask)
     pull_requests = retrieve_pull_requests(formula_or_cask, name) unless args.no_pull_requests?
 
-    print_name = begin
-      "#{name} (cask)" if formula_or_cask.is_a?(Cask::Cask) && Formula[name] && !args.cask?
+    name += begin
+      (" (cask)" if formula_or_cask.is_a?(Cask::Cask) && !args.cask? && Formula[name]).to_s
     rescue FormulaUnavailableError
-      nil
+      ""
     end
-    print_name ||= name
 
     title = if current_version == repology_latest &&
                current_version == livecheck_latest
-      "#{print_name} is up to date!"
+      "#{name} is up to date!"
     else
-      print_name
+      name
     end
 
     ohai title

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -161,11 +161,18 @@ module Homebrew
     livecheck_latest = livecheck_result(formula_or_cask)
     pull_requests = retrieve_pull_requests(formula_or_cask, name) unless args.no_pull_requests?
 
+    print_name = begin
+      "#{name} (cask)" if formula_or_cask.is_a?(Cask::Cask) && Formula[name] && !args.cask?
+    rescue FormulaUnavailableError
+      nil
+    end
+    print_name ||= name
+
     title = if current_version == repology_latest &&
                current_version == livecheck_latest
-      "#{name} is up to date!"
+      "#{print_name} is up to date!"
     else
-      name
+      print_name
     end
 
     ohai title

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -61,44 +61,44 @@ module Homebrew
       puts ENV["HOMEBREW_LIVECHECK_WATCHLIST"] if ENV["HOMEBREW_LIVECHECK_WATCHLIST"].present?
     end
 
-    formulae_and_casks_to_check =
-      if args.tap
-        tap = Tap.fetch(args.tap)
-        formulae = args.cask? ? [] : tap.formula_files.map { |path| Formulary.factory(path) }
-        casks = args.formula? ? [] : tap.cask_files.map { |path| Cask::CaskLoader.load(path) }
-        formulae + casks
-      elsif args.installed?
-        formulae = args.cask? ? [] : Formula.installed
-        casks = args.formula? ? [] : Cask::Caskroom.casks
-        formulae + casks
-      elsif args.all?
-        formulae = args.cask? ? [] : Formula.to_a
-        casks = args.formula? ? [] : Cask::Cask.to_a
-        formulae + casks
-      elsif args.named.present?
-        if args.formula?
-          args.named.to_formulae
-        elsif args.cask?
-          args.named.to_casks
-        else
-          args.named.to_formulae_and_casks
-        end
-      elsif File.exist?(WATCHLIST_PATH)
-        begin
-          names = Pathname.new(WATCHLIST_PATH).read.lines
-                          .reject { |line| line.start_with?("#") || line.blank? }
-                          .map(&:strip)
-
-          named_args = T.unsafe(CLI::NamedArgs).new(*names, parent: args)
-          named_args.to_formulae_and_casks(ignore_unavailable: true)
-        rescue Errno::ENOENT => e
-          onoe e
-        end
+    formulae_and_casks_to_check = if args.tap
+      tap = Tap.fetch(args.tap)
+      formulae = args.cask? ? [] : tap.formula_files.map { |path| Formulary.factory(path) }
+      casks = args.formula? ? [] : tap.cask_files.map { |path| Cask::CaskLoader.load(path) }
+      formulae + casks
+    elsif args.installed?
+      formulae = args.cask? ? [] : Formula.installed
+      casks = args.formula? ? [] : Cask::Caskroom.casks
+      formulae + casks
+    elsif args.all?
+      formulae = args.cask? ? [] : Formula.to_a
+      casks = args.formula? ? [] : Cask::Cask.to_a
+      formulae + casks
+    elsif args.named.present?
+      if args.formula?
+        args.named.to_formulae
+      elsif args.cask?
+        args.named.to_casks
       else
-        raise UsageError, "A watchlist file is required when no arguments are given."
-      end&.sort_by do |formula_or_cask|
-        formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
+        args.named.to_formulae_and_casks
       end
+    elsif File.exist?(WATCHLIST_PATH)
+      begin
+        names = Pathname.new(WATCHLIST_PATH).read.lines
+                        .reject { |line| line.start_with?("#") || line.blank? }
+                        .map(&:strip)
+
+        named_args = T.unsafe(CLI::NamedArgs).new(*names, parent: args)
+        named_args.to_formulae_and_casks(ignore_unavailable: true)
+      rescue Errno::ENOENT => e
+        onoe e
+      end
+    else
+      raise UsageError, "A watchlist file is required when no arguments are given."
+    end
+    formulae_and_casks_to_check = formulae_and_casks_to_check.sort_by do |formula_or_cask|
+      formula_or_cask.respond_to?(:token) ? formula_or_cask.token : formula_or_cask.name
+    end
 
     raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank?
 

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -105,7 +105,7 @@ module Homebrew
     options = {
       json:                 args.json?,
       full_name:            args.full_name?,
-      handle_name_conflict: !args.cask?,
+      handle_name_conflict: !args.formula? && !args.cask?,
       newer_only:           args.newer_only?,
       quiet:                args.quiet?,
       debug:                args.debug?,

--- a/Library/Homebrew/dev-cmd/livecheck.rb
+++ b/Library/Homebrew/dev-cmd/livecheck.rb
@@ -103,12 +103,13 @@ module Homebrew
     raise UsageError, "No formulae or casks to check." if formulae_and_casks_to_check.blank?
 
     options = {
-      json:       args.json?,
-      full_name:  args.full_name?,
-      newer_only: args.newer_only?,
-      quiet:      args.quiet?,
-      debug:      args.debug?,
-      verbose:    args.verbose?,
+      json:                 args.json?,
+      full_name:            args.full_name?,
+      handle_name_conflict: !args.cask?,
+      newer_only:           args.newer_only?,
+      quiet:                args.quiet?,
+      debug:                args.debug?,
+      verbose:              args.verbose?,
     }.compact
 
     Livecheck.run_checks(formulae_and_casks_to_check, **options)

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -105,19 +105,20 @@ module Homebrew
 
       ambiguous_casks = []
       if handle_name_conflict
-        ambiguous_casks = formulae_and_casks_to_check
-                          .group_by { |item| formula_or_cask_name(item, full_name: true) }
-                          .select { |_name, items| items.length > 1 }
-                          .values.flatten
-                          .select { |item| item.is_a?(Cask::Cask) }
+        ambiguous_casks = formulae_and_casks_to_check.group_by { |item| formula_or_cask_name(item, full_name: true) }
+                                                     .values
+                                                     .select { |items| items.length > 1 }
+                                                     .flatten
+                                                     .select { |item| item.is_a?(Cask::Cask) }
       end
 
       ambiguous_names = []
       unless full_name
-        ambiguous_names = (formulae_and_casks_to_check - ambiguous_casks)
-                          .group_by { |item| formula_or_cask_name(item) }
-                          .select { |_name, items| items.length > 1 }
-                          .values.flatten
+        ambiguous_names =
+          (formulae_and_casks_to_check - ambiguous_casks).group_by { |item| formula_or_cask_name(item) }
+                                                         .values
+                                                         .select { |items| items.length > 1 }
+                                                         .flatten
       end
 
       has_a_newer_upstream_version = T.let(false, T::Boolean)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

When running `livecheck` without the `--json` option, or `bump`, formulae and casks with the same name are indistinguishable in the output even when using `--full-name`, if they are from `homebrew-core` and `homebrew-cask`.

Example:

```
➜ brew livecheck volt homebrew/cask/volt --full-name
Warning: Treating volt as a formula. For the cask, use homebrew/cask/volt
volt : 0.3.7 ==> 0.3.7
volt : 0.80 ==> 0.87
```

It would be desirable to disambiguate names in such cases, unless the `--cask` option is explicitly given.

```
➜ brew livecheck homebrew/cask/volt volt                    
Warning: Treating volt as a formula. For the cask, use homebrew/cask/volt
volt (cask) : 0.80 ==> 0.87
volt : 0.3.7 ==> 0.3.7
```

I'm not sure if handling this in `livecheck` or `bump` is ideal, maybe we would want a method in `cask` instead?