### PR TITLE
dependency: avoid tap infinite recursion

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -91,12 +91,12 @@ class Dependency
     def expand(dependent, deps = dependent.deps, &block)
       # Keep track dependencies to avoid infinite cyclic dependency recursion.
       @expand_stack ||= []
-      @expand_stack.push dependent.name
+      @expand_stack.push dependent.full_name
 
       expanded_deps = []
 
       deps.each do |dep|
-        next if dependent.name == dep.name
+        next if dependent.full_name == dep.name
 
         case action(dependent, dep, &block)
         when :prune


### PR DESCRIPTION
For formulae in homebrew/core, `formula.name == dep.name`, but taps can use the fully qualified name for their dependencies. Change the comparison to use `full_name` which preserves behavior in core formulae but fix infinite loops in taps.

Fixes https://github.com/Homebrew/brew/issues/10550.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----