### PR TITLE
Fix range requests with `curl`

### DIFF
--- a/Library/Homebrew/test/download_strategies/curl_spec.rb
+++ b/Library/Homebrew/test/download_strategies/curl_spec.rb
@@ -23,9 +23,10 @@ describe CurlDownloadStrategy do
 
     it "calls curl with default arguments" do
       expect(strategy).to receive(:curl).with(
+        # example.com supports partial requests.
+        "--continue-at", "-",
         "--location",
         "--remote-time",
-        "--continue-at", "0",
         "--output", an_instance_of(Pathname),
         url,
         an_instance_of(Hash)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -138,7 +138,7 @@ module Utils
 
         # Any value for `accept-ranges` other than none indicates that the server supports partial requests.
         # Its absence indicates no support.
-        supports_partial = headers.key? "accept-ranges" && headers["accept-ranges"] != "none"
+        supports_partial = headers.key?("accept-ranges") && headers["accept-ranges"] != "none"
 
         if supports_partial &&
            destination.exist? &&

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -119,6 +119,8 @@ module Utils
     end
 
     def parse_headers(headers)
+      return {} unless headers
+
       headers.split("\n").to_h do |h|
         partitioned = h.partition(": ")
         [partitioned.first, partitioned.last]
@@ -145,10 +147,9 @@ module Utils
         end
       end
 
-
-      args += ["--location", "--remote-time", "--output", destination]
+      args = ["--location", "--remote-time", "--output", destination] + args
       # continue-at shouldn't be used with servers that don't support partial requests.
-      args += ["--continue-at", "-"] if destination.exist? && supports_partial
+      args = ["--continue-at", "-"] + args if destination.exist? && supports_partial
 
       curl(*args, **options)
     end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -144,9 +144,9 @@ module Utils
         end
       end
 
-      args = ["--location", "--remote-time", "--output", destination, *args]
+      args.prepend "--location", "--remote-time", "--output", destination
       # continue-at shouldn't be used with servers that don't support partial requests.
-      args = ["--continue-at", "-", *args] if destination.exist? && supports_partial
+      args.prepend "--continue-at", "-" if destination.exist? && supports_partial
 
       curl(*args, **options)
     end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -144,7 +144,7 @@ module Utils
         end
       end
 
-      args = ["--location", "--remote-time", "--output", destination] + args
+      args = ["--location", "--remote-time", "--output", destination, *args]
       # continue-at shouldn't be used with servers that don't support partial requests.
       args = ["--continue-at", "-"] + args if destination.exist? && supports_partial
 

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -122,7 +122,7 @@ module Utils
       return {} unless headers
 
       # Skip status code
-      headers.split("\r\n")[2..].to_h { |h| h.split(": ") }
+      headers.split("\r\n")[1..].to_h { |h| h.split(": ") }
     end
 
     def curl_download(*args, to: nil, try_partial: true, **options)
@@ -130,8 +130,7 @@ module Utils
       destination.dirname.mkpath
 
       if try_partial
-        range_stdout = curl_output("--location", "--dump-header", "-",
-                                   "--head", *args, **options).stdout
+        range_stdout = curl_output("--location", "--head", *args, **options).stdout
         headers = parse_headers(range_stdout.split("\r\n\r\n").first)
 
         # Any value for `accept-ranges` other than none indicates that the server supports partial requests.

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -138,7 +138,7 @@ module Utils
 
         # Any value for `accept-ranges` other than none indicates that the server supports partial requests.
         # Its absence indicates no support.
-        supports_partial = headers["accept-ranges"] && headers["accept-ranges"] != "none"
+        supports_partial = headers.key? "accept-ranges" && headers["accept-ranges"] != "none"
 
         if supports_partial &&
            destination.exist? &&

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -121,10 +121,8 @@ module Utils
     def parse_headers(headers)
       return {} unless headers
 
-      headers.split("\n").to_h do |h|
-        partitioned = h.partition(": ")
-        [partitioned.first, partitioned.last]
-      end
+      # Skip status code
+      headers.split("\r\n")[2..].to_h { |h| h.split(": ") }
     end
 
     def curl_download(*args, to: nil, try_partial: true, **options)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -118,6 +118,13 @@ module Utils
       result
     end
 
+    def parse_headers(headers)
+      headers.split("\n").to_h do |h|
+        partitioned = h.partition(": ")
+        [partitioned.first, partitioned.last]
+      end
+    end
+
     def curl_download(*args, to: nil, try_partial: true, **options)
       destination = Pathname(to)
       destination.dirname.mkpath

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -122,7 +122,10 @@ module Utils
       return {} unless headers
 
       # Skip status code
-      headers.split("\r\n")[1..].to_h { |h| h.split(": ") }
+      headers.split("\r\n")[1..].to_h do |h|
+        name, content = h.split(": ")
+        [name.downcase, content]
+      end
     end
 
     def curl_download(*args, to: nil, try_partial: true, **options)

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -147,9 +147,9 @@ module Utils
         end
       end
 
-      args.prepend "--location", "--remote-time", "--output", destination
+      args = ["--location", "--remote-time", "--output", destination, *args]
       # continue-at shouldn't be used with servers that don't support partial requests.
-      args.prepend "--continue-at", "-" if destination.exist? && supports_partial
+      args = ["--continue-at", "-", *args] if destination.exist? && supports_partial
 
       curl(*args, **options)
     end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -118,15 +118,15 @@ module Utils
       result
     end
 
-    def curl_download(*args, to: nil, partial: true, **options)
+    def curl_download(*args, to: nil, try_partial: true, **options)
       destination = Pathname(to)
       destination.dirname.mkpath
 
-      if partial
+      if try_partial
         range_stdout = curl_output("--location", "--range", "0-1",
                                    "--dump-header", "-",
                                    "--write-out", "%\{http_code}",
-                                   "--output", "/dev/null", *args, **options).stdout
+                                   "--head", *args, **options).stdout
         headers, _, http_status = range_stdout.partition("\r\n\r\n")
 
         supports_partial_download = http_status.to_i == 206 # Partial Content

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -146,7 +146,7 @@ module Utils
 
       args = ["--location", "--remote-time", "--output", destination, *args]
       # continue-at shouldn't be used with servers that don't support partial requests.
-      args = ["--continue-at", "-"] + args if destination.exist? && supports_partial
+      args = ["--continue-at", "-", *args] if destination.exist? && supports_partial
 
       curl(*args, **options)
     end

--- a/Library/Homebrew/utils/curl.rb
+++ b/Library/Homebrew/utils/curl.rb
@@ -119,7 +119,7 @@ module Utils
     end
 
     def parse_headers(headers)
-      return {} unless headers
+      return {} if headers.blank?
 
       # Skip status code
       headers.split("\r\n")[1..].to_h do |h|

--- a/Library/Homebrew/utils/spdx.rb
+++ b/Library/Homebrew/utils/spdx.rb
@@ -34,8 +34,8 @@ module SPDX
 
   def download_latest_license_data!(to: DATA_PATH)
     data_url = "https://raw.githubusercontent.com/spdx/license-list-data/#{latest_tag}/json/"
-    curl_download("#{data_url}licenses.json", to: to/"spdx_licenses.json", partial: false)
-    curl_download("#{data_url}exceptions.json", to: to/"spdx_exceptions.json", partial: false)
+    curl_download("#{data_url}licenses.json", to: to/"spdx_licenses.json", try_partial: false)
+    curl_download("#{data_url}exceptions.json", to: to/"spdx_exceptions.json", try_partial: false)
   end
 
   def parse_license_expression(license_expression)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Closes #10528.

The primary issue that these changes fix is that the initial request sent to determine if a server supports range (partial) requests isn't a `HEAD` request. If the server doesn't support range requests, this downloads the entire file. Another request (the one that is actually meant to download the file) follows and downloads the entire file a second time. A minimal fix would be to add the `--head` flag to the first request, as suggested by @wilkmaciej.

The way that `curl_download` currently checks for range request support is a bit strange. It sends a range request asking for the first byte of the content and checks for the presence of the `Content-Range` header. The proper way to check for range request support is to send a normal (i.e., not range) `HEAD` request to the server and check for the presence of the `Accept-Ranges` header. If it is present and its value isn't `none`, the server supports range requests. These changes implement this methodology.