### PR TITLE
service: delegate more path methods

### DIFF
--- a/Library/Homebrew/service.rb
+++ b/Library/Homebrew/service.rb
@@ -111,7 +111,7 @@ module Homebrew
       end
     end
 
-    delegate [:bin, :var, :etc, :opt_bin, :opt_sbin, :opt_prefix] => :@formula
+    delegate [:bin, :etc, :libexec, :opt_bin, :opt_libexec, :opt_pkgshare, :opt_prefix, :opt_sbin, :var] => :@formula
 
     sig { returns(String) }
     def std_service_path_env


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `service` DSL needs access to some more formula methods such as `libexec` and `opt_libexec` which weren't added earlier.

Here's a list of all methods/variables used (some are formula-specific) which I found by `grep`ping and `awk`ing, may not be entirely accurate:
```
#{var}                                259
#{opt_bin}                            174
#{etc}                                 67
#{HOMEBREW_PREFIX}                     60
#{opt_sbin}                            37
#{opt_libexec}                         15
#{postgresql_log_path}                 11
#{sbin}                                 9
#{datadir}                              9
#{bin}                                  7
#{postgresql_datadir}                   7
#{ENV["HOME"]}                          6
#{opt_prefix}                           6
#{name}                                 6
#{libexec}                              3
#{MAX_FDS}                              2
#{Formula["openjdk"].opt_bin}           2
#{Formula["openjdk@11"].opt_bin}        2
#{log_path}                             2
#{etc/"traefik/traefik.toml"}           2
#{nagios_etc}                           1
#{Formula["openjdk@8"].opt_prefix}      1
#{`whoami`.chomp}                       1
#{opt_pkgshare}                         1
#{Formula["pinentry-mac"].opt_bin}      1
#{config_path}                          1
#{version}                              1
```