### PR TITLE
github_packages: use json_schemer gem.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,6 @@
 **/vendor/bundle/ruby/*/gems/thread_safe-*/lib/thread_safe/util
 
 # Ignore dependencies we don't wish to vendor
-**/vendor/bundle/ruby/*/gems/addressable-*/
 **/vendor/bundle/ruby/*/gems/ast-*/
 **/vendor/bundle/ruby/*/gems/bootsnap-*/
 **/vendor/bundle/ruby/*/gems/bundler-*/
@@ -97,11 +96,14 @@
 **/vendor/bundle/ruby/*/gems/diff-lcs-*/
 **/vendor/bundle/ruby/*/gems/docile-*/
 **/vendor/bundle/ruby/*/gems/domain_name-*/
+**/vendor/bundle/ruby/*/gems/ecma-re-validator-*/
+**/vendor/bundle/ruby/*/gems/hana-*/
 **/vendor/bundle/ruby/*/gems/highline-*/
 **/vendor/bundle/ruby/*/gems/http-cookie-*/
 **/vendor/bundle/ruby/*/gems/hpricot-*/
 **/vendor/bundle/ruby/*/gems/jaro_winkler-*/
 **/vendor/bundle/ruby/*/gems/json-*/
+**/vendor/bundle/ruby/*/gems/json_schemer-*/
 **/vendor/bundle/ruby/*/gems/method_source-*/
 **/vendor/bundle/ruby/*/gems/mime-types-data-*/
 **/vendor/bundle/ruby/*/gems/mime-types-*/
@@ -120,7 +122,6 @@
 **/vendor/bundle/ruby/*/gems/powerpack-*/
 **/vendor/bundle/ruby/*/gems/psych-*/
 **/vendor/bundle/ruby/*/gems/pry-*/
-**/vendor/bundle/ruby/*/gems/public_suffix-*/
 **/vendor/bundle/ruby/*/gems/racc-*/
 **/vendor/bundle/ruby/*/gems/rainbow-*/
 **/vendor/bundle/ruby/*/gems/rdiscount-*/
@@ -152,6 +153,7 @@
 **/vendor/bundle/ruby/*/gems/unf_ext-*/
 **/vendor/bundle/ruby/*/gems/unf-*/
 **/vendor/bundle/ruby/*/gems/unicode-display_width-*/
+**/vendor/bundle/ruby/*/gems/uri_template-*/
 **/vendor/bundle/ruby/*/gems/webrobots-*/
 
 # Ignore `bin` contents (again).

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -543,7 +543,7 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
 
     _, org, repo, = *url.match(GitHubPackages::URL_REGEX)
 
-    blob_url = "https://ghcr.io/v2/#{org}/#{repo}/#{name}/blobs/sha256:#{checksum}"
+    blob_url = "#{GitHubPackages::URL_PREFIX}#{org}/#{repo}/#{name}/blobs/sha256:#{checksum}"
     curl_download(blob_url, "--header", "Authorization: Bearer", to: temporary_path)
   end
 end

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -290,6 +290,7 @@ class GitHubPackages
 
   def write_image_index(manifests, blobs, annotations)
     image_index = {
+      # Currently needed for correct multi-arch display in GitHub Packages UI
       mediaType:     "application/vnd.docker.distribution.manifest.list.v2+json",
       schemaVersion: 2,
       manifests:     manifests,

--- a/Library/Homebrew/sorbet/rbi/todo.rbi
+++ b/Library/Homebrew/sorbet/rbi/todo.rbi
@@ -4,8 +4,7 @@
 # typed: strong
 module ::StackProf; end
 module DependencyCollector::Compat; end
-module JSON::Schema; end
-module JSON::Validator; end
+module GitHubPackages::JSONSchemer; end
 module OS::Mac::Version::NULL; end
 module T::InterfaceWrapper::Helpers; end
 module T::Private::Abstract::Hooks; end

--- a/Library/Homebrew/utils/gems.rb
+++ b/Library/Homebrew/utils/gems.rb
@@ -88,7 +88,10 @@ module Homebrew
       specs = Gem.install name, version, document: []
     end
 
-    # Add the new specs to the $LOAD_PATH.
+    specs += specs.flat_map(&:runtime_dependencies)
+                  .flat_map(&:to_specs)
+
+    # Add the specs to the $LOAD_PATH.
     specs.each do |spec|
       spec.require_paths.each do |path|
         full_path = File.join(spec.full_gem_path, path)


### PR DESCRIPTION
Instead of the deprecated json-schema.

Also:
- `utils/gems`: add dependencies to `LOAD_PATH`.
- `download_strategy`: use `GitHubPackages` constant.
- import fixes from #10947 and add `mediaType` comment.
- tweak package name (remove `homebrew-` prefix) and output URL when uploaded

Example uploaded package in https://github.com/orgs/Homebrew/packages/container/package/core/libev