### PR TITLE
tap-new: fix invalid tap name message

### DIFF
--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -36,7 +36,7 @@ module Homebrew
     branch = args.branch || "main"
 
     tap = args.named.to_taps.first
-    odie "Invalid tap name '#{tap_name}'" unless tap.path.to_s.match?(HOMEBREW_TAP_PATH_REGEX)
+    odie "Invalid tap name '#{tap}'" unless tap.path.to_s.match?(HOMEBREW_TAP_PATH_REGEX)
 
     titleized_user = tap.user.dup
     titleized_repo = tap.repo.dup


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #11121.

Before:
```
➜ brew tap-new this/isn.tvalid
Error: undefined local variable or method `tap_name' for Homebrew:Module
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Homebrew/dev-cmd/tap-new.rb:39:in `tap_new'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```

After:
```
➜ brew tap-new this/isn.tvalid
Error: Invalid tap name 'this/isn.tvalid'
```