### PR TITLE
formula: add `to_recursive_bottle_hash` method

### DIFF
--- a/Library/Homebrew/cmd/info.rb
+++ b/Library/Homebrew/cmd/info.rb
@@ -50,6 +50,9 @@ module Homebrew
              description: "Print a JSON representation. Currently the default value for <version> is `v1` for "\
                           "<formula>. For <formula> and <cask> use `v2`. See the docs for examples of using the "\
                           "JSON output: <https://docs.brew.sh/Querying-Brew>"
+      switch "--bottle",
+             depends_on:  "--json",
+             description: "Output information about the bottles for <formula> and its dependencies."
       switch "--installed",
              depends_on:  "--json",
              description: "Print JSON of formulae that are currently installed."
@@ -65,6 +68,10 @@ module Homebrew
 
       conflicts "--installed", "--all"
       conflicts "--formula", "--cask"
+
+      %w[--cask --analytics --github].each do |conflict|
+        conflicts "--bottle", conflict
+      end
 
       named_args [:formula, :cask]
     end
@@ -184,7 +191,11 @@ module Homebrew
         args.named.to_formulae
       end
 
-      formulae.map(&:to_hash)
+      if args.bottle?
+        formulae.map(&:to_recursive_bottle_hash)
+      else
+        formulae.map(&:to_hash)
+      end
     when :v2
       formulae, casks = if args.all?
         [Formula.sort, Cask::Cask.to_a.sort_by(&:full_name)]
@@ -194,10 +205,14 @@ module Homebrew
         args.named.to_formulae_to_casks
       end
 
-      {
-        "formulae" => formulae.map(&:to_hash),
-        "casks"    => casks.map(&:to_h),
-      }
+      if args.bottle?
+        { "formulae" => formulae.map(&:to_recursive_bottle_hash) }
+      else
+        {
+          "formulae" => formulae.map(&:to_hash),
+          "casks"    => casks.map(&:to_h),
+        }
+      end
     else
       raise
     end

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1908,6 +1908,27 @@ class Formula
     hsh
   end
 
+  # @api private
+  # Generate a hash to be used to install a formula from a JSON file
+  def to_bottle_hash(top_level: true)
+    bottle = bottle_hash
+
+    bottles = bottle["files"].map do |tag, file|
+      info = {
+        "url"    => file["url"],
+        "sha256" => file["sha256"],
+      }
+      [tag.to_s, info]
+    end.to_h
+
+    return bottles unless top_level
+
+    {
+      "bottles"      => bottles,
+      "dependencies" => deps.map { |dep| dep.to_formula.to_bottle_hash(top_level: false) },
+    }
+  end
+
   # Returns the bottle information for a formula
   def bottle_hash
     bottle_spec = stable.bottle_specification

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1915,7 +1915,7 @@ class Formula
 
     bottles = bottle["files"].map do |tag, file|
       info = { "url" => file["url"] }
-      info["sha256"] = file["sha256"] unless tap.name == "homebrew/core"
+      info["sha256"] = file["sha256"] if tap.name != "homebrew/core"
       [tag.to_s, info]
     end.to_h
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1925,7 +1925,7 @@ class Formula
 
     {
       "bottles"      => bottles,
-      "dependencies" => deps.map { |dep| dep.to_formula.to_bottle_hash(top_level: false) },
+      "dependencies" => declared_runtime_dependencies.map { |dep| dep.to_formula.to_bottle_hash(top_level: false) },
     }
   end
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1914,10 +1914,8 @@ class Formula
     bottle = bottle_hash
 
     bottles = bottle["files"].map do |tag, file|
-      info = {
-        "url"    => file["url"],
-        "sha256" => file["sha256"],
-      }
+      info = { "url" => file["url"] }
+      info["sha256"] = file["sha256"] unless tap.name == "homebrew/core"
       [tag.to_s, info]
     end.to_h
 

--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1910,7 +1910,7 @@ class Formula
 
   # @api private
   # Generate a hash to be used to install a formula from a JSON file
-  def to_bottle_hash(top_level: true)
+  def to_recursive_bottle_hash(top_level: true)
     bottle = bottle_hash
 
     bottles = bottle["files"].map do |tag, file|
@@ -1923,9 +1923,14 @@ class Formula
 
     return bottles unless top_level
 
+    dependencies = declared_runtime_dependencies.map do |dep|
+      dep.to_formula.to_recursive_bottle_hash(top_level: false)
+    end
+
     {
+      "name"         => name,
       "bottles"      => bottles,
-      "dependencies" => declared_runtime_dependencies.map { |dep| dep.to_formula.to_bottle_hash(top_level: false) },
+      "dependencies" => dependencies,
     }
   end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -871,7 +871,7 @@ describe Formula do
     expect(h["versions"]["bottle"]).to be_truthy
   end
 
-  specify "#to_bottle_hash" do
+  specify "#to_recursive_bottle_hash" do
     f1 = formula "foo" do
       url "foo-1.0"
 
@@ -881,9 +881,10 @@ describe Formula do
       end
     end
 
-    h = f1.to_bottle_hash
+    h = f1.to_recursive_bottle_hash
 
     expect(h).to be_a(Hash)
+    expect(h["name"]).to eq "foo"
     expect(h["bottles"].keys).to eq [Utils::Bottles.tag.to_s, "x86_64_foo"]
     expect(h["bottles"][Utils::Bottles.tag.to_s].keys).to eq ["url", "sha256"]
     expect(h["bottles"][Utils::Bottles.tag.to_s]["sha256"]).to eq TEST_SHA256

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -886,8 +886,7 @@ describe Formula do
     expect(h).to be_a(Hash)
     expect(h["name"]).to eq "foo"
     expect(h["bottles"].keys).to eq [Utils::Bottles.tag.to_s, "x86_64_foo"]
-    expect(h["bottles"][Utils::Bottles.tag.to_s].keys).to eq ["url", "sha256"]
-    expect(h["bottles"][Utils::Bottles.tag.to_s]["sha256"]).to eq TEST_SHA256
+    expect(h["bottles"][Utils::Bottles.tag.to_s].keys).to eq ["url"]
     expect(h["dependencies"]).to eq []
   end
 

--- a/Library/Homebrew/test/formula_spec.rb
+++ b/Library/Homebrew/test/formula_spec.rb
@@ -871,6 +871,25 @@ describe Formula do
     expect(h["versions"]["bottle"]).to be_truthy
   end
 
+  specify "#to_bottle_hash" do
+    f1 = formula "foo" do
+      url "foo-1.0"
+
+      bottle do
+        sha256 cellar: :any, Utils::Bottles.tag.to_sym => TEST_SHA256
+        sha256 cellar: :any, foo:                         TEST_SHA256
+      end
+    end
+
+    h = f1.to_bottle_hash
+
+    expect(h).to be_a(Hash)
+    expect(h["bottles"].keys).to eq [Utils::Bottles.tag.to_s, "x86_64_foo"]
+    expect(h["bottles"][Utils::Bottles.tag.to_s].keys).to eq ["url", "sha256"]
+    expect(h["bottles"][Utils::Bottles.tag.to_s]["sha256"]).to eq TEST_SHA256
+    expect(h["dependencies"]).to eq []
+  end
+
   describe "#eligible_kegs_for_cleanup" do
     it "returns Kegs eligible for cleanup" do
       f1 = Class.new(Testball) do


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds the `Formula#to_bottle_hash` method to be used to create bottle JSON files for #11426.

This will be used in Homebrew/formulae.brew.sh to create the `/api/bottles` API.

Click these links for gists showing the output of this method (when converted to JSON) is for these formulae: [`hello`](https://gist.github.com/Rylan12/bf0adea0d317697a8f16dfc12637ab1c), [`youtube-dl`](https://gist.github.com/Rylan12/5756038a327159cf7f449f44f7406de2)