### PR TITLE
audit: Remove SYMROOT

### DIFF
--- a/Library/Homebrew/rubocops/text.rb
+++ b/Library/Homebrew/rubocops/text.rb
@@ -53,12 +53,6 @@ module RuboCop
             problem "\"Formula.factory(name)\" is deprecated in favor of \"Formula[name]\""
           end
 
-          find_every_method_call_by_name(body_node, :xcodebuild).each do |m|
-            next if parameters_passed?(m, /SYMROOT=/)
-
-            problem 'xcodebuild should be passed an explicit "SYMROOT"'
-          end
-
           find_method_with_args(body_node, :system, "xcodebuild") do
             problem %q(use "xcodebuild *args" instead of "system 'xcodebuild', *args")
           end

--- a/Library/Homebrew/test/rubocops/text_spec.rb
+++ b/Library/Homebrew/test/rubocops/text_spec.rb
@@ -71,32 +71,6 @@ describe RuboCop::Cop::FormulaAudit::Text do
       RUBY
     end
 
-    it "reports an offense if xcodebuild is called without SYMROOT" do
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          url "https://brew.sh/foo-1.0.tgz"
-          homepage "https://brew.sh"
-
-          def install
-            xcodebuild "-project", "meow.xcodeproject"
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ xcodebuild should be passed an explicit \"SYMROOT\"
-          end
-        end
-      RUBY
-
-      expect_offense(<<~RUBY)
-        class Foo < Formula
-          url "https://brew.sh/foo-1.0.tgz"
-          homepage "https://brew.sh"
-
-          def install
-            xcodebuild
-            ^^^^^^^^^^ xcodebuild should be passed an explicit \"SYMROOT\"
-          end
-        end
-      RUBY
-    end
-
     it "reports an offense if `go get` is executed" do
       expect_offense(<<~RUBY)
         class Foo < Formula


### PR DESCRIPTION
`SYMROOT` is only a valid argument when `-project` is used.

xcodebuild has other uses than building Xcode projects.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Here is an example of the current behavior incorrectly falling an audit for correct usage of xcodebuild https://github.com/Homebrew/homebrew-core/pull/76696 due to not using `SYMROOT`

Here is the output from xcodebuild if you pass `SYMROOT` when not passing `-project`
```
xcodebuild
-quiet
-create-xcframework
-output
SPIRVCross.xcframework
-library
External/build/Intermediates/XCFrameworkStaging/Release/Platform/libSPIRVCross.a
SYMROOT=External/build/Latest

error: invalid argument 'SYMROOT=External/build/Latest'.
```