### PR TITLE
Always take latest item in `Sparkle` strategy.

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -36,6 +36,8 @@ module Homebrew
         Item = Struct.new(
           # @api public
           :title,
+          # @api private
+          :pub_date,
           # @api public
           :url,
           # @api private
@@ -72,6 +74,7 @@ module Homebrew
             version ||= (item > "version").first&.text&.strip
 
             title = (item > "title").first&.text&.strip
+            pub_date = (item > "pubDate").first&.text&.strip&.yield_self { |d| Time.parse(d) }
 
             if (match = title&.match(/(\d+(?:\.\d+)*)\s*(\([^)]+\))?\Z/))
               short_version ||= match[1]
@@ -84,6 +87,7 @@ module Homebrew
 
             data = {
               title:          title,
+              pub_date:       pub_date,
               url:            url,
               bundle_version: bundle_version,
             }.compact
@@ -91,7 +95,7 @@ module Homebrew
             Item.new(**data) unless data.empty?
           end.compact
 
-          items.first
+          items.max_by { |item| [item.pub_date, item.bundle_version] }
         end
 
         # Checks the content at the URL for new versions.


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The first item is not necessarily the latest, so sort the items by date first. Secondly, sort by version in case some versions were released at the same time.

Fixes breakage introduced by https://github.com/Homebrew/brew/pull/11146.