### PR TITLE
github_packages: odie on missing skopeo.

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -58,6 +58,8 @@ class GitHubPackages
       HOMEBREW_PREFIX/"bin/skopeo",
     ].compact.first
     unless skopeo.exist?
+      odie "no `skoepeo` and HOMEBREW_FORCE_HOMEBREW_ON_LINUX is set!" if Homebrew::EnvConfig.force_homebrew_on_linux?
+
       ohai "Installing `skopeo` for upload..."
       safe_system HOMEBREW_BREW_FILE, "install", "--formula", "skopeo"
       skopeo = Formula["skopeo"].opt_bin/"skopeo"


### PR DESCRIPTION
If `HOMEBREW_FORCE_HOMEBREW_ON_LINUX` is set then we don't want to try to `brew install` or it will try and install from source (which takes too long).