### PR TITLE
Update clt_installed error message to be more clear

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2932,13 +2932,20 @@ class Formula
       when :clt_installed
         lambda do |_|
           on_macos do
-            T.cast(self, PourBottleCheck).reason(+<<~EOS)
-              The bottle needs the standalone Apple Command Line Tools to be installed. #{if MacOS::Xcode.installed?
-          "\nThe full version of Xcode is not compatible with this bottle."
-              end}
-                You can install them, if desired, with:
-                  xcode-select --install
-            EOS
+            if MacOS::Xcode.installed?
+              T.cast(self, PourBottleCheck).reason(+<<~EOS)
+                This bottle requires the standalone Apple Command Line Tools to be installed.
+                You have an Xcode installation, and the Xcode Command Line Tools are not sufficient.
+                  You can install the Apple Command Line Tools in addition to Xcode, if desired, with:
+                    xcode-select --install
+              EOS
+            else
+              T.cast(self, PourBottleCheck).reason(+<<~EOS)
+                The bottle needs the Apple Command Line Tools to be installed.
+                  You can install them, if desired, with:
+                    xcode-select --install
+              EOS
+            end
             T.cast(self, PourBottleCheck).satisfy { MacOS::CLT.installed? }
           end
         end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2935,7 +2935,6 @@ class Formula
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
               The bottle needs the standalone Apple Command Line Tools to be installed.
               The full version of Xcode is not compatible with this bottle.
-              You will need to install the standalone version.
                 You can install them, if desired, with:
                   xcode-select --install
             EOS

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2933,8 +2933,9 @@ class Formula
         lambda do |_|
           on_macos do
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
-              The bottle needs the standalone Apple Command Line Tools to be installed.
-              The full version of Xcode is not compatible with this bottle.
+              The bottle needs the standalone Apple Command Line Tools to be installed. #{if MacOS::Xcode.installed?
+          "\nThe full version of Xcode is not compatible with this bottle."
+              end}
                 You can install them, if desired, with:
                   xcode-select --install
             EOS

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2933,7 +2933,9 @@ class Formula
         lambda do |_|
           on_macos do
             T.cast(self, PourBottleCheck).reason(+<<~EOS)
-              The bottle needs the Apple Command Line Tools to be installed.
+              The bottle needs the standalone Apple Command Line Tools to be installed.
+              The full version of Xcode is not compatible with this bottle.
+              You will need to install the standalone version.
                 You can install them, if desired, with:
                   xcode-select --install
             EOS


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
The error that appears on formula that require the standalone CLT doesn't make it clear that the full version of Xcode is not compatible.  I made this more clear by changing the error message to the following
```
Error: python@3.9: the bottle needs the standalone Apple Command Line Tools to be installed.
The full version of Xcode is not compatible with this bottle.
You will need to install the standalone version.
  You can install them, if desired, with:
    xcode-select --install
```