### PR TITLE
formula: add rpath helper method

### DIFF
--- a/Library/Homebrew/extend/os/linux/formula.rb
+++ b/Library/Homebrew/extend/os/linux/formula.rb
@@ -3,6 +3,7 @@
 
 class Formula
   undef shared_library
+  undef rpath
 
   def shared_library(name, version = nil)
     suffix = if version == "*" || (name == "*" && version.blank?)
@@ -11,6 +12,10 @@ class Formula
       ".#{version}"
     end
     "#{name}.so#{suffix}"
+  end
+
+  def rpath
+    "'$ORIGIN/../lib'"
   end
 
   class << self

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1523,6 +1523,12 @@ class Formula
     "#{name}#{infix}.dylib"
   end
 
+  # Executable/Library RPATH according to platform conventions.
+  sig { returns(String) }
+  def rpath
+    "@loader_path/../lib"
+  end
+
   # an array of all core {Formula} names
   # @private
   def self.core_names


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

About 40 formulae set `CMAKE_INSTALL_RPATH` to `lib` or `opt_lib`, but
this breaks bottle relocatability.

The correct solution is to use `@loader_path/../lib`, but this is macOS
specific, so it requires some OS-specific logic. Rather than replicating
this logic over many formulae, we may as well define a helper method for
it.

See https://github.com/Homebrew/homebrew-core/issues/75458.