### PR TITLE
Deprecate HOMEBREW_NO_ENV_FILTERING

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -108,6 +108,8 @@ then
 
   exec /usr/bin/env -i "${FILTERED_ENV[@]}" /bin/bash "$HOMEBREW_LIBRARY/Homebrew/brew.sh" "$@"
 else
+  echo "Warning: HOMEBREW_NO_ENV_FILTERING is undocumented, deprecated and will be removed in a future Homebrew release (because it breaks many things)!" >&2
+
   # Don't need shellcheck to follow this `source`.
   # shellcheck disable=SC1090
   source "$HOMEBREW_LIBRARY/Homebrew/brew.sh"


### PR DESCRIPTION
It's undocumented so we don't need to do the full deprecation dance here but let's give people a bit of a head up.