### PR TITLE
extend/os/mac/keg_relocate: implement `RPATH` relocation

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -35,6 +35,18 @@ class Keg
 
           change_install_name(old_name, new_name, file) if new_name
         end
+
+        if ENV["HOMEBREW_RELOCATE_RPATHS"]
+          each_rpath_for(file) do |old_name|
+            if old_name.start_with? relocation.old_cellar
+              new_name = old_name.sub(relocation.old_cellar, relocation.new_cellar)
+            elsif old_name.start_with? relocation.old_prefix
+              new_name = old_name.sub(relocation.old_prefix, relocation.new_prefix)
+            end
+
+            change_rpath(old_name, new_name, file) if new_name
+          end
+        end
       end
     end
   end
@@ -109,6 +121,12 @@ class Keg
     dylibs.reject! { |fn| fn =~ /^@(loader|executable)_path/ }
     dylibs.reject! { |fn| fn =~ /^@rpath/ } unless ENV["HOMEBREW_RELOCATE_METAVARS"]
     dylibs.each(&block)
+  end
+
+  def each_rpath_for(file, &block)
+    rpaths = file.rpaths
+    rpaths.reject! { |fn| fn =~ /^@(loader|executable)_path/ }
+    rpaths.each(&block)
   end
 
   def dylib_id_for(file)

--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -38,10 +38,10 @@ class Keg
 
         if ENV["HOMEBREW_RELOCATE_RPATHS"]
           each_rpath_for(file) do |old_name|
-            if old_name.start_with? relocation.old_cellar
-              new_name = old_name.sub(relocation.old_cellar, relocation.new_cellar)
+            new_name = if old_name.start_with? relocation.old_cellar
+              old_name.sub(relocation.old_cellar, relocation.new_cellar)
             elsif old_name.start_with? relocation.old_prefix
-              new_name = old_name.sub(relocation.old_prefix, relocation.new_prefix)
+              old_name.sub(relocation.old_prefix, relocation.new_prefix)
             end
 
             change_rpath(old_name, new_name, file) if new_name
@@ -125,7 +125,7 @@ class Keg
 
   def each_rpath_for(file, &block)
     rpaths = file.rpaths
-    rpaths.reject! { |fn| fn =~ /^@(loader|executable)_path/ }
+                 .reject { |fn| fn =~ /^@(loader|executable)_path/ }
     rpaths.each(&block)
   end
 

--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -34,6 +34,22 @@ class Keg
     raise
   end
 
+  def change_rpath(old, new, file)
+    return if old == new
+
+    @require_relocation = true
+    odebug "Changing rpath in #{file}\n  from #{old}\n    to #{new}"
+    MachO::Tools.change_rpath(file, old, new, strict: false)
+    apply_ad_hoc_signature(file)
+  rescue MachO::MachOError
+    onoe <<~EOS
+      Failed changing rpath in #{file}
+        from #{old}
+          to #{new}
+    EOS
+    raise
+  end
+
   def apply_ad_hoc_signature(file)
     return if MacOS.version < :big_sur
     return unless Hardware::CPU.arm?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This implements `RPATH` relocation on macOS.

I've tested this successfully locally, but I've gated this behind `HOMEBREW_RELOCATE_RPATHS` for now so that I can test this with various formulae in an external tap when this is merged.

Using a bottled `hello`, built with the appropriate `LDFLAGS` to create an `LC_RPATH` entry:
```
❯ otool -l ./hello | rg -A2 LC_RPATH
          cmd LC_RPATH
      cmdsize 48
         path @@HOMEBREW_PREFIX@@/opt/llvm/lib (offset 12)
```

After pouring the bottle:
```
❯ otool -l $(brew --prefix hello)/bin/hello | rg -A2 LC_RPATH
          cmd LC_RPATH
      cmdsize 40
         path /usr/local/opt/llvm/lib (offset 12)
```

See #11329.