### PR TITLE
Introduce Ignorable module and provide the facility to try and ignore errors when loading historical formulae

### DIFF
--- a/Library/Homebrew/debrew/irb.rb
+++ b/Library/Homebrew/debrew/irb.rb
@@ -5,8 +5,6 @@ require "irb"
 
 # @private
 module IRB
-  def self.parse_opts(argv: nil); end
-
   def self.start_within(binding)
     unless @setup_done
       setup(nil, argv: [])
@@ -19,7 +17,7 @@ module IRB
     @CONF[:IRB_RC]&.call(irb.context)
     @CONF[:MAIN_CONTEXT] = irb.context
 
-    trap("SIGINT") do
+    prev_trap = trap("SIGINT") do
       irb.signal_handle
     end
 
@@ -28,6 +26,7 @@ module IRB
         irb.eval_input
       end
     ensure
+      trap("SIGINT", prev_trap)
       irb_at_exit
     end
   end

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -45,7 +45,7 @@ class FormulaVersions
 
     yield @formula_at_revision[rev] ||= begin
       contents = file_contents_at_revision(rev)
-      nostdout { Formulary.from_contents(name, path, contents) }
+      nostdout { Formulary.from_contents(name, path, contents, ignore_errors: true) }
     end
   rescue *IGNORED_EXCEPTIONS => e
     # We rescue these so that we can skip bad versions and

--- a/Library/Homebrew/ignorable.rb
+++ b/Library/Homebrew/ignorable.rb
@@ -1,0 +1,58 @@
+# typed: false
+# frozen_string_literal: true
+
+require "warnings"
+Warnings.ignore(/warning: callcc is obsolete; use Fiber instead/) do
+  require "continuation"
+end
+
+# Provides the ability to optionally ignore errors raised and continue execution.
+#
+# @api private
+module Ignorable
+  # Marks exceptions which can be ignored and provides
+  # the ability to jump back to where it was raised.
+  module ExceptionMixin
+    attr_accessor :continuation
+
+    def ignore
+      continuation.call
+    end
+  end
+
+  def self.hook_raise
+    Object.class_eval do
+      alias_method :original_raise, :raise
+
+      def raise(*)
+        callcc do |continuation|
+          super
+        rescue Exception => e # rubocop:disable Lint/RescueException
+          unless e.is_a?(ScriptError)
+            e.extend(ExceptionMixin)
+            e.continuation = continuation
+          end
+          super(e)
+        end
+      end
+
+      alias_method :fail, :raise
+    end
+
+    return unless block_given?
+
+    yield
+    unhook_raise
+  end
+
+  def self.unhook_raise
+    Object.class_eval do
+      # False positive - https://github.com/rubocop/rubocop/issues/5022
+      # rubocop:disable Lint/DuplicateMethods
+      alias_method :raise, :original_raise
+      alias_method :fail, :original_raise
+      # rubocop:enable Lint/DuplicateMethods
+      undef :original_raise
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Currently when formula methods are deprecated, that formula becomes unreadable. This causes problems with anything that uses `formula_at_revision`, such as the version/revision audit. Notably, with the cellar line deprecation, a massive amount of historical formulae versions are no longer readable.

This PR introduces the functionality to try ignore such errors and continue loading the formula, using the same system as we use to ignore exceptions in Debrew.

This started as an experimental proof of concept based on a Slack discussion, but does seem to work without issues.

Alternatives include:

* Keeping a list of removed or modified formula API permanently.
* Using `method_missing` (this does not work however for the `cellar` situation).