### PR TITLE
python: handle PEP 517-based build backends

### DIFF
--- a/Library/Homebrew/language/python.rb
+++ b/Library/Homebrew/language/python.rb
@@ -188,17 +188,13 @@ module Language
         passed_build_tools = !build_tools.nil?
 
         resources.each do |r|
-          next if r.name.start_with? "homebrew-pep517-build-"
+          next if r.pep517_build_targets.any?
 
-          unless passed_build_tools
-            build_tools = resources.select { |dep| dep.name.start_with? "homebrew-pep517-build-#{r.name}-" }
-          end
+          build_tools = resources.select { |dep| dep.pep517_build_targets.include? r.name } unless passed_build_tools
           venv.pip_install r, { using: python, build_with: build_tools }
         end
 
-        unless passed_build_tools
-          build_tools = resources.select { |dep| dep.name.start_with? "homebrew-pep517-build-formula-" }
-        end
+        build_tools = resources.select { |dep| dep.pep517_build_targets.include? :formula } unless passed_build_tools
         venv.pip_install_and_link buildpath, { using: python, build_with: build_tools }
 
         venv

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -19,7 +19,7 @@ class Resource
   include FileUtils
   include OnOS
 
-  attr_reader :mirrors, :specs, :using, :source_modified_time, :patches, :owner
+  attr_reader :mirrors, :specs, :using, :source_modified_time, :patches, :pep517_build_targets, :owner
   attr_writer :version
   attr_accessor :download_strategy, :checksum
 
@@ -36,6 +36,7 @@ class Resource
     @checksum = nil
     @using = nil
     @patches = []
+    @pep517_build_targets = []
     instance_eval(&block) if block
   end
 
@@ -174,6 +175,10 @@ class Resource
     @specs.merge!(specs)
     @using = @specs.delete(:using)
     @download_strategy = DownloadStrategyDetector.detect(url, using)
+  end
+
+  def pep517_build(targets)
+    @pep517_build_targets = Array(targets)
   end
 
   def version(val = nil)

--- a/Library/Homebrew/test/language/python/virtualenv_spec.rb
+++ b/Library/Homebrew/test/language/python/virtualenv_spec.rb
@@ -23,16 +23,16 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
   describe "#pip_install" do
     it "accepts a string" do
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo")
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-index",
+              "--no-binary", ":all:", "--no-build-isolation", "--ignore-installed", "foo")
         .and_return(true)
       virtualenv.pip_install "foo"
     end
 
     it "accepts a multi-line strings" do
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo", "bar")
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-index",
+              "--no-binary", ":all:", "--no-build-isolation", "--ignore-installed", "foo", "bar")
         .and_return(true)
 
       virtualenv.pip_install <<~EOS
@@ -43,13 +43,13 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
     it "accepts an array" do
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "foo")
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-index",
+              "--no-binary", ":all:", "--no-build-isolation", "--ignore-installed", "foo")
         .and_return(true)
 
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", "bar")
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-index",
+              "--no-binary", ":all:", "--no-build-isolation", "--ignore-installed", "bar")
         .and_return(true)
 
       virtualenv.pip_install ["foo", "bar"]
@@ -60,8 +60,8 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
 
       expect(res).to receive(:stage).and_yield
       expect(formula).to receive(:system)
-        .with(dir/"bin/pip", "install", "-v", "--no-deps",
-              "--no-binary", ":all:", "--ignore-installed", Pathname.pwd)
+        .with(dir/"bin/pip", "install", "-v", "--no-deps", "--no-index",
+              "--no-binary", ":all:", "--no-build-isolation", "--ignore-installed", Pathname.pwd)
         .and_return(true)
 
       virtualenv.pip_install res
@@ -83,7 +83,7 @@ describe Language::Python::Virtualenv::Virtualenv, :needs_python do
       FileUtils.touch src_bin/"kilroy"
       bin_after = Dir.glob(src_bin/"*")
 
-      expect(virtualenv).to receive(:pip_install).with("foo")
+      expect(virtualenv).to receive(:pip_install).with("foo", {})
       expect(Dir).to receive(:[]).with(src_bin/"*").twice.and_return(bin_before, bin_after)
 
       virtualenv.pip_install_and_link "foo"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

### Rationale

Currently, there are some Python packages that use the [Poetry](https://python-poetry.org/) tool/ecosystem to build. Poetry conforms to [PEP 517/518](https://grassfedcode.medium.com/pep-517-and-518-in-plain-english-47208ca8b7a6), which basically allows for `pip` to install Poetry-generated packages as well as the older, more conventional `setuptools`-based packages.

The installation flows for Poetry-based packages look something like this:
- If user is installing from wheel (binary/compiled), download/install the prebuilt `.whl` file. No Poetry installation is needed, because Poetry has already packaged the built package into the standardized wheel format (as defined by [PEP 491](https://www.python.org/dev/peps/pep-0491/)).
- If user is installing from sdist (**s**ource **d**istribution), which is the format that Homebrew tends to prefer, `pip` will delegate build actions to Poetry by downloading and invoking `poetry-core`, Poetry's PEP 517-compliant build backend. From what I can tell, this download of `poetry-core` is not pinned to a particular version - it seems to just pull the latest version from PyPI (although I would expect some form of checksumming to be occurring there). In any case, it doesn't seem possible to convince `pip` to use a vendored copy of `poetry-core`, not to mention it seems to be difficult to determine what version of `poetry-core` would even get pulled at a given time.

Currently, we have a handful of formulae that depend on packages that use Poetry as a build tool. For instance, `richmd`, `name-that-hash`, `ansible-lint`, and `molecule` all pull in `rich`, which uses Poetry. When we `virtualenv_install_with_resources` or `venv.pip_install` the `rich` resource in each of these formulae, we're actually performing an unversioned download of the `poetry-core` component in this build process. I imagine that this is unlikely to _really_ break between builds, but it is still nonetheless an unversioned resource that is unaccounted for.

`rich` is also not the only package that this applies to. `flatten-dict` (used in `dvc`) is another one, for instance. Because `pip` will happily chug a Poetry-based sdist and install it (with the aforementioned caveats), the easiest way to see if a package is affected is to check the source repository and see if `pyproject.toml` is present and indicates Poetry usage or if `poetry.lock` is present, or to look through the (very verbose) `pip` install logs for instances of `poetry-core`.

### Proposed resolution

With this pull request, we instead opt to follow the first of the two installation flows listed above. We already ship Poetry in Homebrew, so where needed, declare `poetry` as a build-time dependency, and then use Poetry to build a wheel (this process does _not_ download the `poetry-core` resource). We can then use `pip` to install the newly built wheel archive, which also does not invoke the need for `poetry-core`.

With this approach, the build-time dependency on Poetry becomes _explicit_, rather than _implicit_, and results in no unversioned downloads.

### Example
Here's an example of what our `venv.pip_install` looks like with the `rich` package with the current vs new (proposed) installation methods within the `richmd` formula:
<details>
<summary>Current output of building the rich package (1,783 files, 19.9MB, 34 seconds)</summary>
<pre>
==> /usr/local/Cellar/richmd/9.13.0/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/richmd-20210308-350-1tl714q/rich-9.13.0
Using pip 21.0.1 from /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip (python 3.9)
Non-user install because user site-packages disabled
Created temporary directory: /private/tmp/pip-ephem-wheel-cache-_yhhhb_n
Created temporary directory: /private/tmp/pip-req-tracker-u83ykbzs
Initialized build tracking at /private/tmp/pip-req-tracker-u83ykbzs
Created build tracker: /private/tmp/pip-req-tracker-u83ykbzs
Entered build tracker: /private/tmp/pip-req-tracker-u83ykbzs
Created temporary directory: /private/tmp/pip-install-pua3vzue
Processing /private/tmp/richmd-20210308-350-1tl714q/rich-9.13.0
  Created temporary directory: /private/tmp/pip-req-build-sohmk_5y
  Added file:///private/tmp/richmd-20210308-350-1tl714q/rich-9.13.0 to build tracker '/private/tmp/pip-req-tracker-u83ykbzs'
  Created temporary directory: /private/tmp/pip-build-env-_6z4mciq
  Installing build dependencies: started
  Running command /usr/local/Cellar/richmd/9.13.0/libexec/bin/python3.9 /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip install --ignore-installed --no-user --prefix /private/tmp/pip-build-env-_6z4mciq/overlay --no-warn-script-location -v --no-binary :all: --only-binary :none: -i https://pypi.org/simple -- 'poetry-core>=1.0.0'
  Using pip 21.0.1 from /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip (python 3.9)
  Non-user install by explicit request
  Created temporary directory: /private/tmp/pip-ephem-wheel-cache-q_hsy7jn
  Created build tracker: /private/tmp/pip-req-tracker-u83ykbzs
  Entered build tracker: /private/tmp/pip-req-tracker-u83ykbzs
  Created temporary directory: /private/tmp/pip-install-pp5fwdj0
  1 location(s) to search for versions of poetry-core:
  * https://pypi.org/simple/poetry-core/
  Fetching project page and analyzing links: https://pypi.org/simple/poetry-core/
  Getting page https://pypi.org/simple/poetry-core/
  Found index url https://pypi.org/simple
  Looking up "https://pypi.org/simple/poetry-core/" in the cache
  Request header has "max_age" as 0, cache bypassed
  Starting new HTTPS connection (1): pypi.org:443
  https://pypi.org:443 "GET /simple/poetry-core/ HTTP/1.1" 200 3425
  Updating cache with response from "https://pypi.org/simple/poetry-core/"
  Caching due to etag
    Found link https://files.pythonhosted.org/packages/a5/6a/ae017843c144c627b37c125134ab32fd1287fcb2bc95793cd00af2c584af/poetry-core-1.0.0a0.tar.gz#sha256=361a8cdcb833c14c0e754fe12ccf0f23a1c8b6261095279d9272a759e8935396 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*), version: 1.0.0a0
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/65/9d/2c3285421474412a0b16048b6405cf45615bb8c2437bba2e99f20801a2cc/poetry_core-1.0.0a0-py2.py3-none-any.whl#sha256=8161315a5ae9984af7ffe1004644a462ffbbc9736d2890f40345ddb857e732a1 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*)
    Found link https://files.pythonhosted.org/packages/b9/9d/ee3b9c3ca4e15562bf3bc383d64ab1a11c6434c187ca6c951c3327f72c51/poetry-core-1.0.0a1.tar.gz#sha256=8baeb2d9980091bf8e4375c0f6a87e19a8d56083bdfb5a3875a7bd57befc257e (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*), version: 1.0.0a1
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/50/a6/ede2185e777bbce89530c3f1c7f5ef155eb8510fa8655af77a1763de72b2/poetry_core-1.0.0a1-py2.py3-none-any.whl#sha256=ed6c10cd45b91281e535f6ae5d223d9347278ef847805307615b32269693eb73 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*)
    Found link https://files.pythonhosted.org/packages/17/c6/05e0e09b564178dd7b81821dd5448d9d366f6dccccd28c2dfe5cda7c8183/poetry-core-1.0.0a2.tar.gz#sha256=7ca384da50b14cf163f6cf04d3b0900bdb32aefa04b13652a49551090722f188 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a2
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/b2/f8/aa9dbbd5cab341ac91aa13dea969732f15f02b0e5f963c339f0629147215/poetry_core-1.0.0a2-py2.py3-none-any.whl#sha256=e742467689173a282d9f83d35a72f7e42ac5543cb6ad55130aebbc4e314c8302 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/7d/38/bbc4ecee9c0cf121d7354733e2778d708fc30da48395e20069f2487333bc/poetry-core-1.0.0a3.tar.gz#sha256=02d1bfed4a53dbe8570c6bc94164d7a5e1b01630f74174f03bc932e8b334be5a (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a3
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/1c/bc/905daad562b9b6114044f156188f965e1f3ffa8e8486bef7633482657457/poetry_core-1.0.0a3-py2.py3-none-any.whl#sha256=2351a1e3a8e18414236f1c7db31c0c7d19bd240c27b5540abf9d81156a10da4c (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/cc/7a/8103474ff3820db01120cfc4a7ee3e4c69620703b6c92939783f8d99a0ef/poetry-core-1.0.0a4.tar.gz#sha256=a95aa0454b539ca6f98056aac5743de273762161aaf2db68152b8510de6849f1 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a4
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/3e/b4/57fa9a5a7723814045dd6869b4c2865001b62b0ecaa80c5fe721d8e94416/poetry_core-1.0.0a4-py2.py3-none-any.whl#sha256=2c6b7be852f9eb772823fcff8a0a912b49cbe57c6dfe26f17799df65eccee8b8 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/b7/70/5c287bd1e7c8c86a318755514e02c6d431335de541c43eef65d0fb5af955/poetry-core-1.0.0a5.tar.gz#sha256=afac65874baf2030328f43df840cec2b5a17bcdad0a04c55b0f830e444ef1120 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a5
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/a3/15/e4992c1fd66765a47b267f3d390e67066ff16764d419101dc9af7cb0d6a6/poetry_core-1.0.0a5-py2.py3-none-any.whl#sha256=ffbd0512d80affce937ce53db2d35bf28ea52d287bae61da5b5d63058618d6b9 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/7b/c9/f6acb3b355be9cebb7c9e40c5db24f1da6592fe16754de0472c8659cef77/poetry-core-1.0.0a6.tar.gz#sha256=965869ce488869e473f5afb96e6155724fce9ce8ed2ef71c7e47a900c6159ea8 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a6
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/37/07/1c188d7ea2c91a5e792dde29aa6d931e84a44f4f5cf06342ab85d5cead94/poetry_core-1.0.0a6-py2.py3-none-any.whl#sha256=440d3b43b64db47c2c348f784f770a1cbc83ae0aacb4f66d9f2f82b35366303f (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/45/1d/34f0f441d48bece9c92488977ce4aa72f464e79bb8e9c8f454976864bcaf/poetry-core-1.0.0a7.tar.gz#sha256=f627d32e0c78e7219e0f3b040f3a2a6a6eb9074e0cc04f8d0fec13f258013929 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a7
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/a9/f4/b65a655c632e11ffdd156beb2965cd0876d01317c0a589fdbd519d015932/poetry_core-1.0.0a7-py2.py3-none-any.whl#sha256=ccaf834e5e015452fa637781c0125c24458dc66eb7af2db88a6d3cba1c42f6e0 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/1b/47/3f770be8226e0e34d40dbe42e19076c793194ea936163c9fb1c79e9510f5/poetry-core-1.0.0a8.tar.gz#sha256=02237e5abaa4fda4ef865cc49111a3f8a7999cfb149b30d5e93f85c3acdc4d95 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a8
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/43/68/084aa9085f903b19ea85f1993035998cb78ebdb244648a097b39b6c37755/poetry_core-1.0.0a8-py2.py3-none-any.whl#sha256=d7d9e702fbae06c05abb1ada63678e940d746b2696f4601b951b27ac7c2c5337 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/90/cd/b65ab6b3a3a44a474f43a7906f31a1b159ffa63bebd7125ed1f91c06c5e4/poetry-core-1.0.0a9.tar.gz#sha256=f08e9829fd06609ca5615faa91739b589eb71e025a6aaf7ddffb698676eb7c8c (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0a9
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/6f/d3/dd3d7c608d495b3f2a5f0dd40c2901e6c1d6aceba6e3f3131147f9259b3e/poetry_core-1.0.0a9-py2.py3-none-any.whl#sha256=79a63629ae44533ba9aa828e0eff0002c61b3af5fc9bec212e006cc643f4eb19 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/dc/c9/d0a648ca07e20810d889f33d0ea3ddc7ef610f42510305dc484a00425ed0/poetry-core-1.0.0b1.tar.gz#sha256=c7a64770780f6a4998eee1e260fc3b7e22fa1c9b94b05c0faa13aa512f95eaa1 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0b1
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/db/81/6447beb70ca2ab3274046b1276b6301782392cd39e0e946dc4d08f7f8c3b/poetry_core-1.0.0b1-py2.py3-none-any.whl#sha256=92d2a33c27c733e746425c6506fdf583909e3ce5de4591deb23a4efb13f1a72c (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/90/2c/b440db634995f35cf7430b6a6c030ac629858e7620edb28992e89a08ec53/poetry-core-1.0.0rc1.tar.gz#sha256=aad65fe96586f741afe582590912ad8e82823671c46c2550a8f9dc74cd4f769d (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0rc1
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/5a/98/47251b64c62f949ece8f5e6b6086a4cc591df364ca2fdbc80d96e7b7b271/poetry_core-1.0.0rc1-py2.py3-none-any.whl#sha256=f63476c92d4d6205ea4fd28a9a9496a465ad15f573ce974dd3ef3a7807c4a919 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/10/dd/21b1c5e89504bfa746b58cdecaeae3cf423f438f690706b3ea3a68f562bf/poetry-core-1.0.0rc2.tar.gz#sha256=abbe4059433e6d51aff024986b19919319e084592203f17e5354e7c0a7dee6f4 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0rc2
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/32/67/9906f8cd22b09d17aa1d5998e7284ecb4099a7886734d65febf4561538df/poetry_core-1.0.0rc2-py2.py3-none-any.whl#sha256=f536d59ee0be81f7c689a1a30e9894cb24abeb23f4ff4e2130583fca9863272d (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/a0/90/93840d54683cd7f407fc83cb5a998e4d758cf53b879e59689db292785a7c/poetry-core-1.0.0rc3.tar.gz#sha256=0e3d23a4c5acc14c5f1703b12645692bf24461c8c8e3fff32ca80a5462beccdf (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0rc3
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/89/ef/5170513520199fef278f3dfe110f1ddb6607103453c7f1db2543dbc4f9d8/poetry_core-1.0.0rc3-py2.py3-none-any.whl#sha256=2c9ee2b3f7b40047bafdc2239fbb9de73637edc07a9697a3a66ac15fe6b040f5 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/42/21/5335c7eceff3dccb3b415018bb17db0c442b599f610fd5712021d5f9403f/poetry-core-1.0.0.tar.gz#sha256=6a664ff389b9f45382536f8fa1611a0cb4d2de7c5a5c885db1f0c600cd11fbd5 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.0
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/4f/c1/2222bcb8040b32c2119bb70ac59711fd916f6f029d598439a2fecaab9b55/poetry_core-1.0.0-py2.py3-none-any.whl#sha256=769288e0e1b88dfcceb3185728f0b7388b26d5f93d6c22d2dcae372da51d200d (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/26/b8/8156fb0992cc8cbde9d3ad74c467aa8ab454a7fc6a34f701255b57c7b5da/poetry-core-1.0.1.tar.gz#sha256=a54bbb12c445b266eee0faf5d38f09dae9860cffa32ad7d99c7b345c94fb6f7b (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.1
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/ba/21/4b0a3fa8f42518c885955c924dcca6eeb7b8ebbc30b71c5ff00b0abe090b/poetry_core-1.0.1-py2.py3-none-any.whl#sha256=94db888849966730a12111a2530548b01b0c22720b69d5561648af8de6a3ea5f (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
    Found link https://files.pythonhosted.org/packages/d7/5a/58944c8905bb2519ae58cfab0a663fdfd88c692a6bdc51cc99416cd2f9e8/poetry-core-1.0.2.tar.gz#sha256=ff505d656a6cf40ffbf84393d8b5bf37b78523a15def3ac473b6fad74261ee71 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*), version: 1.0.2
    Skipping link: No binaries permitted for poetry-core: https://files.pythonhosted.org/packages/a0/56/d7923fb39395c662bab9e6044e290458a77204ea3cafc3b1ea88e27b8f4c/poetry_core-1.0.2-py2.py3-none-any.whl#sha256=ee0ed4164440eeab27d1b01bc7b9b3afdc3124f68d4ea28d0821a402a9c7c044 (from https://pypi.org/simple/poetry-core/) (requires-python:>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*)
  Given no hashes to check 3 links for project 'poetry-core': discarding no candidates
  Collecting poetry-core>=1.0.0
    Created temporary directory: /private/tmp/pip-unpack-8mak3f3s
    Looking up "https://files.pythonhosted.org/packages/d7/5a/58944c8905bb2519ae58cfab0a663fdfd88c692a6bdc51cc99416cd2f9e8/poetry-core-1.0.2.tar.gz" in the cache
    No cache entry available
    Starting new HTTPS connection (1): files.pythonhosted.org:443
    https://files.pythonhosted.org:443 "GET /packages/d7/5a/58944c8905bb2519ae58cfab0a663fdfd88c692a6bdc51cc99416cd2f9e8/poetry-core-1.0.2.tar.gz HTTP/1.1" 200 345730
    Downloading poetry-core-1.0.2.tar.gz (345 kB)
    Ignoring unknown cache-control directive: immutable
    Updating cache with response from "https://files.pythonhosted.org/packages/d7/5a/58944c8905bb2519ae58cfab0a663fdfd88c692a6bdc51cc99416cd2f9e8/poetry-core-1.0.2.tar.gz"
    Caching due to etag
    Added poetry-core>=1.0.0 from https://files.pythonhosted.org/packages/d7/5a/58944c8905bb2519ae58cfab0a663fdfd88c692a6bdc51cc99416cd2f9e8/poetry-core-1.0.2.tar.gz#sha256=ff505d656a6cf40ffbf84393d8b5bf37b78523a15def3ac473b6fad74261ee71 to build tracker '/private/tmp/pip-req-tracker-u83ykbzs'
    Created temporary directory: /private/tmp/pip-build-env-x3yiiuf5
    Getting requirements to build wheel: started
    Running command /usr/local/Cellar/richmd/9.13.0/libexec/bin/python3.9 /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /private/tmp/tmplnu_q1xy
    Getting requirements to build wheel: finished with status 'done'
      Created temporary directory: /private/tmp/pip-modern-metadata-hxg3a5_0
      Preparing wheel metadata: started
      Running command /usr/local/Cellar/richmd/9.13.0/libexec/bin/python3.9 /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /private/tmp/tmp1laux0a3
      Preparing wheel metadata: finished with status 'done'
    Source in /private/tmp/pip-install-pp5fwdj0/poetry-core_0a359ead662140578647217ceb73329f has version 1.0.2, which satisfies requirement poetry-core>=1.0.0 from https://files.pythonhosted.org/packages/d7/5a/58944c8905bb2519ae58cfab0a663fdfd88c692a6bdc51cc99416cd2f9e8/poetry-core-1.0.2.tar.gz#sha256=ff505d656a6cf40ffbf84393d8b5bf37b78523a15def3ac473b6fad74261ee71
    Removed poetry-core>=1.0.0 from https://files.pythonhosted.org/packages/d7/5a/58944c8905bb2519ae58cfab0a663fdfd88c692a6bdc51cc99416cd2f9e8/poetry-core-1.0.2.tar.gz#sha256=ff505d656a6cf40ffbf84393d8b5bf37b78523a15def3ac473b6fad74261ee71 from build tracker '/private/tmp/pip-req-tracker-u83ykbzs'
  Created temporary directory: /private/tmp/pip-unpack-sbsvahgx
  Building wheels for collected packages: poetry-core
    Created temporary directory: /private/tmp/pip-wheel-8ddnpcg7
    Destination directory: /private/tmp/pip-wheel-8ddnpcg7
    Building wheel for poetry-core (PEP 517): started
    Running command /usr/local/Cellar/richmd/9.13.0/libexec/bin/python3.9 /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /private/tmp/tmp90ibjsop
    Building wheel for poetry-core (PEP 517): finished with status 'done'
    Created wheel for poetry-core: filename=poetry_core-1.0.2-py2.py3-none-any.whl size=424275 sha256=8624ce59f5ef6cd421e5f38003087990f460672ec68514e5200929fe55dba95d
    Stored in directory: /private/tmp/richmd-20210308-350-1tl714q/rich-9.13.0/.brew_home/Library/Caches/pip/wheels/ea/cc/41/af346500a768a43cb45e87ce19da9020a6d77f7828079b9e49
  Successfully built poetry-core
  Installing collected packages: poetry-core

  Successfully installed poetry-core-1.0.2
  Removed build tracker: '/private/tmp/pip-req-tracker-u83ykbzs'
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Running command /usr/local/Cellar/richmd/9.13.0/libexec/bin/python3.9 /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /private/tmp/tmpzyrayhqp
  Getting requirements to build wheel: finished with status 'done'
    Created temporary directory: /private/tmp/pip-modern-metadata-uprq4xvk
    Preparing wheel metadata: started
    Running command /usr/local/Cellar/richmd/9.13.0/libexec/bin/python3.9 /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /private/tmp/tmpdj8aotgu
    Preparing wheel metadata: finished with status 'done'
  Source in /private/tmp/pip-req-build-sohmk_5y has version 9.13.0, which satisfies requirement rich==9.13.0 from file:///private/tmp/richmd-20210308-350-1tl714q/rich-9.13.0
  Removed rich==9.13.0 from file:///private/tmp/richmd-20210308-350-1tl714q/rich-9.13.0 from build tracker '/private/tmp/pip-req-tracker-u83ykbzs'
Created temporary directory: /private/tmp/pip-unpack-37mqbzra
Building wheels for collected packages: rich
  Created temporary directory: /private/tmp/pip-wheel-hvi51oae
  Destination directory: /private/tmp/pip-wheel-hvi51oae
  Building wheel for rich (PEP 517): started
  Running command /usr/local/Cellar/richmd/9.13.0/libexec/bin/python3.9 /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /private/tmp/tmp26ysa018
  Building wheel for rich (PEP 517): finished with status 'done'
  Created wheel for rich: filename=rich-9.13.0-py3-none-any.whl size=197269 sha256=8c28c91c3982f487ecedcbab1317f0cc7f1e8a6ed1f43a56d677d3015b253cef
  Stored in directory: /private/tmp/richmd-20210308-350-1tl714q/rich-9.13.0/.brew_home/Library/Caches/pip/wheels/db/bc/37/b922936e742b6b094909ca4837a62e7e76e6edff0bc899e3c5
Successfully built rich
Installing collected packages: rich

Successfully installed rich-9.13.0
Removed build tracker: '/private/tmp/pip-req-tracker-u83ykbzs'
</pre>
</details>

<details>
<summary>New output of building the rich package (1,783 files, 19.9MB, 30 seconds)</summary>
<pre>
==> /usr/local/opt/poetry/bin/poetry build -vvv --format wheel
Creating virtualenv rich-e42lqf7a-py3.9 in /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/.brew_home/Library/Caches/pypoetry/virtualenvs
Using virtualenv: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/.brew_home/Library/Caches/pypoetry/virtualenvs/rich-e42lqf7a-py3.9
Building rich (9.13.0)
  - Building wheel
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/__init__.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/__main__.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_cell_widths.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_emoji_codes.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_emoji_replace.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_inspect.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_log_render.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_loop.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_lru_cache.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_palettes.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_pick.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_ratio.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_spinners.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_stack.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_timer.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_windows.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/_wrap.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/abc.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/align.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/ansi.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/bar.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/box.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/cells.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/color.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/color_triplet.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/columns.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/console.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/constrain.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/containers.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/control.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/default_styles.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/diagnose.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/emoji.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/errors.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/file_proxy.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/filesize.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/highlighter.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/jupyter.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/layout.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/live.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/live_render.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/logging.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/markdown.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/markup.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/measure.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/padding.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/pager.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/palette.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/panel.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/pretty.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/progress.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/progress_bar.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/prompt.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/protocol.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/py.typed
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/rule.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/scope.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/screen.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/segment.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/spinner.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/status.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/style.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/styled.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/syntax.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/table.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/tabulate.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/terminal_theme.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/text.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/theme.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/themes.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/traceback.py
  - Adding: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/rich/tree.py
Skipping: /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/COPYING
  - Built rich-9.13.0-py3-none-any.whl
==> /usr/local/Cellar/richmd/9.13.0/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/dist/rich-9.13.0-py3-none-any.whl
Using pip 21.0.1 from /usr/local/Cellar/richmd/9.13.0/libexec/lib/python3.9/site-packages/pip (python 3.9)
Non-user install because user site-packages disabled
Created temporary directory: /private/tmp/pip-ephem-wheel-cache-dzsczv3n
Created temporary directory: /private/tmp/pip-req-tracker-0xk4_r_b
Initialized build tracking at /private/tmp/pip-req-tracker-0xk4_r_b
Created build tracker: /private/tmp/pip-req-tracker-0xk4_r_b
Entered build tracker: /private/tmp/pip-req-tracker-0xk4_r_b
Created temporary directory: /private/tmp/pip-install-fa7v0m7b
Processing ./dist/rich-9.13.0-py3-none-any.whl
  Added rich==9.13.0 from file:///private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/dist/rich-9.13.0-py3-none-any.whl to build tracker '/private/tmp/pip-req-tracker-0xk4_r_b'
  Removed rich==9.13.0 from file:///private/tmp/richmd-20210308-97926-l6pumw/rich-9.13.0/dist/rich-9.13.0-py3-none-any.whl from build tracker '/private/tmp/pip-req-tracker-0xk4_r_b'
Created temporary directory: /private/tmp/pip-unpack-nnx9vd8s
Installing collected packages: rich

Successfully installed rich-9.13.0
Removed build tracker: '/private/tmp/pip-req-tracker-0xk4_r_b'
</pre>
</details>

### Alternatives

- If we deem that this pull in of an unversioned `poetry-core` is not an issue, no action is needed. The current mode of installation will continue without changes.
- We could disable `pip`'s PEP 517/518 mode. This would make `pip` reject Poetry-based packages entirely. Some packages may also include `setuptools`-compatible installation flows for the sake of redundancy but there are some packages (e.g. `rich` and `ciphey`, which I am attempting to ship via Homebrew, which led me down this rabbit hole in the first place) that don't include a `setup.py` (or have a broken one), so the only supported installation method is via Poetry/`pip` running with PEP 517/518 mode enabled.
- We could address this in specific formulae that pull in packages using Poetry. The additional snippet would look something like:
```ruby
resource("rich").stage do
    system "poetry", "build", "-vvv", "--format", "wheel"
    venv.pip_install Dir["dist/rich-*.whl"].first
  end

  res = resources.map(&:name).to_set - ["rich"]
  res.each do |r|
    venv.pip_install resource(r)
  end
```
Note that this involves knowledge about which packages use Poetry (and adjusting/updating individual formulae if a package switches over), and this may have to be repeated on multiple formulae for multiple packages.

### Other thoughts

With the implementation of PEP 517/518 in `pip`, I would expect us to gradually see more projects moving away from the traditional `setuptools`-based setup for tools such as Poetry and Flit. In the future, it may be worth revisiting this section of code once more to add a more generic handling system for common PEP 517/518 build and packaging ecosystems.