### PR TITLE
Don't uninstall `stable` keg with `--HEAD`

### DIFF
--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -322,8 +322,7 @@ module Homebrew
     installed_formulae.each do |f|
       Migrator.migrate_if_needed(f, force: args.force?)
       install_formula(f, args: args)
-      # Don't uninstall older keg(s) if installing HEAD keg(s).
-      Cleanup.install_formula_clean!(f) unless args.HEAD?
+      Cleanup.install_formula_clean!(f)
     end
 
     Upgrade.check_installed_dependents(

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -322,7 +322,8 @@ module Homebrew
     installed_formulae.each do |f|
       Migrator.migrate_if_needed(f, force: args.force?)
       install_formula(f, args: args)
-      Cleanup.install_formula_clean!(f)
+      # Don't uninstall older keg(s) if installing HEAD keg(s).
+      Cleanup.install_formula_clean!(f) unless args.HEAD?
     end
 
     Upgrade.check_installed_dependents(

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2181,8 +2181,10 @@ class Formula
   def eligible_kegs_for_cleanup(quiet: false)
     eligible_for_cleanup = []
     if latest_version_installed?
-      eligible_kegs = if head? && (head_prefix = latest_head_prefix)
-        installed_kegs - [Keg.new(head_prefix)]
+      eligible_kegs = if head?
+        # Remove latest head and stable kegs
+        head, stable = installed_kegs.partition { |k| k.version.head? }
+        head.sort_by(&:version).slice(0...-1) + stable.sort_by(&:version).slice(0...-1)
       else
         installed_kegs.select do |keg|
           tab = Tab.for_keg(keg)

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2182,8 +2182,8 @@ class Formula
     eligible_for_cleanup = []
     if latest_version_installed?
       eligible_kegs = if head?
-        # Remove latest head and stable kegs
         head, stable = installed_kegs.partition { |k| k.version.head? }
+        # Remove newest head and stable kegs
         head.sort_by(&:version).slice(0...-1) + stable.sort_by(&:version).slice(0...-1)
       else
         installed_kegs.select do |keg|

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -928,20 +928,17 @@ describe Formula do
         head("foo")
       end
 
-      stable_prefix = f.latest_installed_prefix
-      stable_prefix.mkpath
-
-      [["000000_1", 1], ["111111", 2], ["111111_1", 2]].each do |pkg_version_suffix, stamp|
-        prefix = f.prefix("HEAD-#{pkg_version_suffix}")
+      ["0.0.1", "0.0.2", "0.1", "HEAD-000000", "HEAD-111111", "HEAD-111111_1"].each do |version|
+        prefix = f.prefix(version)
         prefix.mkpath
         tab = Tab.empty
         tab.tabfile = prefix/Tab::FILENAME
-        tab.source_modified_time = stamp
+        tab.source_modified_time = 1
         tab.write
       end
 
-      eligible_kegs = f.installed_kegs - [Keg.new(f.prefix("HEAD-111111_1"))]
-      expect(f.eligible_kegs_for_cleanup).to eq(eligible_kegs)
+      eligible_kegs = f.installed_kegs - [Keg.new(f.prefix("HEAD-111111_1")), Keg.new(f.prefix("0.1"))]
+      expect(f.eligible_kegs_for_cleanup.sort_by(&:version)).to eq(eligible_kegs.sort_by(&:version))
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
At the moment, installing the `head` version of a formula with `brew install --HEAD` uninstalls the `stable` version of the formula if it is installed. This is obviously undesirable if you want to have the `head` and `stable` versions of a formula installed simultaneously.

This behavior seemed odd when I first discovered it, but it's actually the product of `brew install` uninstalling any kegs that have older versions than the one being installed. The `stable` keg is obviously older than the `head` keg, so it's uninstalled.

This PR changes `brew install` so that it doesn't do any clean-up if `--HEAD` is given.