### PR TITLE
feat(pypi-proxy): add support for proxying of PyPI with custom TLS cert

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -103,6 +103,7 @@ then
              http_proxy https_proxy ftp_proxy no_proxy all_proxy HTTPS_PROXY FTP_PROXY ALL_PROXY \
              GITHUB_ACTIONS GITHUB_WORKSPACE GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED \
              GITHUB_REPOSITORY GITHUB_RUN_ID GITHUB_SHA GITHUB_HEAD_REF GITHUB_BASE_REF GITHUB_REF \
+             PIP_CERT PIP_INDEX_URL \
              "${!HOMEBREW_@}"
   do
     # Skip if variable value is empty.


### PR DESCRIPTION
This merge request removes environment filtering for

* PIP_CERT
* PIP_INDEX_URL

so that python based formula, such as `awscli` can be installed when the end-user device is behind an inspecting proxy.

Some discussion of this particular issue was undertaken in https://github.com/Homebrew/discussions/discussions/863.

In this change I have made the simplest and smallest edit to achieve the desired outcome.  Another alternative I considered was including an option along a similar line to the unsupported `HOMEBREW_NO_ENV_FILTERING`, e.g. `HOMEBREW_USE_PIP_CONFIG` to make this an opt-in feature, and I'd be happy to implement that if that is a preferred approach.

I need to dig into the code a bit more around tests, but am submitting this for early feedback.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
