### PR TITLE
python: stop passing no-user flag on installation

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -287,7 +287,7 @@ module Language
           targets = Array(targets)
           @formula.system @venv_root/"bin/pip", "install",
                           "-v", "--no-deps", "--no-binary", ":all:",
-                          "--no-user", "--ignore-installed", *targets
+                          "--ignore-installed", *targets
         end
       end
     end

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -24,7 +24,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts a string" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--no-user", "--ignore-installed", "foo")
+              "--no-binary", ":all:", "--ignore-installed", "foo")
         .and_return(true)
       virtualenv.pip_install "foo"
     end
@@ -32,7 +32,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts a multi-line strings" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--no-user", "--ignore-installed", "foo", "bar")
+              "--no-binary", ":all:", "--ignore-installed", "foo", "bar")
         .and_return(true)
 
       virtualenv.pip_install <<~EOS
@@ -44,12 +44,12 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
     it "accepts an array" do
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--no-user", "--ignore-installed", "foo")
+              "--no-binary", ":all:", "--ignore-installed", "foo")
         .and_return(true)
 
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--no-user", "--ignore-installed", "bar")
+              "--no-binary", ":all:", "--ignore-installed", "bar")
         .and_return(true)
 
       virtualenv.pip_install ["foo", "bar"]
@@ -61,7 +61,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       expect(res).to receive(:stage).and_yield
       expect(formula).to receive(:system)
         .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--no-user", "--ignore-installed", Pathname.pwd)
+              "--no-binary", ":all:", "--ignore-installed", Pathname.pwd)
         .and_return(true)
 
       virtualenv.pip_install res


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [ ] Have you successfully run `brew man` locally and committed any changes?

-----
`--no-user` is not a supported end-user flag in pip, and is explicitly non-documented: https://github.com/pypa/pip/issues/8977#issuecomment-706535089
https://github.com/pypa/pip/commit/87bb4f9c13d5a4f1c5b746670705ae044112f854

It was [added](https://github.com/Homebrew/brew/pull/10039) as part of building python packages from source in case a user's configuration specified `--user` installs due to the fact that you cannot do a `--user` install within a `venv`:
```
$ pip install --user foo
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
``` 

Recent versions of pip fall back to a user installation if site-packages is not writeable. Additionally, when building a formula, only the global and site pip configurations are looked at -- the user configuration is empty within `..../.brew_home/`, so this change in Homebrew doesn't impact users who have `user` installs as a local configuration.