### PR TITLE
Documentation: Fix link on website

### DIFF
--- a/docs/Acceptable-Casks.md
+++ b/docs/Acceptable-Casks.md
@@ -2,8 +2,7 @@
 
 Some casks should not go in
 [homebrew/cask](https://github.com/Homebrew/homebrew-cask). But there are
-additional [Interesting Taps and Forks](Interesting-Taps-and-Forks.md) and anyone can [start their
-own](Taps.md)!
+additional [Interesting Taps and Forks](Interesting-Taps-and-Forks.md) and anyone can [start their own](Taps.md)!
 
 ## Finding a Home For Your Cask
 


### PR DESCRIPTION
Removing a linebreak in an attempt to fix the third link on https://docs.brew.sh/Acceptable-Casks such that the web page links to https://docs.brew.sh/Taps instead of https://docs.brew.sh/Taps.md

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
