### PR TITLE
cask/installer: Add Cask caveats to the end-of-operation summary

### DIFF
--- a/Library/Homebrew/cask/installer.rb
+++ b/Library/Homebrew/cask/installer.rb
@@ -56,6 +56,8 @@ module Cask
       caveats = cask.caveats
       return if caveats.empty?
 
+      Homebrew.messages.record_caveats(cask.token, caveats)
+
       <<~EOS
         #{ohai_title "Caveats"}
         #{caveats}

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -769,7 +769,7 @@ class FormulaInstaller
 
     @show_summary_heading = true
     ohai "Caveats", caveats.to_s
-    Homebrew.messages.record_caveats(formula, caveats)
+    Homebrew.messages.record_caveats(formula.name, caveats)
   end
 
   sig { void }

--- a/Library/Homebrew/messages.rb
+++ b/Library/Homebrew/messages.rb
@@ -15,8 +15,8 @@ class Messages
     @install_times = []
   end
 
-  def record_caveats(f, caveats)
-    @caveats.push(formula: f.name, caveats: caveats)
+  def record_caveats(package, caveats)
+    @caveats.push(package: package, caveats: caveats)
   end
 
   def formula_installed(f, elapsed_time)
@@ -36,7 +36,7 @@ class Messages
 
     oh1 "Caveats"
     @caveats.each do |c|
-      ohai c[:formula], c[:caveats]
+      ohai c[:package], c[:caveats]
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

- Both formulae and casks can have caveats, but only formulae caveats were shown at the end of a bulk install/upgrade/reinstall operation via `Homebrew.messages.record_caveats`. This fixes that to show Cask caveats too, for consistency (scrolling up all of the multi-formulae-and-casks output to see caveats is time-consuming and users might miss them).
- In doing this I had to change how `Messages#record_caveats` works since the cask name is just a string, not an object.
- Fixes #11421.

----

Before:

```
➜ brew install macfuse kube-linter gh
==> Caveats
You must reboot for the installation of macfuse to take effect.

==> Downloading https://github.com/osxfuse/osxfuse/releases/download/macfuse-4.1.2/macfuse-4.1.2.dmg
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/9a9c1e4033ad7046b2404c776abebd5bb9bfb54169236eea695d82fd92b32f0d--macfuse-4.1.2.dmg
==> Installing Cask macfuse
==> Running installer for macfuse; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
installer: Package name is macFUSE
installer: Installing at base path /
installer: The install was successful.
==> Changing ownership of paths required by macfuse; your password may be necessary.
🍺  macfuse was successfully installed!
==> Downloading https://ghcr.io/v2/homebrew/core/kube-linter/manifests/0.2.2
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/7cbabba966f12048003fb1882bf5a6ace1b25902ebe86e8f049a3dfb6aad37d9--kube-linter-0.2.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/kube-linter/blobs/sha256:831b22931fea72de98b288d96f2ff9c13ad078a88ab2600748434dbd7b8dfd65
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/23466b6dae061ee7c1a1ecced21c2ecede51f364599549e766a32a5838cca98b--kube-linter--0.2.2.big_sur.bottle.tar.gz
==> Pouring kube-linter--0.2.2.big_sur.bottle.tar.gz
🍺  /usr/local/Cellar/kube-linter/0.2.2: 5 files, 34.8MB
==> Downloading https://ghcr.io/v2/homebrew/core/gh/manifests/1.11.0
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/ddad4ddc988804cf6037325a229259e1d5267e9203e69cf901f3e97c93395f7a--gh-1.11.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/gh/blobs/sha256:34313bfaca6995d40836da15f3c1cf7579689f5ac1bdcf3e2e4e50ceb4cbb3e1
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/1eb3f40cf6fa82560f54b235fdedb761b36170a5b9d5c26b58be3d3b9afcb89b--gh--1.11.0.big_sur.bottle.tar.gz
==> Pouring gh--1.11.0.big_sur.bottle.tar.gz
==> Caveats
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/gh/1.11.0: 89 files, 28.6MB
==> Caveats
==> gh
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
```

After

```
➜ brew install macfuse kube-linter gh
==> Caveats
You must reboot for the installation of macfuse to take effect.

==> Downloading https://github.com/osxfuse/osxfuse/releases/download/macfuse-4.1.2/macfuse-4.1.2.dmg
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/9a9c1e4033ad7046b2404c776abebd5bb9bfb54169236eea695d82fd92b32f0d--macfuse-4.1.2.dmg
==> Installing Cask macfuse
==> Running installer for macfuse; your password may be necessary.
Package installers may write to any location; options such as `--appdir` are ignored.
installer: Package name is macFUSE
installer: Installing at base path /
installer: The install was successful.
==> Changing ownership of paths required by macfuse; your password may be necessary.
🍺  macfuse was successfully installed!
==> Downloading https://ghcr.io/v2/homebrew/core/kube-linter/manifests/0.2.2
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/7cbabba966f12048003fb1882bf5a6ace1b25902ebe86e8f049a3dfb6aad37d9--kube-linter-0.2.2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/kube-linter/blobs/sha256:831b22931fea72de98b288d96f2ff9c13ad078a88ab2600748434dbd7b8dfd65
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/23466b6dae061ee7c1a1ecced21c2ecede51f364599549e766a32a5838cca98b--kube-linter--0.2.2.big_sur.bottle.tar.gz
==> Pouring kube-linter--0.2.2.big_sur.bottle.tar.gz
🍺  /usr/local/Cellar/kube-linter/0.2.2: 5 files, 34.8MB
==> Downloading https://ghcr.io/v2/homebrew/core/gh/manifests/1.11.0
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/ddad4ddc988804cf6037325a229259e1d5267e9203e69cf901f3e97c93395f7a--gh-1.11.0.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/gh/blobs/sha256:34313bfaca6995d40836da15f3c1cf7579689f5ac1bdcf3e2e4e50ceb4cbb3e1
Already downloaded: /Users/issyl0/Library/Caches/Homebrew/downloads/1eb3f40cf6fa82560f54b235fdedb761b36170a5b9d5c26b58be3d3b9afcb89b--gh--1.11.0.big_sur.bottle.tar.gz
==> Pouring gh--1.11.0.big_sur.bottle.tar.gz
==> Caveats
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/gh/1.11.0: 89 files, 28.6MB
==> Caveats
==> macfuse
You must reboot for the installation of macfuse to take effect.
==> gh
zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
```
