### PR TITLE
Revert "extend/os/mac/keg_relocate: fix relocation of duplicate `RPATH`s"

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -94,7 +94,6 @@ class Keg
   def each_linkage_for(file, linkage_type, &block)
     links = file.method(linkage_type)
                 .call
-                .uniq
                 .grep_v(/^@(loader_|executable_|r)path/)
     links.each(&block)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Upon reflection, I realised that this is probably a bug in `ruby-macho`,
and should be fixed there instead.

Needs https://github.com/Homebrew/ruby-macho/pull/362.

This reverts commit e8b5eb7e42c925b7cc10c78a029b8c70e4d7965b.