### PR TITLE
repair pubDate statement in livecheck

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -75,7 +75,7 @@ module Homebrew
             version ||= (item > "version").first&.text&.strip
 
             title = (item > "title").first&.text&.strip
-            pub_date = (item > "pubDate").first&.text&.strip&.yield_self { |d| Time.parse(d) }
+            pub_date = (item > "pubDate").first&.text&.strip&.presence&.yield_self { |d| Time.parse(d) }
 
             if (match = title&.match(/(\d+(?:\.\d+)*)\s*(\([^)]+\))?\Z/))
               short_version ||= match[1]

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -75,7 +75,12 @@ module Homebrew
             version ||= (item > "version").first&.text&.strip
 
             title = (item > "title").first&.text&.strip
-            pub_date = (item > "pubDate").first&.text&.strip&.presence&.yield_self { |d| Time.parse(d) }
+            pub_date = (item > "pubDate").first&.text&.strip&.presence&.yield_self do |date_string|
+              Time.parse(date_string)
+            rescue ArgumentError
+              # Omit unparseable strings (e.g. non-English dates)
+              nil
+            end
 
             if (match = title&.match(/(\d+(?:\.\d+)*)\s*(\([^)]+\))?\Z/))
               short_version ||= match[1]

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -75,7 +75,7 @@ module Homebrew
             version ||= (item > "version").first&.text&.strip
 
             title = (item > "title").first&.text&.strip
-            pub_date = (item > "pubDate").first&.text&.strip&.yield_self { |d| Time.parse(d) } || Time.new(0)
+            pub_date = (item > "pubDate").first&.text&.strip&.yield_self { |d| Time.parse(d) }
 
             if (match = title&.match(/(\d+(?:\.\d+)*)\s*(\([^)]+\))?\Z/))
               short_version ||= match[1]
@@ -88,7 +88,7 @@ module Homebrew
 
             data = {
               title:          title,
-              pub_date:       pub_date,
+              pub_date:       pub_date || Time.new(0),
               url:            url,
               bundle_version: bundle_version,
             }.compact

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -75,7 +75,7 @@ module Homebrew
             version ||= (item > "version").first&.text&.strip
 
             title = (item > "title").first&.text&.strip
-            pub_date = (item > "pubDate").first&.text&.strip&.yield_self { |d| Time.parse(d) }
+            pub_date = (item > "pubDate").first&.text&.strip&.yield_self { |d| Time.parse(d) } || Time.new(0)
 
             if (match = title&.match(/(\d+(?:\.\d+)*)\s*(\([^)]+\))?\Z/))
               short_version ||= match[1]


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
avoid `brew livecheck` error when `pubDate` of item is null in `Sparkle::item_from_content`.

related with https://github.com/Homebrew/homebrew-cask/issues/105918
