### PR TITLE
utils/ruby.sh: fix Ruby path searching

### DIFF
--- a/Library/Homebrew/utils/ruby.sh
+++ b/Library/Homebrew/utils/ruby.sh
@@ -15,14 +15,15 @@ test_ruby() {
 
 # HOMEBREW_MACOS is set by brew.sh
 # HOMEBREW_PATH is set by global.rb
-# shellcheck disable=SC2154
+# SC2230 falsely flags `which -a`
+# shellcheck disable=SC2154,SC2230
 find_ruby() {
   if [[ -n "${HOMEBREW_MACOS}" ]]
   then
     echo "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby"
   else
     IFS=$'\n' # Do word splitting on new lines only
-    for ruby_exec in $(command -v -a ruby 2>/dev/null) $(PATH=${HOMEBREW_PATH} command -v -a ruby 2>/dev/null)
+    for ruby_exec in $(which -a ruby 2>/dev/null) $(PATH=${HOMEBREW_PATH} which -a ruby 2>/dev/null)
     do
       if test_ruby "${ruby_exec}"; then
         echo "${ruby_exec}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`command -a` is invalid.

(This doesn't cover the concerns I had under env filtering - it's just something else I noticed when trying to workaround with a symlink to `/usr/bin`.)