### PR TITLE
Use File.read over IO.read

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -567,7 +567,7 @@ module Homebrew
 
   def parse_json_files(filenames)
     filenames.map do |filename|
-      JSON.parse(IO.read(filename))
+      JSON.parse(File.read(filename))
     end
   end
 

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -91,7 +91,7 @@ module Homebrew
     odie "No bottle JSON files found in the current working directory" if json_files.empty?
 
     bottles_hash = json_files.reduce({}) do |hash, json_file|
-      hash.deep_merge(JSON.parse(IO.read(json_file)))
+      hash.deep_merge(JSON.parse(File.read(json_file)))
     end
 
     if args.root_url


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`IO.read` can allow arbitrary command execution. Since we know we only want to read files, `File.read` is safer here for security.

The usage of `IO.read` in the cases here weren't particularly exploitable - they mostly required there to be JSON files in the working directory with maliciously crafted filenames. Not knowing what's in your working directory when running `brew pr-upload` or `brew bottle --merge` isn't a situation I expect anyone to ever be in and it would require some extreme levels of social engineering to trick someone into thinking a funky looking JSON file is ok. A formula file with a maliciously crafted name should also never get any further than the CI, where exploits have negligible impact due to the fact you can just run arbitrary Ruby code.