### PR TITLE
Revert "Enable HOMEBREW_BOOTSNAP for developers"

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -584,11 +584,6 @@ then
   export HOMEBREW_BOTTLE_DOMAIN="$HOMEBREW_BOTTLE_DEFAULT_DOMAIN"
 fi
 
-if [[ -n "$HOMEBREW_DEVELOPER" || -n "$HOMEBREW_DEV_CMD_RUN" ]]
-then
-  export HOMEBREW_BOOTSNAP="1"
-fi
-
 export HOMEBREW_BREW_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/brew"
 if [[ -z "$HOMEBREW_BREW_GIT_REMOTE" ]]
 then

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -40,9 +40,8 @@ module Homebrew
         description: "Use this username when accessing the Bintray API (where bottles are stored).",
       },
       HOMEBREW_BOOTSNAP:                      {
-        description: "If set, use Bootsnap to speed up repeated `brew` calls. " \
-                     "A no-op in various configurations where it doesn't work. " \
-                     "Enabled by default if HOMEBREW_DEVELOPER is set or a developer command has been run.",
+        description: "If set, use Bootsnap to speed up repeated `brew` calls. "\
+                     "A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).",
         boolean:     true,
       },
       HOMEBREW_BOTTLE_DOMAIN:                 {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1725,7 +1725,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
   <br>Use this username when accessing the Bintray API (where bottles are stored).
 
 - `HOMEBREW_BOOTSNAP`
-  <br>If set, use Bootsnap to speed up repeated `brew` calls. A no-op in various configurations where it doesn't work. Enabled by default if HOMEBREW_DEVELOPER is set or a developer command has been run.
+  <br>If set, use Bootsnap to speed up repeated `brew` calls. A no-op when using Homebrew's vendored, relocatable Ruby on macOS (as it doesn't work).
 
 - `HOMEBREW_BOTTLE_DOMAIN`
   <br>Use this URL as the download mirror for bottles. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to download from the prefix `http://localhost:8080/`.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2406,7 +2406,7 @@ Use this username when accessing the Bintray API (where bottles are stored)\.
 \fBHOMEBREW_BOOTSNAP\fR
 .
 .br
-If set, use Bootsnap to speed up repeated \fBbrew\fR calls\. A no\-op in various configurations where it doesn\'t work\. Enabled by default if HOMEBREW_DEVELOPER is set or a developer command has been run\.
+If set, use Bootsnap to speed up repeated \fBbrew\fR calls\. A no\-op when using Homebrew\'s vendored, relocatable Ruby on macOS (as it doesn\'t work)\.
 .
 .TP
 \fBHOMEBREW_BOTTLE_DOMAIN\fR


### PR DESCRIPTION
Reverts Homebrew/brew#10680

This seems to be causing a lot of issues and I don't think dealing with these is worth it.