### PR TITLE
extend/pathname: limit `write` override to a refinement 

### DIFF
--- a/Library/Homebrew/build.rb
+++ b/Library/Homebrew/build.rb
@@ -171,6 +171,7 @@ class Build
           interactive_shell(formula)
         else
           formula.prefix.mkpath
+          formula.logs.mkpath
 
           (formula.logs/"00.options.out").write \
             "#{formula.full_name} #{formula.build.used_options.sort.join(" ")}".strip

--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -215,6 +215,7 @@ module Homebrew
       path.delete
     end
     ohai "Writing formula for #{name} from revision #{rev} to:", path
+    path.dirname.mkpath
     path.write result
   end
 

--- a/Library/Homebrew/extend/pathname.rb
+++ b/Library/Homebrew/extend/pathname.rb
@@ -165,19 +165,6 @@ class Pathname
   end
   private :install_symlink_p
 
-  # @private
-  alias old_write write
-
-  # We assume this pathname object is a file, obviously.
-  sig { params(content: String, offset: Integer, open_args: T::Hash[Symbol, T.untyped]).returns(Integer) }
-  def write(content, offset = 0, open_args = {})
-    raise "Will not overwrite #{self}" if exist?
-
-    dirname.mkpath
-
-    old_write(content, offset, open_args)
-  end
-
   # Only appends to a file that is already created.
   sig { params(content: String, open_args: T.untyped).void }
   def append_lines(content, **open_args)
@@ -420,6 +407,7 @@ class Pathname
     ).returns(Integer)
   }
   def write_jar_script(target_jar, script_name, java_opts = "", java_version: nil)
+    mkpath
     (self/script_name).write <<~EOS
       #!/bin/bash
       export JAVA_HOME="#{Language::Java.overridable_java_home_env(java_version)[:JAVA_HOME]}"

--- a/Library/Homebrew/formula_creator.rb
+++ b/Library/Homebrew/formula_creator.rb
@@ -87,6 +87,7 @@ module Homebrew
         end
       end
 
+      path.dirname.mkpath
       path.write ERB.new(template, trim_mode: ">").result(binding)
     end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -47,6 +47,20 @@ module Formulary
     super
   end
 
+  # @private
+  module PathnameWriteMkpath
+    refine Pathname do
+      def write(content, offset = nil, **open_args)
+        raise "Will not overwrite #{self}" if exist? && !offset && !open_args[:mode]&.match?(/^a\+?$/)
+
+        dirname.mkpath
+
+        super
+      end
+    end
+  end
+
+  using PathnameWriteMkpath
   def self.load_formula(name, path, contents, namespace, flags:, ignore_errors:)
     raise "Formula loading disabled by HOMEBREW_DISABLE_LOAD_FORMULA!" if Homebrew::EnvConfig.disable_load_formula?
 

--- a/Library/Homebrew/test/completions_spec.rb
+++ b/Library/Homebrew/test/completions_spec.rb
@@ -27,11 +27,16 @@ describe Homebrew::Completions do
 
   context "when linking or unlinking completions" do
     def setup_completions(external:)
-      (internal_path/"completions/bash/foo_internal").write "#foo completions"
+      internal_bash_completion = internal_path/"completions/bash"
+      external_bash_completion = external_path/"completions/bash"
+
+      internal_bash_completion.mkpath
+      (internal_bash_completion/"foo_internal").write "#foo completions"
       if external
-        (external_path/"completions/bash/foo_external").write "#foo completions"
-      elsif (external_path/"completions/bash/foo_external").exist?
-        (external_path/"completions/bash/foo_external").delete
+        external_bash_completion.mkpath
+        (external_bash_completion/"foo_external").write "#foo completions"
+      elsif (external_bash_completion/"foo_external").exist?
+        (external_bash_completion/"foo_external").delete
       end
     end
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -833,6 +833,7 @@ module Homebrew
       let(:formula_path) { tap_path/formula_subpath }
 
       before do
+        origin_formula_path.dirname.mkpath
         origin_formula_path.write <<~RUBY
           class Foo#{foo_version} < Formula
             url "https://brew.sh/foo-1.0.tar.gz"

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -57,6 +57,7 @@ describe Formulary do
 
   describe "::factory" do
     before do
+      formula_path.dirname.mkpath
       formula_path.write formula_content
     end
 
@@ -194,6 +195,7 @@ describe Formulary do
       end
 
       it "raises an error if a Formula is in multiple Taps" do
+        another_tap.path.mkpath
         (another_tap.path/"#{formula_name}.rb").write formula_content
 
         expect {

--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -63,19 +63,6 @@ describe Pathname do
     end
   end
 
-  describe "#write" do
-    it "creates a file and writes to it" do
-      expect(file).not_to exist
-      file.write("CONTENT")
-      expect(File.read(file)).to eq("CONTENT")
-    end
-
-    it "raises an error if the file already exists" do
-      touch file
-      expect { file.write("CONTENT") }.to raise_error(RuntimeError)
-    end
-  end
-
   describe "#append_lines" do
     it "appends lines to a file" do
       touch file

--- a/Library/Homebrew/test/tab_spec.rb
+++ b/Library/Homebrew/test/tab_spec.rb
@@ -348,6 +348,7 @@ describe Tab do
     end
 
     it "can create a Tab for a Formula with an outdated Kegs" do
+      f.prefix.mkpath
       f_tab_path.write f_tab_content
 
       f2 = formula { url "foo-2.0" }

--- a/Library/Homebrew/test/tap_spec.rb
+++ b/Library/Homebrew/test/tap_spec.rb
@@ -23,6 +23,7 @@ describe Tap do
   end
 
   def setup_tap_files
+    formula_file.dirname.mkpath
     formula_file.write <<~RUBY
       class Foo < Formula
         url "https://brew.sh/foo-1.0.tar.gz"
@@ -41,6 +42,8 @@ describe Tap do
     JSON
 
     %w[audit_exceptions style_exceptions].each do |exceptions_directory|
+      (path/exceptions_directory).mkpath
+
       (path/"#{exceptions_directory}/formula_list.json").write <<~JSON
         [ "foo", "bar" ]
       JSON
@@ -516,6 +519,7 @@ describe Tap do
     specify "files" do
       path = Tap::TAP_DIRECTORY/"homebrew/homebrew-core"
       formula_file = core_tap.formula_dir/"foo.rb"
+      core_tap.formula_dir.mkpath
       formula_file.write <<~RUBY
         class Foo < Formula
           url "https://brew.sh/foo-1.0.tar.gz"
@@ -531,6 +535,7 @@ describe Tap do
         style_exceptions/formula_hash.json
         pypi_formula_mappings.json
       ].each do |file|
+        (path/file).dirname.mkpath
         (path/file).write formula_list_file_json
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The original purpose of this method was for pre-2.1 Rubies which did not have such a method.

Nowadays, this was actively breaking things:
* Passing an "open arg" without an offset was broken and causes errors.
* Passing an offset is useless and non-functional because overwriting was blocked.
* Performing `Pathname#write(string, mode: "a")` was also incorrectly blocked.