### PR TITLE
fix: log message telling users how to disable developer mode

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -569,6 +569,14 @@ then
   HOMEBREW_GIT_CONFIG_DEVELOPERMODE="$(git config --file="$HOMEBREW_GIT_CONFIG_FILE" --get homebrew.devcmdrun 2>/dev/null)"
   if [[ "$HOMEBREW_GIT_CONFIG_DEVELOPERMODE" = "true" ]]
   then
+    # Tell users who accidentally enabled developer mode how to get out of it.
+    # Only do this the first time we run the script.
+    if [[ -z "$HOMEBREW_DEV_CMD_RUN" ]]
+    then
+      # shellcheck disable=SC2016 # Don't want to expand this till the user runs the command.
+      ohai 'Homebrew developer mode enabled, to disable run:
+    git -C "$(brew --repo)" config --unset homebrew.devcmdrun'
+    fi
     export HOMEBREW_DEV_CMD_RUN="1"
   fi
 


### PR DESCRIPTION
---

#### Commits _(oldest to newest)_

004322da3 fix: log message telling users how to disable developer mode

It's fairly common in my experience for Homebrew users to accidentally
have enabled developer mode without realising, and then assume "homebrew
is broken" when (for example) `brew upgrade` doesn't call `brew update`
first, and thus `brew upgrade` doesn't actually upgrade everything in
their taps.

Make it easier for folks to:

1. Know that they enabled developer mode.
2. Know how to disable developer mode.

Ideally this would also link to some docs, but I haven't found any, so
just including the unsetting command, on the assumption that those who
didn't mean to enter developer mode will probably just blindly run the
command, and those who did will be okay with having confirmation that
they are in developer mode.

<br/>