### PR TITLE
Don't touch PATH, GEM_HOME and GEM_PATH when testing formula

### DIFF
--- a/Library/Homebrew/dev-cmd/test.rb
+++ b/Library/Homebrew/dev-cmd/test.rb
@@ -35,7 +35,7 @@ module Homebrew
   def test
     args = test_args.parse
 
-    Homebrew.install_bundler_gems!
+    Homebrew.install_bundler_gems!(setup_path: false)
 
     require "formula_assertions"
     require "formula_free_port"

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -125,7 +125,11 @@ module Homebrew
     )
   end
 
-  def install_bundler_gems!(only_warn_on_failure: false)
+  def install_bundler_gems!(only_warn_on_failure: false, setup_path: true)
+    old_path = ENV["PATH"]
+    old_gem_path = ENV["GEM_PATH"]
+    old_gem_home = ENV["GEM_HOME"]
+
     install_bundler!
 
     ENV["BUNDLE_GEMFILE"] = File.join(ENV.fetch("HOMEBREW_LIBRARY"), "Homebrew", "Gemfile")
@@ -152,5 +156,12 @@ module Homebrew
     end
 
     setup_gem_environment!
+  ensure
+    unless setup_path
+      # Reset the paths. We need to have at least temporarily changed them while invoking `bundle`.
+      ENV["PATH"] = old_path
+      ENV["GEM_PATH"] = old_gem_path
+      ENV["GEM_HOME"] = old_gem_home
+    end
   end
 end

--- a/Library/Homebrew/utils/gems.rbi
+++ b/Library/Homebrew/utils/gems.rbi
@@ -22,6 +22,6 @@ module Homebrew
   sig { void }
   def install_bundler!; end
 
-  sig { params(only_warn_on_failure: T::Boolean).void }
-  def install_bundler_gems!(only_warn_on_failure: false); end
+  sig { params(only_warn_on_failure: T::Boolean, setup_path: T::Boolean).void }
+  def install_bundler_gems!(only_warn_on_failure: false, setup_path: false); end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

We call `Homebrew.install_bundler_gems!` during `brew test` now, so clearing these ENVs is now needed to ensure we aren't polluting the PATH with portable-ruby bin directories etc.
