### PR TITLE
livecheck/strategy/gnome: handle new GNOME versioning

### DIFF
--- a/Library/Homebrew/livecheck/strategy/gnome.rb
+++ b/Library/Homebrew/livecheck/strategy/gnome.rb
@@ -12,16 +12,16 @@ module Homebrew
       #
       # * `https://download.gnome.org/sources/example/1.2/example-1.2.3.tar.xz`
       #
-      # Before version 40, GNOME used a versioning scheme where unstable
-      # releases were indicated with a minor that's 90+ or odd. The newer
-      # version scheme uses trailing alpha/beta/rc text to identify unstable
-      # versions (e.g., `40.alpha`).
+      # Before version 40, GNOME used a version scheme where unstable releases
+      # were indicated with a minor that's 90+ or odd. The newer version scheme
+      # uses trailing alpha/beta/rc text to identify unstable versions
+      # (e.g., `40.alpha`).
       #
-      # When a regex isn't provided in a `livecheck` block, this strategy uses
-      # a default regex that matches versions that don't include trailing text
-      # after the numeric version (e.g., `40.0` instead of `40.alpha`, etc.)
-      # and it selectively filters out unstable versions below 40 using the
-      # older scheme.
+      # When a regex isn't provided in a `livecheck` block, the strategy uses
+      # a default regex that matches versions which don't include trailing text
+      # after the numeric version (e.g., `40.0` instead of `40.alpha`) and it
+      # selectively filters out unstable versions below 40 using the rules for
+      # the older version scheme.
       #
       # @api public
       class Gnome


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR updates the `Gnome`strategy for `livecheck` to handle the [new GNOME versioning scheme](https://discourse.gnome.org/t/new-gnome-versioning-scheme/4235) in addition to the older one. Some discussion to provide context is in Homebrew/homebrew-core#78278.

One thing that I had an issue with is how the `Version` objects are displayed in the debug output:
```
40.1.1 => #<Version:0x00007fed9ace3530 @version="40.1.1", @detected_from_url=false, @tokens=[#<Version::NumericToken 40>, #<Version::NumericToken 1>, #<Version::NumericToken 1>]>
```
This is because I've used the `major` and `minor` methods, which tokenise the version string. It would be great if we can avoid showing the tokens in the output.