### PR TITLE
workflows/tests: simulate macOS for `brew style homebrew-core`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,8 @@ jobs:
 
       - name: Run brew style on homebrew-core
         run: brew style --display-cop-names homebrew/core
+        env:
+          HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
 
       - name: Run brew audit --skip-style on homebrew-core
         run: brew audit --skip-style --tap=homebrew/core


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We currently run `brew style homebrew/core` twice in the `tap syntax (Linux)` workflow, but both times the Homebrew/linuxbrew-core repo is checked. THis PR adds `HOMEBREW_SIMULATE_MACOS_ON_LINUX=1` to the second `brew style` call so that Homebrew/homebrew-core is checked.
