### PR TITLE
Allow specifying committer for some `dev-cmd`s

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -30,6 +30,8 @@ module Homebrew
       switch "--warn-on-upload-failure",
              description: "Warn instead of raising an error if the bottle upload fails. "\
                           "Useful for repairing bottle uploads that previously failed."
+      flag   "--committer=",
+             description: "Specify a committer name and email in `git`'s standard author format."
       flag   "--archive-item=",
              description: "Upload to the specified Internet Archive item (default: `homebrew`)."
       flag   "--bintray-org=",
@@ -103,6 +105,7 @@ module Homebrew
     bottle_args << "--debug" if args.debug?
     bottle_args << "--keep-old" if args.keep_old?
     bottle_args << "--root-url=#{args.root_url}" if args.root_url
+    bottle_args << "--committer='#{args.committer}'" if args.committer
     bottle_args << "--no-commit" if args.no_commit?
     bottle_args += json_files
 

--- a/Library/Homebrew/test/utils_spec.rb
+++ b/Library/Homebrew/test/utils_spec.rb
@@ -210,6 +210,19 @@ describe "globally-scoped helper methods" do
     end
   end
 
+  specify "#parse_author!" do
+    parse_error_msg = /Unable to parse name and email/
+
+    expect(parse_author!("John Doe <john.doe@example.com>"))
+      .to eq({ name: "John Doe", email: "john.doe@example.com" })
+    expect { parse_author!("") }
+      .to raise_error(parse_error_msg)
+    expect { parse_author!("John Doe") }
+      .to raise_error(parse_error_msg)
+    expect { parse_author!("<john.doe@example.com>") }
+      .to raise_error(parse_error_msg)
+  end
+
   specify "#disk_usage_readable" do
     expect(disk_usage_readable(1)).to eq("1B")
     expect(disk_usage_readable(1000)).to eq("1000B")

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -467,6 +467,13 @@ module Kernel
     end.uniq.compact
   end
 
+  def parse_author!(author)
+    /^(?<name>[^<]+?)[ \t]*<(?<email>[^>]+?)>$/ =~ author
+    raise "Unable to parse name and email." if name.blank? && email.blank?
+
+    { name: name, email: email }
+  end
+
   def disk_usage_readable(size_in_bytes)
     if size_in_bytes >= 1_073_741_824
       size = size_in_bytes.to_f / 1_073_741_824

--- a/Library/Homebrew/utils.rb
+++ b/Library/Homebrew/utils.rb
@@ -469,7 +469,7 @@ module Kernel
 
   def parse_author!(author)
     /^(?<name>[^<]+?)[ \t]*<(?<email>[^>]+?)>$/ =~ author
-    raise "Unable to parse name and email." if name.blank? && email.blank?
+    raise UsageError, "Unable to parse name and email." if name.blank? && email.blank?
 
     { name: name, email: email }
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds a `--committer` option to `brew bottle`, `brew pr-pull` and `brew pr-upload` to specify the committer name  and email address. The intention is to use this for `BrewTestBot` creating commits on CI, where the user dispatching the workflow is the commit author.