### PR TITLE
dependabot: ignore updates to `actions/stale` and `dessant/lock-threads`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # The actions in triage-issues.yml are updated in the Homebrew/.github repo
+    ignore:
+      - dependency-name: actions/stale
+      - dependency-name: dessant/lock-threads
 
   - package-ecosystem: bundler
     directory: /docs


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

-----

See https://github.com/Homebrew/brew/issues/11401

These actions should be updated by dependabot in Homebrew/.github so, to avoid extra PRs, let's ignore them here.

I don't know how to test this, but assuming this gets approved and merged I'll make the same changes to the other repos that will have similar problems.
