### PR TITLE
utils/popen: redirect stderr to /dev/null rather than close

### DIFF
--- a/Library/Homebrew/utils/popen.rb
+++ b/Library/Homebrew/utils/popen.rb
@@ -50,7 +50,7 @@ module Utils
 
         yield pipe
       else
-        options[:err] ||= :close unless ENV["HOMEBREW_STDERR"]
+        options[:err] ||= "/dev/null" unless ENV["HOMEBREW_STDERR"]
         begin
           exec(*args, options)
         rescue Errno::ENOENT


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`Utils.popen_read("brew", "deps", "cmake")` currently fails because it invokes an `opoo` and prints to `stderr`, causing a non-success exit code because printing to a closed `stderr` triggers a `EPIPE` (broken pipe) error.

Instead, redirect `stderr` to `/dev/null` so that it doesn't cause broken pipes.