### PR TITLE
doc: adds missing required `procps` package

### DIFF
--- a/docs/Homebrew-on-Linux.md
+++ b/docs/Homebrew-on-Linux.md
@@ -57,14 +57,14 @@ Paste at a terminal prompt:
 ### Debian or Ubuntu
 
 ```sh
-sudo apt-get install build-essential curl file git
+sudo apt-get install build-essential procps curl file git
 ```
 
 ### Fedora, CentOS, or Red Hat
 
 ```sh
 sudo yum groupinstall 'Development Tools'
-sudo yum install curl file git
+sudo yum install procps-ng curl file git
 sudo yum install libxcrypt-compat # needed by Fedora 30 and up
 ```
 


### PR DESCRIPTION
In very limited environments, Homebrew manual install fails with :

```
/root/.linuxbrew/Homebrew/Library/Homebrew/cmd/shellenv.sh: line 9: /bin/ps: No such file or directory
```

This has to be fixed by explicitly provisioning `ps` command on the system, since Brew 2.4.7 (see `c1666676`).

---

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~~Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).~~
- ~~Have you successfully run `brew style` with your changes locally?~~
- ~~Have you successfully run `brew typecheck` with your changes locally?~~
- ~~Have you successfully run `brew tests` with your changes locally?~~

-----
