### PR TITLE
github_packages: remove invalid docker tag characters.

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -110,6 +110,11 @@ class GitHubPackages
                 .tr("+", "x")
   end
 
+  def self.image_version_rebuild(version_rebuild)
+    # invalid docker tag characters
+    version_rebuild.tr("+", ".")
+  end
+
   private
 
   IMAGE_CONFIG_SCHEMA_URI = "https://opencontainers.org/schema/image/config"
@@ -183,11 +188,12 @@ class GitHubPackages
     rebuild = bottle_hash["bottle"]["rebuild"]
     version_rebuild = GitHubPackages.version_rebuild(version, rebuild)
 
-    image_formula_name = GitHubPackages.image_formula_name(formula_name)
-    image_tag = "#{GitHubPackages.root_url(org, repo, DOCKER_PREFIX)}/#{image_formula_name}:#{version_rebuild}"
+    image_name = GitHubPackages.image_formula_name(formula_name)
+    image_tag = GitHubPackages.image_version_rebuild(version_rebuild)
+    image_uri = "#{GitHubPackages.root_url(org, repo, DOCKER_PREFIX)}/#{image_name}:#{image_tag}"
 
     puts
-    inspect_args = ["inspect", image_tag.to_s]
+    inspect_args = ["inspect", image_uri.to_s]
     if dry_run
       puts "#{skopeo} #{inspect_args.join(" ")} --dest-creds=#{user}:$HOMEBREW_GITHUB_PACKAGES_TOKEN"
     else
@@ -195,10 +201,10 @@ class GitHubPackages
       inspect_result = system_command(skopeo, args: args)
       if inspect_result.status.success?
         if warn_on_error
-          opoo "#{image_tag} already exists, skipping upload!"
+          opoo "#{image_uri} already exists, skipping upload!"
           return
         else
-          odie "#{image_tag} already exists!"
+          odie "#{image_uri} already exists!"
         end
       end
     end
@@ -343,7 +349,7 @@ class GitHubPackages
                      "org.opencontainers.image.ref.name" => version_rebuild)
 
     puts
-    args = ["copy", "--all", "oci:#{root}", image_tag.to_s]
+    args = ["copy", "--all", "oci:#{root}", image_uri.to_s]
     if dry_run
       puts "#{skopeo} #{args.join(" ")} --dest-creds=#{user}:$HOMEBREW_GITHUB_PACKAGES_TOKEN"
     else

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -403,7 +403,8 @@ class Bottle
       resource.version(version_rebuild)
 
       image_name = GitHubPackages.image_formula_name(@name)
-      resource.url("#{@spec.root_url}/#{image_name}/manifests/#{version_rebuild}", {
+      image_tag = GitHubPackages.image_version_rebuild(version_rebuild)
+      resource.url("#{@spec.root_url}/#{image_name}/manifests/#{image_tag}", {
         using:   CurlGitHubPackagesDownloadStrategy,
         headers: ["Accept: application/vnd.oci.image.index.v1+json"],
       })


### PR DESCRIPTION
Some versions have `+` in them.