### PR TITLE
formulary: add auto-tap to def formula_name_path

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -271,6 +271,7 @@ module Formulary
     def formula_name_path(tapped_name, warn: true)
       user, repo, name = tapped_name.split("/", 3).map(&:downcase)
       @tap = Tap.fetch user, repo
+      @tap.install unless @tap.installed?
       formula_dir = @tap.formula_dir || @tap.path
       path = formula_dir/"#{name}.rb"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

add `@tap.install` to `def formula_name_path`, because I guess method in `if only != :cask` of `cli/named_args` statements should do auto-tap like`Cask::CaskLoader.load(name, config: Cask::Config.from_args(@parent))` in `if only != :formula` statements  of `cli/named_args`

related to https://github.com/Homebrew/brew/issues/10584
