### PR TITLE
extract: use downcased version in filename

### DIFF
--- a/Library/Homebrew/dev-cmd/extract.rb
+++ b/Library/Homebrew/dev-cmd/extract.rb
@@ -202,7 +202,7 @@ module Homebrew
     # Remove bottle blocks, they won't work.
     result.sub!(/  bottle do.+?end\n\n/m, "") if destination_tap != source_tap
 
-    path = destination_tap.path/"Formula/#{name}@#{version}.rb"
+    path = destination_tap.path/"Formula/#{name}@#{version.to_s.downcase}.rb"
     if path.exist?
       unless args.force?
         odie <<~EOS


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

Formula filenames are required to be lowercase, so the `brew extract` command should downcase the version before using it to construct the filename. I noticed this while performing `brew extract tbb@2020`, which has [version 2020_U3](https://github.com/Homebrew/homebrew-core/blob/754d838326a1fff4e281176de155c3b734b2abac/Formula/tbb%402020.rb#L5) and resulted in a formula with filename `tbb@2020_U3.rb`
