### PR TITLE
Always take first item in `Sparkle` strategy.

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -91,7 +91,7 @@ module Homebrew
             Item.new(**data) unless data.empty?
           end.compact
 
-          items.max_by(&:bundle_version)
+          items.first
         end
 
         # Checks the content at the URL for new versions.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Always take the first (i.e. latest) item. From what I've seen it is more likely that the `BundleVersion#version` (most often build number) of an older item is higher rather than a newer item being for a legitimate older version (i.e. a patch update for a previous major version).