### PR TITLE
github_packages: Rename sh.brew.bottle.digest

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -287,7 +287,7 @@ class GitHubPackages
         platform:    platform_hash,
         annotations: {
           "org.opencontainers.image.ref.name" => tag,
-          "sh.brew.bottle.checksum"           => tar_gz_sha256,
+          "sh.brew.bottle.digest"             => tar_gz_sha256,
           "sh.brew.tab"                       => tab.to_json,
         },
       }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -370,9 +370,9 @@ class Bottle
     manifests_annotations = manifests.map { |m| m["annotations"] }
     raise ArgumentError, "Missing 'annotations' section." if manifests_annotations.blank?
 
-    bottle_checksum = @resource.checksum.hexdigest
+    bottle_digest = @resource.checksum.hexdigest
     manifest_annotations = manifests_annotations.find do |m|
-      m["sh.brew.bottle.checksum"] == bottle_checksum
+      m["sh.brew.bottle.digest"] == bottle_digest
     end
     raise ArgumentError, "Couldn't find manifest matching bottle checksum." if manifest_annotations.blank?
 


### PR DESCRIPTION
Rename `sh.brew.bottle.checksum` to `sh.brew.bottle.digest` for consistency with the OCI descriptor spec. See https://github.com/opencontainers/image-spec/blob/master/descriptor.md#properties

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?