### PR TITLE
Fix GitHub Packages filenames.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -538,7 +538,7 @@ module Homebrew
           "date"     => Pathname(local_filename).mtime.strftime("%F"),
           "tags"     => {
             bottle_tag.to_s => {
-              "filename"              => filename.bintray,
+              "filename"              => filename.github_packages,
               "local_filename"        => local_filename,
               "sha256"                => sha256,
               "formulae_brew_sh_path" => formulae_brew_sh_path,

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1905,8 +1905,7 @@ class Formula
       os_cellar = os_cellar.is_a?(Symbol) ? os_cellar.inspect : os_cellar
 
       checksum = collector_os[:checksum].hexdigest
-      filename = Bottle::Filename.create(self, os, bottle_spec.rebuild).bintray
-      path, = bottle_spec.path_resolved_basename(name, checksum, filename)
+      path, = bottle_spec.path_resolved_basename(name, checksum, nil)
       url = "#{bottle_spec.root_url}/#{path}"
 
       hash["files"][os] = {

--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -281,6 +281,10 @@ class Bottle
       ERB::Util.url_encode("#{name}-#{version}#{extname}")
     end
 
+    def github_packages
+      "#{name}--#{version}#{extname}"
+    end
+
     sig { returns(String) }
     def extname
       s = rebuild.positive? ? ".#{rebuild}" : ""
@@ -304,12 +308,13 @@ class Bottle
 
     checksum, tag, cellar = spec.checksum_for(Utils::Bottles.tag)
 
-    filename = Filename.create(formula, tag, spec.rebuild).bintray
+    filename = Filename.create(formula, tag, spec.rebuild)
 
     path, resolved_basename = spec.path_resolved_basename(@name, checksum, filename)
 
     @resource.url("#{spec.root_url}/#{path}", select_download_strategy(spec.root_url_specs))
     @resource.downloader.resolved_basename = resolved_basename if resolved_basename.present?
+    p resolved_basename
     @resource.version = formula.pkg_version
     @resource.checksum = checksum
     @prefix = spec.prefix
@@ -449,10 +454,10 @@ class BottleSpecification
   def path_resolved_basename(name, checksum, filename)
     if root_url.match?(GitHubPackages::URL_REGEX)
       image_name = GitHubPackages.image_formula_name(name)
-      ["#{image_name}/blobs/sha256:#{checksum}", filename]
+      ["#{image_name}/blobs/sha256:#{checksum}", filename&.github_packages]
     else
       # TODO: this can be removed when we no longer use Bintray
-      filename
+      filename&.bintray
     end
   end
 


### PR DESCRIPTION
They don't need escaped like the Bintray ones did.

Fixes https://github.com/Homebrew/brew/issues/11090 (but note this may require the cache entry to be cleared and the package to be redownloaded).