### PR TITLE
GitHub Packages cleanup

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -563,7 +563,8 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
 
   def initialize(url, name, version, **meta)
     meta ||= {}
-    meta[:header] = ["Authorization: Bearer", "Accept: application/vnd.oci.image.index.v1+json"]
+    meta[:headers] ||= []
+    meta[:headers] << ["Authorization: Bearer"]
     super(url, name, version, meta)
   end
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -343,7 +343,7 @@ module Homebrew
       return unless @core_tap
 
       version = formula.version.to_s
-      return if version == "2.23"
+      return if version == OS::GLIBC_CI_VERSION
 
       problem "The glibc version must be #{version}, as this is the version used by our CI on Linux. " \
               "Glibc is for users who have a system Glibc with a lower version, " \

--- a/Library/Homebrew/hardware.rb
+++ b/Library/Homebrew/hardware.rb
@@ -20,6 +20,8 @@ module Hardware
       *ARM_64BIT_ARCHS,
     ].freeze
 
+    INTEL_64BIT_OLDEST_CPU = :core2
+
     class << self
       extend T::Sig
 
@@ -198,7 +200,7 @@ module Hardware
     def oldest_cpu(_version = nil)
       if Hardware::CPU.intel?
         if Hardware::CPU.is_64_bit?
-          :core2
+          Hardware::CPU::INTEL_64BIT_OLDEST_CPU
         else
           :core
         end

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -37,6 +37,8 @@ module OS
 
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]
 
+  GLIBC_CI_VERSION = "2.23"
+
   if OS.mac?
     require "os/mac"
     # Don't tell people to report issues on unsupported configurations.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -306,6 +306,7 @@ class Bottle
 
     filename = Filename.create(formula, tag, spec.rebuild).bintray
 
+    # TODO: this will need adjusted when if we use GitHub Packages by default
     path, resolved_basename = if spec.root_url.match?(GitHubPackages::URL_REGEX)
       ["#{@name}/blobs/sha256:#{checksum}", filename]
     else
@@ -400,8 +401,10 @@ class Bottle
       version_rebuild = GitHubPackages.version_rebuild(@resource.version, rebuild)
       resource.version(version_rebuild)
 
-      resource.url("#{@spec.root_url}/#{name}/manifests/#{version_rebuild}",
-                   using: CurlGitHubPackagesDownloadStrategy)
+      resource.url("#{@spec.root_url}/#{name}/manifests/#{version_rebuild}", {
+        using:   CurlGitHubPackagesDownloadStrategy,
+        headers: ["Accept: application/vnd.oci.image.index.v1+json"],
+      })
       resource.downloader.resolved_basename = "#{name}-#{version_rebuild}.bottle_manifest.json"
       resource
     end


### PR DESCRIPTION
- `download_strategy`: only request image index JSON for downloading the manifest for the tab
- use a shared `OS` constant for the version of `glibc` we use in CI
- fix `skoepeo` typo
- ensure that blank hash values are deleted (again) rather than just `nil` ones
- use a shared `Hardware::CPU` constant for oldest CPU we're supporting/using on Intel 64-bit
- re-add comment to `software_spec`