### PR TITLE
Use GITHUB_TOKEN more consistently.

### DIFF
--- a/.github/workflows/sorbet.yml
+++ b/.github/workflows/sorbet.yml
@@ -61,7 +61,7 @@ jobs:
         if: steps.update.outputs.committed == 'true'
         uses: Homebrew/actions/git-try-push@master
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           branch: ${{ steps.update.outputs.branch }}
           force: true
           origin_branch: "master"
@@ -70,4 +70,4 @@ jobs:
         if: steps.update.outputs.pull_request == 'true'
         run: hub pull-request --no-edit
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Update SPDX license data
         id: update
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
         run: |
           git fetch origin
@@ -59,7 +57,7 @@ jobs:
         if: steps.update.outputs.committed == 'true'
         uses: Homebrew/actions/git-try-push@master
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           branch: ${{ steps.update.outputs.branch }}
           force: true
           origin_branch: "master"
@@ -68,4 +66,4 @@ jobs:
         if: steps.update.outputs.pull_request == 'true'
         run: hub pull-request --no-edit
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Mark/Close Stale Issues and Pull Requests
         uses: actions/stale@v3
         with:
-          repo-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          repo-token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           days-before-stale: 21
           days-before-close: 7
           stale-issue-message: >
@@ -43,7 +43,7 @@ jobs:
       - name: Lock Outdated Threads
         uses: dessant/lock-threads@486f7380c15596f92b724e4260e4981c68d6bde6
         with:
-          github-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-lock-inactive-days: 30
           issue-lock-labels: outdated
           pr-lock-inactive-days: 30

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -21,7 +21,7 @@ jobs:
         if: github.event_name == 'schedule' || github.event.action == 'closed'
         uses: reitermarkus/rerun-workflow@64cba9e834916060e77b7dad424d086837fdd0a6
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           continuous-label: waiting for feedback
           trigger-labels: critical
           workflow: triage.yml
@@ -31,7 +31,7 @@ jobs:
             github.event.action != 'closed' && github.event.pull_request.state != 'closed'
         uses: actions/github-script@v3
         with:
-          github-token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          github-token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           script: |
             async function approvePullRequest(pullRequestNumber) {
               const reviews = await approvalsByAuthenticatedUser(pullRequestNumber)

--- a/.github/workflows/update-manpage.yml
+++ b/.github/workflows/update-manpage.yml
@@ -69,14 +69,14 @@ jobs:
             fi
           fi
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_BREW_UPDATE_MAINTAINERS_TOKEN }}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Push commits
         if: steps.update.outputs.committed == 'true'
         uses: Homebrew/actions/git-try-push@master
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           branch: ${{ steps.update.outputs.branch }}
           force: true
           origin_branch: "master"
@@ -85,4 +85,4 @@ jobs:
         if: steps.update.outputs.pull_request == 'true'
         run: hub pull-request --no-edit
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}

--- a/.github/workflows/vendor-gems.yml
+++ b/.github/workflows/vendor-gems.yml
@@ -43,7 +43,7 @@ jobs:
           gem_name="$(echo "${branch}" | sed -E 's|.*/||;s|(.*)-.*$|\1|')"
           echo "::set-output name=gem_name::${gem_name}"
         env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Vendor Gems
         env:
           GEM_NAME: ${{ steps.checkout.outputs.gem_name }}
@@ -73,6 +73,6 @@ jobs:
       - name: Push to pull request
         uses: Homebrew/actions/git-try-push@master
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           branch: ${{ steps.checkout.outputs.branch }}
           force: true


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

This provides enough permissions for almost everything we want to do.

When it's not enough (e.g. for `brew update-maintainers`): generate a dedicated, repo-specific token for when increased scopes are needed and setup a new organisation-wide token on the new PAT format.

---

**This may well break things. If so: please do not revert this PR but specifically revert the workflow(s) token changes that are failing.**