### PR TITLE
pr-upload: Fix a typo affecting Internet Archive

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -52,7 +52,7 @@ module Homebrew
 
   def archive?(bottles_hash)
     @archive ||= bottles_hash.values.all? do |bottle_hash|
-      bottle_hash["bottle"]["root_url"].start_with? "https://archive.com/"
+      bottle_hash["bottle"]["root_url"].start_with? "https://archive.org/"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix a typo in `pr-upload` affecting Internet Archive. Not sure how this typo slipped in. Sigh
