### PR TITLE
rubocops/patches: GitLab patches should use .diff

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -56,8 +56,10 @@ module RuboCop
             problem "GitHub patches should end with .patch, not .diff: #{patch_url}"
           end
 
-          if regex_match_group(patch_url_node, %r{.*gitlab.*/commit/[a-fA-F0-9]*\.diff})
-            problem "GitLab patches should end with .patch, not .diff: #{patch_url}"
+          # Only .diff passes `--full-index` to `git diff` and there is no documented way
+          # to get .patch to behave the same for GitLab.
+          if regex_match_group(patch_url_node, %r{.*gitlab.*/commit/[a-fA-F0-9]*\.patch})
+            problem "GitLab patches should end with .diff, not .patch: #{patch_url}"
           end
 
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}

--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -56,11 +56,12 @@ module RuboCop
             problem "GitHub patches should end with .patch, not .diff: #{patch_url}"
           end
 
+          # TODO: Uncomment once offenses have been fixed in Homebrew/homebrew-core and Homebrew/linuxbrew-core
           # Only .diff passes `--full-index` to `git diff` and there is no documented way
           # to get .patch to behave the same for GitLab.
-          if regex_match_group(patch_url_node, %r{.*gitlab.*/commit/[a-fA-F0-9]*\.patch})
-            problem "GitLab patches should end with .diff, not .patch: #{patch_url}"
-          end
+          # if regex_match_group(patch_url_node, %r{.*gitlab.*/commit/[a-fA-F0-9]*\.patch})
+          #   problem "GitLab patches should end with .diff, not .patch: #{patch_url}"
+          # end
 
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch_url_node, gh_patch_param_pattern) && !patch_url.match?(/\?full_index=\w+$/)

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -181,7 +181,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         "https://github.com/uber/h3/pull/362.patch?full_index=1",
         "https://gitlab.gnome.org/GNOME/gitg/-/merge_requests/142.diff",
         "https://github.com/michaeldv/pit/commit/f64978d.diff?full_index=1",
-        "https://gitlab.gnome.org/GNOME/msitools/commit/248450a.diff",
+        "https://gitlab.gnome.org/GNOME/msitools/commit/248450a.patch",
       ]
       patch_urls.each do |patch_url|
         source = <<~RUBY
@@ -225,7 +225,7 @@ describe RuboCop::Cop::FormulaAudit::Patches do
           EOS
         elsif patch_url.match?(%r{.*gitlab.*/commit/})
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
-            GitLab patches should end with .patch, not .diff: #{patch_url}
+            GitLab patches should end with .diff, not .patch: #{patch_url}
           EOS
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})

--- a/Library/Homebrew/test/rubocops/patches_spec.rb
+++ b/Library/Homebrew/test/rubocops/patches_spec.rb
@@ -181,7 +181,8 @@ describe RuboCop::Cop::FormulaAudit::Patches do
         "https://github.com/uber/h3/pull/362.patch?full_index=1",
         "https://gitlab.gnome.org/GNOME/gitg/-/merge_requests/142.diff",
         "https://github.com/michaeldv/pit/commit/f64978d.diff?full_index=1",
-        "https://gitlab.gnome.org/GNOME/msitools/commit/248450a.patch",
+        # TODO: Uncomment once the corresponding check is re-enabled
+        # "https://gitlab.gnome.org/GNOME/msitools/commit/248450a.patch",
       ]
       patch_urls.each do |patch_url|
         source = <<~RUBY
@@ -223,10 +224,11 @@ describe RuboCop::Cop::FormulaAudit::Patches do
           expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
             GitHub patches should end with .patch, not .diff: #{patch_url}
           EOS
-        elsif patch_url.match?(%r{.*gitlab.*/commit/})
-          expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
-            GitLab patches should end with .diff, not .patch: #{patch_url}
-          EOS
+        # TODO: Uncomment once the corresponding check is re-enabled
+        # elsif patch_url.match?(%r{.*gitlab.*/commit/})
+        #   expect_offense_hash message: <<~EOS.chomp, severity: :convention, line: 5, column: 8, source: source
+        #     GitLab patches should end with .diff, not .patch: #{patch_url}
+        #   EOS
         # rubocop:disable Layout/LineLength
         elsif patch_url.match?(%r{https?://patch-diff\.githubusercontent\.com/raw/(.+)/(.+)/pull/(.+)\.(?:diff|patch)})
           # rubocop:enable Layout/LineLength


### PR DESCRIPTION
Only `.diff` URLs return output comparable to the diffs from `git diff --full-index`. While the extra metadata from `.patch` is nice, the instability of the patch contents is undesirable. This has caused issues with patch contents changing over time, for example in https://github.com/Homebrew/homebrew-core/issues/43156 and https://github.com/Homebrew/homebrew-core/pull/72297.

I'll coordinate getting this into homebrew/core and linuxbrew/core but it will take a little while.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----