### PR TITLE
github_packages: fix versioned bottle names.

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -101,6 +101,10 @@ class GitHubPackages
     "#{prefix}#{org}/#{repo_without_prefix(repo)}"
   end
 
+  def self.image_formula_name(formula_name)
+    formula_name.tr("@", "/")
+  end
+
   private
 
   IMAGE_CONFIG_SCHEMA_URI = "https://opencontainers.org/schema/image/config"
@@ -312,7 +316,8 @@ class GitHubPackages
     write_index_json(index_json_sha256, index_json_size, root,
                      "org.opencontainers.image.ref.name" => version_rebuild)
 
-    image_tag = "#{GitHubPackages.root_url(org, repo, DOCKER_PREFIX)}/#{formula_name}:#{version_rebuild}"
+    image_formula_name = GitHubPackages.image_formula_name(formula_name)
+    image_tag = "#{GitHubPackages.root_url(org, repo, DOCKER_PREFIX)}/#{image_formula_name}:#{version_rebuild}"
 
     puts
     args = ["copy", "--all", "oci:#{root}", image_tag.to_s]
@@ -321,7 +326,7 @@ class GitHubPackages
     else
       args << "--dest-creds=#{user}:#{token}"
       system_command!(skopeo, verbose: true, print_stdout: true, args: args)
-      package_name = "#{GitHubPackages.repo_without_prefix(repo)}/#{formula_name}"
+      package_name = "#{GitHubPackages.repo_without_prefix(repo)}/#{image_formula_name}"
       ohai "Uploaded to https://github.com/orgs/Homebrew/packages/container/package/#{package_name}"
     end
   end

--- a/Library/Homebrew/mktemp.rb
+++ b/Library/Homebrew/mktemp.rb
@@ -40,7 +40,7 @@ class Mktemp
   end
 
   def run
-    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix.tr "@", "-"}-", HOMEBREW_TEMP))
+    @tmpdir = Pathname.new(Dir.mktmpdir("#{@prefix.tr "@", "AT"}-", HOMEBREW_TEMP))
 
     # Make sure files inside the temporary directory have the same group as the
     # brew instance.

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -308,7 +308,8 @@ class Bottle
 
     # TODO: this will need adjusted when if we use GitHub Packages by default
     path, resolved_basename = if spec.root_url.match?(GitHubPackages::URL_REGEX)
-      ["#{@name}/blobs/sha256:#{checksum}", filename]
+      image_name = GitHubPackages.image_formula_name(@name)
+      ["#{image_name}/blobs/sha256:#{checksum}", filename]
     else
       filename
     end
@@ -401,7 +402,8 @@ class Bottle
       version_rebuild = GitHubPackages.version_rebuild(@resource.version, rebuild)
       resource.version(version_rebuild)
 
-      resource.url("#{@spec.root_url}/#{name}/manifests/#{version_rebuild}", {
+      image_name = GitHubPackages.image_formula_name(@name)
+      resource.url("#{@spec.root_url}/#{image_name}/manifests/#{version_rebuild}", {
         using:   CurlGitHubPackagesDownloadStrategy,
         headers: ["Accept: application/vnd.oci.image.index.v1+json"],
       })


### PR DESCRIPTION
`@` cannot be used in Docker image names. Use `AT` instead (which we already use in class names so has some precedent).

Make `mktemp` consistent, too.