### PR TITLE
Better handle `brew bottle --only-json-tab` bottles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,7 +234,7 @@ jobs:
 
       - run: brew test-bot --only-cleanup-before
 
-      - run: brew test-bot --only-formulae --test-default-formula
+      - run: brew test-bot --only-formulae --only-json-tab --test-default-formula
 
   test-everything:
     name: test everything (macOS)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -326,6 +326,8 @@ module Homebrew
       local_filename = bottle_path.basename.to_s
 
       tab_path = Utils::Bottles.receipt_path(f.local_bottle_path)
+      raise "This bottle does not contain the file INSTALL_RECEIPT.json: #{bottle_path}" unless tab_path
+
       tab_json = Utils.safe_popen_read("tar", "xfO", f.local_bottle_path, tab_path)
       tab = Tab.from_file_content(tab_json, tab_path)
 


### PR DESCRIPTION
- test them in `brew test-bot` (before we do so in homebrew/core)
- don't fail if we cannot find the tab/install receipt in a bottle
- cache listing the files in a bottle so we don't do it more times than necessary
- fix resolution of version and formula names from a bottle if we're getting them from a bottle without a tab/install receipt

This will need to be in a tagged release before we can ship tab-less bottles to users.