### PR TITLE
Improve suggestions for depends_on_java

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -114,7 +114,7 @@ module Cask
             #{@cask} requires Java. You can install the latest version with:
               brew install --cask adoptopenjdk
           EOS
-        elsif java_version.include?("11") || java_version.include?("+")
+        elsif java_version.include?("+")
           <<~EOS
             #{@cask} requires Java #{java_version}. You can install the latest version with:
               brew install --cask adoptopenjdk


### PR DESCRIPTION
The current behavior of the `depends_on_java` stanza has 3 shortcomings:

1. The caveat is hardcoded to treat a dependency on Java `11` as a dependency on the *latest* Java. That is no longer a correct assumption, as Java 16 is the latest version. 
2. When a caveat lists a specific version (without the `+` quantifier), Homebrew advises users to install that version of `adoptopenjdk` from `cask-versions`. However, `cask-versions` only has `adoptopenjdk8`, not the full array of versions (8-16, etc.). Only the `adoptopenjdk/openjdk` tap has the full array. 
3. The caveat doesn't handle an array of versions (e.g., `depends_on_java ["8", "11"]`) particularly gracefully. The URL it constructs outputs the array instead of per-version URLs (i.e., `adoptopenjdk["8", "11"]` instead of `adoptopenjdk8` and `adoptopenjdk11`).

This PR fixes issues the first two issues above:

1. Rather than having to track Java stable releases, this PR removes the hardcoded reference to Java 11. Any cask with the stanza using `11+` (or `12+`, for example), will be told how to install the *latest* version:

    > ... requires Java 11+. You can install the latest version with:
    >
    >     brew install --cask adoptopenjdk

2. However, a stanza without the `+` will be told to install a *specific* version - which now conforms to https://github.com/Homebrew/homebrew-cask/pull/54074/files:

    > ... requires Java 11. You can install it with:
    >
    >     brew tap adoptopenjdk/openjdk
    >     brew install --cask adoptopenjdk11

3. Unfortunately, my Ruby skills are too limited to fix the 3rd issue above - the presentation of arrays. Ideally, we could take the array described by @vitorgalvao in https://github.com/Homebrew/homebrew-cask/issues/16383 and output sample installation commands for each version, instead of what would appear for the [exist-db](https://github.com/Homebrew/homebrew-cask/blob/18a57bc3823eee078c7ce339f58fb9b31bcf9925/Casks/exist-db.rb#L16) cask:

    > exist-db requires Java ["8", "11"]. You can install it with:
    >
    >     brew tap adoptopenjdk/openjdk
    >     brew install --cask adoptopenjdk["8", "11"]

    A better output would be:

    > exist-db requires Java 8 or 11. You can install it with:
    >
    >     brew tap adoptopenjdk/openjdk
    >
    > and one of the following, depending on the desired version: 
    >
    >     brew install --cask adoptopenjdk8
    >     brew install --cask adoptopenjdk11

    I would welcome anyone with Ruby skills to contribute a fix to this issue, either in this PR or in a follow-on PR.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
    **Note:** My apologies. I lack the Ruby skills to write tests for this PR.
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
    **Note:** regarding `brew tests`, running it on my branch failed (see `brew config` output below), but the log does not appear to fail due to anything changed in my PR. See the console log: [brew-tests-log.txt.zip](https://github.com/Homebrew/brew/files/6402096/brew-tests-log.txt.zip)

My `brew config`:

```text
HOMEBREW_VERSION: 3.1.5-2-g05fe138
ORIGIN: https://github.com/Homebrew/brew
HEAD: 05fe138bae3bde404e5beb05482952205d9df65c
Last commit: 6 minutes ago
Core tap ORIGIN: https://github.com/Homebrew/homebrew-core
Core tap HEAD: db2cd52c78fc9ba01fa8ff65e9bdc6e2028c4b7d
Core tap last commit: 79 minutes ago
Core tap branch: master
HOMEBREW_PREFIX: /usr/local
HOMEBREW_CASK_OPTS: []
HOMEBREW_EDITOR: nano
HOMEBREW_MAKE_JOBS: 16
Homebrew Ruby: 2.6.3 => /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/bin/ruby
CPU: 16-core 64-bit dunno
Clang: 12.0 build 1205
Git: 2.31.1 => /usr/local/bin/git
Curl: 7.64.1 => /usr/bin/curl
macOS: 11.3-x86_64
CLT: 12.5.0.22.9
Xcode: 12.5
```