### PR TITLE
formula_auditor: add audit for elasticsearch and kibana

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -353,6 +353,17 @@ module Homebrew
               "which allows them to use our Linux bottles, which were compiled against system Glibc on CI."
     end
 
+    ELASTICSEARCH_KIBANA_RELICENSED_VERSION = "7.11"
+
+    def audit_elasticsearch_kibana
+      return if formula.name != "elasticsearch" && formula.name != "kibana"
+      return unless @core_tap
+      return if formula.version < Version.new(ELASTICSEARCH_KIBANA_RELICENSED_VERSION)
+
+      problem "Elasticsearch and Kibana were relicensed to a non-open-source license from version 7.11. " \
+              "They must not be upgraded to version 7.11 or newer."
+    end
+
     def audit_versioned_keg_only
       return unless @versioned_formula
       return unless @core_tap


### PR DESCRIPTION
Prevent upgrading them to version 7.11 or newer, as they were
relicensed to an incompatible license.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Output:
```
➜ brew audit --strict elasticsearch
elasticsearch:
  * Elasticsearch and Kibana were relicensed to a non-open-source license from version 7.11. They must not be upgraded to version 7.11 or newer.
Error: 1 problem in 1 formula detected
```