### PR TITLE
pathname: convert Cellar to opt paths before symlinking

### DIFF
--- a/Library/Homebrew/test/pathname_spec.rb
+++ b/Library/Homebrew/test/pathname_spec.rb
@@ -42,6 +42,24 @@ describe Pathname do
     end
   end
 
+  describe "#to_opt" do
+    context "when called on a descendant of HOMEBREW_CELLAR" do
+      it "returns the equivalent opt path" do
+        expect((HOMEBREW_CELLAR/"foo/1.2.3/lib/libfoo.so").to_opt).to eq(HOMEBREW_PREFIX/"opt/foo/lib/libfoo.so")
+        expect((HOMEBREW_CELLAR/"foo/1.2.3/lib").to_opt).to eq(HOMEBREW_PREFIX/"opt/foo/lib")
+        expect((HOMEBREW_CELLAR/"foo/1.2.3").to_opt).to eq(HOMEBREW_PREFIX/"opt/foo")
+        expect((HOMEBREW_CELLAR/"foo").to_opt).to eq(HOMEBREW_PREFIX/"opt/foo")
+        expect(HOMEBREW_CELLAR.to_opt).to eq(HOMEBREW_PREFIX/"opt")
+      end
+    end
+
+    context "when called on a path outside of HOMEBREW_CELLAR" do
+      it "returns the path unchanged" do
+        expect(dir.to_opt).to eq(described_class.new(dir))
+      end
+    end
+  end
+
   describe "#rmdir_if_possible" do
     before { mkdir_p dir }
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Some formulae (e.g. `include-what-you-use`) install symlinks to a
descendant of another formula's prefix in their install methods.

Currently, `install_symlink` fully resolves symlinks, so using it to
install such a symlink creates a reference to a Cellar path. This
reference is invalidated with version or revision bumps to the
referenced formula.

Let's fix that by converting Cellar references into equivalent opt
references before constructing the relative path.

I'm hoping that the Cellar-to-opt conversion will prove useful elsewhere
(e.g. `keg_relocate`), so I've created a separate method for it.

-----

CC @sjackman (Ref. #5793)