### PR TITLE
Docs: brew audit --strict is not enough when renaming a formula

### DIFF
--- a/docs/Rename-A-Formula.md
+++ b/docs/Rename-A-Formula.md
@@ -3,7 +3,7 @@
 Sometimes software and formulae need to be renamed. To rename a formula
 you need to:
 
-1. Rename the formula file and its class to a new formula. The new name must meet all the usual rules of formula naming. Fix any test failures that may occur due to the stricter requirements for new formulae than existing formulae (i.e. `brew audit --strict` must pass for that formula).
+1. Rename the formula file and its class to a new formula. The new name must meet all the usual rules of formula naming. Fix any test failures that may occur due to the stricter requirements for new formulae than existing formulae (i.e. `brew audit --online --new-formula` must pass for that formula).
 
 2. Create a pull request to the corresponding tap deleting the old formula file, adding the new formula file, and adding it to `formula_renames.json` with a commit message like `newack: renamed from ack`. Use the canonical name (e.g. `ack` instead of `user/repo/ack`).
 


### PR DESCRIPTION
brew audit --strict does not catch all the issues. The CI/CD uses "brew audit --online --new-formula" and is more thorough, catching e.g. "New formulae in homebrew/core should not have a 'bottle do'" which brew audit --strict does not.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
(not applicable)
- [x] Have you successfully run `brew style` with your changes locally?
(not applicable)
- [x] Have you successfully run `brew typecheck` with your changes locally?
(not applicable)
- [x] Have you successfully run `brew tests` with your changes locally?
(not applicable)
-----

I [got got today when renaming a formula](https://github.com/Homebrew/homebrew-core/pull/73448#issuecomment-802402642). Even though `brew audit --strict` passed, the CI/CD uses `brew audit --online --new-formula`, which caught an issue that the former did not. Since the CI/CD uses the latter, the renaming docs should suggest the same.
