### PR TITLE
github_packages: write tab.

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -14,7 +14,7 @@ Lint/NestedMethodDefinition:
 
 # TODO: Try to bring down all metrics maximums.
 Metrics/AbcSize:
-  Max: 250
+  Max: 275
 Metrics/BlockLength:
   Max: 100
   Exclude:

--- a/Library/Homebrew/cleanup.rb
+++ b/Library/Homebrew/cleanup.rb
@@ -64,7 +64,7 @@ module Homebrew
         def stale_formula?(scrub)
           return false unless HOMEBREW_CELLAR.directory?
 
-          version = if to_s.match?(Pathname::BOTTLE_EXTNAME_RX)
+          version = if HOMEBREW_BOTTLES_EXTNAME_REGEX.match?(to_s)
             begin
               Utils::Bottles.resolve_version(self)
             rescue

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -92,6 +92,12 @@ module Homebrew
       hash.deep_merge(JSON.parse(IO.read(json_file)))
     end
 
+    if args.root_url
+      bottles_hash.each_value do |bottle_hash|
+        bottle_hash["bottle"]["root_url"] = args.root_url
+      end
+    end
+
     bottle_args = ["bottle", "--merge", "--write"]
     bottle_args << "--verbose" if args.verbose?
     bottle_args << "--debug" if args.debug?

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -538,8 +538,8 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
   private
 
   def _fetch(url:, resolved_url:)
-    raise "Empty checksum" if checksum.blank?
-    raise "Empty name" if name.blank?
+    raise CurlDownloadStrategyError, "Empty checksum" if checksum.blank?
+    raise CurlDownloadStrategyError, "Empty name" if name.blank?
 
     _, org, repo, = *url.match(GitHubPackages::URL_REGEX)
 

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -81,9 +81,6 @@ class Pathname
 
   include DiskUsageExtension
 
-  # @private
-  BOTTLE_EXTNAME_RX = /(\.[a-z0-9_]+\.bottle\.(\d+\.)?tar\.gz)$/.freeze
-
   # Moves a file from the original location to the {Pathname}'s.
   sig {
     params(sources: T.any(
@@ -243,7 +240,7 @@ class Pathname
   def extname
     basename = File.basename(self)
 
-    bottle_ext = basename[BOTTLE_EXTNAME_RX, 1]
+    bottle_ext, = HOMEBREW_BOTTLES_EXTNAME_REGEX.match(basename).to_a
     return bottle_ext if bottle_ext
 
     archive_ext = basename[/(\.(tar|cpio|pax)\.(gz|bz2|lz|xz|Z))\Z/, 1]

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1139,14 +1139,21 @@ class FormulaInstaller
       )
     end
 
-    tab.tap = formula.tap
+    # fill in missing/outdated parts of the tab
+    # keep in sync with Tab#to_bottle_json
+    tab.used_options = []
+    tab.unused_options = []
+    tab.built_as_bottle = true
     tab.poured_from_bottle = true
-    tab.time = Time.now.to_i
-    tab.head = HOMEBREW_REPOSITORY.git_head
-    tab.source["path"] = formula.specified_path.to_s
     tab.installed_as_dependency = installed_as_dependency?
     tab.installed_on_request = installed_on_request?
+    tab.time = Time.now.to_i
     tab.aliases = formula.aliases
+    tab.arch = Hardware::CPU.arch
+    tab.source["versions"]["stable"] = formula.stable.version.to_s
+    tab.source["path"] = formula.specified_path.to_s
+    tab.source["tap_git_head"] = formula.tap&.git_head
+    tab.tap = formula.tap
     tab.write
   end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -52,6 +52,7 @@ module Formulary
     require "formula"
 
     mod = Module.new
+    remove_const(namespace) if const_defined?(namespace)
     const_set(namespace, mod)
 
     begin

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -4,6 +4,7 @@
 require "digest/md5"
 require "extend/cachable"
 require "tab"
+require "utils/bottles"
 
 # The {Formulary} is responsible for creating instances of {Formula}.
 # It is not meant to be used directly from formulae.
@@ -458,7 +459,7 @@ module Formulary
 
   def self.loader_for(ref, from: nil)
     case ref
-    when Pathname::BOTTLE_EXTNAME_RX
+    when HOMEBREW_BOTTLES_EXTNAME_REGEX
       return BottleLoader.new(ref)
     when URL_START_REGEX
       return FromUrlLoader.new(ref)

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -233,7 +233,8 @@ class GitHubPackages
 
     index_json_sha256, index_json_size = write_image_index(manifests, blobs, formula_annotations_hash)
 
-    write_index_json(index_json_sha256, index_json_size, root)
+    write_index_json(index_json_sha256, index_json_size, root,
+                     "org.opencontainers.image.ref.name" => version_rebuild)
 
     # docker/skopeo insist on lowercase org ("repository name")
     org_prefix = "#{DOCKER_PREFIX}#{org.downcase}"
@@ -287,16 +288,15 @@ class GitHubPackages
     write_hash(blobs, image_index)
   end
 
-  def write_index_json(index_json_sha256, index_json_size, root)
+  def write_index_json(index_json_sha256, index_json_size, root, annotations)
     index_json = {
       schemaVersion: 2,
       manifests:     [{
         mediaType:   "application/vnd.oci.image.index.v1+json",
         digest:      "sha256:#{index_json_sha256}",
         size:        index_json_size,
-        annotations: {},
+        annotations: annotations,
       }],
-      annotations:   {},
     }
     validate_schema!(IMAGE_INDEX_SCHEMA_URI, index_json)
     write_hash(root, index_json, "index.json")

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -137,8 +137,9 @@ class GitHubPackages
     blobs = root/"blobs/sha256"
     blobs.mkpath
 
-    git_revision = bottle_hash["formula"]["tap_git_head"]
     git_path = bottle_hash["formula"]["tap_git_path"]
+    git_revision = bottle_hash["formula"]["tap_git_revision"]
+    git_revision ||= "HEAD"
     source = "https://github.com/#{org}/#{repo}/blob/#{git_revision}/#{git_path}"
 
     formula_core_tap = formula_full_name.exclude?("/")

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -123,6 +123,7 @@ class GitHubPackages
     formula_name = bottle_hash["formula"]["name"]
 
     _, org, repo, = *bottle_hash["bottle"]["root_url"].match(URL_REGEX)
+    repo = "homebrew-#{repo}" unless HOMEBREW_OFFICIAL_REPO_PREFIXES_REGEX.match?(repo)
 
     version = bottle_hash["formula"]["pkg_version"]
     rebuild = if (rebuild = bottle_hash["bottle"]["rebuild"]).positive?
@@ -139,8 +140,7 @@ class GitHubPackages
 
     git_path = bottle_hash["formula"]["tap_git_path"]
     git_revision = bottle_hash["formula"]["tap_git_revision"]
-    git_revision ||= "HEAD"
-    source = "https://github.com/#{org}/#{repo}/blob/#{git_revision}/#{git_path}"
+    source = "https://github.com/#{org}/#{repo}/blob/#{git_revision.presence || "HEAD"}/#{git_path}"
 
     formula_core_tap = formula_full_name.exclude?("/")
     documentation = if formula_core_tap

--- a/Library/Homebrew/global.rb
+++ b/Library/Homebrew/global.rb
@@ -71,6 +71,7 @@ HOMEBREW_PULL_API_REGEX =
   %r{https://api\.github\.com/repos/([\w-]+)/([\w-]+)?/pulls/(\d+)}.freeze
 HOMEBREW_PULL_OR_COMMIT_URL_REGEX =
   %r[https://github\.com/([\w-]+)/([\w-]+)?/(?:pull/(\d+)|commit/[0-9a-fA-F]{4,40})].freeze
+HOMEBREW_BOTTLES_EXTNAME_REGEX = /\.([a-z0-9_]+)\.bottle\.(?:(\d+)\.)?tar\.gz$/.freeze
 
 require "fileutils"
 

--- a/Library/Homebrew/tab.rb
+++ b/Library/Homebrew/tab.rb
@@ -33,17 +33,17 @@ class Tab < OpenStruct
       "poured_from_bottle"      => false,
       "time"                    => Time.now.to_i,
       "source_modified_time"    => formula.source_modified_time.to_i,
-      "HEAD"                    => HOMEBREW_REPOSITORY.git_head,
       "compiler"                => compiler,
       "stdlib"                  => stdlib,
       "aliases"                 => formula.aliases,
       "runtime_dependencies"    => Tab.runtime_deps_hash(runtime_deps),
       "arch"                    => Hardware::CPU.arch,
       "source"                  => {
-        "path"     => formula.specified_path.to_s,
-        "tap"      => formula.tap&.name,
-        "spec"     => formula.active_spec_sym.to_s,
-        "versions" => {
+        "path"         => formula.specified_path.to_s,
+        "tap"          => formula.tap&.name,
+        "tap_git_head" => formula.tap&.git_head,
+        "spec"         => formula.active_spec_sym.to_s,
+        "versions"     => {
           "stable"         => formula.stable&.version.to_s,
           "head"           => formula.head&.version.to_s,
           "version_scheme" => formula.version_scheme,
@@ -188,17 +188,17 @@ class Tab < OpenStruct
       "poured_from_bottle"      => false,
       "time"                    => nil,
       "source_modified_time"    => 0,
-      "HEAD"                    => nil,
       "stdlib"                  => nil,
       "compiler"                => DevelopmentTools.default_compiler,
       "aliases"                 => [],
       "runtime_dependencies"    => nil,
       "arch"                    => nil,
       "source"                  => {
-        "path"     => nil,
-        "tap"      => nil,
-        "spec"     => "stable",
-        "versions" => {
+        "path"         => nil,
+        "tap"          => nil,
+        "tap_git_head" => nil,
+        "spec"         => "stable",
+        "versions"     => {
           "stable"         => nil,
           "head"           => nil,
           "version_scheme" => 0,
@@ -330,17 +330,33 @@ class Tab < OpenStruct
       "changed_files"           => changed_files&.map(&:to_s),
       "time"                    => time,
       "source_modified_time"    => source_modified_time.to_i,
-      "HEAD"                    => self.HEAD,
       "stdlib"                  => stdlib&.to_s,
       "compiler"                => compiler&.to_s,
       "aliases"                 => aliases,
       "runtime_dependencies"    => runtime_dependencies,
       "source"                  => source,
-      "arch"                    => Hardware::CPU.arch,
+      "arch"                    => arch,
       "built_on"                => built_on,
     }
+    attributes.delete("stdlib") if attributes["stdlib"].blank?
 
-    JSON.generate(attributes, options)
+    JSON.pretty_generate(attributes, options)
+  end
+
+  # a subset of to_json that we care about for bottles
+  def to_bottle_hash
+    attributes = {
+      "homebrew_version"     => homebrew_version,
+      "changed_files"        => changed_files&.map(&:to_s),
+      "source_modified_time" => source_modified_time.to_i,
+      "stdlib"               => stdlib&.to_s,
+      "compiler"             => compiler&.to_s,
+      "runtime_dependencies" => runtime_dependencies,
+      "arch"                 => arch,
+      "built_on"             => built_on,
+    }
+    attributes.delete("stdlib") if attributes["stdlib"].blank?
+    attributes
   end
 
   def write

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -42,6 +42,8 @@ describe Tab do
           "head"   => "HEAD-1111111",
         },
       },
+      "arch"                 => Hardware::CPU.arch,
+      "built_on"             => DevelopmentTools.build_system_info,
     )
   }
 
@@ -360,6 +362,7 @@ describe Tab do
 
   specify "#to_json" do
     json_tab = described_class.new(JSON.parse(tab.to_json))
+    expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
     expect(json_tab.used_options.sort).to eq(tab.used_options.sort)
     expect(json_tab.unused_options.sort).to eq(tab.unused_options.sort)
     expect(json_tab.built_as_bottle).to eq(tab.built_as_bottle)
@@ -368,13 +371,26 @@ describe Tab do
     expect(json_tab.tap).to eq(tab.tap)
     expect(json_tab.spec).to eq(tab.spec)
     expect(json_tab.time).to eq(tab.time)
-    expect(json_tab.HEAD).to eq(tab.HEAD)
     expect(json_tab.compiler).to eq(tab.compiler)
     expect(json_tab.stdlib).to eq(tab.stdlib)
     expect(json_tab.runtime_dependencies).to eq(tab.runtime_dependencies)
     expect(json_tab.stable_version).to eq(tab.stable_version)
     expect(json_tab.head_version).to eq(tab.head_version)
     expect(json_tab.source["path"]).to eq(tab.source["path"])
+    expect(json_tab.arch).to eq(tab.arch.to_s)
+    expect(json_tab.built_on["os"]).to eq(tab.built_on["os"])
+  end
+
+  specify "#to_bottle_hash" do
+    json_tab = described_class.new(JSON.parse(tab.to_bottle_hash.to_json))
+    expect(json_tab.homebrew_version).to eq(tab.homebrew_version)
+    expect(json_tab.changed_files).to eq(tab.changed_files)
+    expect(json_tab.source_modified_time).to eq(tab.source_modified_time)
+    expect(json_tab.stdlib).to eq(tab.stdlib)
+    expect(json_tab.compiler).to eq(tab.compiler)
+    expect(json_tab.runtime_dependencies).to eq(tab.runtime_dependencies)
+    expect(json_tab.arch).to eq(tab.arch.to_s)
+    expect(json_tab.built_on["os"]).to eq(tab.built_on["os"])
   end
 
   specify "::remap_deprecated_options" do

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -24,14 +24,22 @@ module Utils
 
       def file_outdated?(f, file)
         filename = file.basename.to_s
-        return if f.bottle.blank? || !filename.match?(Pathname::BOTTLE_EXTNAME_RX)
+        return false if f.bottle.blank?
 
-        bottle_ext = filename[native_regex, 1]
-        bottle_url_ext = f.bottle.url[native_regex, 1]
+        bottle_ext, bottle_tag, = extname_tag_rebuild(filename)
+        return false if bottle_ext.blank?
+        return false if bottle_tag != tag.to_s
+
+        bottle_url_ext, = extname_tag_rebuild(f.bottle.url)
 
         bottle_ext && bottle_url_ext && bottle_ext != bottle_url_ext
       end
 
+      def extname_tag_rebuild(filename)
+        HOMEBREW_BOTTLES_EXTNAME_REGEX.match(filename).to_a
+      end
+
+      # TODO: remove when removed from brew-test-bot
       sig { returns(Regexp) }
       def native_regex
         /(\.#{Regexp.escape(tag.to_s)}\.bottle\.(\d+\.)?tar\.gz)$/o

--- a/completions/bash/brew
+++ b/completions/bash/brew
@@ -380,6 +380,7 @@ _brew_bottle() {
       --merge
       --no-commit
       --no-rebuild
+      --only-json-tab
       --quiet
       --root-url
       --skip-relocation

--- a/completions/fish/brew.fish
+++ b/completions/fish/brew.fish
@@ -365,6 +365,7 @@ __fish_brew_complete_arg 'bottle' -l keep-old -d 'If the formula specifies a reb
 __fish_brew_complete_arg 'bottle' -l merge -d 'Generate an updated bottle block for a formula and optionally merge it into the formula file. Instead of a formula name, requires the path to a JSON file generated with `brew bottle --json` formula'
 __fish_brew_complete_arg 'bottle' -l no-commit -d 'When passed with `--write`, a new commit will not generated after writing changes to the formula file'
 __fish_brew_complete_arg 'bottle' -l no-rebuild -d 'If the formula specifies a rebuild version, remove it from the generated DSL'
+__fish_brew_complete_arg 'bottle' -l only-json-tab -d 'When passed with `--json`, the tab will be written to the JSON file but not the bottle'
 __fish_brew_complete_arg 'bottle' -l quiet -d 'Make some output more quiet'
 __fish_brew_complete_arg 'bottle' -l root-url -d 'Use the specified URL as the root of the bottle\'s URL instead of Homebrew\'s default'
 __fish_brew_complete_arg 'bottle' -l skip-relocation -d 'Do not check if the bottle can be marked as relocatable'

--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -453,6 +453,7 @@ _brew_bottle() {
     '--merge[Generate an updated bottle block for a formula and optionally merge it into the formula file. Instead of a formula name, requires the path to a JSON file generated with `brew bottle --json` formula]' \
     '--no-commit[When passed with `--write`, a new commit will not generated after writing changes to the formula file]' \
     '(--keep-old)--no-rebuild[If the formula specifies a rebuild version, remove it from the generated DSL]' \
+    '--only-json-tab[When passed with `--json`, the tab will be written to the JSON file but not the bottle]' \
     '--quiet[Make some output more quiet]' \
     '--root-url[Use the specified URL as the root of the bottle'\''s URL instead of Homebrew'\''s default]' \
     '--skip-relocation[Do not check if the bottle can be marked as relocatable]' \

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -823,6 +823,8 @@ value, while `--no-rebuild` will remove it.
   Write changes to the formula file. A new commit will be generated unless `--no-commit` is passed.
 * `--no-commit`:
   When passed with `--write`, a new commit will not generated after writing changes to the formula file.
+* `--only-json-tab`:
+  When passed with `--json`, the tab will be written to the JSON file but not the bottle.
 * `--root-url`:
   Use the specified *`URL`* as the root of the bottle's URL instead of Homebrew's default.
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1133,6 +1133,10 @@ Write changes to the formula file\. A new commit will be generated unless \fB\-\
 When passed with \fB\-\-write\fR, a new commit will not generated after writing changes to the formula file\.
 .
 .TP
+\fB\-\-only\-json\-tab\fR
+When passed with \fB\-\-json\fR, the tab will be written to the JSON file but not the bottle\.
+.
+.TP
 \fB\-\-root\-url\fR
 Use the specified \fIURL\fR as the root of the bottle\'s URL instead of Homebrew\'s default\.
 .


### PR DESCRIPTION
- Write a subset of the tab required for bottles as an annotation.
- Add option on new bottle creation to skip writing tab into bottle and instead add it (and other useful metadata) to bottle JSON.
- Read formula information and tab from bottle JSON.
- Write prettier JSON to disk.
- Don't write `HEAD` to tab; this duplicates `HOMEBREW_VERSION`.
- Allow `brew bottle` to use `--json` to generate JSON files from a local bottle file.