### PR TITLE
removed option reference from 'odie' example code snippet in documentation FormulaCookbook markdown file

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -410,13 +410,14 @@ Three commands are provided for displaying informational messages to the user:
 * `opoo` for warning messages
 * `odie` for error messages and immediately exiting
 
-In particular, when a test needs to be performed before installation use `odie` to bail out gracefully. For example:
+Use `odie` when you need to exit a formula gracefully for any reason. For example:
 
 ```ruby
-if build.with?("qt") && build.with?("qt5")
-  odie "Options --with-qt and --with-qt5 are mutually exclusive."
+if build.head?
+  lib_jar = Dir["cfr-*-SNAPSHOT.jar"]
+  doc_jar = Dir["cfr-*-SNAPSHOT-javadoc.jar"]
+  odie "Unexpected number of artifacts!" if (lib_jar.length != 1) || (doc_jar.length != 1)
 end
-system "make", "install"
 ```
 
 ### `bin.install "foo"`


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully run `brew style` with your changes locally?


## My changes are to documentation **only** I do not believe the following check boxes apply for this change

- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

# Summary:

From what I have read, Formula options were removed a while ago. Documentation still contains many references/examples for using options.

These references can be confusing and misleading for new brew users.

This change is my first brew pull request (it is very small) - proposing a change that removes a reference to options in the FormulaCookbook documentation.

# changes:

only 1 file has changes - docs/FormulaCookbook.md

I changed the `odie` example code snippet beginning ~ line 413

The new snippet is modified/minified from the `odie` usage in the cfr-decompiler formula ~ line 39

# Reference:

Here is where I initially read about options being removed - https://github.com/Homebrew/homebrew-core/issues/31510

