### PR TITLE
livecheck/strategy/sparkle: install bundler gems

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -57,6 +57,7 @@ module Homebrew
 
         sig { params(content: String).returns(T.nilable(Item)) }
         def self.item_from_content(content)
+          Homebrew.install_bundler_gems!
           require "nokogiri"
 
           xml = Nokogiri::XML(content)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR should fix #11419, at least on Intel Macs. The `Sparkle` strategy used in `livecheck` blocks currently uses `nokogiri` to extract content. On updates to this (vendored) gem, users would see errors on running `brew livecheck` for some Casks.

This PR ensures `Homebrew.install_bundler_gems!` is run before `require "nokogiri"` in the `Sparkle` strategy.

(Note: This will unfortunately not fix the issue on ARM Macs, as pointed out in https://github.com/Homebrew/discussions/discussions/1299#discussioncomment-706030. We might have to move away from `nokogiri` or find some other solution for that issue.)