### PR TITLE
shims/super/cc: don't refurbish ld.gold args

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -105,7 +105,7 @@ class Cmd
       return @args.dup
     end
 
-    args = if !refurbish_args? || tool == "ld" || configure?
+    args = if !refurbish_args? || mode == :ld || configure?
       @args.dup
     else
       refurbished_args


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This makes the behaviour consistent to regular BFD `ld`.

This may or may not fix the issues noted [here](https://github.com/Homebrew/linuxbrew-core/pull/22742#issuecomment-808976914), but I believe this change is correct to make anyway. I see no reason why `ld` should be treated differently to `ld.gold`.