### PR TITLE
Fix broken rmdir script

### DIFF
--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -111,6 +111,10 @@ module Cask
       set -euo pipefail
 
       for path in "${@}"; do
+        if [[ ! -e "${path}" ]]; then
+          continue
+        fi
+
         if [[ -e "${path}/.DS_Store" ]]; then
           /bin/rm -f "${path}/.DS_Store"
         fi
@@ -135,8 +139,6 @@ module Cask
 
     sig { params(path: T.any(Pathname, T::Array[Pathname])).void }
     def rmdir(path)
-      return unless path.exist?
-
       @command.run!(
         "/usr/bin/xargs",
         args:  ["-0", "--", "/bin/bash", "-c", RMDIR_SH, "--"],

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -135,6 +135,8 @@ module Cask
 
     sig { params(path: T.any(Pathname, T::Array[Pathname])).void }
     def rmdir(path)
+      return unless path.exist?
+
       @command.run!(
         "/usr/bin/xargs",
         args:  ["-0", "--", "/bin/bash", "-c", RMDIR_SH, "--"],


### PR DESCRIPTION
Unfortunately, the removal shell script introduced in #10860 does not handle paths very well that dont exist, e.g.

* [`find`](https://github.com/Homebrew/brew/pull/10860/files#diff-a8ad32ef9807334306b04d125710e7f0953b8dfbdc8435e0630509a5b939a340R120) runs before its `-exec` test, thus throws `find: "${path}": No such file or directory`
* it seem that [`/bin/rmdir`](https://github.com/Homebrew/brew/commit/1a4874dc6253f2eb2d077fbfc40ae88457a4ba40#diff-a8ad32ef9807334306b04d125710e7f0953b8dfbdc8435e0630509a5b939a340R130) is intended to break is certain cases, thus `-f` is not desired. so, if `${path}` does not exist, it'll still break, which is most likely not one of those cases.

This change reintroduces a check for existence. This way, it is ensured that there is actually a directory to be removed when invoking the script.

/cc @reitermarkus 