### PR TITLE
brew: disable compat mode when running sw_vers

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -319,7 +319,7 @@ then
   HOMEBREW_PRODUCT="Homebrew"
   HOMEBREW_SYSTEM="Macintosh"
   [[ "$HOMEBREW_PROCESSOR" = "x86_64" ]] && HOMEBREW_PROCESSOR="Intel"
-  HOMEBREW_MACOS_VERSION="$(/usr/bin/sw_vers -productVersion)"
+  HOMEBREW_MACOS_VERSION="$(SYSTEM_VERSION_COMPAT=0 /usr/bin/sw_vers -productVersion)"
   # Don't change this from Mac OS X to match what macOS itself does in Safari on 10.12
   HOMEBREW_OS_USER_AGENT_VERSION="Mac OS X $HOMEBREW_MACOS_VERSION"
 
@@ -330,7 +330,7 @@ then
   # Don't include minor versions for Big Sur and later.
   if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -gt "110000" ]]
   then
-    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION%.*}"
+    HOMEBREW_OS_VERSION="macOS ${HOMEBREW_MACOS_VERSION%%.*}"
   else
     HOMEBREW_OS_VERSION="macOS $HOMEBREW_MACOS_VERSION"
   fi


### PR DESCRIPTION
As far as I can tell, Homebrew believes Big Sur == 11.x, so we should make sure `sw_vers` doesn't output 10.16.

Addresses https://github.com/Homebrew/discussions/discussions/941

-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
