### PR TITLE
utils/fork: handle termsig in safe_fork

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -240,7 +240,14 @@ rescue Exception => e # rubocop:disable Lint/RescueException
     error_hash["env"] = e.env
   when "ErrorDuringExecution"
     error_hash["cmd"] = e.cmd
-    error_hash["status"] = e.status.exitstatus
+    error_hash["status"] = if e.status.is_a?(Process::Status)
+      {
+        exitstatus: e.status.exitstatus,
+        termsig:    e.status.termsig,
+      }
+    else
+      e.status
+    end
     error_hash["output"] = e.output
   end
 

--- a/Library/Homebrew/test/error_during_execution_spec.rb
+++ b/Library/Homebrew/test/error_during_execution_spec.rb
@@ -5,7 +5,7 @@ describe ErrorDuringExecution do
   subject(:error) { described_class.new(command, status: status, output: output) }
 
   let(:command) { ["false"] }
-  let(:status) { instance_double(Process::Status, exitstatus: exitstatus) }
+  let(:status) { instance_double(Process::Status, exitstatus: exitstatus, termsig: nil) }
   let(:exitstatus) { 1 }
   let(:output) { nil }
 

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -186,7 +186,7 @@ describe "Exception" do
   describe ErrorDuringExecution do
     subject { described_class.new(["badprg", "arg1", "arg2"], status: status) }
 
-    let(:status) { instance_double(Process::Status, exitstatus: 17) }
+    let(:status) { instance_double(Process::Status, exitstatus: 17, termsig: nil) }
 
     its(:to_s) { is_expected.to eq("Failure while executing; `badprg arg1 arg2` exited with 17.") }
   end

--- a/Library/Homebrew/utils/fork.rb
+++ b/Library/Homebrew/utils/fork.rb
@@ -51,7 +51,14 @@ module Utils
           # to rescue them further down.
           if e.is_a?(ErrorDuringExecution)
             error_hash["cmd"] = e.cmd
-            error_hash["status"] = e.status.exitstatus
+            error_hash["status"] = if e.status.is_a?(Process::Status)
+              {
+                exitstatus: e.status.exitstatus,
+                termsig:    e.status.termsig,
+              }
+            else
+              e.status
+            end
             error_hash["output"] = e.output
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When `safe_fork` fails due to application termination rather than exist, `exitstatus` will be nil. Instead we should pass more of the object, as it has other methods like `termsig` for those cases. When you pass `ErrorDuringExecution` a `Process::Status` object, it will handle that and provide proper information on the failure, rather than choking because the passed exit status is nil.

It is unfortunately impossible to create a `Process::Status` object without using `Marshal.load`. There is no security risk though as this isn't user input.

Fixes #10661.