### PR TITLE
Fix Linuxbrew URL handling

### DIFF
--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -15,8 +15,11 @@ class GitHubPackages
   URL_DOMAIN = "ghcr.io"
   URL_PREFIX = "https://#{URL_DOMAIN}/v2/"
   DOCKER_PREFIX = "docker://#{URL_DOMAIN}/"
+  private_constant :URL_DOMAIN
+  private_constant :URL_PREFIX
+  private_constant :DOCKER_PREFIX
+
   URL_REGEX = %r{(?:#{Regexp.escape(URL_PREFIX)}|#{Regexp.escape(DOCKER_PREFIX)})([\w-]+)/([\w-]+)}.freeze
-  GITHUB_PACKAGE_TYPE = "homebrew_bottle"
 
   # Translate Homebrew tab.arch to OCI platform.architecture
   TAB_ARCH_TO_PLATFORM_ARCHITECTURE = {
@@ -102,6 +105,15 @@ class GitHubPackages
     "#{prefix}#{org}/#{repo_without_prefix(repo)}"
   end
 
+  def self.root_url_if_match(url)
+    return if url.blank?
+
+    _, org, repo, = *url.to_s.match(URL_REGEX)
+    return if org.blank? || repo.blank?
+
+    root_url(org, repo)
+  end
+
   def self.image_formula_name(formula_name)
     # invalid docker name characters
     # / makes sense because we already use it to separate repo/formula
@@ -123,6 +135,8 @@ class GitHubPackages
   IMAGE_INDEX_SCHEMA_URI = "https://opencontainers.org/schema/image/index"
   IMAGE_LAYOUT_SCHEMA_URI = "https://opencontainers.org/schema/image/layout"
   IMAGE_MANIFEST_SCHEMA_URI = "https://opencontainers.org/schema/image/manifest"
+
+  GITHUB_PACKAGE_TYPE = "homebrew_bottle"
 
   def load_schemas!
     schema_uri("content-descriptor",

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -447,15 +447,14 @@ class BottleSpecification
 
   def root_url(var = nil, specs = {})
     if var.nil?
-      @root_url ||= if Homebrew::EnvConfig.bottle_domain.match?(GitHubPackages::URL_REGEX)
-        GitHubPackages.root_url(tap.user, tap.repo).to_s
+      @root_url ||= if (github_packages_url = GitHubPackages.root_url_if_match(Homebrew::EnvConfig.bottle_domain))
+        github_packages_url
       else
         "#{Homebrew::EnvConfig.bottle_domain}/#{Utils::Bottles::Bintray.repository(tap)}"
       end
     else
-      @root_url = if var.to_s.start_with? "docker://"
-        _, registry, org, repo = *var.match(%r{docker://([\w.-]+)/([\w-]+)/([\w-]+)})
-        GitHubPackages.root_url(org, repo, "https://#{registry}/v2/").to_s
+      @root_url = if (github_packages_url = GitHubPackages.root_url_if_match(var))
+        github_packages_url
       else
         var
       end


### PR DESCRIPTION
After this `HOMEBREW_BOTTLE_DOMAIN=https://ghcr.io/v2/linuxbrew/core` will work as expected.

While we're here, do a bit of cleanup of constant usage; we don't want some of these leaking outside the `GitHubPackages` class.

In doing so `docker://` will continue to work for `ghcr.io` but won't work for arbitrary other Docker hosts; this isn't something we want to support yet.