### PR TITLE
utils/pypi: use `opt_bin` for pipgrip

### DIFF
--- a/Library/Homebrew/utils/pypi.rb
+++ b/Library/Homebrew/utils/pypi.rb
@@ -212,7 +212,7 @@ module PyPI
     odie '"pipgrip" must be installed (`brew install pipgrip`)' unless @pipgrip_installed
 
     ohai "Retrieving PyPI dependencies for \"#{input_packages.join(" ")}\"..." if !print_only && !silent
-    command = [Formula["pipgrip"].bin/"pipgrip", "--json", "--no-cache-dir", *input_packages.map(&:to_s)]
+    command = [Formula["pipgrip"].opt_bin/"pipgrip", "--json", "--no-cache-dir", *input_packages.map(&:to_s)]
     pipgrip_output = Utils.popen_read(*command)
     unless $CHILD_STATUS.success?
       odie <<~EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The `pipgrip` formula was recently bumped in `homebrew/core`, and I hadn't upgraded it locally. When I tried running `brew update-python-resources`, I was thrown off by the error until I realised that it was because I hadn't upgraded.
```
➜ brew update-python-resources pympress
==> Retrieving PyPI dependencies for "pympress==1.5.3"...
Error: Unable to determine dependencies for "pympress==1.5.3" because of a failure when running
`/usr/local/Cellar/pipgrip/0.6.8/bin/pipgrip --json --no-cache-dir pympress==1.5.3`.
Please update the resources for "pympress" manually.
```
This PR modifies the method to use `Formula["pipgrip"].opt_bin` instead of `bin`, to prevent this from happening.
```
➜ brew update-python-resources pympress
==> Retrieving PyPI dependencies for "pympress==1.5.3"...
==> Excluding "pympress==1.5.3"
==> Getting PyPI info for "python-vlc==3.0.12118"
==> Getting PyPI info for "watchdog==2.1.1"
==> Updating resource blocks
```
I should be keeping `pipgrip` up to date, but it wasn't time for my daily `brew upgrade` yet 😅.