### PR TITLE
Speedup `brew --prefix <formula>`

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -48,7 +48,6 @@ HOMEBREW_TEMP="${HOMEBREW_TEMP:-${HOMEBREW_DEFAULT_TEMP}}"
 # Don't need shellcheck to follow these `source`.
 # shellcheck disable=SC1090
 case "$*" in
-  --prefix)            echo "$HOMEBREW_PREFIX"; exit 0 ;;
   --cellar)            echo "$HOMEBREW_CELLAR"; exit 0 ;;
   --repository|--repo) echo "$HOMEBREW_REPOSITORY"; exit 0 ;;
   --caskroom)          echo "$HOMEBREW_PREFIX/Caskroom"; exit 0 ;;
@@ -56,6 +55,8 @@ case "$*" in
   shellenv)            source "$HOMEBREW_LIBRARY/Homebrew/cmd/shellenv.sh"; homebrew-shellenv; exit 0 ;;
   formulae)            source "$HOMEBREW_LIBRARY/Homebrew/cmd/formulae.sh"; homebrew-formulae; exit 0 ;;
   casks)               source "$HOMEBREW_LIBRARY/Homebrew/cmd/casks.sh"; homebrew-casks; exit 0 ;;
+  # falls back to cmd/prefix.rb on a non-zero return
+  --prefix*)           source "$HOMEBREW_LIBRARY/Homebrew/prefix.sh"; homebrew-prefix "$@" && exit 0 ;;
 esac
 
 #####

--- a/Library/Homebrew/cmd/--prefix.rb
+++ b/Library/Homebrew/cmd/--prefix.rb
@@ -18,8 +18,7 @@ module Homebrew
           - macOS ARM: `#{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}`
           - Linux: `#{HOMEBREW_LINUX_DEFAULT_PREFIX}`
 
-        If <formula> is provided, display the location in the Cellar where <formula>
-        is or would be installed.
+        If <formula> is provided, display the location where <formula> is or would be installed.
       EOS
       switch "--unbrewed",
              description: "List files in Homebrew's prefix not installed by Homebrew."
@@ -45,13 +44,10 @@ module Homebrew
     else
       formulae = args.named.to_resolved_formulae
       prefixes = formulae.map do |f|
-        if f.opt_prefix.exist?
-          f.opt_prefix
-        elsif args.installed?
-          nil
-        else
-          f.latest_installed_prefix
-        end
+        next nil if args.installed? && !f.opt_prefix.exist?
+
+        # this case wil be short-circuited by brew.sh logic for a single formula
+        f.opt_prefix
       end.compact
       puts prefixes
       if args.installed?

--- a/Library/Homebrew/prefix.sh
+++ b/Library/Homebrew/prefix.sh
@@ -1,0 +1,29 @@
+# does the quickest output of brew --prefix possible for the basic cases:
+# - `brew --prefix` (output HOMEBREW_PREFIX)
+# - `brew --prefix <formula>` (output HOMEBREW_PREFIX/opt/<formula>)
+# anything else? delegate to the slower cmd/--prefix.rb
+
+homebrew-prefix() {
+  while [[ "$#" -gt 0 ]]; do
+      case $1 in
+          # check we actually have --prefix and not e.g. --prefixsomething
+          --prefix) local prefix="1"; shift ;;
+          # reject all other flags
+          -*) return 1 ;;
+          *) [ -n "$formula" ] && return 1; local formula="$1"; shift ;;
+      esac
+  done
+  [ -z "$prefix" ] && return 1
+  [ -z "$formula" ] && echo "$HOMEBREW_PREFIX" && return 0
+
+  local formula_path
+  if [ -f "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core/${formula}.rb" ]; then
+    formula_path="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core/${formula}.rb"
+  else
+    formula_path="$(find "$HOMEBREW_REPOSITORY/Library/Taps" -name "${formula}.rb" -print -quit)"
+  fi
+  [ -z "$formula_path" ] && return 1
+
+  echo "$HOMEBREW_PREFIX/opt/$formula"
+  return 0
+}

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -8,7 +8,7 @@ describe "brew --prefix" do
 
   it "prints a given Formula's prefix", :integration_test do
     expect { brew "--prefix", testball }
-      .to output(%r{#{HOMEBREW_CELLAR}/testball}o).to_stdout
+      .to output("#{HOMEBREW_PREFIX}/opt/testball\n").to_stdout
       .and not_to_output.to_stderr
       .and be_a_success
   end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -734,8 +734,7 @@ Display Homebrew's install path. *Default:*
   - macOS ARM: `/opt/homebrew`
   - Linux: `/home/linuxbrew/.linuxbrew`
 
-If *`formula`* is provided, display the location in the Cellar where *`formula`*
-is or would be installed.
+If *`formula`* is provided, display the location where *`formula`* is or would be installed.
 
 * `--unbrewed`:
   List files in Homebrew's prefix not installed by Homebrew.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -997,7 +997,7 @@ Linux: \fB/home/linuxbrew/\.linuxbrew\fR
 .IP "" 0
 .
 .P
-If \fIformula\fR is provided, display the location in the Cellar where \fIformula\fR is or would be installed\.
+If \fIformula\fR is provided, display the location where \fIformula\fR is or would be installed\.
 .
 .TP
 \fB\-\-unbrewed\fR


### PR DESCRIPTION
This case is _really_ slow even although it's something we encourage people to run often and build systems often do. The `brew --prefix` case is really fast because it's just in Bash so: let's pull the `brew --prefix <formula>` case into Bash too.

This doesn't handle any edge-cases like `--installed` and the formula detection is pretty simple.

Also, to make this behaviour consistent, never output `Cellar` paths from the (Ruby) `brew --prefix`; we never want people relying on the Cellar paths anyway, only output them if the formula wasn't installed (where, arguably, using a Cellar path is even worse) and the speedup is worth this deviation in behaviour.

Benchmarks:

```console
$ hyperfine --min-runs=3 --warmup=1 "git checkout origin/master; brew --prefix" "git checkout speedup_brew_prefix; brew --prefix"                    
Benchmark #1: git checkout origin/master; brew --prefix
  Time (mean ± σ):     163.6 ms ±  21.2 ms    [User: 19.5 ms, System: 74.1 ms]
  Range (min … max):   133.8 ms … 184.6 ms    19 runs
 
Benchmark #2: git checkout speedup_brew_prefix; brew --prefix
  Time (mean ± σ):     168.0 ms ±  20.1 ms    [User: 20.3 ms, System: 77.4 ms]
  Range (min … max):   134.3 ms … 186.4 ms    18 runs
 
Summary
  'git checkout origin/master; brew --prefix' ran
    1.03 ± 0.18 times faster than 'git checkout speedup_brew_prefix; brew --prefix'

$ hyperfine --min-runs=3 --warmup=1 "git checkout origin/master; brew --prefix mysql@5.7" "git checkout speedup_brew_prefix; brew --prefix mysql@5.7"
Benchmark #1: git checkout origin/master; brew --prefix mysql@5.7
  Time (mean ± σ):      1.565 s ±  0.102 s    [User: 351.9 ms, System: 577.7 ms]
  Range (min … max):    1.482 s …  1.678 s    3 runs
 
Benchmark #2: git checkout speedup_brew_prefix; brew --prefix mysql@5.7
  Time (mean ± σ):     293.0 ms ±  19.5 ms    [User: 25.9 ms, System: 207.0 ms]
  Range (min … max):   275.2 ms … 333.3 ms    9 runs
 
Summary
  'git checkout speedup_brew_prefix; brew --prefix mysql@5.7' ran
    5.34 ± 0.50 times faster than 'git checkout origin/master; brew --prefix mysql@5.7'
```