### PR TITLE
workflows/tests: disable cask-versions audit test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -280,7 +280,6 @@ jobs:
           brew audit --skip-style --display-failures-only --tap=homebrew/cask
           brew audit --skip-style --display-failures-only --tap=homebrew/cask-drivers
           brew audit --skip-style --display-failures-only --tap=homebrew/cask-fonts
-          brew audit --skip-style --display-failures-only --tap=homebrew/cask-versions
 
       - name: Install brew tests dependencies
         run: |


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This is regularly broken and needs work to make it work offline only.