### PR TITLE
feat: add branch param

### DIFF
--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -20,7 +20,7 @@ module Homebrew
              description: "If supported on the target tap, automatically reformat and reword commits "\
                           "in the pull request to our preferred format."
       flag   "--branch=",
-             description: "Branch to publish (default: `master`)."
+             description: "Branch to publish to (default: `master`)."
       flag   "--message=",
              depends_on:  "--autosquash",
              description: "Message to include when autosquashing revision bumps, deletions, and rebuilds."

--- a/Library/Homebrew/dev-cmd/pr-publish.rb
+++ b/Library/Homebrew/dev-cmd/pr-publish.rb
@@ -19,6 +19,8 @@ module Homebrew
       switch "--autosquash",
              description: "If supported on the target tap, automatically reformat and reword commits "\
                           "in the pull request to our preferred format."
+      flag   "--branch=",
+             description: "Branch to publish (default: `master`)."
       flag   "--message=",
              depends_on:  "--autosquash",
              description: "Message to include when autosquashing revision bumps, deletions, and rebuilds."
@@ -36,7 +38,7 @@ module Homebrew
 
     tap = Tap.fetch(args.tap || CoreTap.instance.name)
     workflow = args.workflow || "publish-commit-bottles.yml"
-    ref = "master"
+    ref = args.branch || "master"
 
     extra_args = []
     extra_args << "--autosquash" if args.autosquash?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

See the Disscusions:  https://github.com/Homebrew/discussions/discussions/1492

Add a `--branch` param for `pr-publish`.
So that we could trigger github action with `pr-publish` in a tap(Third Party Repository) without using `master` as default branch.

And for keeping `homebrew-core` work normally, the default is set to `master`, so no need to change the github actions in `homebrew-core`.
