### PR TITLE
workflows: enable commit signing for BrewTestBot

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -24,8 +24,15 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Update RBI files
         id: update
+        env:
+          GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           git fetch origin
 

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -21,11 +21,17 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Update SPDX license data
         id: update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           git fetch origin
 

--- a/.github/workflows/update-manpage.yml
+++ b/.github/workflows/update-manpage.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
       - name: Update maintainers, manpage and completions
         id: update
         run: |
@@ -65,6 +70,7 @@ jobs:
           fi
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Push commits
         if: steps.update.outputs.committed == 'true'

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -28,6 +28,10 @@ jobs:
         uses: Homebrew/actions/git-user-config@master
         with:
           username: BrewTestBot
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
       - name: Check out pull request
         id: checkout
         run: |
@@ -43,6 +47,7 @@ jobs:
       - name: Vendor Gems
         env:
           GEM_NAME: ${{ steps.checkout.outputs.gem_name }}
+          GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           set -u
 
@@ -54,6 +59,7 @@ jobs:
       - name: Update RBI files
         env:
           GEM_NAME: ${{ steps.checkout.outputs.gem_name }}
+          GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           set -u
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR enables commit signing for BrewTestBot in workflows, using the `setup-commit-signing` action. (See #10672)