### PR TITLE
Default download to GitHub Packages

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -444,7 +444,7 @@ fi
 
 if [[ -n "$HOMEBREW_MACOS" || -n "$HOMEBREW_FORCE_HOMEBREW_ON_LINUX" ]]
 then
-  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://homebrew.bintray.com"
+  HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"
 else
   HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://linuxbrew.bintray.com"
 fi

--- a/Library/Homebrew/env_config.rb
+++ b/Library/Homebrew/env_config.rb
@@ -52,8 +52,8 @@ module Homebrew
                       "download from the prefix `http://localhost:8080/`. " \
                       "If bottles are not available at `HOMEBREW_BOTTLE_DOMAIN` " \
                       "they will be downloaded from the default bottle domain.",
-        default_text: "macOS: `https://homebrew.bintray.com/`, " \
-                      "Linux: `https://linuxbrew.bintray.com/`.",
+        default_text: "macOS: `https://ghcr.io/v2/homebrew/core`, " \
+                      "Linux: `https://linuxbrew.bintray.com`.",
         default:      HOMEBREW_BOTTLE_DEFAULT_DOMAIN,
       },
       HOMEBREW_BREW_GIT_REMOTE:               {

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1750,7 +1750,7 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_BOTTLE_DOMAIN`
   <br>Use this URL as the download mirror for bottles. If bottles at that URL are temporarily unavailable, the default bottle domain will be used as a fallback mirror. For example, `HOMEBREW_BOTTLE_DOMAIN=http://localhost:8080` will cause all bottles to download from the prefix `http://localhost:8080/`. If bottles are not available at `HOMEBREW_BOTTLE_DOMAIN` they will be downloaded from the default bottle domain.
 
-  *Default:* macOS: `https://homebrew.bintray.com/`, Linux: `https://linuxbrew.bintray.com/`.
+  *Default:* macOS: `https://ghcr.io/v2/homebrew/core`, Linux: `https://linuxbrew.bintray.com`.
 
 - `HOMEBREW_BREW_GIT_REMOTE`
   <br>Use this URL as the Homebrew/brew `git`(1) remote.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2458,7 +2458,7 @@ If set, use Bootsnap to speed up repeated \fBbrew\fR calls\. A no\-op when using
 Use this URL as the download mirror for bottles\. If bottles at that URL are temporarily unavailable, the default bottle domain will be used as a fallback mirror\. For example, \fBHOMEBREW_BOTTLE_DOMAIN=http://localhost:8080\fR will cause all bottles to download from the prefix \fBhttp://localhost:8080/\fR\. If bottles are not available at \fBHOMEBREW_BOTTLE_DOMAIN\fR they will be downloaded from the default bottle domain\.
 .
 .IP
-\fIDefault:\fR macOS: \fBhttps://homebrew\.bintray\.com/\fR, Linux: \fBhttps://linuxbrew\.bintray\.com/\fR\.
+\fIDefault:\fR macOS: \fBhttps://ghcr\.io/v2/homebrew/core\fR, Linux: \fBhttps://linuxbrew\.bintray\.com\fR\.
 .
 .TP
 \fBHOMEBREW_BREW_GIT_REMOTE\fR


### PR DESCRIPTION
Now that all bottles (without existing `sha256` mismatches) have been uploaded to GitHub Packages make it the default download location.

Will give this a few days testing before we make a tag and make this default for everyone.

No migration has been done for Linuxbrew packages yet; those will be done after we have fully migrated over Homebrew.