### PR TITLE
diagnostic: add check for broken taps

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -147,25 +147,23 @@ module Homebrew
         end
       end
 
-      def broken_tap_msg(tap)
-        <<~EOS
-          #{tap.full_name} was not tapped properly.
-          To fix:
-            rm -rf "#{tap.path}"
-            brew tap #{tap.name}
-        EOS
-      end
-
       def broken_tap(tap)
         return unless Utils::Git.available?
         return unless HOMEBREW_REPOSITORY.git?
 
-        return broken_tap_msg(tap) if tap.remote.blank?
+        message = <<~EOS
+          #{tap.full_name} was not tapped properly! Run:
+            rm -rf "#{tap.path}"
+            brew tap #{tap.name}
+        EOS
+
+        return message if tap.remote.blank?
 
         tap_head = tap.git_head
-        return broken_tap_msg(tap) if tap_head.blank?
+        return message if tap_head.blank?
+        return if tap_head != HOMEBREW_REPOSITORY.git_head
 
-        return broken_tap_msg(tap) if tap_head == HOMEBREW_REPOSITORY.git_head
+        message
       end
 
       def check_for_installed_developer_tools

--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -147,6 +147,27 @@ module Homebrew
         end
       end
 
+      def broken_tap_msg(tap)
+        <<~EOS
+          #{tap.full_name} was not tapped properly.
+          To fix:
+            rm -rf "#{tap.path}"
+            brew tap #{tap.name}
+        EOS
+      end
+
+      def broken_tap(tap)
+        return unless Utils::Git.available?
+        return unless HOMEBREW_REPOSITORY.git?
+
+        return broken_tap_msg(tap) if tap.remote.blank?
+
+        tap_head = tap.git_head
+        return broken_tap_msg(tap) if tap_head.blank?
+
+        return broken_tap_msg(tap) if tap_head == HOMEBREW_REPOSITORY.git_head
+      end
+
       def check_for_installed_developer_tools
         return if DevelopmentTools.installed?
 
@@ -558,15 +579,16 @@ module Homebrew
         examine_git_origin(HOMEBREW_REPOSITORY, Homebrew::EnvConfig.brew_git_remote)
       end
 
-      def check_coretap_git_origin
-        examine_git_origin(CoreTap.instance.path, Homebrew::EnvConfig.core_git_remote)
+      def check_coretap_integrity
+        coretap = CoreTap.instance
+        broken_tap(coretap) || examine_git_origin(coretap.path, Homebrew::EnvConfig.core_git_remote)
       end
 
-      def check_casktap_git_origin
+      def check_casktap_integrity
         default_cask_tap = Tap.default_cask_tap
         return unless default_cask_tap.installed?
 
-        examine_git_origin(default_cask_tap.path, default_cask_tap.remote)
+        broken_tap(default_cask_tap) || examine_git_origin(default_cask_tap.path, default_cask_tap.remote)
       end
 
       sig { returns(T.nilable(String)) }


### PR DESCRIPTION
Detect half-baked core taps that show up on a fairly regular basis (e.g. #11465, https://github.com/Homebrew/brew/issues/11243).

A half-baked tap wouldn't have a complete Git config, and is always somewhere below `HOMEBREW_REPOSITORY`, so any Git operation would refer to the Brew repo instead. We simply need to test for any of:

1. Empty tap origin
2. Empty tap HEAD
3. Tap HEAD == Brew HEAD

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally? 

-----
