### PR TITLE
os/mac: set `preferred_perl_version` for Catalina

### DIFF
--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -64,6 +64,8 @@ module OS
     def preferred_perl_version
       if version >= :big_sur
         "5.30"
+      elsif version == :catalina
+        "5.28"
       else
         "5.18"
       end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Our Catalina nodes do not have a `perl5.30` installed.

Fixes a CI failure in Homebrew/homebrew-core#78294.