### PR TITLE
cmd/list: always use `ls` when no named args are passed

### DIFF
--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -57,6 +57,7 @@ module Homebrew
       conflicts "--formula", "--cask"
       conflicts "--full-name", "--versions"
       conflicts "--pinned", "--multiple"
+      conflicts "--pinned", "--cask"
       conflicts "--cask", "--multiple"
       ["--formula", "--cask", "--full-name", "--versions", "--pinned"].each do |flag|
         conflicts "--unbrewed", flag
@@ -68,7 +69,6 @@ module Homebrew
       end
       ["--pinned", "-l", "-r", "-t"].each do |flag|
         conflicts "--full-name", flag
-        conflicts "--cask", flag
       end
 
       named_args [:installed_formula, :installed_cask]

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -45,14 +45,14 @@ module Homebrew
              description: "Force output to be one entry per line. " \
                           "This is the default when output is not to a terminal."
       switch "-l",
-             depends_on:  "--formula",
-             description: "List formulae in long format."
+             description: "List formulae and/or casks in long format. " \
+                          "Has no effect when a formula or cask name is passed as an argument."
       switch "-r",
-             depends_on:  "--formula",
-             description: "Reverse the order of the formulae sort to list the oldest entries first."
+             description: "Reverse the order of the formulae and/or casks sort to list the oldest entries first. " \
+                          "Has no effect when a formula or cask name is passed as an argument."
       switch "-t",
-             depends_on:  "--formula",
-             description: "Sort formulae by time modified, listing most recently modified first."
+             description: "Sort formulae and/or casks by time modified, listing most recently modified first. " \
+                          "Has no effect when a formula or cask name is passed as an argument."
 
       conflicts "--formula", "--cask"
       conflicts "--full-name", "--versions"
@@ -126,7 +126,7 @@ module Homebrew
           puts
           ohai "Casks"
         end
-        list_casks(args: args)
+        safe_system "ls", *ls_args, Cask::Caskroom.path
       end
     elsif args.verbose? || !$stdout.tty?
       system_command! "find", args: args.named.to_kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This has the added benefit of making the indentation in the output of
`brew list` uniform between formulae and casks. Also, you can now do
`brew ls -l` rather than `brew ls -l --formula`.

~~One disadvantage to this is that `brew ls -l --cask`, for example, will
return an error. I'll have to look into fixing that.~~ Fix should be up shortly
once `brew tests` is done running.

Follow-up to #10899. See, in particular, https://github.com/Homebrew/brew/pull/10899#discussion_r598659321.