### PR TITLE
Remove `issue_body` from YAML issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,6 @@
 name: New issue for Reproducible Bug
 description: "If you're sure it's reproducible and not just your machine: submit an issue so we can investigate."
 labels: bug
-issue_body: false
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,6 @@
 name: New issue for Feature Suggestion
 description: Request our thoughts on your suggestion for a new feature for Homebrew.
 labels: features
-issue_body: false
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`issue_body` is now an invalid key (in favour of using WYSIWYG `textarea`s). So `issue_body: false` needs to be removed completely in order for the forms to work 🤗.

> <img width="351" alt="Screenshot 2021-04-20 at 17 03 52" src="https://user-images.githubusercontent.com/1469659/115429464-55022800-a1fb-11eb-8c91-99b3d34f0da5.png">
