### PR TITLE
completions/zsh: fix `__brew_casks()`

### DIFF
--- a/Library/Homebrew/completions/zsh.erb
+++ b/Library/Homebrew/completions/zsh.erb
@@ -84,7 +84,7 @@ __brew_casks() {
   local comp_cachename=brew_casks
 
   if ! _retrieve_cache $comp_cachename; then
-    list=( $(brew search --cask) )
+    list=( $(brew casks) )
     _store_cache $comp_cachename list
   fi
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Now, `brew search` requires a text or regex argument. The `__brew_casks()` completion function was using `brew search --cask` to build a list of casks, resulting in errors like this (when trying to regenerate the cache for e.g. after `brew up`):

```
brew install asciiUsage: brew search, -S [options] text|/regex/ [...]

Perform a substring search of cask tokens and formula names for text. If
text is flanked by slashes, it is interpreted as a regular expression. The
search for text is extended online to homebrew/core and homebrew/cask.

      --formula, --formulae        Search online and locally for formulae.
      --cask, --casks              Search online and locally for casks.
      --desc                       Search for formulae with a description
                                   matching text and casks with a name
                                   matching text.
      --pull-request               Search for GitHub pull requests containing
                                   text.
      --open                       Search for only open GitHub pull requests.
      --closed                     Search for only closed GitHub pull
                                   requests.
      --macports                   Search for text in the given package
                                   manager's list.
      --fink                       Search for text in the given package
                                   manager's list.
      --opensuse                   Search for text in the given package
                                   manager's list.
      --fedora                     Search for text in the given package
                                   manager's list.
      --debian                     Search for text in the given package
                                   manager's list.
      --ubuntu                     Search for text in the given package
                                   manager's list.
  -d, --debug                      Display any debugging information.
  -q, --quiet                      Make some output more quiet.
  -v, --verbose                    Make some output more verbose.
  -h, --help                       Show this message.

Error: Invalid usage: This command requires at least 1 text or regex argument.
       brew install ascii
ascii         asciidoctor   asciinema     asciitex
asciidoc      asciidoctorj  asciiquarium
```

The modification I've made is based on `__brew_formulae()`, which uses the `brew formulae` command to generate the list.