### PR TITLE
.simplecov: delete private method

### DIFF
--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -22,9 +22,9 @@ SimpleCov.start do
     SimpleCov.print_error_status = false
   end
   excludes = ["test", "vendor"]
-  subdirs = Dir.chdir(SimpleCov.root) { Dir.glob("*") }
-               .reject { |d| d.end_with?(".rb") || excludes.include?(d) }
-               .map { |d| "#{d}/**/*.rb" }.join(",")
+  subdirs = Dir.chdir(SimpleCov.root) { Pathname.glob("*") }
+               .reject { |p| p.extname == ".rb" || excludes.include?(p.to_s) }
+               .map { |p| "#{p}/**/*.rb" }.join(",")
   files = "#{SimpleCov.root}/{#{subdirs},*.rb}"
 
   if ENV["HOMEBREW_INTEGRATION_TEST"]

--- a/Library/Homebrew/.simplecov
+++ b/Library/Homebrew/.simplecov
@@ -36,13 +36,11 @@ SimpleCov.start do
 
     SimpleCov.at_exit do
       # Just save result, but don't write formatted output.
-      coverage_result = Coverage.result
-      coverage_result_dup = coverage_result.dup
+      coverage_result = Coverage.result.dup
       Dir[files].each do |file|
         absolute_path = File.expand_path(file)
-        coverage_result_dup[absolute_path] ||= SimpleCov::SimulateCoverage.call(absolute_path)
+        coverage_result[absolute_path] ||= SimpleCov::SimulateCoverage.call(absolute_path)
       end
-      coverage_result = coverage_result_dup
       simplecov_result = SimpleCov::Result.new(coverage_result)
       SimpleCov::ResultMerger.store_result(simplecov_result)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
delete `SimpleCov::add_not_loaded_files` because of private method and repair `.simplecov`