### PR TITLE
rubocops/patches: Fix quoting of the patch `url` when autocorrecting

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -69,7 +69,7 @@ module RuboCop
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch_url_node, gh_patch_param_pattern) && !patch_url.match?(/\?full_index=\w+$/)
             problem "GitHub patches should use the full_index parameter: #{patch_url}?full_index=1" do |corrector|
-              corrector.replace(patch_url_node.source_range, "#{patch_url}?full_index=1")
+              corrector.replace(patch_url_node.source_range, "\"#{patch_url}?full_index=1\"")
             end
           end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- The autocorrections here before (from #10777) were leading to changes like:

```
➜ brew style --fix brewsci/science/beetl
Formula/beetl.rb:15:11: C: [Corrected] GitHub patches should use the full_index parameter: https://github.com/BEETL/BEETL/commit/ba47b6f9.patch?full_index=1
      url "https://github.com/BEETL/BEETL/commit/ba47b6f9.patch"
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

➜ git diff
diff --git a/Formula/beetl.rb b/Formula/beetl.rb
index bbd049aa..7ec6d7bc 100644
--- a/Formula/beetl.rb
+++ b/Formula/beetl.rb
@@ -12,7 +12,7 @@ class Beetl < Formula
     # Fixes "error: 'accumulate' is not a member of 'std'"
     # Upstream commit "Little fix for compilation on mac"
     patch do
-      url "https://github.com/BEETL/BEETL/commit/ba47b6f9.patch"
+      url https://github.com/BEETL/BEETL/commit/ba47b6f9.patch?full_index=1
       sha256 "63b67f3282893d1f74c66aa98f3bf2684aaba2fa9ce77858427b519f1f02807d"
     end
   end

```

- This fixes the URLs generated to have quotes:

```
➜ git diff
diff --git a/Formula/beetl.rb b/Formula/beetl.rb
index bbd049aa..7ec6d7bc 100644
--- a/Formula/beetl.rb
+++ b/Formula/beetl.rb
@@ -12,7 +12,7 @@ class Beetl < Formula
     # Fixes "error: 'accumulate' is not a member of 'std'"
     # Upstream commit "Little fix for compilation on mac"
     patch do
-      url "https://github.com/BEETL/BEETL/commit/ba47b6f9.patch"
+      url "https://github.com/BEETL/BEETL/commit/ba47b6f9.patch?full_index=1"
       sha256 "63b67f3282893d1f74c66aa98f3bf2684aaba2fa9ce77858427b519f1f02807d"
     end
   end
```

