### PR TITLE
--prefix: shortlist only formulae

### DIFF
--- a/Library/Homebrew/prefix.sh
+++ b/Library/Homebrew/prefix.sh
@@ -17,10 +17,13 @@ homebrew-prefix() {
   [ -z "$formula" ] && echo "$HOMEBREW_PREFIX" && return 0
 
   local formula_path
-  if [ -f "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core/${formula}.rb" ]; then
-    formula_path="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core/${formula}.rb"
+  if [ -f "$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core/Formula/${formula}.rb" ]; then
+    formula_path="$HOMEBREW_REPOSITORY/Library/Taps/homebrew/homebrew-core/Formula/${formula}.rb"
   else
-    formula_path="$(find "$HOMEBREW_REPOSITORY/Library/Taps" -name "${formula}.rb" -print -quit)"
+    formula_path="$(
+      shopt -s nullglob
+      echo "$HOMEBREW_REPOSITORY/Library/Taps"/*/*/{Formula/,HomebrewFormula/,}"${formula}.rb"
+    )"
   fi
   [ -z "$formula_path" ] && return 1
 

--- a/Library/Homebrew/test/cmd/--prefix_spec.rb
+++ b/Library/Homebrew/test/cmd/--prefix_spec.rb
@@ -21,7 +21,7 @@ describe "brew --prefix" do
   end
 
   it "errors if the given Formula doesn't exist", :integration_test do
-    expect { brew "--prefix", "--installed", "nonexistent" }
+    expect { brew "--prefix", "nonexistent" }
       .to output(/No available formula/).to_stderr
       .and not_to_output.to_stdout
       .and be_a_failure


### PR DESCRIPTION
`find` should eliminate all `<formula>.rb` that are in a `Casks` directory. Fixes #10799.

Also fixes core formula shortcut path (missing a `Formula` path component).

Also fixes existing test ("errors if the given Formula doesn't exist" should _not_ pass `--installed`).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally? _(only shell script changes)_
- [x] Have you successfully run `brew tests` with your changes locally?
