### PR TITLE
More GitHub Packages bulk upload fixes

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -14,7 +14,7 @@ Lint/NestedMethodDefinition:
 
 # TODO: Try to bring down all metrics maximums.
 Metrics/AbcSize:
-  Max: 275
+  Max: 280
 Metrics/BlockLength:
   Max: 100
   Exclude:

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -531,7 +531,11 @@ module Homebrew
           "tap_git_path"     => f.path.to_s.delete_prefix("#{tap_path}/"),
           "tap_git_revision" => tap_git_revision,
           "tap_git_remote"   => tap_git_remote,
-          "desc"             => f.desc,
+          # descriptions can contain emoji. sigh.
+          "desc"             => f.desc.encode(
+            Encoding.find("ASCII"),
+            invalid: :replace, undef: :replace, replace: "",
+          ).strip,
           "license"          => SPDX.license_expression_to_string(f.license),
           "homepage"         => f.homepage,
         },

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -61,7 +61,7 @@ module Formulary
       # access them from within the formula's class scope.
       mod.const_set(:BUILD_FLAGS, flags)
       mod.module_eval(contents, path)
-    rescue NameError, ArgumentError, ScriptError, MethodDeprecatedError => e
+    rescue NameError, ArgumentError, ScriptError, MethodDeprecatedError, MacOSVersionError => e
       remove_const(namespace)
       raise FormulaUnreadableError.new(name, e)
     end
@@ -246,7 +246,7 @@ module Formulary
     end
 
     def load_file(flags:)
-      if %r{githubusercontent.com/[\w-]+/[\w-]+/[a-f0-9]{40}(?:/Formula)?/(?<formula_name>[\w+-.@]+).rb} =~ url # rubocop:disable Style/CaseLikeIf
+      if %r{githubusercontent.com/[\w-]+/[\w-]+/[a-f0-9]{40}(?:/Formula)?/(?<formula_name>[\w+-.@]+).rb} =~ url
         raise UsageError, "Installation of #{formula_name} from a GitHub commit URL is unsupported! " \
                   "`brew extract #{formula_name}` to a stable tap on GitHub instead."
       elsif url.match?(%r{^(https?|ftp)://})

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -195,9 +195,9 @@ class GitHubPackages
     puts
     inspect_args = ["inspect", image_uri.to_s]
     if dry_run
-      puts "#{skopeo} #{inspect_args.join(" ")} --dest-creds=#{user}:$HOMEBREW_GITHUB_PACKAGES_TOKEN"
+      puts "#{skopeo} #{inspect_args.join(" ")} --creds=#{user}:$HOMEBREW_GITHUB_PACKAGES_TOKEN"
     else
-      inspect_args << "--dest-creds=#{user}:#{token}"
+      inspect_args << "--creds=#{user}:#{token}"
       inspect_result = system_command(skopeo, args: inspect_args)
       if inspect_result.status.success?
         if warn_on_error


### PR DESCRIPTION
- replace invalid non-ASCII characters from the descriptions
- handle invalid macOS versions on attempting to load old formulae from old bottles
- let `rubocop` auto-remove a no-longer needed `rubocop:disable`
- fix `skopeo` credentials argument