### PR TITLE
fix _brew completion default cache path

### DIFF
--- a/completions/zsh/_brew
+++ b/completions/zsh/_brew
@@ -47,7 +47,7 @@ __brew_completion_caching_policy() {
   (( $#tmp )) || return 0
 
   # otherwise, invalidate if latest tap index file is missing or newer than cache file
-  tmp=( ${HOMEBREW_REPOSITORY:-/usr/local/Homebrew}/Library/Taps/*/*/.git/index(om[1]N) )
+  tmp=( ${HOMEBREW_REPOSITORY:-${HOMEBREW_PREFIX}}/Library/Taps/*/*/.git/index(om[1]N) )
   [[ -z $tmp || $tmp -nt $1 ]]
 }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally? _(currently not possible on Apple Silicon)_
- [ ] Have you successfully run `brew typecheck` with your changes locally? _(currently not possible on Apple Silicon)_
- [ ] Have you successfully run `brew tests` with your changes locally? _(currently not possible on Apple Silicon)_

-----

### Context

When we introduced the completion cache mechanism for zsh about 2 years ago, we needed the path to the installed Taps for checking if the current completion cache should be invalidated. This is the relevant code: https://github.com/Homebrew/brew/blob/0ec1f04e635276a530ce58c04702146a0f59f82c/completions/zsh/_brew#L50

But as you can see, the fallback value is hardcoded and often incorrect in more and more cases as users move to `/opt/homebrew`.

### Why it matters

The `HOMEBREW_REPOSITORY` variable is automatically defined in Homebrew scripts, but not outside of those scripts, in particular during execution of shell autocompletion scripts. As a result, if a user has moved to `/opt/homebrew`, then the fallback is incorrect, and the cache is invalidated and recreated on each invocation, which is slow and defeats its purpose. 

### Solutions

Here are the two solutions I have in mind:

- on line 50, replace the fallback `/usr/local/Homebrew` with `${HOMEBREW_PREFIX}`. This assumes the variable is defined for any user with a working Homebrew installation.
- ask the user to `export HOMEBREW_REPOSITORY=${HOMEBREW_PREFIX}` in their shell configuration (not my favorite, but it works)

### This PR

This PR implements the first solution.