### PR TITLE
build: set SOURCE_DATE_EPOCH

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -144,6 +144,9 @@ class Build
         # which is not known until after the formula has been staged.
         ENV["HOMEBREW_FORMULA_PREFIX"] = formula.prefix
 
+        # https://reproducible-builds.org/docs/source-date-epoch/
+        ENV["SOURCE_DATE_EPOCH"] = formula.source_modified_time.to_i.to_s
+
         formula.patch
 
         if args.git?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

https://reproducible-builds.org/docs/source-date-epoch/

This allows more reproducible builds by using a standardised environment variable to set the build date/time.

This env is set to the timestamp of the last git commit to the formula file, or the file's mtime if we don't have a tap.
