### PR TITLE
pod2man: use newer pod2man.

### DIFF
--- a/Library/Homebrew/shims/mac/super/pod2man
+++ b/Library/Homebrew/shims/mac/super/pod2man
@@ -2,7 +2,10 @@
 
 # HOMEBREW_PREFIX is set by bin/brew
 # shellcheck disable=SC2154
-POD2MAN="$(type -P pod2man5.18 ||
+POD2MAN="$(type -P /usr/bin/pod2man ||
+           type -P pod2man5.30 ||
+           type -P pod2man5.28 ||
+           type -P pod2man5.18 ||
            type -P pod2man5.16 ||
            type -P pod2man5.12 ||
            type -P "${HOMEBREW_PREFIX}/opt/pod2man/bin/pod2man" ||


### PR DESCRIPTION
This shim was originally added in 5c973bad7422cf7f335e952a91ddfa2273aa2e4f to workaround a missing
`/usr/bin/pod2man`. It's now unfortunately resulting in using an older `pod2man` on newer macOS versions.

Instead, let's use `/usr/bin/pod2man` if it's available and, if not, work backwards to find the newest available version that is available.