### PR TITLE
Avoid “Failure while executing; `git config --replace-all homebrew.devcmdrun true` exited with 255.” error.

### DIFF
--- a/Library/Homebrew/settings.rb
+++ b/Library/Homebrew/settings.rb
@@ -17,28 +17,27 @@ module Homebrew
     def read(setting, repo: HOMEBREW_REPOSITORY)
       return unless (repo/".git/config").exist?
 
-      repo.cd do
-        Utils.popen_read("git", "config", "--get", "homebrew.#{setting}").chomp.presence
-      end
+      system_command("git", args: ["config", "--get", "homebrew.#{setting}"], chdir: repo).stdout.chomp.presence
     end
 
     sig { params(setting: T.any(String, Symbol), value: T.any(String, T::Boolean), repo: Pathname).void }
     def write(setting, value, repo: HOMEBREW_REPOSITORY)
       return unless (repo/".git/config").exist?
 
-      repo.cd do
-        system_command! "git", args: ["config", "--replace-all", "homebrew.#{setting}", value.to_s]
-      end
+      value = value.to_s
+
+      return if read(setting, repo: repo) == value
+
+      system_command! "git", args: ["config", "--replace-all", "homebrew.#{setting}", value], chdir: repo
     end
 
     sig { params(setting: T.any(String, Symbol), repo: Pathname).void }
     def delete(setting, repo: HOMEBREW_REPOSITORY)
       return unless (repo/".git/config").exist?
+
       return if read(setting, repo: repo).blank?
 
-      repo.cd do
-        system_command! "git", args: ["config", "--unset-all", "homebrew.#{setting}"]
-      end
+      system_command! "git", args: ["config", "--unset-all", "homebrew.#{setting}"], chdir: repo
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This often happens when running multiple dev commands in parallel since it tries to lock the `.git/config` file, so check if the current value is already correct.