### PR TITLE
Override user-set default git template for taps

### DIFF
--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -291,6 +291,9 @@ class Tap
     args << "--origin=origin"
     args << "-q" if quiet
 
+    # Override user-set default template
+    args << "--template="
+
     begin
       safe_system "git", *args
       if !Readall.valid_tap?(self, aliases: true) && !Homebrew::EnvConfig.developer?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Closes #11364.

I elected to use the `--template` flag rather than the `GIT_TEMPLATE_DIR` environment variable because it has higher precedence and seemed more appropriate for this use.