### PR TITLE
feat: add support of xonsh shell to shellenv on Linux

### DIFF
--- a/Library/Homebrew/cmd/shellenv.sh
+++ b/Library/Homebrew/cmd/shellenv.sh
@@ -4,6 +4,7 @@
 #:
 #:  The variables `HOMEBREW_PREFIX`, `HOMEBREW_CELLAR` and `HOMEBREW_REPOSITORY` are also exported to avoid querying them multiple times.
 #:  Consider adding evaluation of this command's output to your dotfiles (e.g. `~/.profile`, `~/.bash_profile`, or `~/.zprofile`) with: `eval $(brew shellenv)`
+#:  or for a xonsh shell with: `execx($(/home/linuxbrew/.linuxbrew/bin/brew shellenv))` (or `execx($(~/.linuxbrew/bin/brew shellenv))` depending on the install path)
 
 homebrew-shellenv() {
   case "$(/bin/ps -p $PPID -c -o comm=)" in
@@ -22,6 +23,18 @@ homebrew-shellenv() {
       echo "setenv PATH $HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/sbin:\$PATH;"
       echo "setenv MANPATH $HOMEBREW_PREFIX/share/man\`[ \${?MANPATH} == 1 ] && echo \":\${MANPATH}\"\`:;"
       echo "setenv INFOPATH $HOMEBREW_PREFIX/share/info\`[ \${?INFOPATH} == 1 ] && echo \":\${INFOPATH}\"\`;"
+      ;;
+    xonsh|-xonsh)
+      echo "\$HOMEBREW_PREFIX='$HOMEBREW_PREFIX';"
+      echo "\$HOMEBREW_CELLAR='$HOMEBREW_CELLAR';"
+      echo "\$HOMEBREW_REPOSITORY='$HOMEBREW_REPOSITORY';"
+      echo "\$PATH = \$PATH if 'PATH' in \${...} else '';"
+      echo "\$PATH.add('$HOMEBREW_PREFIX/sbin', front=True, replace=True);"
+      echo "\$PATH.add('$HOMEBREW_PREFIX/bin', front=True, replace=True);"
+      echo "\$MANPATH = \$MANPATH if 'MANPATH' in \${...} else '';"
+      echo "\$MANPATH.add('$HOMEBREW_PREFIX/share/man', front=True, replace=True);"
+      echo "\$INFOPATH = \$INFOPATH if 'INFOPATH' in \${...} else '';"
+      echo "\$INFOPATH.add('$HOMEBREW_PREFIX/share/info', front=True, replace=True);"
       ;;
     *)
       echo "export HOMEBREW_PREFIX=\"$HOMEBREW_PREFIX\";"

--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -36,6 +36,12 @@ test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew
 test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
 echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
 ```
+Similar instructions to add Homebrew to your xonsh shell profile script at `~/.xonshrc` or `~/.config/rc.xsh`:
+```sh
+test -d ~/.linuxbrew && execx($(~/.linuxbrew/bin/brew shellenv))
+test -d /home/linuxbrew/.linuxbrew && execx($(/home/linuxbrew/.linuxbrew/bin/brew shellenv))
+echo @(f'execx($({$(brew --prefix)}/bin/brew shellenv))'.replace('\n','')) >> ~/.xonshrc # or ~/.config/rc.xsh
+```
 
 You're done! Try installing a package:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
No, don't see any tests for shellenv, so don't know how write such a test. But I did test it in a xonsh shell
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
No, but I also have a few dozen failed tests within WSL on a fresh master. Also, haven't found any failures related to shellenv

-----
Currently on Linux the `shellenv` command only check the process list for the **fish/t/csh** shells and otherwise prints out generic **bash** instructions
I've updated `shellenv`  to also check for the [xonsh shell](https://xon.sh) and print out correct xonsh instructions that can be evaluated to update a xonsh environment and make Linuxbrew usable in xonsh
I've also updated the installation instructions with the relevant xonsh commands