### PR TITLE
feat(download_strategy): allow using netrc auth in curl strategies

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -534,6 +534,8 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
 
     args += ["--user", meta.fetch(:user)] if meta.key?(:user)
 
+    args += ["--netrc"] if meta.key?(:netrc)
+
     args += [meta[:header], meta[:headers]].flatten.compact.flat_map { |h| ["--header", h.strip] }
 
     args


### PR DESCRIPTION
Opening this PR for discussion, having read through https://github.com/Homebrew/brew/pull/3106 and https://github.com/Homebrew/brew/pull/5038, in particular:

https://github.com/Homebrew/brew/pull/5038#issuecomment-428116854

>I do not want to include any more download strategies that will not be used by Homebrew/homebrew-core. Instead I'm interested in allowing taps/private taps formulae to have ways to specify download strategies within their formulae.

I assume that directly adding the `CurlGitHubPrivateRepoDownloadStrategy` to the repo itself wouldn't be okay given that it was just removed in eed1444d61ee6e61c3b683e45effcd3cbaafed94.

<br/>

https://github.com/Homebrew/brew/pull/3106#issuecomment-326379734

>Doing this in specific formulae seems like a better idea and if it's used in multiple, open-source formulae we could accept a new download strategy for this.

This makes sense, but obviously it's unlikely to have open-source formulae that need to download from private repositories.

I believe this line is needed to allow adding this option to Curl, I couldn't see a way to add an arg to curl other than this. Maybe a generic `meta.curl_flags` object would be a better idea?

<br/>

https://github.com/Homebrew/brew/issues/5074#issuecomment-429274286

>That should be possible in some form already by doing what you're doing in the formula spec and doing a require_relative. Let us know if that works for you or if there's an API issue here.

Providing ones own `download_strategy` via `require_relative` is fine for Formulae, although it gets a bit more painful for Casks, which copy their source files into the Caskroom so they can be uninstalled with the same file that installed them, which breaks the relative links unless you also add a postflight task to copy the `download_strategy` lib into the same relative path.


---

#### Commits _(oldest to newest)_

c0d59425c feat(download_strategy): allow using netrc auth in curl strategies

This allows folks to add a custom download strategy for github private
releases as follows:

```ruby
# Strategy for downloading a file from a private GitHub release.
#
# This requires a ~/.netrc file with a GitHub API token with the repo scope of the form:
#     machine api.github.com
#       login <GitHub username>
#       password <https://github.com/settings/tokens>
#
# Use by adding the following to your formula:
#
#   # Get latest asset ID by running:
#   # curl -sLn https://api.github.com/repos/<org>/<repo>/releases/latest| jq '.assets[].id'
#   url "https://api.github.com/repos/<org>/<repo>/releases/assets/<asset_id>", :using => CurlGitHubPrivateRepoDownloadStrategy
#
# @api public
class CurlGitHubPrivateRepoDownloadStrategy < CurlDownloadStrategy
  attr_writer :resolved_basename

  def initialize(url, name, version, **meta)
    meta ||= {}
    meta[:headers] ||= []
    meta[:netrc] ||= true
    meta[:headers] << ["Accept: application/octet-stream"]
    super(url, name, version, meta)
  end

  private

  def resolved_basename
    @resolved_basename.presence || super
  end
end
```

This will have brew run the equivalent of:

```shell
curl -n https://api.github.com/repos/${org?}/${repo?}/releases |
  jq -r '.[] | ("Release: \(.tag_name)", (.assets[] | "  \(.name) => \(.id)"))'

curl --netrc --location --remote-header-name --header "Accept: application/octet-stream" \
  https://api.github.com/repos/${org?}/${repo?}/releases/assets/${asset?}
```

Refs: https://github.com/Homebrew/brew/pull/3106
Refs: https://github.com/Homebrew/brew/pull/5038

<br/>