### PR TITLE
Check homepage with both browser and default user agent.

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -717,7 +717,12 @@ module Cask
 
       check_url_for_https_availability(cask.appcast, check_content: true) if cask.appcast && appcast?
 
-      check_url_for_https_availability(cask.homepage, check_content: true, user_agents: [:browser]) if cask.homepage
+      return unless cask.homepage
+
+      check_url_for_https_availability(cask.homepage,
+                                       user_agents:   [:browser, :default],
+                                       check_content: true,
+                                       strict:        strict?)
     end
 
     def check_url_for_https_availability(url_to_check, **options)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes weird audit error in https://github.com/Homebrew/homebrew-cask/pull/100975. Both adding `--compressed` as well as simply removing the user agent make `curl` succeed. Even simply removing the last `Safari ...` part from the user agent makes it succeed.

Formulae already check both user agents, so this also makes the check consistent.