### PR TITLE
extend/ENV: make 'passphrase' sensitive

### DIFF
--- a/Library/Homebrew/extend/ENV.rb
+++ b/Library/Homebrew/extend/ENV.rb
@@ -57,7 +57,7 @@ module EnvActivation
 
   sig { params(key: T.any(String, Symbol)).returns(T::Boolean) }
   def sensitive?(key)
-    key.match?(/(cookie|key|token|password)/i)
+    key.match?(/(cookie|key|token|password|passphrase)/i)
   end
 
   sig { returns(T::Hash[String, String]) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Keys containing `passphrase` are sensitive, this PR modifies `extend/ENV.rb` to ensure this.