### PR TITLE
test: don't apply timeout with --debug

### DIFF
--- a/Library/Homebrew/test.rb
+++ b/Library/Homebrew/test.rb
@@ -39,8 +39,13 @@ begin
   T.cast(ENV, Stdenv).setup_build_environment(formula: formula, testing_formula: true)
 
   # tests can also return false to indicate failure
-  Timeout.timeout TEST_TIMEOUT_SECONDS do
+  run_test = proc do
     raise "test returned false" if formula.run_test(keep_tmp: args.keep_tmp?) == false
+  end
+  if args.debug? # --debug is interactive
+    run_test.call
+  else
+    Timeout.timeout(TEST_TIMEOUT_SECONDS, &run_test)
   end
 rescue Exception => e # rubocop:disable Lint/RescueException
   error_pipe.puts e.to_json


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`--debug` is interactive because it activates Debrew, so it's annoying to have that be under a time bomb.