### PR TITLE
dev-cmd/bottle: improve filename handling.

### DIFF
--- a/Library/Homebrew/.rubocop.yml
+++ b/Library/Homebrew/.rubocop.yml
@@ -33,7 +33,7 @@ Metrics/PerceivedComplexity:
 Metrics/MethodLength:
   Max: 260
 Metrics/ModuleLength:
-  Max: 600
+  Max: 610
   Exclude:
     - "test/**/*"
 


### PR DESCRIPTION
Rely more heavily on the `Bottle::Filename` class rather than hacking around things manually.

Without this the rebuilding bottles workflow is broken for `all:` bottles.