### PR TITLE
github/workflows/tests: add more `needs: syntax`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
 
   tap-syntax:
     name: tap syntax (Linux)
+    needs: syntax
     if: startsWith(github.repository, 'Homebrew/')
     runs-on: ubuntu-latest
     steps:
@@ -157,6 +158,7 @@ jobs:
         run: git diff --stat --exit-code Library/Homebrew/vendor/bundle/ruby
 
   docker:
+    needs: syntax
     runs-on: ubuntu-latest
     steps:
       - name: Set up Homebrew
@@ -180,6 +182,7 @@ jobs:
 
   tests:
     name: ${{ matrix.name }}
+    needs: syntax
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Make more of the longer (i.e. >5m) jobs require the `syntax` job to have completed. These jobs are so much quicker than the macOS job so that this will not slow down the overall CI run while avoiding the run of some jobs if `syntax` fails.