### PR TITLE
dev-cmd/tap-new: various tweaks.

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -22,9 +22,8 @@ module Homebrew
       flag   "--pull-label=",
              description: "Label name for pull requests ready to be pulled (default: `pr-pull`)."
       flag   "--branch=",
-             description: "Initialize Git repository with the specified branch name (default: `main`)."
-
-      conflicts "--no-git", "--branch"
+             description: "Initialize Git repository and setup GitHub Actions workflows with the " \
+                          "specified branch name (default: `main`)."
 
       named_args :tap, number: 1
     end
@@ -50,11 +49,13 @@ module Homebrew
       # #{titleized_user} #{titleized_repo}
 
       ## How do I install these formulae?
+
       `brew install #{tap}/<formula>`
 
       Or `brew tap #{tap}` and then `brew install <formula>`.
 
       ## Documentation
+
       `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
     MARKDOWN
     write_path(tap, "README.md", readme)
@@ -63,13 +64,14 @@ module Homebrew
       name: brew test-bot
       on:
         push:
-          branches: #{branch}
+          branches:
+            - #{branch}
         pull_request:
       jobs:
         test-bot:
           strategy:
             matrix:
-              os: [ubuntu-latest, macOS-latest]
+              os: [ubuntu-latest, macos-latest]
           runs-on: ${{ matrix.os }}
           steps:
             - name: Set up Homebrew

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -1279,7 +1279,7 @@ __fish_brew_complete_arg 'tap-info' -a '(__fish_brew_suggest_taps_installed)'
 
 
 __fish_brew_complete_cmd 'tap-new' 'Generate the template files for a new tap'
-__fish_brew_complete_arg 'tap-new' -l branch -d 'Initialize Git repository with the specified branch name (default: `main`)'
+__fish_brew_complete_arg 'tap-new' -l branch -d 'Initialize Git repository and setup GitHub Actions workflows with the specified branch name (default: `main`)'
 __fish_brew_complete_arg 'tap-new' -l debug -d 'Display any debugging information'
 __fish_brew_complete_arg 'tap-new' -l help -d 'Show this message'
 __fish_brew_complete_arg 'tap-new' -l no-git -d 'Don\'t initialize a Git repository for the tap'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -1490,10 +1490,10 @@ _brew_tap_info() {
 # brew tap-new
 _brew_tap_new() {
   _arguments \
-    '(--no-git)--branch[Initialize Git repository with the specified branch name (default: `main`)]' \
+    '--branch[Initialize Git repository and setup GitHub Actions workflows with the specified branch name (default: `main`)]' \
     '--debug[Display any debugging information]' \
     '--help[Show this message]' \
-    '(--branch)--no-git[Don'\''t initialize a Git repository for the tap]' \
+    '--no-git[Don'\''t initialize a Git repository for the tap]' \
     '--pull-label[Label name for pull requests ready to be pulled (default: `pr-pull`)]' \
     '--quiet[Make some output more quiet]' \
     '--verbose[Make some output more verbose]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1304,7 +1304,7 @@ Generate the template files for a new tap.
 * `--pull-label`:
   Label name for pull requests ready to be pulled (default: `pr-pull`).
 * `--branch`:
-  Initialize Git repository with the specified branch name (default: `main`).
+  Initialize Git repository and setup GitHub Actions workflows with the specified branch name (default: `main`).
 
 ### `test` [*`options`*] *`installed_formula`* [...]
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "February 2021" "Homebrew" "brew"
+.TH "BREW" "1" "March 2021" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)
@@ -1809,7 +1809,7 @@ Label name for pull requests ready to be pulled (default: \fBpr\-pull\fR)\.
 .
 .TP
 \fB\-\-branch\fR
-Initialize Git repository with the specified branch name (default: \fBmain\fR)\.
+Initialize Git repository and setup GitHub Actions workflows with the specified branch name (default: \fBmain\fR)\.
 .
 .SS "\fBtest\fR [\fIoptions\fR] \fIinstalled_formula\fR [\.\.\.]"
 Run the test method provided by an installed formula\. There is no standard output or return code, but generally it should notify the user if something is wrong with the installed formula\.


### PR DESCRIPTION
- `--no-git` and `--branch` don't conflict as `--branch` is still used for the GitHub Actions branch even with `--no-git`
- fix some README markdown linting errors
- fix some YAML/GitHub Actions configuration linting errors