### PR TITLE
install: Install from GHCR without tapping the tap

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -355,6 +355,8 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
       return path.basename.to_s[/[^?&]+#{Regexp.escape(ext)}/] if ext
     end
 
+    return File.basename(uri_path).split("?").first if uri_path.include? "/blobs/sha256:"
+
     File.basename(uri_path)
   end
 end

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -355,7 +355,7 @@ class AbstractFileDownloadStrategy < AbstractDownloadStrategy
       return path.basename.to_s[/[^?&]+#{Regexp.escape(ext)}/] if ext
     end
 
-    return File.basename(uri_path).split("?").first if uri_path.include? "/blobs/sha256:"
+    uri_path = uri_path.split("?").first if uri_path.include? "/blobs/sha256:"
 
     File.basename(uri_path)
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1157,7 +1157,7 @@ class FormulaInstaller
     tab.arch = Hardware::CPU.arch
     tab.source["versions"]["stable"] = formula.stable.version.to_s
     tab.source["path"] = formula.specified_path.to_s
-    tab.source["tap_git_head"] = formula.tap&.git_head
+    tab.source["tap_git_head"] = formula.tap&.git_head if formula.tap.installed?
     tab.tap = formula.tap
     tab.write
   end

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1157,7 +1157,7 @@ class FormulaInstaller
     tab.arch = Hardware::CPU.arch
     tab.source["versions"]["stable"] = formula.stable.version.to_s
     tab.source["path"] = formula.specified_path.to_s
-    tab.source["tap_git_head"] = formula.tap&.git_head if formula.tap.installed?
+    tab.source["tap_git_head"] = formula.tap&.git_head if formula.tap&.installed?
     tab.tap = formula.tap
     tab.write
   end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -273,16 +273,15 @@ module Formulary
       basename = File.basename(url)
       name = basename[/^[^@:]+/]
       digest = basename[GitHubPackages::URL_SHA256_REGEX, 1]&.downcase
-      blob_digest = if digest
-        ref = "sha256:#{digest}"
-        GitHubPackages.new(org: org).get_bottle_digest(repo, name, ref) || digest
+      ref = if digest
+        "sha256:#{digest}"
       else
-        ref = basename[/:([\w.-]+)$/, 1] || "latest"
-        GitHubPackages.new(org: org).get_bottle_digest(repo, name, ref)
+        basename[/:([\w.-]+)$/, 1] || "latest"
       end
-      raise ArgumentError, "No such package: #{url}" if blob_digest.blank?
+      bottle_digest = GitHubPackages.new(org: org).get_bottle_digest(repo, name, ref) || digest
+      raise "No such package: #{url}" if bottle_digest.blank?
 
-      blob_url = "#{GitHubPackages::URL_PREFIX}#{org}/#{repo}/#{name}/blobs/sha256:#{blob_digest}"
+      blob_url = "#{GitHubPackages::URL_PREFIX}#{org}/#{repo}/#{name}/blobs/sha256:#{bottle_digest}"
       resource = Resource.new(name) { url blob_url }
       resource.specs[:bottle] = true
       downloader = resource.downloader

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -275,7 +275,7 @@ module Formulary
       checksum = basename[GitHubPackages::URL_SHA256_REGEX, 1]&.downcase
       unless checksum
         tag = basename[/:([^:]+)$/, 1] || "latest"
-        checksum = GitHubPackages.new(org: org).get_bottle_hash(repo, name, tag)
+        checksum = GitHubPackages.new(org: org).get_bottle_digest(repo, name, tag)
       end
       raise ArgumentError, "Empty checksum: #{url}" if checksum.blank?
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -272,7 +272,7 @@ module Formulary
       _, org, repo = *url.match(GitHubPackages::URL_REGEX)
       basename = File.basename(url)
       name = basename[/^[^@:]+/, 0]
-      checksum = basename[/sha256:([0-9a-fA-F]{64})$/, 1]&.downcase
+      checksum = basename[GitHubPackages::URL_SHA256_REGEX, 1]&.downcase
       raise ArgumentError, "Empty checksum: #{url}" if checksum.blank?
 
       blob_url = "#{GitHubPackages::URL_PREFIX}#{org}/#{repo}/#{name}/blobs/sha256:#{checksum}"

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -271,8 +271,12 @@ module Formulary
     def initialize(url)
       _, org, repo = *url.match(GitHubPackages::URL_REGEX)
       basename = File.basename(url)
-      name = basename[/^[^@:]+/, 0]
+      name = basename[/^[^@:]+/]
       checksum = basename[GitHubPackages::URL_SHA256_REGEX, 1]&.downcase
+      unless checksum
+        tag = basename[/:([^:]+)$/, 1] || "latest"
+        checksum = GitHubPackages.new(org: org).get_bottle_hash(repo, name, tag)
+      end
       raise ArgumentError, "Empty checksum: #{url}" if checksum.blank?
 
       blob_url = "#{GitHubPackages::URL_PREFIX}#{org}/#{repo}/#{name}/blobs/sha256:#{checksum}"

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -56,10 +56,19 @@ class GitHubPackages
     JSON.parse(out)
   end
 
-  # Return the bottle digest suitable for this machine.
-  def get_bottle_digest(repo, name, tag)
-    index_json = get_index(repo, name, tag)
-    raise "No such tag: #{@github_org}/#{repo}/#{name}:#{tag}" unless index_json
+  # Return the string representation of a reference
+  def self.ref_to_s(org, repo, name, ref)
+    if ref.start_with? "sha256:"
+      "#{org}/#{repo}/#{name}@#{ref}"
+    else
+      "#{org}/#{repo}/#{name}:#{ref}"
+    end
+  end
+
+  # Return the bottle hash suitable for this machine.
+  def get_bottle_digest(repo, name, ref)
+    index_json = get_index(repo, name, ref)
+    raise "No such reference: #{ref_to_s(@github_org, repo, name, ref)}" unless index_json
 
     bottles = index_json["manifests"].map do |manifest|
       platform = manifest["platform"]

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -63,6 +63,9 @@ class GitHubPackages
 
     bottles = index_json["manifests"].map do |manifest|
       platform = manifest["platform"]
+      architecture = TAB_ARCH_TO_PLATFORM_ARCHITECTURE[Hardware::CPU.arch.to_s]
+      next if platform["architecture"] != architecture
+
       os = platform["os"]
       os_version = platform["os.version"]
       next if os != RbConfig::CONFIG["host_os"][/^[a-z]+/]

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -16,6 +16,7 @@ class GitHubPackages
   URL_PREFIX = "https://#{URL_DOMAIN}/v2/"
   DOCKER_PREFIX = "docker://#{URL_DOMAIN}/"
   URL_REGEX = %r{(?:#{Regexp.escape(URL_PREFIX)}|#{Regexp.escape(DOCKER_PREFIX)})([\w-]+)/([\w-]+)}.freeze
+  URL_SHA256_REGEX = /sha256:([0-9a-fA-F]{64})$/.freeze
   GITHUB_PACKAGE_TYPE = "homebrew_bottle"
 
   # Translate Homebrew tab.arch to OCI platform.architecture

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -56,8 +56,8 @@ class GitHubPackages
     JSON.parse(out)
   end
 
-  # Return the bottle hash suitable for this machine.
-  def get_bottle_hash(repo, name, tag)
+  # Return the bottle digest suitable for this machine.
+  def get_bottle_digest(repo, name, tag)
     index_json = get_index(repo, name, tag)
     raise "No such tag: #{@github_org}/#{repo}/#{name}:#{tag}" unless index_json
 
@@ -70,7 +70,7 @@ class GitHubPackages
       os_version = platform["os.version"]
       next if os != RbConfig::CONFIG["host_os"][/^[a-z]+/]
 
-      checksum = manifest["annotations"]["sh.brew.bottle.checksum"]
+      checksum = manifest["annotations"]["sh.brew.bottle.digest"]
       if os == "darwin"
         macos_version = OS::Mac::Version.new(os_version[/macOS ([0-9]+\.[0-9]+)/, 1])
         [macos_version, checksum] if OS::Mac.version >= macos_version

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -209,6 +209,7 @@ class Tap
   # True if the remote of this {Tap} is a private repository.
   def private?
     return @private if instance_variable_defined?(:@private)
+    return false unless installed?
 
     @private = read_or_set_private_config
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR demos a proof of concept permitting installing a package from GitHub Packages without cloning the Git repo of the tap.

```bash
brew install docker://ghcr.io/brewsci/bio/seqkit@sha256:831fc5b89602adc8cfaa943c40522a345a020d3487b5d06b89d3aaf36a9e408b
```

This PR currently requires the SHA-256 provided in the URL. The goal is that `brew install ghcr.io/brewsci/bio/seqkit` would get the bottle hash from the image manifest fetched from GitHub Container Registry.
