### PR TITLE
search: properly deprecate `brew search --cask`

### DIFF
--- a/Library/Homebrew/cmd/search.rb
+++ b/Library/Homebrew/cmd/search.rb
@@ -60,7 +60,8 @@ module Homebrew
       conflicts "--open", "--closed"
       conflicts(*package_manager_switches)
 
-      named_args :text_or_regex, min: 1
+      # TODO: (3.2) Add `min: 1` the `named_args` once `brew search --cask` is removed
+      named_args :text_or_regex
     end
   end
 
@@ -71,6 +72,12 @@ module Homebrew
       _, url = package_manager
       exec_browser url.call(URI.encode_www_form_component(args.named.join(" ")))
       return
+    end
+
+    if args.no_named?
+      odisabled "`brew search --cask` with no arguments to output casks", "`brew casks`" if args.cask?
+
+      raise UsageError, "This command requires at least 1 text or regex argument."
     end
 
     query = args.named.join(" ")

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -482,7 +482,7 @@ reinstalled formulae or, every 30 days, for all formulae.
 * `--skip-cask-deps`:
   Skip installing cask dependencies.
 
-### `search`, `-S` [*`options`*] *`text`*|`/`*`regex`*`/` [...]
+### `search`, `-S` [*`options`*] [*`text`*|`/`*`regex`*`/` ...]
 
 Perform a substring search of cask tokens and formula names for *`text`*. If *`text`*
 is flanked by slashes, it is interpreted as a regular expression.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -654,7 +654,7 @@ Disable/enable quarantining of downloads (default: enabled)\.
 \fB\-\-skip\-cask\-deps\fR
 Skip installing cask dependencies\.
 .
-.SS "\fBsearch\fR, \fB\-S\fR [\fIoptions\fR] \fItext\fR|\fB/\fR\fIregex\fR\fB/\fR [\.\.\.]"
+.SS "\fBsearch\fR, \fB\-S\fR [\fIoptions\fR] [\fItext\fR|\fB/\fR\fIregex\fR\fB/\fR \.\.\.]"
 Perform a substring search of cask tokens and formula names for \fItext\fR\. If \fItext\fR is flanked by slashes, it is interpreted as a regular expression\. The search for \fItext\fR is extended online to \fBhomebrew/core\fR and \fBhomebrew/cask\fR\.
 .
 .TP


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew search`, `brew search --formula`, and `brew search --formula --cask` without any named arguments were properly deprecated, disabled, and removed (removal happened in #11075). However, `brew search --cask` on its own never displayed any message warning that it would be removed. In version 3.1.0, it was removed and hasn't worked since. However, there was a discussion opened recently (https://github.com/Homebrew/discussions/discussions/1303) where a user wasn't aware of the breaking change.

Since this has already been broken since 3.1.0, I opted to deprecate immediately so we can remove it sooner. I wouldn't be opposed to disabling it in this PR, instead, as it's already not functional (just with a less clear error message and no instructions that point to `brew casks`).
