### PR TITLE
dev-cmd/bottle: fix incorrect Cellar value in JSON

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -527,7 +527,7 @@ module Homebrew
         "bottle"  => {
           "root_url" => bottle.root_url,
           "prefix"   => bottle.prefix,
-          "cellar"   => bottle.cellar.to_s,
+          "cellar"   => bottle_cellar.to_s,
           "rebuild"  => bottle.rebuild,
           "date"     => Pathname(local_filename).mtime.strftime("%F"),
           "tags"     => {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`BottleSpecification#cellar` returns the Cellar for the host OS, and this information will not exist if we are dealing with a bottle for another OS version. This leads to the default prefix always being used, which is incorrect behaviour.

This led to Cellar mismatch errors when uploading with `--keep-old` with the bottle block already written as `:any` or `:any_skip_relocation`. I don't know what further impacts this may have had, if any.

To fix the issue, I've used the `bottle_cellar` local variable which had already been prepared with the correct information.