### PR TITLE
formula: make bazel write to .brew_home

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1981,6 +1981,9 @@ class Formula
       import site; site.addsitedir("#{HOMEBREW_PREFIX}/lib/python2.7/site-packages")
       import sys, os; sys.path = (os.environ["PYTHONPATH"].split(os.pathsep) if "PYTHONPATH" in os.environ else []) + ["#{HOMEBREW_PREFIX}/lib/python2.7/site-packages"] + sys.path
     PYTHON
+
+    # Don't let bazel write to tmp directories we don't control or clean.
+    (home/".bazelrc").write "startup --output_user_root=#{home}/_bazel"
   end
 
   # Returns a list of Dependency objects that are declared in the formula.

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -62,9 +62,23 @@ class Mktemp
     begin
       Dir.chdir(tmpdir) { yield self }
     ensure
-      ignore_interrupts { rm_rf(tmpdir) } unless retain?
+      ignore_interrupts { chmod_rm_rf(tmpdir) } unless retain?
     end
   ensure
     ohai "Temporary files retained at:", @tmpdir.to_s if retain? && !@tmpdir.nil? && !@quiet
+  end
+
+  private
+
+  def chmod_rm_rf(path)
+    if path.directory? && !path.symlink?
+      chmod("u+rw", path) if path.owned? # Need permissions in order to see the contents
+      path.children.each { |child| chmod_rm_rf(child) }
+      rmdir(path)
+    else
+      rm_f(path)
+    end
+  rescue
+    nil # Just skip this directory.
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

By default it writes to `/private/var/tmp` (different directory to `/tmp`), which we don't clean.

Instead, let's move it into `.brew_home`, which will be inside our `Mktemp` directory.

Also, adjust `Mktemp` to handle directories with restricted permissions (bazel has a few directories like that). It now fixes the permission before traversing the directory, which ensures the entire directory tree is properly removed. This is a similar practice to what we do in `cleanup` and `homebrew-test-bot`.