### PR TITLE
CurlGitHubPackagesDownloadStrategy: revert allowing timeouts

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -537,14 +537,14 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
 
   private
 
-  def _fetch(url:, resolved_url:, timeout:)
+  def _fetch(url:, resolved_url:)
     raise "Empty checksum" if checksum.blank?
     raise "Empty name" if name.blank?
 
     _, org, repo, = *url.match(GitHubPackages::URL_REGEX)
 
     blob_url = "https://ghcr.io/v2/#{org}/#{repo}/#{name}/blobs/sha256:#{checksum}"
-    curl_download(blob_url, "--header", "Authorization: Bearer", to: temporary_path, timeout: timeout)
+    curl_download(blob_url, "--header", "Authorization: Bearer", to: temporary_path)
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #10922

I noticed that these were added separately in #10891 and should also be reverted before the new tag.
