### PR TITLE
dev-cmd: add more --verbose bottle, pr-upload output.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -662,12 +662,15 @@ module Homebrew
 
               all_bottle_hash = { formula_name => all_bottle_formula_hash }
 
+              "Copying #{local_filename} to #{all_local_filename}" if args.verbose?
               FileUtils.cp local_filename, all_local_filename
+
               all_local_json_path = Pathname(all_local_json_filename)
               all_local_json_path.unlink if all_local_json_path.exist?
               all_local_json_path.write(JSON.pretty_generate(all_bottle_hash))
             end
 
+            "Removing #{local_filename} and #{local_json_filename}" if args.verbose?
             FileUtils.rm_f [local_filename, local_json_filename]
           end
         end

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -84,17 +84,18 @@ module Homebrew
     end
   end
 
-  def json_files_and_bottles_hash_(root_url)
+  def json_files_and_bottles_hash(args)
     json_files = Dir["*.bottle.json"]
     odie "No bottle JSON files found in the current working directory" if json_files.blank?
+    puts "Reading JSON files: #{json_files.join(", ")}" if args.verbose?
 
     bottles_hash = json_files.reduce({}) do |hash, json_file|
       hash.deep_merge(JSON.parse(File.read(json_file)))
     end
 
-    if root_url
+    if args.root_url
       bottles_hash.each_value do |bottle_hash|
-        bottle_hash["bottle"]["root_url"] = root_url
+        bottle_hash["bottle"]["root_url"] = args.root_url
       end
     end
 
@@ -104,7 +105,7 @@ module Homebrew
   def pr_upload
     args = pr_upload_args.parse
 
-    json_files, bottles_hash = json_files_and_bottles_hash_(args.root_url)
+    json_files, bottles_hash = json_files_and_bottles_hash(args)
 
     bottle_args = ["bottle", "--merge", "--write"]
     bottle_args << "--verbose" if args.verbose?
@@ -145,7 +146,7 @@ module Homebrew
 
     # Reload the JSON files (in case `brew bottle --merge` generated
     # `all: $SHA256` bottles)
-    _, bottles_hash = json_files_and_bottles_hash_(args.root_url)
+    _, bottles_hash = json_files_and_bottles_hash(args)
 
     # Check the bottle commits did not break `brew audit`
     unless args.no_commit?


### PR DESCRIPTION
This should make it easier to debug `all:` bottle upload failures.

While we're here, remove the weird `_` that ended up at the end of a method name.