### PR TITLE
GHCR: Add GitHubPackages.sanitize_root_url

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -105,8 +105,8 @@ class GitHubPackages
     if (matches = url.to_s.match(%r{docker://([\w.-]+)/([\w-]+)/([\w-]+)}))
       _, registry, org, repo = *matches.to_a
       GitHubPackages.root_url(org, repo, "https://#{registry}/v2/")
-    elsif url.to_s.start_with? URL_PREFIX
-      _, org, repo = *url.match(URL_REGEX)
+    elsif (matches = url.to_s.match(URL_REGEX))
+      _, org, repo = *matches.to_a
       GitHubPackages.root_url(org, repo)
     else
       url

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -101,6 +101,18 @@ class GitHubPackages
     "#{prefix}#{org}/#{repo_without_prefix(repo)}"
   end
 
+  def self.sanitize_root_url(url)
+    if url.to_s.start_with? "docker://"
+      _, registry, org, repo = *url.match(%r{docker://([\w.-]+)/([\w-]+)/([\w-]+)})
+      GitHubPackages.root_url(org, repo, "https://#{registry}/v2/")
+    elsif url.to_s.start_with? URL_PREFIX
+      _, org, repo = *url.match(URL_REGEX)
+      GitHubPackages.root_url(org, repo)
+    else
+      url
+    end
+  end
+
   private
 
   IMAGE_CONFIG_SCHEMA_URI = "https://opencontainers.org/schema/image/config"

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -102,8 +102,8 @@ class GitHubPackages
   end
 
   def self.sanitize_root_url(url)
-    if url.to_s.start_with? "docker://"
-      _, registry, org, repo = *url.match(%r{docker://([\w.-]+)/([\w-]+)/([\w-]+)})
+    if (matches = url.to_s.match(%r{docker://([\w.-]+)/([\w-]+)/([\w-]+)}))
+      _, registry, org, repo = *matches.to_a
       GitHubPackages.root_url(org, repo, "https://#{registry}/v2/")
     elsif url.to_s.start_with? URL_PREFIX
       _, org, repo = *url.match(URL_REGEX)

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -444,18 +444,11 @@ class BottleSpecification
 
   def root_url(var = nil, specs = {})
     if var.nil?
-      @root_url ||= if Homebrew::EnvConfig.bottle_domain.match?(GitHubPackages::URL_REGEX)
-        GitHubPackages.root_url(tap.user, tap.repo).to_s
-      else
-        "#{Homebrew::EnvConfig.bottle_domain}/#{Utils::Bottles::Bintray.repository(tap)}"
-      end
+      @root_url ||= GitHubPackages.sanitize_root_url(
+        "#{Homebrew::EnvConfig.bottle_domain}/#{Utils::Bottles::Bintray.repository(tap)}",
+      )
     else
-      @root_url = if var.to_s.start_with? "docker://"
-        _, registry, org, repo = *var.match(%r{docker://([\w.-]+)/([\w-]+)/([\w-]+)})
-        GitHubPackages.root_url(org, repo, "https://#{registry}/v2/").to_s
-      else
-        var
-      end
+      @root_url = GitHubPackages.sanitize_root_url(var)
       @root_url_specs.merge!(specs)
     end
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Support `root_url "docker://registry/org/repo"` by translating
    docker://registry/org/repo
to
    https://registry/v2/org/repo
