### PR TITLE
system_command: fix rare scenario of interrupt being reported to stderr

### DIFF
--- a/Library/Homebrew/system_command.rb
+++ b/Library/Homebrew/system_command.rb
@@ -204,6 +204,8 @@ class SystemCommand
       Thread.handle_interrupt(ProcessTerminatedInterrupt => :never) do
         each_line_from [raw_stdout, raw_stderr], &block
       end
+      # Handle race conditions with interrupts
+      Thread.current.report_on_exception = false
     rescue ProcessTerminatedInterrupt
       nil
     end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Apparently interrupts can happen between the rescue block ending and the thread actually ending.