### PR TITLE
bug.yml: remind users to `brew update` twice

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
     attributes:
       description: Please verify that you've followed these steps.
       options:
-        - label: I ran `brew update` and am still able to reproduce my issue.
+        - label: I ran `brew update` twice and am still able to reproduce my issue.
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The autoupdate that happens with `brew install` doesn't switch users
properly over to GitHub Packages from Bintray for some reason, so
there's a need to do it twice to migrate properly.

See, for example https://github.com/Homebrew/brew/issues/11155, https://github.com/Homebrew/homebrew-core/issues/75243.