### PR TITLE
formula_cellar_checks: exclude llvm from Python linkage check

### DIFF
--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -46,6 +46,8 @@ module FormulaCellarChecks
   end
 
   def check_python_framework_links(lib)
+    return if formula.name.start_with?("llvm")
+
     python_modules = Pathname.glob lib/"python*/site-packages/**/*.so"
     framework_links = python_modules.select do |obj|
       dlls = obj.dynamically_linked_libraries

--- a/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
+++ b/Library/Homebrew/extend/os/mac/formula_cellar_checks.rb
@@ -46,7 +46,8 @@ module FormulaCellarChecks
   end
 
   def check_python_framework_links(lib)
-    return if formula.name.start_with?("llvm")
+    # We make a special exception for llvm here in order to build the lldb Python bindings.
+    return if formula.name.match?(/^llvm(@\d+)?$/)
 
     python_modules = Pathname.glob lib/"python*/site-packages/**/*.so"
     framework_links = python_modules.select do |obj|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The LLDB Python bindings embed a Python interpreter into LLDB, so
explicit linkage to a Python interpreter is needed. [1]

This change will allow us to build the Python bindings for LLDB. This
improves feature-parity with system LLDB, which does provide Python
bindings. Currently, these bindings are not built because they fail the
`check_python_framework_links` audit.

[1] https://blog.tim-smith.us/2015/09/python-extension-modules-os-x/