### PR TITLE
dev-cmd/bottle: fix license output.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -532,7 +532,7 @@ module Homebrew
           "tap_git_revision" => tap_git_revision,
           "tap_git_remote"   => tap_git_remote,
           "desc"             => f.desc,
-          "license"          => f.license,
+          "license"          => SPDX.license_expression_to_string(f.license),
           "homepage"         => f.homepage,
         },
         "bottle"  => {


### PR DESCRIPTION
Don't output the complex license object but instead use the same format we use for `Formula#to_hash`.
