### PR TITLE
bottle: properly set rebuild for new formulae

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -341,6 +341,8 @@ module Homebrew
         end
       end
     end
+    # FormulaVersions#formula_at_revision returns nil for new formulae
+    rebuild ||= 0
 
     filename = Bottle::Filename.create(f, bottle_tag.to_sym, rebuild)
     local_filename = filename.to_s

--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -339,10 +339,8 @@ module Homebrew
         else
           0
         end
-      end
+      end || 0
     end
-    # FormulaVersions#formula_at_revision returns nil for new formulae
-    rebuild ||= 0
 
     filename = Bottle::Filename.create(f, bottle_tag.to_sym, rebuild)
     local_filename = filename.to_s


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #11293

As mentioned in https://github.com/Homebrew/brew/pull/11293#issuecomment-832232012 (and seen in https://github.com/Homebrew/homebrew-core/pull/76617), the changes to the handling of bottle rebuild values broke for new formulae. This is because `FormulaVersions#formula_at_revision` returns `nil` if the formula doesn't exist at the given ref (`origin/HEAD`). Since that's the case for new formulae, `nil` was returned and the fallback to zero was never encountered. This PR adds a final fallback so that no matter what, the bottle rebuild will end up being zero if not set before.
