### PR TITLE
rubocops/patches: remove autocorrection of some `url`s

### DIFF
--- a/Library/Homebrew/rubocops/patches.rb
+++ b/Library/Homebrew/rubocops/patches.rb
@@ -53,24 +53,16 @@ module RuboCop
           end
 
           if regex_match_group(patch_url_node, %r{https://github.com/[^/]*/[^/]*/commit/[a-fA-F0-9]*\.diff})
-            problem "GitHub patches should end with .patch, not .diff: #{patch_url}" do |corrector|
-              correct = patch_url_node.source.gsub(/\.diff/, ".patch")
-              corrector.replace(patch_url_node.source_range, correct)
-            end
+            problem "GitHub patches should end with .patch, not .diff: #{patch_url}"
           end
 
           if regex_match_group(patch_url_node, %r{.*gitlab.*/commit/[a-fA-F0-9]*\.diff})
-            problem "GitLab patches should end with .patch, not .diff: #{patch_url}" do |corrector|
-              correct = patch_url_node.source.gsub(/\.diff/, ".patch")
-              corrector.replace(patch_url_node.source_range, correct)
-            end
+            problem "GitLab patches should end with .patch, not .diff: #{patch_url}"
           end
 
           gh_patch_param_pattern = %r{https?://github\.com/.+/.+/(?:commit|pull)/[a-fA-F0-9]*.(?:patch|diff)}
           if regex_match_group(patch_url_node, gh_patch_param_pattern) && !patch_url.match?(/\?full_index=\w+$/)
-            problem "GitHub patches should use the full_index parameter: #{patch_url}?full_index=1" do |corrector|
-              corrector.replace(patch_url_node.source_range, "\"#{patch_url}?full_index=1\"")
-            end
+            problem "GitHub patches should use the full_index parameter: #{patch_url}?full_index=1"
           end
 
           gh_patch_patterns = Regexp.union([%r{/raw\.github\.com/},


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR removes the autocorrection added for some patch `url`s in #10777 until we have a method of also updating the `sha256`s.