### PR TITLE
Remove FormulaInstaller.prevent_build_flags

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -176,7 +176,15 @@ module Homebrew
 
     # if the user's flags will prevent bottle only-installations when no
     # developer tools are available, we need to stop them early on
-    FormulaInstaller.prevent_build_flags(args)
+    unless DevelopmentTools.installed?
+      build_flags = []
+
+      build_flags << "--HEAD" if args.HEAD?
+      build_flags << "--build-bottle" if args.build_bottle?
+      build_flags << "--build-from-source" if args.build_from_source?
+
+      raise BuildFlagsError.new(build_flags, bottled: formulae.all?(&:bottled?)) if build_flags.present?
+    end
 
     installed_formulae = []
 

--- a/Library/Homebrew/cmd/reinstall.rb
+++ b/Library/Homebrew/cmd/reinstall.rb
@@ -81,12 +81,14 @@ module Homebrew
   def reinstall
     args = reinstall_args.parse
 
-    FormulaInstaller.prevent_build_flags(args)
-
-    Install.perform_preinstall_checks
-
     formulae, casks = args.named.to_formulae_and_casks(method: :resolve)
                           .partition { |o| o.is_a?(Formula) }
+
+    if args.build_from_source? && !DevelopmentTools.installed?
+      raise BuildFlagsError.new(["--build-from-source"], bottled: formulae.all?(&:bottled?))
+    end
+
+    Install.perform_preinstall_checks
 
     formulae.each do |formula|
       if formula.pinned?

--- a/Library/Homebrew/cmd/upgrade.rb
+++ b/Library/Homebrew/cmd/upgrade.rb
@@ -115,7 +115,9 @@ module Homebrew
   def upgrade_outdated_formulae(formulae, args:)
     return false if args.cask?
 
-    FormulaInstaller.prevent_build_flags(args)
+    if args.build_from_source? && !DevelopmentTools.installed?
+      raise BuildFlagsError.new(["--build-from-source"], bottled: formulae.all?(&:bottled?))
+    end
 
     Install.perform_preinstall_checks
 

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -115,25 +115,6 @@ class FormulaInstaller
     @installed = Set.new
   end
 
-  # When no build tools are available and build flags are passed through ARGV,
-  # it's necessary to interrupt the user before any sort of installation
-  # can proceed. Only raises when the user has no developer tools.
-  def self.prevent_build_flags(args)
-    return if DevelopmentTools.installed?
-
-    build_flags = []
-
-    build_flags << "--HEAD" if args.HEAD?
-    build_flags << "--universal" if args.universal?
-    build_flags << "--build-bottle" if args.build_bottle?
-    build_flags << "--build-from-source" if args.build_from_source?
-
-    return if build_flags.empty?
-
-    all_bottled = args.named.to_formulae.all?(&:bottled?)
-    raise BuildFlagsError.new(build_flags, bottled: all_bottled)
-  end
-
   sig { returns(T::Boolean) }
   def build_from_source?
     @build_from_source_formulae.include?(formula.full_name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Responsibility of args should lie with the command itself. The args to check for here varied depending on whether it was an install, reinstall or upgrade.

If we want some sort of shared logic, I'd rather it was done in a more generic way - such as having some way to tag which options are "build flags" and iterating over those.

Fixes https://github.com/Homebrew/discussions/discussions/1104.
