### PR TITLE
audit: check for installed empty files

### DIFF
--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -432,6 +432,7 @@ class Pathname
   def install_metafiles(from = Pathname.pwd)
     Pathname(from).children.each do |p|
       next if p.directory?
+      next if File.zero?(p)
       next unless Metafiles.copy?(p.basename.to_s)
 
       # Some software symlinks these files (see help2man.rb)

--- a/Library/Homebrew/test/formula_installer_spec.rb
+++ b/Library/Homebrew/test/formula_installer_spec.rb
@@ -51,7 +51,8 @@ describe FormulaInstaller do
   specify "basic installation" do
     temporary_install(Testball.new) do |f|
       # Test that things made it into the Keg
-      expect(f.prefix/"readme").to exist
+      # "readme" is empty, so it should not be installed
+      expect(f.prefix/"readme").not_to exist
 
       expect(f.bin).to be_a_directory
       expect(f.bin.children.count).to eq(3)


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a check with `brew audit` to check for empty files that were installed, resolving #10768. This takes the approach of warning through `brew audit` rather than automatically removing said files after installation.

There may still be some false positives. I'm open to feedback on how to reduce them (I currently have a "valid" list for names and extensions that can be ignored, which is certainly not comprehensive). For reference, [this is a list of errors I get](https://gist.github.com/kthchew/584d8f5cc561990454b852003afcf24d) related to this check when I run `brew audit` on all of my installed formulae.