### PR TITLE
dev-cmd/audit: delete one variable

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -106,7 +106,6 @@ module Homebrew
     new_formula = args.new_formula?
     strict = new_formula || args.strict?
     online = new_formula || args.online?
-    git = args.git?
     skip_style = args.skip_style? || args.no_named? || args.tap
     no_named_args = false
 
@@ -173,7 +172,7 @@ module Homebrew
         new_formula:          new_formula,
         strict:               strict,
         online:               online,
-        git:                  git,
+        git:                  args.git?,
         only:                 only,
         except:               args.except,
         spdx_license_data:    spdx_license_data,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
delete the variable  `git` in `def audit` of `dev-cmd/audit`, because it was used only once.