### PR TITLE
Fix `TMUX` env variable filtering

### DIFF
--- a/Library/Homebrew/extend/os/mac/caveats.rb
+++ b/Library/Homebrew/extend/os/mac/caveats.rb
@@ -48,7 +48,7 @@ class Caveats
 
     # pbpaste is the system clipboard tool on macOS and fails with `tmux` by default
     # check if this is being run under `tmux` to avoid failing
-    if ENV["TMUX"] && !quiet_system("/usr/bin/pbpaste")
+    if ENV["HOMEBREW_TMUX"] && !quiet_system("/usr/bin/pbpaste")
       s << "" << "WARNING: brew services will fail when run under tmux."
     end
     "#{s.join("\n")}\n" unless s.empty?

--- a/Library/Homebrew/test/caveats_spec.rb
+++ b/Library/Homebrew/test/caveats_spec.rb
@@ -135,7 +135,7 @@ describe Caveats do
             "plist_test.plist"
           end
         end
-        ENV["TMUX"] = "1"
+        ENV["HOMEBREW_TMUX"] = "1"
         allow(Homebrew).to receive(:_system).with("/usr/bin/pbpaste").and_return(false)
         caveats = described_class.new(f).caveats
 

--- a/bin/brew
+++ b/bin/brew
@@ -64,7 +64,7 @@ HOMEBREW_LIBRARY="${HOMEBREW_REPOSITORY}/Library"
 
 # Copy and export all HOMEBREW_* variables previously mentioned in
 # manpage or used elsewhere by Homebrew.
-for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH
+for VAR in BROWSER DISPLAY EDITOR NO_COLOR PATH TMUX
 do
   # Skip if variable value is empty.
   [[ -z "${!VAR}" ]] && continue


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

We currently filter out `TMUX`, but this breaks displaying some caveats. This also enables an alias I use (improved by @Rylan12 -- thanks Rylan):

    brew alias fzp='!id="$(gh pr list -L200 -R github.com/Homebrew/homebrew-core | TMUX=$HOMEBREW_TMUX fzf-tmux -p "90%,50%" --multi | cut -f1)"; [ -n "$id" ] && brew pr-publish --autosquash $id'

Alternatively, we could just stop filtering `TMUX` entirely. I've patched `bin/brew` locally to do that, but I don't know how we feel about adding more env variables to our whitelist. In particular, `TMUX` was mentioned in #1753 but never added, so I assume there's a reason for that.

Or, if we don't want to define `HOMEBREW_TMUX`, we should just remove the caveat that relies on it.