### PR TITLE
utils/github/api: simplify pagination

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -306,11 +306,11 @@ module GitHub
   end
 
   def public_member_usernames(org, per_page: 100)
-    url = "#{API_URL}/orgs/#{org}/public_members?per_page=#{per_page}"
+    url = "#{API_URL}/orgs/#{org}/public_members"
     members = []
 
-    (1..API_MAX_PAGES).each do |page|
-      result = API.open_rest("#{url}&page=#{page}").map { |member| member["login"] }
+    API.paginate_rest(url, per_page: per_page) do |result|
+      result = result.map { |member| member["login"] }
       members.concat(result)
 
       return members if result.length < per_page
@@ -562,8 +562,7 @@ module GitHub
       raise API::Error, "Getting #{commit_count} commits would exceed limit of #{API_MAX_ITEMS} API items!"
     end
 
-    (1..API_MAX_PAGES).each do |page|
-      result = API.open_rest(commits_api + "?per_page=#{per_page}&page=#{page}")
+    API.paginate_rest(commits_api, per_page: per_page) do |result, page|
       commits.concat(result.map { |c| c["sha"] })
 
       return commits if commits.length == commit_count

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -249,6 +249,13 @@ module GitHub
       end
     end
 
+    def paginate_rest(url, per_page: 100)
+      (1..API_MAX_PAGES).each do |page|
+        result = API.open_rest("#{url}?per_page=#{per_page}&page=#{page}")
+        yield(result, page)
+      end
+    end
+
     def open_graphql(query, scopes: [].freeze)
       data = { query: query }
       result = open_rest("https://api.github.com/graphql", scopes: scopes, data: data, request_method: "POST")


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR aims to simplify GitHub REST API pagination.

I plan to open a follow-up PR to modify `fetch_pull_requests` to be able to retrieve all PRs from a Tap (this would be useful to pre-fetch PRs for `brew bump`). This would increase the number of methods that use pagination, so getting rid of the repetitive `(1..API_MAX_PAGES).each` loops seemed desirable.