### PR TITLE
workflows/update-manpage: fix issue

### DIFF
--- a/.github/workflows/update-manpage.yml
+++ b/.github/workflows/update-manpage.yml
@@ -10,6 +10,7 @@ on:
       - Library/Homebrew/completions/**
       - Library/Homebrew/manpages/**
       - Library/Homebrew/cli/parser.rb
+      - Library/Homebrew/completions.rb
       - Library/Homebrew/env_config.rb
     branches:
       - master
@@ -40,7 +41,7 @@ jobs:
 
           if git ls-remote --exit-code --heads origin "$BRANCH"; then
             git checkout "$BRANCH"
-            git reset origin/master
+            git reset --hard origin/master
           else
             git checkout -B "$BRANCH" origin/master
             BRANCH_EXISTS="1"
@@ -72,6 +73,7 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           branch: ${{ steps.update.outputs.branch }}
           force: true
+          origin_branch: "master"
 
       - name: Open a pull request
         if: steps.update.outputs.pull_request == 'true'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR aims to fix problems with the `update-manpage` workflow, as encountered in #10854. We should be using `git reset --hard origin/master` instead. Also replacing `git-try-push` as it does not do a `git push --force-with-lease` on the first try ([Bo98's comment](https://github.com/Homebrew/brew/pull/10854#issuecomment-799414425)).