### PR TITLE
build_info: Add oldest_cpu_family

### DIFF
--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -100,9 +100,10 @@ class DevelopmentTools
 
     def build_system_info
       {
-        "os"         => ENV["HOMEBREW_SYSTEM"],
-        "os_version" => OS_VERSION,
-        "cpu_family" => Hardware::CPU.family,
+        "os"                => ENV["HOMEBREW_SYSTEM"],
+        "os_version"        => OS_VERSION,
+        "cpu_family"        => Hardware::CPU.family,
+        "oldest_cpu_family" => Hardware.oldest_cpu,
       }
     end
     alias generic_build_system_info build_system_info

--- a/Library/Homebrew/development_tools.rb
+++ b/Library/Homebrew/development_tools.rb
@@ -100,10 +100,9 @@ class DevelopmentTools
 
     def build_system_info
       {
-        "os"                => ENV["HOMEBREW_SYSTEM"],
-        "os_version"        => OS_VERSION,
-        "cpu_family"        => Hardware::CPU.family,
-        "oldest_cpu_family" => Hardware.oldest_cpu,
+        "os"         => ENV["HOMEBREW_SYSTEM"],
+        "os_version" => OS_VERSION,
+        "cpu_family" => Hardware::CPU.family,
       }
     end
     alias generic_build_system_info build_system_info

--- a/Library/Homebrew/extend/os/linux/development_tools.rb
+++ b/Library/Homebrew/extend/os/linux/development_tools.rb
@@ -21,7 +21,10 @@ class DevelopmentTools
     end
 
     def build_system_info
-      generic_build_system_info.merge "glibc_version" => OS::Linux::Glibc.version
+      generic_build_system_info.merge({
+        "glibc_version"     => OS::Linux::Glibc.version,
+        "oldest_cpu_family" => Hardware.oldest_cpu,
+      })
     end
   end
 end

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -246,24 +246,14 @@ class GitHubPackages
         (tab["built_on"]["glibc_version"] if tab["built_on"].present?) || "2.23"
       end
 
-      variant = if architecture == "arm64"
-        "v8"
-      elsif tab["oldest_cpu_family"]
-        tab["oldest_cpu_family"]
-      elsif architecture == "amd64"
-        if os == "darwin"
-          Hardware.oldest_cpu(OS::Mac::Version.new(os_version[/macOS ([0-9]+\.[0-9]+)/, 1])).to_s
-        else
-          "core2"
-        end
-      end
+      variant = tab["oldest_cpu_family"] || "core2" if os == "linux"
 
       platform_hash = {
         architecture: architecture,
         variant: variant,
         os: os,
         "os.version" => os_version,
-      }
+      }.compact
       tar_sha256 = Digest::SHA256.hexdigest(
         Utils.safe_popen_read("gunzip", "--stdout", "--decompress", local_file),
       )

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -246,8 +246,21 @@ class GitHubPackages
         (tab["built_on"]["glibc_version"] if tab["built_on"].present?) || "2.23"
       end
 
+      variant = if architecture == "arm64"
+        "v8"
+      elsif tab["oldest_cpu_family"]
+        tab["oldest_cpu_family"]
+      elsif architecture == "amd64"
+        if os == "darwin"
+          Hardware.oldest_cpu(OS::Mac::Version.new(os_version[/macOS ([0-9]+\.[0-9]+)/, 1])).to_s
+        else
+          "core2"
+        end
+      end
+
       platform_hash = {
         architecture: architecture,
+        variant: variant,
         os: os,
         "os.version" => os_version,
       }


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

I would like to include the CPU family architecture that was targeted by the bottle, so that the end-user system can verify that it has a sufficient CPU to use that bottle.

Linux currently targets bottles at `core2`, but we may one day increase that requirement to for example make use of AVX instructions.
Bottles for macOS 10.14 Mojave and up for example target `nehalem`.

See https://github.com/Homebrew/brew/blob/e265664518ad8c2b99ff15694f5f8fc13705a56b/Library/Homebrew/extend/os/mac/hardware.rb#L7
and https://en.wikipedia.org/wiki/List_of_Intel_CPU_microarchitectures
and https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html 