### PR TITLE
cask uninstall script: allow tilde expansion to '$HOME'

### DIFF
--- a/Library/Homebrew/cask/artifact/abstract_artifact.rb
+++ b/Library/Homebrew/cask/artifact/abstract_artifact.rb
@@ -30,6 +30,7 @@ module Cask
 
       def staged_path_join_executable(path)
         path = Pathname(path)
+        path = path.expand_path if path.to_s.start_with?("~")
 
         absolute_path = if path.absolute?
           path

--- a/Library/Homebrew/test/cask/cmd/uninstall_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/uninstall_spec.rb
@@ -90,6 +90,30 @@ describe Cask::Cmd::Uninstall, :cask do
     expect(cask).not_to be_installed
   end
 
+  context "when Casks use script path with `~` as `HOME`" do
+    let(:home_dir) { mktmpdir }
+    let(:app) { Pathname.new("#{home_dir}/MyFancyApp.app") }
+    let(:cask) { Cask::CaskLoader.load(cask_path("with-uninstall-script-user-relative")) }
+
+    before do
+      ENV["HOME"] = home_dir
+    end
+
+    it "can still uninstall them" do
+      Cask::Installer.new(cask).install
+
+      expect(cask).to be_installed
+      expect(app).to exist
+
+      expect {
+        described_class.run("with-uninstall-script-user-relative")
+      }.not_to raise_error
+
+      expect(cask).not_to be_installed
+      expect(app).not_to exist
+    end
+  end
+
   describe "when multiple versions of a cask are installed" do
     let(:token) { "versioned-cask" }
     let(:first_installed_version) { "1.2.3" }

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-user-relative.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/with-uninstall-script-user-relative.rb
@@ -1,0 +1,21 @@
+cask "with-uninstall-script-user-relative" do
+  version "1.2.3"
+  sha256 "5633c3a0f2e572cbf021507dec78c50998b398c343232bdfc7e26221d0a5db4d"
+
+  url "file://#{TEST_FIXTURE_DIR}/cask/MyFancyApp.zip"
+  homepage "https://brew.sh/MyFancyApp"
+
+  app "MyFancyApp/MyFancyApp.app", target: "~/MyFancyApp.app"
+
+  postflight do
+    IO.write "#{ENV["HOME"]}/MyFancyApp.app/uninstall.sh", <<~SH
+      #!/bin/sh
+      /bin/rm -r "#{ENV["HOME"]}/MyFancyApp.app"
+    SH
+  end
+
+  uninstall script: {
+    executable: "~/MyFancyApp.app/uninstall.sh",
+    sudo:       false,
+  }
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

**Changes Summary**
Allow Casks to use uninstall script path with `~` as an alias for `HOME`.
Originally discussed here: https://github.com/Homebrew/homebrew-cask/issues/99043#issuecomment-780233940

**Notes on Checks**
Cannot run `brew typecheck` on M1 Mac
Similarly, 1 failure in `brew tests` due to Rosetta layer
```console
expected "macOS 11.2, Rosetta, non-/usr/local" to include "macOS 11.2, non-/usr/local"
```

**Before Feature: New Testcase result `--only cask/cmd/uninstall`**
```console
Finished in 14.62 seconds (files took 1.99 seconds to load)
11 examples, 1 failure

Failed examples:

rspec ./test/cask/cmd/uninstall_spec.rb:103 # Cask::Cmd::Uninstall when Casks use script path with `~` as `HOME` can still uninstall them


11 examples, 1 failure

Took 17 seconds
Tests Failed
```

**After Feature: New Testcase result `--only cask/cmd/uninstall`**
```console
==> Downloading file:///usr/local/Homebrew/Library/Homebrew/test/support/fixtures/cask/MyFancyApp.zip
==> Installing Cask with-uninstall-script-user-relative
==> Moving App 'MyFancyApp.app' to '/private/tmp/homebrew-tests-20210328-26019-oiomvj/MyFancyApp.app'
🍺  with-uninstall-script-user-relative was successfully installed!
==> Uninstalling Cask with-uninstall-script-user-relative
==> Running uninstall script ~/MyFancyApp.app/uninstall.sh
==> Purging files for version 1.2.3 of Cask with-uninstall-script-user-relative

...

Finished in 15.68 seconds (files took 2 seconds to load)
11 examples, 0 failures


11 examples, 0 failures

Took 17 seconds
```