### PR TITLE
bin/brew: add GitHub Actions as default ci

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -87,7 +87,7 @@ then
 fi
 
 # Set CI variable for Azure Pipelines and Jenkins
-# (Set by default on Circle and Travis CI)
+# (Set by default on GitHub Actions, Circle and Travis CI)
 if [[ -z "$CI" ]] && [[ -n "$TF_BUILD" || -n "$JENKINS_HOME" ]]
 then
   export CI="1"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
repair a comment of when we set `CI` in `bin/brew` because  we use `GitHub Actions`