### PR TITLE
Speed up version map

### DIFF
--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -30,7 +30,8 @@ class FormulaVersions
 
   def rev_list(branch)
     repository.cd do
-      Utils.popen_read("git", "rev-list", "--abbrev-commit", "--remove-empty", branch, "--", entry_name) do |io|
+      Utils.popen_read("git", "rev-list", "--abbrev-commit", "--remove-empty", "--first-parent", branch, "--",
+                       entry_name) do |io|
         yield io.readline.chomp until io.eof?
       end
     end

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -75,4 +75,20 @@ class FormulaVersions
     end
     map
   end
+
+  def latest_bottle_rebuild(branch, pkg_version)
+    map = Hash.new { |h, k| h[k] = [] }
+
+    rev_list(branch) do |rev|
+      formula_at_revision(rev) do |f|
+        bottle = f.bottle_specification
+        map[f.pkg_version] << bottle.rebuild unless bottle.checksums.empty?
+        return map[pkg_version] if f.pkg_version < pkg_version || !map[f.pkg_version].empty?
+      end
+    rescue MacOSVersionError => e
+      odebug "#{e} in #{name} at revision #{rev}"
+      break
+    end
+    map[pkg_version]
+  end
 end

--- a/Library/Homebrew/formula_versions.rb
+++ b/Library/Homebrew/formula_versions.rb
@@ -15,7 +15,7 @@ class FormulaVersions
     ErrorDuringExecution, LoadError, MethodDeprecatedError
   ].freeze
 
-  MAX_VERSIONS_DEPTH = 2
+  MAX_VERSIONS_DEPTH = 1
 
   attr_reader :name, :path, :repository, :entry_name
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Attempts to address #11281 in two ways:

* Stop looking at formula revisions after viewing all revisions of a single pkg_version
* Don't look at the formula at each individual commit pulled into master via a merge, only look at the formula at the point it was merged into master

This seems logically correct to me but probably need to find some formula with a convoluted history to test it on.

Here's a quick benchmark of getting the `bottle_version_map` (twice) for `python@3.8`:

```
Rehearsal ---------------------------------------------------------------------
depth=2 first_parent=false (orig)   0.028839   0.022891   8.828547 (  8.672422)
depth=1 first_parent=false          0.001221   0.004078   5.830595 (  5.843517)
depth=1 first_parent=true           0.001118   0.003426   5.817436 (  5.834915)
depth=2 first_parent=true           0.002547   0.004504   7.563878 (  7.584342)
latest_bottle_rebuild               0.000744   0.003529   4.737067 (  4.752579)
----------------------------------------------------------- total: 32.777523sec

                                        user     system      total        real
depth=2 first_parent=false (orig)   0.002320   0.004377   7.499702 (  7.518854)
depth=1 first_parent=false          0.001254   0.003911   5.797942 (  5.808991)
depth=1 first_parent=true           0.001219   0.003896   5.851955 (  5.882971)
depth=2 first_parent=true           0.002558   0.004528   7.528107 (  7.550281)
latest_bottle_rebuild               0.000699   0.003799   4.707501 (  4.726870)
```

`depth=1 first_parent=true` is the proposed alternative for bottle_version_map. Not a groundbreaking improvement, but better. latest_bottle_rebuild is an even more aggressive version that takes a specific pkg_version and stops after it finds the first bottled revision for that pkg_version (or first encounters an earlier pkg_version).