### PR TITLE
bottle: calculate rebuild correctly when removing `bottle :unneeded`

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -312,7 +312,7 @@ module Homebrew
     else
       ohai "Determining #{f.full_name} bottle rebuild..."
       FormulaVersions.new(f).formula_at_revision("origin/HEAD") do |upstream_f|
-        if f.pkg_version == upstream_f.pkg_version
+        if f.pkg_version == upstream_f.pkg_version && !upstream_f.bottle_unneeded?
           upstream_f.bottle_specification.rebuild + 1
         else
           0


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

See https://github.com/Homebrew/homebrew-core/pull/78408#issuecomment-851328637

When a formula specified `bottle :unneeded`, `f.bottle_specification.rebuild` is still set to `0` even though this is never used because it's always accessed behind a `f.bottle_unneeded?` check.

However, when calculating the new rebuild value, there was no check for when `bottle :unneeded` is being removed. This means that the new rebuild is calculated with a simple `f.bottle_specification.rebuild + 1` which will return `1` not `0`. This PR adds a check for whether the formula previously had `bottle :unneeded` and defaults to `0` if it did.
