### PR TITLE
brew tap-new: tests.yml workflow fails with casks

### DIFF
--- a/Library/Homebrew/dev-cmd/audit.rb
+++ b/Library/Homebrew/dev-cmd/audit.rb
@@ -204,6 +204,7 @@ module Homebrew
     cask_results = if audit_casks.empty?
       {}
     else
+      require "cask/cmd/abstract_command"
       require "cask/cmd/audit"
 
       Cask::Cmd::Audit.audit_casks(

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -95,7 +95,6 @@ module Homebrew
             - run: brew test-bot --only-setup
 
             - run: brew test-bot --only-tap-syntax
-              if: matrix.os == 'macos-latest'
 
             - run: brew test-bot --only-formulae
               if: github.event_name == 'pull_request'

--- a/Library/Homebrew/dev-cmd/tap-new.rb
+++ b/Library/Homebrew/dev-cmd/tap-new.rb
@@ -95,6 +95,7 @@ module Homebrew
             - run: brew test-bot --only-setup
 
             - run: brew test-bot --only-tap-syntax
+              if: matrix.os == 'macos-latest'
 
             - run: brew test-bot --only-formulae
               if: github.event_name == 'pull_request'


### PR DESCRIPTION
Running `brew test-bot --only-tap-syntax` fails on `ubuntu-latest` if any casks are added later to the tap, since casks are macOS only.

See [github.com/ncruces/homebrew-tap](https://github.com/ncruces/homebrew-tap) for my custom tap. I've fixed this in `main` by adding this line (which prevents `brew test-bot --only-tap-syntax` from running on `ubuntu-latest`, but still runs it on `macos-latest`, which should be enough to ensure correctness).

The [`casks-not-supported`](https://github.com/ncruces/homebrew-tap/pull/4) branch reverts the change, and causes the [failure](https://github.com/ncruces/homebrew-tap/runs/2773518480?check_suite_focus=true).

This was my best attempt for a fix, but I'm open to suggestions and doing the necessary leg work to get them through.


- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
