### PR TITLE
services: fix array being flattened

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -121,20 +121,17 @@ module Homebrew
     sig { returns(T::Array[String]) }
     def command
       instance_eval(&@service_block)
-      @run.select { |i| i.is_a?(Pathname) }
-          .map(&:to_s)
+      @run.map(&:to_s)
     end
 
     # Returns a `String` plist.
     # @return [String]
     sig { returns(String) }
     def to_plist
-      instance_eval(&@service_block)
-
       base = {
         Label:            @formula.plist_name,
         RunAtLoad:        @run_type == RUN_TYPE_IMMEDIATE,
-        ProgramArguments: command.join,
+        ProgramArguments: command,
       }
 
       base[:KeepAlive] = @keep_alive if @keep_alive == true
@@ -150,15 +147,13 @@ module Homebrew
     # @return [String]
     sig { returns(String) }
     def to_systemd_unit
-      instance_eval(&@service_block)
-
       unit = <<~EOS
         [Unit]
         Description=Homebrew generated unit for #{@formula.name}
 
         [Service]
         Type=simple
-        ExecStart=#{command.join}
+        ExecStart=#{command.join(" ")}
       EOS
 
       options = []

--- a/Library/Homebrew/test/service_spec.rb
+++ b/Library/Homebrew/test/service_spec.rb
@@ -35,7 +35,7 @@ describe Homebrew::Service do
   describe "#to_plist" do
     it "returns valid plist" do
       f.class.service do
-        run opt_bin/"beanstalkd"
+        run [opt_bin/"beanstalkd", "test"]
         run_type :immediate
         environment_variables PATH: std_service_path_env
         error_log_path var/"log/beanstalkd.error.log"
@@ -45,46 +45,70 @@ describe Homebrew::Service do
       end
 
       plist = f.service.to_plist
-      expect(plist).to include("<key>Label</key>")
-      expect(plist).to include("<string>homebrew.mxcl.#{name}</string>")
-      expect(plist).to include("<key>KeepAlive</key>")
-      expect(plist).to include("<key>RunAtLoad</key>")
-      expect(plist).to include("<key>ProgramArguments</key>")
-      expect(plist).to include("<string>#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd</string>")
-      expect(plist).to include("<key>WorkingDirectory</key>")
-      expect(plist).to include("<string>#{HOMEBREW_PREFIX}/var</string>")
-      expect(plist).to include("<key>StandardOutPath</key>")
-      expect(plist).to include("<string>#{HOMEBREW_PREFIX}/var/log/beanstalkd.log</string>")
-      expect(plist).to include("<key>StandardErrorPath</key>")
-      expect(plist).to include("<string>#{HOMEBREW_PREFIX}/var/log/beanstalkd.error.log</string>")
-      expect(plist).to include("<key>EnvironmentVariables</key>")
-      expect(plist).to include("<key>PATH</key>")
-      expect(plist).to include("<string>#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:")
+      plist_expect = <<~EOS
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        \t<key>EnvironmentVariables</key>
+        \t<dict>
+        \t\t<key>PATH</key>
+        \t\t<string>#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        \t</dict>
+        \t<key>KeepAlive</key>
+        \t<true/>
+        \t<key>Label</key>
+        \t<string>homebrew.mxcl.formula_name</string>
+        \t<key>ProgramArguments</key>
+        \t<array>
+        \t\t<string>#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd</string>
+        \t\t<string>test</string>
+        \t</array>
+        \t<key>RunAtLoad</key>
+        \t<true/>
+        \t<key>StandardErrorPath</key>
+        \t<string>#{HOMEBREW_PREFIX}/var/log/beanstalkd.error.log</string>
+        \t<key>StandardOutPath</key>
+        \t<string>#{HOMEBREW_PREFIX}/var/log/beanstalkd.log</string>
+        \t<key>WorkingDirectory</key>
+        \t<string>#{HOMEBREW_PREFIX}/var</string>
+        </dict>
+        </plist>
+      EOS
+      expect(plist).to eq(plist_expect)
     end
 
     it "returns valid partial plist" do
       f.class.service do
-        run bin/"beanstalkd"
+        run opt_bin/"beanstalkd"
         run_type :immediate
       end
 
       plist = f.service.to_plist
-      expect(plist).to include("<string>homebrew.mxcl.#{name}</string>")
-      expect(plist).to include("<key>Label</key>")
-      expect(plist).not_to include("<key>KeepAlive</key>")
-      expect(plist).to include("<key>RunAtLoad</key>")
-      expect(plist).to include("<key>ProgramArguments</key>")
-      expect(plist).not_to include("<key>WorkingDirectory</key>")
-      expect(plist).not_to include("<key>StandardOutPath</key>")
-      expect(plist).not_to include("<key>StandardErrorPath</key>")
-      expect(plist).not_to include("<key>EnvironmentVariables</key>")
+      plist_expect = <<~EOS
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        \t<key>Label</key>
+        \t<string>homebrew.mxcl.formula_name</string>
+        \t<key>ProgramArguments</key>
+        \t<array>
+        \t\t<string>#{HOMEBREW_PREFIX}/opt/formula_name/bin/beanstalkd</string>
+        \t</array>
+        \t<key>RunAtLoad</key>
+        \t<true/>
+        </dict>
+        </plist>
+      EOS
+      expect(plist).to eq(plist_expect)
     end
   end
 
   describe "#to_systemd_unit" do
     it "returns valid unit" do
       f.class.service do
-        run opt_bin/"beanstalkd"
+        run [opt_bin/"beanstalkd", "test"]
         run_type :immediate
         environment_variables PATH: std_service_path_env
         error_log_path var/"log/beanstalkd.error.log"
@@ -94,15 +118,21 @@ describe Homebrew::Service do
       end
 
       unit = f.service.to_systemd_unit
-      expect(unit).to include("Description=Homebrew generated unit for formula_name")
-      expect(unit).to include("Type=simple")
-      expect(unit).to include("ExecStart=#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd")
-      expect(unit).to include("Restart=always")
-      expect(unit).to include("WorkingDirectory=#{HOMEBREW_PREFIX}/var")
-      expect(unit).to include("StandardOutput=append:#{HOMEBREW_PREFIX}/var/log/beanstalkd.log")
-      expect(unit).to include("StandardError=append:#{HOMEBREW_PREFIX}/var/log/beanstalkd.error.log")
       std_path = "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
-      expect(unit).to include("Environment=\"PATH=#{std_path}\"")
+      unit_expect = <<~EOS
+        [Unit]
+        Description=Homebrew generated unit for formula_name
+
+        [Service]
+        Type=simple
+        ExecStart=#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd test
+        Restart=always
+        WorkingDirectory=#{HOMEBREW_PREFIX}/var
+        StandardOutput=append:#{HOMEBREW_PREFIX}/var/log/beanstalkd.log
+        StandardError=append:#{HOMEBREW_PREFIX}/var/log/beanstalkd.error.log
+        Environment=\"PATH=#{std_path}\"
+      EOS
+      expect(unit).to eq(unit_expect.strip)
     end
 
     it "returns valid partial unit" do
@@ -112,27 +142,27 @@ describe Homebrew::Service do
       end
 
       unit = f.service.to_systemd_unit
-      expect(unit).to include("Description=Homebrew generated unit for formula_name")
-      expect(unit).to include("Type=simple")
-      expect(unit).to include("ExecStart=#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd")
-      expect(unit).not_to include("Restart=always")
-      expect(unit).not_to include("WorkingDirectory=#{HOMEBREW_PREFIX}/var")
-      expect(unit).not_to include("StandardOutput=append:#{HOMEBREW_PREFIX}/var/log/beanstalkd.log")
-      expect(unit).not_to include("StandardError=append:#{HOMEBREW_PREFIX}/var/log/beanstalkd.error.log")
-      std_path = "#{HOMEBREW_PREFIX}/bin:#{HOMEBREW_PREFIX}/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
-      expect(unit).not_to include("Environment=\"PATH=#{std_path}\"")
+      unit_expect = <<~EOS
+        [Unit]
+        Description=Homebrew generated unit for formula_name
+
+        [Service]
+        Type=simple
+        ExecStart=#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd
+      EOS
+      expect(unit).to eq(unit_expect)
     end
   end
 
   describe "#command" do
     it "returns @run data" do
       f.class.service do
-        run opt_bin/"beanstalkd"
+        run [opt_bin/"beanstalkd", "test"]
         run_type :immediate
       end
 
       command = f.service.command
-      expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd"])
+      expect(command).to eq(["#{HOMEBREW_PREFIX}/opt/#{name}/bin/beanstalkd", "test"])
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This should fix https://github.com/Homebrew/discussions/discussions/1372 the audit accidentally broke the PLIST generation because the test wasn't good enough to catch the expected format. That should be fixed now.