### PR TITLE
brew.sh: remove problematic HOMEBREW_BOTTLE_DOMAIN export

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -587,11 +587,6 @@ then
   export HOMEBREW_RUBY_WARNINGS="-W1"
 fi
 
-if [[ -z "$HOMEBREW_BOTTLE_DOMAIN" ]]
-then
-  export HOMEBREW_BOTTLE_DOMAIN="$HOMEBREW_BOTTLE_DEFAULT_DOMAIN"
-fi
-
 export HOMEBREW_BREW_DEFAULT_GIT_REMOTE="https://github.com/Homebrew/brew"
 if [[ -z "$HOMEBREW_BREW_GIT_REMOTE" ]]
 then


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When running a preinstall update, the envs from the previous brew instance are inherited. Since `HOMEBREW_BOTTLE_DOMAIN` is guaranteed to be set at this point due to the block of code I have now removed, the new updated brew instance will inherit this and see it as a custom domain.

Setting it here is however unnecessary. `EnvConfig` has its own default system which we can use. It is already set up to default to `HOMEBREW_BOTTLE_DEFAULT_DOMAIN`.

Unfortunately, this won't do anything to help those who are updating from old versions, since the env is set prior to the update. Only some custom handling would help combat that.

Partially fixes #11123.