### PR TITLE
Expand quiet checks in update and update-report

### DIFF
--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -129,7 +129,7 @@ module Homebrew
       if hub.empty?
         puts_stdout_or_stderr "No changes to formulae." unless args.quiet?
       else
-        hub.dump(updated_formula_report: !args.preinstall?)
+        hub.dump(updated_formula_report: !args.preinstall?) unless args.quiet?
         hub.reporters.each(&:migrate_tap_migration)
         hub.reporters.each { |r| r.migrate_formula_rename(force: args.force?, verbose: args.verbose?) }
         CacheStoreDatabase.use(:descriptions) do |db|
@@ -137,7 +137,7 @@ module Homebrew
                                .update_from_report!(hub)
         end
 
-        unless args.preinstall?
+        if !args.preinstall? && !args.quiet?
           outdated_formulae = Formula.installed.count(&:outdated?)
           outdated_casks = Cask::Caskroom.casks.count(&:outdated?)
           update_pronoun = if (outdated_formulae + outdated_casks) == 1

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -308,6 +308,7 @@ homebrew-update() {
       -\?|-h|--help|--usage)          brew help update; exit $? ;;
       --verbose)                      HOMEBREW_VERBOSE=1 ;;
       --debug)                        HOMEBREW_DEBUG=1 ;;
+      --quiet)                        HOMEBREW_QUIET=1 ;;
       --merge)                        HOMEBREW_MERGE=1 ;;
       --force)                        HOMEBREW_UPDATE_FORCE=1 ;;
       --simulate-from-current-branch) HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH=1 ;;
@@ -315,6 +316,7 @@ homebrew-update() {
       --*)                            ;;
       -*)
         [[ "$option" = *v* ]] && HOMEBREW_VERBOSE=1
+        [[ "$option" = *q* ]] && HOMEBREW_QUIET=1
         [[ "$option" = *d* ]] && HOMEBREW_DEBUG=1
         [[ "$option" = *f* ]] && HOMEBREW_UPDATE_FORCE=1
         ;;
@@ -661,7 +663,8 @@ EOS
   then
     brew update-report "$@"
     return $?
-  elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" ]]
+  elif [[ -z "$HOMEBREW_UPDATE_PREINSTALL" &&
+	  -z "$HOMEBREW_QUIET" ]]
   then
     echo "Already up-to-date."
   fi


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----
The output from brew update can be voluminous. To reduce what is reported, this pull request expands the `--quiet` checks in `update-report` and adds it to `update`. This follows up on https://github.com/Homebrew/brew/pull/10581#issuecomment-791670209 and seeks to partially address https://github.com/Homebrew/brew/issues/10609.