### PR TITLE
add pcsc-lite to uses_from_macos

### DIFF
--- a/Library/Homebrew/rubocops/uses_from_macos.rb
+++ b/Library/Homebrew/rubocops/uses_from_macos.rb
@@ -42,6 +42,7 @@ module RuboCop
           netcat
           openldap
           openlibm
+          pcsc-lite
           pod2man
           rpcgen
           ruby


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`pcsc-lite` is keg-only on macOS because its functionality is provided by `PCSC.framework`.  However it is needed for some formula to build on Linux.  See https://github.com/Homebrew/homebrew-core/pull/72773 

cc @iMichka 