### PR TITLE
extend/os/mac/keg_relocate: fix relocation of duplicate `RPATH`s

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -94,6 +94,7 @@ class Keg
   def each_linkage_for(file, linkage_type, &block)
     links = file.method(linkage_type)
                 .call
+                .uniq
                 .reject { |fn| fn =~ /^@(loader_|executable_|r)path/ }
     links.each(&block)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Homebrew/homebrew-core#77263 revealed two bugs. One in `ruby-macho`,
which turns out to be unable to delete duplicated `RPATH`s. This was
fixed with `ruby-macho` 2.5.1.

The second, which this PR fixes, is in our handling of duplicate
`RPATH`s. Since we iterate over each `RPATH`, attempting to relocate the
first duplicate fails since it will no longer exist after having
relocated the original.

Unblocks Homebrew/homebrew-core#77263.