### PR TITLE
Allow formulae to prevent optimization level stripping

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -89,8 +89,8 @@ module Superenv
     #     make/bsdmake wrappers currently.
     # x - Enable C++11 mode.
     # g - Enable "-stdlib=libc++" for clang.
-    # h - Enable "-stdlib=libstdc++" for clang.
     # K - Don't strip -arch <arch>, -m32, or -m64
+    # P - Don't strip -O[0-9zs]
     # w - Pass -no_weak_imports to the linker
     #
     # These flags will also be present:
@@ -296,6 +296,11 @@ module Superenv
   sig { void }
   def permit_arch_flags
     append_to_cccfg "K"
+  end
+
+  sig { void }
+  def permit_optimization_level
+    append_to_cccfg "P"
   end
 
   sig { void }

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -174,9 +174,11 @@ class Cmd
     case arg
     when /^-g\d?$/, /^-gstabs\d+/, "-gstabs+", /^-ggdb\d?/,
       /^-march=.+/, /^-mtune=.+/, /^-mcpu=.+/,
-      /^-O[0-9zs]?$/, "-fast", "-no-cpp-precomp",
+      "-fast", "-no-cpp-precomp",
       "-pedantic", "-pedantic-errors", "-Wno-long-double",
       "-Wno-unused-but-set-variable"
+    when /^-O[0-9zs]?$/
+      args << arg if permit_optimization_level?
     when "-fopenmp", "-lgomp", "-mno-fused-madd", "-fforce-addr", "-fno-defer-pop",
       "-mno-dynamic-no-pic", "-fearly-inlining", /^-f(?:no-)?inline-functions-called-once/,
       /^-finline-limit/, /^-f(?:no-)?check-new/, "-fno-delete-null-pointer-checks",
@@ -271,7 +273,7 @@ class Cmd
 
     args << "-pipe"
     args << "-w" unless configure?
-    args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}"
+    args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}" unless permit_optimization_level?
     args.concat(optflags)
     args.concat(archflags)
     args << "-std=#{@arg0}" if /c[89]9/.match?(@arg0)
@@ -372,6 +374,10 @@ class Cmd
 
   def permit_arch_flags?
     config.include?("K")
+  end
+
+  def permit_optimization_level?
+    config.include?("P")
   end
 
   def no_weak_imports?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Some upstream build systems require finer control over the optimisation
level. For example, `libgcrypt` sets `-O0` when building its
[jitter-based entropy collector](https://www.chronox.de/jent/doc/CPU-Jitter-NPTRNG.html) (`jent`), but `-O2` otherwise.

This allows formulae to set `ENV.permit_optimization_level` in the
install method to prevent the stripping of `-O[0-9zs]` flags. In particular,
it will allow us to build `libgcrypt` with the jitter-based entropy collector
which, as far as I can tell, is a valuable additional source of entropy. (Not
an expert though. But I assume there's a good reason upstream build this
unless you explicitly [disable it](https://github.com/Homebrew/homebrew-core/blob/a54a050d3fa5572259db48c2e7d6a8c521600dbe/Formula/libgcrypt.rb#L33).)

While we're here, clean up an old comment referencing `ENV.libstdcxx`.