### PR TITLE
software_spec: fix bottle domain fallback handling

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -364,7 +364,7 @@ class Formula
   # @private
   sig { returns(T.nilable(Bottle)) }
   def bottle
-    Bottle.new(self, bottle_specification) if bottled?
+    @bottle ||= Bottle.new(self, bottle_specification) if bottled?
   end
 
   # The description of the software.
@@ -1906,7 +1906,7 @@ class Formula
 
       checksum = collector_os[:checksum].hexdigest
       filename = Bottle::Filename.create(self, os, bottle_spec.rebuild)
-      path, = bottle_spec.path_resolved_basename(name, checksum, filename)
+      path, = Utils::Bottles.path_resolved_basename(bottle_spec.root_url, name, checksum, filename)
       url = "#{bottle_spec.root_url}/#{path}"
 
       hash["files"][os] = {

--- a/Library/Homebrew/resource.rb
+++ b/Library/Homebrew/resource.rb
@@ -174,6 +174,7 @@ class Resource
     @specs.merge!(specs)
     @using = @specs.delete(:using)
     @download_strategy = DownloadStrategyDetector.detect(url, using)
+    @downloader = nil
   end
 
   def version(val = nil)

--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -85,6 +85,15 @@ module Utils
 
         contents
       end
+
+      def path_resolved_basename(root_url, name, checksum, filename)
+        if root_url.match?(GitHubPackages::URL_REGEX)
+          image_name = GitHubPackages.image_formula_name(name)
+          ["#{image_name}/blobs/sha256:#{checksum}", filename&.github_packages]
+        else
+          filename&.url_encode
+        end
+      end
     end
 
     # Denotes the arch and OS of a bottle.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If we are using a non-GHCR `HOMEBREW_BOTTLE_DOMAIN`, then we can't use the download strategy `mirror` system as the URLs etc will all be different.

Instead we have to catch the error and reconstruct the URL before sending another fetch.
