### PR TITLE
os/mac/keg_relocate: add fallback to default Perl version when using tab

### DIFF
--- a/Library/Homebrew/extend/os/mac/keg_relocate.rb
+++ b/Library/Homebrew/extend/os/mac/keg_relocate.rb
@@ -159,13 +159,16 @@ class Keg
     brewed_perl = runtime_dependencies&.any? { |dep| dep["full_name"] == "perl" && dep["declared_directly"] }
     perl_path = if brewed_perl || name == "perl"
       "#{HOMEBREW_PREFIX}/opt/perl/bin/perl"
+    elsif tab["built_on"].present?
+      perl_path = "/usr/bin/perl#{tab["built_on"]["preferred_perl"]}"
+
+      # For `:all` bottles, we could have built this bottle with a Perl we don't have.
+      # Such bottles typically don't have strict version requirements.
+      perl_path = "/usr/bin/perl#{MacOS.preferred_perl_version}" unless File.exist?(perl_path)
+
+      perl_path
     else
-      perl_version = if tab["built_on"].present?
-        tab["built_on"]["preferred_perl"]
-      else
-        MacOS.preferred_perl_version
-      end
-      "/usr/bin/perl#{perl_version}"
+      "/usr/bin/perl#{MacOS.preferred_perl_version}"
     end
     relocation.add_replacement_pair(:perl, PERL_PLACEHOLDER, perl_path)
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

While this should never be necessary for per-OS bottles, this could be useful for `:all` bottles where the OS it was built on could use a Perl version that doesn't exist on all macOS versions.