### PR TITLE
dev-cmd/update-maintainers: fix require

### DIFF
--- a/Library/Homebrew/dev-cmd/update-maintainers.rb
+++ b/Library/Homebrew/dev-cmd/update-maintainers.rb
@@ -3,7 +3,7 @@
 
 require "cli/parser"
 require "utils/github"
-require "dev-cmd/man"
+require "dev-cmd/generate-man-completions"
 
 module Homebrew
   extend T::Sig


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Use require "dev-cmd/generate-man-completions" instead of require "dev-cmd/man".

I missed changing this when renaming `brew man` to `brew generate-man-completions`.