### PR TITLE
Conditional formulae and casks completion for Fish

### DIFF
--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -318,11 +318,14 @@ module Homebrew
           next unless FISH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING.key? type
 
           named_arg_function = FISH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING[type]
-          named_arg_prefix = "complete -f -c brew -n '__fish_brew_command #{command}; and not __fish_seen_argument"
+          named_arg_prefix = "__fish_brew_complete_arg '#{command}; and not __fish_seen_argument"
 
-          named_args << if type == :formula && named_args_types.include?(:cask)
+          formula_option = command_options(command).key?("--formula")
+          cask_option = command_options(command).key?("--cask")
+
+          named_args << if formula_option && cask_option && type.to_s.end_with?("formula")
             "#{named_arg_prefix} -l cask -l casks' -a '(#{named_arg_function})'"
-          elsif type == :cask && named_args_types.include?(:formula)
+          elsif formula_option && cask_option && type.to_s.end_with?("cask")
             "#{named_arg_prefix} -l formula -l formulae' -a '(#{named_arg_function})'"
           else
             "__fish_brew_complete_arg '#{command}' -a '(#{named_arg_function})'"

--- a/Library/Homebrew/completions.rb
+++ b/Library/Homebrew/completions.rb
@@ -318,7 +318,15 @@ module Homebrew
           next unless FISH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING.key? type
 
           named_arg_function = FISH_NAMED_ARGS_COMPLETION_FUNCTION_MAPPING[type]
-          named_args << "__fish_brew_complete_arg '#{command}' -a '(#{named_arg_function})'"
+          named_arg_prefix = "complete -f -c brew -n '__fish_brew_command #{command}; and not __fish_seen_argument"
+
+          named_args << if type == :formula && named_args_types.include?(:cask)
+            "#{named_arg_prefix} -l cask -l casks' -a '(#{named_arg_function})'"
+          elsif type == :cask && named_args_types.include?(:formula)
+            "#{named_arg_prefix} -l formula -l formulae' -a '(#{named_arg_function})'"
+          else
+            "__fish_brew_complete_arg '#{command}' -a '(#{named_arg_function})'"
+          end
         end
 
         named_args_strings.each do |subcommand|

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -403,10 +403,13 @@ describe Homebrew::Completions do
 
       it "returns appropriate completion for a command with multiple named arg types" do
         completion = described_class.generate_fish_subcommand_completion("upgrade")
+        expected_line_start = "__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument"
         expect(completion).to match(
-          /__fish_brew_complete_arg 'upgrade' -a '\(__fish_brew_suggest_formulae_outdated\)'/,
+          /#{expected_line_start} -l cask -l casks' -a '\(__fish_brew_suggest_formulae_outdated\)'/,
         )
-        expect(completion).to match(/__fish_brew_complete_arg 'upgrade' -a '\(__fish_brew_suggest_casks_outdated\)'/)
+        expect(completion).to match(
+          /#{expected_line_start} -l formula -l formulae' -a '\(__fish_brew_suggest_casks_outdated\)'/,
+        )
       end
     end
 

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -208,8 +208,8 @@ __fish_brew_complete_arg '--cache' -l formula -d 'Only show cache files for form
 __fish_brew_complete_arg '--cache' -l help -d 'Show this message'
 __fish_brew_complete_arg '--cache' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg '--cache' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command --cache; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command --cache; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg '--cache; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg '--cache; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd '--caskroom' 'Display Homebrew\'s Caskroom path'
@@ -304,8 +304,8 @@ __fish_brew_complete_arg 'abv' -l installed -d 'Print JSON of formulae that are 
 __fish_brew_complete_arg 'abv' -l json -d 'Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew'
 __fish_brew_complete_arg 'abv' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'abv' -l verbose -d 'Show more verbose analytics data for formula'
-complete -f -c brew -n '__fish_brew_command abv; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command abv; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'abv; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'abv; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'analytics' 'Control Homebrew\'s anonymous aggregate user behaviour analytics'
@@ -344,8 +344,8 @@ __fish_brew_complete_arg 'audit' -l strict -d 'Run additional, stricter style ch
 __fish_brew_complete_arg 'audit' -l tap -d 'Check the formulae within the given tap, specified as user`/`repo'
 __fish_brew_complete_arg 'audit' -l token-conflicts -d 'Audit for token conflicts'
 __fish_brew_complete_arg 'audit' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command audit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command audit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'audit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'audit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'autoremove' 'Uninstall formulae that were only installed as a dependency of another formula and are now no longer needed'
@@ -385,8 +385,8 @@ __fish_brew_complete_arg 'bump' -l limit -d 'Limit number of package results ret
 __fish_brew_complete_arg 'bump' -l no-pull-requests -d 'Do not retrieve pull requests from GitHub'
 __fish_brew_complete_arg 'bump' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'bump' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command bump; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command bump; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'bump; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'bump; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'bump-cask-pr' 'Create a pull request to update cask with a new version'
@@ -465,8 +465,8 @@ __fish_brew_complete_arg 'cat' -l formula -d 'Treat all named arguments as formu
 __fish_brew_complete_arg 'cat' -l help -d 'Show this message'
 __fish_brew_complete_arg 'cat' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'cat' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command cat; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command cat; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'cat; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'cat; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'cleanup' 'Remove stale lock files and outdated downloads for all formulae and casks, and remove old versions of installed formulae'
@@ -478,8 +478,8 @@ __fish_brew_complete_arg 'cleanup' -l prune-prefix -d 'Only prune the symlinks a
 __fish_brew_complete_arg 'cleanup' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'cleanup' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'cleanup' -l s -d 'Scrub the cache, including downloads for even the latest versions. Note downloads for any installed formulae or casks will still not be deleted. If you want to delete those too: `rm -rf "$(brew --cache)"`'
-complete -f -c brew -n '__fish_brew_command cleanup; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command cleanup; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'cleanup' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'cleanup' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'command' 'Display the path to the file being used when invoking `brew` cmd'
@@ -561,8 +561,8 @@ __fish_brew_complete_arg 'deps' -l tree -d 'Show dependencies as a tree. When gi
 __fish_brew_complete_arg 'deps' -l union -d 'Show the union of dependencies for multiple formula, instead of the intersection'
 __fish_brew_complete_arg 'deps' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'deps' -l n -d 'Sort dependencies in topological order'
-complete -f -c brew -n '__fish_brew_command deps; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command deps; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'deps; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'deps; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'desc' 'Display formula\'s name and one-line description'
@@ -617,8 +617,8 @@ __fish_brew_complete_arg 'edit' -l formula -d 'Treat all named arguments as form
 __fish_brew_complete_arg 'edit' -l help -d 'Show this message'
 __fish_brew_complete_arg 'edit' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'edit' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command edit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command edit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'edit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'edit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'environment' 'Summarise Homebrew\'s build environment as a plain list'
@@ -658,8 +658,8 @@ __fish_brew_complete_arg 'fetch' -l quarantine -d 'Disable/enable quarantining o
 __fish_brew_complete_arg 'fetch' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'fetch' -l retry -d 'Retry if downloading fails or re-download if the checksum of a previously cached version no longer matches'
 __fish_brew_complete_arg 'fetch' -l verbose -d 'Do a verbose VCS checkout, if the URL represents a VCS. This is useful for seeing if an existing VCS cache has been updated'
-complete -f -c brew -n '__fish_brew_command fetch; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command fetch; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'fetch; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'fetch; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'formula' 'Display the path where formula is located'
@@ -688,8 +688,8 @@ __fish_brew_complete_arg 'home' -l formula -d 'Treat all named arguments as form
 __fish_brew_complete_arg 'home' -l help -d 'Show this message'
 __fish_brew_complete_arg 'home' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'home' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command home; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command home; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'home; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'home; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'homepage' 'Open a formula or cask\'s homepage in a browser, or open Homebrew\'s own homepage if no argument is provided'
@@ -699,8 +699,8 @@ __fish_brew_complete_arg 'homepage' -l formula -d 'Treat all named arguments as 
 __fish_brew_complete_arg 'homepage' -l help -d 'Show this message'
 __fish_brew_complete_arg 'homepage' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'homepage' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command homepage; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command homepage; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'homepage; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'homepage; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'info' 'Display brief statistics for your Homebrew installation'
@@ -717,8 +717,8 @@ __fish_brew_complete_arg 'info' -l installed -d 'Print JSON of formulae that are
 __fish_brew_complete_arg 'info' -l json -d 'Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew'
 __fish_brew_complete_arg 'info' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'info' -l verbose -d 'Show more verbose analytics data for formula'
-complete -f -c brew -n '__fish_brew_command info; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command info; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'info; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'info; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'instal' 'Install a formula or cask'
@@ -765,8 +765,8 @@ __fish_brew_complete_arg 'instal' -l skip-cask-deps -d 'Skip installing cask dep
 __fish_brew_complete_arg 'instal' -l verbose -d 'Print the verification and postinstall steps'
 __fish_brew_complete_arg 'instal' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'instal' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-complete -f -c brew -n '__fish_brew_command instal; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command instal; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'instal; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'instal; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'install' 'Install a formula or cask'
@@ -813,8 +813,8 @@ __fish_brew_complete_arg 'install' -l skip-cask-deps -d 'Skip installing cask de
 __fish_brew_complete_arg 'install' -l verbose -d 'Print the verification and postinstall steps'
 __fish_brew_complete_arg 'install' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'install' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-complete -f -c brew -n '__fish_brew_command install; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command install; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'install; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'install; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'install-bundler-gems' 'Install Homebrew\'s Bundler gems'
@@ -877,8 +877,8 @@ __fish_brew_complete_arg 'list' -l 1 -d 'Force output to be one entry per line. 
 __fish_brew_complete_arg 'list' -l l -d 'List formulae and/or casks in long format. Has no effect when a formula or cask name is passed as an argument'
 __fish_brew_complete_arg 'list' -l r -d 'Reverse the order of the formulae and/or casks sort to list the oldest entries first. Has no effect when a formula or cask name is passed as an argument'
 __fish_brew_complete_arg 'list' -l t -d 'Sort formulae and/or casks by time modified, listing most recently modified first. Has no effect when a formula or cask name is passed as an argument'
-__fish_brew_complete_arg 'list' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'list' -a '(__fish_brew_suggest_casks_installed)'
+__fish_brew_complete_arg 'list; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'list; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'livecheck' 'Check for newer versions of formulae and/or casks from upstream'
@@ -894,8 +894,8 @@ __fish_brew_complete_arg 'livecheck' -l newer-only -d 'Show the latest version o
 __fish_brew_complete_arg 'livecheck' -l quiet -d 'Suppress warnings, don\'t print a progress bar for JSON output'
 __fish_brew_complete_arg 'livecheck' -l tap -d 'Check formulae/casks within the given tap, specified as user`/`repo'
 __fish_brew_complete_arg 'livecheck' -l verbose -d 'Make some output more verbose'
-complete -f -c brew -n '__fish_brew_command livecheck; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command livecheck; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'livecheck; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'livecheck; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'ln' 'Symlink all of formula\'s installed files into Homebrew\'s prefix'
@@ -937,8 +937,8 @@ __fish_brew_complete_arg 'ls' -l 1 -d 'Force output to be one entry per line. Th
 __fish_brew_complete_arg 'ls' -l l -d 'List formulae and/or casks in long format. Has no effect when a formula or cask name is passed as an argument'
 __fish_brew_complete_arg 'ls' -l r -d 'Reverse the order of the formulae and/or casks sort to list the oldest entries first. Has no effect when a formula or cask name is passed as an argument'
 __fish_brew_complete_arg 'ls' -l t -d 'Sort formulae and/or casks by time modified, listing most recently modified first. Has no effect when a formula or cask name is passed as an argument'
-__fish_brew_complete_arg 'ls' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'ls' -a '(__fish_brew_suggest_casks_installed)'
+__fish_brew_complete_arg 'ls; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'ls; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'man' 'Generate Homebrew\'s manpages'
@@ -1000,8 +1000,8 @@ __fish_brew_complete_arg 'outdated' -l help -d 'Show this message'
 __fish_brew_complete_arg 'outdated' -l json -d 'Print output in JSON format. There are two versions: `v1` and `v2`. `v1` is deprecated and is currently the default if no version is specified. `v2` prints outdated formulae and casks. '
 __fish_brew_complete_arg 'outdated' -l quiet -d 'List only the names of outdated kegs (takes precedence over `--verbose`)'
 __fish_brew_complete_arg 'outdated' -l verbose -d 'Include detailed version information'
-complete -f -c brew -n '__fish_brew_command outdated; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command outdated; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'outdated; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'outdated; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'pin' 'Pin the specified formula, preventing them from being upgraded when issuing the `brew upgrade` formula command'
@@ -1142,8 +1142,8 @@ __fish_brew_complete_arg 'reinstall' -l skip-cask-deps -d 'Skip installing cask 
 __fish_brew_complete_arg 'reinstall' -l verbose -d 'Print the verification and postinstall steps'
 __fish_brew_complete_arg 'reinstall' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'reinstall' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-complete -f -c brew -n '__fish_brew_command reinstall; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command reinstall; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'reinstall; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'reinstall; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'release' 'Create a new draft Homebrew/brew release with the appropriate version number and release notes'
@@ -1173,8 +1173,8 @@ __fish_brew_complete_arg 'remove' -l ignore-dependencies -d 'Don\'t fail uninsta
 __fish_brew_complete_arg 'remove' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'remove' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'remove' -l zap -d 'Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'remove' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'remove' -a '(__fish_brew_suggest_casks_installed)'
+__fish_brew_complete_arg 'remove; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'remove; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'rm' 'Uninstall a formula or cask'
@@ -1187,8 +1187,8 @@ __fish_brew_complete_arg 'rm' -l ignore-dependencies -d 'Don\'t fail uninstall, 
 __fish_brew_complete_arg 'rm' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'rm' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'rm' -l zap -d 'Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'rm' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'rm' -a '(__fish_brew_suggest_casks_installed)'
+__fish_brew_complete_arg 'rm; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'rm; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'ruby' 'Run a Ruby instance with Homebrew\'s libraries loaded'
@@ -1248,8 +1248,8 @@ __fish_brew_complete_arg 'style' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'style' -l reset-cache -d 'Reset the RuboCop cache'
 __fish_brew_complete_arg 'style' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'style' -a '(__fish_brew_suggest_taps_installed)'
-complete -f -c brew -n '__fish_brew_command style; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
-complete -f -c brew -n '__fish_brew_command style; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
+__fish_brew_complete_arg 'style; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'style; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'tap' 'Tap a formula repository'
@@ -1361,8 +1361,8 @@ __fish_brew_complete_arg 'uninstal' -l ignore-dependencies -d 'Don\'t fail unins
 __fish_brew_complete_arg 'uninstal' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'uninstal' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'uninstal' -l zap -d 'Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'uninstal' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'uninstal' -a '(__fish_brew_suggest_casks_installed)'
+__fish_brew_complete_arg 'uninstal; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'uninstal; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'uninstall' 'Uninstall a formula or cask'
@@ -1375,8 +1375,8 @@ __fish_brew_complete_arg 'uninstall' -l ignore-dependencies -d 'Don\'t fail unin
 __fish_brew_complete_arg 'uninstall' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'uninstall' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'uninstall' -l zap -d 'Remove all files associated with a cask. *May remove files which are shared between applications.*'
-__fish_brew_complete_arg 'uninstall' -a '(__fish_brew_suggest_formulae_installed)'
-__fish_brew_complete_arg 'uninstall' -a '(__fish_brew_suggest_casks_installed)'
+__fish_brew_complete_arg 'uninstall; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_installed)'
+__fish_brew_complete_arg 'uninstall; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_installed)'
 
 
 __fish_brew_complete_cmd 'unlink' 'Remove symlinks for formula from Homebrew\'s prefix'
@@ -1523,8 +1523,8 @@ __fish_brew_complete_arg 'upgrade' -l skip-cask-deps -d 'Skip installing cask de
 __fish_brew_complete_arg 'upgrade' -l verbose -d 'Print the verification and postinstall steps'
 __fish_brew_complete_arg 'upgrade' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'upgrade' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-__fish_brew_complete_arg 'upgrade' -a '(__fish_brew_suggest_formulae_outdated)'
-__fish_brew_complete_arg 'upgrade' -a '(__fish_brew_suggest_casks_outdated)'
+__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_outdated)'
+__fish_brew_complete_arg 'upgrade; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_outdated)'
 
 
 __fish_brew_complete_cmd 'uses' 'Show formulae and casks that specify formula as a dependency; that is, show dependents of formula'
@@ -1540,7 +1540,7 @@ __fish_brew_complete_arg 'uses' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'uses' -l recursive -d 'Resolve more than one level of dependencies'
 __fish_brew_complete_arg 'uses' -l skip-recommended -d 'Skip all formulae that specify formula as `:recommended` type dependency'
 __fish_brew_complete_arg 'uses' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'uses' -a '(__fish_brew_suggest_formulae_all)'
+__fish_brew_complete_arg 'uses; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
 
 
 __fish_brew_complete_cmd 'vendor-gems' 'Install and commit Homebrew\'s vendored gems'

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -208,8 +208,8 @@ __fish_brew_complete_arg '--cache' -l formula -d 'Only show cache files for form
 __fish_brew_complete_arg '--cache' -l help -d 'Show this message'
 __fish_brew_complete_arg '--cache' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg '--cache' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg '--cache' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg '--cache' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command --cache; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command --cache; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd '--caskroom' 'Display Homebrew\'s Caskroom path'
@@ -304,8 +304,8 @@ __fish_brew_complete_arg 'abv' -l installed -d 'Print JSON of formulae that are 
 __fish_brew_complete_arg 'abv' -l json -d 'Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew'
 __fish_brew_complete_arg 'abv' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'abv' -l verbose -d 'Show more verbose analytics data for formula'
-__fish_brew_complete_arg 'abv' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'abv' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command abv; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command abv; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'analytics' 'Control Homebrew\'s anonymous aggregate user behaviour analytics'
@@ -344,8 +344,8 @@ __fish_brew_complete_arg 'audit' -l strict -d 'Run additional, stricter style ch
 __fish_brew_complete_arg 'audit' -l tap -d 'Check the formulae within the given tap, specified as user`/`repo'
 __fish_brew_complete_arg 'audit' -l token-conflicts -d 'Audit for token conflicts'
 __fish_brew_complete_arg 'audit' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'audit' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'audit' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command audit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command audit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'autoremove' 'Uninstall formulae that were only installed as a dependency of another formula and are now no longer needed'
@@ -385,8 +385,8 @@ __fish_brew_complete_arg 'bump' -l limit -d 'Limit number of package results ret
 __fish_brew_complete_arg 'bump' -l no-pull-requests -d 'Do not retrieve pull requests from GitHub'
 __fish_brew_complete_arg 'bump' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'bump' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'bump' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'bump' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command bump; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command bump; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'bump-cask-pr' 'Create a pull request to update cask with a new version'
@@ -465,8 +465,8 @@ __fish_brew_complete_arg 'cat' -l formula -d 'Treat all named arguments as formu
 __fish_brew_complete_arg 'cat' -l help -d 'Show this message'
 __fish_brew_complete_arg 'cat' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'cat' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'cat' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'cat' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command cat; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command cat; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'cleanup' 'Remove stale lock files and outdated downloads for all formulae and casks, and remove old versions of installed formulae'
@@ -478,8 +478,8 @@ __fish_brew_complete_arg 'cleanup' -l prune-prefix -d 'Only prune the symlinks a
 __fish_brew_complete_arg 'cleanup' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'cleanup' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'cleanup' -l s -d 'Scrub the cache, including downloads for even the latest versions. Note downloads for any installed formulae or casks will still not be deleted. If you want to delete those too: `rm -rf "$(brew --cache)"`'
-__fish_brew_complete_arg 'cleanup' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'cleanup' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command cleanup; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command cleanup; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'command' 'Display the path to the file being used when invoking `brew` cmd'
@@ -561,8 +561,8 @@ __fish_brew_complete_arg 'deps' -l tree -d 'Show dependencies as a tree. When gi
 __fish_brew_complete_arg 'deps' -l union -d 'Show the union of dependencies for multiple formula, instead of the intersection'
 __fish_brew_complete_arg 'deps' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'deps' -l n -d 'Sort dependencies in topological order'
-__fish_brew_complete_arg 'deps' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'deps' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command deps; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command deps; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'desc' 'Display formula\'s name and one-line description'
@@ -617,8 +617,8 @@ __fish_brew_complete_arg 'edit' -l formula -d 'Treat all named arguments as form
 __fish_brew_complete_arg 'edit' -l help -d 'Show this message'
 __fish_brew_complete_arg 'edit' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'edit' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'edit' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'edit' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command edit; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command edit; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'environment' 'Summarise Homebrew\'s build environment as a plain list'
@@ -658,8 +658,8 @@ __fish_brew_complete_arg 'fetch' -l quarantine -d 'Disable/enable quarantining o
 __fish_brew_complete_arg 'fetch' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'fetch' -l retry -d 'Retry if downloading fails or re-download if the checksum of a previously cached version no longer matches'
 __fish_brew_complete_arg 'fetch' -l verbose -d 'Do a verbose VCS checkout, if the URL represents a VCS. This is useful for seeing if an existing VCS cache has been updated'
-__fish_brew_complete_arg 'fetch' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'fetch' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command fetch; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command fetch; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'formula' 'Display the path where formula is located'
@@ -688,8 +688,8 @@ __fish_brew_complete_arg 'home' -l formula -d 'Treat all named arguments as form
 __fish_brew_complete_arg 'home' -l help -d 'Show this message'
 __fish_brew_complete_arg 'home' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'home' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'home' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'home' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command home; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command home; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'homepage' 'Open a formula or cask\'s homepage in a browser, or open Homebrew\'s own homepage if no argument is provided'
@@ -699,8 +699,8 @@ __fish_brew_complete_arg 'homepage' -l formula -d 'Treat all named arguments as 
 __fish_brew_complete_arg 'homepage' -l help -d 'Show this message'
 __fish_brew_complete_arg 'homepage' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'homepage' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'homepage' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'homepage' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command homepage; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command homepage; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'info' 'Display brief statistics for your Homebrew installation'
@@ -717,8 +717,8 @@ __fish_brew_complete_arg 'info' -l installed -d 'Print JSON of formulae that are
 __fish_brew_complete_arg 'info' -l json -d 'Print a JSON representation. Currently the default value for version is `v1` for formula. For formula and cask use `v2`. See the docs for examples of using the JSON output: https://docs.brew.sh/Querying-Brew'
 __fish_brew_complete_arg 'info' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'info' -l verbose -d 'Show more verbose analytics data for formula'
-__fish_brew_complete_arg 'info' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'info' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command info; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command info; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'instal' 'Install a formula or cask'
@@ -765,8 +765,8 @@ __fish_brew_complete_arg 'instal' -l skip-cask-deps -d 'Skip installing cask dep
 __fish_brew_complete_arg 'instal' -l verbose -d 'Print the verification and postinstall steps'
 __fish_brew_complete_arg 'instal' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'instal' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-__fish_brew_complete_arg 'instal' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'instal' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command instal; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command instal; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'install' 'Install a formula or cask'
@@ -813,8 +813,8 @@ __fish_brew_complete_arg 'install' -l skip-cask-deps -d 'Skip installing cask de
 __fish_brew_complete_arg 'install' -l verbose -d 'Print the verification and postinstall steps'
 __fish_brew_complete_arg 'install' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'install' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-__fish_brew_complete_arg 'install' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'install' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command install; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command install; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'install-bundler-gems' 'Install Homebrew\'s Bundler gems'
@@ -894,8 +894,8 @@ __fish_brew_complete_arg 'livecheck' -l newer-only -d 'Show the latest version o
 __fish_brew_complete_arg 'livecheck' -l quiet -d 'Suppress warnings, don\'t print a progress bar for JSON output'
 __fish_brew_complete_arg 'livecheck' -l tap -d 'Check formulae/casks within the given tap, specified as user`/`repo'
 __fish_brew_complete_arg 'livecheck' -l verbose -d 'Make some output more verbose'
-__fish_brew_complete_arg 'livecheck' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'livecheck' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command livecheck; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command livecheck; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'ln' 'Symlink all of formula\'s installed files into Homebrew\'s prefix'
@@ -1000,8 +1000,8 @@ __fish_brew_complete_arg 'outdated' -l help -d 'Show this message'
 __fish_brew_complete_arg 'outdated' -l json -d 'Print output in JSON format. There are two versions: `v1` and `v2`. `v1` is deprecated and is currently the default if no version is specified. `v2` prints outdated formulae and casks. '
 __fish_brew_complete_arg 'outdated' -l quiet -d 'List only the names of outdated kegs (takes precedence over `--verbose`)'
 __fish_brew_complete_arg 'outdated' -l verbose -d 'Include detailed version information'
-__fish_brew_complete_arg 'outdated' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'outdated' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command outdated; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command outdated; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'pin' 'Pin the specified formula, preventing them from being upgraded when issuing the `brew upgrade` formula command'
@@ -1142,8 +1142,8 @@ __fish_brew_complete_arg 'reinstall' -l skip-cask-deps -d 'Skip installing cask 
 __fish_brew_complete_arg 'reinstall' -l verbose -d 'Print the verification and postinstall steps'
 __fish_brew_complete_arg 'reinstall' -l vst-plugindir -d 'Target location for VST Plugins (default: `~/Library/Audio/Plug-Ins/VST`)'
 __fish_brew_complete_arg 'reinstall' -l vst3-plugindir -d 'Target location for VST3 Plugins (default: `~/Library/Audio/Plug-Ins/VST3`)'
-__fish_brew_complete_arg 'reinstall' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'reinstall' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command reinstall; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command reinstall; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'release' 'Create a new draft Homebrew/brew release with the appropriate version number and release notes'
@@ -1248,8 +1248,8 @@ __fish_brew_complete_arg 'style' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'style' -l reset-cache -d 'Reset the RuboCop cache'
 __fish_brew_complete_arg 'style' -l verbose -d 'Make some output more verbose'
 __fish_brew_complete_arg 'style' -a '(__fish_brew_suggest_taps_installed)'
-__fish_brew_complete_arg 'style' -a '(__fish_brew_suggest_formulae_all)'
-__fish_brew_complete_arg 'style' -a '(__fish_brew_suggest_casks_all)'
+complete -f -c brew -n '__fish_brew_command style; and not __fish_seen_argument -l cask -l casks' -a '(__fish_brew_suggest_formulae_all)'
+complete -f -c brew -n '__fish_brew_command style; and not __fish_seen_argument -l formula -l formulae' -a '(__fish_brew_suggest_casks_all)'
 
 
 __fish_brew_complete_cmd 'tap' 'Tap a formula repository'

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1545,7 +1545,7 @@ to send a notification when the autoupdate process has finished successfully.
 <br>Output this tool's current version.
 
 * `--upgrade`:
-  Automatically upgrade your installed formulae. If the Caskroom exists locally Casks will be upgraded as well.  Must be passed with `start`.
+  Automatically upgrade your installed formulae. If the Caskroom exists locally Casks will be upgraded as well. Must be passed with `start`.
 * `--cleanup`:
   Automatically clean brew's cache and logs. Must be passed with `start`.
 * `--enable-notification`:

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1545,7 +1545,7 @@ to send a notification when the autoupdate process has finished successfully.
 <br>Output this tool's current version.
 
 * `--upgrade`:
-  Automatically upgrade your installed formulae. If the Caskroom exists locally Casks will be upgraded as well. Must be passed with `start`.
+  Automatically upgrade your installed formulae. If the Caskroom exists locally Casks will be upgraded as well.  Must be passed with `start`.
 * `--cleanup`:
   Automatically clean brew's cache and logs. Must be passed with `start`.
 * `--enable-notification`:


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Quoting myself from #10123:

> Propsed design:
> - brew install --formula should only lists available formulae, while brew install --cask should only lists available casks.
> - brew install (without specifying --formula or --cask) should list all formulae and casks available.

(`brew install` is only an example, it applies to all commands accepting both `--formula` and `--cask`.)

I implemented it locally before the shell completion becomes auto generated. This is a rough remake, but definitely better than writing all the things by hand.

https://user-images.githubusercontent.com/44045911/110425186-e8b1e600-80de-11eb-834b-ca3b7036c2c1.mov

Unfortunately I'm only familiar with writing Fish completions, I will try to implement it in Bash and Zsh, either in the future or this PR.
