### PR TITLE
More official Homebrew taps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
           git -C "$HOMEBREW_CORE_REPOSITORY" checkout --force -B master homebrew_core/master
 
           brew tap homebrew/aliases
+          brew tap homebrew/autoupdate
           brew tap homebrew/bundle
           brew tap homebrew/cask
           brew tap homebrew/cask-drivers
@@ -121,6 +122,7 @@ jobs:
                                          homebrew/test-bot
 
           brew style --display-cop-names homebrew/aliases\
+                                         homebrew/autoupdate\
                                          homebrew/command-not-found \
                                          homebrew/formula-analytics \
                                          homebrew/linux-dev \

--- a/Library/Homebrew/commands.rb
+++ b/Library/Homebrew/commands.rb
@@ -108,10 +108,10 @@ module Commands
   end
 
   def official_external_commands_paths(quiet:)
-    %w[bundle services test-bot].map do |cmd|
-      tap = Tap.fetch("Homebrew/#{cmd}")
+    OFFICIAL_CMD_TAPS.flat_map do |tap_name, cmds|
+      tap = Tap.fetch(tap_name)
       tap.install(quiet: quiet) unless tap.installed?
-      external_ruby_v2_cmd_path(cmd)
+      cmds.map(&method(:external_ruby_v2_cmd_path)).compact
     end
   end
 

--- a/Library/Homebrew/official_taps.rb
+++ b/Library/Homebrew/official_taps.rb
@@ -7,9 +7,12 @@ OFFICIAL_CASK_TAPS = %w[
 ].freeze
 
 OFFICIAL_CMD_TAPS = {
-  "homebrew/bundle"   => ["bundle"],
-  "homebrew/test-bot" => ["test-bot"],
-  "homebrew/services" => ["services"],
+  "homebrew/aliases"           => ["alias", "unalias"],
+  "homebrew/autoupdate"        => ["autoupdate"],
+  "homebrew/bundle"            => ["bundle"],
+  "homebrew/command-not-found" => ["command-not-found-init", "which-formula", "which-update"],
+  "homebrew/test-bot"          => ["test-bot"],
+  "homebrew/services"          => ["services"],
 }.freeze
 
 DEPRECATED_OFFICIAL_TAPS = %w[

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -1515,6 +1515,46 @@ These options are applicable across multiple subcommands.
 
 ## OFFICIAL EXTERNAL COMMANDS
 
+### `alias` [*`alias`* ... | *`alias`*=*`command`*]
+
+Show existing aliases. If no aliases are given, print the whole list.
+
+* `--edit`:
+  Edit aliases in a text editor. Either one or all aliases may be opened at once. If the given alias doesn't exist it'll be pre-populated with a template.
+
+### `autoupdate` *`subcommand`* [*`interval`*] [*`options`*]
+
+An easy, convenient way to automatically update Homebrew.
+
+This script will run `brew update` in the background once every 24 hours (by default)
+until explicitly told to stop, utilising `launchd`.
+
+`brew autoupdate start` [*``interval``*] [*``options``*]
+<br>Start autoupdating either once every `interval` hours or once every 24 hours.
+Please note the interval has to be passed in seconds, so 12 hours would be
+`brew autoupdate start 43200`. Pass `--upgrade` or `--cleanup` to automatically
+run `brew upgrade` and/or `brew cleanup` respectively. Pass `--enable-notification`
+to send a notification when the autoupdate process has finished successfully.
+
+`brew autoupdate stop`
+<br>Stop autoupdating, but retain plist & logs.
+
+`brew autoupdate delete`
+<br>Cancel the autoupdate, delete the plist and logs.
+
+`brew autoupdate status`
+<br>Prints the current status of this tool.
+
+`brew autoupdate version`
+<br>Output this tool's current version.
+
+* `--upgrade`:
+  Automatically upgrade your installed formulae. If the Caskroom exists locally Casks will be upgraded as well. Must be passed with `start`.
+* `--cleanup`:
+  Automatically clean brew's cache and logs. Must be passed with `start`.
+* `--enable-notification`:
+  Send a notification when the autoupdate process has finished successfully, if `terminal-notifier` is installed & found. Note that currently a new experimental notifier runs automatically on macOS Big Sur, without requiring any external dependencies. Must be passed with `start`.
+
 ### `bundle` [*`subcommand`*]
 
 Bundler for non-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store and Whalebrew.
@@ -1583,6 +1623,11 @@ This sanitized build environment ignores unrequested dependencies, which makes s
   `dump` does not add `restart_service` to formula lines.
 * `--zap`:
   `cleanup` casks using the `zap` command instead of `uninstall`.
+
+### `command-not-found-init`
+
+Print instructions for setting up the command-not-found hook for your shell.
+If the output is not to a tty, print the appropriate handler script for your shell.
 
 ### `services` [*`subcommand`*]
 
@@ -1666,6 +1711,32 @@ Only supports GitHub Actions as a CI provider. This is because Homebrew uses Git
   Only run the formulae steps.
 * `--only-cleanup-after`:
   Only run the post-cleanup step. Needs `--cleanup`.
+
+### `unalias` *`alias`* [...]
+
+Remove aliases.
+
+### `which-formula` [*`--explain`*] *`command`* [...]
+
+Prints the formula(e) which provides the given command.
+
+* `--explain`:
+  Output explanation of how to get 'cmd' by installing one of the providing formulae.
+
+### `which-update` [*`options`*] [*`database`*]
+
+Database update for `brew which-formula`
+
+* `--stats`:
+  Print statistics about the database contents (number of commands and formulae, list of missing formulae).
+* `--commit`:
+  Commit the changes using `git`.
+* `--update-existing`:
+  Update database entries with outdated formula versions.
+* `--install-missing`:
+  Install and update formulae that are missing from the database and don't have bottles.
+* `--max-downloads`:
+  Specify a maximum number of formulae to download and update.
 
 ## CUSTOM EXTERNAL COMMANDS
 

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2113,6 +2113,51 @@ Show this message\.
 .
 .SH "OFFICIAL EXTERNAL COMMANDS"
 .
+.SS "\fBalias\fR [\fIalias\fR \.\.\. | \fIalias\fR=\fIcommand\fR]"
+Show existing aliases\. If no aliases are given, print the whole list\.
+.
+.TP
+\fB\-\-edit\fR
+Edit aliases in a text editor\. Either one or all aliases may be opened at once\. If the given alias doesn\'t exist it\'ll be pre\-populated with a template\.
+.
+.SS "\fBautoupdate\fR \fIsubcommand\fR [\fIinterval\fR] [\fIoptions\fR]"
+An easy, convenient way to automatically update Homebrew\.
+.
+.P
+This script will run \fBbrew update\fR in the background once every 24 hours (by default) until explicitly told to stop, utilising \fBlaunchd\fR\.
+.
+.P
+\fBbrew autoupdate start\fR [\fI\fBinterval\fR\fR] [\fI\fBoptions\fR\fR]
+    Start autoupdating either once every \fBinterval\fR hours or once every 24 hours\. Please note the interval has to be passed in seconds, so 12 hours would be \fBbrew autoupdate start 43200\fR\. Pass \fB\-\-upgrade\fR or \fB\-\-cleanup\fR to automatically run \fBbrew upgrade\fR and/or \fBbrew cleanup\fR respectively\. Pass \fB\-\-enable\-notification\fR to send a notification when the autoupdate process has finished successfully\.
+.
+.P
+\fBbrew autoupdate stop\fR
+    Stop autoupdating, but retain plist & logs\.
+.
+.P
+\fBbrew autoupdate delete\fR
+    Cancel the autoupdate, delete the plist and logs\.
+.
+.P
+\fBbrew autoupdate status\fR
+    Prints the current status of this tool\.
+.
+.P
+\fBbrew autoupdate version\fR
+    Output this tool\'s current version\.
+.
+.TP
+\fB\-\-upgrade\fR
+Automatically upgrade your installed formulae\. If the Caskroom exists locally Casks will be upgraded as well\. Must be passed with \fBstart\fR\.
+.
+.TP
+\fB\-\-cleanup\fR
+Automatically clean brew\'s cache and logs\. Must be passed with \fBstart\fR\.
+.
+.TP
+\fB\-\-enable\-notification\fR
+Send a notification when the autoupdate process has finished successfully, if \fBterminal\-notifier\fR is installed & found\. Note that currently a new experimental notifier runs automatically on macOS Big Sur, without requiring any external dependencies\. Must be passed with \fBstart\fR\.
+.
 .SS "\fBbundle\fR [\fIsubcommand\fR]"
 Bundler for non\-Ruby dependencies from Homebrew, Homebrew Cask, Mac App Store and Whalebrew\.
 .
@@ -2224,6 +2269,9 @@ Read the \fBBrewfile\fR from \fB~/\.Brewfile\fR\.
 .TP
 \fB\-\-zap\fR
 \fBcleanup\fR casks using the \fBzap\fR command instead of \fBuninstall\fR\.
+.
+.SS "\fBcommand\-not\-found\-init\fR"
+Print instructions for setting up the command\-not\-found hook for your shell\. If the output is not to a tty, print the appropriate handler script for your shell\.
 .
 .SS "\fBservices\fR [\fIsubcommand\fR]"
 Manage background services with macOS\' \fBlaunchctl\fR(1) daemon manager\.
@@ -2360,6 +2408,39 @@ Only run the formulae steps\.
 .TP
 \fB\-\-only\-cleanup\-after\fR
 Only run the post\-cleanup step\. Needs \fB\-\-cleanup\fR\.
+.
+.SS "\fBunalias\fR \fIalias\fR [\.\.\.]"
+Remove aliases\.
+.
+.SS "\fBwhich\-formula\fR [\fI\-\-explain\fR] \fIcommand\fR [\.\.\.]"
+Prints the formula(e) which provides the given command\.
+.
+.TP
+\fB\-\-explain\fR
+Output explanation of how to get \'cmd\' by installing one of the providing formulae\.
+.
+.SS "\fBwhich\-update\fR [\fIoptions\fR] [\fIdatabase\fR]"
+Database update for \fBbrew which\-formula\fR
+.
+.TP
+\fB\-\-stats\fR
+Print statistics about the database contents (number of commands and formulae, list of missing formulae)\.
+.
+.TP
+\fB\-\-commit\fR
+Commit the changes using \fBgit\fR\.
+.
+.TP
+\fB\-\-update\-existing\fR
+Update database entries with outdated formula versions\.
+.
+.TP
+\fB\-\-install\-missing\fR
+Install and update formulae that are missing from the database and don\'t have bottles\.
+.
+.TP
+\fB\-\-max\-downloads\fR
+Specify a maximum number of formulae to download and update\.
 .
 .SH "CUSTOM EXTERNAL COMMANDS"
 Homebrew, like \fBgit\fR(1), supports external commands\. These are executable scripts that reside somewhere in the \fBPATH\fR, named \fBbrew\-\fR\fIcmdname\fR or \fBbrew\-\fR\fIcmdname\fR\fB\.rb\fR, which can be invoked like \fBbrew\fR \fIcmdname\fR\. This allows you to create your own commands without modifying Homebrew\'s internals\.


### PR DESCRIPTION
Make `brew alias`, `brew autoupdate` and `brew command-not-found-init` official commands. This means we:
- make sure we don't break their style with `brew style` changes
- autotap them when you run the command and they aren't installed
- include them in the manpage

CC @bfontaine and @DomT4 for your 👍🏻 (don't want to do it without) and @Homebrew/maintainers for general thoughts.

This would also solidify the "external command taps in the @Homebrew org are official external commands" loose policy (with the exceptions being homebrew/formula-analytics,homebrew/portable-ruby and `brew homebrew/linux-dev which no users and most maintainers shouldn't care about)