### PR TITLE
test/rubocops: Fix mismatched test descriptions

### DIFF
--- a/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
+++ b/Library/Homebrew/test/rubocops/bottle/bottle_format_spec.rb
@@ -65,7 +65,7 @@ describe RuboCop::Cop::FormulaAudit::BottleFormat do
     RUBY
   end
 
-  it "reports and corrects old `sha256` syntax in `bottle` block without cellars" do
+  it "reports and corrects old `sha256` syntax in `bottle` block with cellars" do
     expect_offense(<<~RUBY)
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tgz"

--- a/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
+++ b/Library/Homebrew/test/rubocops/text/option_declarations_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::FormulaAudit::OptionDeclarations do
       RUBY
     end
 
-    it "reports an offense when `build.without?` is used for a conditional dependency" do
+    it "reports an offense when `build.with?` is used for a conditional dependency" do
       expect_offense(<<~RUBY)
         class Foo < Formula
           depends_on "bar" if build.with?("baz")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?
- [x] Have you successfully run `brew man` locally and committed any changes?

-----

- After doing #10658, I moved onto other TODOs in that file. Enabling `RSpec/RepeatedDescription` momentarily revealed that two test descriptions had been copypasted between two similar, but not identical, tests. (Actually fixing the other offenses for that cop will be for another day!)
