### PR TITLE
formula_installer: write tab when pouring local --only-json-tab bottles

### DIFF
--- a/Library/Homebrew/utils/bottles.rb
+++ b/Library/Homebrew/utils/bottles.rb
@@ -92,6 +92,23 @@ module Utils
         end
       end
 
+      def load_tab(formula)
+        keg = Keg.new(formula.prefix)
+        tabfile = keg/Tab::FILENAME
+        bottle_json_path = formula.local_bottle_path&.sub(/\.tar\.gz$/, ".json")
+
+        if (tab_attributes = formula.bottle_tab_attributes.presence)
+          Tab.from_file_content(tab_attributes.to_json, tabfile)
+        elsif !tabfile.exist? && bottle_json_path&.exist?
+          _, tag, = Utils::Bottles.extname_tag_rebuild(formula.local_bottle_path)
+          bottle_hash = JSON.parse(File.read(bottle_json_path))
+          tab_json = bottle_hash[formula.full_name]["bottle"]["tags"][tag]["tab"].to_json
+          Tab.from_file_content(tab_json, tabfile)
+        else
+          Tab.for_keg(keg)
+        end
+      end
+
       private
 
       def bottle_file_list(bottle_file)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

When installing a _local_ bottle built via `--only-json-tab`, the tab was never populated and thus an empty one was created. This is a scenario that really only happens in `brew test-bot`.

This PR tries to correct this by reading the bottle JSON (if found) and extracting the tab from that.

This fixes issues with Perl relocation as relocation requires the tab to determine the correct Perl shebang to apply.

This PR also tweaks the ordering so that tab writing happens _before_ relocation. This potentially fixes issues with Perl relocation for published bottles (if there are any - might need a new tag for this).