### PR TITLE
docs: add terminology to manpage

### DIFF
--- a/Library/Homebrew/dev-cmd/generate-man-completions.rb
+++ b/Library/Homebrew/dev-cmd/generate-man-completions.rb
@@ -67,7 +67,6 @@ module Homebrew
       generate_cmd_manpages(Commands.official_external_commands_paths(quiet: quiet))
     variables[:global_cask_options] = global_cask_options_manpage
     variables[:global_options] = global_options_manpage
-    variables[:terminology] = terminology_manpage
     variables[:environment_variables] = env_vars_manpage
 
     readme = HOMEBREW_REPOSITORY/"README.md"
@@ -228,22 +227,6 @@ module Homebrew
       generate_option_doc(short, long, desc)
     end
     lines.join("\n")
-  end
-
-  sig { returns(String) }
-  def terminology_manpage
-    formula_cookbook_text = (HOMEBREW_REPOSITORY/"docs/Formula-Cookbook.md").read.split("\n")
-
-    start_term = "## Homebrew terminology"
-    start_index = formula_cookbook_text.index(start_term) + 4 # Skip ahead to the table contents
-    end_index = formula_cookbook_text.index "## An introduction"
-    formula_cookbook_text[start_index...end_index].map do |item|
-      next "" unless item.include? "|"
-
-      term, definition, example = item.split("|").map(&:strip)[1..]
-      definition.gsub!(/\[(.*)\]\(.*\)/, '\1')
-      "#{term}: #{definition} (e.g. #{example})"
-    end.join("\n\n")
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/dev-cmd/generate-man-completions.rb
+++ b/Library/Homebrew/dev-cmd/generate-man-completions.rb
@@ -67,6 +67,7 @@ module Homebrew
       generate_cmd_manpages(Commands.official_external_commands_paths(quiet: quiet))
     variables[:global_cask_options] = global_cask_options_manpage
     variables[:global_options] = global_options_manpage
+    variables[:terminology] = terminology_manpage
     variables[:environment_variables] = env_vars_manpage
 
     readme = HOMEBREW_REPOSITORY/"README.md"
@@ -227,6 +228,22 @@ module Homebrew
       generate_option_doc(short, long, desc)
     end
     lines.join("\n")
+  end
+
+  sig { returns(String) }
+  def terminology_manpage
+    formula_cookbook_text = (HOMEBREW_REPOSITORY/"docs/Formula-Cookbook.md").read.split("\n")
+
+    start_term = "## Homebrew terminology"
+    start_index = formula_cookbook_text.index(start_term) + 4 # Skip ahead to the table contents
+    end_index = formula_cookbook_text.index "## An introduction"
+    formula_cookbook_text[start_index...end_index].map do |item|
+      next "" unless item.include? "|"
+
+      term, definition, example = item.split("|").map(&:strip)[1..]
+      definition.gsub!(/\[(.*)\]\(.*\)/, '\1')
+      "#{term}: #{definition} (e.g. #{example})"
+    end.join("\n\n")
   end
 
   sig { returns(String) }

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -28,6 +28,24 @@ Homebrew is the easiest and most flexible way to install the UNIX tools Apple
 didn't include with macOS. It can also install software not packaged for your
 Linux distribution to your home directory without requiring `sudo`.
 
+## TERMINOLOGY
+
+**Formula**: The package definition
+
+**Cask**: An extension of Homebrew to install macOS native apps
+
+**Keg**: The installation prefix of a **Formula**
+
+**Keg-only**: A **Formula** is **Keg-only** if it is not linked into the Homebrew prefix
+
+**Cellar**: All **Kegs** are installed here
+
+**Caskroom**: All **Casks** are installed here
+
+**Tap**: A Git repository of **Formulae** and/or commands
+
+**Bottle**: Pre-built **Keg** used instead of building from source
+
 ## ESSENTIAL COMMANDS
 
 For the full command list, see the [COMMANDS](#commands) section.
@@ -136,10 +154,6 @@ For example, to use an unauthenticated HTTP or SOCKS5 proxy:
 And for an authenticated HTTP proxy:
 
     export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
-
-## TERMINOLOGY
-
-<%= terminology %>
 
 ## SEE ALSO
 

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -30,21 +30,25 @@ Linux distribution to your home directory without requiring `sudo`.
 
 ## TERMINOLOGY
 
-**Formula**: The package definition
+**formula**: Homebrew package definition built from upstream sources
 
-**Cask**: An extension of Homebrew to install macOS native apps
+**cask**: Homebrew package definition that installs macOS native applications
 
-**Keg**: The installation prefix of a **Formula**
+**keg**: installation destination directory of a given **formula** version e.g. `/usr/local/Cellar/foo/0.1`
 
-**Keg-only**: A **Formula** is **Keg-only** if it is not linked into the Homebrew prefix
+**rack**: directory containing one or more versioned kegs e.g. `/usr/local/Cellar/foo`
 
-**Cellar**: All **Kegs** are installed here
+**keg-only**: a **formula** is **keg-only** if it is not symlinked into Homebrew's prefix (e.g. `/usr/local`)
 
-**Caskroom**: All **Casks** are installed here
+**cellar**: directory containing one or more named **racks** e.g. `/usr/local/Cellar`
 
-**Tap**: A Git repository of **Formulae** and/or commands
+**Caskroom**: directory containing one or more named **casks** e.g. `/usr/local/Caskroom`
 
-**Bottle**: Pre-built **Keg** used instead of building from source
+**external command**: `brew` subcommand defined outside of the Homebrew/brew GitHub repository
+
+**tap**: directory (and usually Git repository) of **formulae**, **casks** and/or **external commands**
+
+**bottle**: pre-built **keg** poured into the **cellar**/**rack** instead of building from upstream sources
 
 ## ESSENTIAL COMMANDS
 

--- a/Library/Homebrew/manpages/brew.1.md.erb
+++ b/Library/Homebrew/manpages/brew.1.md.erb
@@ -137,6 +137,10 @@ And for an authenticated HTTP proxy:
 
     export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 
+## TERMINOLOGY
+
+<%= terminology %>
+
 ## SEE ALSO
 
 Homebrew Documentation: <https://docs.brew.sh>

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -8,7 +8,7 @@ A *formula* is a package definition written in Ruby. It can be created with `bre
 |----------------|------------------------------------------------------------|-----------------------------------------------------------------|
 | **Formula**    | The package definition                                     | `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/foo.rb` |
 | **Keg**        | The installation prefix of a **Formula**                   | `/usr/local/Cellar/foo/0.1`                                     |
-| **opt prefix** | A symlink to the active version of a **Keg**               | `/usr/local/opt/foo `                                           |
+| **opt prefix** | A symlink to the active version of a **Keg**               | `/usr/local/opt/foo`                                            |
 | **Cellar**     | All **Kegs** are installed here                            | `/usr/local/Cellar`                                             |
 | **Tap**        | A Git repository of **Formulae** and/or commands | `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core`   |
 | **Bottle**     | Pre-built **Keg** used instead of building from source     | `qt-4.8.4.catalina.bottle.tar.gz`                              |

--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -8,7 +8,8 @@ A *formula* is a package definition written in Ruby. It can be created with `bre
 |----------------|------------------------------------------------------------|-----------------------------------------------------------------|
 | **Formula**    | The package definition                                     | `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/foo.rb` |
 | **Keg**        | The installation prefix of a **Formula**                   | `/usr/local/Cellar/foo/0.1`                                     |
-| **opt prefix** | A symlink to the active version of a **Keg**               | `/usr/local/opt/foo`                                            |
+| **Keg-only**   | A **Formula** is **Keg-only** if it is not linked into the Homebrew prefix | The [`openjdk` formula](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/openjdk.rb) |
+| **opt prefix** | A symlink to the active version of a **Keg**               | `/usr/local/opt/foo `                                           |
 | **Cellar**     | All **Kegs** are installed here                            | `/usr/local/Cellar`                                             |
 | **Tap**        | A Git repository of **Formulae** and/or commands | `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core`   |
 | **Bottle**     | Pre-built **Keg** used instead of building from source     | `qt-4.8.4.catalina.bottle.tar.gz`                              |

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -14,21 +14,25 @@ Linux distribution to your home directory without requiring `sudo`.
 
 ## TERMINOLOGY
 
-**Formula**: The package definition
+**formula**: Homebrew package definition built from upstream sources
 
-**Cask**: An extension of Homebrew to install macOS native apps
+**cask**: Homebrew package definition that installs macOS native applications
 
-**Keg**: The installation prefix of a **Formula**
+**keg**: installation destination directory of a given **formula** version e.g. `/usr/local/Cellar/foo/0.1`
 
-**Keg-only**: A **Formula** is **Keg-only** if it is not linked into the Homebrew prefix
+**rack**: directory containing one or more versioned kegs e.g. `/usr/local/Cellar/foo`
 
-**Cellar**: All **Kegs** are installed here
+**keg-only**: a **formula** is **keg-only** if it is not symlinked into Homebrew's prefix (e.g. `/usr/local`)
 
-**Caskroom**: All **Casks** are installed here
+**cellar**: directory containing one or more named **racks** e.g. `/usr/local/Cellar`
 
-**Tap**: A Git repository of **Formulae** and/or commands
+**Caskroom**: directory containing one or more named **casks** e.g. `/usr/local/Caskroom`
 
-**Bottle**: Pre-built **Keg** used instead of building from source
+**external command**: `brew` subcommand defined outside of the Homebrew/brew GitHub repository
+
+**tap**: directory (and usually Git repository) of **formulae**, **casks** and/or **external commands**
+
+**bottle**: pre-built **keg** poured into the **cellar**/**rack** instead of building from upstream sources
 
 ## ESSENTIAL COMMANDS
 

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2052,6 +2052,24 @@ And for an authenticated HTTP proxy:
 
     export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 
+## TERMINOLOGY
+
+**Formula**: The package definition (e.g. `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/foo.rb`)
+
+**Keg**: The installation prefix of a **Formula** (e.g. `/usr/local/Cellar/foo/0.1`)
+
+**opt prefix**: A symlink to the active version of a **Keg** (e.g. `/usr/local/opt/foo`)
+
+**Cellar**: All **Kegs** are installed here (e.g. `/usr/local/Cellar`)
+
+**Tap**: A Git repository of **Formulae** and/or commands (e.g. `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core`)
+
+**Bottle**: Pre-built **Keg** used instead of building from source (e.g. `qt-4.8.4.catalina.bottle.tar.gz`)
+
+**Cask**: An extension of Homebrew to install macOS native apps (e.g. `/Applications/MacDown.app/Contents/SharedSupport/bin/macdown`)
+
+**Brew Bundle**: An extension of Homebrew to describe dependencies (e.g. `brew 'myservice', restart_service: true`)
+
 ## SEE ALSO
 
 Homebrew Documentation: <https://docs.brew.sh>
@@ -2100,6 +2118,7 @@ See our issues on GitHub:
 [SPECIFYING CASKS]: #SPECIFYING-CASKS "SPECIFYING CASKS"
 [ENVIRONMENT]: #ENVIRONMENT "ENVIRONMENT"
 [USING HOMEBREW BEHIND A PROXY]: #USING-HOMEBREW-BEHIND-A-PROXY "USING HOMEBREW BEHIND A PROXY"
+[TERMINOLOGY]: #TERMINOLOGY "TERMINOLOGY"
 [SEE ALSO]: #SEE-ALSO "SEE ALSO"
 [AUTHORS]: #AUTHORS "AUTHORS"
 [BUGS]: #BUGS "BUGS"

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -12,6 +12,24 @@ Homebrew is the easiest and most flexible way to install the UNIX tools Apple
 didn't include with macOS. It can also install software not packaged for your
 Linux distribution to your home directory without requiring `sudo`.
 
+## TERMINOLOGY
+
+**Formula**: The package definition
+
+**Cask**: An extension of Homebrew to install macOS native apps
+
+**Keg**: The installation prefix of a **Formula**
+
+**Keg-only**: A **Formula** is **Keg-only** if it is not linked into the Homebrew prefix
+
+**Cellar**: All **Kegs** are installed here
+
+**Caskroom**: All **Casks** are installed here
+
+**Tap**: A Git repository of **Formulae** and/or commands
+
+**Bottle**: Pre-built **Keg** used instead of building from source
+
 ## ESSENTIAL COMMANDS
 
 For the full command list, see the [COMMANDS](#commands) section.
@@ -2052,24 +2070,6 @@ And for an authenticated HTTP proxy:
 
     export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 
-## TERMINOLOGY
-
-**Formula**: The package definition (e.g. `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/foo.rb`)
-
-**Keg**: The installation prefix of a **Formula** (e.g. `/usr/local/Cellar/foo/0.1`)
-
-**opt prefix**: A symlink to the active version of a **Keg** (e.g. `/usr/local/opt/foo`)
-
-**Cellar**: All **Kegs** are installed here (e.g. `/usr/local/Cellar`)
-
-**Tap**: A Git repository of **Formulae** and/or commands (e.g. `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core`)
-
-**Bottle**: Pre-built **Keg** used instead of building from source (e.g. `qt-4.8.4.catalina.bottle.tar.gz`)
-
-**Cask**: An extension of Homebrew to install macOS native apps (e.g. `/Applications/MacDown.app/Contents/SharedSupport/bin/macdown`)
-
-**Brew Bundle**: An extension of Homebrew to describe dependencies (e.g. `brew 'myservice', restart_service: true`)
-
 ## SEE ALSO
 
 Homebrew Documentation: <https://docs.brew.sh>
@@ -2107,6 +2107,7 @@ See our issues on GitHub:
 
 [SYNOPSIS]: #SYNOPSIS "SYNOPSIS"
 [DESCRIPTION]: #DESCRIPTION "DESCRIPTION"
+[TERMINOLOGY]: #TERMINOLOGY "TERMINOLOGY"
 [ESSENTIAL COMMANDS]: #ESSENTIAL-COMMANDS "ESSENTIAL COMMANDS"
 [COMMANDS]: #COMMANDS "COMMANDS"
 [DEVELOPER COMMANDS]: #DEVELOPER-COMMANDS "DEVELOPER COMMANDS"
@@ -2118,7 +2119,6 @@ See our issues on GitHub:
 [SPECIFYING CASKS]: #SPECIFYING-CASKS "SPECIFYING CASKS"
 [ENVIRONMENT]: #ENVIRONMENT "ENVIRONMENT"
 [USING HOMEBREW BEHIND A PROXY]: #USING-HOMEBREW-BEHIND-A-PROXY "USING HOMEBREW BEHIND A PROXY"
-[TERMINOLOGY]: #TERMINOLOGY "TERMINOLOGY"
 [SEE ALSO]: #SEE-ALSO "SEE ALSO"
 [AUTHORS]: #AUTHORS "AUTHORS"
 [BUGS]: #BUGS "BUGS"

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -16,36 +16,44 @@
 Homebrew is the easiest and most flexible way to install the UNIX tools Apple didn\'t include with macOS\. It can also install software not packaged for your Linux distribution to your home directory without requiring \fBsudo\fR\.
 .
 .SH "TERMINOLOGY"
-\fBFormula\fR
-    The package definition
+\fBformula\fR
+    Homebrew package definition built from upstream sources
 .
 .P
-\fBCask\fR
-    An extension of Homebrew to install macOS native apps
+\fBcask\fR
+    Homebrew package definition that installs macOS native applications
 .
 .P
-\fBKeg\fR
-    The installation prefix of a \fBFormula\fR
+\fBkeg\fR
+    installation destination directory of a given \fBformula\fR version e\.g\. \fB/usr/local/Cellar/foo/0\.1\fR
 .
 .P
-\fBKeg\-only\fR
-    A \fBFormula\fR is \fBKeg\-only\fR if it is not linked into the Homebrew prefix
+\fBrack\fR
+    directory containing one or more versioned kegs e\.g\. \fB/usr/local/Cellar/foo\fR
 .
 .P
-\fBCellar\fR
-    All \fBKegs\fR are installed here
+\fBkeg\-only\fR
+    a \fBformula\fR is \fBkeg\-only\fR if it is not symlinked into Homebrew\'s prefix (e\.g\. \fB/usr/local\fR)
+.
+.P
+\fBcellar\fR
+    directory containing one or more named \fBracks\fR e\.g\. \fB/usr/local/Cellar\fR
 .
 .P
 \fBCaskroom\fR
-    All \fBCasks\fR are installed here
+    directory containing one or more named \fBcasks\fR e\.g\. \fB/usr/local/Caskroom\fR
 .
 .P
-\fBTap\fR
-    A Git repository of \fBFormulae\fR and/or commands
+\fBexternal command\fR
+    \fBbrew\fR subcommand defined outside of the Homebrew/brew GitHub repository
 .
 .P
-\fBBottle\fR
-    Pre\-built \fBKeg\fR used instead of building from source
+\fBtap\fR
+    directory (and usually Git repository) of \fBformulae\fR, \fBcasks\fR and/or \fBexternal commands\fR
+.
+.P
+\fBbottle\fR
+    pre\-built \fBkeg\fR poured into the \fBcellar\fR/\fBrack\fR instead of building from upstream sources
 .
 .SH "ESSENTIAL COMMANDS"
 For the full command list, see the \fICOMMANDS\fR section\.

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -2988,6 +2988,38 @@ export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 .
 .IP "" 0
 .
+.SH "TERMINOLOGY"
+\fBFormula\fR
+    The package definition (e\.g\. \fB/usr/local/Homebrew/Library/Taps/homebrew/homebrew\-core/Formula/foo\.rb\fR)
+.
+.P
+\fBKeg\fR
+    The installation prefix of a \fBFormula\fR (e\.g\. \fB/usr/local/Cellar/foo/0\.1\fR)
+.
+.P
+\fBopt prefix\fR
+    A symlink to the active version of a \fBKeg\fR (e\.g\. \fB/usr/local/opt/foo\fR)
+.
+.P
+\fBCellar\fR
+    All \fBKegs\fR are installed here (e\.g\. \fB/usr/local/Cellar\fR)
+.
+.P
+\fBTap\fR
+    A Git repository of \fBFormulae\fR and/or commands (e\.g\. \fB/usr/local/Homebrew/Library/Taps/homebrew/homebrew\-core\fR)
+.
+.P
+\fBBottle\fR
+    Pre\-built \fBKeg\fR used instead of building from source (e\.g\. \fBqt\-4\.8\.4\.catalina\.bottle\.tar\.gz\fR)
+.
+.P
+\fBCask\fR
+    An extension of Homebrew to install macOS native apps (e\.g\. \fB/Applications/MacDown\.app/Contents/SharedSupport/bin/macdown\fR)
+.
+.P
+\fBBrew Bundle\fR: An extension of Homebrew to describe dependencies (e\.g\. \fBbrew \'myservice\', restart_service
+    true\fR)
+.
 .SH "SEE ALSO"
 Homebrew Documentation: \fIhttps://docs\.brew\.sh\fR
 .

--- a/manpages/brew.1
+++ b/manpages/brew.1
@@ -15,6 +15,38 @@
 .SH "DESCRIPTION"
 Homebrew is the easiest and most flexible way to install the UNIX tools Apple didn\'t include with macOS\. It can also install software not packaged for your Linux distribution to your home directory without requiring \fBsudo\fR\.
 .
+.SH "TERMINOLOGY"
+\fBFormula\fR
+    The package definition
+.
+.P
+\fBCask\fR
+    An extension of Homebrew to install macOS native apps
+.
+.P
+\fBKeg\fR
+    The installation prefix of a \fBFormula\fR
+.
+.P
+\fBKeg\-only\fR
+    A \fBFormula\fR is \fBKeg\-only\fR if it is not linked into the Homebrew prefix
+.
+.P
+\fBCellar\fR
+    All \fBKegs\fR are installed here
+.
+.P
+\fBCaskroom\fR
+    All \fBCasks\fR are installed here
+.
+.P
+\fBTap\fR
+    A Git repository of \fBFormulae\fR and/or commands
+.
+.P
+\fBBottle\fR
+    Pre\-built \fBKeg\fR used instead of building from source
+.
 .SH "ESSENTIAL COMMANDS"
 For the full command list, see the \fICOMMANDS\fR section\.
 .
@@ -2987,38 +3019,6 @@ export http_proxy=http://$USER:$PASSWORD@$HOST:$PORT
 .fi
 .
 .IP "" 0
-.
-.SH "TERMINOLOGY"
-\fBFormula\fR
-    The package definition (e\.g\. \fB/usr/local/Homebrew/Library/Taps/homebrew/homebrew\-core/Formula/foo\.rb\fR)
-.
-.P
-\fBKeg\fR
-    The installation prefix of a \fBFormula\fR (e\.g\. \fB/usr/local/Cellar/foo/0\.1\fR)
-.
-.P
-\fBopt prefix\fR
-    A symlink to the active version of a \fBKeg\fR (e\.g\. \fB/usr/local/opt/foo\fR)
-.
-.P
-\fBCellar\fR
-    All \fBKegs\fR are installed here (e\.g\. \fB/usr/local/Cellar\fR)
-.
-.P
-\fBTap\fR
-    A Git repository of \fBFormulae\fR and/or commands (e\.g\. \fB/usr/local/Homebrew/Library/Taps/homebrew/homebrew\-core\fR)
-.
-.P
-\fBBottle\fR
-    Pre\-built \fBKeg\fR used instead of building from source (e\.g\. \fBqt\-4\.8\.4\.catalina\.bottle\.tar\.gz\fR)
-.
-.P
-\fBCask\fR
-    An extension of Homebrew to install macOS native apps (e\.g\. \fB/Applications/MacDown\.app/Contents/SharedSupport/bin/macdown\fR)
-.
-.P
-\fBBrew Bundle\fR: An extension of Homebrew to describe dependencies (e\.g\. \fBbrew \'myservice\', restart_service
-    true\fR)
 .
 .SH "SEE ALSO"
 Homebrew Documentation: \fIhttps://docs\.brew\.sh\fR


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Closes https://github.com/Homebrew/brew/issues/11489

This PR adds the [terminology table](https://docs.brew.sh/Formula-Cookbook#homebrew-terminology) from the Formula Cookbook to the manpage. I've chosen to add it toward the bottom in a `TERMINOLOGY` section. I chose the bottom because I felt that the command descriptions should be first, but if there's a better place for it I can move.

I've also converted from table format to list format because tables don't seem to be doable in the manpage (or, at least, `ronn` doesn't convert them).

At the moment, this just copies directly from the formula cookbook but this can be converted to its own list if we think that makes more sense.