### PR TITLE
Deprecate no timeout in fetch methods

### DIFF
--- a/Library/Homebrew/cask/download.rb
+++ b/Library/Homebrew/cask/download.rb
@@ -22,7 +22,13 @@ module Cask
     def fetch(quiet: nil, verify_download_integrity: true, timeout: nil)
       downloaded_path = begin
         downloader.shutup! if quiet
-        downloader.fetch(timeout: timeout)
+        begin
+          downloader.fetch(timeout: timeout)
+        rescue ArgumentError
+          odeprecated "`#{downloader.class}#fetch` without a timeout",
+                      "a properly configured `#{downloader.class}#fetch` method"
+          downloader.fetch
+        end
         downloader.cached_location
       rescue => e
         error = CaskError.new("Download failed on Cask '#{cask}' with message: #{e}")

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -388,6 +388,10 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       else
         begin
           _fetch(url: url, resolved_url: resolved_url, timeout: end_time&.remaining!)
+        rescue ArgumentError
+          odeprecated "`#{self.class}#_fetch` without a timeout",
+                      "a properly configured `#{self.class}#_fetch` method"
+          _fetch(url: url, resolved_url: resolved_url)
         rescue ErrorDuringExecution
           raise CurlDownloadStrategyError, url
         end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow-up to #10864
Fixes #10913

While #10864 doesn't technically change the public API, it does cause problems for custom download strategies because they may override private methods that _were_ changed. See #10913 for context.

This PR adds a deprecation message in two places to help combat this. First, it adds the message to the `downloader.fetch(timeout: timeout)` line in `Cask::Download#fetch`. Since this method may not have `timeout` defined as a possible parameter, it could fail. If it does, display a deprecation message and run without the timeout.

Similarly, the `CurlDownloadStrategy#_fetch` could also be overridden. This is called automatically by `CurlDownloadStrategy#fetch`, so it is another instance where an error could be thrown. I've added the same logic here as well.

A few things I'm not sure about:
1. This would add deprecations even though I don't believe we are on a major/minor release. Although, we could go ahead and make a new one if needed (it's been plenty of time since 3.0.0). Normally these would just be added as comments, but the old logic has already been removed so we've already bitten the bullet, so to speak. Another option would be to revert #10864 until a new release could be made.
2. There are other methods that now have a `timeout` parameter that could theoretically cause problems (e.g. `clone_repo` or `resolved_url_and_basename`). Should these get deprecations as well? I'd guess that these are overridden less often in custom download strategies, so it may not be as crucial unless we start to get complaints.
