### PR TITLE
dev-cmd/unbottled: fix arch requirement handling

### DIFF
--- a/Library/Homebrew/dev-cmd/unbottled.rb
+++ b/Library/Homebrew/dev-cmd/unbottled.rb
@@ -158,10 +158,6 @@ module Homebrew
 
     formulae.each do |f|
       name = f.name.downcase
-      if f.bottle_specification.tag?(@bottle_tag, no_older_versions: true)
-        puts "#{Tty.bold}#{Tty.green}#{name}#{Tty.reset}: already bottled" if any_named_args
-        next
-      end
 
       if f.disabled?
         puts "#{Tty.bold}#{Tty.green}#{name}#{Tty.reset}: formula disabled" if any_named_args
@@ -190,11 +186,7 @@ module Homebrew
 
             Version.new(MacOS::Xcode.latest_version(macos: macos_version)) >= r.version
           when ArchRequirement
-            arch = r.arch
-            arch = :intel if arch == :x86_64
-            arch = :arm64 if arch == :arm
-
-            arch == macos_version.arch
+            r.arch == @bottle_tag.arch
           else
             true
           end
@@ -212,6 +204,11 @@ module Homebrew
           "disabled"
         end
         puts "#{Tty.bold}#{Tty.red}#{name}#{Tty.reset}: bottle #{reason}" if any_named_args
+        next
+      end
+
+      if f.bottle_specification.tag?(@bottle_tag, no_older_versions: true)
+        puts "#{Tty.bold}#{Tty.green}#{name}#{Tty.reset}: already bottled" if any_named_args
         next
       end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

* Fix `ArchRequirement` comparison. Closes #11456.
* Move bottle tag check to after the requirement check, so that a formula that depends on x86_64 but has an `:all` bottle will now print "doesn't support this macOS" rather than "already bottled".
