### PR TITLE
Improved Command Lines Tool update instructions

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -305,6 +305,8 @@ module OS
 
           Alternatively, manually download them from:
             #{Formatter.url("https://developer.apple.com/download/more/")}.
+          Check the latest available version for your system on:
+            #{Formatter.url("https://developer.apple.com/support/xcode/#minimum-requirements")}.
         EOS
       end
 

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -304,9 +304,8 @@ module OS
             sudo xcode-select --install
 
           Alternatively, manually download them from:
-            #{Formatter.url("https://developer.apple.com/download/more/")}
-          after checking the latest available version for your system on:
-            #{Formatter.url("https://developer.apple.com/support/xcode/#minimum-requirements")}.
+            #{Formatter.url("https://developer.apple.com/download/more/")}.
+          You should download the Command Line Tools for Xcode #{MacOS::Xcode.latest_version}.
         EOS
       end
 

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -304,8 +304,8 @@ module OS
             sudo xcode-select --install
 
           Alternatively, manually download them from:
-            #{Formatter.url("https://developer.apple.com/download/more/")}.
-          Check the latest available version for your system on:
+            #{Formatter.url("https://developer.apple.com/download/more/")}
+          after checking the latest available version for your system on:
             #{Formatter.url("https://developer.apple.com/support/xcode/#minimum-requirements")}.
         EOS
       end


### PR DESCRIPTION
Added link to Apple's page with latest version of XCode for each macOS release to the message that suggest downloading latest version.

Test fails on my machine but it's only a string in the XCode file, and Ruby's syntax checker doesn't complain about it - the failing test is 
`rspec ./test/cmd/--version_spec.rb:7 # brew --version prints the Homebrew's version`
so completely unrelated.

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
