### PR TITLE
software_spec: Add HOMEBREW_BOTTLE_DEFAULT_DOMAIN as a fallback option

### DIFF
--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -46,8 +46,12 @@ module Homebrew
       },
       HOMEBREW_BOTTLE_DOMAIN:                 {
         description:  "Use this URL as the download mirror for bottles. " \
+                      "If bottles at that URL are temporarily unavailable, " \
+                      "the default bottle domain will be used as a fallback mirror. " \
                       "For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to " \
-                      "download from the prefix `http://localhost:8080/`.",
+                      "download from the prefix `http://localhost:8080/`. " \
+                      "If bottles are not available at `HOMEBREW_BOTTLE_DOMAIN` " \
+                      "they will be downloaded from the default bottle domain.",
         default_text: "macOS: `https://homebrew.bintray.com/`, " \
                       "Linux: `https://linuxbrew.bintray.com/`.",
         default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1729,7 +1729,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>If set, use Bootsnap to speed up repeated `brew` calls. A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).
 
 - `HOMEBREW_BOTTLE_DOMAIN`
-  <br>Use this URL as the download mirror for bottles. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to download from the prefix `http://localhost:8080/`.
+  <br>Use this URL as the download mirror for bottles. If bottles at that URL are temporarily unavailable, the default bottle domain will be used as a fallback mirror. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to download from the prefix `http://localhost:8080/`. If bottles are not available at `HOMEBREW_BOTTLE_DOMAIN` they will be downloaded from the default bottle domain.
 
   *Default:* macOS: `https://homebrew.bintray.com/`, Linux: `https://linuxbrew.bintray.com/`.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2415,7 +2415,7 @@ If set, use Bootsnap to speed up repeated \fBbrew\fR calls\. A no\-op when using
 \fBHOMEBREW_BOTTLE_DOMAIN\fR
 .
 .br
-Use this URL as the download mirror for bottles\. For example, \fBHOMEBREW_BOTTLE_DOMAIN=http://localhost:8080\fR will cause all bottles to download from the prefix \fBhttp://localhost:8080/\fR\.
+Use this URL as the download mirror for bottles\. If bottles at that URL are temporarily unavailable, the default bottle domain will be used as a fallback mirror\. For example, \fBHOMEBREW_BOTTLE_DOMAIN=http://localhost:8080\fR will cause all bottles to download from the prefix \fBhttp://localhost:8080/\fR\. If bottles are not available at \fBHOMEBREW_BOTTLE_DOMAIN\fR they will be downloaded from the default bottle domain\.
 .
 .IP
 \fIDefault:\fR macOS: \fBhttps://homebrew\.bintray\.com/\fR, Linux: \fBhttps://linuxbrew\.bintray\.com/\fR\.


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?
- [X] Have you successfully run `brew man` locally and committed any changes?

-----

Add HOMEBREW_BOTTLE_DEFAULT_DOMAIN to downloader mirror list if HOMEBREW_BOTTLE_DOMAIN is other than the default. The downloader may use the HOMEBREW_BOTTLE_DEFAULT_DOMAIN as a fallback option. (resolves #10660)
