### PR TITLE
software_spec: remove debug statement

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -314,7 +314,6 @@ class Bottle
 
     @resource.url("#{spec.root_url}/#{path}", select_download_strategy(spec.root_url_specs))
     @resource.downloader.resolved_basename = resolved_basename if resolved_basename.present?
-    p resolved_basename
     @resource.version = formula.pkg_version
     @resource.checksum = checksum
     @prefix = spec.prefix


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Before:
```
➜ brew reinstall asciiquarium
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
==> Downloading https://ghcr.io/v2/homebrew/core/asciiquarium/manifests/1.1_1
Already downloaded: /Users/nanda/Library/Caches/Homebrew/downloads/38390234a9d3a8145387f34a82fb783681260f9acf16ff6b37314ab95e4471d1--asciiquarium-1.1_1.bottle_manifest.json
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
==> Downloading https://ghcr.io/v2/homebrew/core/asciiquarium/blobs/sha256:9bf092861aad33c28e8f7
Already downloaded: /Users/nanda/Library/Caches/Homebrew/downloads/6de61a44e803723a045e349e55211e67d5bb4e69efd59ea0c771cb2b126b8f96--asciiquarium--1.1_1.catalina.bottle.tar.gz
==> Reinstalling asciiquarium
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
==> Pouring asciiquarium--1.1_1.catalina.bottle.tar.gz
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
🍺  /usr/local/Cellar/asciiquarium/1.1_1: 17 files, 373.3KB
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
"asciiquarium--1.1_1.catalina.bottle.tar.gz"
```

After:
```
➜ brew reinstall asciiquarium
==> Downloading https://ghcr.io/v2/homebrew/core/asciiquarium/manifests/1.1_1
Already downloaded: /Users/nanda/Library/Caches/Homebrew/downloads/38390234a9d3a8145387f34a82fb783681260f9acf16ff6b37314ab95e4471d1--asciiquarium-1.1_1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/asciiquarium/blobs/sha256:9bf092861aad33c28e8f7
Already downloaded: /Users/nanda/Library/Caches/Homebrew/downloads/6de61a44e803723a045e349e55211e67d5bb4e69efd59ea0c771cb2b126b8f96--asciiquarium--1.1_1.catalina.bottle.tar.gz
==> Reinstalling asciiquarium
==> Pouring asciiquarium--1.1_1.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/asciiquarium/1.1_1: 17 files, 373.3KB
```