### PR TITLE
Don't require HOMEBREW_DEVELOPER for _CURL_PATH & _GIT_PATH

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -369,7 +369,7 @@ then
   # The system Git on macOS versions before Sierra is too old for some Homebrew functionality we rely on.
   HOMEBREW_MINIMUM_GIT_VERSION="2.14.3"
   if [[ "$HOMEBREW_MACOS_VERSION_NUMERIC" -lt "101200" &&
-     -z "$HOMEBREW_GIT_PATH ]]
+     -z "$HOMEBREW_GIT_PATH" ]]
   then
     HOMEBREW_FORCE_BREWED_GIT="1"
   fi

--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -287,7 +287,7 @@ if [[ -n "$HOMEBREW_FORCE_BREWED_CURL" &&
          "$HOMEBREW_PREFIX/opt/curl/bin/curl" --version >/dev/null
 then
   HOMEBREW_CURL="$HOMEBREW_PREFIX/opt/curl/bin/curl"
-elif [[ -n "$HOMEBREW_DEVELOPER" && -x "$HOMEBREW_CURL_PATH" ]]
+elif [[ -x "$HOMEBREW_CURL_PATH" ]]
 then
   HOMEBREW_CURL="$HOMEBREW_CURL_PATH"
 else
@@ -299,7 +299,7 @@ if [[ -n "$HOMEBREW_FORCE_BREWED_GIT" &&
          "$HOMEBREW_PREFIX/opt/git/bin/git" --version >/dev/null
 then
   HOMEBREW_GIT="$HOMEBREW_PREFIX/opt/git/bin/git"
-elif [[ -n "$HOMEBREW_DEVELOPER" && -x "$HOMEBREW_GIT_PATH" ]]
+elif [[ -x "$HOMEBREW_GIT_PATH" ]]
 then
   HOMEBREW_GIT="$HOMEBREW_GIT_PATH"
 else

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -96,6 +96,10 @@ module Homebrew
                       "Linux: `https://github.com/Homebrew/linuxbrew-core`.",
         default:      HOMEBREW_CORE_DEFAULT_GIT_REMOTE,
       },
+      HOMEBREW_CURL_PATH:                     {
+        description: "Use this executable when invoking `curl`(1).",
+        default:     "curl",
+      },
       HOMEBREW_CURLRC:                        {
         description: "If set, do not pass `--disable` when invoking `curl`(1), which disables the " \
                      "use of `curlrc`.",
@@ -177,6 +181,10 @@ module Homebrew
       },
       HOMEBREW_GIT_NAME:                      {
         description: "Set the Git author and committer name to this value.",
+      },
+      HOMEBREW_GIT_PATH:                      {
+        description: "Use this executable when invoking `git`(1).",
+        default:     "git",
       },
       HOMEBREW_INSTALL_BADGE:                 {
         description:  "Print this text before the installation summary of each successful build.",

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1772,6 +1772,11 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
   *Default:* macOS: `https://github.com/Homebrew/homebrew-core`, Linux: `https://github.com/Homebrew/linuxbrew-core`.
 
+- `HOMEBREW_CURL_PATH`
+  <br>Use this executable when invoking `curl`(1).
+
+  *Default:* `curl`.
+
 - `HOMEBREW_CURLRC`
   <br>If set, do not pass `--disable` when invoking `curl`(1), which disables the use of `curlrc`.
 
@@ -1834,6 +1839,11 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 
 - `HOMEBREW_GIT_NAME`
   <br>Set the Git author and committer name to this value.
+
+- `HOMEBREW_GIT_PATH`
+  <br>Use this executable when invoking `git`(1).
+
+  *Default:* `git`.
 
 - `HOMEBREW_INSTALL_BADGE`
   <br>Print this text before the installation summary of each successful build.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2494,6 +2494,15 @@ Use this URL as the Homebrew/homebrew\-core \fBgit\fR(1) remote\.
 \fIDefault:\fR macOS: \fBhttps://github\.com/Homebrew/homebrew\-core\fR, Linux: \fBhttps://github\.com/Homebrew/linuxbrew\-core\fR\.
 .
 .TP
+\fBHOMEBREW_CURL_PATH\fR
+.
+.br
+Use this executable when invoking \fBcurl\fR(1)\.
+.
+.IP
+\fIDefault:\fR \fBcurl\fR\.
+.
+.TP
 \fBHOMEBREW_CURLRC\fR
 .
 .br
@@ -2612,6 +2621,15 @@ Set the Git author and committer email to this value\.
 .
 .br
 Set the Git author and committer name to this value\.
+.
+.TP
+\fBHOMEBREW_GIT_PATH\fR
+.
+.br
+Use this executable when invoking \fBgit\fR(1)\.
+.
+.IP
+\fIDefault:\fR \fBgit\fR\.
 .
 .TP
 \fBHOMEBREW_INSTALL_BADGE\fR


### PR DESCRIPTION
These environment variables allow the use of good system curl & git in non-standard locations, which is especially useful for bootstrapping a brew install. This allows their use without opening the whole can of worms behind `HOMEBREW_DEVELOPER`.
Suggested by @Bo98 (https://github.com/Homebrew/brew/issues/10776#issuecomment-791835940).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
