### PR TITLE
rubocop: Enable RSpec/ContextWording cop & fix offenses

### DIFF
--- a/Library/.rubocop_rspec.yml
+++ b/Library/.rubocop_rspec.yml
@@ -11,8 +11,6 @@ RSpec/SubjectStub:
   Enabled: false
 
 # TODO: try to enable these
-RSpec/ContextWording:
-  Enabled: false
 RSpec/DescribeClass:
   Enabled: false
 RSpec/LeakyConstantDeclaration:

--- a/Library/Homebrew/test/bash_spec.rb
+++ b/Library/Homebrew/test/bash_spec.rb
@@ -18,13 +18,13 @@ describe "Bash" do
     end
   end
 
-  context "brew" do
+  describe "brew" do
     subject { HOMEBREW_LIBRARY_PATH.parent.parent/"bin/brew" }
 
     it { is_expected.to have_valid_bash_syntax }
   end
 
-  context "every `.sh` file" do
+  describe "every `.sh` file" do
     it "has valid Bash syntax" do
       Pathname.glob("#{HOMEBREW_LIBRARY_PATH}/**/*.sh").each do |path|
         relative_path = path.relative_path_from(HOMEBREW_LIBRARY_PATH)
@@ -35,13 +35,13 @@ describe "Bash" do
     end
   end
 
-  context "Bash completion" do
+  describe "Bash completion" do
     subject { HOMEBREW_LIBRARY_PATH.parent.parent/"completions/bash/brew" }
 
     it { is_expected.to have_valid_bash_syntax }
   end
 
-  context "every shim script" do
+  describe "every shim script" do
     it "has valid Bash syntax" do
       # These have no file extension, but can be identified by their shebang.
       (HOMEBREW_LIBRARY_PATH/"shims").find do |path|

--- a/Library/Homebrew/test/build_environment_spec.rb
+++ b/Library/Homebrew/test/build_environment_spec.rb
@@ -45,7 +45,7 @@ describe BuildEnvironment do
   describe BuildEnvironment::DSL do
     subject(:build_environment_dsl) { double.extend(described_class) }
 
-    context "single argument" do
+    context "with a single argument" do
       before do
         build_environment_dsl.instance_eval do
           env :userpaths
@@ -55,7 +55,7 @@ describe BuildEnvironment do
       its(:env) { is_expected.to use_userpaths }
     end
 
-    context "multiple arguments" do
+    context "with multiple arguments" do
       before do
         build_environment_dsl.instance_eval do
           env :userpaths, :std

--- a/Library/Homebrew/test/cache_store_spec.rb
+++ b/Library/Homebrew/test/cache_store_spec.rb
@@ -32,7 +32,7 @@ describe CacheStoreDatabase do
   end
 
   describe "#get" do
-    context "database created" do
+    context "with a database created" do
       let(:db) { double("db", :[] => "bar") }
 
       it "gets value in the `CacheStoreDatabase` corresponding to the key" do
@@ -44,7 +44,7 @@ describe CacheStoreDatabase do
       end
     end
 
-    context "database not created" do
+    context "without a database created" do
       let(:db) { double("db", :[] => nil) }
 
       before do
@@ -64,7 +64,7 @@ describe CacheStoreDatabase do
   end
 
   describe "#delete" do
-    context "database created" do
+    context "with a database created" do
       let(:db) { double("db", :[] => { foo: "bar" }) }
 
       before do
@@ -78,7 +78,7 @@ describe CacheStoreDatabase do
       end
     end
 
-    context "database not created" do
+    context "without a database created" do
       let(:db) { double("db", delete: nil) }
 
       before do
@@ -94,13 +94,13 @@ describe CacheStoreDatabase do
   end
 
   describe "#write_if_dirty!" do
-    context "database open" do
+    context "with an open database" do
       it "does not raise an error when `close` is called on the database" do
         expect { sample_db.write_if_dirty! }.not_to raise_error(NoMethodError)
       end
     end
 
-    context "database not open" do
+    context "without an open database" do
       before do
         sample_db.instance_variable_set(:@db, nil)
       end
@@ -118,7 +118,7 @@ describe CacheStoreDatabase do
       allow(sample_db).to receive(:cache_path).and_return(cache_path)
     end
 
-    context "`cache_path.exist?` returns `true`" do
+    context "when `cache_path.exist?` returns `true`" do
       before do
         allow(cache_path).to receive(:exist?).and_return(true)
       end
@@ -128,7 +128,7 @@ describe CacheStoreDatabase do
       end
     end
 
-    context "`cache_path.exist?` returns `false`" do
+    context "when `cache_path.exist?` returns `false`" do
       before do
         allow(cache_path).to receive(:exist?).and_return(false)
       end

--- a/Library/Homebrew/test/cask/artifact/binary_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/binary_spec.rb
@@ -96,7 +96,7 @@ describe Cask::Artifact::Binary, :cask do
     expect(expected_path.exist?).to be true
   end
 
-  context "binary is inside an app package" do
+  context "when the binary is inside an app package" do
     let(:cask) {
       Cask::CaskLoader.load(cask_path("with-embedded-binary")).tap do |cask|
         InstallHelper.install_without_artifacts(cask)

--- a/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/uninstall_spec.rb
@@ -11,7 +11,7 @@ describe Cask::Artifact::Uninstall, :cask do
   describe "#post_uninstall_phase" do
     subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
 
-    context "using :rmdir" do
+    context "when using :rmdir" do
       let(:fake_system_command) { NeverSudoSystemCommand }
       let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-rmdir")) }
       let(:empty_directory) { Pathname.new("#{TEST_TMPDIR}/empty_directory_path") }

--- a/Library/Homebrew/test/cask/artifact/zap_spec.rb
+++ b/Library/Homebrew/test/cask/artifact/zap_spec.rb
@@ -7,7 +7,7 @@ describe Cask::Artifact::Zap, :cask do
   describe "#zap_phase" do
     include_examples "#uninstall_phase or #zap_phase"
 
-    context "using :rmdir" do
+    context "when using :rmdir" do
       subject(:artifact) { cask.artifacts.find { |a| a.is_a?(described_class) } }
 
       let(:fake_system_command) { NeverSudoSystemCommand }

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -315,7 +315,7 @@ describe Cask::Audit, :cask do
         end
       end
 
-      context "when cask token is in tap_migrations.json" do
+      context "when cask token is in tap_migrations.json and" do
         let(:cask_token) { "token-migrated" }
         let(:tap) { Tap.fetch("homebrew/cask") }
 
@@ -324,7 +324,7 @@ describe Cask::Audit, :cask do
           allow(cask).to receive(:tap).and_return(tap)
         end
 
-        context "and `new_cask` is true" do
+        context "when `new_cask` is true" do
           let(:new_cask) { true }
 
           it "fails" do
@@ -332,7 +332,7 @@ describe Cask::Audit, :cask do
           end
         end
 
-        context "and `new_cask` is false" do
+        context "when `new_cask` is false" do
           let(:new_cask) { false }
 
           it "does not fail" do
@@ -688,14 +688,14 @@ describe Cask::Audit, :cask do
         it { is_expected.to pass }
       end
 
-      context "when the Cask is on the denylist" do
-        context "and it's in the official Homebrew tap" do
+      context "when the Cask is on the denylist and" do
+        context "when it's in the official Homebrew tap" do
           let(:cask_token) { "adobe-illustrator" }
 
           it { is_expected.to fail_with(/#{cask_token} is not allowed: \w+/) }
         end
 
-        context "and it isn't in the official Homebrew tap" do
+        context "when it isn't in the official Homebrew tap" do
           let(:cask_token) { "pharo" }
 
           it { is_expected.to pass }
@@ -786,7 +786,7 @@ describe Cask::Audit, :cask do
     end
 
     describe "url checks" do
-      context "given a block" do
+      context "with a block" do
         let(:cask_token) { "booby-trap" }
 
         context "when loading the cask" do

--- a/Library/Homebrew/test/cask/cask_spec.rb
+++ b/Library/Homebrew/test/cask/cask_spec.rb
@@ -6,7 +6,7 @@ describe Cask::Cask, :cask do
 
   context "when multiple versions are installed" do
     describe "#versions" do
-      context "and there are duplicate versions" do
+      context "when there are duplicate versions" do
         it "uses the last unique version" do
           allow(cask).to receive(:timestamped_versions).and_return([
             ["1.2.2", "0999"],

--- a/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/upgrade_spec.rb
@@ -12,7 +12,7 @@ describe Cask::Cmd::Upgrade, :cask do
   let(:local_caffeine_path) { local_caffeine.config.appdir.join("Caffeine.app") }
   let(:local_caffeine) { Cask::CaskLoader.load("local-caffeine") }
 
-  context "successful upgrade" do
+  context "when the upgrade is successful" do
     let(:installed) {
       [
         "outdated/local-caffeine",
@@ -149,7 +149,7 @@ describe Cask::Cmd::Upgrade, :cask do
     end
   end
 
-  context "dry run upgrade" do
+  context "when the upgrade is a dry run" do
     let(:installed) {
       [
         "outdated/local-caffeine",
@@ -294,7 +294,7 @@ describe Cask::Cmd::Upgrade, :cask do
     end
   end
 
-  context "failed upgrade" do
+  context "when an upgrade failed" do
     let(:installed) {
       [
         "outdated/bad-checksum",
@@ -349,7 +349,7 @@ describe Cask::Cmd::Upgrade, :cask do
     end
   end
 
-  context "multiple failures" do
+  context "when there were multiple failures" do
     let(:installed) {
       [
         "outdated/bad-checksum",

--- a/Library/Homebrew/test/cask/depends_on_spec.rb
+++ b/Library/Homebrew/test/cask/depends_on_spec.rb
@@ -32,7 +32,7 @@ describe "Satisfy Dependencies and Requirements", :cask do
   end
 
   describe "depends_on macos" do
-    context "given an array" do
+    context "with an array" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-array")) }
 
       it "does not raise an error" do
@@ -40,7 +40,7 @@ describe "Satisfy Dependencies and Requirements", :cask do
       end
     end
 
-    context "given a comparison" do
+    context "with a comparison" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-comparison")) }
 
       it "does not raise an error" do
@@ -48,7 +48,7 @@ describe "Satisfy Dependencies and Requirements", :cask do
       end
     end
 
-    context "given a symbol" do
+    context "with a symbol" do
       let(:cask) { Cask::CaskLoader.load(cask_path("with-depends-on-macos-symbol")) }
 
       it "does not raise an error" do

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -168,37 +168,37 @@ describe Cask::DSL, :cask do
         cask.config = config
       end
 
-      context "when it is 'zh'" do
+      describe "to 'zh'" do
         let(:languages) { ["zh"] }
 
         it { is_expected.to be_the_chinese_version }
       end
 
-      context "when it is 'zh-XX'" do
+      describe "to 'zh-XX'" do
         let(:languages) { ["zh-XX"] }
 
         it { is_expected.to be_the_chinese_version }
       end
 
-      context "when it is 'en'" do
+      describe "to 'en'" do
         let(:languages) { ["en"] }
 
         it { is_expected.to be_the_english_version }
       end
 
-      context "when it is 'xx-XX'" do
+      describe "to 'xx-XX'" do
         let(:languages) { ["xx-XX"] }
 
         it { is_expected.to be_the_english_version }
       end
 
-      context "when it is 'xx-XX,zh,en'" do
+      describe "to 'xx-XX,zh,en'" do
         let(:languages) { ["xx-XX", "zh", "en"] }
 
         it { is_expected.to be_the_chinese_version }
       end
 
-      context "when it is 'xx-XX,en-US,zh'" do
+      describe "to 'xx-XX,en-US,zh'" do
         let(:languages) { ["xx-XX", "en-US", "zh"] }
 
         it { is_expected.to be_the_english_version }

--- a/Library/Homebrew/test/cask/dsl_spec.rb
+++ b/Library/Homebrew/test/cask/dsl_spec.rb
@@ -5,7 +5,7 @@ describe Cask::DSL, :cask do
   let(:cask) { Cask::CaskLoader.load(cask_path(token.to_s)) }
   let(:token) { "basic-cask" }
 
-  context "stanzas" do
+  describe "stanzas" do
     it "lets you set url, homepage, and version" do
       expect(cask.url.to_s).to eq("https://brew.sh/TestCask-1.2.3.dmg")
       expect(cask.homepage).to eq("https://brew.sh/")
@@ -168,37 +168,37 @@ describe Cask::DSL, :cask do
         cask.config = config
       end
 
-      context "to 'zh'" do
+      context "when it is 'zh'" do
         let(:languages) { ["zh"] }
 
         it { is_expected.to be_the_chinese_version }
       end
 
-      context "to 'zh-XX'" do
+      context "when it is 'zh-XX'" do
         let(:languages) { ["zh-XX"] }
 
         it { is_expected.to be_the_chinese_version }
       end
 
-      context "to 'en'" do
+      context "when it is 'en'" do
         let(:languages) { ["en"] }
 
         it { is_expected.to be_the_english_version }
       end
 
-      context "to 'xx-XX'" do
+      context "when it is 'xx-XX'" do
         let(:languages) { ["xx-XX"] }
 
         it { is_expected.to be_the_english_version }
       end
 
-      context "to 'xx-XX,zh,en'" do
+      context "when it is 'xx-XX,zh,en'" do
         let(:languages) { ["xx-XX", "zh", "en"] }
 
         it { is_expected.to be_the_chinese_version }
       end
 
-      context "to 'xx-XX,en-US,zh'" do
+      context "when it is 'xx-XX,en-US,zh'" do
         let(:languages) { ["xx-XX", "en-US", "zh"] }
 
         it { is_expected.to be_the_english_version }
@@ -356,7 +356,7 @@ describe Cask::DSL, :cask do
   end
 
   describe "depends_on cask" do
-    context "specifying one" do
+    context "with a single cask" do
       let(:token) { "with-depends-on-cask" }
 
       it "is allowed" do
@@ -364,7 +364,7 @@ describe Cask::DSL, :cask do
       end
     end
 
-    context "specifying multiple" do
+    context "when specifying multiple" do
       let(:token) { "with-depends-on-cask-multiple" }
 
       it "is allowed" do
@@ -374,7 +374,7 @@ describe Cask::DSL, :cask do
   end
 
   describe "depends_on macos" do
-    context "invalid depends_on macos value" do
+    context "when the depends_on macos value is invalid" do
       let(:token) { "invalid/invalid-depends-on-macos-bad-release" }
 
       it "refuses to load" do
@@ -382,7 +382,7 @@ describe Cask::DSL, :cask do
       end
     end
 
-    context "conflicting depends_on macos forms" do
+    context "when there are conflicting depends_on macos forms" do
       let(:token) { "invalid/invalid-depends-on-macos-conflicting-forms" }
 
       it "refuses to load" do
@@ -392,7 +392,7 @@ describe Cask::DSL, :cask do
   end
 
   describe "depends_on arch" do
-    context "valid" do
+    context "when valid" do
       let(:token) { "with-depends-on-arch" }
 
       it "is allowed to be specified" do
@@ -400,7 +400,7 @@ describe Cask::DSL, :cask do
       end
     end
 
-    context "invalid depends_on arch value" do
+    context "with invalid depends_on arch value" do
       let(:token) { "invalid/invalid-depends-on-arch-value" }
 
       it "refuses to load" do
@@ -410,7 +410,7 @@ describe Cask::DSL, :cask do
   end
 
   describe "depends_on x11" do
-    context "invalid depends_on x11 value" do
+    context "with invalid depends_on x11 value" do
       let(:token) { "invalid/invalid-depends-on-x11-value" }
 
       it "refuses to load" do
@@ -420,7 +420,7 @@ describe Cask::DSL, :cask do
   end
 
   describe "conflicts_with stanza" do
-    context "valid" do
+    context "when valid" do
       let(:token) { "with-conflicts-with" }
 
       it "allows conflicts_with stanza to be specified" do
@@ -428,7 +428,7 @@ describe Cask::DSL, :cask do
       end
     end
 
-    context "invalid conflicts_with key" do
+    context "with invalid conflicts_with key" do
       let(:token) { "invalid/invalid-conflicts-with-key" }
 
       it "refuses to load invalid conflicts_with key" do
@@ -438,7 +438,7 @@ describe Cask::DSL, :cask do
   end
 
   describe "installer stanza" do
-    context "script" do
+    context "when script" do
       let(:token) { "with-installer-script" }
 
       it "allows installer script to be specified" do
@@ -449,7 +449,7 @@ describe Cask::DSL, :cask do
       end
     end
 
-    context "manual" do
+    context "when manual" do
       let(:token) { "with-installer-manual" }
 
       it "allows installer manual to be specified" do
@@ -487,7 +487,7 @@ describe Cask::DSL, :cask do
   end
 
   describe "#appdir" do
-    context "interpolation of the appdir in stanzas" do
+    context "with interpolation of the appdir in stanzas" do
       let(:token) { "appdir-interpolation" }
 
       it "is allowed" do

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -35,7 +35,7 @@ describe Cask::Pkg, :cask do
       expect(root_dir).not_to exist
     end
 
-    context "pkgutil" do
+    describe "pkgutil" do
       it "forgets the pkg" do
         allow(fake_system_command).to receive(:run!).with(
           "/usr/sbin/pkgutil",

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -176,7 +176,7 @@ describe Caveats do
       end
     end
 
-    context "shell completions" do
+    describe "shell completions" do
       let(:f) {
         formula do
           url "foo-1.0"

--- a/Library/Homebrew/test/cleanup_spec.rb
+++ b/Library/Homebrew/test/cleanup_spec.rb
@@ -328,7 +328,7 @@ describe Homebrew::Cleanup do
       expect(foo).to exist
     end
 
-    context "cleans old files in HOMEBREW_CACHE" do
+    context "when cleaning old files in HOMEBREW_CACHE" do
       let(:bottle) { (HOMEBREW_CACHE/"testball--0.0.1.tag.bottle.tar.gz") }
       let(:testball) { (HOMEBREW_CACHE/"testball--0.0.1") }
       let(:testball_resource) { (HOMEBREW_CACHE/"testball--rsrc--0.0.1.txt") }

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -3,7 +3,7 @@
 
 require "commands"
 
-RSpec.shared_context "custom internal commands" do
+RSpec.shared_context "with custom internal commands" do
   let(:cmds) do
     [
       # internal commands

--- a/Library/Homebrew/test/commands_spec.rb
+++ b/Library/Homebrew/test/commands_spec.rb
@@ -3,7 +3,7 @@
 
 require "commands"
 
-RSpec.shared_context "with custom internal commands" do
+RSpec.shared_context "custom internal commands" do # rubocop:disable RSpec/ContextWording
   let(:cmds) do
     [
       # internal commands

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -817,8 +817,8 @@ module Homebrew
         end
       end
 
-      context "checksums" do
-        context "should not change with the same version" do
+      describe "checksums" do
+        describe "should not change with the same version" do
           before do
             formula_gsub(
               'sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"',
@@ -829,7 +829,7 @@ module Homebrew
           it { is_expected.to match("stable sha256 changed without the url/version also changing") }
         end
 
-        context "should not change with the same version when not the first commit" do
+        describe "should not change with the same version when not the first commit" do
           before do
             formula_gsub_origin_commit(
               'sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"',
@@ -846,7 +846,7 @@ module Homebrew
           it { is_expected.to match("stable sha256 changed without the url/version also changing") }
         end
 
-        context "can change with the different version" do
+        describe "can change with the different version" do
           before do
             formula_gsub_origin_commit(
               'sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"',
@@ -862,7 +862,7 @@ module Homebrew
           it { is_expected.to be_nil }
         end
 
-        context "can be removed when switching schemes" do
+        describe "can be removed when switching schemes" do
           before do
             formula_gsub_origin_commit(
               'url "https://brew.sh/foo-1.0.tar.gz"',
@@ -876,42 +876,42 @@ module Homebrew
         end
       end
 
-      context "revisions" do
-        context "should not be removed when first committed above 0" do
+      describe "revisions" do
+        describe "should not be removed when first committed above 0" do
           it { is_expected.to be_nil }
         end
 
-        context "should not decrease with the same version" do
+        describe "with the same version, should not decrease" do
           before { formula_gsub_origin_commit "revision 2", "revision 1" }
 
           it { is_expected.to match("revision should not decrease (from 2 to 1)") }
         end
 
-        context "should not be removed with the same version" do
+        describe "should not be removed with the same version" do
           before { formula_gsub_origin_commit "revision 2" }
 
           it { is_expected.to match("revision should not decrease (from 2 to 0)") }
         end
 
-        context "should not decrease with the same, uncommitted version" do
+        describe "should not decrease with the same, uncommitted version" do
           before { formula_gsub "revision 2", "revision 1" }
 
           it { is_expected.to match("revision should not decrease (from 2 to 1)") }
         end
 
-        context "should be removed with a newer version" do
+        describe "should be removed with a newer version" do
           before { formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz" }
 
           it { is_expected.to match("'revision 2' should be removed") }
         end
 
-        context "should be removed with a newer local version" do
+        describe "should be removed with a newer local version" do
           before { formula_gsub "foo-1.0.tar.gz", "foo-1.1.tar.gz" }
 
           it { is_expected.to match("'revision 2' should be removed") }
         end
 
-        context "should not warn on an newer version revision removal" do
+        describe "should not warn on an newer version revision removal" do
           before do
             formula_gsub_origin_commit "revision 2", ""
             formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
@@ -920,7 +920,7 @@ module Homebrew
           it { is_expected.to be_nil }
         end
 
-        context "should not warn when revision from previous version matches current revision" do
+        describe "should not warn when revision from previous version matches current revision" do
           before do
             formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
             formula_gsub_origin_commit "revision 2", "# no revision"
@@ -931,7 +931,7 @@ module Homebrew
           it { is_expected.to be_nil }
         end
 
-        context "should only increment by 1 with an uncommitted version" do
+        describe "should only increment by 1 with an uncommitted version" do
           before do
             formula_gsub "foo-1.0.tar.gz", "foo-1.1.tar.gz"
             formula_gsub "revision 2", "revision 4"
@@ -940,7 +940,7 @@ module Homebrew
           it { is_expected.to match("revisions should only increment by 1") }
         end
 
-        context "should not warn on past increment by more than 1" do
+        describe "should not warn on past increment by more than 1" do
           before do
             formula_gsub_origin_commit "revision 2", "# no revision"
             formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
@@ -951,14 +951,14 @@ module Homebrew
         end
       end
 
-      context "version_schemes" do
-        context "should not decrease with the same version" do
+      describe "version_schemes" do
+        describe "should not decrease with the same version" do
           before { formula_gsub_origin_commit "version_scheme 1" }
 
           it { is_expected.to match("version_scheme should not decrease (from 1 to 0)") }
         end
 
-        context "should not decrease with a new version" do
+        describe "should not decrease with a new version" do
           before do
             formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
             formula_gsub_origin_commit "revision 2", ""
@@ -968,7 +968,7 @@ module Homebrew
           it { is_expected.to match("version_scheme should not decrease (from 1 to 0)") }
         end
 
-        context "should only increment by 1" do
+        describe "should only increment by 1" do
           before do
             formula_gsub_origin_commit "version_scheme 1", "# no version_scheme"
             formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-1.1.tar.gz"
@@ -980,14 +980,14 @@ module Homebrew
         end
       end
 
-      context "versions" do
-        context "uncommitted should not decrease" do
+      describe "versions" do
+        context "when uncommitted should not decrease" do
           before { formula_gsub "foo-1.0.tar.gz", "foo-0.9.tar.gz" }
 
           it { is_expected.to match("stable version should not decrease (from 1.0 to 0.9)") }
         end
 
-        context "committed can decrease" do
+        context "when committed can decrease" do
           before do
             formula_gsub_origin_commit "revision 2"
             formula_gsub_origin_commit "foo-1.0.tar.gz", "foo-0.9.tar.gz"
@@ -996,7 +996,7 @@ module Homebrew
           it { is_expected.to be_nil }
         end
 
-        context "can decrease with version_scheme increased" do
+        describe "can decrease with version_scheme increased" do
           before do
             formula_gsub "revision 2"
             formula_gsub "foo-1.0.tar.gz", "foo-0.9.tar.gz"

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -87,7 +87,7 @@ describe "Exception" do
       end
     end
 
-    context "no classes" do
+    context "when there are no classes" do
       let(:list) { [] }
 
       its(:to_s) {
@@ -95,7 +95,7 @@ describe "Exception" do
       }
     end
 
-    context "class not derived from Formula" do
+    context "when the class is not derived from Formula" do
       let(:list) { [mod.const_get(:Bar)] }
 
       its(:to_s) {
@@ -103,7 +103,7 @@ describe "Exception" do
       }
     end
 
-    context "class derived from Formula" do
+    context "when the class is derived from Formula" do
       let(:list) { [mod.const_get(:Baz)] }
 
       its(:to_s) { is_expected.to match(/Expected to find class Foo, but only found: Baz\./) }
@@ -170,13 +170,13 @@ describe "Exception" do
   end
 
   describe CurlDownloadStrategyError do
-    context "file does not exist" do
+    context "when the file does not exist" do
       subject { described_class.new("file:///tmp/foo") }
 
       its(:to_s) { is_expected.to eq("File does not exist: /tmp/foo") }
     end
 
-    context "download failed" do
+    context "when the download failed" do
       subject { described_class.new("https://brew.sh") }
 
       its(:to_s) { is_expected.to eq("Download failed: https://brew.sh") }

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -56,7 +56,7 @@ describe Formula do
       expect { klass.new }.to raise_error(ArgumentError)
     end
 
-    context "in a Tap" do
+    context "when in a Tap" do
       let(:tap) { Tap.new("foo", "bar") }
       let(:path) { (tap.path/"Formula/#{name}.rb") }
       let(:full_name) { "#{tap.user}/#{tap.repo}/#{name}" }

--- a/Library/Homebrew/test/linkage_cache_store_spec.rb
+++ b/Library/Homebrew/test/linkage_cache_store_spec.rb
@@ -10,14 +10,14 @@ describe LinkageCacheStore do
   let(:database) { double("database") }
 
   describe "#keg_exists?" do
-    context "`keg_name` exists in cache" do
+    context "when `keg_name` exists in cache" do
       it "returns `true`" do
         expect(database).to receive(:get).with(keg_name).and_return("")
         expect(linkage_cache.keg_exists?).to be(true)
       end
     end
 
-    context "`keg_name` does not exist in cache" do
+    context "when `keg_name` does not exist in cache" do
       it "returns `false`" do
         expect(database).to receive(:get).with(keg_name).and_return(nil)
         expect(linkage_cache.keg_exists?).to be(false)
@@ -26,14 +26,14 @@ describe LinkageCacheStore do
   end
 
   describe "#update!" do
-    context "a `value` is a `Hash`" do
+    context "when a `value` is a `Hash`" do
       it "sets the cache for the `keg_name`" do
         expect(database).to receive(:set).with(keg_name, anything)
         linkage_cache.update!(keg_files_dylibs: { key: ["value"] })
       end
     end
 
-    context "a `value` is not a `Hash`" do
+    context "when a `value` is not a `Hash`" do
       it "raises a `TypeError` if a `value` is not a `Hash`" do
         expect { linkage_cache.update!(a_value: ["value"]) }.to raise_error(TypeError)
       end
@@ -48,14 +48,14 @@ describe LinkageCacheStore do
   end
 
   describe "#fetch" do
-    context "`HASH_LINKAGE_TYPES.include?(type)`" do
+    context "when `HASH_LINKAGE_TYPES.include?(type)`" do
       it "returns a `Hash` of values" do
         expect(database).to receive(:get).with(keg_name).and_return(nil)
         expect(linkage_cache.fetch(:keg_files_dylibs)).to be_an_instance_of(Hash)
       end
     end
 
-    context "`type` not in `HASH_LINKAGE_TYPES`" do
+    context "when `type` is not in `HASH_LINKAGE_TYPES`" do
       it "raises a `TypeError` if the `type` is not supported" do
         expect { linkage_cache.fetch(:bad_type) }.to raise_error(TypeError)
       end

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -265,56 +265,56 @@ describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::skip_conditions" do
-    context "a deprecated formula without a livecheckable" do
+    context "when the formula is deprecated without a livecheckable" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:deprecated]))
           .to eq(status_hashes[:formula][:deprecated])
       end
     end
 
-    context "a disabled formula without a livecheckable" do
+    context "when the formula is disabled without a livecheckable" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:disabled]))
           .to eq(status_hashes[:formula][:disabled])
       end
     end
 
-    context "a versioned formula without a livecheckable" do
+    context "when the formula is versioned without a livecheckable" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:versioned]))
           .to eq(status_hashes[:formula][:versioned])
       end
     end
 
-    context "a HEAD-only formula that is not installed" do
+    context "when the formula is HEAD-only and not installed" do
       it "skips " do
         expect(skip_conditions.skip_information(formulae[:head_only]))
           .to eq(status_hashes[:formula][:head_only])
       end
     end
 
-    context "a formula with a GitHub Gist stable URL" do
+    context "when the formula has a GitHub Gist stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:gist]))
           .to eq(status_hashes[:formula][:gist])
       end
     end
 
-    context "a formula with a Google Code Archive stable URL" do
+    context "when the formula has a Google Code Archive stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:google_code_archive]))
           .to eq(status_hashes[:formula][:google_code_archive])
       end
     end
 
-    context "a formula with an Internet Archive stable URL" do
+    context "when the formula has an Internet Archive stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:internet_archive]))
           .to eq(status_hashes[:formula][:internet_archive])
       end
     end
 
-    context "a formula with a `livecheck` block containing `skip`" do
+    context "when the formula has a `livecheck` block containing `skip`" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:skip]))
           .to eq(status_hashes[:formula][:skip])
@@ -324,28 +324,28 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a discontinued cask without a livecheckable" do
+    context "when a cask is discontinued without a livecheckable" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:discontinued]))
           .to eq(status_hashes[:cask][:discontinued])
       end
     end
 
-    context "a cask containing `version :latest` without a livecheckable" do
+    context "when a cask has `version :latest` without a livecheckable" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:latest]))
           .to eq(status_hashes[:cask][:latest])
       end
     end
 
-    context "a cask containing an unversioned URL without a livecheckable" do
+    context "when a cask has an unversioned URL without a livecheckable" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:unversioned]))
           .to eq(status_hashes[:cask][:unversioned])
       end
     end
 
-    context "a cask with a `livecheck` block containing `skip`" do
+    context "when a cask has a `livecheck` block containing `skip`" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:skip]))
           .to eq(status_hashes[:cask][:skip])
@@ -365,7 +365,7 @@ describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::print_skip_information" do
-    context "a deprecated formula without a livecheckable" do
+    context "when the formula is deprecated without a livecheckable" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:deprecated]) }
           .to output("test_deprecated : deprecated\n").to_stdout
@@ -373,7 +373,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a disabled formula without a livecheckable" do
+    context "when the formula is disabled without a livecheckable" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:disabled]) }
           .to output("test_disabled : disabled\n").to_stdout
@@ -381,7 +381,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a versioned formula without a livecheckable" do
+    context "when the formula is versioned without a livecheckable" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:versioned]) }
           .to output("test@0.0.1 : versioned\n").to_stdout
@@ -389,7 +389,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a HEAD-only formula that is not installed" do
+    context "when the formula is HEAD-only and not installed" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:head_only]) }
           .to output("test_head_only : HEAD only formula must be installed to be livecheckable\n").to_stdout
@@ -397,7 +397,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a formula with a GitHub Gist stable URL" do
+    context "when the formula has a GitHub Gist stable URL" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:gist]) }
           .to output("test_gist : skipped - Stable URL is a GitHub Gist\n").to_stdout
@@ -405,7 +405,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a formula with a Google Code Archive stable URL" do
+    context "when the formula has a Google Code Archive stable URL" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:google_code_archive]) }
           .to output("test_google_code_archive : skipped - Stable URL is from Google Code Archive\n").to_stdout
@@ -413,7 +413,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a formula with an Internet Archive stable URL" do
+    context "when the formula has an Internet Archive stable URL" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:internet_archive]) }
           .to output("test_internet_archive : skipped - Stable URL is from Internet Archive\n").to_stdout
@@ -421,7 +421,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a formula with a `livecheck` block containing `skip`" do
+    context "when the formula has a `livecheck` block containing `skip`" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:skip]) }
           .to output("test_skip : skipped\n").to_stdout
@@ -433,7 +433,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a discontinued cask without a livecheckable" do
+    context "when the cask is discontinued without a livecheckable" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:discontinued]) }
           .to output("test_discontinued : discontinued\n").to_stdout
@@ -441,7 +441,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a cask containing `version :latest` without a livecheckable" do
+    context "when the cask has `version :latest` without a livecheckable" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:latest]) }
           .to output("test_latest : latest\n").to_stdout
@@ -449,7 +449,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a cask containing an unversioned URL without a livecheckable" do
+    context "when the cask has an unversioned URL without a livecheckable" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:unversioned]) }
           .to output("test_unversioned : unversioned\n").to_stdout
@@ -457,7 +457,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a cask with a `livecheck` block containing `skip`" do
+    context "when the cask has a `livecheck` block containing `skip`" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:cask][:skip]) }
           .to output("test_skip : skipped\n").to_stdout
@@ -469,7 +469,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "a blank parameter" do
+    context "with a blank parameter" do
       it "prints nothing" do
         expect { skip_conditions.print_skip_information({}) }
           .to not_to_output.to_stdout

--- a/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
+++ b/Library/Homebrew/test/livecheck/skip_conditions_spec.rb
@@ -265,56 +265,56 @@ describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::skip_conditions" do
-    context "when the formula is deprecated without a livecheckable" do
+    context "when a formula without a livecheckable is deprecated" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:deprecated]))
           .to eq(status_hashes[:formula][:deprecated])
       end
     end
 
-    context "when the formula is disabled without a livecheckable" do
+    context "when a formula without a livecheckable is disabled" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:disabled]))
           .to eq(status_hashes[:formula][:disabled])
       end
     end
 
-    context "when the formula is versioned without a livecheckable" do
+    context "when a formula without a livecheckable is versioned" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:versioned]))
           .to eq(status_hashes[:formula][:versioned])
       end
     end
 
-    context "when the formula is HEAD-only and not installed" do
+    context "when a formula is HEAD-only and not installed" do
       it "skips " do
         expect(skip_conditions.skip_information(formulae[:head_only]))
           .to eq(status_hashes[:formula][:head_only])
       end
     end
 
-    context "when the formula has a GitHub Gist stable URL" do
+    context "when a formula has a GitHub Gist stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:gist]))
           .to eq(status_hashes[:formula][:gist])
       end
     end
 
-    context "when the formula has a Google Code Archive stable URL" do
+    context "when a formula has a Google Code Archive stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:google_code_archive]))
           .to eq(status_hashes[:formula][:google_code_archive])
       end
     end
 
-    context "when the formula has an Internet Archive stable URL" do
+    context "when a formula has an Internet Archive stable URL" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:internet_archive]))
           .to eq(status_hashes[:formula][:internet_archive])
       end
     end
 
-    context "when the formula has a `livecheck` block containing `skip`" do
+    context "when a formula has a `livecheck` block containing `skip`" do
       it "skips" do
         expect(skip_conditions.skip_information(formulae[:skip]))
           .to eq(status_hashes[:formula][:skip])
@@ -324,21 +324,21 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when a cask is discontinued without a livecheckable" do
+    context "when a cask without a livecheckable is discontinued" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:discontinued]))
           .to eq(status_hashes[:cask][:discontinued])
       end
     end
 
-    context "when a cask has `version :latest` without a livecheckable" do
+    context "when a cask without a livecheckable has `version :latest`" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:latest]))
           .to eq(status_hashes[:cask][:latest])
       end
     end
 
-    context "when a cask has an unversioned URL without a livecheckable" do
+    context "when a cask without a livecheckable has an unversioned URL" do
       it "skips" do
         expect(skip_conditions.skip_information(casks[:unversioned]))
           .to eq(status_hashes[:cask][:unversioned])
@@ -365,7 +365,7 @@ describe Homebrew::Livecheck::SkipConditions do
   end
 
   describe "::print_skip_information" do
-    context "when the formula is deprecated without a livecheckable" do
+    context "when a formula without a livecheckable is deprecated" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:deprecated]) }
           .to output("test_deprecated : deprecated\n").to_stdout
@@ -373,7 +373,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the formula is disabled without a livecheckable" do
+    context "when a formula without a livecheckable is disabled" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:disabled]) }
           .to output("test_disabled : disabled\n").to_stdout
@@ -381,7 +381,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the formula is versioned without a livecheckable" do
+    context "when a formula without a livecheckable is versioned" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:versioned]) }
           .to output("test@0.0.1 : versioned\n").to_stdout
@@ -389,7 +389,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the formula is HEAD-only and not installed" do
+    context "when a formula is HEAD-only and not installed" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:head_only]) }
           .to output("test_head_only : HEAD only formula must be installed to be livecheckable\n").to_stdout
@@ -397,7 +397,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the formula has a GitHub Gist stable URL" do
+    context "when a formula has a GitHub Gist stable URL" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:gist]) }
           .to output("test_gist : skipped - Stable URL is a GitHub Gist\n").to_stdout
@@ -405,7 +405,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the formula has a Google Code Archive stable URL" do
+    context "when a formula has a Google Code Archive stable URL" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:google_code_archive]) }
           .to output("test_google_code_archive : skipped - Stable URL is from Google Code Archive\n").to_stdout
@@ -413,7 +413,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the formula has an Internet Archive stable URL" do
+    context "when a formula has an Internet Archive stable URL" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:internet_archive]) }
           .to output("test_internet_archive : skipped - Stable URL is from Internet Archive\n").to_stdout
@@ -421,7 +421,7 @@ describe Homebrew::Livecheck::SkipConditions do
       end
     end
 
-    context "when the formula has a `livecheck` block containing `skip`" do
+    context "when a formula has a `livecheck` block containing `skip`" do
       it "prints skip information" do
         expect { skip_conditions.print_skip_information(status_hashes[:formula][:skip]) }
           .to output("test_skip : skipped\n").to_stdout

--- a/Library/Homebrew/test/locale_spec.rb
+++ b/Library/Homebrew/test/locale_spec.rb
@@ -16,7 +16,7 @@ describe Locale do
       expect(described_class.parse("es-419")).to eql(described_class.new("es", "419", nil))
     end
 
-    context "raises a ParserError when given" do
+    describe "raises a ParserError when given" do
       it "an empty string" do
         expect { described_class.parse("") }.to raise_error(Locale::ParserError)
       end
@@ -60,12 +60,12 @@ describe Locale do
   describe "#eql?" do
     subject(:locale) { described_class.new("zh", "CN", "Hans") }
 
-    context "all parts match" do
+    context "when all parts match" do
       it { is_expected.to eql("zh-CN-Hans") }
       it { is_expected.to eql(locale) }
     end
 
-    context "only some parts match" do
+    context "when only some parts match" do
       it { is_expected.not_to eql("zh") }
       it { is_expected.not_to eql("zh-CN") }
       it { is_expected.not_to eql("CN") }

--- a/Library/Homebrew/test/missing_formula_spec.rb
+++ b/Library/Homebrew/test/missing_formula_spec.rb
@@ -118,7 +118,7 @@ describe Homebrew::MissingFormula do
   describe "::suggest_command", :cask do
     subject { described_class.suggest_command(name, command) }
 
-    context "brew install" do
+    context "when installing" do
       let(:name) { "local-caffeine" }
       let(:command) { "install" }
 
@@ -126,7 +126,7 @@ describe Homebrew::MissingFormula do
       it { is_expected.to match(/Try\n  brew install --cask local-caffeine/) }
     end
 
-    context "brew uninstall" do
+    context "when uninstalling" do
       let(:name) { "local-caffeine" }
       let(:command) { "uninstall" }
 
@@ -142,7 +142,7 @@ describe Homebrew::MissingFormula do
       end
     end
 
-    context "brew info" do
+    context "when getting info" do
       let(:name) { "local-caffeine" }
       let(:command) { "info" }
 

--- a/Library/Homebrew/test/os/mac/version_spec.rb
+++ b/Library/Homebrew/test/os/mac/version_spec.rb
@@ -40,7 +40,7 @@ describe OS::Mac::Version do
     expect(version).to be < Version.create("10.15")
   end
 
-  context "after Big Sur" do
+  context "when after Big Sur" do
     specify "comparison with :big_sur" do
       expect(big_sur_major).to eq :big_sur
       expect(big_sur_major).to be <= :big_sur

--- a/Library/Homebrew/test/os/mac/version_spec.rb
+++ b/Library/Homebrew/test/os/mac/version_spec.rb
@@ -40,7 +40,7 @@ describe OS::Mac::Version do
     expect(version).to be < Version.create("10.15")
   end
 
-  context "when after Big Sur" do
+  describe "after Big Sur" do
     specify "comparison with :big_sur" do
       expect(big_sur_major).to eq :big_sur
       expect(big_sur_major).to be <= :big_sur

--- a/Library/Homebrew/test/patch_spec.rb
+++ b/Library/Homebrew/test/patch_spec.rb
@@ -5,7 +5,7 @@ require "patch"
 
 describe Patch do
   describe "#create" do
-    context "simple patch" do
+    context "with a simple patch" do
       subject { described_class.create(:p2, nil) }
 
       it { is_expected.to be_kind_of ExternalPatch }
@@ -13,28 +13,28 @@ describe Patch do
       its(:strip) { is_expected.to eq(:p2) }
     end
 
-    context "string patch" do
+    context "with a string patch" do
       subject { described_class.create(:p0, "foo") }
 
       it { is_expected.to be_kind_of StringPatch }
       its(:strip) { is_expected.to eq(:p0) }
     end
 
-    context "string patch without strip" do
+    context "with a string patch without strip" do
       subject { described_class.create("foo", nil) }
 
       it { is_expected.to be_kind_of StringPatch }
       its(:strip) { is_expected.to eq(:p1) }
     end
 
-    context "data patch" do
+    context "with a data patch" do
       subject { described_class.create(:p0, :DATA) }
 
       it { is_expected.to be_kind_of DATAPatch }
       its(:strip) { is_expected.to eq(:p0) }
     end
 
-    context "data patch without strip" do
+    context "with a data patch without strip" do
       subject { described_class.create(:DATA, nil) }
 
       it { is_expected.to be_kind_of DATAPatch }
@@ -55,7 +55,7 @@ describe Patch do
   describe "#patch_files" do
     subject(:patch) { described_class.create(:p2, nil) }
 
-    context "empty patch" do
+    context "when the patch is empty" do
       its(:resource) { is_expected.to be_kind_of Resource::PatchResource }
       its(:patch_files) { is_expected.to eq(patch.resource.patch_files) }
       its(:patch_files) { is_expected.to eq([]) }

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -14,25 +14,25 @@ describe Requirement do
   describe "#tags" do
     subject { described_class.new(tags) }
 
-    context "single tag" do
+    context "with a single tag" do
       let(:tags) { ["bar"] }
 
       its(:tags) { are_expected.to eq(tags) }
     end
 
-    context "multiple tags" do
+    context "with multiple tags" do
       let(:tags) { ["bar", "baz"] }
 
       its(:tags) { are_expected.to eq(tags) }
     end
 
-    context "symbol tags" do
+    context "with symbol tags" do
       let(:tags) { [:build] }
 
       its(:tags) { are_expected.to eq(tags) }
     end
 
-    context "symbol and string tags" do
+    context "with symbol and string tags" do
       let(:tags) { [:build, "bar"] }
 
       its(:tags) { are_expected.to eq(tags) }
@@ -148,7 +148,7 @@ describe Requirement do
   end
 
   describe "#build?" do
-    context ":build tag is specified" do
+    context "when :build tag is specified" do
       subject { described_class.new([:build]) }
 
       it { is_expected.to be_a_build_requirement }

--- a/Library/Homebrew/test/requirement_spec.rb
+++ b/Library/Homebrew/test/requirement_spec.rb
@@ -148,7 +148,7 @@ describe Requirement do
   end
 
   describe "#build?" do
-    context "when :build tag is specified" do
+    context "when the :build tag is specified" do
       subject { described_class.new([:build]) }
 
       it { is_expected.to be_a_build_requirement }

--- a/Library/Homebrew/test/rubocops/components_order_spec.rb
+++ b/Library/Homebrew/test/rubocops/components_order_spec.rb
@@ -491,7 +491,7 @@ describe RuboCop::Cop::FormulaAudit::ComponentsOrder do
       RUBY
     end
 
-    context "in a resource block" do
+    context "when in a resource block" do
       it "reports no offenses for a valid `on_macos` and `on_linux` block" do
         expect_no_offenses(<<~RUBY)
           class Foo < Formula

--- a/Library/Homebrew/test/rubocops/formula_desc_spec.rb
+++ b/Library/Homebrew/test/rubocops/formula_desc_spec.rb
@@ -6,7 +6,7 @@ require "rubocops/formula_desc"
 describe RuboCop::Cop::FormulaAudit::Desc do
   subject(:cop) { described_class.new }
 
-  context "When auditing formula `desc` methods" do
+  context "when auditing formula `desc` methods" do
     it "reports an offense when there is no `desc`" do
       expect_offense(<<~RUBY)
         class Foo < Formula
@@ -48,7 +48,7 @@ describe RuboCop::Cop::FormulaAudit::Desc do
     end
   end
 
-  context "When auditing formula description texts" do
+  context "when auditing formula description texts" do
     it "reports an offense when the description starts with a leading space" do
       expect_offense(<<~RUBY, "/homebrew-core/Formula/foo.rb")
         class Foo < Formula

--- a/Library/Homebrew/test/rubocops/homepage_spec.rb
+++ b/Library/Homebrew/test/rubocops/homepage_spec.rb
@@ -80,7 +80,7 @@ describe RuboCop::Cop::FormulaAudit::Homepage do
       RUBY
     end
 
-    context "for Sourceforge" do
+    describe "for Sourceforge" do
       correct_formula = <<~RUBY
         class Foo < Formula
           homepage "https://foo.sourceforge.io/"

--- a/Library/Homebrew/test/searchable_spec.rb
+++ b/Library/Homebrew/test/searchable_spec.rb
@@ -37,7 +37,7 @@ describe Searchable do
         expect(searchable_collection.search("foo")).to eq "foo" => "bar"
       end
 
-      context "containing nil" do
+      context "with a nil value" do
         let(:collection) { { "foo" => nil } }
 
         it "does not raise an error" do

--- a/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/homebrew_cask.rb
@@ -31,7 +31,7 @@ module Cask
   end
 end
 
-RSpec.shared_context "Homebrew Cask", :needs_macos do
+RSpec.shared_context "Homebrew Cask", :needs_macos do # rubocop:disable RSpec/ContextWording
   around do |example|
     third_party_tap = Tap.fetch("third-party", "tap")
 

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -7,7 +7,7 @@ require "formula_installer"
 
 RSpec::Matchers.define_negated_matcher :be_a_failure, :be_a_success
 
-RSpec.shared_context "integration test" do
+RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWording
   extend RSpec::Matchers::DSL
 
   matcher :be_a_success do

--- a/Library/Homebrew/test/system_command_result_spec.rb
+++ b/Library/Homebrew/test/system_command_result_spec.rb
@@ -155,7 +155,7 @@ describe SystemCommand::Result do
       end
     end
 
-    context "given a hdiutil stdout" do
+    context "when there's a hdiutil stdout" do
       let(:stdout) { plist }
 
       it "successfully parses it" do

--- a/Library/Homebrew/test/system_command_spec.rb
+++ b/Library/Homebrew/test/system_command_spec.rb
@@ -79,7 +79,7 @@ describe SystemCommand do
   context "when the exit code is 1" do
     let(:command) { "false" }
 
-    context "and the command must succeed" do
+    context "with a command that must succeed" do
       it "throws an error" do
         expect {
           described_class.run!(command)
@@ -87,7 +87,7 @@ describe SystemCommand do
       end
     end
 
-    context "and the command does not have to succeed" do
+    context "with a command that does not have to succeed" do
       describe "its result" do
         subject { described_class.run(command) }
 

--- a/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
+++ b/Library/Homebrew/test/utils/string_inreplace_extension_spec.rb
@@ -7,7 +7,7 @@ describe StringInreplaceExtension do
   subject(:string_extension) { described_class.new(string.dup) }
 
   describe "#change_make_var!" do
-    context "flag" do
+    context "with a flag" do
       context "with spaces" do
         let(:string) do
           <<~EOS
@@ -72,7 +72,7 @@ describe StringInreplaceExtension do
       end
     end
 
-    context "empty flag between other flags" do
+    context "with an empty flag between other flags" do
       let(:string) do
         <<~EOS
           OTHER=def
@@ -91,7 +91,7 @@ describe StringInreplaceExtension do
       end
     end
 
-    context "empty flag" do
+    context "with an empty flag" do
       let(:string) do
         <<~EOS
           FLAG =
@@ -108,7 +108,7 @@ describe StringInreplaceExtension do
       end
     end
 
-    context "shell-style variable" do
+    context "with shell-style variable" do
       let(:string) do
         <<~EOS
           OTHER=def
@@ -129,7 +129,7 @@ describe StringInreplaceExtension do
   end
 
   describe "#remove_make_var!" do
-    context "flag" do
+    context "with a flag" do
       context "with spaces" do
         let(:string) do
           <<~EOS
@@ -182,7 +182,7 @@ describe StringInreplaceExtension do
       end
     end
 
-    context "multiple flags" do
+    context "with multiple flags" do
       let(:string) do
         <<~EOS
           OTHER=def


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- This was TODO, so I thought I'd do it.
- Most interesting is probably the last commit where I disabled the cop for three out of 150 surfaced problems.
