### PR TITLE
extend/os/mac/keg_relocate: fix post-bottling dylib ID relocation

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -22,8 +22,8 @@ class Keg
     mach_o_files.each do |file|
       file.ensure_writable do
         if file.dylib?
-          id = relocated_name_for(dylib_id_for(file), relocation)
-          change_dylib_id(id, file) if id
+          id = relocated_name_for(file.dylib_id, relocation)
+          change_dylib_id(id, file)
         end
 
         each_install_name_for(file) do |old_name|


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Running `brew bottle` changes dylib IDs, install names, and rpaths into
placeholders for the bottle, creates a bottle tarball, and then changes
the placeholders back to their correct values.

With my refactoring in #11358, the behaviour of this relocation changed:
dylib IDs would no longer be changed back from placeholders into their
correct values after the creation of the bottle tarball.