### PR TITLE
Implement nested `url do` API.

### DIFF
--- a/Library/Homebrew/cask/url.rb
+++ b/Library/Homebrew/cask/url.rb
@@ -4,21 +4,146 @@
 # Class corresponding to the `url` stanza.
 #
 # @api private
-class URL
+class URL < Delegator
   extend T::Sig
 
-  attr_reader :uri, :specs,
-              :verified, :using,
-              :tag, :branch, :revisions, :revision,
-              :trust_cert, :cookies, :referer, :header, :user_agent,
-              :data
+  # @api private
+  class DSL
+    extend T::Sig
 
-  extend Forwardable
-  def_delegators :uri, :path, :scheme, :to_s
+    attr_reader :uri, :specs,
+                :verified, :using,
+                :tag, :branch, :revisions, :revision,
+                :trust_cert, :cookies, :referer, :header, :user_agent,
+                :data
+
+    extend Forwardable
+    def_delegators :uri, :path, :scheme, :to_s
+
+    # @api public
+    sig {
+      params(
+        uri:        T.any(URI::Generic, String),
+        verified:   T.nilable(String),
+        using:      T.nilable(Symbol),
+        tag:        T.nilable(String),
+        branch:     T.nilable(String),
+        revisions:  T.nilable(T::Array[String]),
+        revision:   T.nilable(String),
+        trust_cert: T.nilable(T::Boolean),
+        cookies:    T.nilable(T::Hash[String, String]),
+        referer:    T.nilable(T.any(URI::Generic, String)),
+        header:     T.nilable(String),
+        user_agent: T.nilable(T.any(Symbol, String)),
+        data:       T.nilable(T::Hash[String, String]),
+      ).void
+    }
+    def initialize(
+      uri,
+      verified: nil,
+      using: nil,
+      tag: nil,
+      branch: nil,
+      revisions: nil,
+      revision: nil,
+      trust_cert: nil,
+      cookies: nil,
+      referer: nil,
+      header: nil,
+      user_agent: nil,
+      data: nil
+    )
+
+      @uri = URI(uri)
+
+      specs = {}
+      specs[:verified]   = @verified   = verified
+      specs[:using]      = @using      = using
+      specs[:tag]        = @tag        = tag
+      specs[:branch]     = @branch     = branch
+      specs[:revisions]  = @revisions  = revisions
+      specs[:revision]   = @revision   = revision
+      specs[:trust_cert] = @trust_cert = trust_cert
+      specs[:cookies]    = @cookies    = cookies
+      specs[:referer]    = @referer    = referer
+      specs[:header]     = @header     = header
+      specs[:user_agent] = @user_agent = user_agent || :default
+      specs[:data]       = @data       = data
+
+      @specs = specs.compact
+    end
+  end
+
+  # @api private
+  class BlockDSL
+    extend T::Sig
+
+    module PageWithURL
+      extend T::Sig
+
+      # @api public
+      sig { returns(URI::Generic) }
+      attr_accessor :url
+    end
+
+    sig {
+      params(
+        uri:   T.nilable(T.any(URI::Generic, String)),
+        dsl:   T.nilable(Cask::DSL),
+        block: T.proc.params(arg0: T.all(String, PageWithURL)).returns(T.untyped),
+      ).void
+    }
+    def initialize(uri, dsl: nil, &block)
+      @uri = uri
+      @dsl = dsl
+      @block = block
+    end
+
+    sig { returns(T.untyped) }
+    def call
+      if @uri
+        result = curl_output("--fail", "--silent", "--location", @uri)
+        result.assert_success!
+
+        page = result.stdout
+        page.extend PageWithURL
+        page.url = URI(@uri)
+
+        instance_exec(page, &@block)
+      else
+        instance_exec(&@block)
+      end
+    end
+
+    # @api public
+    sig {
+      params(
+        uri:   T.any(URI::Generic, String),
+        block: T.proc.params(arg0: T.all(String, PageWithURL)).returns(T.untyped),
+      ).void
+    }
+    def url(uri, &block)
+      self.class.new(uri, &block).call
+    end
+    private :url
+
+    # @api public
+    def method_missing(method, *args, **options, &block)
+      if @dsl.respond_to?(method)
+        T.unsafe(@dsl).public_send(method, *args, **options, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method, include_all)
+      @dsl.respond_to?(method, include_all) || super
+    end
+  end
 
   sig {
     params(
-      uri:             T.any(URI::Generic, String),
+      uri:             T.nilable(T.any(URI::Generic, String)),
       verified:        T.nilable(String),
       using:           T.nilable(Symbol),
       tag:             T.nilable(String),
@@ -31,12 +156,13 @@ class URL
       header:          T.nilable(String),
       user_agent:      T.nilable(T.any(Symbol, String)),
       data:            T.nilable(T::Hash[String, String]),
-      from_block:      T::Boolean,
       caller_location: Thread::Backtrace::Location,
-    ).returns(T.untyped)
+      dsl:             T.nilable(Cask::DSL),
+      block:           T.nilable(T.proc.params(arg0: T.all(String, BlockDSL::PageWithURL)).returns(T.untyped)),
+    ).void
   }
   def initialize(
-    uri,
+    uri = nil,
     verified: nil,
     using: nil,
     tag: nil,
@@ -49,30 +175,47 @@ class URL
     header: nil,
     user_agent: nil,
     data: nil,
-    from_block: false,
-    caller_location: T.must(caller_locations).fetch(0)
+    caller_location: T.must(caller_locations).fetch(0),
+    dsl: nil,
+    &block
   )
+    super(
+    if block
+      LazyObject.new do
+        *args = BlockDSL.new(uri, dsl: dsl, &block).call
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        uri = T.let(args.first, T.any(URI::Generic, String))
+        DSL.new(uri, **options)
+      end
+    else
+      DSL.new(
+        T.must(uri),
+        verified:   verified,
+        using:      using,
+        tag:        tag,
+        branch:     branch,
+        revisions:  revisions,
+        revision:   revision,
+        trust_cert: trust_cert,
+        cookies:    cookies,
+        referer:    referer,
+        header:     header,
+        user_agent: user_agent,
+        data:       data,
+      )
+    end
+    )
 
-    @uri = URI(uri)
-
-    specs = {}
-    specs[:verified]   = @verified   = verified
-    specs[:using]      = @using      = using
-    specs[:tag]        = @tag        = tag
-    specs[:branch]     = @branch     = branch
-    specs[:revisions]  = @revisions  = revisions
-    specs[:revision]   = @revision   = revision
-    specs[:trust_cert] = @trust_cert = trust_cert
-    specs[:cookies]    = @cookies    = cookies
-    specs[:referer]    = @referer    = referer
-    specs[:header]     = @header     = header
-    specs[:user_agent] = @user_agent = user_agent || :default
-    specs[:data]       = @data       = data
-
-    @specs = specs.compact
-
-    @from_block = from_block
+    @from_block = !block.nil?
     @caller_location = caller_location
+  end
+
+  def __getobj__
+    @dsl
+  end
+
+  def __setobj__(dsl)
+    @dsl = dsl
   end
 
   sig { returns(T.nilable(String)) }

--- a/Library/Homebrew/cask/url.rbi
+++ b/Library/Homebrew/cask/url.rbi
@@ -1,0 +1,6 @@
+# typed: strict
+# typed: false
+
+class URL
+  include Kernel
+end

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -795,7 +795,17 @@ describe Cask::Audit, :cask do
           end
         end
 
-        context "when doing the audit" do
+        context "when doing an offline audit" do
+          let(:online) { false }
+
+          it "does not evaluate the block" do
+            expect(run).not_to pass
+          end
+        end
+
+        context "when doing and online audit" do
+          let(:online) { true }
+
           it "evaluates the block" do
             expect(run).to fail_with(/Boom/)
           end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Allows using nested `url do` blocks in order to allow fetching a chain of URLs for retrieving the final URL.

See https://github.com/Homebrew/homebrew-cask-versions/pull/10620 for examples.

Also, skip auditing URLs using `url do` unless running with `--online`.