### PR TITLE
utils/tar: fix validation for tar without directory or extensions

### DIFF
--- a/Library/Homebrew/utils/tar.rb
+++ b/Library/Homebrew/utils/tar.rb
@@ -1,6 +1,8 @@
 # typed: true
 # frozen_string_literal: true
 
+require "system_command"
+
 module Utils
   # Helper functions for interacting with tar files.
   #
@@ -26,9 +28,9 @@ module Utils
 
         path = Pathname.new(path)
         return unless TAR_FILE_EXTENSIONS.include? path.extname
-        return if Utils.popen_read(executable, "--list", "--file", path).match?(%r{/.*\.})
 
-        odie "#{path} is not a valid tar file!"
+        stdout, _, status = system_command(executable, args: ["--list", "--file", path], print_stderr: false)
+        odie "#{path} is not a valid tar file!" if !status.success? || stdout.blank?
       end
 
       def clear_executable_cache


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

While running `brew bump-cask-pr ...` I have seen a tar validation issue a few times.
For example:
```make
==> Verifying checksum for 'f4a5f395b90a4e7a31973a859427284a3c6bec550dbc480a3c588bb68d3dd978--helix-core-server.tgz'
Warning: Cannot verify integrity of 'f4a5f395b90a4e7a31973a859427284a3c6bec550dbc480a3c588bb68d3dd978--helix-core-server.tgz'.
No checksum was provided for this resource.
For your reference, the checksum is:
  sha256 "9a1f528f92568531785b1f125e60a48e84b1a958f9e1d74dfc6e61c060e08721"
Error: /Users/cho-m/Library/Caches/Homebrew/downloads/f4a5f395b90a4e7a31973a859427284a3c6bec550dbc480a3c588bb68d3dd978--helix-core-server.tgz is not a valid tar file!
```

The problem seems to be that the validation of tar file depends on regex `/.*\.`, which means that a directory must exist and at least one file must have an extension.

This shouldn't be a restriction on validity of tar file.

I decided to use logic similar to unpack:
https://github.com/Homebrew/brew/blob/5115cc25fa89192feee16245b7d048ee3324077b/Library/Homebrew/unpack_strategy/tar.rb#L32-L34