### PR TITLE
formula_installer: move deprecation/disabled checking earlier

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -179,6 +179,24 @@ class FormulaInstaller
 
   sig { void }
   def prelude
+    type, reason = DeprecateDisable.deprecate_disable_info formula
+    if type.present?
+      case type
+      when :deprecated
+        if reason.present?
+          opoo "#{formula.full_name} has been deprecated because it #{reason}!"
+        else
+          opoo "#{formula.full_name} has been deprecated!"
+        end
+      when :disabled
+        if reason.present?
+          raise CannotInstallFormulaError, "#{formula.full_name} has been disabled because it #{reason}!"
+        end
+
+        raise CannotInstallFormulaError, "#{formula.full_name} has been disabled!"
+      end
+    end
+
     Tab.clear_cache
     verify_deps_exist unless ignore_deps?
     forbidden_license_check
@@ -245,25 +263,6 @@ class FormulaInstaller
           official channels.
         EOS
         raise CannotInstallFormulaError, message
-      end
-    end
-
-    type, reason = DeprecateDisable.deprecate_disable_info formula
-
-    if type.present?
-      case type
-      when :deprecated
-        if reason.present?
-          opoo "#{formula.full_name} has been deprecated because it #{reason}!"
-        else
-          opoo "#{formula.full_name} has been deprecated!"
-        end
-      when :disabled
-        if reason.present?
-          raise CannotInstallFormulaError, "#{formula.full_name} has been disabled because it #{reason}!"
-        end
-
-        raise CannotInstallFormulaError, "#{formula.full_name} has been disabled!"
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Perhaps resolves some confusion in Homebrew/homebrew-core#73825.

The deprecation and disabled messages currently only print _after_ the dependencies and requirements have been satisfied. I think it's better to instead print them earlier, so we don't send people to install the `osxfuse` Cask to only later inform them that the formula is deprecated or disabled.