### PR TITLE
dev-cmd/bottle: revert filename in JSON to use single dash always

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -512,12 +512,6 @@ module Homebrew
 
     return unless args.json?
 
-    bottle_filename = if bottle.root_url.match?(GitHubPackages::URL_REGEX)
-      filename.github_packages
-    else
-      filename.url_encode
-    end
-
     json = {
       f.full_name => {
         "formula" => {
@@ -543,7 +537,7 @@ module Homebrew
           "date"     => Pathname(local_filename).mtime.strftime("%F"),
           "tags"     => {
             bottle_tag.to_s => {
-              "filename"              => bottle_filename,
+              "filename"              => filename.url_encode,
               "local_filename"        => local_filename,
               "sha256"                => sha256,
               "formulae_brew_sh_path" => formulae_brew_sh_path,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

If this causes any issues in GitHub Packages, it should be fixed elsewhere to use `local_filename`. I don't see anything that would break though.

Fixes #11136.