### PR TITLE
os/mac: fix version error for prerelease macOS

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -25,7 +25,7 @@ module OS
     # This can be compared to numerics, strings, or symbols
     # using the standard Ruby Comparable methods.
     def version
-      @version ||= Version.from_symbol(full_version.to_sym)
+      @version ||= full_version.strip_patch
     end
 
     # This can be compared to numerics, strings, or symbols


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I guess this makes `brew` sort of work on macOS 12 now.

```
Traceback (most recent call last):
	14: from /usr/local/Homebrew/Library/Homebrew/brew.rb:31:in `<main>'
	13: from /usr/local/Homebrew/Library/Homebrew/brew.rb:31:in `require_relative'
	12: from /usr/local/Homebrew/Library/Homebrew/global.rb:79:in `<top (required)>'
	11: from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
	10: from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
	 9: from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
	 8: from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
	 7: from /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
	 6: from /usr/local/Homebrew/Library/Homebrew/os.rb:7:in `<main>'
	 5: from /usr/local/Homebrew/Library/Homebrew/os.rb:43:in `<module:OS>'
	 4: from /usr/local/Homebrew/Library/Homebrew/os/mac.rb:60:in `prerelease?'
	 3: from /usr/local/Homebrew/Library/Homebrew/os/mac.rb:28:in `version'
	 2: from /usr/local/Homebrew/Library/Homebrew/os/mac/version.rb:33:in `from_symbol'
	 1: from /usr/local/Homebrew/Library/Homebrew/os/mac/version.rb:33:in `fetch'
/usr/local/Homebrew/Library/Homebrew/os/mac/version.rb:33:in `block in from_symbol': unknown or unsupported macOS version: :dunno (MacOSVersionError)
```