### PR TITLE
bintray: fix filename for bottle uploads

### DIFF
--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -218,8 +218,8 @@ class Bintray
       bottle_count = bottle_hash["bottle"]["tags"].length
 
       bottle_hash["bottle"]["tags"].each do |tag, tag_hash|
-        filename = Bottle::Filename.create(bottle_hash["formula"]["name"], tag,
-                                           bottle_hash["bottle"]["rebuild"]).bintray
+        filename = Bottle::Filename.new(bottle_hash["formula"]["name"], bottle_hash["formula"]["pkg_version"],
+                                        tag, bottle_hash["bottle"]["rebuild"]).bintray
         sha256 = tag_hash["sha256"]
         delete_instructions = file_delete_instructions(bintray_repo, bintray_package, filename)
 

--- a/Library/Homebrew/bintray.rb
+++ b/Library/Homebrew/bintray.rb
@@ -217,8 +217,9 @@ class Bintray
       bintray_repo = bottle_hash["bintray"]["repository"]
       bottle_count = bottle_hash["bottle"]["tags"].length
 
-      bottle_hash["bottle"]["tags"].each do |_tag, tag_hash|
-        filename = tag_hash["filename"] # URL encoded in Bottle::Filename#bintray
+      bottle_hash["bottle"]["tags"].each do |tag, tag_hash|
+        filename = Bottle::Filename.create(bottle_hash["formula"]["name"], tag,
+                                           bottle_hash["bottle"]["rebuild"]).bintray
         sha256 = tag_hash["sha256"]
         delete_instructions = file_delete_instructions(bintray_repo, bintray_package, filename)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

In #11092, the `filename` was changed to use the one from GitHub Packages, but the logic in Bintray wasn't updated to reflect this. As a result, bottle downloads are failing as reported in Homebrew/homebrew-core#74878. Here's a [run](https://github.com/Homebrew/homebrew-core/runs/2307931714?check_suite_focus=true) showing the filenames used. I'm assuming formulae updated within the last ~3 hours would have to be rebottled.

I'm unsure if anything's wrong here, please feel free to commit to this branch if this is incorrect.