### PR TITLE
PR template: remove local 'brew man' step now that it's scheduled

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,5 @@
 - [ ] Have you successfully run `brew style` with your changes locally?
 - [ ] Have you successfully run `brew typecheck` with your changes locally?
 - [ ] Have you successfully run `brew tests` with your changes locally?
-- [ ] Have you successfully run `brew man` locally and committed any changes?
 
 -----

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,6 @@ jobs:
 
       - run: brew style --display-cop-names
 
-      - run: brew man --fail-if-changed
-
       - run: brew typecheck
 
       - name: Run vale for docs linting


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
After https://github.com/Homebrew/brew/pull/10650, there isn't a need to locally run `brew man` anymore, so this PR removes it from the Pull Request template.