### PR TITLE
workflows/{sorbet,spdx}: use origin_branch with git-try-push

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -41,7 +41,7 @@ jobs:
 
           if git ls-remote --exit-code --heads origin "$BRANCH"; then
             git checkout "$BRANCH"
-            git reset origin/master
+            git reset --hard origin/master
           else
             git checkout -B "$BRANCH" origin/master
             BRANCH_EXISTS="1"
@@ -64,6 +64,7 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           branch: ${{ steps.update.outputs.branch }}
           force: true
+          origin_branch: "master"
 
       - name: Open a pull request
         if: steps.update.outputs.pull_request == 'true'

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -40,7 +40,7 @@ jobs:
 
           if git ls-remote --exit-code --heads origin "$BRANCH"; then
             git checkout "$BRANCH"
-            git reset origin/master
+            git reset --hard origin/master
           else
             git checkout -B "$BRANCH" origin/master
             BRANCH_EXISTS="1"
@@ -62,6 +62,7 @@ jobs:
           token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
           branch: ${{ steps.update.outputs.branch }}
           force: true
+          origin_branch: "master"
 
       - name: Open a pull request
         if: steps.update.outputs.pull_request == 'true'


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We should be using `origin_branch` to avoid a repeat of #10981.