### PR TITLE
dev-cmd/pr-automerge: skip automerge for "linux to homebrew-core" by default

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-automerge.rb
+++ b/Library/Homebrew/dev-cmd/pr-automerge.rb
@@ -21,7 +21,8 @@ module Homebrew
              description: "Pull requests must have this label."
       comma_array "--without-labels",
                   description: "Pull requests must not have these labels (default: "\
-                               "`do not merge`, `new formula`, `automerge-skip`, `linux-only`)."
+                               "`do not merge`, `new formula`, `automerge-skip`, `linux-only`, "\
+                               "`linux to homebrew-core`)."
       switch "--without-approval",
              description: "Pull requests do not require approval to be merged."
       switch "--publish",
@@ -39,7 +40,13 @@ module Homebrew
   def pr_automerge
     args = pr_automerge_args.parse
 
-    without_labels = args.without_labels || ["do not merge", "new formula", "automerge-skip", "linux-only"]
+    without_labels = args.without_labels || [
+      "do not merge",
+      "new formula",
+      "automerge-skip",
+      "linux-only",
+      "linux to homebrew-core",
+    ]
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
 
     query = "is:pr is:open repo:#{tap.full_name} draft:false"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

PRs labelled with this almost always contain changes that do not require disposing of old macOS bottles. In the rare cases where they don't, a `brew pr-publish` can still be performed.