### PR TITLE
Add macOS 12 (Monterey) support

### DIFF
--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -14,7 +14,7 @@ module OS
       extend T::Sig
 
       SYMBOLS = {
-        monterey:    "12"
+        monterey:    "12",
         big_sur:     "11",
         catalina:    "10.15",
         mojave:      "10.14",

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -14,6 +14,7 @@ module OS
       extend T::Sig
 
       SYMBOLS = {
+        monterey:    "12"
         big_sur:     "11",
         catalina:    "10.15",
         mojave:      "10.14",


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Homebrew is a tool millions of developers rely on every day, and its imperative macOS 12 support is added as quickly as possible. I was going to open an issue on GitHub, but as the homebrew output explicitly stated not to do that and instead try making a PR, I decided to take a crack at it. 

Right now macOS 12 somewhat works, but 

1. requires you to build things from source 
2. dependencies fail to install as it attempts to grab the bottle 

Once all dependencies are installed for a specific formula, `brew install -s` still works as expected