### PR TITLE
formula_creator: use tool-agnostic cmake commands

### DIFF
--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -153,11 +153,14 @@ module Homebrew
           def install
             # ENV.deparallelize  # if your formula fails when building in parallel
         <% if mode == :cmake %>
-            system "cmake", ".", *std_cmake_args
+            system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+            system "cmake", "--build", "build"
+            system "cmake", "--install", "build"
         <% elsif mode == :autotools %>
             # Remove unrecognized options if warned by configure
             # https://rubydoc.brew.sh/Formula.html#std_configure_args-instance_method
             system "./configure", *std_configure_args, "--disable-silent-rules"
+            system "make", "install" # if this fails, try separate make/make install steps
         <% elsif mode == :crystal %>
             system "shards", "build", "--release"
             bin.install "bin/#{name}"
@@ -206,10 +209,7 @@ module Homebrew
             # Remove unrecognized options if warned by configure
             # https://rubydoc.brew.sh/Formula.html#std_configure_args-instance_method
             system "./configure", *std_configure_args, "--disable-silent-rules"
-            # system "cmake", ".", *std_cmake_args
-        <% end %>
-        <% if mode == :autotools || mode == :cmake %>
-            system "make", "install" # if this fails, try separate make/make install steps
+            # system "cmake", "-S", ".", "-B", "build", *std_cmake_args
         <% end %>
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

New versions of CMake know how to invoke the appropriate build tool
(i.e. `make` or `ninja`), so let's try to leave that to CMake.

This also builds out-of-tree, without having to deal with the `mkdir
"build" do` business.