### PR TITLE
pod2man: further tweak logic.

### DIFF
--- a/Library/Homebrew/shims/mac/super/pod2man
+++ b/Library/Homebrew/shims/mac/super/pod2man
@@ -2,12 +2,13 @@
 
 # HOMEBREW_PREFIX is set by bin/brew
 # shellcheck disable=SC2154
-POD2MAN="$(type -P /usr/bin/pod2man ||
+POD2MAN="$(type -P pod2man ||
            type -P pod2man5.30 ||
            type -P pod2man5.28 ||
            type -P pod2man5.18 ||
            type -P pod2man5.16 ||
            type -P pod2man5.12 ||
+           type -P /usr/bin/pod2man ||
            type -P "${HOMEBREW_PREFIX}/opt/pod2man/bin/pod2man" ||
            echo /usr/bin/pod2man)"
 exec "${POD2MAN}" "$@"


### PR DESCRIPTION
- prioritise the first `pod2man` in the `PATH` if possible. This shim was created to handle the case where there isn't one but, if there is, we want to allow e.g. using a `pod2man` dependency to override the use of the system version
- make `/usr/bin/pod2man` lower priority but still prioritise it over a Homebrew-installed `pod2man` that's not in the `PATH` unless it doesn't exist.