### PR TITLE
dev-cmd/bottle: Support adding root_url specs to bottle spec

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -16,7 +16,7 @@ BOTTLE_ERB = <<-EOS
   bottle do
     <% if [HOMEBREW_BOTTLE_DEFAULT_DOMAIN.to_s,
            "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/bottles"].exclude?(root_url) %>
-    root_url "<%= root_url %>"<% unless download_strategy.blank? %>,
+    root_url "<%= root_url %>"<% if download_strategy.present? %>,
       using: <%= download_strategy %>
     <% end %>
     <% end %>

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -78,7 +78,7 @@ module Homebrew
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--root-url-using=",
-             description: "Use the specified download strategy for the root_url in the generated DSL via `using:' arg"
+             description: "Use the specified download strategy class for downloading the bottle's URL instead of Homebrew's default."
 
       conflicts "--no-rebuild", "--keep-old"
 

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -16,7 +16,9 @@ BOTTLE_ERB = <<-EOS
   bottle do
     <% if [HOMEBREW_BOTTLE_DEFAULT_DOMAIN.to_s,
            "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/bottles"].exclude?(root_url) %>
-    root_url "<%= root_url %>"
+    root_url "<%= root_url %>"<% unless root_url_specs.blank? %>,
+      <%= root_url_specs %>
+    <% end %>
     <% end %>
     <% if rebuild.positive? %>
     rebuild <%= rebuild %>
@@ -75,6 +77,8 @@ module Homebrew
              description: "Specify a committer name and email in `git`'s standard author format."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
+      flag   "--root-url-specs=",
+             description: "Append the specified specs to the root_url line in the generated DSL"
 
       conflicts "--no-rebuild", "--keep-old"
 
@@ -221,7 +225,7 @@ module Homebrew
     %Q(#{line}"#{digest}")
   end
 
-  def bottle_output(bottle)
+  def bottle_output(bottle, root_url_specs)
     cellars = bottle.checksums.map do |checksum|
       cellar = checksum["cellar"]
       next unless cellar_parameter_needed? cellar
@@ -244,6 +248,7 @@ module Homebrew
     end
     erb_binding = bottle.instance_eval { binding }
     erb_binding.local_variable_set(:sha256_lines, sha256_lines)
+    erb_binding.local_variable_set(:root_url_specs, root_url_specs)
     erb = ERB.new BOTTLE_ERB
     erb.result(erb_binding).gsub(/^\s*$\n/, "")
   end
@@ -529,7 +534,7 @@ module Homebrew
       end
     end
 
-    output = bottle_output bottle
+    output = bottle_output(bottle, args.root_url_specs)
 
     puts "./#{local_filename}"
     puts output
@@ -641,7 +646,7 @@ module Homebrew
       end
 
       unless args.write?
-        puts bottle_output(bottle)
+        puts bottle_output(bottle, args.root_url_specs)
         next
       end
 
@@ -720,7 +725,7 @@ module Homebrew
       update_or_add = checksums.nil? ? "add" : "update"
 
       checksums&.each(&bottle.method(:sha256))
-      output = bottle_output(bottle)
+      output = bottle_output(bottle, args.root_url_specs)
       puts output
 
       case update_or_add

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -78,7 +78,8 @@ module Homebrew
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--root-url-using=",
-             description: "Use the specified download strategy class for downloading the bottle's URL instead of Homebrew's default."
+             description: "Use the specified download strategy class for downloading the bottle's URL instead of "\
+                          "Homebrew's default."
 
       conflicts "--no-rebuild", "--keep-old"
 

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -16,8 +16,8 @@ BOTTLE_ERB = <<-EOS
   bottle do
     <% if [HOMEBREW_BOTTLE_DEFAULT_DOMAIN.to_s,
            "#{HOMEBREW_BOTTLE_DEFAULT_DOMAIN}/bottles"].exclude?(root_url) %>
-    root_url "<%= root_url %>"<% if download_strategy.present? %>,
-      using: <%= download_strategy %>
+    root_url "<%= root_url %>"<% if root_url_using.present? %>,
+      using: <%= root_url_using %>
     <% end %>
     <% end %>
     <% if rebuild.positive? %>
@@ -77,8 +77,8 @@ module Homebrew
              description: "Specify a committer name and email in `git`'s standard author format."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
-      flag   "--download-strategy=",
-             description: "Use the specified download strategy for the root_url in the generated DSL"
+      flag   "--root-url-using=",
+             description: "Use the specified download strategy for the root_url in the generated DSL via `using:' arg"
 
       conflicts "--no-rebuild", "--keep-old"
 
@@ -225,7 +225,7 @@ module Homebrew
     %Q(#{line}"#{digest}")
   end
 
-  def bottle_output(bottle, download_strategy)
+  def bottle_output(bottle, root_url_using)
     cellars = bottle.checksums.map do |checksum|
       cellar = checksum["cellar"]
       next unless cellar_parameter_needed? cellar
@@ -248,7 +248,7 @@ module Homebrew
     end
     erb_binding = bottle.instance_eval { binding }
     erb_binding.local_variable_set(:sha256_lines, sha256_lines)
-    erb_binding.local_variable_set(:download_strategy, download_strategy)
+    erb_binding.local_variable_set(:root_url_using, root_url_using)
     erb = ERB.new BOTTLE_ERB
     erb.result(erb_binding).gsub(/^\s*$\n/, "")
   end
@@ -534,7 +534,7 @@ module Homebrew
       end
     end
 
-    output = bottle_output(bottle, args.download_strategy)
+    output = bottle_output(bottle, args.root_url_using)
 
     puts "./#{local_filename}"
     puts output
@@ -646,7 +646,7 @@ module Homebrew
       end
 
       unless args.write?
-        puts bottle_output(bottle, args.download_strategy)
+        puts bottle_output(bottle, args.root_url_using)
         next
       end
 
@@ -725,7 +725,7 @@ module Homebrew
       update_or_add = checksums.nil? ? "add" : "update"
 
       checksums&.each(&bottle.method(:sha256))
-      output = bottle_output(bottle, args.download_strategy)
+      output = bottle_output(bottle, args.root_url_using)
       puts output
 
       case update_or_add

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -62,7 +62,7 @@ module Homebrew
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--root-url-using=",
-             description: "Use the specified download strategy for the root_url in the generated DSL via `using:' arg"
+             description: "Use the specified download strategy class for downloading the bottle's URL instead of Homebrew's default."
       flag   "--bintray-mirror=",
              description: "Use the specified Bintray repository to automatically mirror stable URLs "\
                           "defined in the formulae (default: `mirror`)."

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -61,8 +61,8 @@ module Homebrew
              description: "Target tap repository (default: `homebrew/core`)."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
-      flag   "--root-url-specs=",
-             description: "Append the specified specs to the root_url line in the generated DSL"
+      flag   "--download-strategy=",
+             description: "Use the specified download strategy for the root_url in the generated DSL"
       flag   "--bintray-mirror=",
              description: "Use the specified Bintray repository to automatically mirror stable URLs "\
                           "defined in the formulae (default: `mirror`)."
@@ -445,7 +445,7 @@ module Homebrew
           upload_args << "--warn-on-upload-failure" if args.warn_on_upload_failure?
           upload_args << "--committer=#{args.committer}" if args.committer
           upload_args << "--root-url=#{args.root_url}" if args.root_url
-          upload_args << "--root-url-specs=#{args.root_url_specs}" if args.root_url_specs
+          upload_args << "--download-strategy=#{args.download_strategy}" if args.download_strategy
           upload_args << if archive_item.present?
             "--archive-item=#{archive_item}"
           else

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -61,8 +61,8 @@ module Homebrew
              description: "Target tap repository (default: `homebrew/core`)."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
-      flag   "--download-strategy=",
-             description: "Use the specified download strategy for the root_url in the generated DSL"
+      flag   "--root-url-using=",
+             description: "Use the specified download strategy for the root_url in the generated DSL via `using:' arg"
       flag   "--bintray-mirror=",
              description: "Use the specified Bintray repository to automatically mirror stable URLs "\
                           "defined in the formulae (default: `mirror`)."
@@ -445,7 +445,7 @@ module Homebrew
           upload_args << "--warn-on-upload-failure" if args.warn_on_upload_failure?
           upload_args << "--committer=#{args.committer}" if args.committer
           upload_args << "--root-url=#{args.root_url}" if args.root_url
-          upload_args << "--download-strategy=#{args.download_strategy}" if args.download_strategy
+          upload_args << "--root-url-using=#{args.root_url_using}" if args.root_url_using
           upload_args << if archive_item.present?
             "--archive-item=#{archive_item}"
           else

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -62,7 +62,8 @@ module Homebrew
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--root-url-using=",
-             description: "Use the specified download strategy class for downloading the bottle's URL instead of Homebrew's default."
+             description: "Use the specified download strategy class for downloading the bottle's URL instead of "\
+                          "Homebrew's default."
       flag   "--bintray-mirror=",
              description: "Use the specified Bintray repository to automatically mirror stable URLs "\
                           "defined in the formulae (default: `mirror`)."

--- a/Library/Homebrew/dev-cmd/pr-pull.rb
+++ b/Library/Homebrew/dev-cmd/pr-pull.rb
@@ -61,6 +61,8 @@ module Homebrew
              description: "Target tap repository (default: `homebrew/core`)."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
+      flag   "--root-url-specs=",
+             description: "Append the specified specs to the root_url line in the generated DSL"
       flag   "--bintray-mirror=",
              description: "Use the specified Bintray repository to automatically mirror stable URLs "\
                           "defined in the formulae (default: `mirror`)."
@@ -443,6 +445,7 @@ module Homebrew
           upload_args << "--warn-on-upload-failure" if args.warn_on_upload_failure?
           upload_args << "--committer=#{args.committer}" if args.committer
           upload_args << "--root-url=#{args.root_url}" if args.root_url
+          upload_args << "--root-url-specs=#{args.root_url_specs}" if args.root_url_specs
           upload_args << if archive_item.present?
             "--archive-item=#{archive_item}"
           else

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -41,7 +41,7 @@ module Homebrew
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--root-url-using=",
-             description: "Use the specified download strategy for the root_url in the generated DSL via `using:' arg"
+             description: "Use the specified download strategy class for downloading the bottle's URL instead of Homebrew's default."
 
       named_args :none
     end

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -41,7 +41,8 @@ module Homebrew
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
       flag   "--root-url-using=",
-             description: "Use the specified download strategy class for downloading the bottle's URL instead of Homebrew's default."
+             description: "Use the specified download strategy class for downloading the bottle's URL instead of "\
+                          "Homebrew's default."
 
       named_args :none
     end

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -40,8 +40,8 @@ module Homebrew
              description: "Upload to the specified GitHub organisation's GitHub Packages (default: `homebrew`)."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
-      flag   "--download-strategy=",
-             description: "Use the specified download strategy for the root_url in the generated DSL"
+      flag   "--root-url-using=",
+             description: "Use the specified download strategy for the root_url in the generated DSL via `using:' arg"
 
       named_args :none
     end
@@ -116,7 +116,7 @@ module Homebrew
     bottle_args << "--root-url=#{args.root_url}" if args.root_url
     bottle_args << "--committer=#{args.committer}" if args.committer
     bottle_args << "--no-commit" if args.no_commit?
-    bottle_args << "--download-strategy=#{args.download_strategy}" if args.download_strategy
+    bottle_args << "--root-url-using=#{args.root_url_using}" if args.root_url_using
     bottle_args += json_files
 
     if args.dry_run?

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -40,8 +40,8 @@ module Homebrew
              description: "Upload to the specified GitHub organisation's GitHub Packages (default: `homebrew`)."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
-      flag   "--root-url-specs=",
-             description: "Append the specified specs to the root_url line in the generated DSL"
+      flag   "--download-strategy=",
+             description: "Use the specified download strategy for the root_url in the generated DSL"
 
       named_args :none
     end
@@ -116,7 +116,7 @@ module Homebrew
     bottle_args << "--root-url=#{args.root_url}" if args.root_url
     bottle_args << "--committer=#{args.committer}" if args.committer
     bottle_args << "--no-commit" if args.no_commit?
-    bottle_args << "--root-url-specs=#{args.root_url_specs}" if args.root_url_specs
+    bottle_args << "--download-strategy=#{args.download_strategy}" if args.download_strategy
     bottle_args += json_files
 
     if args.dry_run?

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -40,6 +40,8 @@ module Homebrew
              description: "Upload to the specified GitHub organisation's GitHub Packages (default: `homebrew`)."
       flag   "--root-url=",
              description: "Use the specified <URL> as the root of the bottle's URL instead of Homebrew's default."
+      flag   "--root-url-specs=",
+             description: "Append the specified specs to the root_url line in the generated DSL"
 
       named_args :none
     end
@@ -114,6 +116,7 @@ module Homebrew
     bottle_args << "--root-url=#{args.root_url}" if args.root_url
     bottle_args << "--committer=#{args.committer}" if args.committer
     bottle_args << "--no-commit" if args.no_commit?
+    bottle_args << "--root-url-specs=#{args.root_url_specs}" if args.root_url_specs
     bottle_args += json_files
 
     if args.dry_run?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This allows additional root_url specs to be provided with a custom root_url when `brew bottle` updates a formula. This addresses the feature request raised in #5424. Specifically, it makes it easier to support private taps that may need additional authentication to fetch artifacts.

As an alternative to this, I considered implementing a flag to accept a complete replacement bottle ERB template. This had the advantage of simplifying maintenance of this functionality from a homebrew maintainer perspective, while allowing for further arbitrary customizations of the bottle block. On the other hand, if the bottle template is likely to change significantly, users of this functionality could wind up with automated processes generating broken formulae until they update their bottle template, which also didn't seem awesome. But I'd be happy to implement this strategy if preferred-- either would work for me at the moment.