### PR TITLE
bottle: do not fail on missing bottle block

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -717,10 +717,7 @@ module Homebrew
 
   def old_checksums(formula, formula_ast, bottle_hash, args:)
     bottle_node = formula_ast.bottle_block
-    if bottle_node.nil?
-      odie "`--keep-old` was passed but there was no existing bottle block!" if args.keep_old?
-      return
-    end
+    return if bottle_node.nil?
     return [] unless args.keep_old?
 
     old_keys = Utils::AST.body_children(bottle_node.body).map(&:method_name)

--- a/Library/Homebrew/test/dev-cmd/bottle_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/bottle_spec.rb
@@ -273,25 +273,6 @@ describe "brew bottle" do
       EOS
     end
 
-    it "fails to add the bottle block to a formula that has no bottle block when using --keep-old" do
-      core_tap.path.cd do
-        system "git", "init"
-        setup_test_formula("testball")
-        system "git", "add", "--all"
-        system "git", "commit", "-m", "testball 0.1"
-      end
-
-      expect {
-        brew "bottle",
-             "--merge",
-             "--write",
-             "--keep-old",
-             "#{TEST_TMPDIR}/testball-1.0.arm64_big_sur.bottle.json",
-             "#{TEST_TMPDIR}/testball-1.0.big_sur.bottle.json",
-             "#{TEST_TMPDIR}/testball-1.0.catalina.bottle.json"
-      }.to output("Error: `--keep-old` was passed but there was no existing bottle block!\n").to_stderr
-    end
-
     it "updates the bottle block in a formula that already has a bottle block (old format) when using --keep-old" do
       core_tap.path.cd do
         system "git", "init"


### PR DESCRIPTION
For :all bottle blocks in linuxbrew-core, we are going to remove the bottle
block completely before rebottling.
In linuxbrew-core, we use --keep-old to keep the macOS sha lines.

I am not sure why this exception was written initially, but it
now prevents bottling these formulae, because we have no bottle block
and use --keep-old.

I think it's safe to just skip this check, when there is no bottle block
the old_checksum can just directly return nil.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
