### PR TITLE
formula: improve `to_recursive_bottle_hash`

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1919,17 +1919,19 @@ class Formula
       [tag.to_s, info]
     end.to_h
 
-    return bottles unless top_level
+    hash = {
+      "name"        => name,
+      "pkg_version" => pkg_version,
+      "rebuild"     => bottle["rebuild"],
+      "bottles"     => bottles,
+    }
 
-    dependencies = declared_runtime_dependencies.map do |dep|
+    return hash unless top_level
+
+    hash["dependencies"] = declared_runtime_dependencies.map do |dep|
       dep.to_formula.to_recursive_bottle_hash(top_level: false)
     end
-
-    {
-      "name"         => name,
-      "bottles"      => bottles,
-      "dependencies" => dependencies,
-    }
+    hash
   end
 
   # Returns the bottle information for a formula


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR makes some improvements to the `Formula#to_recursive_bottle_hash` method. This is a private method that is not publicly disclosed (as of the next tag) so these changes should be okay.

The changes add a `pkg_version`, and `rebuild` item to the bottle. It also modifies the way that dependencies are represented so that they match the top level completely (except for the missing `dependencies` field).

This means that a basic example now looks like this:

```json
{
  "name": "foo",
  "pkg_version": "1.2.3_1",
  "rebuild": 0,
  "bottles": {
    "big_sur": {
      "url": "https://example.com"
    }
  },
  "dependencies": [
    {
      "name": "bar",
      "pkg_version": "5.6.7",
      "rebuild": 3,
      "bottles": {
        "big_sur": {
          "url": "https://example.com"
        }
      }
    }
  ]
}
```

Links to example gists: [`hello`](https://gist.github.com/Rylan12/bf0adea0d317697a8f16dfc12637ab1c), [`youtube-dl`](https://gist.github.com/Rylan12/5756038a327159cf7f449f44f7406de2)