### PR TITLE
formula: add ldflags parameter to std_go_args

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1457,9 +1457,11 @@ class Formula
   end
 
   # Standard parameters for Go builds.
-  sig { returns(T::Array[T.any(String, Pathname)]) }
-  def std_go_args
-    ["-trimpath", "-o", bin/name]
+  sig { params(ldflags: T.nilable(String)).returns(T::Array[String]) }
+  def std_go_args(ldflags: nil)
+    args = ["-trimpath", "-o=#{bin/name}"]
+    args += ["-ldflags=#{ldflags}"] if ldflags
+    args
   end
 
   # Standard parameters for cabal-v2 builds.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I'm hoping to add ldflags to `std_go_args` in the near future. However there is a problem: multiple ldflags must be passed as one parameter.

In many formulae we have something like `*std_go_args, "-ldflags", ...`. If I were to add ldflags to `std_go_args` then they would be overriden by the later `-ldflags` in formulae, even if the individual flags don't overlap. The same applies vice versa if `std_go_args` comes after a formula's `-ldflags`.

This pull request paves the way to support adding ldflags to `std_go_args` by supporting a `ldflags` parameter.

Currently, this provides little value until I add some standard ldflags. But since I want to avoid breaking existing formulae builds for a few days, the plan I have is:

1. Add basic `ldflags` parameter to `std_go_args`.
2. Wait for next `brew` tag.
3. Update formulae to use new parameter.
4. Write audit to flag formulae which supply `-ldflags` separately to `std_go_args`.
5. Update `std_go_args` to add new standard ldflags, as originally planned.
6. (Optionally, retest everything with the new standard ldflags.)