### PR TITLE
download_strategy: clear referer by default with curl

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -515,7 +515,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["-b", meta.fetch(:cookies).map { |k, v| "#{k}=#{v}" }.join(";")] if meta.key?(:cookies)
 
-    args += ["-e", meta.fetch(:referer)] if meta.key?(:referer)
+    args += ["--referer", meta.key?(:referer) ? meta.fetch(:referer) : ""]
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 

--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -12,7 +12,7 @@ describe CurlDownloadStrategy do
   let(:specs) { { user: "download:123456" } }
 
   it "parses the opts and sets the corresponding args" do
-    expect(strategy.send(:_curl_args)).to eq(["--user", "download:123456"])
+    expect(strategy.send(:_curl_args)).to eq(["--referer", "", "--user", "download:123456"])
   end
 
   describe "#fetch" do
@@ -97,7 +97,7 @@ describe CurlDownloadStrategy do
       it "adds the appropriate curl args" do
         expect(strategy).to receive(:system_command).with(
           /curl/,
-          hash_including(args: array_including_cons("-e", "https://somehost/also")),
+          hash_including(args: array_including_cons("--referer", "https://somehost/also")),
         )
         .at_least(:once)
         .and_return(instance_double(SystemCommand::Result, success?: true, stdout: "", assert_success!: nil))


### PR DESCRIPTION
This fixes the situaiton when a user `.curlrc` [contains](https://github.com/mathiasbynens/dotfiles/blob/529b9d156b8fed333826c5f8244e64166b12ec64/.curlrc#L5) e.g. `--referer ';auto'` which in turn may break download URLs unless reset to the default (empty) value. Such download URLs are anything under `https://downloads.sourceforge.net/`.

Also switch to the long-form of the `-e` option, which is `--referer`, for readability/discoverability.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Test:
```
$ brew install --cask bibdesk
==> Downloading https://downloads.sourceforge.net/bibdesk/BibDesk/BibDesk-1.8.2/BibDesk-1.8.2.zip
==> Downloading from https://sourceforge.net/projects/bibdesk/files/BibDesk/BibDesk-1.8.2/BibDesk-1.8.2.zip/download?use_mirror=kumisystems
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: f5db9daad0239e6e851efbcc45e51d5ffb20003790d7784500307930be16cfab
  Actual: 081a53e1c2aa802fcc6c52be54c19428d60f224990e380fd50f682534148790a
    File: ~/Library/Caches/Homebrew/downloads/[...]--BibDesk-1.8.2.zip
To retry an incomplete download, remove the file above.
```
