### PR TITLE
Curl: Add methods to parse response

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -603,7 +603,8 @@ module Cask
 
       version_stanza = cask.version.to_s
       adjusted_version_stanza = cask.appcast.must_contain.presence || version_stanza.match(/^[[:alnum:].]+/)[0]
-      return if appcast_contents.include? adjusted_version_stanza
+      return if appcast_contents.blank?
+      return if appcast_contents.include?(adjusted_version_stanza)
 
       add_error <<~EOS.chomp
         appcast at URL '#{Formatter.url(appcast_url)}' does not contain \

--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -461,27 +461,16 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
       url = url.sub(%r{^(https?://#{GitHubPackages::URL_DOMAIN}/)?}o, "#{domain.chomp("/")}/")
     end
 
-    out, _, status= curl_output("--location", "--silent", "--head", "--request", "GET", url.to_s, timeout: timeout)
+    output, _, _status = curl_output(
+      "--location", "--silent", "--head", "--request", "GET", url.to_s,
+      timeout: timeout
+    )
+    parsed_output = parse_curl_output(output)
 
-    lines = status.success? ? out.lines.map(&:chomp) : []
+    lines = output.to_s.lines.map(&:chomp)
 
-    locations = lines.map { |line| line[/^Location:\s*(.*)$/i, 1] }
-                     .compact
-
-    redirect_url = locations.reduce(url) do |current_url, location|
-      if location.start_with?("//")
-        uri = URI(current_url)
-        "#{uri.scheme}:#{location}"
-      elsif location.start_with?("/")
-        uri = URI(current_url)
-        "#{uri.scheme}://#{uri.host}#{location}"
-      elsif location.start_with?("./")
-        uri = URI(current_url)
-        "#{uri.scheme}://#{uri.host}#{Pathname(uri.path).dirname/location}"
-      else
-        location
-      end
-    end
+    final_url = curl_response_last_location(parsed_output[:responses], absolutize: true, base_url: url)
+    final_url ||= url
 
     content_disposition_parser = Mechanize::HTTP::ContentDispositionParser.new
 
@@ -515,10 +504,10 @@ class CurlDownloadStrategy < AbstractFileDownloadStrategy
            .map(&:to_i)
            .last
 
-    is_redirection = url != redirect_url
-    basename = filenames.last || parse_basename(redirect_url, search_query: !is_redirection)
+    is_redirection = url != final_url
+    basename = filenames.last || parse_basename(final_url, search_query: !is_redirection)
 
-    @resolved_info_cache[url] = [redirect_url, basename, time, file_size, is_redirection]
+    @resolved_info_cache[url] = [final_url, basename, time, file_size, is_redirection]
   end
 
   def _fetch(url:, resolved_url:, timeout:)

--- a/Library/Homebrew/livecheck/strategy.rb
+++ b/Library/Homebrew/livecheck/strategy.rb
@@ -72,11 +72,6 @@ module Homebrew
         retries:         0,
       }.freeze
 
-      # HTTP response head(s) and body are typically separated by a double
-      # `CRLF` (whereas HTTP header lines are separated by a single `CRLF`).
-      # In rare cases, this can also be a double newline (`\n\n`).
-      HTTP_HEAD_BODY_SEPARATOR = "\r\n\r\n"
-
       # A regex used to identify a tarball extension at the end of a string.
       TARBALL_EXTENSION_REGEX = /
         \.t
@@ -180,22 +175,17 @@ module Homebrew
         headers = []
 
         [:default, :browser].each do |user_agent|
-          stdout, _, status = curl_with_workarounds(
+          output, _, status = curl_with_workarounds(
             *PAGE_HEADERS_CURL_ARGS, url,
             **DEFAULT_CURL_OPTIONS,
             use_homebrew_curl: homebrew_curl,
             user_agent:        user_agent
           )
+          next unless status.success?
 
-          while stdout.match?(/\AHTTP.*\r$/)
-            h, stdout = stdout.split("\r\n\r\n", 2)
-
-            headers << h.split("\r\n").drop(1)
-                        .to_h { |header| header.split(/:\s*/, 2) }
-                        .transform_keys(&:downcase)
-          end
-
-          return headers if status.success?
+          parsed_output = parse_curl_output(output)
+          parsed_output[:responses].each { |response| headers << response[:headers] }
+          break if headers.present?
         end
 
         headers
@@ -211,8 +201,6 @@ module Homebrew
       # @return [Hash]
       sig { params(url: String, homebrew_curl: T::Boolean).returns(T::Hash[Symbol, T.untyped]) }
       def self.page_content(url, homebrew_curl: false)
-        original_url = url
-
         stderr = nil
         [:default, :browser].each do |user_agent|
           stdout, stderr, status = curl_with_workarounds(
@@ -229,27 +217,11 @@ module Homebrew
 
           # Separate the head(s)/body and identify the final URL (after any
           # redirections)
-          max_iterations = 5
-          iterations = 0
-          output = output.lstrip
-          while output.match?(%r{\AHTTP/[\d.]+ \d+}) && output.include?(HTTP_HEAD_BODY_SEPARATOR)
-            iterations += 1
-            raise "Too many redirects (max = #{max_iterations})" if iterations > max_iterations
+          parsed_output = parse_curl_output(output)
+          final_url = curl_response_last_location(parsed_output[:responses], absolutize: true, base_url: url)
 
-            head_text, _, output = output.partition(HTTP_HEAD_BODY_SEPARATOR)
-            output = output.lstrip
-
-            location = head_text[/^Location:\s*(.*)$/i, 1]
-            next if location.blank?
-
-            location.chomp!
-            # Convert a relative redirect URL to an absolute URL
-            location = URI.join(url, location) unless location.match?(PageMatch::URL_MATCH_REGEX)
-            final_url = location
-          end
-
-          data = { content: output }
-          data[:final_url] = final_url if final_url.present? && final_url != original_url
+          data = { content: parsed_output[:body] }
+          data[:final_url] = final_url if final_url.present? && final_url != url
           return data
         end
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -14,6 +14,11 @@ module Utils
 
     using TimeRemaining
 
+    # This regex is used to extract the part of an ETag within quotation marks,
+    # ignoring any leading weak validator indicator (`W/`). This simplifies
+    # ETag comparison in `#curl_check_http_content`.
+    ETAG_VALUE_REGEX = %r{^(?:[wW]/)?"((?:[^"]|\\")*)"}.freeze
+
     # HTTP responses and body content are typically separated by a double
     # `CRLF` (whereas HTTP header lines are separated by a single `CRLF`).
     # In rare cases, this can also be a double newline (`\n\n`).
@@ -23,7 +28,7 @@ module Utils
     # the status code and any following descriptive text (e.g., `Not Found`).
     HTTP_STATUS_LINE_REGEX = %r{^HTTP/.* (?<code>\d+)(?: (?<text>[^\r\n]+))?}.freeze
 
-    private_constant :HTTP_RESPONSE_BODY_SEPARATOR, :HTTP_STATUS_LINE_REGEX
+    private_constant :ETAG_VALUE_REGEX, :HTTP_RESPONSE_BODY_SEPARATOR, :HTTP_STATUS_LINE_REGEX
 
     module_function
 
@@ -156,23 +161,19 @@ module Utils
       result
     end
 
-    def parse_headers(headers)
-      return {} if headers.blank?
-
-      # Skip status code
-      headers.split("\r\n")[1..].to_h do |h|
-        name, content = h.split(": ")
-        [name.downcase, content]
-      end
-    end
-
     def curl_download(*args, to: nil, try_partial: true, **options)
       destination = Pathname(to)
       destination.dirname.mkpath
 
       if try_partial
         range_stdout = curl_output("--location", "--head", *args, **options).stdout
-        headers = parse_headers(range_stdout.split("\r\n\r\n").first)
+        parsed_output = parse_curl_output(range_stdout)
+
+        headers = if parsed_output[:responses].present?
+          parsed_output[:responses].last[:headers]
+        else
+          {}
+        end
 
         # Any value for `accept-ranges` other than none indicates that the server supports partial requests.
         # Its absence indicates no support.
@@ -198,6 +199,8 @@ module Utils
 
     # Check if a URL is protected by CloudFlare (e.g. badlion.net and jaxx.io).
     def url_protected_by_cloudflare?(details)
+      return false if details[:headers].blank?
+
       [403, 503].include?(details[:status].to_i) &&
         details[:headers].match?(/^Set-Cookie: (__cfduid|__cf_bm)=/i) &&
         details[:headers].match?(/^Server: cloudflare/i)
@@ -205,6 +208,8 @@ module Utils
 
     # Check if a URL is protected by Incapsula (e.g. corsair.com).
     def url_protected_by_incapsula?(details)
+      return false if details[:headers].blank?
+
       details[:status].to_i == 403 &&
         details[:headers].match?(/^Set-Cookie: visid_incap_/i) &&
         details[:headers].match?(/^Set-Cookie: incap_ses_/i)
@@ -266,7 +271,7 @@ module Utils
       end
 
       if url.start_with?("https://") && Homebrew::EnvConfig.no_insecure_redirect? &&
-         !details[:final_url].start_with?("https://")
+         (details[:final_url].present? && !details[:final_url].start_with?("https://"))
         return "The #{url_type} #{url} redirects back to HTTP"
       end
 
@@ -281,9 +286,11 @@ module Utils
         details[:content_length] == secure_details[:content_length]
       file_match = details[:file_hash] == secure_details[:file_hash]
 
-      if (etag_match || content_length_match || file_match) &&
-         secure_details[:final_url].start_with?("https://") &&
-         url.start_with?("http://")
+      http_with_https_available =
+        url.start_with?("http://") &&
+        (secure_details[:final_url].present? && secure_details[:final_url].start_with?("https://"))
+
+      if (etag_match || content_length_match || file_match) && http_with_https_available
         return "The #{url_type} #{url} should use HTTPS rather than HTTP"
       end
 
@@ -294,8 +301,7 @@ module Utils
       https_content = secure_details[:file]&.gsub(no_protocol_file_contents, "/")
 
       # Check for the same content after removing all protocols
-      if (http_content && https_content) && (http_content == https_content) &&
-         url.start_with?("http://") && secure_details[:final_url].start_with?("https://")
+      if (http_content && https_content) && (http_content == https_content) && http_with_https_available
         return "The #{url_type} #{url} should use HTTPS rather than HTTP"
       end
 
@@ -339,30 +345,33 @@ module Utils
         user_agent:        user_agent
       )
 
-      status_code = :unknown
-      while status_code == :unknown || status_code.to_s.start_with?("3")
-        headers, _, output = output.partition("\r\n\r\n")
-        status_code = headers[%r{HTTP/.* (\d+)}, 1]
-        location = headers[/^Location:\s*(.*)$/i, 1]
-        final_url = location.chomp if location
-      end
-
       if status.success?
+        parsed_output = parse_curl_output(output)
+        responses = parsed_output[:responses]
+
+        final_url = curl_response_last_location(responses)
+        headers = if responses.last.present?
+          status_code = responses.last[:status_code]
+          responses.last[:headers]
+        else
+          {}
+        end
+        etag = headers["etag"][ETAG_VALUE_REGEX, 1] if headers["etag"].present?
+        content_length = headers["content-length"]
+
         file_contents = File.read(file.path)
         file_hash = Digest::SHA2.hexdigest(file_contents) if hash_needed
       end
-
-      final_url ||= url
 
       {
         url:            url,
         final_url:      final_url,
         status:         status_code,
-        etag:           headers[%r{ETag: ([wW]/)?"(([^"]|\\")*)"}, 2],
-        content_length: headers[/Content-Length: (\d+)/, 1],
         headers:        headers,
-        file_hash:      file_hash,
+        etag:           etag,
+        content_length: content_length,
         file:           file_contents,
+        file_hash:      file_hash,
       }
     ensure
       file.unlink


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

## Overview

This work was originally part of #9535 and then #10834 (a recreation of the former PR) but I've refactored the methods to make them a bit more general purpose here. While working on migrating livecheck to curl, it became apparent that there are a few areas in brew where similar code exists to parse curl output.

The intention of this PR is to provide methods for working with curl output in a standardized way, so we can avoid unnecessary code duplication. Notable changes are as follows:

* Adds `parse_curl_output` and `parse_curl_head` methods to parse curl output (a string containing response head(s) and/or the final response body). The code in these methods is partly taken from existing code in brew, as the aim is to replace existing code with these methods. The main difference is that these methods parse response heads into hashes and organize the data in a specific fashion (so we're not reinventing the wheel in multiple locations).
* Adds `curl_response_status_code` and `curl_response_last_location` methods that take the parsed output from the aforementioned methods and extract specific information (the status code of the last response and the last `location` header, respectively).
* Expands `Utils::Curl` tests to cover the new methods.

## Example

If we have curl output like:

```
HTTP/2 301 \r
date: Mon, 26 Apr 2021 15:06:34 GMT\r
content-type: text/plain; charset=utf-8\r
content-length: 21\r
location: https://example.com/\r
\r
HTTP/2 200 \r
content-encoding: gzip\r
cache-control: max-age=604800\r
content-type: text/html; charset=UTF-8\r
date: Mon, 26 Apr 2021 15:09:15 GMT\r
last-modified: Mon, 26 Apr 2021 12:34:56 GMT\r
content-length: 169\r
\r
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8">
    <title>Example</title>
  </head>
  <body>
    <h1>Example</h1>
    <p>Hello, world!</p>
  </body>
</html>
```

`parse_curl_output` will produce a hash like:

```ruby
{
  heads: [
    {
      status_code: "301",
      headers: {
        "date"           => "Mon, 26 Apr 2021 15:06:34 GMT",
        "content-type"   => "text/plain; charset=utf-8",
        "content-length" => "21",
        "location"       => "https://example.com/"
      }
    },
    {
      status_code: "200",
      headers: {
        "content-encoding" => "gzip",
        "cache-control"    => "max-age=604800",
        "content-type"     => "text/html; charset=UTF-8",
        "date"             => "Mon, 26 Apr 2021 15:09:15 GMT",
        "last-modified"    => "Mon, 26 Apr 2021 12:34:56 GMT",
        "content-length"   =>  "169"
      }
    }
  ],
  body: "<!DOCTYPE html>\n<html>\n  <head>\n    <meta charset=\"utf-8\">\n    <title>Example</title>\n  </head>\n  <body>\n    <h1>Example</h1>\n    <p>Hello, world!</p>\n  </body>\n</html>\n"
}
```

The response heads are parsed using `parse_curl_head`, which produces a hash containing the status code and header strings.

If we provide the heads array (the first member of the output array from `parse_curl_output`), it returns `"200"`. If we do the same with `curl_response_last_location`, it returns `"https://example.com/"`.

## Conclusion

This PR only focuses on adding these methods and I would appreciate feedback on the shape of this. I'll add comments in places that I think may benefit from discussion.

If/when this is merged, I'll create a follow-up PR that replaces existing code with these methods (as it was suggested that it may be better to keep this separate). I'll be rebasing #10834 onto this shortly and I'll also update that PR to account for any changes that we make here in review.