### PR TITLE
build_info: Add glibc_version for Linux

### DIFF
--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -21,7 +21,7 @@ class DevelopmentTools
     end
 
     def build_system_info
-      generic_build_system_info.merge "glibc_version" => OS::Linux::Glibc.system_version
+      generic_build_system_info.merge "glibc_version" => OS::Linux::Glibc.version
     end
   end
 end

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -19,5 +19,15 @@ class DevelopmentTools
     def default_compiler
       :gcc
     end
+
+    def build_system_info
+      brewed_glibc_version = begin
+        Formula["glibc"].any_installed_version
+      rescue FormulaUnavailableError
+        nil
+      end
+      glibc_version = brewed_glibc_version || OS::Linux::Glibc.system_version
+      generic_build_system_info.merge "glibc_version" => glibc_version
+    end
   end
 end

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -21,13 +21,7 @@ class DevelopmentTools
     end
 
     def build_system_info
-      brewed_glibc_version = begin
-        Formula["glibc"].any_installed_version
-      rescue FormulaUnavailableError
-        nil
-      end
-      glibc_version = brewed_glibc_version || OS::Linux::Glibc.system_version
-      generic_build_system_info.merge "glibc_version" => glibc_version
+      generic_build_system_info.merge "glibc_version" => OS::Linux::Glibc.system_version
     end
   end
 end

--- a/Library/Homebrew/os/linux/glibc.rb
+++ b/Library/Homebrew/os/linux/glibc.rb
@@ -21,13 +21,14 @@ module OS
       end
 
       def version
-        return @version if @version
-
-        ldd = HOMEBREW_PREFIX/"opt/glibc/bin/ldd"
-        version = Utils.popen_read(ldd, "--version")[/ (\d+\.\d+)/, 1] if ldd.executable?
-        return system_version unless version
-
-        @version = Version.new version
+        @version ||= begin
+          ldd = HOMEBREW_PREFIX/"opt/glibc/bin/ldd"
+          version = Utils.popen_read(ldd, "--version")[/ (\d+\.\d+)/, 1] if ldd.executable?
+          if version
+            Version.new version
+          else
+            system_version
+          end
       end
 
       sig { returns(Version) }

--- a/Library/Homebrew/os/linux/glibc.rb
+++ b/Library/Homebrew/os/linux/glibc.rb
@@ -20,6 +20,16 @@ module OS
         @system_version = Version.new version
       end
 
+      def version
+        return @version if @version
+
+        ldd = HOMEBREW_PREFIX/"opt/glibc/bin/ldd"
+        version = Utils.popen_read(ldd, "--version")[/ (\d+\.\d+)/, 1] if ldd.executable?
+        return system_version unless version
+
+        @version = Version.new version
+      end
+
       sig { returns(Version) }
       def minimum_version
         Version.new(ENV.fetch("HOMEBREW_LINUX_MINIMUM_GLIBC_VERSION"))

--- a/Library/Homebrew/os/linux/glibc.rb
+++ b/Library/Homebrew/os/linux/glibc.rb
@@ -12,23 +12,25 @@ module OS
       module_function
 
       def system_version
-        return @system_version if @system_version
-
-        version = Utils.popen_read("/usr/bin/ldd", "--version")[/ (\d+\.\d+)/, 1]
-        return Version::NULL unless version
-
-        @system_version = Version.new version
+        @system_version ||= begin
+          version = Utils.popen_read("/usr/bin/ldd", "--version")[/ (\d+\.\d+)/, 1]
+          if version
+            Version.new version
+          else
+            Version::NULL
+          end
+        end
       end
 
       def version
         @version ||= begin
-          ldd = HOMEBREW_PREFIX/"opt/glibc/bin/ldd"
-          version = Utils.popen_read(ldd, "--version")[/ (\d+\.\d+)/, 1] if ldd.executable?
+          version = Utils.popen_read(HOMEBREW_PREFIX/"opt/glibc/bin/ldd", "--version")[/ (\d+\.\d+)/, 1]
           if version
             Version.new version
           else
             system_version
           end
+        end
       end
 
       sig { returns(Version) }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I would like to include the Glibc version that was used to build the bottle on Linux, so that the end-user system can verify that it has a sufficient Glibc version installed (either provided by the host or brewed) to use that bottle.