### PR TITLE
Prevent loading all non-Bundler gems

### DIFF
--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -6,6 +6,7 @@ source "https://rubygems.org"
 gem "bootsnap", require: false
 gem "byebug", require: false
 gem "codecov", require: false
+gem "minitest", require: false
 gem "nokogiri", require: false
 gem "parallel_tests", require: false
 gem "ronn", require: false

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -179,6 +179,7 @@ DEPENDENCIES
   codecov
   concurrent-ruby
   mechanize
+  minitest
   nokogiri
   parallel_tests
   patchelf

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -568,11 +568,11 @@ then
   # Don't allow non-developers to customise Ruby warnings.
   unset HOMEBREW_RUBY_WARNINGS
 
-  # Disable Ruby options we don't need. RubyGems provides a decent speedup.
-  RUBY_DISABLE_OPTIONS="--disable=gems,did_you_mean,rubyopt"
+  # Disable Ruby options we don't need.
+  RUBY_DISABLE_OPTIONS="--disable=did_you_mean,rubyopt"
 else
   # Don't disable did_you_mean for developers as it's useful.
-  RUBY_DISABLE_OPTIONS="--disable=gems,rubyopt"
+  RUBY_DISABLE_OPTIONS="--disable=rubyopt"
 fi
 
 if [[ -z "$HOMEBREW_RUBY_WARNINGS" ]]

--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -6,7 +6,7 @@
 
 old_trap = trap("INT") { exit! 130 }
 
-require "global"
+require_relative "global"
 require "build_options"
 require "cxxstdlib"
 require "keg"

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -3,7 +3,6 @@
 
 require "utils/bottles"
 
-require "utils/gems"
 require "formula"
 require "cask/cask_loader"
 require "set"

--- a/Library/Homebrew/config.rb
+++ b/Library/Homebrew/config.rb
@@ -67,3 +67,9 @@ HOMEBREW_TEMP = Pathname(EnvVar["HOMEBREW_TEMP"]).yield_self do |tmp|
   tmp.mkpath unless tmp.exist?
   tmp.realpath
 end.freeze
+
+# The Ruby path and args to use for forked Ruby calls
+HOMEBREW_RUBY_EXEC_ARGS = [
+  RUBY_PATH,
+  ENV["HOMEBREW_RUBY_WARNINGS"],
+].freeze

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -77,10 +77,7 @@ module Homebrew
       env = ENV.to_hash
 
       begin
-        exec_args = %W[
-          #{RUBY_PATH}
-          #{ENV["HOMEBREW_RUBY_WARNINGS"]}
-          -I #{$LOAD_PATH.join(File::PATH_SEPARATOR)}
+        exec_args = HOMEBREW_RUBY_EXEC_ARGS + %W[
           --
           #{HOMEBREW_LIBRARY_PATH}/test.rb
           #{f.path}

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -35,6 +35,8 @@ module Homebrew
   def test
     args = test_args.parse
 
+    Homebrew.install_bundler_gems!
+
     require "formula_assertions"
     require "formula_free_port"
 

--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -105,7 +105,7 @@ module Homebrew
       rescue Exception => e # rubocop:disable Lint/RescueException
         retry if retry_test?(f, args: args)
         ofail "#{f.full_name}: failed"
-        puts e, e.backtrace
+        $stderr.puts e, e.backtrace
       ensure
         ENV.replace(env)
       end

--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -35,7 +35,7 @@ module EnvActivation
     params(
       env:          T.nilable(String),
       cc:           T.nilable(String),
-      build_bottle: T.nilable(T::Boolean),
+      build_bottle: T::Boolean,
       bottle_arch:  T.nilable(String),
       _block:       T.proc.returns(T.untyped),
     ).returns(T.untyped)

--- a/Library/Homebrew/extend/ENV/shared.rb
+++ b/Library/Homebrew/extend/ENV/shared.rb
@@ -35,13 +35,14 @@ module SharedEnvExtension
 
   sig {
     params(
-      formula:      T.nilable(Formula),
-      cc:           T.nilable(String),
-      build_bottle: T.nilable(T::Boolean),
-      bottle_arch:  T.nilable(T::Boolean),
+      formula:         T.nilable(Formula),
+      cc:              T.nilable(String),
+      build_bottle:    T.nilable(T::Boolean),
+      bottle_arch:     T.nilable(String),
+      testing_formula: T::Boolean,
     ).void
   }
-  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil)
+  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
     @formula = formula
     @cc = cc
     @build_bottle = build_bottle

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -16,13 +16,14 @@ module Stdenv
   # @private
   sig {
     params(
-      formula:      T.nilable(Formula),
-      cc:           T.nilable(String),
-      build_bottle: T.nilable(T::Boolean),
-      bottle_arch:  T.nilable(T::Boolean),
+      formula:         T.nilable(Formula),
+      cc:              T.nilable(String),
+      build_bottle:    T.nilable(T::Boolean),
+      bottle_arch:     T.nilable(String),
+      testing_formula: T::Boolean,
     ).void
   }
-  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil)
+  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
     super
 
     self["HOMEBREW_ENV"] = "std"

--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -44,13 +44,14 @@ module Superenv
   # @private
   sig {
     params(
-      formula:      T.nilable(Formula),
-      cc:           T.nilable(String),
-      build_bottle: T.nilable(T::Boolean),
-      bottle_arch:  T.nilable(T::Boolean),
+      formula:         T.nilable(Formula),
+      cc:              T.nilable(String),
+      build_bottle:    T.nilable(T::Boolean),
+      bottle_arch:     T.nilable(String),
+      testing_formula: T::Boolean,
     ).void
   }
-  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil)
+  def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
     super
     send(compiler)
 

--- a/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/std.rb
@@ -3,7 +3,10 @@
 
 module Stdenv
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
+    generic_setup_build_environment(
+      formula: formula, cc: cc, build_bottle: build_bottle,
+      bottle_arch: bottle_arch, testing_formula: testing_formula
+    )
 
     prepend_path "CPATH", HOMEBREW_PREFIX/"include"
     prepend_path "LIBRARY_PATH", HOMEBREW_PREFIX/"lib"

--- a/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/linux/extend/ENV/super.rb
@@ -11,7 +11,10 @@ module Superenv
 
   # @private
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
+    generic_setup_build_environment(
+      formula: formula, cc: cc, build_bottle: build_bottle,
+      bottle_arch: bottle_arch, testing_formula: testing_formula
+    )
     self["HOMEBREW_OPTIMIZATION_LEVEL"] = "O2"
     self["HOMEBREW_DYNAMIC_LINKER"] = determine_dynamic_linker_path
     self["HOMEBREW_RPATH_PATHS"] = determine_rpath_paths(@formula)

--- a/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/std.rb
@@ -11,7 +11,10 @@ module Stdenv
   end
 
   def setup_build_environment(formula: nil, cc: nil, build_bottle: false, bottle_arch: nil, testing_formula: false)
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
+    generic_setup_build_environment(
+      formula: formula, cc: cc, build_bottle: build_bottle,
+      bottle_arch: bottle_arch, testing_formula: testing_formula
+    )
 
     # sed is strict, and errors out when it encounters files with
     # mixed character sets

--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -121,7 +121,10 @@ module Superenv
       self["HOMEBREW_SDKROOT"] = nil
       self["HOMEBREW_DEVELOPER_DIR"] = nil
     end
-    generic_setup_build_environment(formula: formula, cc: cc, build_bottle: build_bottle, bottle_arch: bottle_arch)
+    generic_setup_build_environment(
+      formula: formula, cc: cc, build_bottle: build_bottle,
+      bottle_arch: bottle_arch, testing_formula: testing_formula
+    )
 
     # Filter out symbols known not to be defined since GNU Autotools can't
     # reliably figure this out with Xcode 8 and above.

--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -8,8 +8,38 @@ module Homebrew
   module Assertions
     include Context
 
-    require "test/unit/assertions"
-    include ::Test::Unit::Assertions
+    require "minitest"
+    require "minitest/assertions"
+    include ::Minitest::Assertions
+
+    attr_writer :assertions
+
+    def assertions
+      @assertions ||= 0
+    end
+
+    # Test::Unit backwards compatibility methods
+    {
+      assert_raise:           :assert_raises,
+      assert_not_empty:       :refute_empty,
+      assert_not_equal:       :refute_equal,
+      assert_not_in_delta:    :refute_in_delta,
+      assert_not_in_epsilon:  :refute_in_epsilon,
+      assert_not_includes:    :refute_includes,
+      assert_not_instance_of: :refute_instance_of,
+      assert_not_kind_of:     :refute_kind_of,
+      assert_no_match:        :refute_match,
+      assert_not_nil:         :refute_nil,
+      assert_not_operator:    :refute_operator,
+      assert_not_predicate:   :refute_predicate,
+      assert_not_respond_to:  :refute_respond_to,
+      assert_not_same:        :refute_same,
+    }.each do |old_method, new_method|
+      define_method(old_method) do |*args|
+        # odeprecated old_method, new_method
+        send(new_method, *args)
+      end
+    end
 
     # Returns the output of running cmd, and asserts the exit status.
     # @api public
@@ -18,7 +48,7 @@ module Homebrew
       output = `#{cmd}`
       assert_equal result, $CHILD_STATUS.exitstatus
       output
-    rescue Test::Unit::AssertionFailedError
+    rescue Minitest::Assertion
       puts output if verbose?
       raise
     end
@@ -35,7 +65,7 @@ module Homebrew
       end
       assert_equal result, $CHILD_STATUS.exitstatus unless result.nil?
       output
-    rescue Test::Unit::AssertionFailedError
+    rescue Minitest::Assertion
       puts output if verbose?
       raise
     end

--- a/Library/Homebrew/formula_info.rb
+++ b/Library/Homebrew/formula_info.rb
@@ -16,13 +16,11 @@ class FormulaInfo
   # Returns nil if formula is absent or if there was an error reading it.
   def self.lookup(name)
     json = Utils.popen_read(
-      RUBY_PATH,
-      ENV["HOMEBREW_RUBY_WARNINGS"],
-      "-I", $LOAD_PATH.join(File::PATH_SEPARATOR),
+      *HOMEBREW_RUBY_EXEC_ARGS,
       HOMEBREW_LIBRARY_PATH/"brew.rb",
       "info",
       "--json=v1",
-      name
+      name,
     )
 
     return unless $CHILD_STATUS.success?

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -896,13 +896,12 @@ class FormulaInstaller
     # 1. formulae can modify ENV, so we must ensure that each
     #    installation has a pristine ENV when it starts, forking now is
     #    the easiest way to do this
-    args = %W[
-      nice #{RUBY_PATH}
-      #{ENV["HOMEBREW_RUBY_WARNINGS"]}
-      -I #{$LOAD_PATH.join(File::PATH_SEPARATOR)}
-      --
-      #{HOMEBREW_LIBRARY_PATH}/build.rb
-      #{formula.specified_path}
+    args = [
+      "nice",
+      *HOMEBREW_RUBY_EXEC_ARGS,
+      "--",
+      HOMEBREW_LIBRARY_PATH/"build.rb",
+      formula.specified_path,
     ].concat(build_argv)
 
     Utils.safe_fork do

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -16,7 +16,6 @@ require "rbconfig"
 RUBY_PATH = Pathname.new(RbConfig.ruby).freeze
 RUBY_BIN = RUBY_PATH.dirname.freeze
 
-require "rubygems"
 # Only require "core_ext" here to ensure we're only requiring the minimum of
 # what we need.
 require "active_support/core_ext/object/blank"

--- a/Library/Homebrew/homebrew_bootsnap.rb
+++ b/Library/Homebrew/homebrew_bootsnap.rb
@@ -17,13 +17,10 @@ else
 end
 
 if homebrew_bootsnap_enabled
-  require "rubygems"
-
   begin
     require "bootsnap"
   rescue LoadError
     unless ENV["HOMEBREW_BOOTSNAP_RETRY"]
-      require "utils/gems"
       Homebrew.install_bundler_gems!(only_warn_on_failure: true)
 
       ENV["HOMEBREW_BOOTSNAP_RETRY"] = "1"

--- a/Library/Homebrew/load_path.rb
+++ b/Library/Homebrew/load_path.rb
@@ -5,12 +5,21 @@ require "pathname"
 
 HOMEBREW_LIBRARY_PATH = Pathname(__dir__).realpath.freeze
 
-$LOAD_PATH.push HOMEBREW_LIBRARY_PATH.to_s
+require_relative "utils/gems"
+Homebrew.setup_gem_environment!(setup_path: false)
 
-require "vendor/bundle/bundler/setup"
-require "homebrew_bootsnap"
+$LOAD_PATH.push HOMEBREW_LIBRARY_PATH.to_s unless $LOAD_PATH.include?(HOMEBREW_LIBRARY_PATH.to_s)
+require_relative "vendor/bundle/bundler/setup"
+$LOAD_PATH.uniq!
 
-unless defined?(Bootsnap)
-  $LOAD_PATH.select! { |d| Pathname(d).directory? }
-  $LOAD_PATH.uniq!
+# Block any gem loading by bypassing rubygem's `require`.
+# Helps make sure we don't accidentally use things not in bundler's load path.
+# Bundler 2.2.7+ and non-standalone mode both do this automatically.
+# https://github.com/rubygems/rubygems/blob/5841761974bef324a33ef1cb650bbf8a2457805b/bundler/lib/bundler/installer/standalone.rb#L55-L63
+if Kernel.private_method_defined?(:gem_original_require)
+  Kernel.send(:remove_method, :require)
+  Kernel.send(:define_method, :require, Kernel.instance_method(:gem_original_require))
+  Kernel.send(:private, :require)
 end
+
+require_relative "homebrew_bootsnap"

--- a/Library/Homebrew/postinstall.rb
+++ b/Library/Homebrew/postinstall.rb
@@ -3,7 +3,7 @@
 
 old_trap = trap("INT") { exit! 130 }
 
-require "global"
+require_relative "global"
 require "debrew"
 require "fcntl"
 require "socket"

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -11,7 +11,6 @@ require "dependency_collector"
 require "utils/bottles"
 require "patch"
 require "compilers"
-require "global"
 require "os/mac/version"
 require "extend/on_os"
 

--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -3,7 +3,7 @@
 
 old_trap = trap("INT") { exit! 130 }
 
-require "global"
+require_relative "global"
 require "extend/ENV"
 require "timeout"
 require "debrew"

--- a/Library/Homebrew/test/dev-cmd/test_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/test_spec.rb
@@ -6,8 +6,7 @@ require "cmd/shared_examples/args_parse"
 describe "brew test" do
   it_behaves_like "parseable arguments"
 
-  # randomly segfaults on Linux with portable-ruby.
-  it "tests a given Formula", :integration_test, :needs_macos do
+  it "tests a given Formula", :integration_test do
     install_test_formula "testball", <<~'RUBY'
       test do
         assert_equal "test", shell_output("#{bin}/test")

--- a/Library/Homebrew/test/formula_info_spec.rb
+++ b/Library/Homebrew/test/formula_info_spec.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "formula_info"
-require "global"
 
 describe FormulaInfo, :integration_test do
   it "tests the FormulaInfo class" do

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -87,10 +87,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
     )
 
     @ruby_args ||= begin
-      ruby_args = [
-        ENV["HOMEBREW_RUBY_WARNINGS"],
-        "-I", $LOAD_PATH.join(File::PATH_SEPARATOR)
-      ]
+      ruby_args = HOMEBREW_RUBY_EXEC_ARGS.dup
       if ENV["HOMEBREW_TESTS_COVERAGE"]
         simplecov_spec = Gem.loaded_specs["simplecov"]
         specs = [simplecov_spec]
@@ -111,12 +108,12 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
         libs.each { |lib| ruby_args << "-I" << lib }
         ruby_args << "-rsimplecov"
       end
-      ruby_args << "-rtest/support/helper/integration_mocks"
+      ruby_args << "-r#{HOMEBREW_LIBRARY_PATH}/test/support/helper/integration_mocks"
       ruby_args << (HOMEBREW_LIBRARY_PATH/"brew.rb").resolved_path.to_s
     end
 
     Bundler.with_clean_env do
-      stdout, stderr, status = Open3.capture3(env, RUBY_PATH, *@ruby_args, *args)
+      stdout, stderr, status = Open3.capture3(env, *@ruby_args, *args)
       $stdout.print stdout
       $stderr.print stderr
       status

--- a/Library/Homebrew/test/support/lib/config.rb
+++ b/Library/Homebrew/test/support/lib/config.rb
@@ -37,6 +37,11 @@ HOMEBREW_LOCKS         = (HOMEBREW_PREFIX.parent/"locks").freeze
 HOMEBREW_CELLAR        = (HOMEBREW_PREFIX.parent/"cellar").freeze
 HOMEBREW_LOGS          = (HOMEBREW_PREFIX.parent/"logs").freeze
 HOMEBREW_TEMP          = (HOMEBREW_PREFIX.parent/"temp").freeze
+HOMEBREW_RUBY_EXEC_ARGS = [
+  RUBY_PATH,
+  ENV["HOMEBREW_RUBY_WARNINGS"],
+  "-I", HOMEBREW_LIBRARY_PATH/"test/support/lib"
+].freeze
 
 TEST_FIXTURE_DIR = (HOMEBREW_LIBRARY_PATH/"test/support/fixtures").freeze
 

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -22,7 +22,6 @@ module Homebrew
   end
 
   def gem_user_bindir
-    require "rubygems"
     "#{gem_user_dir}/bin"
   end
 
@@ -51,13 +50,11 @@ module Homebrew
     end
   end
 
-  def setup_gem_environment!(gem_home: nil, gem_bindir: nil)
-    require "rubygems"
-
+  def setup_gem_environment!(gem_home: nil, gem_bindir: nil, setup_path: true)
     # Match where our bundler gems are.
     gem_home ||= "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
     ENV["GEM_HOME"] = gem_home
-    ENV["GEM_PATH"] = "#{ENV["GEM_HOME"]}:#{Gem.default_dir}"
+    ENV["GEM_PATH"] = gem_home
 
     # Set TMPDIR so Xcode's `make` doesn't fall back to `/var/tmp/`,
     # which may be not user-writable.
@@ -66,6 +63,8 @@ module Homebrew
     # Make RubyGems notice environment changes.
     Gem.clear_paths
     Gem::Specification.reset
+
+    return unless setup_path
 
     # Add necessary Ruby and Gem binary directories to `PATH`.
     gem_bindir ||= Gem.bindir
@@ -103,7 +102,6 @@ module Homebrew
   end
 
   def install_bundler!
-    require "rubygems"
     setup_gem_environment!(gem_home: gem_user_dir, gem_bindir: gem_user_bindir)
     install_gem_setup_path!(
       "bundler",

--- a/Library/Homebrew/utils/sorbet.rb
+++ b/Library/Homebrew/utils/sorbet.rb
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 if ENV["HOMEBREW_SORBET_RUNTIME"]
-  require "utils/gems"
   Homebrew.install_bundler_gems!
   require "sorbet-runtime"
 else


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This prevents random user-installed gems from breaking `brew` in various ways, including but not limited to:

* Broken native extensions of critical components, like `fileutils`, causing `brew` to not load. [#10520, #10684, many many discussions]
* Various warnings about user-installed gems that `brew` isn't responsible for. [#10649, #10675, #10688]
* Breaking-change updates of gems being used which `brew` has not been tested against. [#2984]

Prior discussion in #7681.