### PR TITLE
Version: Add parser for additional hyphenated filenames

### DIFF
--- a/Library/Homebrew/test/version_spec.rb
+++ b/Library/Homebrew/test/version_spec.rb
@@ -479,6 +479,12 @@ describe Version do
     specify "version internal dash" do
       expect(described_class.create("1.1-2"))
         .to be_detected_from("https://brew.sh/foo-arse-1.1-2.tar.gz")
+      expect(described_class.create("3.3.04-1"))
+        .to be_detected_from("https://brew.sh/3.3.04-1.tar.gz")
+      expect(described_class.create("1.2-20200102"))
+        .to be_detected_from("https://brew.sh/v1.2-20200102.tar.gz")
+      expect(described_class.create("3.6.6-0.2"))
+        .to be_detected_from("https://brew.sh/v3.6.6-0.2.tar.gz")
     end
 
     specify "version single digit" do

--- a/Library/Homebrew/version.rb
+++ b/Library/Homebrew/version.rb
@@ -417,6 +417,14 @@ class Version
     # e.g. ruby-1.9.1-p243
     StemParser.new(/[_-](#{NUMERIC_WITH_DOTS}-(?:p|rc|RC)?\d+)#{CONTENT_SUFFIX}?$/),
 
+    # Hyphenated versions without software-name prefix (e.g. brew-)
+    # e.g. v0.0.8-12.tar.gz
+    # e.g. 3.3.04-1.tar.gz
+    # e.g. v2.1-20210510.tar.gz
+    # e.g. 2020.11.11-3.tar.gz
+    # e.g. v3.6.6-0.2
+    StemParser.new(/^v?(#{NUMERIC_WITH_DOTS}(?:-#{NUMERIC_WITH_OPTIONAL_DOTS})+)/),
+
     # URL with no extension
     # e.g. https://waf.io/waf-1.8.12
     # e.g. https://codeload.github.com/gsamokovarov/jump/tar.gz/v0.7.1


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

The version for the `luajit-openresty` formula is currently parsed from the `stable` URL (`https://github.com/openresty/luajit2/archive/refs/tags/v2.1-20210510.tar.gz`) as `20210510` instead of `2.1-20210510` (see Homebrew/homebrew-core#78791). This should have used `version` to specify the full version that wasn't being properly parsed when the formula was added but that wasn't addressed at the time. [Other formulae with a similar version format run into the same parsing issue and they use `version` because of it.]

We could simply add `version "v2.1-20210510"` to `luajit-openresty` (doing what formulae with a similar version format have done) but I figured it would be better to support this version format internally (i.e., fixing this issue for both existing and future formulae without needing to use `version`).

---

This PR addresses this by adding a `StemParser` to `Version::VERSION_PARSERS` that matches versions that start with a numeric version like `1.2`/`v1.2`, `1.2.3`/`v1.2.3`, etc. followed by a hyphen and a trailing number (e.g., `-12`), numeric version (e.g., `-0.2`), date (e.g., `20210605`), etc. This allows these versions to be correctly parsed without needing to use `version` in the formula/cask.

This not only fixes the version parsing for `luajit-openresty` but also for six formulae that are currently using ` version` due to this shortcoming in the current version parsing logic. This would allow us to remove `version` from the following formulae: `bandcamp-dl`, `inxi`, `jnethack`, `luv`, `redir`, `youtube-dlc`.

---

The only other formula or cask that this affects is the `ammonite-repl` formula, which uses a filename like `2.13-2.3.8`, where the numeric version before the hyphen is a Scala version and the numeric version after the hyphen is the `ammonite-repl` version. The aforementioned version parsing bug was unintentionally producing the correct version for this formula because the leading `2.13-` was treated like a software name prefix (e.g., `brew-`) and omitted from the capture group.

Accounting for filenames like `v0.0.8-12.tar.gz` means that we have to use `version` in `ammonite-repl` to manually isolate the formula version. This would need to be done before this PR could be merged.

It's worth mentioning that there are other formulae that have a leading Scala version in the numeric portion of the filename (`akka`, `giter8`, `scalastyle`, `kafka`) but they're unaffected by the change in this PR because they all have a software name prefix before the numeric version (e.g., `akka_2.11-2.4.20.zip`) and the added parser in this PR only matches filenames without one.