### PR TITLE
GitHub Packages Tab download

### DIFF
--- a/Library/Homebrew/cmd/fetch.rb
+++ b/Library/Homebrew/cmd/fetch.rb
@@ -88,6 +88,7 @@ module Homebrew
         fetched_bottle = false
         if fetch_bottle?(f, args: args)
           begin
+            f.fetch_bottle_tab
             fetch_formula(f.bottle, args: args)
           rescue Interrupt
             raise

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -538,6 +538,7 @@ module Homebrew
           "prefix"   => bottle.prefix,
           "cellar"   => bottle.cellar.to_s,
           "rebuild"  => bottle.rebuild,
+          "date"     => Time.now.strftime("%F"),
           "tags"     => {
             bottle_tag.to_s => {
               "filename"              => filename.bintray,

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -533,20 +533,18 @@ end
 #
 # @api public
 class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
-  attr_accessor :checksum, :name
+  attr_writer :resolved_basename
+
+  def initialize(url, name, version, **meta)
+    meta ||= {}
+    meta[:header] = "Authorization: Bearer"
+    super(url, name, version, meta)
+  end
 
   private
 
-  def _fetch(url:, resolved_url:)
-    raise CurlDownloadStrategyError, "Empty checksum" if checksum.blank?
-    raise CurlDownloadStrategyError, "Empty name" if name.blank?
-
-    _, org, repo, = *url.match(GitHubPackages::URL_REGEX)
-
-    # remove redundant repo prefix for a shorter name
-    repo = repo.delete_prefix("homebrew-")
-    blob_url = "#{GitHubPackages::URL_PREFIX}#{org}/#{repo}/#{name}/blobs/sha256:#{checksum}"
-    curl_download(blob_url, "--header", "Authorization: Bearer", to: temporary_path)
+  def resolved_basename
+    @resolved_basename.presence || super
   end
 end
 

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -426,7 +426,7 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       url = url.sub(%r{^((ht|f)tps?://)?}, "#{domain.chomp("/")}/")
     end
 
-    out, _, status= curl_output("--location", "--silent", "--head", "--request", "GET", url.to_s)
+    out, _, status = curl_output("--location", "--silent", "--head", "--request", "GET", url.to_s)
 
     lines = status.success? ? out.lines.map(&:chomp) : []
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2211,6 +2211,20 @@ class Formula
     patchlist.select(&:external?).each(&:fetch)
   end
 
+  sig { void }
+  def fetch_bottle_tab
+    return unless bottled?
+
+    T.must(bottle).fetch_tab
+  end
+
+  sig { returns(Hash) }
+  def bottle_tab_attributes
+    return {} unless bottled?
+
+    T.must(bottle).tab_attributes
+  end
+
   private
 
   def prepare_patches

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -192,13 +192,19 @@ module Formulary
     end
 
     def get_formula(spec, force_bottle: false, flags: [], **)
-      contents = Utils::Bottles.formula_contents @bottle_filename, name: name
       formula = begin
+        contents = Utils::Bottles.formula_contents @bottle_filename, name: name
         Formulary.from_contents(name, path, contents, spec, force_bottle: force_bottle, flags: flags)
       rescue FormulaUnreadableError => e
         opoo <<~EOS
           Unreadable formula in #{@bottle_filename}:
           #{e}
+        EOS
+        super
+      rescue BottleFormulaUnavailableError => e
+        opoo <<~EOS
+          #{e}
+          Falling back to non-bottle formula.
         EOS
         super
       end

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -68,10 +68,18 @@ class GitHubPackages
     end
   end
 
-  def self.version_rebuild(version, rebuild)
-    return version.to_s unless rebuild.to_i.positive?
+  def self.version_rebuild(version, rebuild, bottle_tag = nil)
+    bottle_tag = (".#{bottle_tag}" if bottle_tag.present?)
 
-    "#{version}.#{rebuild}"
+    rebuild = if rebuild.to_i.positive?
+      if bottle_tag
+        ".#{rebuild}"
+      else
+        "-#{rebuild}"
+      end
+    end
+
+    "#{version}#{bottle_tag}#{rebuild}"
   end
 
   def self.repo_without_prefix(repo)
@@ -222,8 +230,7 @@ class GitHubPackages
       formulae_dir = tag_hash["formulae_brew_sh_path"]
       documentation = "https://formulae.brew.sh/#{formulae_dir}/#{formula_name}" if formula_core_tap
 
-      rebuild = ".#{rebuild}" if rebuild.to_i.positive?
-      tag = "#{version}.#{bottle_tag}#{rebuild}"
+      tag = GitHubPackages.version_rebuild(version, rebuild, bottle_tag)
 
       annotations_hash = formula_annotations_hash.merge({
         "org.opencontainers.image.created"       => created_date,

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -177,8 +177,9 @@ class GitHubPackages
       remote
     end
 
+    created_date = bottle_hash["bottle"]["date"]
     formula_annotations_hash = {
-      "org.opencontainers.image.created"       => Time.now.strftime("%F"),
+      "org.opencontainers.image.created"       => created_date,
       "org.opencontainers.image.description"   => bottle_hash["formula"]["desc"],
       "org.opencontainers.image.documentation" => documentation,
       "org.opencontainers.image.license"       => bottle_hash["formula"]["license"],
@@ -225,7 +226,7 @@ class GitHubPackages
       tag = "#{version}.#{bottle_tag}#{rebuild}"
 
       annotations_hash = formula_annotations_hash.merge({
-        "org.opencontainers.image.created"       => Time.at(tag_hash["tab"]["source_modified_time"]).strftime("%F"),
+        "org.opencontainers.image.created"       => created_date,
         "org.opencontainers.image.documentation" => documentation,
         "org.opencontainers.image.ref.name"      => tag,
         "org.opencontainers.image.title"         => "#{formula_full_name} #{tag}",

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -39,12 +39,6 @@ module Utils
         HOMEBREW_BOTTLES_EXTNAME_REGEX.match(filename).to_a
       end
 
-      # TODO: remove when removed from brew-test-bot
-      sig { returns(Regexp) }
-      def native_regex
-        /(\.#{Regexp.escape(tag.to_s)}\.bottle\.(\d+\.)?tar\.gz)$/o
-      end
-
       def receipt_path(bottle_file)
         path = Utils.popen_read("tar", "-tzf", bottle_file).lines.map(&:chomp).find do |line|
           line =~ %r{.+/.+/INSTALL_RECEIPT.json}


### PR DESCRIPTION
- Simplify and improve the GitHub Packages bottle download logic to be more idiomatic (and allow easier removal if GitHub ever drops the special header requirement).
- Make use of the tabs uploaded to GitHub Packages manifests by downloading, parsing and installing them (based on the bottle checksum). This will allow adding `brew bottle --only-json-tab` in future to stop building tabs into our bottles (making them more reproducible as the e.g. timestamps in our current bottles guarantee non-reproducibility).

While we're here:
- `utils/bottles`: remove unused method
- `download_strategy`: fix whitespace.

For testing use `HOMEBREW_BOTTLE_DOMAIN=https://ghcr.io/v2/Homebrew/core brew fetch git-delta` and `HOMEBREW_BOTTLE_DOMAIN=https://ghcr.io/v2/Homebrew/core brew reinstall git-delta`.