### PR TITLE
formula: tweak preset `pour_bottle?` symbols

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2920,16 +2920,16 @@ class Formula
     # the {Formula} will be built from source and `reason` will be printed.
     #
     # Alternatively, a preset reason can be passed as a symbol:
-    # <pre>pour_bottle? reason: :clt_required</pre>
-    def pour_bottle?(reason: nil, &block)
+    # <pre>pour_bottle? requirement: :clt</pre>
+    def pour_bottle?(requirement: nil, &block)
       @pour_bottle_check = PourBottleCheck.new(self)
 
-      if reason.present? && block.present?
-        raise ArgumentError, "Do not pass both a reason and a block to `pour_bottle?`"
+      if requirement.present? && block.present?
+        raise ArgumentError, "Do not pass both a requirement and a block to `pour_bottle?`"
       end
 
-      block ||= case reason
-      when :clt_required
+      block ||= case requirement
+      when :clt
         lambda do |_|
           on_macos do
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
@@ -2941,7 +2941,7 @@ class Formula
           end
         end
       else
-        raise ArgumentError, "Invalid `pour_bottle?` reason" if reason.present?
+        raise ArgumentError, "Invalid `pour_bottle?` requirement" if requirement.present?
       end
 
       @pour_bottle_check.instance_eval(&block)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2920,16 +2920,16 @@ class Formula
     # the {Formula} will be built from source and `reason` will be printed.
     #
     # Alternatively, a preset reason can be passed as a symbol:
-    # <pre>pour_bottle? requirement: :clt</pre>
-    def pour_bottle?(requirement: nil, &block)
+    # <pre>pour_bottle? only_if: :clt</pre>
+    def pour_bottle?(only_if: nil, &block)
       @pour_bottle_check = PourBottleCheck.new(self)
 
-      if requirement.present? && block.present?
-        raise ArgumentError, "Do not pass both a requirement and a block to `pour_bottle?`"
+      if only_if.present? && block.present?
+        raise ArgumentError, "Do not pass both a preset condition and a block to `pour_bottle?`"
       end
 
-      block ||= case requirement
-      when :clt
+      block ||= case only_if
+      when :clt_installed
         lambda do |_|
           on_macos do
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
@@ -2941,7 +2941,7 @@ class Formula
           end
         end
       else
-        raise ArgumentError, "Invalid `pour_bottle?` requirement" if requirement.present?
+        raise ArgumentError, "Invalid preset `pour_bottle?` condition" if only_if.present?
       end
 
       @pour_bottle_check.instance_eval(&block)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2920,7 +2920,7 @@ class Formula
     # the {Formula} will be built from source and `reason` will be printed.
     #
     # Alternatively, a preset reason can be passed as a symbol:
-    # <pre>pour_bottle? only_if: :clt</pre>
+    # <pre>pour_bottle? only_if: :clt_installed</pre>
     def pour_bottle?(only_if: nil, &block)
       @pour_bottle_check = PourBottleCheck.new(self)
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -996,37 +996,37 @@ describe Formula do
       expect(f).to pour_bottle
     end
 
-    it "returns false with `requirement: :clt` on macOS", :needs_macos do
+    it "returns false with `only_if: :clt_installed` on macOS", :needs_macos do
       # Pretend CLT is not installed
       allow(MacOS::CLT).to receive(:installed?).and_return(false)
 
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? requirement: :clt
+        pour_bottle? only_if: :clt_installed
       end
 
       expect(f).not_to pour_bottle
     end
 
-    it "returns true with `requirement: :clt` on macOS", :needs_macos do
+    it "returns true with `only_if: :clt_installed` on macOS", :needs_macos do
       # Pretend CLT is installed
       allow(MacOS::CLT).to receive(:installed?).and_return(true)
 
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? requirement: :clt
+        pour_bottle? only_if: :clt_installed
       end
 
       expect(f).to pour_bottle
     end
 
-    it "returns true with `requirement: :clt` on Linux", :needs_linux do
+    it "returns true with `only_if: :clt_installed` on Linux", :needs_linux do
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? requirement: :clt
+        pour_bottle? only_if: :clt_installed
       end
 
       expect(f).to pour_bottle
@@ -1037,12 +1037,12 @@ describe Formula do
         formula "foo" do
           url "foo-1.0"
 
-          pour_bottle? requirement: :clt do
+          pour_bottle? only_if: :clt_installed do
             reason "true reason"
             satisfy { true }
           end
         end
-      end.to raise_error(ArgumentError, "Do not pass both a requirement and a block to `pour_bottle?`")
+      end.to raise_error(ArgumentError, "Do not pass both a preset condition and a block to `pour_bottle?`")
     end
 
     it "throws an error if passed an invalid symbol" do
@@ -1050,9 +1050,9 @@ describe Formula do
         formula "foo" do
           url "foo-1.0"
 
-          pour_bottle? requirement: :foo
+          pour_bottle? only_if: :foo
         end
-      end.to raise_error(ArgumentError, "Invalid `pour_bottle?` requirement")
+      end.to raise_error(ArgumentError, "Invalid preset `pour_bottle?` condition")
     end
   end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -996,37 +996,37 @@ describe Formula do
       expect(f).to pour_bottle
     end
 
-    it "returns false with `reason: :clt_required` on macOS", :needs_macos do
+    it "returns false with `requirement: :clt` on macOS", :needs_macos do
       # Pretend CLT is not installed
       allow(MacOS::CLT).to receive(:installed?).and_return(false)
 
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? reason: :clt_required
+        pour_bottle? requirement: :clt
       end
 
       expect(f).not_to pour_bottle
     end
 
-    it "returns true with `reason: :clt_required` on macOS", :needs_macos do
+    it "returns true with `requirement: :clt` on macOS", :needs_macos do
       # Pretend CLT is installed
       allow(MacOS::CLT).to receive(:installed?).and_return(true)
 
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? reason: :clt_required
+        pour_bottle? requirement: :clt
       end
 
       expect(f).to pour_bottle
     end
 
-    it "returns true with `reason: :clt_required` on Linux", :needs_linux do
+    it "returns true with `requirement: :clt` on Linux", :needs_linux do
       f = formula "foo" do
         url "foo-1.0"
 
-        pour_bottle? reason: :clt_required
+        pour_bottle? requirement: :clt
       end
 
       expect(f).to pour_bottle
@@ -1037,12 +1037,12 @@ describe Formula do
         formula "foo" do
           url "foo-1.0"
 
-          pour_bottle? reason: :clt_required do
+          pour_bottle? requirement: :clt do
             reason "true reason"
             satisfy { true }
           end
         end
-      end.to raise_error(ArgumentError, "Do not pass both a reason and a block to `pour_bottle?`")
+      end.to raise_error(ArgumentError, "Do not pass both a requirement and a block to `pour_bottle?`")
     end
 
     it "throws an error if passed an invalid symbol" do
@@ -1050,9 +1050,9 @@ describe Formula do
         formula "foo" do
           url "foo-1.0"
 
-          pour_bottle? reason: :foo
+          pour_bottle? requirement: :foo
         end
-      end.to raise_error(ArgumentError, "Invalid `pour_bottle?` reason")
+      end.to raise_error(ArgumentError, "Invalid `pour_bottle?` requirement")
     end
   end
 

--- a/docs/Bottles.md
+++ b/docs/Bottles.md
@@ -68,7 +68,13 @@ A full example:
 
 ```ruby
 pour_bottle? do
-  reason "The bottle needs the Xcode CLT to be installed."
-  satisfy { MacOS::CLT.installed? }
+  reason "The bottle needs to be installed into #{Homebrew::DEFAULT_PREFIX}."
+  satisfy { HOMEBREW_PREFIX.to_s == Homebrew::DEFAULT_PREFIX }
 end
+```
+
+Commonly used `pour_bottle?` conditions can be added as preset symbols to the `pour_bottle?` method, allowing them to be specified like this:
+
+```ruby
+pour_bottle? only_if: :clt_installed
 ```


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Let's rename `reason` to `requirement` so the preset symbol can just be
`:clt`. See Homebrew/homebrew-core#77509.

This leads to the easier to parse (IMHO)
```ruby
pour_bottle? requirement: :clt
```