### PR TITLE
Make `livecheck` audit mandatory for versioned casks.

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -542,12 +542,20 @@ module Cask
 
     def check_livecheck_version
       return unless appcast?
-      return unless cask.livecheckable?
       return if cask.livecheck.skip?
       return if cask.version.latest?
 
       latest_version = Homebrew::Livecheck.latest_version(cask)&.fetch(:latest)
-      return if cask.version.to_s == latest_version.to_s
+      if cask.version.to_s == latest_version.to_s
+        if cask.appcast
+          add_error "Version '#{latest_version}' was automatically detected by livecheck; " \
+                    "the appcast should be removed."
+        end
+
+        return
+      end
+
+      return if cask.appcast && !cask.livecheckable?
 
       add_error "Version '#{cask.version}' differs from '#{latest_version}' retrieved by livecheck."
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Some `livecheck`s work using the auto-detected strategy, but we don't have a way to *know* the difference between a missing `livecheck` block and implicitly using the auto-detected strategy.

For now, casks with an existing `appcast` are still skipped.