### PR TITLE
dev-cmd/bump: fix empty array check

### DIFF
--- a/Library/Homebrew/dev-cmd/bump.rb
+++ b/Library/Homebrew/dev-cmd/bump.rb
@@ -53,7 +53,7 @@ module Homebrew
 
     limit = args.limit.to_i if args.limit.present?
 
-    if formulae_and_casks
+    if formulae_and_casks.present?
       Livecheck.load_other_tap_strategies(formulae_and_casks)
 
       ambiguous_casks = []


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

`brew bump` works without any named arguments, but the condition to check for an empty array of formulae and casks was incorrect. This PR fixes the issue.