### PR TITLE
Bump Codecov action to 1.4.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,7 +222,7 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: codecov/codecov-action@0e28ff86a50029a44d10df6ed4c308711925a6a8
+      - uses: codecov/codecov-action@967e2b38a85a62bd61be5529ada27ebc109948c2
 
   test-default-formula-linux:
     name: test default formula (Linux)
@@ -314,4 +314,4 @@ jobs:
 
       - run: brew test-bot --only-formulae --test-default-formula
 
-      - uses: codecov/codecov-action@0e28ff86a50029a44d10df6ed4c308711925a6a8
+      - uses: codecov/codecov-action@967e2b38a85a62bd61be5529ada27ebc109948c2


### PR DESCRIPTION
@MikeMcQuaid this should fix the issue from https://github.com/Homebrew/brew/pull/11167#issuecomment-823488919
This change will bump the Codecov action from `1.4.0` to `1.4.1`


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
