### PR TITLE
create: improve cask token & version generation

### DIFF
--- a/Library/Homebrew/cask/utils.rb
+++ b/Library/Homebrew/cask/utils.rb
@@ -79,6 +79,18 @@ module Cask
       path.exist? || path.symlink?
     end
 
+    sig { params(name: String).returns(String) }
+    def self.token_from(name)
+      name.downcase
+          .gsub("+", "-plus-")
+          .gsub("@", "-at-")
+          .gsub(/[ _·•]/, "-")
+          .gsub(/[^\w-]/, "")
+          .gsub(/--+/, "-")
+          .delete_prefix("-")
+          .delete_suffix("-")
+    end
+
     sig { returns(String) }
     def self.error_message_with_suggestions
       <<~EOS

--- a/Library/Homebrew/dev-cmd/create.rb
+++ b/Library/Homebrew/dev-cmd/create.rb
@@ -85,11 +85,11 @@ module Homebrew
   end
 
   def create_cask(args:)
-    url = args.named.first
+    raise UsageError, "The `--set-name` flag is required for creating casks." if args.set_name.blank?
 
-    if (token = args.set_name).nil?
-      raise UsageError, "The `--set-name` flag is required for creating casks."
-    end
+    url = args.named.first
+    name = args.set_name
+    token = Cask::Utils.token_from(args.set_name)
 
     cask_tap = Tap.fetch(args.tap || "homebrew/cask")
     raise TapUnavailableError, args.tap unless cask_tap.installed?
@@ -101,7 +101,7 @@ module Homebrew
     version = if args.set_version
       Version.create(args.set_version)
     else
-      Version.detect(url.gsub(token, ""))
+      Version.detect(url.gsub(token, "").gsub(/x86(_64)?/, ""))
     end
 
     interpolated_url, sha256 = if version.null?
@@ -125,7 +125,7 @@ module Homebrew
         sha256 "#{sha256}"
 
         url "#{interpolated_url}"
-        name ""
+        name "#{name}"
         desc ""
         homepage ""
 

--- a/Library/Homebrew/test/dev-cmd/create_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/create_spec.rb
@@ -15,4 +15,9 @@ describe "brew create" do
     expect(formula_file).to exist
     expect(formula_file.read).to match(%Q(sha256 "#{TESTBALL_SHA256}"))
   end
+
+  it "generates valid cask tokens" do
+    t = Cask::Utils.token_from("A Foo@Bar_Baz++!")
+    expect(t).to eq("a-foo-at-bar-baz-plus-plus")
+  end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
When creating cask definitions with `brew create`, use the `--set-name` argument for the `name` and automatically generate the `token` from it according to the [docs](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md#converting-the-simplified-name-to-a-token), as implied by the current command documentation.

Also, drop `x86_64` before detecting the version number, which can be mistakenly caught by [this line](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/version.rb#L413).