### PR TITLE
Bottle reproducibility tweaks

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -331,18 +331,6 @@ module Homebrew
       tab_json = Utils.safe_popen_read("tar", "xfO", f.local_bottle_path, tab_path)
       tab = Tab.from_file_content(tab_json, tab_path)
 
-      # TODO: most of this logic can be removed when we're done with bulk GitHub Packages bottle uploading
-      tap_git_revision = tab["source"]["tap_git_head"]
-      if tap.core_tap?
-        if bottle_tag.to_s.end_with?("_linux")
-          tap_git_remote = "https://github.com/Homebrew/linuxbrew-core"
-          formulae_brew_sh_path = "formula-linux"
-        else
-          tap_git_remote = "https://github.com/Homebrew/homebrew-core"
-          formulae_brew_sh_path = "formula"
-        end
-      end
-
       _, _, bottle_cellar = Formula[f.name].bottle_specification.checksum_for(bottle_tag, no_older_versions: true)
       relocatable = [:any, :any_skip_relocation].include?(bottle_cellar)
       skip_relocation = bottle_cellar == :any_skip_relocation

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -325,10 +325,10 @@ module Homebrew
       bottle_path = f.local_bottle_path
       local_filename = bottle_path.basename.to_s
 
-      tab_path = Utils::Bottles.receipt_path(f.local_bottle_path)
+      tab_path = Utils::Bottles.receipt_path(bottle_path)
       raise "This bottle does not contain the file INSTALL_RECEIPT.json: #{bottle_path}" unless tab_path
 
-      tab_json = Utils.safe_popen_read("tar", "xfO", f.local_bottle_path, tab_path)
+      tab_json = Utils::Bottles.file_from_bottle(bottle_path, tab_path)
       tab = Tab.from_file_content(tab_json, tab_path)
 
       _, _, bottle_cellar = Formula[f.name].bottle_specification.checksum_for(bottle_tag, no_older_versions: true)

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -377,6 +377,7 @@ module Homebrew
         end
 
         keg.find do |file|
+          # Set the times for reproducible bottles.
           if file.symlink?
             File.lutime(tab.source_modified_time, tab.source_modified_time, file)
           else
@@ -386,8 +387,11 @@ module Homebrew
 
         cd cellar do
           sudo_purge
-          safe_system "tar", "cf", tar_path, "#{f.name}/#{f.pkg_version}"
+          # Unset the owner/group for reproducible bottles.
+          # Tar then gzip for reproducible bottles.
+          safe_system "tar", "--create", "--numeric-owner", "--file", tar_path, "#{f.name}/#{f.pkg_version}"
           sudo_purge
+          # Set more times for reproducible bottles.
           tar_path.utime(tab.source_modified_time, tab.source_modified_time)
           relocatable_tar_path = "#{f}-bottle.tar"
           mv tar_path, relocatable_tar_path

--- a/Library/Homebrew/test/unpack_strategy_spec.rb
+++ b/Library/Homebrew/test/unpack_strategy_spec.rb
@@ -32,7 +32,7 @@ describe UnpackStrategy do
         (mktmpdir/"file.tar").tap do |path|
           mktmpdir do |dir|
             (dir/directories).mkpath
-            system "tar", "-c", "-f", path, "-C", dir, "A/"
+            system "tar", "--create", "--file", path, "--directory", dir, "A/"
           end
         end
       }
@@ -49,7 +49,7 @@ describe UnpackStrategy do
         (mktmpdir/basename).tap do |path|
           mktmpdir do |dir|
             FileUtils.touch dir/"file.txt"
-            system "tar", "-c", "-f", path, "-C", dir, "file.txt"
+            system "tar", "--create", "--file", path, "--directory", dir, "file.txt"
           end
         end
       }

--- a/Library/Homebrew/unpack_strategy/tar.rb
+++ b/Library/Homebrew/unpack_strategy/tar.rb
@@ -30,7 +30,7 @@ module UnpackStrategy
       return false unless [Bzip2, Gzip, Lzip, Xz].any? { |s| s.can_extract?(path) }
 
       # Check if `tar` can list the contents, then it can also extract it.
-      stdout, _, status = system_command("tar", args: ["tf", path], print_stderr: false)
+      stdout, _, status = system_command("tar", args: ["--list", "--file", path], print_stderr: false)
       status.success? && !stdout.empty?
     end
 
@@ -48,7 +48,9 @@ module UnpackStrategy
         end
 
         system_command! "tar",
-                        args:    ["xof", tar_path, "-C", unpack_dir],
+                        args:    ["--extract", "--no-same-owner",
+                                  "--file", tar_path,
+                                  "--directory", unpack_dir],
                         verbose: verbose
       end
     end

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -47,7 +47,7 @@ module Utils
       end
 
       def file_from_bottle(bottle_file, file_path)
-        Utils.popen_read("tar", "--extract", "--stdout", "--file", bottle_file, file_path)
+        Utils.popen_read("tar", "--extract", "--to-stdout", "--file", bottle_file, file_path)
       end
 
       def resolve_formula_names(bottle_file)

--- a/Library/Homebrew/utils/tar.rb
+++ b/Library/Homebrew/utils/tar.rb
@@ -26,7 +26,7 @@ module Utils
 
         path = Pathname.new(path)
         return unless TAR_FILE_EXTENSIONS.include? path.extname
-        return if Utils.popen_read(executable, "-tf", path).match?(%r{/.*\.})
+        return if Utils.popen_read(executable, "--list", "--file", path).match?(%r{/.*\.})
 
         odie "#{path} is not a valid tar file!"
       end


### PR DESCRIPTION
- `dev-cmd/bottle`: improve reproducibility and add more comments explaining what's being done. Setting a consistent owner/group results in more consistent bottles.
- Use long/readable `tar` flags consistently.
- `utils/bottles`: tweak/improve some of the API.
- `bottle`: remove GitHub Packages bulk upload logic.