### PR TITLE
Speed up `pkg` uninstallation and only call `find` on directories.

### DIFF
--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -110,6 +110,12 @@ module Cask
     RMDIR_SH = <<~'BASH'
       set -euo pipefail
 
+      # Try removing as many empty directories as possible with a single
+      # `rmdir` call to avoid or at least speed up the loop below.
+      if /bin/rmdir -- "${@}" &>/dev/null; then
+        exit
+      fi
+
       for path in "${@}"; do
         symlink=true
         [[ -L "${path}" ]] || symlink=false

--- a/Library/Homebrew/cask/pkg.rb
+++ b/Library/Homebrew/cask/pkg.rb
@@ -111,27 +111,34 @@ module Cask
       set -euo pipefail
 
       for path in "${@}"; do
-        if [[ ! -e "${path}" ]]; then
+        symlink=true
+        [[ -L "${path}" ]] || symlink=false
+
+        directory=false
+        if [[ -d "${path}"  ]]; then
+          directory=true
+
+          if [[ -e "${path}/.DS_Store" ]]; then
+            /bin/rm -- "${path}/.DS_Store"
+          fi
+
+          # Some packages leave broken symlinks around; we clean them out before
+          # attempting to `rmdir` to prevent extra cruft from accumulating.
+          /usr/bin/find -f "${path}" -- -mindepth 1 -maxdepth 1 -type l ! -exec /bin/test -e {} \; -delete
+        elif ! ${symlink} && [[ ! -e "${path}" ]]; then
+          # Skip paths that don't exists and aren't a broken symlink.
           continue
         fi
 
-        if [[ -e "${path}/.DS_Store" ]]; then
-          /bin/rm -f "${path}/.DS_Store"
-        fi
-
-        # Some packages leave broken symlinks around; we clean them out before
-        # attempting to `rmdir` to prevent extra cruft from accumulating.
-        /usr/bin/find "${path}" -mindepth 1 -maxdepth 1 -type l ! -exec /bin/test -e {} \; -delete
-
-        if [[ -L "${path}" ]]; then
+        if ${symlink}; then
           # Delete directory symlink.
-          /bin/rm "${path}"
-        elif [[ -d "${path}" ]]; then
+          /bin/rm -- "${path}"
+        elif ${directory}; then
           # Delete directory if empty.
-          /usr/bin/find "${path}" -maxdepth 0 -type d -empty -exec /bin/rmdir {} \;
+          /usr/bin/find -f "${path}" -- -maxdepth 0 -type d -empty -exec /bin/rmdir -- {} \;
         else
           # Try `rmdir` anyways to show a proper error.
-          /bin/rmdir "${path}"
+          /bin/rmdir -- "${path}"
         fi
       done
     BASH

--- a/Library/Homebrew/cask/utils/rmdir.sh
+++ b/Library/Homebrew/cask/utils/rmdir.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Try removing as many empty directories as possible with a single
+# `rmdir` call to avoid or at least speed up the loop below.
+if /bin/rmdir -- "${@}" &>/dev/null; then
+  exit
+fi
+
+for path in "${@}"; do
+  symlink=true
+  [[ -L "${path}" ]] || symlink=false
+
+  directory=false
+  if [[ -d "${path}"  ]]; then
+    directory=true
+
+    if [[ -e "${path}/.DS_Store" ]]; then
+      /bin/rm -- "${path}/.DS_Store"
+    fi
+
+    # Some packages leave broken symlinks around; we clean them out before
+    # attempting to `rmdir` to prevent extra cruft from accumulating.
+    /usr/bin/find -f "${path}" -- -mindepth 1 -maxdepth 1 -type l ! -exec /bin/test -e {} \; -delete
+  elif ! ${symlink} && [[ ! -e "${path}" ]]; then
+    # Skip paths that don't exists and aren't a broken symlink.
+    continue
+  fi
+
+  if ${symlink}; then
+    # Delete directory symlink.
+    /bin/rm -- "${path}"
+  elif ${directory}; then
+    # Delete directory if empty.
+    /usr/bin/find -f "${path}" -- -maxdepth 0 -type d -empty -exec /bin/rmdir -- {} \;
+  else
+    # Try `rmdir` anyways to show a proper error.
+    /bin/rmdir -- "${path}"
+  fi
+done

--- a/Library/Homebrew/shims/linux/super/make
+++ b/Library/Homebrew/shims/linux/super/make
@@ -7,7 +7,7 @@ pathremove() {
                   NEWPATH=${NEWPATH:+$NEWPATH:}$DIR
                 fi
         done
-        export $PATHVARIABLE="$NEWPATH"
+        export "$PATHVARIABLE"="$NEWPATH"
 }
 
 if [[ -n "$HOMEBREW_MAKE" && "$HOMEBREW_MAKE" != "make" ]]
@@ -16,7 +16,8 @@ then
 else
   SAVED_PATH="$PATH"
   pathremove "$HOMEBREW_LIBRARY/Homebrew/shims/linux/super"
-  export MAKE="$(which make)"
+  MAKE="$(which make)"
+  export MAKE
   export PATH="$SAVED_PATH"
 fi
 

--- a/Library/Homebrew/shims/mac/super/ruby
+++ b/Library/Homebrew/shims/mac/super/ruby
@@ -1,6 +1,9 @@
 #!/bin/bash
+
 # System Ruby's mkmf on Mojave (10.14) and later require SDKROOT set to work correctly.
 
+# Don't need shellcheck to follow the `source`.
+# shellcheck disable=SC1090
 source "$HOMEBREW_LIBRARY/Homebrew/shims/utils.sh"
 
 try_exec_non_system "$SHIM_FILE" "$@"

--- a/Library/Homebrew/shims/mac/super/xcrun
+++ b/Library/Homebrew/shims/mac/super/xcrun
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Historically, xcrun has had various bugs, and in some cases it didn't
 # work at all (e.g. CLT-only in the Xcode 4.3 era). This script emulates
 # it and attempts to avoid these issues.
@@ -27,10 +28,10 @@ arg0=$1
 shift
 
 exe="/usr/bin/${arg0}"
-if [ -x "$exe" ]; then
-  if [ -n "$HOMEBREW_PREFER_CLT_PROXIES" ]; then
+if [[ -x "$exe" ]]; then
+  if [[ -n "$HOMEBREW_PREFER_CLT_PROXIES" ]]; then
     exec "$exe" "$@"
-  elif [ -z "$HOMEBREW_SDKROOT" -o ! -d "$HOMEBREW_SDKROOT" ]; then
+  elif [[ -z "$HOMEBREW_SDKROOT" || ! -d "$HOMEBREW_SDKROOT" ]]; then
     exec "$exe" "$@"
   fi
 fi
@@ -38,7 +39,7 @@ fi
 SUPERBIN=$(cd "${0%/*}" && pwd -P)
 
 exe=$(/usr/bin/xcrun --find "$arg0" 2>/dev/null)
-if [ -x "$exe" -a "${exe%/*}" != "$SUPERBIN" ]; then
+if [[ -x "$exe" && "${exe%/*}" != "$SUPERBIN" ]]; then
   exec "$exe" "$@"
 fi
 
@@ -57,7 +58,7 @@ done
 IFS=$old_IFS
 
 echo >&2 "
-Failed to execute $arg0 $@
+Failed to execute ${arg0} ${*}
 
 Xcode and/or the CLT appear to be misconfigured. Try one or both of the following:
   xcodebuild -license

--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -9,6 +9,8 @@ then
   exit 1
 fi
 
+# Don't need shellcheck to follow the `source`.
+# shellcheck disable=SC1090
 source "$HOMEBREW_LIBRARY/Homebrew/shims/utils.sh"
 
 case "$(lowercase "$SHIM_FILE")" in

--- a/Library/Homebrew/shims/utils.sh
+++ b/Library/Homebrew/shims/utils.sh
@@ -60,8 +60,10 @@ safe_exec() {
   fi
   if [[ "$HOMEBREW" = "print-path" ]]
   then
-    local dir="$(quiet_safe_cd "${arg0%/*}/" && pwd)"
-    local path="$(dirbasepath "$dir" "$arg0")"
+    local dir
+    dir="$(quiet_safe_cd "${arg0%/*}/" && pwd)"
+    local path
+    path="$(dirbasepath "$dir" "$arg0")"
     echo "$path"
     exit
   fi

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -177,13 +177,16 @@ module Homebrew
         files = [
           HOMEBREW_BREW_FILE,
           # TODO: HOMEBREW_REPOSITORY/"completions/bash/brew",
-          *Pathname.glob("#{HOMEBREW_LIBRARY}/Homebrew/*.sh"),
-          *Pathname.glob("#{HOMEBREW_LIBRARY}/Homebrew/cmd/*.sh"),
-          *Pathname.glob("#{HOMEBREW_LIBRARY}/Homebrew/utils/*.sh"),
+          *HOMEBREW_LIBRARY.glob("Homebrew/*.sh"),
+          *HOMEBREW_LIBRARY.glob("Homebrew/shims/**/*").map(&:realpath).uniq
+                           .reject { |path| path.directory? || path.basename.to_s == "cc" },
+          *HOMEBREW_LIBRARY.glob("Homebrew/{dev-,}cmd/*.sh"),
+          *HOMEBREW_LIBRARY.glob("Homebrew/{cask/,}utils/*.sh"),
         ]
       end
 
-      args = ["--shell=bash", "--", *files] # TODO: Add `--enable=all` to check for more problems.
+      # TODO: Add `--enable=all` to check for more problems.
+      args = ["--shell=bash", "--external-sources", "--", *files]
 
       case output_type
       when :print

--- a/Library/Homebrew/test/cask/pkg_spec.rb
+++ b/Library/Homebrew/test/cask/pkg_spec.rb
@@ -97,7 +97,7 @@ describe Cask::Pkg, :cask do
       allow(fake_system_command).to receive(:run!).and_call_original
       expect(fake_system_command).to receive(:run!).with(
         "/usr/bin/xargs",
-        args:  ["-0", "--", "/bin/bash", "-c", a_string_including("/bin/rmdir"), "--"],
+        args:  ["-0", "--", a_string_including("rmdir")],
         input: [fake_dir].join("\0"),
         sudo:  true,
       ).and_return(instance_double(SystemCommand::Result, stdout: ""))


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Don't skip broken symlinks and check `-d` instead of `-e` to avoid calling `find` on non-directories.

Includes and closes https://github.com/Homebrew/brew/pull/10882.