### PR TITLE
update-python-resources: include wheel in resources

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -182,7 +182,7 @@ module PyPI
 
     extra_packages = (extra_packages || []).map { |p| Package.new p }
     exclude_packages = (exclude_packages || []).map { |p| Package.new p }
-    exclude_packages += %W[#{main_package.name} argparse pip setuptools wheel wsgiref].map { |p| Package.new p }
+    exclude_packages += %W[#{main_package.name} argparse pip setuptools wsgiref].map { |p| Package.new p }
     # remove packages from the exclude list if we've explicitly requested them as an extra package
     exclude_packages.delete_if { |package| extra_packages.include?(package) }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

When we used `virtualenv` for our Python virtual environments, the `wheel` resource from the `python@3.X` formula was pulled in automatically, so there was no need (or rarely a need) for `wheel` to be specified as a resource. Now that we use `python3 -m venv` for virtual environments, though, the `wheel` resource is no longer automatically installed in the virtual environment:

```console
$ python3 -m pip list
Package    Version
---------- -------
pip        21.0.1
setuptools 53.0.0
wheel      0.36.2

$ python3 -m venv venv

$ source venv/bin/activate

$ python3 -m pip list
Package    Version
---------- -------
pip        21.0.1
setuptools 53.0.0
```

For some more context into why `wheel` was added, see https://github.com/Homebrew/brew/pull/8059#discussion_r461064786 which points to https://github.com/Homebrew/homebrew-core/pull/58380#discussion_r458830938. Again, the information in that thread is outdated now that we use `python3 -m venv`.

As a result, the number of times that `wheel` is added as an `extra_packages` item to the [`pypi_formula_mappings.json`](https://github.com/Homebrew/homebrew-core/blob/master/pypi_formula_mappings.json) file (overriding the exclusion) has increased a lot recently.

I don't think it makes sense for us to exclude `wheel` as a resource anymore, given this. As far as I know, it doesn't show up in the `pipgrip` output by mistake enough to be an issue. I would guess that we already include a few resources that aren't needed because they are output by `pipgrip`, so I don't think `wheel` showing up in a few extra cases where it may not really be needed is a hueg deal. Plus, we can always exclude `wheel` manually if needed.

This also may solve some of the issues mentioned in https://github.com/Homebrew/brew/pull/10811#issuecomment-797273663 with `wheel`.

Lastly, I left the remaining excluded resources (`argparse`, `pip`, `setuptools`, `wsgiref`) in the sclude list. Of these, only `pip` and `setuptools` are installed automatically, so I think `argparse` and `wsgiref` could probably be removed from this list. I couldn't figure out why I added them to this list in the first place, though. I bet that I just copied the items in an exclude list from somewhere else, but I can't seem to find where that would be, and I wonder if there's a reason for them being there. If anyone remembers and has some insight, I'd appreciate it.
