### PR TITLE
Livecheck: Replace OpenURI#open with Curl

### DIFF
--- a/Library/Homebrew/livecheck/strategy/page_match.rb
+++ b/Library/Homebrew/livecheck/strategy/page_match.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require "open-uri"
-
 module Homebrew
   module Livecheck
     module Strategy


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is a recreation of #9535, as that PR somehow lost its association with the related branch in my fork and the PR stopped reflecting new pushes.

This migrates `brew livecheck` from `open-uri` to `Utils::Curl`, as `Curl` is used throughout brew for network requests and livecheck is the only place where `open-uri` is used (outside of a vendored gem).

## Notable Changes

* Replaces `URI.parse(url).open` in `Livecheck::Strategy#page_content` with `#curl_with_workarounds`. Strategies use `#page_content` to fetch a page, so this effectively replaces `open-uri` in livecheck with `Utils::Curl`.