### PR TITLE
-Library/Homebrew/shims/mac/super/sed: causes more problems than what it purports to fix

### DIFF
--- a/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/os/mac/extend/ENV/super.rb
@@ -98,8 +98,6 @@ module Superenv
 
   def determine_cccfg
     s = +""
-    # Fix issue with sed barfing on unicode characters on Mountain Lion
-    s << "s"
     # Fix issue with >= Mountain Lion apr-1-config having broken paths
     s << "a"
     s.freeze

--- a/Library/Homebrew/shims/mac/super/sed
+++ b/Library/Homebrew/shims/mac/super/sed
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ "$HOMEBREW_CCCFG" = *s* ]]
-then
-  # Fix issue with sed barfing on unicode characters on Mountain Lion
-  unset LC_ALL
-  export LC_CTYPE="C"
-fi
-exec /usr/bin/sed "$@"


### PR DESCRIPTION
Mountain Lion isn't even supported by Homebrew anymore.

This shim hails back to Homebrew/legacy-homebrew#13787 @MikeMcQuaid

This gets picked up by `configure` scripts (which is fine during builds),
but occasionally gets [baked into binaries][fixincl], triggering:

    Error: Files were found with references to the Homebrew shims directory.

This in turn causes tap maintainers to just override `SED=/usr/bin/sed` for
`configure`, which doesn't always work properly: osx-cross/homebrew-avr#230

Other instances:

 * https://stackoverflow.com/questions/40357246/usr-local-library-homebrew-shims-super-sed-no-such-file-or-directory
 * https://github.com/laruence/yaconf/issues/17
 * https://github.com/Amar1729/homebrew-formulae/issues/1
 * https://blog.logical-dice.com/articles/wp/295

[fixincl]: https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=fixincludes/fixincl.tpl;h=3d70cabc7fd6dd0e63033e6523fac1dca01b285a;hb=HEAD#l42

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] ~~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~~
- [ ] ~~Have you successfully run `brew style` with your changes locally?~~
- [ ] ~~Have you successfully run `brew typecheck` with your changes locally?~~
- [ ] ~~Have you successfully run `brew tests` with your changes locally?~~

-----
