### PR TITLE
Revert "dev-cmd/bottle: set uid/gid."

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -389,14 +389,7 @@ module Homebrew
           sudo_purge
           # Unset the owner/group for reproducible bottles.
           # Tar then gzip for reproducible bottles.
-          owner_group_args = if OS.mac?
-            ["--uid",   "0", "--gid",   "0"]
-          else
-            ["--owner", "0", "--group", "0"]
-          end
-          safe_system "tar", "--create", "--numeric-owner",
-                      *owner_group_args,
-                      "--file", tar_path, "#{f.name}/#{f.pkg_version}"
+          safe_system "tar", "--create", "--numeric-owner", "--file", tar_path, "#{f.name}/#{f.pkg_version}"
           sudo_purge
           # Set more times for reproducible bottles.
           tar_path.utime(tab.source_modified_time, tab.source_modified_time)


### PR DESCRIPTION
`--uid` doesn't exist on old BSD tar e.g. Mojave and below.

Reverts Homebrew/brew#11165

