### PR TITLE
GHCR: Authorization bearer requires a token

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -564,7 +564,7 @@ class CurlGitHubPackagesDownloadStrategy < CurlDownloadStrategy
   def initialize(url, name, version, **meta)
     meta ||= {}
     meta[:headers] ||= []
-    meta[:headers] << ["Authorization: Bearer"]
+    meta[:headers] << ["Authorization: Bearer QQ=="]
     super(url, name, version, meta)
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----


```console
$ curl -H 'Authorization: Bearer' https://ghcr.io/v2/brewsci/bio/adam/blobs/sha256:f6d0f054e4c33368eda8f39b60b777fd0a5dc6df585b4e138edf08f5f072c86a
{"errors":[{"code":"UNAUTHORIZED","message":"authentication token not provided"}]}
$ curl -sL -H 'Authorization: Bearer QQ==' https://ghcr.io/v2/brewsci/bio/adam/blobs/sha256:f6d0f054e4c33368eda8f39b60b777fd0a5dc6df585b4e138edf08f5f072c86a | file -
/dev/stdin: gzip compressed data, was "adam-bottle.tar", last modified: Mon Mar 15 14:37:35 2021, from Unix
```