### PR TITLE
docs: fix Cask Cookbook placeholders being discarded on docs.brew.sh

### DIFF
--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -303,7 +303,7 @@ The [`find-appcast`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/develop
 
 | key             | value       |
 | --------------- | ----------- |
-| `must_contain:` | a custom string for `brew audit --appcast {{cask_file}}` to check against. |
+| `must_contain:` | a custom string for `brew audit --appcast <cask_file>` to check against. |
 
 Sometimes a `version` doesn’t match a string on the webpage, in which case we tweak what to search for. Example: if `version` is `6.26.1440` and the appcast’s contents only show `6.24`, the check for “is `version` in the appcast feed” will fail. With `must_contain`, the check is told to “look for this string instead of `version`”. In the example, `must_contain: version.major_minor` is saying “look for `6.24`”, making the check succeed.
 
@@ -362,7 +362,7 @@ When `caveats` is a string, it is evaluated at compile time. The following metho
 | `version`          | the Cask version
 | `homepage`         | the Cask homepage
 | `caskroom_path`    | the containing directory for all staged Casks, typically `/usr/local/Caskroom` (only available with block form)
-| `staged_path`      | the staged location for this Cask, including version number: `/usr/local/Caskroom/{{token}}/{{version}}` (only available with block form)
+| `staged_path`      | the staged location for this Cask, including version number: `/usr/local/Caskroom/<token>/<version>` (only available with block form)
 
 Example:
 
@@ -1142,21 +1142,21 @@ SourceForge and OSDN (formerly `SourceForge.JP`) projects are common ways to dis
 We prefer URLs of this format:
 
 ```
-https://downloads.sourceforge.net/{{project_name}}/{{filename}}.{{ext}}
+https://downloads.sourceforge.net/<project_name>/<filename>.<ext>
 ```
 
 Or, if it’s from [OSDN](https://osdn.jp/):
 
 ```
-http://{{subdomain}}.osdn.jp/{{project_name}}/{{release_id}}/{{filename}}.{{ext}}
+http://<subdomain>.osdn.jp/<project_name>/<release_id>/<filename>.<ext>
 ```
 
-`{{subdomain}}` is typically of the form `dl` or `{{user}}.dl`.
+`<subdomain>` is typically of the form `dl` or `<user>.dl`.
 
 If these formats are not available, and the application is macOS-exclusive (otherwise a command-line download defaults to the Windows version) we prefer the use of this format:
 
 ```
-https://sourceforge.net/projects/{{project_name}}/files/latest/download
+https://sourceforge.net/projects/<project_name>/files/latest/download
 ```
 
 #### Some Providers Block Command-line Downloads


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Example screenshot of issue on https://docs.brew.sh/Cask-Cookbook
<img width="646" alt="cask-cookbook" src="https://user-images.githubusercontent.com/20700669/118722709-55cdb000-b7e1-11eb-9947-d39850eb0ef8.png">

Looks like some templating logic may be eating the text `{{...}}`

I see `<...>` used in other locations, so hopefully that works and isn't picked up as XML/HTML.