### PR TITLE
Remove reference to the deprecated SPDX + syntax

### DIFF
--- a/docs/License-Guidelines.md
+++ b/docs/License-Guidelines.md
@@ -28,12 +28,6 @@ license :cannot_represent
 
 Some formulae have multiple licenses that need to be combined in different ways. In these cases, a more complex license expression can be used. These expressions are based on the [SPDX License Expression Guidelines](https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/).
 
-Add a `+` to indicate that the user can choose a later version of the same license:
-
-```ruby
-license "EPL-1.0+"
-```
-
 GNU licenses (`GPL`, `LGPL`, `AGPL` and `GFDL`) require either the `-only` or the `-or-later` suffix to indicate whether a later version of the license is allowed:
 
 ```ruby


### PR DESCRIPTION
The "+" is supported but now deprecated and should be avoided.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
