### PR TITLE
dev-cmd/bottle: fix INSTALL_RECEIPT appearing in changed_files

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -380,8 +380,9 @@ module Homebrew
         tab.poured_from_bottle = false
         tab.HEAD = nil
         tab.time = nil
-        tab.changed_files = changed_files
+        tab.changed_files = changed_files.dup
         if args.only_json_tab?
+          tab.changed_files.delete(Pathname.new(Tab::FILENAME))
           tab.tabfile.unlink
         else
           tab.write


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Because `INSTALL_RECEIPT.json` can get rewritten in `Keg#replace_locations_with_placeholders`, it can appear in the `changed_files` section of the tab.

This causes errors when pouring bottles without this file present (`--only-json-tab`).