### PR TITLE
github_packages: Translate tab.arch to OCI

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -17,6 +17,12 @@ class GitHubPackages
   DOCKER_PREFIX = "docker://#{URL_DOMAIN}/"
   URL_REGEX = %r{(?:#{Regexp.escape(URL_PREFIX)}|#{Regexp.escape(DOCKER_PREFIX)})([\w-]+)/([\w-]+)}.freeze
 
+  # Translate Homebrew tab.arch to OCI platform.architecture
+  TAB_ARCH_TO_PLATFORM_ARCHITECTURE = {
+    "arm64"  => "arm64",
+    "x86_64" => "amd64",
+  }.freeze
+
   # Translate Homebrew built_on.os to OCI platform.os
   BUILT_ON_OS_TO_PLATFORM_OS = {
     "Linux"     => "linux",
@@ -179,11 +185,14 @@ class GitHubPackages
       tar_gz_sha256 = write_tar_gz(local_file, blobs)
 
       tab = tag_hash["tab"]
+      architecture = TAB_ARCH_TO_PLATFORM_ARCHITECTURE[tab["arch"]]
+      raise TypeError, "unknown tab['arch']: #{tab["arch"]}" if architecture.blank?
+
       os = BUILT_ON_OS_TO_PLATFORM_OS[tab["built_on"]["os"]]
       raise TypeError, "unknown tab['built_on']['os']: #{tab["built_on"]["os"]}" if os.blank?
 
       platform_hash = {
-        architecture: tab["arch"],
+        architecture: architecture,
         os: os,
         "os.version" => tab["built_on"]["os_version"],
       }


### PR DESCRIPTION
Translate Homebrew tab.arch to OCI platform.architecture.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

OCI `platform.architecture` is a closed vocabulary, and x86-64 is called `amd64`.
