### PR TITLE
Remove Audacity block

### DIFF
--- a/Library/Homebrew/cask/denylist.rb
+++ b/Library/Homebrew/cask/denylist.rb
@@ -13,8 +13,6 @@ module Cask
       case name
       when /^adobe-(after|illustrator|indesign|photoshop|premiere)/
         "Adobe casks were removed because they are too difficult to maintain."
-      when /^audacity$/
-        "Audacity was removed because it is too difficult to download programmatically."
       when /^pharo$/
         "Pharo developers maintain their own tap."
       end

--- a/Library/Homebrew/test/cask/denylist_spec.rb
+++ b/Library/Homebrew/test/cask/denylist_spec.rb
@@ -17,7 +17,6 @@ describe Cask::Denylist, :cask do
     it { is_expected.to disallow("adobe-indesign") }
     it { is_expected.to disallow("adobe-photoshop") }
     it { is_expected.to disallow("adobe-premiere") }
-    it { is_expected.to disallow("audacity") }
     it { is_expected.to disallow("pharo") }
     it { is_expected.not_to disallow("allowed-cask") }
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
See  [homebrew-cask#102986](https://github.com/Homebrew/homebrew-cask/pull/102986)

Since Audacity is no longer "too difficult to download programmatically", this hard block should be removed.