### PR TITLE
Fix `BundleVersion` comparison when one part is `nil`.

### DIFF
--- a/Library/Homebrew/bundle_version.rb
+++ b/Library/Homebrew/bundle_version.rb
@@ -10,6 +10,8 @@ module Homebrew
   class BundleVersion
     extend T::Sig
 
+    include Comparable
+
     extend SystemCommand::Mixin
 
     sig { params(info_plist_path: Pathname).returns(T.nilable(T.attached_class)) }
@@ -55,9 +57,14 @@ module Homebrew
     end
 
     def <=>(other)
-      [version, short_version].map { |v| v&.yield_self(&Version.public_method(:new)) } <=>
-        [other.version, other.short_version].map { |v| v&.yield_self(&Version.public_method(:new)) }
+      [version, short_version].map { |v| v&.yield_self(&Version.public_method(:new)) || Version::NULL } <=>
+        [other.version, other.short_version].map { |v| v&.yield_self(&Version.public_method(:new)) || Version::NULL }
     end
+
+    def ==(other)
+      instance_of?(other.class) && short_version == other.short_version && version == other.version
+    end
+    alias eql? ==
 
     # Create a nicely formatted version (on a best effort basis).
     sig { returns(String) }

--- a/Library/Homebrew/test/bundle_version_spec.rb
+++ b/Library/Homebrew/test/bundle_version_spec.rb
@@ -26,4 +26,10 @@ describe Homebrew::BundleVersion do
       end
     end
   end
+
+  describe "#<=>" do
+    it "does not fail when a `version` is nil" do
+      expect(described_class.new("1.06", nil)).to be < described_class.new("1.12", "1.12")
+    end
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

---

Fixes audit failure in https://github.com/Homebrew/homebrew-cask/pull/102748.