### PR TITLE
Allow overriding environment variables defined with write_env_script

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -392,7 +392,7 @@ class Pathname
       args = nil
     end
     env_export = +""
-    env.each { |key, value| env_export << "#{key}=\"#{value}\" " }
+    env.each { |key, value| env_export << "#{key}=${#{key}-'#{value}'} " }
     dirname.mkpath
     write <<~SH
       #!/bin/bash


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Use Bash's [Parameter Substitution](https://tldp.org/LDP/abs/html/parameter-substitution.html) feature (`${parameter-default}`) we can allow users to override the environment variables defined with `write_env_script`.

This is useful but potentially breaking, so nix's [`makeWrapper`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/make-wrapper.sh) makes a good example, which offers a variety of options. This PR mimics the `--set-default` option (*only adds VAR if not already set in the environment*) which IMO is a sane default. But more options could be implemented if needed.