### PR TITLE
formula_assertions: add assert_not_match compat

### DIFF
--- a/Library/Homebrew/formula_assertions.rb
+++ b/Library/Homebrew/formula_assertions.rb
@@ -28,6 +28,7 @@ module Homebrew
       assert_not_includes:    :refute_includes,
       assert_not_instance_of: :refute_instance_of,
       assert_not_kind_of:     :refute_kind_of,
+      assert_not_match:       :refute_match,
       assert_no_match:        :refute_match,
       assert_not_nil:         :refute_nil,
       assert_not_operator:    :refute_operator,


### PR DESCRIPTION
There are some formulae using this method:
https://github.com/Homebrew/homebrew-core/search?q=assert_not_match&type=

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
