### PR TITLE
dev-cmd/man: modify '--fail-if-changed' to '--fail-if-not-changed'

### DIFF
--- a/.github/workflows/update-manpage.yml
+++ b/.github/workflows/update-manpage.yml
@@ -50,9 +50,7 @@ jobs:
             brew update-maintainers
           fi
 
-          brew man
-
-          if [ -n "$(git status --porcelain=v1 2>/dev/null)" ]; then
+          if brew man --fail-if-not-changed; then
             git add "$GITHUB_WORKSPACE/README.md" \
                     "$GITHUB_WORKSPACE/docs/Manpage.md" \
                     "$GITHUB_WORKSPACE/manpages/brew.1" \

--- a/Library/Homebrew/dev-cmd/man.rb
+++ b/Library/Homebrew/dev-cmd/man.rb
@@ -24,9 +24,9 @@ module Homebrew
 
         *Note:* Not (yet) working on Apple Silicon.
       EOS
-      switch "--fail-if-changed",
-             description: "Return a failing status code if changes are detected in the manpage outputs. This "\
-                          "can be used to notify CI when the manpages are out of date. Additionally, "\
+      switch "--fail-if-not-changed",
+             description: "Return a failing status code if no changes are detected in the manpage outputs. "\
+                          "This can be used to notify CI when the manpages are out of date. Additionally, "\
                           "the date used in new manpages will match those in the existing manpages (to allow "\
                           "comparison without factoring in the date)."
       named_args :none
@@ -42,19 +42,17 @@ module Homebrew
     args = man_args.parse
 
     Commands.rebuild_internal_commands_completion_list
-    regenerate_man_pages(preserve_date: args.fail_if_changed?, quiet: args.quiet?)
+    regenerate_man_pages(preserve_date: args.fail_if_not_changed?, quiet: args.quiet?)
     Completions.update_shell_completions!
 
     diff = system_command "git", args: [
       "-C", HOMEBREW_REPOSITORY, "diff", "--exit-code", "docs/Manpage.md", "manpages", "completions"
     ]
-    if diff.status.success?
-      puts "No changes to manpage or completions output detected."
-    elsif args.fail_if_changed?
-      puts "Changes to manpage or completions detected:"
-      puts diff.stdout
-      Homebrew.failed = true
-    end
+
+    return unless diff.status.success?
+
+    puts "No changes to manpage or completions output detected."
+    Homebrew.failed = true if args.fail_if_not_changed?
   end
 
   def regenerate_man_pages(preserve_date:, quiet:)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR modifies the `--fail-if-changed` option in `brew man` to `--fail-if-not-changed` for two reasons:
* To maintain consistency with the `update-license-data` command
* The earlier option made sense when CI was supposed to detect if the contributor hadn't run `brew man` and committed the changes. Now that we've automated the process and removed the CI check, it would be good to change this functionality for use in the `update-manpage` workflow.