### PR TITLE
rubocop: allow pypi sdists which contain macos in url

### DIFF
--- a/Library/Homebrew/rubocops/urls.rb
+++ b/Library/Homebrew/rubocops/urls.rb
@@ -238,6 +238,7 @@ module RuboCop
 
           # Check for binary URLs
           audit_urls(urls, /(darwin|macos|osx)/i) do |match, url|
+            next if url.match?(%r{https://files\.pythonhosted\.org.*tar\.gz})
             next if @formula_name.include?(match.to_s.downcase)
             next if url.match?(/.(patch|diff)(\?full_index=1)?$/)
             next if tap_style_exception? :not_a_binary_url_prefix_allowlist


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Supports https://github.com/Homebrew/homebrew-core/pull/75671 which is reporting `https://files.pythonhosted.org/packages/d4/6e/e0b2ea37ef831a5c6b5aebbd14701d96d9dc061f04a867b05335a4bc099d/macos-tags-1.5.1.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.`

even though it is a source archive.
