### PR TITLE
brew.sh: add workaround for old auto-updates

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -442,6 +442,17 @@ Your Git executable: $(unset git && type -p $HOMEBREW_GIT)"
   unset HOMEBREW_MACOS_SYSTEM_RUBY_NEW_ENOUGH
 fi
 
+# A bug in the auto-update process prior to 3.1.2 means $HOMEBREW_BOTTLE_DOMAIN
+# could be passed down with the default domain.
+# This is problematic as this is will be the old bottle domain.
+# This workaround is necessary for many CI images starting on old version,
+# and will only be unnecessary when updating from <3.1.2 is not a concern.
+# That will be when macOS 12 is the minimum required version.
+if [[ -n "$HOMEBREW_BOTTLE_DEFAULT_DOMAIN" && "$HOMEBREW_BOTTLE_DOMAIN" = "$HOMEBREW_BOTTLE_DEFAULT_DOMAIN" ]]
+then
+  unset HOMEBREW_BOTTLE_DOMAIN
+fi
+
 if [[ -n "$HOMEBREW_MACOS" || -n "$HOMEBREW_FORCE_HOMEBREW_ON_LINUX" ]]
 then
   HOMEBREW_BOTTLE_DEFAULT_DOMAIN="https://ghcr.io/v2/homebrew/core"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

While we fixed the cause of the bug in 3.1.2, we unfortunately need to add this workaround if we want to actually fix the problem for those updating from <3.1.2.

The bug was caused because auto-update passes envs from the old instance into the new instance, including both `$HOMEBREW_BOTTLE_DOMAIN` and `$HOMEBREW_BOTTLE_DEFAULT_DOMAIN`. At this point `$HOMEBREW_BOTTLE_DOMAIN` will have been set to `$HOMEBREW_BOTTLE_DEFAULT_DOMAIN` or the user's provided value. Brew 3.1.2 adjusted this so the former case never happens.

This PR adds a check for this case to handle old auto-updates, that is if the passed `$HOMEBREW_BOTTLE_DOMAIN` is equal to the passed `$HOMEBREW_BOTTLE_DEFAULT_DOMAIN`, and unsets `$HOMEBREW_BOTTLE_DOMAIN` in that scenario.

This workaround applies to anyone updating from 1.6.10 through 3.1.1 inclusive. Versions prior to 1.6.10 do not set `$HOMEBREW_BOTTLE_DOMAIN` to a default value, and so are unaffected by the issue.