### PR TITLE
upgrade: fix broken dependents never being built from source

### DIFF
--- a/Library/Homebrew/upgrade.rb
+++ b/Library/Homebrew/upgrade.rb
@@ -302,7 +302,7 @@ module Homebrew
           formula,
           flags:                      flags,
           force_bottle:               force_bottle,
-          build_from_source_formulae: build_from_source_formulae + [formula],
+          build_from_source_formulae: build_from_source_formulae + [formula.full_name],
           interactive:                interactive,
           keep_tmp:                   keep_tmp,
           force:                      force,


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`build_from_source_formulae` is a list of `full_name` strings.