### PR TITLE
formula: reject only the latest head keg when cleaning up

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -2179,10 +2179,10 @@ class Formula
   def eligible_kegs_for_cleanup(quiet: false)
     eligible_for_cleanup = []
     if latest_version_installed?
-      eligible_kegs = if head?
+      eligible_kegs = if head? && (head_prefix = latest_head_prefix)
         head, stable = installed_kegs.partition { |k| k.version.head? }
         # Remove newest head and stable kegs
-        head.sort_by(&:version).slice(0...-1) + stable.sort_by(&:version).slice(0...-1)
+        head - [Keg.new(head_prefix)] + stable.sort_by(&:version).slice(0...-1)
       else
         installed_kegs.select do |keg|
           tab = Tab.for_keg(keg)

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "BREW" "1" "May 2021" "Homebrew" "brew"
+.TH "BREW" "1" "June 2021" "Homebrew" "brew"
 .
 .SH "NAME"
 \fBbrew\fR \- The Missing Package Manager for macOS (or Linux)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Follow up to #11438. See https://github.com/Homebrew/brew/pull/11438#issuecomment-851481188

`Version`s can be compared to each other using so using `.sort_by(&:version)` works fine. `HeadVersion`s, though, cannot be compared in this way. Instead, the latest version is found by checking the time the tab was modified (done in `Formula#latest_head_version`).

Since `.sort_by(&:version)` on and array of HEAD kegs just returns the same array (of which all items except for the last were selected for cleanup), it is arbitrary which HEAD version doesn't get selected for cleanup.

Instead of sorting the HEAD keg array, I've chosen to just remove the latest HEAD keg as found using `Formula#latest_head_version`. This is essentially the same behavior that existed prior to #11438.

Here's the net diff of #11438 and this PR:

```diff
        eligible_kegs = if head? && (head_prefix = latest_head_prefix)
-         installed_kegs - [Keg.new(head_prefix)]
+         head, stable = installed_kegs.partition { |k| k.version.head? }
+         # Remove newest head and stable kegs
+         head - [Keg.new(head_prefix)] + stable.sort_by(&:version).slice(0...-1)
        else
```
