### PR TITLE
diagnostic: suggest update-reset after set-url

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -143,6 +143,7 @@ module Homebrew
             With a non-standard origin, Homebrew won't update properly.
             You can solve this by setting the origin remote:
               git -C "#{repository_path}" remote set-url origin #{Formatter.url(desired_origin)}
+              brew update-reset "#{repository_path}"
           EOS
         end
       end


### PR DESCRIPTION
For those folks who b0rked their core repo origin remotes (e.g. https://github.com/Homebrew/discussions/discussions/822, https://github.com/Homebrew/brew/issues/10709), I can't think of a reason not to do a force-fetch after resetting the URLs, and `brew update-reset` seems to be a better "next step" than manually executing the necessary `git` commands.

-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N/A] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [N/A] Have you successfully run `brew typecheck` with your changes locally?
- [N/A] Have you successfully run `brew tests` with your changes locally?
