### PR TITLE
Allow deps auditing to run on Linux via HOMEBREW_SIMULATE_MACOS_ON_LINUX

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,6 +107,11 @@ jobs:
       - name: Run brew style on homebrew-core
         run: brew style --display-cop-names homebrew/core
 
+      - name: Run brew audit --skip-style on homebrew-core
+        run: brew audit --skip-style --tap=homebrew/core
+        env:
+          HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
+
       - name: Run brew style on official taps
         run: |
           brew style --display-cop-names homebrew/bundle \
@@ -270,8 +275,12 @@ jobs:
       - name: Run brew readall on all taps
         run: brew readall --aliases
 
-      - name: Run brew audit --skip-style on all taps
-        run: brew audit --skip-style
+      - name: Run brew audit --skip-style on Cask taps
+        run: |
+          brew audit --skip-style --tap=homebrew/cask
+          brew audit --skip-style --tap=homebrew/cask-drivers
+          brew audit --skip-style --tap=homebrew/cask-fonts
+          brew audit --skip-style --tap=homebrew/cask-versions
 
       - name: Install brew tests dependencies
         run: |

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -323,6 +323,11 @@ case "$*" in
   --version|-v) source "$HOMEBREW_LIBRARY/Homebrew/cmd/--version.sh"; homebrew-version; exit 0 ;;
 esac
 
+if [[ -n "$HOMEBREW_SIMULATE_MACOS_ON_LINUX" ]]
+then
+  export HOMEBREW_FORCE_HOMEBREW_ON_LINUX="1"
+fi
+
 if [[ -n "$HOMEBREW_MACOS" ]]
 then
   HOMEBREW_PRODUCT="Homebrew"

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -262,7 +262,7 @@ module Homebrew
       },
       HOMEBREW_SIMULATE_MACOS_ON_LINUX:       {
         description: "If set, running Homebrew on Linux will simulate certain macOS code paths. This is useful " \
-                     "when auditing macOS formulae while on Linux.",
+                     "when auditing macOS formulae while on Linux. Implies `HOMEBREW_FORCE_HOMEBREW_ON_LINUX`.",
         boolean:     true,
       },
       HOMEBREW_SKIP_OR_LATER_BOTTLES:         {

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -260,6 +260,11 @@ module Homebrew
         description: "If set, use Pry for the `brew irb` command.",
         boolean:     true,
       },
+      HOMEBREW_SIMULATE_MACOS_ON_LINUX:       {
+        description: "If set, running Homebrew on Linux will simulate certain macOS code paths. This is useful " \
+                     "when auditing macOS formulae while on Linux.",
+        boolean:     true,
+      },
       HOMEBREW_SKIP_OR_LATER_BOTTLES:         {
         description: "If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions " \
                      "of macOS. This is useful in development on new macOS versions.",

--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -1,6 +1,8 @@
 # typed: false
 # frozen_string_literal: true
 
+# The Library/Homebrew/extend/os/software_spec.rb conditional logic will need to be more nuanced
+# if this file ever includes more than `uses_from_macos`.
 class SoftwareSpec
   undef uses_from_macos
 

--- a/Library/Homebrew/extend/os/mac/software_spec.rb
+++ b/Library/Homebrew/extend/os/mac/software_spec.rb
@@ -15,7 +15,8 @@ class SoftwareSpec
     end
 
     bounds = bounds.transform_values { |v| MacOS::Version.from_symbol(v) }
-    if MacOS.version >= bounds[:since]
+    if MacOS.version >= bounds[:since] ||
+       (Homebrew::EnvConfig.simulate_macos_on_linux? && !bounds.key?(:since))
       @uses_from_macos_elements << deps
     else
       depends_on deps

--- a/Library/Homebrew/extend/os/on_os.rb
+++ b/Library/Homebrew/extend/os/on_os.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-if OS.mac?
+if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
   require "extend/os/mac/on_os"
 elsif OS.linux?
   require "extend/os/linux/on_os"

--- a/Library/Homebrew/extend/os/software_spec.rb
+++ b/Library/Homebrew/extend/os/software_spec.rb
@@ -1,8 +1,9 @@
 # typed: strict
 # frozen_string_literal: true
 
-if OS.linux?
-  require "extend/os/linux/software_spec"
-elsif OS.mac?
+# This logic will need to be more nuanced if this file includes more than `uses_from_macos`.
+if OS.mac? || Homebrew::EnvConfig.force_homebrew_on_linux?
   require "extend/os/mac/software_spec"
+elsif OS.linux?
+  require "extend/os/linux/software_spec"
 end

--- a/Library/Homebrew/extend/os/software_spec.rb
+++ b/Library/Homebrew/extend/os/software_spec.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 # This logic will need to be more nuanced if this file includes more than `uses_from_macos`.
-if OS.mac? || Homebrew::EnvConfig.force_homebrew_on_linux?
+if OS.mac? || Homebrew::EnvConfig.simulate_macos_on_linux?
   require "extend/os/mac/software_spec"
 elsif OS.linux?
   require "extend/os/linux/software_spec"

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -282,7 +282,7 @@ module Homebrew
 
       # The number of conflicts on Linux is absurd.
       # TODO: remove this and check these there too.
-      return if OS.linux? && !Homebrew::EnvConfig.force_homebrew_on_linux?
+      return if OS.linux? && !Homebrew::EnvConfig.simulate_macos_on_linux?
 
       recursive_runtime_formulae = formula.runtime_formula_dependencies(undeclared: false)
       version_hash = {}

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -282,7 +282,7 @@ module Homebrew
 
       # The number of conflicts on Linux is absurd.
       # TODO: remove this and check these there too.
-      return if OS.linux?
+      return if OS.linux? && !Homebrew::EnvConfig.force_homebrew_on_linux?
 
       recursive_runtime_formulae = formula.runtime_formula_dependencies(undeclared: false)
       version_hash = {}

--- a/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
+++ b/Library/Homebrew/sorbet/rbi/hidden-definitions/hidden.rbi
@@ -8234,6 +8234,8 @@ module Homebrew::EnvConfig
 
   def self.pry?(); end
 
+  def self.simulate_macos_on_linux?(); end
+
   def self.skip_or_later_bottles?(); end
 
   def self.sorbet_runtime?(); end

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1897,6 +1897,9 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_PRY`
   <br>If set, use Pry for the `brew irb` command.
 
+- `HOMEBREW_SIMULATE_MACOS_ON_LINUX`
+  <br>If set, running Homebrew on Linux will simulate certain macOS code paths. This is useful when auditing macOS formulae while on Linux. Implies `HOMEBREW_FORCE_HOMEBREW_ON_LINUX`.
+
 - `HOMEBREW_SKIP_OR_LATER_BOTTLES`
   <br>If set along with `HOMEBREW_DEVELOPER`, do not use bottles from older versions of macOS. This is useful in development on new macOS versions.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2731,6 +2731,12 @@ If set, \fBbrew install\fR, \fBbrew upgrade\fR and \fBbrew reinstall\fR will nev
 If set, use Pry for the \fBbrew irb\fR command\.
 .
 .TP
+\fBHOMEBREW_SIMULATE_MACOS_ON_LINUX\fR
+.
+.br
+If set, running Homebrew on Linux will simulate certain macOS code paths\. This is useful when auditing macOS formulae while on Linux\. Implies \fBHOMEBREW_FORCE_HOMEBREW_ON_LINUX\fR\.
+.
+.TP
 \fBHOMEBREW_SKIP_OR_LATER_BOTTLES\fR
 .
 .br


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew audit` currently fails on macOS because `audit_deps` is not run on Linux and all auditing on homebrew-core is done on Linux.

This attempts to prevent that happening again by allowing the audit to run under `HOMEBREW_FORCE_HOMEBREW_ON_LINUX`.

This PR reverts 93362547c99d880e59d0e11f4127f01145ea5b1d which removed the conditional. This PR also restores a867e78f62c807b65ff4f80587d1a512252febf0 for `uses_for_macos` handling, with a fix for it not working due to the `:since` handling. In addition, I've added handling of `on_os` blocks.

To ensure this works, I've added a step to the Linux CI.

See: https://github.com/Homebrew/homebrew-core/pull/70826#issuecomment-789300223