### PR TITLE
formula_installer: don't output caveats for dependencies.

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -760,6 +760,8 @@ class FormulaInstaller
 
     audit_installed if Homebrew::EnvConfig.developer?
 
+    return if !installed_on_request? || installed_as_dependency?
+
     caveats = Caveats.new(formula)
 
     return if caveats.empty?


### PR DESCRIPTION
If a formula is installed as a dependency (or not on request) then don't output its caveats.

Inspired by conversation in https://github.com/Homebrew/brew/pull/11367.
Closes https://github.com/Homebrew/brew/pull/11367