### PR TITLE
extend/ENV/super: allow bottles with custom architectures

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -261,6 +261,9 @@ module Superenv
   sig { returns(String) }
   def determine_optflags
     Hardware::CPU.optimization_flags.fetch(effective_arch)
+  rescue KeyError
+    odebug "Building a bottle for custom architecture (#{effective_arch})..."
+    Hardware::CPU.arch_flag(effective_arch)
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -395,10 +395,6 @@ class FormulaInstaller
 
     return if only_deps?
 
-    if build_bottle? && (arch = @bottle_arch) && Hardware::CPU.optimization_flags.exclude?(arch.to_sym)
-      raise CannotInstallFormulaError, "Unrecognized architecture for --bottle-arch: #{arch}"
-    end
-
     formula.deprecated_flags.each do |deprecated_option|
       old_flag = deprecated_option.old_flag
       new_flag = deprecated_option.current_flag


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? -- one cask failure and a `--version_spec` failure (I amended my latest commit while the tests were running...)

-----

Currently, Homebrew recognises only the architectures listed in
`hardware.rb`. [1] Attempting to pass an unrecognised architecture to
`--bottle-arch` while building a bottle returns an error.

Let's change that by passing unrecognised bottle arches to the compiler
instead of immediately failing with a `CannotInstallFormulaError`.

Partially resolves #5815.

[1] https://github.com/Homebrew/brew/blob/64b6846d6078525b8569834718f7b093a7dd05e1/Library/Homebrew/hardware.rb#L28-L42