### PR TITLE
shims/super/cc: fix `sysroot` flag handling

### DIFF
--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -212,13 +212,24 @@ class Cmd
       args << "-Wl,-multiply_defined,suppress"
     when "-undefineddynamic_lookup"
       args << "-Wl,-undefined,dynamic_lookup"
-    when /^-isysroot/, /^--sysroot/
+    when /^-isysroot=/, /^--sysroot=/
       if mac?
-        sdk = enum.next
+        sdk = arg.split("=")[1..-1].join("=")
+        # We set the sysroot for macOS SDKs
+        args << arg unless sdk.downcase.include? "osx"
+      else
+        args << arg
+      end
+    when /^-isysroot(.+)?/, /^--sysroot(.+)?/
+      # Support both "-isysrootfoo" and "-isysroot foo" (two arguments)
+      sdk = chuzzle(Regexp.last_match(1))
+      if mac?
+        sdk ||= enum.next
         # We set the sysroot for macOS SDKs
         args << "-isysroot#{sdk}" unless sdk.downcase.include? "osx"
       else
-        args << arg << enum.next
+        args << arg
+        args << enum.next unless sdk
       end
     when "-dylib"
       args << "-Wl,#{arg}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

The shim currently does not handle `--sysroot=` and `-isysroot=` flags
correctly. For example, the LLVM build passes `--sysroot=.`, and this is
incorrectly parsed by the shim.