### PR TITLE
formula_installer: fix typo in install_dependency

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -718,7 +718,7 @@ class FormulaInstaller
 
     if df.latest_version_installed?
       installed_keg = Keg.new(df.prefix)
-      tab ||= Tab.for_keg(linked_keg)
+      tab ||= Tab.for_keg(installed_keg)
       tmp_keg = Pathname.new("#{installed_keg}.tmp")
       installed_keg.rename(tmp_keg)
     end


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The linked_keg variable is referenced outside the block where it is defined; I think it should be the installed_keg variable.

I noticed this from a failing job in our CI system:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gazebo-install-one_liner-homebrew-amd64&build=1974)](https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/1974/) https://build.osrfoundation.org/job/gazebo-install-one_liner-homebrew-amd64/1974/

~~~
Error: undefined method `/' for nil:NilClass
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/tab.rb:111:in `for_keg'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:721:in `install_dependency'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:679:in `block in install_dependencies'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:679:in `each'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:679:in `install_dependencies'
/usr/local/Homebrew/Library/Homebrew/formula_installer.rb:406:in `install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:402:in `install_formula'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:315:in `block in install'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:313:in `each'
/usr/local/Homebrew/Library/Homebrew/cmd/install.rb:313:in `install'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
~~~