### PR TITLE
bottle: Restore old filename for non-GitHub package URLs

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -507,6 +507,12 @@ module Homebrew
 
     return unless args.json?
 
+    bottle_filename = if bottle.root_url.match?(GitHubPackages::URL_REGEX)
+      filename.github_packages
+    else
+      filename.bintray
+    end
+
     json = {
       f.full_name => {
         "formula" => {
@@ -532,7 +538,7 @@ module Homebrew
           "date"     => Pathname(local_filename).mtime.strftime("%F"),
           "tags"     => {
             bottle_tag.to_s => {
-              "filename"              => filename.github_packages,
+              "filename"              => bottle_filename,
               "local_filename"        => local_filename,
               "sha256"                => sha256,
               "formulae_brew_sh_path" => formulae_brew_sh_path,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----



The fix for #11090 in bd3f1d2 changed the bottle json content but the downloader still expects bottles at the old location.

Bottle publishers that are using the dev-cmd/bottle json to publish to bintray-like repositories are getting the wrong file path.