### PR TITLE
dev-cmd/prof: prevent from running on Apple Silicon

### DIFF
--- a/Library/Homebrew/dev-cmd/prof.rb
+++ b/Library/Homebrew/dev-cmd/prof.rb
@@ -13,6 +13,8 @@ module Homebrew
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Run Homebrew with a Ruby profiler. For example, `brew prof readall`.
+
+        *Note:* Not (yet) working on Apple Silicon.
       EOS
       switch "--stackprof",
              description: "Use `stackprof` instead of `ruby-prof` (the default)."
@@ -22,6 +24,8 @@ module Homebrew
   end
 
   def prof
+    raise UsageError, "not (yet) working on Apple Silicon!" if Hardware::CPU.arm?
+
     args = prof_args.parse
 
     brew_rb = (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The prof command does not currently work on Apple silicon
```
$ brew prof readall
Traceback (most recent call last):
	7: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/ruby-prof:23:in `<main>'
	6: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/ruby-prof:23:in `load'
	5: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/bin/ruby-prof:4:in `<top (required)>'
	4: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	3: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	2: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/lib/ruby-prof.rb:7:in `<top (required)>'
	1: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- 2.6/ruby_prof.so (LoadError)
	7: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/ruby-prof:23:in `<main>'
	6: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/bin/ruby-prof:23:in `load'
	5: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/bin/ruby-prof:4:in `<top (required)>'
	4: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	3: from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	2: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/lib/ruby-prof.rb:5:in `<top (required)>'
	1: from /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/lib/ruby-prof.rb:9:in `rescue in <top (required)>'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/lib/ruby-prof.rb:9:in `require_relative': dlopen(/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/ext/ruby_prof/ruby_prof.bundle, 0x0009): missing compatible arch in /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/ext/ruby_prof/ruby_prof.bundle - /opt/homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/ruby-prof-1.4.3/ext/ruby_prof/ruby_prof.bundle (LoadError)
```
