### PR TITLE
Fix regression with bottle URLs in `brew info` JSON output

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1905,7 +1905,8 @@ class Formula
       os_cellar = os_cellar.is_a?(Symbol) ? os_cellar.inspect : os_cellar
 
       checksum = collector_os[:checksum].hexdigest
-      path, = bottle_spec.path_resolved_basename(name, checksum, nil)
+      filename = Bottle::Filename.create(self, os, bottle_spec.rebuild)
+      path, = bottle_spec.path_resolved_basename(name, checksum, filename)
       url = "#{bottle_spec.root_url}/#{path}"
 
       hash["files"][os] = {


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR is to fix a bug in this previous PR:
https://github.com/Homebrew/brew/pull/11092

With bottles not hosted on GitHub (e.g. third-party taps and their own hosting solutions), the output from `brew info --json=v1 <formula>` has incorrect values for the bottle file URLs. Example:
```
...
    "bottle": {
      "stable": {
        "rebuild": 0,
        "root_url": "https://<domain>/homebrew/bottles",
        "files": {
          "catalina": {
            "cellar": "/usr/local/Cellar",
            "url": "https://<domain>/homebrew/bottles/",
            "sha256": "..."
          }
        }
      }
    },
 ...
```

This still should function correctly for the GitHub case due to the function it is calling having a special conditional specifically for the GitHub case:
https://github.com/Homebrew/brew/blob/d81a047544c431ab733f21d8ebd028a44341bfa6/Library/Homebrew/software_spec.rb#L456