### PR TITLE
GHCR: Add constant OS::CI_OS_VERSION

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -343,7 +343,7 @@ module Homebrew
       return unless @core_tap
 
       version = formula.version.to_s
-      return if version == OS::GLIBC_CI_VERSION
+      return if version == OS::CI_GLIBC_VERSION
 
       problem "The glibc version must be #{version}, as this is the version used by our CI on Linux. " \
               "Glibc is for users who have a system Glibc with a lower version, " \

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -234,13 +234,15 @@ class GitHubPackages
       end
       raise TypeError, "unknown tab['built_on']['os']: #{tab["built_on"]["os"]}" if os.blank?
 
-      os_version = tab["built_on"]["os_version"] if tab["built_on"].present?
+      os_version = tab["built_on"]["os_version"].presence if tab["built_on"].present?
       case os
       when "darwin"
         os_version ||= "macOS #{MacOS::Version.from_symbol(bottle_tag)}"
       when "linux"
-        os_version = (os_version || "Ubuntu 16.04.7").delete_suffix " LTS"
-        glibc_version = (tab["built_on"]["glibc_version"] if tab["built_on"].present?) || OS::GLIBC_CI_VERSION
+        os_version&.delete_suffix!(" LTS")
+        os_version ||= OS::CI_OS_VERSION
+        glibc_version = tab["built_on"]["glibc_version"].presence if tab["built_on"].present?
+        glibc_version ||= OS::CI_GLIBC_VERSION
         cpu_variant = tab["oldest_cpu_family"] || Hardware::CPU::INTEL_64BIT_OLDEST_CPU.to_s
       end
 

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -37,7 +37,8 @@ module OS
 
   ::OS_VERSION = ENV["HOMEBREW_OS_VERSION"]
 
-  GLIBC_CI_VERSION = "2.23"
+  CI_GLIBC_VERSION = "2.23"
+  CI_OS_VERSION = "Ubuntu 16.04"
 
   if OS.mac?
     require "os/mac"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Add constant `OS::CI_OS_VERSION`.
- Rename constant `OS::GLIBC_CI_VERSION` to `OS::CI_GLIBC_VERSION`.

See https://github.com/Homebrew/brew/pull/11013#discussion_r607078338
