### PR TITLE
dev-cmd: run Homebrew.install_bundler_gems! earlier.

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -90,7 +90,10 @@ module Homebrew
   def bottle
     args = bottle_args.parse
 
-    return merge(args: args) if args.merge?
+    if args.merge?
+      Homebrew.install_bundler_gems!
+      return merge(args: args)
+    end
 
     ensure_relocation_formulae_installed! unless args.skip_relocation?
     args.named.to_resolved_formulae(uniq: false).each do |f|
@@ -718,9 +721,7 @@ module Homebrew
 
       next if no_bottle_changes
 
-      Homebrew.install_bundler_gems!
       require "utils/ast"
-
       formula_ast = Utils::AST::FormulaAST.new(path.read)
       checksums = old_checksums(formula, formula_ast, bottle_hash, args: args)
       update_or_add = checksums.nil? ? "add" : "update"

--- a/Library/Homebrew/dev-cmd/bump-cask-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-cask-pr.rb
@@ -60,6 +60,10 @@ module Homebrew
   def bump_cask_pr
     args = bump_cask_pr_args.parse
 
+    # This will be run by `brew style` later so run it first to not start
+    # spamming during normal output.
+    Homebrew.install_bundler_gems!
+
     # As this command is simplifying user-run commands then let's just use a
     # user path, too.
     ENV["PATH"] = ENV["HOMEBREW_PATH"]

--- a/Library/Homebrew/dev-cmd/bump-formula-pr.rb
+++ b/Library/Homebrew/dev-cmd/bump-formula-pr.rb
@@ -147,6 +147,10 @@ module Homebrew
     formula_spec = formula.stable
     odie "#{formula}: no stable specification found!" if formula_spec.blank?
 
+    # This will be run by `brew audit` later so run it first to not start
+    # spamming during normal output.
+    Homebrew.install_bundler_gems!
+
     tap_remote_repo, remote, remote_branch, previous_branch = use_correct_linux_tap(formula, args: args)
     check_open_pull_requests(formula, tap_remote_repo, args: args)
 

--- a/Library/Homebrew/dev-cmd/pr-upload.rb
+++ b/Library/Homebrew/dev-cmd/pr-upload.rb
@@ -146,6 +146,10 @@ module Homebrew
 
     check_bottled_formulae!(bottles_hash)
 
+    # This will be run by `brew bottle` and `brew audit` later so run it first
+    # to not start spamming during normal output.
+    Homebrew.install_bundler_gems!
+
     safe_system HOMEBREW_BREW_FILE, *bottle_args
 
     json_files = Dir["*.bottle.json"]


### PR DESCRIPTION
Run `Homebrew.install_bundler_gems!` a bit earlier for some developer commands to avoid printing gem installation output in the middle of normal developer command output.