### PR TITLE
Add initial documentation for Java-based packages

### DIFF
--- a/docs/Homebrew-and-Java.md
+++ b/docs/Homebrew-and-Java.md
@@ -1,0 +1,9 @@
+# Homebrew and Java
+
+This page describes how Java is handled in Homebrew for users. Prospective formula authors may refer to existing Java-based formulae for examples of how to install packages written in Java via Homebrew, or visit the [Homebrew discussion forum](https://github.com/Homebrew/discussions/discussions) to seek guidance for their specific situation.
+
+Most Java-based packages in Homebrew use the default Homebrew-provided `openjdk` package for their JDK dependency, although some packages with specific version requirements may use a versioned package such as `openjdk@8`.
+
+## Executing commands using a different JDK
+
+In situations where the user wants to override the use of the Homebrew-provided JDK, setting the `JAVA_HOME` environment variable will cause the specified location to be used as the Java home directory instead of the version of `openjdk` specified as a dependency.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----
Per the discussion at https://github.com/Homebrew/discussions/discussions/910, this PR adds a "Homebrew and Java" page that documents the use of `openjdk` or versioned alternatives by Java-based packages, as well as the ability to bring your own JDK by means of the `JAVA_HOME` environment variable.