### PR TITLE
Support alternate container registries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@
 **/vendor/bundle/ruby/*/gems/i18n-*/lib/i18n/tests*
 **/vendor/bundle/ruby/*/gems/mechanize-*/lib/*.rb
 **/vendor/bundle/ruby/*/gems/mechanize-*/lib/mechanize/http/agent.rb
-**/vendor/bundle/ruby/*/gems/mechanize-*/lib/mechanize/http/*auth*.rb
+**/vendor/bundle/ruby/*/gems/mechanize-*/lib/mechanize/http/auth_store.rb
 **/vendor/bundle/ruby/*/gems/mechanize-*/lib/mechanize/c*
 **/vendor/bundle/ruby/*/gems/mechanize-*/lib/mechanize/d*
 **/vendor/bundle/ruby/*/gems/mechanize-*/lib/mechanize/e*

--- a/Library/Homebrew/github_packages.rb
+++ b/Library/Homebrew/github_packages.rb
@@ -13,13 +13,13 @@ class GitHubPackages
   include Context
 
   URL_DOMAIN = "ghcr.io"
-  URL_PREFIX = "https://#{URL_DOMAIN}/v2/"
-  DOCKER_PREFIX = "docker://#{URL_DOMAIN}/"
+  URL_PREFIX = "https://#{URL_DOMAIN}/v2"
+  DOCKER_PREFIX = "docker://"
   private_constant :URL_DOMAIN
   private_constant :URL_PREFIX
   private_constant :DOCKER_PREFIX
 
-  URL_REGEX = %r{(?:#{Regexp.escape(URL_PREFIX)}|#{Regexp.escape(DOCKER_PREFIX)})([\w-]+)/([\w-]+)}.freeze
+  URL_REGEX = %r{(#{Regexp.escape(URL_PREFIX)}|#{Regexp.escape(DOCKER_PREFIX)}[^/]+)/([\w-]+)/([\w-]+)}.freeze
 
   # Translate Homebrew tab.arch to OCI platform.architecture
   TAB_ARCH_TO_PLATFORM_ARCHITECTURE = {
@@ -109,16 +109,16 @@ class GitHubPackages
     # docker/skopeo insist on lowercase org ("repository name")
     org = org.downcase
 
-    "#{prefix}#{org}/#{repo_without_prefix(repo)}"
+    "#{prefix}/#{org}/#{repo_without_prefix(repo)}"
   end
 
   def self.root_url_if_match(url)
     return if url.blank?
 
-    _, org, repo, = *url.to_s.match(URL_REGEX)
-    return if org.blank? || repo.blank?
+    _, prefix, org, repo, = *url.to_s.match(URL_REGEX)
+    return if prefix.blank? || org.blank? || repo.blank?
 
-    root_url(org, repo)
+    root_url(org, repo, prefix)
   end
 
   def self.image_formula_name(formula_name)

--- a/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/mechanize-2.8.0/lib/mechanize/http/auth_challenge.rb
+++ b/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/mechanize-2.8.0/lib/mechanize/http/auth_challenge.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+class Mechanize::HTTP
+
+  AuthChallenge = Struct.new :scheme, :params, :raw
+
+  ##
+  # A parsed WWW-Authenticate header
+
+  class AuthChallenge
+
+    ##
+    # :attr_accessor: scheme
+    #
+    # The authentication scheme
+
+    ##
+    # :attr_accessor: params
+    #
+    # The authentication parameters
+
+    ##
+    # :method: initialize
+    #
+    # :call-seq:
+    #   initialize(scheme = nil, params = nil)
+    #
+    # Creates a new AuthChallenge header with the given scheme and parameters
+
+    ##
+    # Retrieves +param+ from the params list
+
+    def [] param
+      params[param]
+    end
+
+    ##
+    # Constructs an AuthRealm for this challenge
+
+    def realm uri
+      case scheme
+      when 'Basic' then
+        raise ArgumentError, "provide uri for Basic authentication" unless uri
+        Mechanize::HTTP::AuthRealm.new scheme, uri + '/', self['realm']
+      when 'Digest' then
+        Mechanize::HTTP::AuthRealm.new scheme, uri + '/', self['realm']
+      else
+        raise Mechanize::Error, "unknown HTTP authentication scheme #{scheme}"
+      end
+    end
+
+    ##
+    # The name of the realm for this challenge
+
+    def realm_name
+      params['realm'] if Hash === params # NTLM has a string for params
+    end
+
+    ##
+    # The raw authentication challenge
+
+    alias to_s raw
+
+  end
+
+end
+

--- a/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/mechanize-2.8.0/lib/mechanize/http/auth_realm.rb
+++ b/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/mechanize-2.8.0/lib/mechanize/http/auth_realm.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class Mechanize::HTTP::AuthRealm
+
+  attr_reader :scheme
+  attr_reader :uri
+  attr_reader :realm
+
+  def initialize scheme, uri, realm
+    @scheme = scheme
+    @uri    = uri
+    @realm  = realm if realm
+  end
+
+  def == other
+    self.class === other and
+      @scheme == other.scheme and
+      @uri    == other.uri    and
+      @realm  == other.realm
+  end
+
+  alias eql? ==
+
+  def hash # :nodoc:
+    [@scheme, @uri, @realm].hash
+  end
+
+  def inspect # :nodoc:
+    "#<AuthRealm %s %p \"%s\">" % [@scheme, @uri, @realm]
+  end
+
+end
+

--- a/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/mechanize-2.8.0/lib/mechanize/http/www_authenticate_parser.rb
+++ b/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/mechanize-2.8.0/lib/mechanize/http/www_authenticate_parser.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'strscan'
+
+##
+# Parses the WWW-Authenticate HTTP header into separate challenges.
+
+class Mechanize::HTTP::WWWAuthenticateParser
+
+  attr_accessor :scanner # :nodoc:
+
+  ##
+  # Creates a new header parser for WWW-Authenticate headers
+
+  def initialize
+    @scanner = nil
+  end
+
+  ##
+  # Parsers the header.  Returns an Array of challenges as strings
+
+  def parse www_authenticate
+    challenges = []
+    @scanner = StringScanner.new www_authenticate
+
+    while true do
+      break if @scanner.eos?
+      start = @scanner.pos
+      challenge = Mechanize::HTTP::AuthChallenge.new
+
+      scheme = auth_scheme
+
+      if scheme == 'Negotiate'
+        scan_comma_spaces
+      end
+
+      break unless scheme
+      challenge.scheme = scheme
+
+      space = spaces
+
+      if scheme == 'NTLM' then
+        if space then
+          challenge.params = @scanner.scan(/.*/)
+        end
+
+        challenge.raw = www_authenticate[start, @scanner.pos]
+        challenges << challenge
+        next
+      else
+        scheme.capitalize!
+      end
+
+      next unless space
+
+      params = {}
+
+      while true do
+        pos = @scanner.pos
+        name, value = auth_param
+
+        name.downcase! if name =~ /^realm$/i
+
+        unless name then
+          challenge.params = params
+          challenges << challenge
+
+          if @scanner.eos? then
+            challenge.raw = www_authenticate[start, @scanner.pos]
+            break
+          end
+
+          @scanner.pos = pos # rewind
+          challenge.raw = www_authenticate[start, @scanner.pos].sub(/(,+)? *$/, '')
+          challenge = nil # a token should be next, new challenge
+          break
+        else
+          params[name] = value
+        end
+
+        spaces
+
+        @scanner.scan(/(, *)+/)
+      end
+    end
+
+    challenges
+  end
+
+  ##
+  #   1*SP
+  #
+  # Parses spaces
+
+  def spaces
+    @scanner.scan(/ +/)
+  end
+
+  ##
+  # scans a comma followed by spaces
+  # needed for Negotiation, NTLM
+  #
+
+  def scan_comma_spaces
+    @scanner.scan(/, +/)
+  end
+
+  ##
+  #   token = 1*<any CHAR except CTLs or separators>
+  #
+  # Parses a token
+
+  def token
+    @scanner.scan(/[^\000-\037\177()<>@,;:\\"\/\[\]?={} ]+/)
+  end
+
+  ##
+  #   auth-scheme = token
+  #
+  # Parses an auth scheme (a token)
+
+  alias auth_scheme token
+
+  ##
+  #   auth-param = token "=" ( token | quoted-string )
+  #
+  # Parses an auth parameter
+
+  def auth_param
+    return nil unless name = token
+    return nil unless @scanner.scan(/ *= */)
+
+    value = if @scanner.peek(1) == '"' then
+              quoted_string
+            else
+              token
+            end
+
+    return nil unless value
+
+    return name, value
+  end
+
+  ##
+  #   quoted-string = ( <"> *(qdtext | quoted-pair ) <"> )
+  #   qdtext        = <any TEXT except <">>
+  #   quoted-pair   = "\" CHAR
+  #
+  # For TEXT, the rules of RFC 2047 are ignored.
+
+  def quoted_string
+    return nil unless @scanner.scan(/"/)
+
+    text = String.new
+
+    while true do
+      chunk = @scanner.scan(/[\r\n \t\x21\x23-\x7e\u0080-\u00ff]+/) # not " which is \x22
+
+      if chunk then
+        text << chunk
+
+        text << @scanner.get_byte if
+          chunk.end_with? '\\' and '"' == @scanner.peek(1)
+      else
+        if '"' == @scanner.peek(1) then
+          @scanner.get_byte
+          break
+        else
+          return nil
+        end
+      end
+    end
+
+    text
+  end
+
+end
+


### PR DESCRIPTION
Addresses #11287.

Generalizes the Github Container Registry code to enable other container registries by specifying a `HOMEBREW_BOTTLE_DOMAIN` with the `docker://` scheme.

## Authentication changes
- Only Bearer auth is implemented (not Basic) for anonymous access (no username/password).
- Authentication works by catching HTTP 401 responses when fetching container image resources 
- Bearer tokens are re-used when possible

## Bottle download changes
- Fetch the platform-specific manifest is as well so that registries which use on-demand mirroring (e.g. Artifactory) can fetch the blobs from that manifest
- Set the "Accept" header based on the content type specified in the manifest to accommodate registries that expect it

-----

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
