### PR TITLE
audit: complain about uppercase formula names

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -120,10 +120,12 @@ module Homebrew
     end
 
     def audit_formula_name
+      name = formula.name
+
+      problem "Formula name '#{name}' must not contain uppercase letters." if name != name.downcase
+
       return unless @strict
       return unless @core_tap
-
-      name = formula.name
 
       problem "'#{name}' is not allowed in homebrew/core." if MissingFormula.disallowed_reason(name)
 

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -488,6 +488,32 @@ module Homebrew
       end
     end
 
+    describe "#audit_formula_name" do
+      specify "no issue" do
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true, strict: true
+          class Foo < Formula
+            url "https://brew.sh/foo-1.0.tgz"
+            homepage "https://brew.sh"
+          end
+        RUBY
+
+        fa.audit_formula_name
+        expect(fa.problems).to be_empty
+      end
+
+      specify "uppercase formula name" do
+        fa = formula_auditor "Foo", <<~RUBY
+          class Foo < Formula
+            url "https://brew.sh/Foo-1.0.tgz"
+            homepage "https://brew.sh"
+          end
+        RUBY
+
+        fa.audit_formula_name
+        expect(fa.problems.first[:message]).to match "must not contain uppercase letters"
+      end
+    end
+
     describe "#check_service_command" do
       specify "Not installed" do
         fa = formula_auditor "foo", <<~RUBY


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [X] Have you successfully run `brew style` with your changes locally?
- [X] Have you successfully run `brew typecheck` with your changes locally?
- [X] Have you successfully run `brew tests` with your changes locally?

-----

As recently discussed in https://github.com/Homebrew/brew/pull/11440#issuecomment-849354045, our docs state that "[Filenames should be all lowercase](https://github.com/Homebrew/brew/blame/3.1.9/docs/Formula-Cookbook.md#L346)". This adds an audit to complain about formula names with uppercase letters and a test.