### PR TITLE
`Formula#bottle_hash`: various fixes/updates.

### DIFF
--- a/Library/Homebrew/cask/cmd/info.rb
+++ b/Library/Homebrew/cask/cmd/info.rb
@@ -39,7 +39,7 @@ module Cask
       sig { void }
       def run
         if args.json == "v1"
-          puts JSON.generate(args.named.to_casks.map(&:to_h))
+          puts JSON.pretty_generate(args.named.to_casks.map(&:to_h))
         elsif args.github?
           raise CaskUnspecifiedError if args.no_named?
 

--- a/Library/Homebrew/cask/cmd/list.rb
+++ b/Library/Homebrew/cask/cmd/list.rb
@@ -45,7 +45,7 @@ module Cask
         end
 
         if json
-          puts JSON.generate(output.map(&:to_h))
+          puts JSON.pretty_generate(output.map(&:to_h))
         elsif one
           puts output.map(&:to_s)
         elsif full_name

--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -202,7 +202,7 @@ module Homebrew
       raise
     end
 
-    puts JSON.generate(json)
+    puts JSON.pretty_generate(json)
   end
 
   def github_remote_path(remote, path)

--- a/Library/Homebrew/cmd/outdated.rb
+++ b/Library/Homebrew/cmd/outdated.rb
@@ -64,7 +64,7 @@ module Homebrew
         "formulae" => json_info(formulae, args: args),
         "casks"    => json_info(casks, args: args),
       }
-      puts JSON.generate(json)
+      puts JSON.pretty_generate(json)
 
       outdated = formulae + casks
 

--- a/Library/Homebrew/cmd/tap-info.rb
+++ b/Library/Homebrew/cmd/tap-info.rb
@@ -88,6 +88,6 @@ module Homebrew
   end
 
   def print_tap_json(taps)
-    puts JSON.generate(taps.map(&:to_hash))
+    puts JSON.pretty_generate(taps.map(&:to_hash))
   end
 end

--- a/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
+++ b/Library/Homebrew/dev-cmd/bump-unversioned-casks.rb
@@ -78,7 +78,7 @@ module Homebrew
 
       state[key] = new_state
 
-      state_file.atomic_write JSON.generate(state) unless args.dry_run?
+      state_file.atomic_write JSON.pretty_generate(state) unless args.dry_run?
     end
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1896,17 +1896,23 @@ class Formula
     bottle_spec = stable.bottle_specification
     hash = {
       "rebuild"  => bottle_spec.rebuild,
-      "cellar"   => (cellar = bottle_spec.cellar).is_a?(Symbol) ? cellar.inspect : cellar,
-      "prefix"   => bottle_spec.prefix,
       "root_url" => bottle_spec.root_url,
       "files"    => {},
     }
     bottle_spec.collector.each_key do |os|
-      bottle_url = "#{bottle_spec.root_url}/#{Bottle::Filename.create(self, os, bottle_spec.rebuild).bintray}"
-      checksum = bottle_spec.collector[os][:checksum]
+      collector_os = bottle_spec.collector[os]
+      os_cellar = collector_os[:cellar]
+      os_cellar = os_cellar.is_a?(Symbol) ? os_cellar.inspect : os_cellar
+
+      checksum = collector_os[:checksum].hexdigest
+      filename = Bottle::Filename.create(self, os, bottle_spec.rebuild).bintray
+      path, = bottle_spec.path_resolved_basename(name, checksum, filename)
+      url = "#{bottle_spec.root_url}/#{path}"
+
       hash["files"][os] = {
-        "url"    => bottle_url,
-        "sha256" => checksum.hexdigest,
+        "cellar" => os_cellar,
+        "url"    => url,
+        "sha256" => checksum,
       }
     end
     hash

--- a/Library/Homebrew/livecheck/livecheck.rb
+++ b/Library/Homebrew/livecheck/livecheck.rb
@@ -274,7 +274,7 @@ module Homebrew
         end
       end
 
-      puts JSON.generate(formulae_checked.compact)
+      puts JSON.pretty_generate(formulae_checked.compact)
     end
 
     sig { params(formula_or_cask: T.any(Formula, Cask::Cask), full_name: T::Boolean).returns(String) }

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -306,13 +306,7 @@ class Bottle
 
     filename = Filename.create(formula, tag, spec.rebuild).bintray
 
-    # TODO: this will need adjusted when if we use GitHub Packages by default
-    path, resolved_basename = if spec.root_url.match?(GitHubPackages::URL_REGEX)
-      image_name = GitHubPackages.image_formula_name(@name)
-      ["#{image_name}/blobs/sha256:#{checksum}", filename]
-    else
-      filename
-    end
+    path, resolved_basename = spec.path_resolved_basename(@name, checksum, filename)
 
     @resource.url("#{spec.root_url}/#{path}", select_download_strategy(spec.root_url_specs))
     @resource.downloader.resolved_basename = resolved_basename if resolved_basename.present?
@@ -424,7 +418,7 @@ class BottleSpecification
 
   attr_rw :rebuild
   attr_accessor :tap
-  attr_reader :all_tags_cellar, :checksum, :collector, :root_url_specs, :repository, :prefix
+  attr_reader :all_tags_cellar, :collector, :root_url_specs, :repository, :prefix
 
   sig { void }
   def initialize
@@ -449,6 +443,16 @@ class BottleSpecification
         var
       end
       @root_url_specs.merge!(specs)
+    end
+  end
+
+  def path_resolved_basename(name, checksum, filename)
+    if root_url.match?(GitHubPackages::URL_REGEX)
+      image_name = GitHubPackages.image_formula_name(name)
+      ["#{image_name}/blobs/sha256:#{checksum}", filename]
+    else
+      # TODO: this can be removed when we no longer use Bintray
+      filename
     end
   end
 

--- a/Library/Homebrew/test/cask/cmd/list_spec.rb
+++ b/Library/Homebrew/test/cask/cmd/list_spec.rb
@@ -87,7 +87,89 @@ describe Cask::Cmd::List, :cask do
     let(:casks) { ["local-caffeine", "local-transmission", "third-party/tap/third-party-cask"] }
     let(:expected_output) {
       <<~EOS
-        [{"token":"local-caffeine","full_token":"local-caffeine","tap":"homebrew/cask","name":[],"desc":null,"homepage":"https://brew.sh/","url":"file:///usr/local/Homebrew/Library/Homebrew/test/support/fixtures/cask/caffeine.zip","appcast":null,"version":"1.2.3","installed":"1.2.3","outdated":false,"sha256":"67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94","artifacts":[["Caffeine.app"]],"caveats":null,"depends_on":{},"conflicts_with":null,"container":null,"auto_updates":null},{"token":"local-transmission","full_token":"local-transmission","tap":"homebrew/cask","name":["Transmission"],"desc":"BitTorrent client","homepage":"https://transmissionbt.com/","url":"file:///usr/local/Homebrew/Library/Homebrew/test/support/fixtures/cask/transmission-2.61.dmg","appcast":null,"version":"2.61","installed":"2.61","outdated":false,"sha256":"e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68","artifacts":[["Transmission.app"]],"caveats":null,"depends_on":{},"conflicts_with":null,"container":null,"auto_updates":null},{"token":"third-party-cask","full_token":"third-party/tap/third-party-cask","tap":"third-party/tap","name":[],"desc":null,"homepage":"https://brew.sh/","url":"https://brew.sh/ThirdParty.dmg","appcast":null,"version":"1.2.3","installed":"1.2.3","outdated":false,"sha256":"8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b","artifacts":[["ThirdParty.app"]],"caveats":null,"depends_on":{},"conflicts_with":null,"container":null,"auto_updates":null}]
+        [
+          {
+            "token": "local-caffeine",
+            "full_token": "local-caffeine",
+            "tap": "homebrew/cask",
+            "name": [
+
+            ],
+            "desc": null,
+            "homepage": "https://brew.sh/",
+            "url": "file:///usr/local/Homebrew/Library/Homebrew/test/support/fixtures/cask/caffeine.zip",
+            "appcast": null,
+            "version": "1.2.3",
+            "installed": "1.2.3",
+            "outdated": false,
+            "sha256": "67cdb8a02803ef37fdbf7e0be205863172e41a561ca446cd84f0d7ab35a99d94",
+            "artifacts": [
+              [
+                "Caffeine.app"
+              ]
+            ],
+            "caveats": null,
+            "depends_on": {
+            },
+            "conflicts_with": null,
+            "container": null,
+            "auto_updates": null
+          },
+          {
+            "token": "local-transmission",
+            "full_token": "local-transmission",
+            "tap": "homebrew/cask",
+            "name": [
+              "Transmission"
+            ],
+            "desc": "BitTorrent client",
+            "homepage": "https://transmissionbt.com/",
+            "url": "file:///usr/local/Homebrew/Library/Homebrew/test/support/fixtures/cask/transmission-2.61.dmg",
+            "appcast": null,
+            "version": "2.61",
+            "installed": "2.61",
+            "outdated": false,
+            "sha256": "e44ffa103fbf83f55c8d0b1bea309a43b2880798dae8620b1ee8da5e1095ec68",
+            "artifacts": [
+              [
+                "Transmission.app"
+              ]
+            ],
+            "caveats": null,
+            "depends_on": {
+            },
+            "conflicts_with": null,
+            "container": null,
+            "auto_updates": null
+          },
+          {
+            "token": "third-party-cask",
+            "full_token": "third-party/tap/third-party-cask",
+            "tap": "third-party/tap",
+            "name": [
+
+            ],
+            "desc": null,
+            "homepage": "https://brew.sh/",
+            "url": "https://brew.sh/ThirdParty.dmg",
+            "appcast": null,
+            "version": "1.2.3",
+            "installed": "1.2.3",
+            "outdated": false,
+            "sha256": "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b",
+            "artifacts": [
+              [
+                "ThirdParty.app"
+              ]
+            ],
+            "caveats": null,
+            "depends_on": {
+            },
+            "conflicts_with": null,
+            "container": null,
+            "auto_updates": null
+          }
+        ]
       EOS
     }
 

--- a/Library/Homebrew/test/cmd/outdated_spec.rb
+++ b/Library/Homebrew/test/cmd/outdated_spec.rb
@@ -10,7 +10,7 @@ describe "brew outdated" do
     setup_test_formula "testball"
     (HOMEBREW_CELLAR/"testball/0.0.1/foo").mkpath
 
-    expected_json = {
+    expected_json = JSON.pretty_generate({
       formulae: [{
         name:               "testball",
         installed_versions: ["0.0.1"],
@@ -19,7 +19,7 @@ describe "brew outdated" do
         pinned_version:     nil,
       }],
       casks:    [],
-    }.to_json
+    })
 
     expect { brew "outdated", "--json=v2" }
       .to output("#{expected_json}\n").to_stdout

--- a/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
+++ b/Library/Homebrew/test/support/helper/spec/shared_context/integration_test.rb
@@ -235,7 +235,7 @@ RSpec.shared_context "integration test" do # rubocop:disable RSpec/ContextWordin
       brew "install", old_name
 
       (tap_path/"Formula/#{old_name}.rb").unlink
-      (tap_path/"formula_renames.json").write JSON.generate(old_name => new_name)
+      (tap_path/"formula_renames.json").write JSON.pretty_generate(old_name => new_name)
 
       system "git", "add", "--all"
       system "git", "commit", "-m",

--- a/Library/Homebrew/utils/github/api.rb
+++ b/Library/Homebrew/utils/github/api.rb
@@ -193,7 +193,7 @@ module GitHub
       data_tmpfile = nil
       if data
         begin
-          data = JSON.generate data
+          data = JSON.pretty_generate data
           data_tmpfile = Tempfile.new("github_api_post", HOMEBREW_TEMP)
         rescue JSON::ParserError => e
           raise Error, "Failed to parse JSON request:\n#{e.message}\n#{data}", e.backtrace


### PR DESCRIPTION
- remove `cellar` because it's no longer global
- remove `prefix` because it's no longer customisable
- add `cellar` for each bottle tag
- fix `url` for GitHub Packages. This will fix the formulae.brew.sh URLs being broken (https://formulae.brew.sh/api/formula/hello.json)

While we're here:
- Use `JSON.pretty_generate` globally as it's dramatically more human readable for very little difference in space (and we've used it a few other places already)

