### PR TITLE
release_notes: append #PR to markdown link text

### DIFF
--- a/Library/Homebrew/release_notes.rb
+++ b/Library/Homebrew/release_notes.rb
@@ -19,8 +19,13 @@ module ReleaseNotes
     ).lines.grep(/Merge pull request/)
 
     log_output.map! do |s|
-      s.gsub(%r{.*Merge pull request #(\d+) from ([^/]+)/[^>]*(>>)*},
-             "https://github.com/Homebrew/brew/pull/\\1 (@\\2)")
+      matches = s.match(%r{.*Merge pull request #(?<pr>\d+) from (?<user>[^/]+)/[^>]*>> - (?<body>.*)})
+      body = if matches[:body].empty?
+        s.gsub(/.*(Merge pull request .*) >> - .*/, "\\1").chomp
+      else
+        matches[:body]
+      end
+      "https://github.com/Homebrew/brew/pull/#{matches[:pr]} (@#{matches[:user]}) - #{body}\n"
     end
 
     if markdown

--- a/Library/Homebrew/test/release_notes_spec.rb
+++ b/Library/Homebrew/test/release_notes_spec.rb
@@ -12,12 +12,15 @@ describe ReleaseNotes do
       system "git", "commit", "--allow-empty", "-m", "Merge pull request #1 from Homebrew/fix", "-m", "Do something"
       system "git", "commit", "--allow-empty", "-m", "make a change"
       system "git", "commit", "--allow-empty", "-m", "Merge pull request #2 from User/fix", "-m", "Do something else"
+      system "git", "commit", "--allow-empty", "-m", "another change"
+      system "git", "commit", "--allow-empty", "-m", "Merge pull request #3 from User/another_change"
     end
   end
 
   describe ".generate_release_notes" do
     it "generates release notes" do
       expect(described_class.generate_release_notes("release-notes-testing", "HEAD")).to eq <<~NOTES
+        https://github.com/Homebrew/brew/pull/3 (@User) - Merge pull request #3 from User/another_change
         https://github.com/Homebrew/brew/pull/2 (@User) - Do something else
         https://github.com/Homebrew/brew/pull/1 (@Homebrew) - Do something
       NOTES
@@ -25,6 +28,7 @@ describe ReleaseNotes do
 
     it "generates markdown release notes" do
       expect(described_class.generate_release_notes("release-notes-testing", "HEAD", markdown: true)).to eq <<~NOTES
+        - [Merge pull request #3 from User/another_change](https://github.com/Homebrew/brew/pull/3) (@User)
         - [Do something else](https://github.com/Homebrew/brew/pull/2) (@User)
         - [Do something](https://github.com/Homebrew/brew/pull/1) (@Homebrew)
       NOTES


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

I noticed in the [release notes for 3.1.4](https://github.com/Homebrew/brew/releases/tag/3.1.4) that some lines have an author name but no pull request. As of this writing, the release notes start with the following markdown code (reproduce with `brew ruby -rrelease_notes -e 'puts ReleaseNotes.generate_release_notes("3.1.3", "3.1.4", markdown: true)'`):

~~~
- [upgrade: fix broken dependents never being built from source](https://github.com/Homebrew/brew/pull/11263) (@Bo98)
- [Update maintainers, manpage and completions.](https://github.com/Homebrew/brew/pull/11261) (@Homebrew)
- [Allow man and prof Apple Silicon](https://github.com/Homebrew/brew/pull/11256) (@dtrodrigues)
- [Interesting-Taps-and-Forks.md: add gromgit/fuse](https://github.com/Homebrew/brew/pull/11255) (@gromgit)
- [docs: add Cask Cookbook](https://github.com/Homebrew/brew/pull/11249) (@SMillerDev)
- [dev-cmd/bottle: use gnu-tar universally, sort entries & use PAX](https://github.com/Homebrew/brew/pull/11253) (@Bo98)
- [](https://github.com/Homebrew/brew/pull/11129) (@SMillerDev)
~~~

Notice that the last line has a markdown link to #11129, but it is not rendered because it has no link text. I believe this is because the merge commit for that pull request https://github.com/Homebrew/brew/commit/afa99b49630614119321429c8e84b37941bd228d has only one line of description, while other merge commits, such as https://github.com/Homebrew/brew/commit/94ce3236a517dfae6b492dcb4fd6b726a6175e8f for https://github.com/Homebrew/brew/pull/11263, have an additional line of description.

There are 3 pull requests in 3.1.4 that have this issue. I don't know why these merge commits are like this. As a workaround, I've modified `release_notes.rb` to append an extra ` #11129` to the Markdown link text. With this change the beginning of the 3.1.4 release notes would have the following markdown:

~~~
- [upgrade: fix broken dependents never being built from source #11263](https://github.com/Homebrew/brew/pull/11263) (@Bo98)
- [Update maintainers, manpage and completions. #11261](https://github.com/Homebrew/brew/pull/11261) (@Homebrew)
- [Allow man and prof Apple Silicon #11256](https://github.com/Homebrew/brew/pull/11256) (@dtrodrigues)
- [Interesting-Taps-and-Forks.md: add gromgit/fuse #11255](https://github.com/Homebrew/brew/pull/11255) (@gromgit)
- [docs: add Cask Cookbook #11249](https://github.com/Homebrew/brew/pull/11249) (@SMillerDev)
- [dev-cmd/bottle: use gnu-tar universally, sort entries & use PAX #11253](https://github.com/Homebrew/brew/pull/11253) (@Bo98)
- [ #11129](https://github.com/Homebrew/brew/pull/11129) (@SMillerDev)
~~~