### PR TITLE
Revert "github_packages: update mediaType."

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -263,12 +263,12 @@ class GitHubPackages
       image_manifest = {
         schemaVersion: 2,
         config:        {
-          mediaType: "application/vnd.homebrew.formula.config.v1+json",
+          mediaType: "application/vnd.oci.image.config.v1+json",
           digest:    "sha256:#{config_json_sha256}",
           size:      config_json_size,
         },
         layers:        [{
-          mediaType:   "application/vnd.homebrew.bottle.layer.v1.tar+gzip",
+          mediaType:   "application/vnd.oci.image.layer.v1.tar+gzip",
           digest:      "sha256:#{tar_gz_sha256}",
           size:        File.size(local_file),
           annotations: {


### PR DESCRIPTION
> After merging this PR, we are unable to use `skopeo` to copy the resulting OCI image.
```console
$ brew pr-upload --no-commit --github-org=brewsci
…
Error: Failure while executing; `/usr/local/bin/skopeo copy --all oci:seqkit--0.15.0 docker://ghcr.io/brewsci/bio/seqkit:0.15.0` exited with 1. Here's the output:
Getting image list signatures
Copying 2 of 2 images in list
Copying image sha256:68fa14405fdf83b46275c18c66705a55456b8ba4294a97367164f9182000d3de (1/2)
time="2021-04-01T16:10:37-07:00" level=fatal msg="Error initializing image from source oci:seqkit--0.15.0:: unsupported docker v2s2 media type: \"\""
$ skopeo copy --all oci:seqkit--0.15.0 oci:seqkit--0.15.0.copy
Getting image list signatures
Copying 2 of 2 images in list
Copying image sha256:68fa14405fdf83b46275c18c66705a55456b8ba4294a97367164f9182000d3de (1/2)
FATA[0000] Error initializing image from source oci:seqkit--0.15.0:: unsupported docker v2s2 media type: ""
```

Reverts Homebrew/brew#10978