### PR TITLE
write_image_index: Remove Docker mediaType

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -340,8 +340,6 @@ class GitHubPackages
 
   def write_image_index(manifests, blobs, annotations)
     image_index = {
-      # Currently needed for correct multi-arch display in GitHub Packages UI
-      mediaType:     "application/vnd.docker.distribution.manifest.list.v2+json",
       schemaVersion: 2,
       manifests:     manifests,
       annotations:   annotations,


### PR DESCRIPTION
Remove `mediaType: "application/vnd.docker.distribution.manifest.list.v2+json"`
previously needed for correct multi-arch display in GitHub Packages UI.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The current image index is non-conforming, because they contain `mediaType: "application/vnd.docker.distribution.manifest.list.v2+json"`, whereas their actual `mediaType` is `application/vnd.oci.image.index.v1+json`.

See https://github.com/opencontainers/image-spec/blob/master/image-index.md#image-index-property-descriptions

`mediaType: "application/vnd.docker.distribution.manifest.list.v2+json"` was used as a workaround for a GitHub Packages display issue. See the comment below.
