### PR TITLE
LocalBottleDownloadStrategy: extend Pourable

### DIFF
--- a/Library/Homebrew/download_strategy.rb
+++ b/Library/Homebrew/download_strategy.rb
@@ -651,6 +651,7 @@ end
 class LocalBottleDownloadStrategy < AbstractFileDownloadStrategy
   def initialize(path) # rubocop:disable Lint/MissingSuper
     @cached_location = path
+    extend Pourable
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Local bottles should also extend the `Pourable` module so that the `==> Pouring hello--2.10.big_sur.bottle.tar.gz` message shows up as expected.

This does mean that the output of an install command on a bottle file path is a bit more verbose, but I think it looks better overall:

Before:

```console
$ brew install /Users/rylanpolster/Library/Caches/Homebrew/downloads/e0395c201b40d07f50d44b84fccab28bb89bb292929894555688f6510f583a4c--hello--2.10.big_sur.bottle.tar.gz
🍺  /usr/local/Cellar/hello/2.10: 11 files, 165.7KB
```

After:

```console 
$ brew install /Users/rylanpolster/Library/Caches/Homebrew/downloads/e0395c201b40d07f50d44b84fccab28bb89bb292929894555688f6510f583a4c--hello--2.10.big_sur.bottle.tar.gz
==> Pouring hello--2.10.big_sur.bottle.tar.gz
🍺  /usr/local/Cellar/hello/2.10: 11 files, 165.7KB
```
