### PR TITLE
github_packages: fix HOMEBREW_BOTTLE_DOMAIN usage.

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -13,7 +13,8 @@ class GitHubPackages
   include Context
   include Utils::Curl
 
-  URL_REGEX = %r{https://ghcr.io/v2/([\w-]+)/([\w-]+)}.freeze
+  URL_PREFIX = "https://ghcr.io/v2/"
+  URL_REGEX = %r{#{Regexp.escape(URL_PREFIX)}([\w-]+)/([\w-]+)}.freeze
 
   sig { returns(String) }
   def inspect

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -379,7 +379,11 @@ class BottleSpecification
 
   def root_url(var = nil, specs = {})
     if var.nil?
-      @root_url ||= "#{Homebrew::EnvConfig.bottle_domain}/#{Utils::Bottles::Bintray.repository(tap)}"
+      @root_url ||= if Homebrew::EnvConfig.bottle_domain.start_with?(GitHubPackages::URL_PREFIX)
+        "#{GitHubPackages::URL_PREFIX}#{tap.full_name}"
+      else
+        "#{Homebrew::EnvConfig.bottle_domain}/#{Utils::Bottles::Bintray.repository(tap)}"
+      end
     else
       @root_url = var
       @root_url_specs.merge!(specs)


### PR DESCRIPTION
This still worked but ended up always having a `/bottles-*/` part of the URL that was unnecessary when using `HOMEBREW_BOTTLE_DOMAIN`.

CC @sjackman who bumped into this.