### PR TITLE
extend/os/mac/keg_relocate: remove `RPATH`s rooted in build directory

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -55,6 +55,14 @@ class Keg
           new_name = fixed_name(file, bad_name)
           change_install_name(bad_name, new_name, file) unless new_name == bad_name
         end
+
+        each_linkage_for(file, :rpaths) do |bad_name|
+          # Strip rpaths rooted in the build directory
+          next if !bad_name.start_with?(HOMEBREW_TEMP.to_s) &&
+                  !bad_name.start_with?(HOMEBREW_TEMP.realpath.to_s)
+
+          delete_rpath(bad_name, file)
+        end
       end
     end
 

--- a/Library/Homebrew/os/mac/keg.rb
+++ b/Library/Homebrew/os/mac/keg.rb
@@ -50,6 +50,17 @@ class Keg
     raise
   end
 
+  def delete_rpath(rpath, file)
+    odebug "Deleting rpath #{rpath} in #{file}"
+    MachO::Tools.delete_rpath(file, rpath, strict: false)
+    apply_ad_hoc_signature(file)
+  rescue MachO::MachOError
+    onoe <<~EOS
+      Failed deleting rpath #{rpath} in #{file}
+    EOS
+    raise
+  end
+
   def apply_ad_hoc_signature(file)
     return if MacOS.version < :big_sur
     return unless Hardware::CPU.arm?

--- a/Library/Homebrew/os/mac/mach.rb
+++ b/Library/Homebrew/os/mac/mach.rb
@@ -10,7 +10,7 @@ require "os/mac/architecture_list"
 module MachOShim
   extend Forwardable
 
-  delegate [:dylib_id, :rpaths, :delete_rpath] => :macho
+  delegate [:dylib_id, :rpaths] => :macho
 
   def macho
     @macho ||= MachO.open(to_s)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Keeping dangling `RPATH`s is a security risk, and is bad for build
reproducibility.

-----

I'm tempted to remove all `RPATH`s referencing non-existent directories, but I don't know if that will break anything.

Note that delegating `delete_rpath` doesn't work here. See https://github.com/Homebrew/ruby-macho/issues/355.