### PR TITLE
formula: show full commands of system call

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2036,7 +2036,7 @@ class Formula
     pretty_args.each_index do |i|
       pretty_args[i] = "import setuptools..." if pretty_args[i].to_s.start_with? "import setuptools"
     end
-    ohai "#{cmd} #{pretty_args * " "}".strip
+    ohai "#{cmd} #{pretty_args * " "}".strip, truncate: false
 
     @exec_count ||= 0
     @exec_count += 1

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -95,25 +95,25 @@ module Kernel
     raise unless e.message.include?(path)
   end
 
-  def ohai_title(title)
+  def ohai_title(title, truncate: :auto, color: :blue)
     verbose = if respond_to?(:verbose?)
       verbose?
     else
       Context.current.verbose?
     end
 
-    title = Tty.truncate(title) if $stdout.tty? && !verbose
-    Formatter.headline(title, color: :blue)
+    title = Tty.truncate(title) if $stdout.tty? && !verbose && truncate == :auto
+    Formatter.headline(title, color: color)
   end
 
-  def ohai(title, *sput)
-    puts ohai_title(title)
+  def ohai(title, *sput, truncate: :auto)
+    puts ohai_title(title, truncate: truncate)
     puts sput
   end
 
-  def ohai_stdout_or_stderr(message, *sput)
+  def ohai_stdout_or_stderr(message, *sput, truncate: :auto)
     if $stdout.tty?
-      ohai(message, *sput)
+      ohai(message, *sput, truncate: truncate)
     else
       $stderr.puts(ohai_title(message))
       $stderr.puts(sput)
@@ -143,14 +143,7 @@ module Kernel
   end
 
   def oh1(title, truncate: :auto)
-    verbose = if respond_to?(:verbose?)
-      verbose?
-    else
-      Context.current.verbose?
-    end
-
-    title = Tty.truncate(title) if $stdout.tty? && !verbose && truncate == :auto
-    puts Formatter.headline(title, color: :green)
+    puts ohai_title(title, truncate: truncate, color: :green)
   end
 
   # Print a message prefixed with "Warning" (do this rarely).


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

`system` truncates the command to terminal width while prompting. This issue usually raises up for a very long `./configure ...` command when installing or upgrading formula(e) from source without `verbose` flag. Users have no idea what is happening on their devices.
