### PR TITLE
utils/github: handle non-standard tap remotes

### DIFF
--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -199,7 +199,8 @@ module Homebrew
   end
 
   def check_open_pull_requests(cask, args:)
-    GitHub.check_for_duplicate_pull_requests(cask.token, cask.tap.full_name,
+    tap_remote_repo = cask.tap.remote_repo || cask.tap.full_name
+    GitHub.check_for_duplicate_pull_requests(cask.token, tap_remote_repo,
                                              state: "open",
                                              file:  cask.sourcefile_path.relative_path_from(cask.tap.path).to_s,
                                              args:  args)

--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -170,7 +170,8 @@ module Homebrew
   end
 
   def retrieve_pull_requests(formula_or_cask, name)
-    pull_requests = GitHub.fetch_pull_requests(name, formula_or_cask.tap&.full_name, state: "open")
+    tap_remote_repo = formula_or_cask.tap&.remote_repo || formula_or_cask.tap&.full_name
+    pull_requests = GitHub.fetch_pull_requests(name, tap_remote_repo, state: "open")
     if pull_requests.try(:any?)
       pull_requests = pull_requests.map { |pr| "#{pr["title"]} (#{Formatter.url(pr["html_url"])})" }.join(", ")
     end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -143,7 +143,10 @@ class Tap
   def remote_repo
     raise TapUnavailableError, name unless installed?
 
-    @remote_repo ||= remote&.sub(%r{^https://github\.com/}, "")&.sub(/\.git$/, "")
+    return unless remote
+
+    @remote_repo ||= remote.delete_prefix("https://github.com/")
+                           .delete_suffix(".git")
   end
 
   # The default remote path to this {Tap}.

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -138,6 +138,14 @@ class Tap
     @remote ||= path.git_origin
   end
 
+  # The remote repository name of this {Tap}.
+  # e.g. `user/homebrew-repo`
+  def remote_repo
+    raise TapUnavailableError, name unless installed?
+
+    @remote_repo ||= remote&.sub(%r{^https://github\.com/}, "")&.sub(/\.git$/, "")
+  end
+
   # The default remote path to this {Tap}.
   sig { returns(String) }
   def default_remote

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -205,6 +205,33 @@ describe Tap do
     end
   end
 
+  describe "#remote_repo" do
+    it "returns the remote repository" do
+      setup_git_repo
+
+      expect(homebrew_foo_tap.remote_repo).to eq("Homebrew/homebrew-foo")
+      expect { described_class.new("Homebrew", "bar").remote_repo }.to raise_error(TapUnavailableError)
+
+      services_tap = described_class.new("Homebrew", "services")
+      services_tap.path.mkpath
+      services_tap.path.cd do
+        system "git", "init"
+        system "git", "remote", "add", "origin", "https://github.com/Homebrew/homebrew-bar"
+      end
+      expect(services_tap.remote_repo).to eq("Homebrew/homebrew-bar")
+    end
+
+    it "returns nil if the Tap is not a Git repository" do
+      expect(homebrew_foo_tap.remote_repo).to be nil
+    end
+
+    it "returns nil if Git is not available" do
+      setup_git_repo
+      allow(Utils::Git).to receive(:available?).and_return(false)
+      expect(homebrew_foo_tap.remote_repo).to be nil
+    end
+  end
+
   specify "Git variant" do
     touch path/"README"
     setup_git_repo


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #10881

This PR adds a `Tap#remote_repo` method to extract the remote repository name from the tap remote url. This should be used instead of `Tap#full_name` for methods in the `Utils::GitHub` module so that those methods can be used on taps that use non-standard urls.
