### PR TITLE
rubocops: Permit uses_from_macos "cyrus-sasl"

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -15,6 +15,7 @@ module RuboCop
           bzip2
           cups
           curl
+          cyrus-sasl
           dyld-headers
           ed
           expat


### PR DESCRIPTION
macOS provides `/usr/lib/libsasl2.dylib`

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

macOS Catalina 10.15 provides `/usr/lib/libsasl2.dylib`. I have not checked other versions of macOS.
See the companion PR https://github.com/Homebrew/homebrew-core/pull/72759 `cyrus-sasl 2.1.27 (new formula)`
