### PR TITLE
workflows/tests: remove cask taps audit.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,12 +275,6 @@ jobs:
       - name: Run brew readall on all taps
         run: brew readall --aliases
 
-      - name: Run brew audit --skip-style on Cask taps
-        run: |
-          brew audit --skip-style --display-failures-only --tap=homebrew/cask
-          brew audit --skip-style --display-failures-only --tap=homebrew/cask-drivers
-          brew audit --skip-style --display-failures-only --tap=homebrew/cask-fonts
-
       - name: Install brew tests dependencies
         run: |
           brew install subversion


### PR DESCRIPTION
These are just too error-prone. They shouldn't be re-enabled until our CI is setup such that it's impossible for any changes to be merged into homebrew-cask if these are failing.