### PR TITLE
Implement caching for dependency expansion

### DIFF
--- a/Library/Homebrew/dependencies.rbi
+++ b/Library/Homebrew/dependencies.rbi
@@ -1,0 +1,9 @@
+# typed: strict
+
+class Dependencies < SimpleDelegator
+  include Kernel
+end
+
+class Requirements < SimpleDelegator
+  include Kernel
+end

--- a/Library/Homebrew/dependencies_helpers.rb
+++ b/Library/Homebrew/dependencies_helpers.rb
@@ -35,15 +35,11 @@ module DependenciesHelpers
   end
 
   def recursive_includes(klass, root_dependent, includes, ignores)
-    type = if klass == Dependency
-      :dependencies
-    elsif klass == Requirement
-      :requirements
-    else
-      raise ArgumentError, "Invalid class argument: #{klass}"
-    end
+    raise ArgumentError, "Invalid class argument: #{klass}" if klass != Dependency && klass != Requirement
 
-    root_dependent.send("recursive_#{type}") do |dependent, dep|
+    cache_key = "recursive_includes_#{includes}_#{ignores}"
+
+    klass.expand(root_dependent, cache_key: cache_key) do |dependent, dep|
       if dep.recommended?
         klass.prune if ignores.include?("recommended?") || dependent.build.without?(dep)
       elsif dep.optional?
@@ -57,7 +53,7 @@ module DependenciesHelpers
 
       # If a tap isn't installed, we can't find the dependencies of one of
       # its formulae, and an exception will be thrown if we try.
-      if type == :dependencies &&
+      if klass == Dependency &&
          dep.is_a?(TapDependency) &&
          !dep.tap.installed?
         Dependency.keep_but_prune_recursive_deps

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -310,6 +310,8 @@ module Homebrew
         Formula.clear_cache
         Keg.clear_cache
         Tab.clear_cache
+        Dependency.clear_cache
+        Requirement.clear_cache
         tab = Tab.for_keg(keg)
         original_tab = tab.dup
         tab.poured_from_bottle = false

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -572,8 +572,8 @@ class FormulaInstaller
     unsatisfied_reqs = Hash.new { |h, k| h[k] = [] }
     req_deps = []
     formulae = [formula]
-    formula_deps_map = Dependency.expand(formula)
-                                 .index_by(&:name)
+    formula_deps_map = formula.recursive_dependencies
+                              .index_by(&:name)
 
     while (f = formulae.pop)
       runtime_requirements = runtime_requirements(f)

--- a/Library/Homebrew/options.rb
+++ b/Library/Homebrew/options.rb
@@ -114,6 +114,12 @@ class Options
     @options.to_a * other
   end
 
+  def ==(other)
+    instance_of?(other.class) &&
+      to_a == other.to_a
+  end
+  alias eql? ==
+
   def empty?
     @options.empty?
   end

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -166,8 +166,7 @@ describe Formula do
     end
 
     build_values_with_no_installed_alias = [
-      nil,
-      BuildOptions.new({}, {}),
+      BuildOptions.new(Options.new, f.options),
       Tab.new(source: { "path" => f.path.to_s }),
     ]
     build_values_with_no_installed_alias.each do |build|
@@ -201,7 +200,10 @@ describe Formula do
       url "foo-1.0"
     end
 
-    build_values_with_no_installed_alias = [nil, BuildOptions.new({}, {}), Tab.new(source: { "path" => f.path })]
+    build_values_with_no_installed_alias = [
+      BuildOptions.new(Options.new, f.options),
+      Tab.new(source: { "path" => f.path }),
+    ]
     build_values_with_no_installed_alias.each do |build|
       f.build = build
       expect(f.installed_alias_path).to be nil
@@ -405,7 +407,7 @@ describe Formula do
       f = formula alias_path: alias_path do
         url "foo-1.0"
       end
-      f.build = BuildOptions.new({}, {})
+      f.build = BuildOptions.new(Options.new, f.options)
 
       expect(f.alias_path).to eq(alias_path)
       expect(f.installed_alias_path).to be nil
@@ -802,7 +804,7 @@ describe Formula do
 
     expect(Set.new(f1.recursive_requirements)).to eq(Set[])
 
-    f1.build = BuildOptions.new(["--with-xcode"], f1.options)
+    f1.build = BuildOptions.new(Options.create(["--with-xcode"]), f1.options)
 
     expect(Set.new(f1.recursive_requirements)).to eq(Set[xcode])
 

--- a/Library/Homebrew/test/spec_helper.rb
+++ b/Library/Homebrew/test/spec_helper.rb
@@ -185,6 +185,8 @@ RSpec.configure do |config|
     Formula.clear_cache
     Keg.clear_cache
     Tab.clear_cache
+    Dependency.clear_cache
+    Requirement.clear_cache
     FormulaInstaller.clear_attempted
     FormulaInstaller.clear_installed
 
@@ -229,6 +231,8 @@ RSpec.configure do |config|
       Formula.clear_cache
       Keg.clear_cache
       Tab.clear_cache
+      Dependency.clear_cache
+      Requirement.clear_cache
 
       FileUtils.rm_rf [
         *TEST_DIRECTORIES,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This adds opt-in caching to `Dependency.expand` and `Requirement.expand`.

This massively increases the speed of those functions, if a cache key is passed. I've adjusted `Formula#rescursive_dependencies` and `Formula#recursive_requirements` to do this if no block is passed.

This massively improves the `brew uses` runtime from ~40s on Linux to about 6s, with most of that remaining time now being the actual `Formula.to_a` file loading.

Care is needed when choosing a cache key - the block is not re-evaulated on cache hits and so the cache key should be constructed depending on what variables might require rerunning the block.

I tried to be careful to clear the cache where it might be necessary - hopefully I haven't missed an edge case.

If successful, this should also speed up the `test default formula (Linux)` CI step.