### PR TITLE
bottle: no need to set cellar anymore

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -481,14 +481,8 @@ module Homebrew
 
     old_spec = f.bottle_specification
     if args.keep_old? && !old_spec.checksums.empty?
-      mismatches = [:root_url, :prefix, :cellar, :rebuild].reject do |key|
+      mismatches = [:root_url, :prefix, :rebuild].reject do |key|
         old_spec.send(key) == bottle.send(key)
-      end
-      if (old_spec.cellar == :any && bottle.cellar == :any_skip_relocation) ||
-         (old_spec.cellar == cellar &&
-          [:any, :any_skip_relocation].include?(bottle.cellar))
-        mismatches.delete(:cellar)
-        bottle.cellar old_spec.cellar
       end
       unless mismatches.empty?
         bottle_path.unlink if bottle_path.exist?


### PR DESCRIPTION
Fixes:
Calling `cellar` in a bottle block is deprecated! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.

Fix the error message:
`brew style --fix` does nothing for this issue

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
