### PR TITLE
Fix shellcheck failures

### DIFF
--- a/Library/Homebrew/brew.sh
+++ b/Library/Homebrew/brew.sh
@@ -51,10 +51,9 @@ HOMEBREW_CACHE="${HOMEBREW_CACHE:-${HOMEBREW_DEFAULT_CACHE}}"
 HOMEBREW_LOGS="${HOMEBREW_LOGS:-${HOMEBREW_DEFAULT_LOGS}}"
 HOMEBREW_TEMP="${HOMEBREW_TEMP:-${HOMEBREW_DEFAULT_TEMP}}"
 
-# Don't need shellcheck to follow these `source`.
 # These referenced variables are set by bin/brew
 # Don't need to handle a default case.
-# shellcheck disable=SC1090,SC2154,SC2249
+# shellcheck disable=SC2154,SC2249
 case "$*" in
   --cellar)            echo "${HOMEBREW_CELLAR}"; exit 0 ;;
   --repository|--repo) echo "${HOMEBREW_REPOSITORY}"; exit 0 ;;
@@ -317,8 +316,6 @@ fi
 
 HOMEBREW_CORE_REPOSITORY="${HOMEBREW_LIBRARY}/Taps/homebrew/homebrew-core"
 
-# Don't need shellcheck to follow these `source`.
-# shellcheck disable=SC1090
 case "$*" in
   --version|-v) source "${HOMEBREW_LIBRARY}/Homebrew/cmd/--version.sh"; homebrew-version; exit 0 ;;
 esac
@@ -648,8 +645,6 @@ access to all bottles."
 EOS
 fi
 
-# Don't need shellcheck to follow this `source`.
-# shellcheck disable=SC1090
 source "${HOMEBREW_LIBRARY}/Homebrew/utils/analytics.sh"
 setup-analytics
 
@@ -660,13 +655,11 @@ then
   # a Ruby script and avoids hard-to-debug issues if the Bash script is updated
   # at the same time as being run.
   #
-  # Don't need shellcheck to follow this `source`.
+  # Shellcheck can't follow this dynamic `source`.
   # shellcheck disable=SC1090
   source "${HOMEBREW_BASH_COMMAND}"
   { update-preinstall "$@"; "homebrew-${HOMEBREW_COMMAND}" "$@"; exit $?; }
 else
-  # Don't need shellcheck to follow this `source`.
-  # shellcheck disable=SC1090
   source "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby.sh"
   setup-ruby-path
 

--- a/Library/Homebrew/cmd/casks.sh
+++ b/Library/Homebrew/cmd/casks.sh
@@ -3,8 +3,6 @@
 #:  List all locally installable casks including short names.
 #:
 
-# Don't need shellcheck to follow the `source`.
-# shellcheck disable=SC1090
 source "$HOMEBREW_LIBRARY/Homebrew/items.sh"
 
 homebrew-casks() {

--- a/Library/Homebrew/cmd/formulae.sh
+++ b/Library/Homebrew/cmd/formulae.sh
@@ -3,8 +3,6 @@
 #:  List all locally installable formulae including short names.
 #:
 
-# Don't need shellcheck to follow the `source`.
-# shellcheck disable=SC1090
 source "$HOMEBREW_LIBRARY/Homebrew/items.sh"
 
 homebrew-formulae() {

--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -9,8 +9,6 @@
 #:      -d, --debug                      Display a trace of all shell commands as they are executed.
 #:      -h, --help                       Show this message.
 
-# Don't need shellcheck to follow this `source`.
-# shellcheck disable=SC1090
 source "$HOMEBREW_LIBRARY/Homebrew/utils/lock.sh"
 
 # Replaces the function in Library/Homebrew/brew.sh to cache the Git executable to
@@ -522,6 +520,9 @@ EOS
     # the refspec ensures that the default upstream branch gets updated
     (
       UPSTREAM_REPOSITORY_URL="$(git config remote.origin.url)"
+
+      # HOMEBREW_UPDATE_FORCE and HOMEBREW_UPDATE_PREINSTALL aren't modified here so ignore subshell warning.
+      # shellcheck disable=SC2030
       if [[ "$UPSTREAM_REPOSITORY_URL" = "https://github.com/"* ]]
       then
         UPSTREAM_REPOSITORY="${UPSTREAM_REPOSITORY_URL#https://github.com/}"
@@ -542,6 +543,8 @@ EOS
           GITHUB_API_ENDPOINT="commits/$UPSTREAM_BRANCH_DIR"
         fi
 
+        # HOMEBREW_CURL is set by brew.sh (and isn't mispelt here)
+        # shellcheck disable=SC2153
         UPSTREAM_SHA_HTTP_CODE="$("$HOMEBREW_CURL" \
            "${CURL_DISABLE_CURLRC_ARGS[@]}" \
            --silent --max-time 3 \
@@ -565,6 +568,9 @@ EOS
         fi
       fi
 
+
+      # HOMEBREW_VERBOSE isn't modified here so ignore subshell warning.
+      # shellcheck disable=SC2030
       if [[ -n "$HOMEBREW_VERBOSE" ]]
       then
         echo "Fetching $DIR..."
@@ -636,6 +642,8 @@ EOS
     PREFETCH_REVISION="${!PREFETCH_REVISION_VAR}"
     POSTFETCH_REVISION="$(git rev-parse -q --verify refs/remotes/origin/"$UPSTREAM_BRANCH")"
 
+    # HOMEBREW_UPDATE_FORCE and HOMEBREW_VERBOSE weren't modified in subshell.
+    # shellcheck disable=SC2031
     if [[ -n "$HOMEBREW_SIMULATE_FROM_CURRENT_BRANCH" ]]
     then
       simulate_from_current_branch "$DIR" "$TAP_VAR" "$UPSTREAM_BRANCH" "$CURRENT_REVISION"
@@ -653,6 +661,8 @@ EOS
 
   safe_cd "$HOMEBREW_REPOSITORY"
 
+  # HOMEBREW_UPDATE_PREINSTALL wasn't modified in subshell.
+  # shellcheck disable=SC2031
   if [[ -n "$HOMEBREW_UPDATED" ||
         -n "$HOMEBREW_UPDATE_FAILED" ||
         -n "$HOMEBREW_FAILED_FETCH_DIRS" ||

--- a/Library/Homebrew/cmd/vendor-install.sh
+++ b/Library/Homebrew/cmd/vendor-install.sh
@@ -3,8 +3,6 @@
 #:
 #:  Install Homebrew's portable Ruby.
 
-# Don't need shellcheck to follow this `source`.
-# shellcheck disable=SC1090
 source "$HOMEBREW_LIBRARY/Homebrew/utils/lock.sh"
 
 VENDOR_DIR="$HOMEBREW_LIBRARY/Homebrew/vendor"
@@ -119,6 +117,8 @@ fetch() {
   else
     if [[ -f "$temporary_path" ]]
     then
+      # HOMEBREW_CURL is set by brew.sh (and isn't mispelt here)
+      # shellcheck disable=SC2153
       "$HOMEBREW_CURL" "${curl_args[@]}" -C - "$VENDOR_URL" -o "$temporary_path"
       if [[ $? -eq 33 ]]
       then

--- a/Library/Homebrew/dev-cmd/rubocop.sh
+++ b/Library/Homebrew/dev-cmd/rubocop.sh
@@ -8,8 +8,6 @@
 # HOMEBREW_BREW_FILE is set by extend/ENV/super.rb
 # shellcheck disable=SC2154
 homebrew-rubocop() {
-  # Don't need shellcheck to follow this `source`.
-  # shellcheck disable=SC1090
   source "${HOMEBREW_LIBRARY}/Homebrew/utils/ruby.sh"
   setup-ruby-path
 

--- a/Library/Homebrew/shims/mac/super/ruby
+++ b/Library/Homebrew/shims/mac/super/ruby
@@ -2,10 +2,9 @@
 
 # System Ruby's mkmf on Mojave (10.14) and later require SDKROOT set to work correctly.
 
-# Don't need shellcheck to follow the `source`.
 # HOMEBREW_LIBRARY is set by bin/brew
 # HOMEBREW_SDKROOT is set by extend/ENV/super.rb
-# shellcheck disable=SC1090,SC2154
+# shellcheck disable=SC2154
 source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
 
 try_exec_non_system "${SHIM_FILE}" "$@"

--- a/Library/Homebrew/shims/scm/git
+++ b/Library/Homebrew/shims/scm/git
@@ -15,8 +15,6 @@ then
   exit 1
 fi
 
-# Don't need shellcheck to follow the `source`.
-# shellcheck disable=SC1090
 source "${HOMEBREW_LIBRARY}/Homebrew/shims/utils.sh"
 
 # shellcheck disable=SC2249

--- a/Library/Homebrew/style.rb
+++ b/Library/Homebrew/style.rb
@@ -186,7 +186,7 @@ module Homebrew
       end
 
       # TODO: Add `--enable=all` to check for more problems.
-      args = ["--shell=bash", "--external-sources", "--", *files]
+      args = ["--shell=bash", "--external-sources", "--source-path=#{HOMEBREW_LIBRARY}", "--", *files]
 
       case output_type
       when :print

--- a/bin/brew
+++ b/bin/brew
@@ -121,7 +121,5 @@ then
 else
   echo "Warning: HOMEBREW_NO_ENV_FILTERING is undocumented, deprecated and will be removed in a future Homebrew release (because it breaks many things)!" >&2
 
-  # Don't need shellcheck to follow this `source`.
-  # shellcheck disable=SC1090
   source "${HOMEBREW_LIBRARY}/Homebrew/brew.sh"
 fi


### PR DESCRIPTION
A new version of `shellcheck` (I think?) brought us so new warnings and errors.

To fix:
- pass `--source-path` so we don't need to stop `shellcheck` trying to read sourced files every time
- disable some more warnings/errors we don't care about fixing