### PR TITLE
utils/spdx: correctly detect non-deprecated licenses with plus

### DIFF
--- a/Library/Homebrew/test/utils/spdx_spec.rb
+++ b/Library/Homebrew/test/utils/spdx_spec.rb
@@ -132,8 +132,16 @@ describe SPDX do
       expect(described_class.deprecated_license?("GPL-1.0")).to eq true
     end
 
+    it "returns true for deprecated license identifier with plus" do
+      expect(described_class.deprecated_license?("GPL-1.0+")).to eq true
+    end
+
     it "returns false for non-deprecated license identifier" do
       expect(described_class.deprecated_license?("MIT")).to eq false
+    end
+
+    it "returns false for non-deprecated license identifier with plus" do
+      expect(described_class.deprecated_license?("EPL-1.0+")).to eq false
     end
 
     it "returns false for invalid license identifier" do

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -78,6 +78,7 @@ module SPDX
     return false if ALLOWED_LICENSE_SYMBOLS.include? license
     return false unless valid_license?(license)
 
+    license = license.delete_suffix "+"
     license_data["licenses"].none? do |spdx_license|
       spdx_license["licenseId"] == license && !spdx_license["isDeprecatedLicenseId"]
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?
  - NOTE: ran `brew tests --online --only=utils/spdx`, not `brew tests`

-----

When running `brew audit --strict FORMULA`, it will warn you that a license is deprecated if it ends in a "+", even if it is not deprecated. When I tested an example from the [documentation](https://docs.brew.sh/License-Guidelines#complex-spdx-license-expressions) that was given as an example of a valid license (license "EPL-1.0+"), it was also showing this warning.

I found this over in https://github.com/Homebrew/homebrew-core/pull/71682, when I found that "MPL-1.1+" was incorrectly showing a deprecated SPDX license warning. Essentially, `valid_license?` in `utils/spdx.rb` removed the "+" suffix when checking for validity, but `deprecated_license?` did not, causing something like "MPL-1.1+" to be marked as valid but deprecated.

These changes prevent the false positive and add tests related to this behavior.