### PR TITLE
fix(software_spec): use -- for fetch URL that we use for the bottle

### DIFF
--- a/Library/Homebrew/software_spec.rb
+++ b/Library/Homebrew/software_spec.rb
@@ -279,7 +279,7 @@ class Bottle
     end
 
     def url_encode
-      ERB::Util.url_encode("#{name}-#{version}#{extname}")
+      ERB::Util.url_encode("#{name}--#{version}#{extname}")
     end
 
     def github_packages


### PR DESCRIPTION
I believe this fix is correct, but very much new to this code so not entirely sure.

---

#### Commits _(oldest to newest)_

a81df3f2d fix(software_spec): use -- for fetch URL that we use for the bottle

The other methods on this class all use the `--`, which causes bottles
to be published with `--` but attempted to be downloaded with `-` (which
errors).

I believe this doesn't affect homebrew-core's own bottles any more
because the new GitHub Packages scheme doesn't use the filename in the
URL at all. However it seems to break other bottle `base_url`s.

<br/>