### PR TITLE
cask_loader: do not auto-tap in FromTapLoader

### DIFF
--- a/Library/Homebrew/cask/cask_loader.rb
+++ b/Library/Homebrew/cask/cask_loader.rb
@@ -157,7 +157,7 @@ module Cask
       end
 
       def load(config:)
-        tap.install unless tap.installed?
+        raise TapCaskUnavailableError.new(tap, token) unless tap.installed?
 
         super
       end

--- a/Library/Homebrew/cask/exceptions.rb
+++ b/Library/Homebrew/cask/exceptions.rb
@@ -103,6 +103,27 @@ module Cask
     end
   end
 
+  # Error when a cask in a specific tap is not available.
+  #
+  # @api private
+  class TapCaskUnavailableError < CaskUnavailableError
+    extend T::Sig
+
+    attr_reader :tap
+
+    def initialize(tap, token)
+      super("#{tap}/#{token}")
+      @tap = tap
+    end
+
+    sig { returns(String) }
+    def to_s
+      s = super
+      s += "\nPlease tap it and then try again: brew tap #{tap}" unless tap.installed?
+      s
+    end
+  end
+
   # Error when a cask already exists.
   #
   # @api private

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -132,6 +132,12 @@ module Homebrew
 
         raise unreadable_error if unreadable_error.present?
 
+        user, repo, short_name = name.downcase.split("/", 3)
+        if repo.present? && short_name.present?
+          tap = Tap.fetch(user, repo)
+          raise TapFormulaOrCaskUnavailableError.new(tap, short_name)
+        end
+
         raise FormulaOrCaskUnavailableError, name
       end
       private :load_formula_or_cask

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -97,6 +97,25 @@ class FormulaOrCaskUnavailableError < RuntimeError
   end
 end
 
+# Raised when a formula or cask in a specific tap is not available.
+class TapFormulaOrCaskUnavailableError < FormulaOrCaskUnavailableError
+  extend T::Sig
+
+  attr_reader :tap
+
+  def initialize(tap, name)
+    super "#{tap}/#{name}"
+    @tap = tap
+  end
+
+  sig { returns(String) }
+  def to_s
+    s = super
+    s += "\nPlease tap it and then try again: brew tap #{tap}" unless tap.installed?
+    s
+  end
+end
+
 # Raised when a formula is not available.
 class FormulaUnavailableError < FormulaOrCaskUnavailableError
   extend T::Sig

--- a/Library/Homebrew/test/exceptions_spec.rb
+++ b/Library/Homebrew/test/exceptions_spec.rb
@@ -34,6 +34,14 @@ describe "Exception" do
     }
   end
 
+  describe TapFormulaOrCaskUnavailableError do
+    subject(:error) { described_class.new(tap, "foo") }
+
+    let(:tap) { double(Tap, user: "u", repo: "r", to_s: "u/r", installed?: false) }
+
+    its(:to_s) { is_expected.to match(%r{Please tap it and then try again: brew tap u/r}) }
+  end
+
   describe FormulaUnavailableError do
     subject(:error) { described_class.new("foo") }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR aims to fix #10584, by removing auto-tapping from cask's `FromTapLoader`.

Output:

```
➜ brew info mongodb/brew/mongodb-community
Error: No available formula or cask with the name "mongodb/brew/mongodb-community".
Please tap it and then try again: brew tap mongodb/brew

➜ brew info --formula mongodb/brew/mongodb-community
Error: No available formula with the name "mongodb/brew/mongodb-community".
Please tap it and then try again: brew tap mongodb/brew

➜ brew info --cask mongodb/brew/mongodb-community
Error: Cask 'mongodb/brew/mongodb-community' is unavailable.
Please tap it and then try again: brew tap mongodb/brew
```