### PR TITLE
audit: specify which URL has a content problem in problem message

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -733,20 +733,24 @@ module Cask
     def check_https_availability
       return unless download
 
-      check_url_for_https_availability(cask.url, user_agents: [cask.url.user_agent]) if cask.url && !cask.url.using
+      if cask.url && !cask.url.using
+        check_url_for_https_availability(cask.url, "binary URL",
+                                         user_agents: [cask.url.user_agent])
+      end
 
-      check_url_for_https_availability(cask.appcast, check_content: true) if cask.appcast && appcast?
+      check_url_for_https_availability(cask.appcast, "appcast URL", check_content: true) if cask.appcast && appcast?
 
       return unless cask.homepage
 
       check_url_for_https_availability(cask.homepage,
+                                       "homepage URL",
                                        user_agents:   [:browser, :default],
                                        check_content: true,
                                        strict:        strict?)
     end
 
-    def check_url_for_https_availability(url_to_check, **options)
-      problem = curl_check_http_content(url_to_check.to_s, **options)
+    def check_url_for_https_availability(url_to_check, url_type, **options)
+      problem = curl_check_http_content(url_to_check.to_s, url_type, **options)
       add_error problem if problem
     end
   end

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -380,6 +380,7 @@ module Homebrew
       return unless DevelopmentTools.curl_handles_most_https_certificates?
 
       if (http_content_problem = curl_check_http_content(homepage,
+                                                         "homepage URL",
                                                          user_agents:   [:browser, :default],
                                                          check_content: true,
                                                          strict:        @strict))

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -101,7 +101,7 @@ module Homebrew
 
         strategy = DownloadStrategyDetector.detect(url, using)
         if strategy <= CurlDownloadStrategy && !url.start_with?("file")
-          if (http_content_problem = curl_check_http_content(url, specs: specs))
+          if (http_content_problem = curl_check_http_content(url, "source URL", specs: specs))
             problem http_content_problem
           end
         elsif strategy <= GitDownloadStrategy

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -168,9 +168,8 @@ module Utils
         details[:headers].match?(/^Set-Cookie: incap_ses_/i)
     end
 
-    def curl_check_http_content(
-      url, url_type, specs: {}, user_agents: [:default], check_content: false, strict: false
-    )
+    def curl_check_http_content(url, url_type, specs: {}, user_agents: [:default],
+                                check_content: false, strict: false)
       return unless url.start_with? "http"
 
       secure_url = url.sub(/\Ahttp:/, "https:")


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Implements https://github.com/Homebrew/brew/issues/11183 (CC @cdayjr). The two new messages are (for example):

```
❯ brew audit --online some-test-formula
some-test-formula:
  * The homepage URL https://example.com/some-nonexistent-homepage is not reachable (HTTP status code 404)
  * Stable: The zip/tarball URL https://example.com/some-nonexistent-thing/unknown-0.1.tar.gz is not reachable (HTTP status code 404)
```

(formerly did not mention "homepage" or "zip/tarball")
