### PR TITLE
formula: add preset `pour_bottle?` symbols

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2924,8 +2924,13 @@ class Formula
     def pour_bottle?(reason: nil, &block)
       @pour_bottle_check = PourBottleCheck.new(self)
 
-      if reason == :clt_required
-        block = lambda do |_|
+      if reason.present? && block.present?
+        raise ArgumentError, "Do not pass both a reason and a block to `pour_bottle?`"
+      end
+
+      block ||= case reason
+      when :clt_required
+        lambda do |_|
           on_macos do
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
               The bottle needs the Apple Command Line Tools to be installed.
@@ -2935,6 +2940,8 @@ class Formula
             T.cast(self, PourBottleCheck).satisfy { MacOS::CLT.installed? }
           end
         end
+      else
+        raise ArgumentError, "Invalid `pour_bottle?` reason" if reason.present?
       end
 
       @pour_bottle_check.instance_eval(&block)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2920,21 +2920,12 @@ class Formula
     # the {Formula} will be built from source and `reason` will be printed.
     #
     # Alternatively, a preset reason can be passed as a symbol:
-    # <pre>pour_bottle? :default_prefix_required</pre>
-    # <pre>pour_bottle? :clt_required</pre>
-    def pour_bottle?(requirement = nil, &block)
+    # <pre>pour_bottle? reason: :clt_required</pre>
+    def pour_bottle?(reason: nil, &block)
       @pour_bottle_check = PourBottleCheck.new(self)
 
-      block ||= case requirement
-      when :default_prefix_required
-        lambda do |_|
-          T.cast(self, PourBottleCheck).reason(+<<~EOS)
-            The bottle needs to be installed into #{Homebrew::DEFAULT_PREFIX}.
-          EOS
-          T.cast(self, PourBottleCheck).satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX }
-        end
-      when :clt_required
-        lambda do |_|
+      if reason == :clt_required
+        block = lambda do |_|
           on_macos do
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
               The bottle needs the Apple Command Line Tools to be installed.

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -996,7 +996,7 @@ describe Formula do
       expect(f).to pour_bottle
     end
 
-    it "returns false when set with a symbol" do
+    it "returns false with `reason: :clt_required` on macOS", :needs_macos do
       # Pretend CLT is not installed
       allow(MacOS::CLT).to receive(:installed?).and_return(false)
 
@@ -1009,10 +1009,20 @@ describe Formula do
       expect(f).not_to pour_bottle
     end
 
-    it "returns true when set with a symbol" do
+    it "returns true with `reason: :clt_required` on macOS", :needs_macos do
       # Pretend CLT is installed
       allow(MacOS::CLT).to receive(:installed?).and_return(true)
 
+      f = formula "foo" do
+        url "foo-1.0"
+
+        pour_bottle? reason: :clt_required
+      end
+
+      expect(f).to pour_bottle
+    end
+
+    it "returns true with `reason: :clt_required` on Linux", :needs_linux do
       f = formula "foo" do
         url "foo-1.0"
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -997,26 +997,26 @@ describe Formula do
     end
 
     it "returns false when set with a symbol" do
-      # Ensure that prefix does not match the default
-      stub_const "Homebrew::DEFAULT_PREFIX", "foo"
+      # Pretend CLT is not installed
+      allow(MacOS::CLT).to receive(:installed?).and_return(false)
 
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? :default_prefix_required
+        pour_bottle? reason: :clt_required
       end
 
       expect(f).not_to pour_bottle
     end
 
     it "returns true when set with a symbol" do
-      # Ensure that prefix matches the default
-      stub_const "Homebrew::DEFAULT_PREFIX", HOMEBREW_PREFIX.to_s
+      # Pretend CLT is installed
+      allow(MacOS::CLT).to receive(:installed?).and_return(true)
 
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? :default_prefix_required
+        pour_bottle? reason: :clt_required
       end
 
       expect(f).to pour_bottle

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -997,14 +997,15 @@ describe Formula do
     end
 
     it "returns false when set with a symbol" do
+      # Ensure that prefix does not match the default
+      stub_const "Homebrew::DEFAULT_PREFIX", "foo"
+
       f = formula "foo" do
         url "foo-1.0"
 
         pour_bottle? :default_prefix_required
       end
 
-      # Homebrew::DEFAULT_PREFIX is still /usr/local or /opt/homebrew
-      # and HOMEBREW_PREFIX is a temporary test directory
       expect(f).not_to pour_bottle
     end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -995,6 +995,31 @@ describe Formula do
 
       expect(f).to pour_bottle
     end
+
+    it "returns false when set with a symbol" do
+      f = formula "foo" do
+        url "foo-1.0"
+
+        pour_bottle? :default_prefix_required
+      end
+
+      # Homebrew::DEFAULT_PREFIX is still /usr/local or /opt/homebrew
+      # and HOMEBREW_PREFIX is a temporary test directory
+      expect(f).not_to pour_bottle
+    end
+
+    it "returns true when set with a symbol" do
+      # Ensure that prefix matches the default
+      stub_const "Homebrew::DEFAULT_PREFIX", HOMEBREW_PREFIX.to_s
+
+      f = formula "foo" do
+        url "foo-1.0"
+
+        pour_bottle? :default_prefix_required
+      end
+
+      expect(f).to pour_bottle
+    end
   end
 
   describe "alias changes" do

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -1021,6 +1021,29 @@ describe Formula do
 
       expect(f).to pour_bottle
     end
+
+    it "throws an error if passed both a symbol and a block" do
+      expect do
+        formula "foo" do
+          url "foo-1.0"
+
+          pour_bottle? reason: :clt_required do
+            reason "true reason"
+            satisfy { true }
+          end
+        end
+      end.to raise_error(ArgumentError, "Do not pass both a reason and a block to `pour_bottle?`")
+    end
+
+    it "throws an error if passed an invalid symbol" do
+      expect do
+        formula "foo" do
+          url "foo-1.0"
+
+          pour_bottle? reason: :foo
+        end
+      end.to raise_error(ArgumentError, "Invalid `pour_bottle?` reason")
+    end
   end
 
   describe "alias changes" do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See https://github.com/Homebrew/brew/issues/11302

This PR adds two symbols that can be passed to `pour_bottle?` as shortcuts for commonly used `pour_bottle?` blocks:

- `:default_prefix_required`: for when the bottle only works in the default prefix but relocation detection doesn't find any problematic paths (right now this would apply only to `ocaml`). Using this symbol is a shortcut for:
    ```ruby
    pour_bottle? do
      reason <<~EOS
        The bottle needs to be installed into #{Homebrew::DEFAULT_PREFIX}.
      EOS
      satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX }
    end
    ```
- `:clt_required`: for when the CLT is needed for bottles (right now this would be used by the `gcc` and `python` formulae). Using this symbol is a shortcut for:
    ```ruby
    pour_bottle? do
      reason <<~EOS
        The bottle needs the Apple Command Line Tools to be installed.
          You can install them, if desired, with:
            xcode-select --install
      EOS
      satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX }
    end
    ```

I'm venturing a bit into parts of Ruby that I'm less familiar with so its possible that there's a better way for this to be done that what I have here (e.g. maybe the options should go in the `PourBottleCheck` class rather than `Formula`). I've also needed to add some `T.cast`s which makes me wonder if there is a better way to accomplish this.
