### PR TITLE
Let bin/brew handle its own exporting

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -440,13 +440,6 @@ curl_version_output="$("$HOMEBREW_CURL" --version 2>/dev/null)"
 curl_name_and_version="${curl_version_output%% (*}"
 HOMEBREW_USER_AGENT_CURL="$HOMEBREW_USER_AGENT ${curl_name_and_version// //}"
 
-# Declared in bin/brew
-export HOMEBREW_BREW_FILE
-export HOMEBREW_PREFIX
-export HOMEBREW_REPOSITORY
-export HOMEBREW_LIBRARY
-
-# Declared in brew.sh
 export HOMEBREW_VERSION
 export HOMEBREW_DEFAULT_CACHE
 export HOMEBREW_CACHE

--- a/bin/brew
+++ b/bin/brew
@@ -75,6 +75,11 @@ do
   export "$VAR_NEW"="${!VAR}"
 done
 
+export HOMEBREW_BREW_FILE
+export HOMEBREW_PREFIX
+export HOMEBREW_REPOSITORY
+export HOMEBREW_LIBRARY
+
 # Use VISUAL if HOMEBREW_EDITOR and EDITOR are unset.
 if [[ -z "$HOMEBREW_EDITOR" && -n "$VISUAL" ]]
 then


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

If `HOMEBREW_NO_ENV_FILTERING` is _not_ set, then `/usr/bin/env` already exports these. For consistency, we should be doing the same if `HOMEBREW_NO_ENV_FILTERING` is set.