### PR TITLE
utils/gems: use Gem API rather than ENV to set paths

### DIFF
--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -90,11 +90,15 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
       ruby_args = HOMEBREW_RUBY_EXEC_ARGS.dup
       if ENV["HOMEBREW_TESTS_COVERAGE"]
         simplecov_spec = Gem.loaded_specs["simplecov"]
-        specs = [simplecov_spec]
-        simplecov_spec.runtime_dependencies.each do |dep|
-          specs += dep.to_specs
-        rescue Gem::LoadError => e
-          onoe e
+        parallel_tests_spec = Gem.loaded_specs["parallel_tests"]
+        specs = []
+        [simplecov_spec, parallel_tests_spec].each do |spec|
+          specs << spec
+          spec.runtime_dependencies.each do |dep|
+            specs += dep.to_specs
+          rescue Gem::LoadError => e
+            onoe e
+          end
         end
         libs = specs.flat_map do |spec|
           full_gem_path = spec.full_gem_path

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -53,16 +53,14 @@ module Homebrew
   def setup_gem_environment!(gem_home: nil, gem_bindir: nil, setup_path: true)
     # Match where our bundler gems are.
     gem_home ||= "#{ENV["HOMEBREW_LIBRARY"]}/Homebrew/vendor/bundle/ruby/#{RbConfig::CONFIG["ruby_version"]}"
-    ENV["GEM_HOME"] = gem_home
-    ENV["GEM_PATH"] = gem_home
+    Gem.paths = {
+      "GEM_HOME" => gem_home,
+      "GEM_PATH" => gem_home,
+    }
 
     # Set TMPDIR so Xcode's `make` doesn't fall back to `/var/tmp/`,
     # which may be not user-writable.
     ENV["TMPDIR"] = ENV["HOMEBREW_TEMP"]
-
-    # Make RubyGems notice environment changes.
-    Gem.clear_paths
-    Gem::Specification.reset
 
     return unless setup_path
 

--- a/Library/Homebrew/utils/rubocop.rb
+++ b/Library/Homebrew/utils/rubocop.rb
@@ -2,6 +2,9 @@
 # typed: false
 # frozen_string_literal: true
 
+require_relative "gems"
+Homebrew.setup_gem_environment!
+
 require_relative "../warnings"
 
 Warnings.ignore :parser_syntax do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This prevents the ENV bleeding into child processes, such as system Ruby scripts invoked from formulae.