### PR TITLE
OCI annotation improvements and move platform.variant

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -272,6 +272,7 @@ class GitHubPackages
         "org.opencontainers.image.title"         => "#{formula_full_name} #{tag}",
         "com.github.package.type"                => GITHUB_PACKAGE_TYPE,
         "sh.brew.bottle.glibc.version"           => glibc_version,
+        "sh.brew.tab"                            => tab.to_json,
       }).compact.sort.to_h
 
       image_manifest = {

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -194,6 +194,7 @@ class GitHubPackages
 
     created_date = bottle_hash["bottle"]["date"]
     formula_annotations_hash = {
+      "com.github.package.type"                => GITHUB_PACKAGE_TYPE,
       "org.opencontainers.image.created"       => created_date,
       "org.opencontainers.image.description"   => bottle_hash["formula"]["desc"],
       "org.opencontainers.image.documentation" => documentation,
@@ -233,24 +234,17 @@ class GitHubPackages
       raise TypeError, "unknown tab['built_on']['os']: #{tab["built_on"]["os"]}" if os.blank?
 
       os_version = tab["built_on"]["os_version"] if tab["built_on"].present?
-      os_version = case os
+      case os
       when "darwin"
-        os_version || "macOS #{MacOS::Version.from_symbol(bottle_tag)}"
+        os_version ||= "macOS #{MacOS::Version.from_symbol(bottle_tag)}"
       when "linux"
-        (os_version || "Ubuntu 16.04.7").delete_suffix " LTS"
-      else
-        os_version
+        os_version = (os_version || "Ubuntu 16.04.7").delete_suffix " LTS"
+        glibc_version = (tab["built_on"]["glibc_version"] if tab["built_on"].present?) || "2.23"
+        cpu_variant = tab["oldest_cpu_family"] || "core2"
       end
-
-      glibc_version = if os == "linux"
-        (tab["built_on"]["glibc_version"] if tab["built_on"].present?) || "2.23"
-      end
-
-      variant = tab["oldest_cpu_family"] || "core2" if os == "linux"
 
       platform_hash = {
         architecture: architecture,
-        variant: variant,
         os: os,
         "os.version" => os_version,
       }.compact
@@ -265,15 +259,21 @@ class GitHubPackages
 
       tag = GitHubPackages.version_rebuild(version, rebuild, bottle_tag)
 
-      annotations_hash = formula_annotations_hash.merge({
-        "org.opencontainers.image.created"       => created_date,
-        "org.opencontainers.image.documentation" => documentation,
-        "org.opencontainers.image.ref.name"      => tag,
-        "org.opencontainers.image.title"         => "#{formula_full_name} #{tag}",
-        "com.github.package.type"                => GITHUB_PACKAGE_TYPE,
-        "sh.brew.bottle.glibc.version"           => glibc_version,
-        "sh.brew.tab"                            => tab.to_json,
-      }).compact.sort.to_h
+      descriptor_annotations_hash = {
+        "org.opencontainers.image.ref.name" => tag,
+        "sh.brew.bottle.cpu.variant"        => cpu_variant,
+        "sh.brew.bottle.digest"             => tar_gz_sha256,
+        "sh.brew.bottle.glibc.version"      => glibc_version,
+        "sh.brew.tab"                       => tab.to_json,
+      }.compact
+
+      annotations_hash = formula_annotations_hash.merge(descriptor_annotations_hash).merge(
+        {
+          "org.opencontainers.image.created"       => created_date,
+          "org.opencontainers.image.documentation" => documentation,
+          "org.opencontainers.image.title"         => "#{formula_full_name} #{tag}",
+        },
+      ).compact.sort.to_h
 
       image_manifest = {
         schemaVersion: 2,
@@ -300,12 +300,7 @@ class GitHubPackages
         digest:      "sha256:#{manifest_json_sha256}",
         size:        manifest_json_size,
         platform:    platform_hash,
-        annotations: {
-          "org.opencontainers.image.ref.name" => tag,
-          "sh.brew.bottle.digest"             => tar_gz_sha256,
-          "sh.brew.bottle.glibc.version"      => glibc_version,
-          "sh.brew.tab"                       => tab.to_json,
-        }.compact,
+        annotations: descriptor_annotations_hash,
       }
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Add `"com.github.package.type": "homebrew_bottle"` to the image index annotations.

Add `sh.brew.tab` to the image manifest. The tab is needed to install the package using the SHA-256 of the single-architecture image. See for example the SHA-256 of the single-architecture images advertised under the `OS / Arch` tab of the multi-architecture image at https://github.com/orgs/brewsci/packages/container/package/bio/seqkit-mediatype-docker

Move CPU variant from `platform.variant` to `sh.brew.cpu.variant`. Setting `platform.variant` requires specifying the `--platform` option to the Docker client: `docker pull --platform=linux/amd64/core2`. That's useful if providing multiple images for `linux/amd64` for different CPU variants, but the default `linux/amd64` image should not have `platform.variant` set.

Factor out `descriptor_annotations_hash`, the annotations that are present in both the content descriptor annotations and the image manifest annotations.