### PR TITLE
linux/keg_relocate: patchelf dependency is conditional.

### DIFF
--- a/Library/Homebrew/extend/os/linux/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/linux/keg_relocate.rb
@@ -80,7 +80,11 @@ class Keg
   end
 
   def self.relocation_formulae
-    ["patchelf"]
+    @relocation_formulae ||= if HOMEBREW_PATCHELF_RB_WRITE
+      []
+    else
+      ["patchelf"]
+    end.freeze
   end
 
   def self.bottle_dependencies


### PR DESCRIPTION
This is only needed if we're not using `patchelf.rb`.

Partial fix for https://github.com/Homebrew/brew/issues/10784