### PR TITLE
Add `brew link --HEAD`

### DIFF
--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -98,7 +98,7 @@ module Homebrew
               Formulary.factory(name, *spec, force_bottle: @force_bottle, flags: @flags)
             when :resolve
               resolve_formula(name)
-            when :keg
+            when :default_kegs
               resolve_keg(name)
             when :kegs
               _, kegs = resolve_kegs(name)
@@ -211,7 +211,7 @@ module Homebrew
       sig { returns(T::Array[Keg]) }
       def to_default_kegs
         @to_default_kegs ||= begin
-          to_formulae_and_casks(only: :formula, method: :keg).freeze
+          to_formulae_and_casks(only: :formula, method: :default_kegs).freeze
         rescue NoSuchKegError => e
           if (reason = MissingFormula.suggest_command(e.name, "uninstall"))
             $stderr.puts reason
@@ -237,7 +237,7 @@ module Homebrew
           .returns([T::Array[Keg], T::Array[Cask::Cask]])
       }
       def to_kegs_to_casks(only: parent&.only_formula_or_cask, ignore_unavailable: nil, all_kegs: nil)
-        method = all_kegs ? :kegs : :keg
+        method = all_kegs ? :kegs : :default_kegs
         @to_kegs_to_casks ||= {}
         @to_kegs_to_casks[method] ||=
           to_formulae_and_casks(only: only, ignore_unavailable: ignore_unavailable, method: method)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -220,6 +220,18 @@ module Homebrew
         end
       end
 
+      sig { returns(T::Array[Keg]) }
+      def to_kegs
+        @to_kegs ||= begin
+          to_formulae_and_casks(only: :formula, method: :kegs).freeze
+        rescue NoSuchKegError => e
+          if (reason = MissingFormula.suggest_command(e.name, "uninstall"))
+            $stderr.puts reason
+          end
+          raise e
+        end
+      end
+
       sig {
         params(only: T.nilable(Symbol), ignore_unavailable: T.nilable(T::Boolean), all_kegs: T.nilable(T::Boolean))
           .returns([T::Array[Keg], T::Array[Cask::Cask]])

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -98,8 +98,10 @@ module Homebrew
               Formulary.factory(name, *spec, force_bottle: @force_bottle, flags: @flags)
             when :resolve
               resolve_formula(name)
-            # odeprecated "`method: :keg`"
             when :keg, :default_kegs
+              # TODO: (3.2) Uncomment the following
+              # odeprecated "`load_formula_or_cask` with `method: :keg`",
+              #             "`load_formula_or_cask` with `method: :default_kegs`"
               resolve_default_keg(name)
             when :kegs
               _, kegs = resolve_kegs(name)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -209,8 +209,8 @@ module Homebrew
       end
 
       sig { returns(T::Array[Keg]) }
-      def to_keg
-        @to_keg ||= begin
+      def to_default_kegs
+        @to_default_kegs ||= begin
           to_formulae_and_casks(only: :formula, method: :keg).freeze
         rescue NoSuchKegError => e
           if (reason = MissingFormula.suggest_command(e.name, "uninstall"))

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -100,12 +100,10 @@ module Homebrew
               resolve_formula(name)
             when :latest_kegs
               resolve_latest_keg(name)
-            when :keg
+            when :keg, :default_kegs
               # TODO: (3.2) Uncomment the following
               # odeprecated "`load_formula_or_cask` with `method: :keg`",
               #             "`load_formula_or_cask` with `method: :default_kegs`"
-              resolve_default_keg(name)
-            when :default_kegs
               resolve_default_keg(name)
             when :kegs
               _, kegs = resolve_kegs(name)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -100,10 +100,12 @@ module Homebrew
               resolve_formula(name)
             when :latest_kegs
               resolve_latest_keg(name)
-            when :keg, :default_kegs
+            when :keg
               # TODO: (3.2) Uncomment the following
               # odeprecated "`load_formula_or_cask` with `method: :keg`",
               #             "`load_formula_or_cask` with `method: :default_kegs`"
+              resolve_default_keg(name)
+            when :default_kegs
               resolve_default_keg(name)
             when :kegs
               _, kegs = resolve_kegs(name)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -209,8 +209,8 @@ module Homebrew
       end
 
       sig { returns(T::Array[Keg]) }
-      def to_kegs
-        @to_kegs ||= begin
+      def to_keg
+        @to_keg ||= begin
           to_formulae_and_casks(only: :formula, method: :keg).freeze
         rescue NoSuchKegError => e
           if (reason = MissingFormula.suggest_command(e.name, "uninstall"))

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -99,7 +99,7 @@ module Homebrew
             when :resolve
               resolve_formula(name)
             when :default_kegs
-              resolve_keg(name)
+              resolve_default_keg(name)
             when :kegs
               _, kegs = resolve_kegs(name)
               kegs
@@ -294,7 +294,7 @@ module Homebrew
         [rack, kegs]
       end
 
-      def resolve_keg(name)
+      def resolve_default_keg(name)
         rack, kegs = resolve_kegs(name)
 
         linked_keg_ref = HOMEBREW_LINKED_KEGS/rack.basename

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -314,7 +314,7 @@ module Homebrew
       def resolve_latest_keg(name)
         _, kegs = resolve_kegs(name)
 
-        # Return head keg if it is the only installed keg
+        # Return keg if it is the only installed keg
         return kegs if kegs.length == 1
 
         kegs.reject { |k| k.version.head? }.max_by(&:version)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -98,7 +98,8 @@ module Homebrew
               Formulary.factory(name, *spec, force_bottle: @force_bottle, flags: @flags)
             when :resolve
               resolve_formula(name)
-            when :default_kegs
+            # odeprecated "`method: :keg`"
+            when :keg, :default_kegs
               resolve_default_keg(name)
             when :kegs
               _, kegs = resolve_kegs(name)

--- a/Library/Homebrew/cli/named_args.rb
+++ b/Library/Homebrew/cli/named_args.rb
@@ -227,7 +227,7 @@ module Homebrew
 
       sig { returns(T::Array[Keg]) }
       def to_latest_kegs
-        @to_default_kegs ||= begin
+        @to_latest_kegs ||= begin
           to_formulae_and_casks(only: :formula, method: :latest_kegs).freeze
         rescue NoSuchKegError => e
           if (reason = MissingFormula.suggest_command(e.name, "uninstall"))

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -42,15 +42,18 @@ module Homebrew
       verbose:   args.verbose?,
     }
 
-    args.named.to_formulae_and_casks(only: :formula, method: :kegs).freeze.each do |keg|
-      head = keg.version.head?
-      next if args.HEAD? != head
+    kegs = if args.HEAD?
+      args.named.to_kegs.filter { |keg| keg.version.head? }
+    else
+      args.named.to_keg
+    end
 
+    kegs.freeze.each do |keg|
       keg_only = Formulary.keg_only?(keg.rack)
 
       if keg.linked?
         opoo "Already linked: #{keg}"
-        name_and_flag = "#{"--HEAD " if head}#{"--force " if keg_only}#{keg.name}"
+        name_and_flag = "#{"--HEAD " if args.HEAD?}#{"--force " if keg_only}#{keg.name}"
         puts <<~EOS
           To relink:
             brew unlink #{keg.name} && brew link #{name_and_flag}

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -54,11 +54,11 @@ module Homebrew
 
     kegs.freeze.each do |name, keg|
       # Catch if no HEAD keg is installed
-      if keg.nil? && args.HEAD?
+      if keg.nil?
         opoo <<~EOS
-          No HEAD keg installed for #{name}
+          No #{"HEAD " if args.HEAD?}keg installed for #{name}
           To install, run:
-            brew install --HEAD #{name}
+            brew install #{"--HEAD " if args.HEAD?}#{name}
         EOS
         next
       end

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -27,7 +27,7 @@ module Homebrew
       switch "-f", "--force",
              description: "Allow keg-only formulae to be linked."
       switch "--HEAD",
-             description: "If it is installed, link the HEAD version."
+             description: "Link the HEAD version of the formula if it is installed."
 
       named_args :installed_formula, min: 1
     end

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -45,15 +45,14 @@ module Homebrew
     kegs = if args.HEAD?
       args.named.to_kegs.group_by(&:name).map do |name, resolved_kegs|
         head_keg = resolved_kegs.find { |keg| keg.version.head? }
-        if head_keg.blank?
-          opoo <<~EOS
-            No HEAD keg installed for #{name}
-            To install, run:
-              brew install --HEAD #{name}
-          EOS
-        end
-        head_keg
-      end.reject(&:blank?)
+        next head_keg if head_keg.present?
+
+        opoo <<~EOS
+          No HEAD keg installed for #{name}
+          To install, run:
+            brew install --HEAD #{name}
+        EOS
+      end.compact
     else
       args.named.to_latest_kegs
     end

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -44,7 +44,7 @@ module Homebrew
 
     args.named.to_formulae_and_casks(only: :formula, method: :kegs).freeze.each do |keg|
       head = keg.version.head?
-      next unless args.HEAD? == head
+      next if args.HEAD? != head
 
       keg_only = Formulary.keg_only?(keg.rack)
 

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -45,7 +45,7 @@ module Homebrew
     kegs = if args.HEAD?
       args.named.to_kegs.filter { |keg| keg.version.head? }
     else
-      args.named.to_keg
+      args.named.to_default_kegs
     end
 
     kegs.freeze.each do |keg|

--- a/Library/Homebrew/cmd/link.rb
+++ b/Library/Homebrew/cmd/link.rb
@@ -45,7 +45,7 @@ module Homebrew
     kegs = if args.HEAD?
       args.named.to_kegs.filter { |keg| keg.version.head? }
     else
-      args.named.to_default_kegs
+      args.named.to_latest_kegs
     end
 
     kegs.freeze.each do |keg|

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -129,9 +129,9 @@ module Homebrew
         safe_system "ls", *ls_args, Cask::Caskroom.path
       end
     elsif args.verbose? || !$stdout.tty?
-      system_command! "find", args: args.named.to_keg.map(&:to_s) + %w[-not -type d -print], print_stdout: true
+      system_command! "find", args: args.named.to_default_kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true
     else
-      args.named.to_keg.each { |keg| PrettyListing.new keg }
+      args.named.to_default_kegs.each { |keg| PrettyListing.new keg }
     end
   end
 

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -129,7 +129,8 @@ module Homebrew
         safe_system "ls", *ls_args, Cask::Caskroom.path
       end
     elsif args.verbose? || !$stdout.tty?
-      system_command! "find", args: args.named.to_default_kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true
+      system_command! "find", args:         args.named.to_default_kegs.map(&:to_s) + %w[-not -type d -print],
+                              print_stdout: true
     else
       args.named.to_default_kegs.each { |keg| PrettyListing.new keg }
     end

--- a/Library/Homebrew/cmd/list.rb
+++ b/Library/Homebrew/cmd/list.rb
@@ -129,9 +129,9 @@ module Homebrew
         safe_system "ls", *ls_args, Cask::Caskroom.path
       end
     elsif args.verbose? || !$stdout.tty?
-      system_command! "find", args: args.named.to_kegs.map(&:to_s) + %w[-not -type d -print], print_stdout: true
+      system_command! "find", args: args.named.to_keg.map(&:to_s) + %w[-not -type d -print], print_stdout: true
     else
-      args.named.to_kegs.each { |keg| PrettyListing.new keg }
+      args.named.to_keg.each { |keg| PrettyListing.new keg }
     end
   end
 

--- a/Library/Homebrew/cmd/unlink.rb
+++ b/Library/Homebrew/cmd/unlink.rb
@@ -31,7 +31,7 @@ module Homebrew
 
     options = { dry_run: args.dry_run?, verbose: args.verbose? }
 
-    args.named.to_kegs.each do |keg|
+    args.named.to_keg.each do |keg|
       if args.dry_run?
         puts "Would remove:"
         keg.unlink(**options)

--- a/Library/Homebrew/cmd/unlink.rb
+++ b/Library/Homebrew/cmd/unlink.rb
@@ -31,7 +31,7 @@ module Homebrew
 
     options = { dry_run: args.dry_run?, verbose: args.verbose? }
 
-    args.named.to_keg.each do |keg|
+    args.named.to_default_kegs.each do |keg|
       if args.dry_run?
         puts "Would remove:"
         keg.unlink(**options)

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -35,10 +35,10 @@ module Homebrew
     args = linkage_args.parse
 
     CacheStoreDatabase.use(:linkage) do |db|
-      kegs = if args.named.to_kegs.empty?
+      kegs = if args.named.to_keg.empty?
         Formula.installed.map(&:any_installed_keg).reject(&:nil?)
       else
-        args.named.to_kegs
+        args.named.to_keg
       end
       kegs.each do |keg|
         ohai "Checking #{keg.name} linkage" if kegs.size > 1

--- a/Library/Homebrew/dev-cmd/linkage.rb
+++ b/Library/Homebrew/dev-cmd/linkage.rb
@@ -35,10 +35,10 @@ module Homebrew
     args = linkage_args.parse
 
     CacheStoreDatabase.use(:linkage) do |db|
-      kegs = if args.named.to_keg.empty?
+      kegs = if args.named.to_default_kegs.empty?
         Formula.installed.map(&:any_installed_keg).reject(&:nil?)
       else
-        args.named.to_keg
+        args.named.to_default_kegs
       end
       kegs.each do |keg|
         ohai "Checking #{keg.name} linkage" if kegs.size > 1

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -188,7 +188,7 @@ describe Homebrew::CLI::NamedArgs do
     end
 
     it "resolves kegs with multiple versions with #resolve_keg" do
-      expect(described_class.new("foo").to_kegs.map { |k| k.version.version }).to eq ["1.0", "2.0"]
+      expect(described_class.new("foo").to_kegs.map { |k| k.version.version.to_s }).to eq ["1.0", "2.0"]
     end
 
     it "when there are no matching kegs returns an empty array" do
@@ -207,6 +207,10 @@ describe Homebrew::CLI::NamedArgs do
 
     it "resolves kegs with #resolve_default_keg" do
       expect(described_class.new("foo", "bar").to_default_kegs.map(&:name)).to eq ["foo", "bar"]
+    end
+
+    it "resolves the default keg" do
+      expect(described_class.new("foo").to_default_kegs.map { |k| k.version.version.to_s }).to eq ["2.0"]
     end
 
     it "when there are no matching kegs returns an empty array" do

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -188,7 +188,7 @@ describe Homebrew::CLI::NamedArgs do
     end
 
     it "resolves kegs with multiple versions with #resolve_keg" do
-      expect(described_class.new("foo").to_kegs.map(&->(k) { k.version.version })).to eq ["1.0", "2.0"]
+      expect(described_class.new("foo").to_kegs.map { |k| k.version.version }).to eq ["1.0", "2.0"]
     end
 
     it "when there are no matching kegs returns an empty array" do

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -182,7 +182,7 @@ describe Homebrew::CLI::NamedArgs do
       (HOMEBREW_CELLAR/"bar/1.0").mkpath
     end
 
-    it "resolves kegs with #resolve_keg" do
+    it "resolves kegs with #resolve_default_keg" do
       expect(described_class.new("foo", "bar").to_default_kegs.map(&:name)).to eq ["foo", "bar"]
     end
 

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -200,13 +200,16 @@ describe Homebrew::CLI::NamedArgs do
     before do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath
       (HOMEBREW_CELLAR/"bar/1.0").mkpath
+      linked_path = (HOMEBREW_CELLAR/"foo/2.0")
+      linked_path.mkpath
+      Keg.new(linked_path).link
     end
 
     it "resolves kegs with #resolve_default_keg" do
       expect(described_class.new("foo", "bar").to_default_kegs.map(&:name)).to eq ["foo", "bar"]
     end
 
-    it "when there are no matching kegs returns an array of Kegs" do
+    it "when there are no matching kegs returns an empty array" do
       expect(described_class.new.to_default_kegs).to be_empty
     end
   end

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -191,7 +191,7 @@ describe Homebrew::CLI::NamedArgs do
       expect(described_class.new("foo").to_kegs.map(&->(k) { k.version.version })).to eq ["1.0", "2.0"]
     end
 
-    it "when there are no matching kegs returns an array of Kegs" do
+    it "when there are no matching kegs returns an empty array" do
       expect(described_class.new.to_kegs).to be_empty
     end
   end

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -176,18 +176,18 @@ describe Homebrew::CLI::NamedArgs do
     end
   end
 
-  describe "#to_keg" do
+  describe "#to_default_kegs" do
     before do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath
       (HOMEBREW_CELLAR/"bar/1.0").mkpath
     end
 
     it "resolves kegs with #resolve_keg" do
-      expect(described_class.new("foo", "bar").to_keg.map(&:name)).to eq ["foo", "bar"]
+      expect(described_class.new("foo", "bar").to_default_kegs.map(&:name)).to eq ["foo", "bar"]
     end
 
     it "when there are no matching kegs returns an array of Kegs" do
-      expect(described_class.new.to_keg).to be_empty
+      expect(described_class.new.to_default_kegs).to be_empty
     end
   end
 

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -188,7 +188,7 @@ describe Homebrew::CLI::NamedArgs do
     end
 
     it "resolves kegs with multiple versions with #resolve_keg" do
-      expect(described_class.new("foo").to_kegs.map { |k| k.version.version.to_s }).to eq ["1.0", "2.0"]
+      expect(described_class.new("foo").to_kegs.map { |k| k.version.version.to_s }.sort).to eq ["1.0", "2.0"]
     end
 
     it "when there are no matching kegs returns an empty array" do

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -176,18 +176,18 @@ describe Homebrew::CLI::NamedArgs do
     end
   end
 
-  describe "#to_kegs" do
+  describe "#to_keg" do
     before do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath
       (HOMEBREW_CELLAR/"bar/1.0").mkpath
     end
 
-    it "resolves kegs with #resolve_kegs" do
-      expect(described_class.new("foo", "bar").to_kegs.map(&:name)).to eq ["foo", "bar"]
+    it "resolves kegs with #resolve_keg" do
+      expect(described_class.new("foo", "bar").to_keg.map(&:name)).to eq ["foo", "bar"]
     end
 
     it "when there are no matching kegs returns an array of Kegs" do
-      expect(described_class.new.to_kegs).to be_empty
+      expect(described_class.new.to_keg).to be_empty
     end
   end
 

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -176,6 +176,26 @@ describe Homebrew::CLI::NamedArgs do
     end
   end
 
+  describe "#to_kegs" do
+    before do
+      (HOMEBREW_CELLAR/"foo/1.0").mkpath
+      (HOMEBREW_CELLAR/"foo/2.0").mkpath
+      (HOMEBREW_CELLAR/"bar/1.0").mkpath
+    end
+
+    it "resolves kegs with #resolve_kegs" do
+      expect(described_class.new("foo", "bar").to_kegs.map(&:name)).to eq ["foo", "foo", "bar"]
+    end
+
+    it "resolves kegs with multiple versions with #resolve_keg" do
+      expect(described_class.new("foo").to_kegs.map(&->(k) { k.version.version })).to eq ["1.0", "2.0"]
+    end
+
+    it "when there are no matching kegs returns an array of Kegs" do
+      expect(described_class.new.to_kegs).to be_empty
+    end
+  end
+
   describe "#to_default_kegs" do
     before do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath

--- a/Library/Homebrew/test/cli/named_args_spec.rb
+++ b/Library/Homebrew/test/cli/named_args_spec.rb
@@ -218,6 +218,24 @@ describe Homebrew::CLI::NamedArgs do
     end
   end
 
+  describe "#to_latest_kegs" do
+    before do
+      (HOMEBREW_CELLAR/"foo/1.0").mkpath
+      (HOMEBREW_CELLAR/"foo/2.0").mkpath
+      (HOMEBREW_CELLAR/"bar/1.0").mkpath
+    end
+
+    it "resolves the latest kegs with #resolve_latest_keg" do
+      latest_kegs = described_class.new("foo", "bar").to_latest_kegs
+      expect(latest_kegs.map(&:name)).to eq ["foo", "bar"]
+      expect(latest_kegs.map { |k| k.version.version.to_s }).to eq ["2.0", "1.0"]
+    end
+
+    it "when there are no matching kegs returns an empty array" do
+      expect(described_class.new.to_latest_kegs).to be_empty
+    end
+  end
+
   describe "#to_kegs_to_casks" do
     before do
       (HOMEBREW_CELLAR/"foo/1.0").mkpath


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
Closes #11224.

Currently, if the `head` and `stable` versions of a formula are both installed, it isn't possible to link the `head` version of the formula. This PR adds the `--HEAD` flag to link the `head` version of a formula.

I had to revise the link command to use `to_formulae_and_casks(only: :formula, method: :kegs)` rather than `to_kegs` (which calls `to_formulae_and_casks(only: :formula, method: :keg)` to get both the `head` and `stable` kegs. I may have inadvertently created an issue if multiple non-head kegs can be installed. My modifications make the `link` command attempt to link any non-head kegs unless `--HEAD` is given.

I would appreciate it if a maintainer weighed in on this.