### PR TITLE
dependency: don't merge formula and cask cache in `::expand`

### DIFF
--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -96,7 +96,7 @@ class Dependency
 
       if cache_key.present?
         cache[cache_key] ||= {}
-        return cache[cache_key][dependent.full_name].dup if cache[cache_key][dependent.full_name]
+        return cache[cache_key][cache_id dependent].dup if cache[cache_key][cache_id dependent]
       end
 
       expanded_deps = []
@@ -122,7 +122,7 @@ class Dependency
       end
 
       expanded_deps = merge_repeats(expanded_deps)
-      cache[cache_key][dependent.full_name] = expanded_deps.dup if cache_key.present?
+      cache[cache_key][cache_id dependent] = expanded_deps.dup if cache_key.present?
       expanded_deps
     ensure
       @expand_stack.pop
@@ -169,6 +169,10 @@ class Dependency
     end
 
     private
+
+    def cache_id(dependent)
+      "#{dependent.full_name}_#{dependent.class}"
+    end
 
     def merge_tags(deps)
       other_tags = deps.flat_map(&:option_tags).uniq

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -223,7 +223,7 @@ class Requirement
     def expand(dependent, cache_key: nil, &block)
       if cache_key.present?
         cache[cache_key] ||= {}
-        return cache[cache_key][dependent.full_name].dup if cache[cache_key][dependent.full_name]
+        return cache[cache_key][cache_id dependent].dup if cache[cache_key][cache_id dependent]
       end
 
       reqs = Requirements.new
@@ -239,7 +239,7 @@ class Requirement
         end
       end
 
-      cache[cache_key][dependent.full_name] = reqs.dup if cache_key.present?
+      cache[cache_key][cache_id dependent] = reqs.dup if cache_key.present?
       reqs
     end
 
@@ -257,6 +257,12 @@ class Requirement
     sig { void }
     def prune
       throw(:prune, true)
+    end
+
+    private
+
+    def cache_id(dependent)
+      "#{dependent.full_name}_#{dependent.class}"
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes #11453

Before, `Dependency::expand` would cache the expanded dependencies based on the dependent's name. This doesn't work for formulae and casks that share a name (e.g. `julia`, `mkvtoolnix`, and `r`) because the cached dependencies from the formula might be used and not recalculated for the cask (and vice-versa).

In #11453, when neither `--formula` nor `--cask` were passed, the formulae were evaluated first and the dependents of the `julia`, `mkvtoolnix`, and `r` _formuae_ were cached. Then, when the casks were evaluated, the cached dependents from the corresponding formulae were used for those three.

Now, the key used in the cache to identify the dependencies for a given dependent has been changed to include the class name of the root dependent, removing conflicts. For example, before the dependents for `r` were cached under `r` but now they are cached under `r_Formulary::FormulaNamespace026a0acb685cf2bcb6fd05507c6a2f4e::R` and `r_CaskDependent`.
