### PR TITLE
remove installer manual casks from upgraded casks

### DIFF
--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -93,6 +93,12 @@ module Cask
           end
         end
 
+        manual_installer_casks = outdated_casks.select do |cask|
+          cask.artifacts.any?(Artifact::Installer::ManualInstaller)
+        end
+
+        outdated_casks -= manual_installer_casks
+
         return false if outdated_casks.empty?
 
         if casks.empty? && !greedy

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -98,11 +98,11 @@ module Cask
         end
 
         if manual_installer_casks.present?
-          ofail "Not upgrading #{manual_installer_casks.count} casks because they was install manually"
+          count = manual_installer_casks.count
+          ofail "Not upgrading #{count} `installer manual` #{"cask".pluralize(count)}."
           puts manual_installer_casks.map(&:to_s)
+          outdated_casks -= manual_installer_casks
         end
-
-        outdated_casks -= manual_installer_casks
 
         return false if outdated_casks.empty?
 

--- a/Library/Homebrew/cask/cmd/upgrade.rb
+++ b/Library/Homebrew/cask/cmd/upgrade.rb
@@ -97,6 +97,11 @@ module Cask
           cask.artifacts.any?(Artifact::Installer::ManualInstaller)
         end
 
+        if manual_installer_casks.present?
+          ofail "Not upgrading #{manual_installer_casks.count} casks because they was install manually"
+          puts manual_installer_casks.map(&:to_s)
+        end
+
         outdated_casks -= manual_installer_casks
 
         return false if outdated_casks.empty?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
remove casks with `installer manual:` from `outdated_casks` when `brew upgrade`.

Fixes https://github.com/Homebrew/homebrew-cask/issues/105622