### PR TITLE
workflows/tests.yml: don't report coverage on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,11 +188,11 @@ jobs:
       matrix:
         include:
           - name: tests (no-compatibility mode)
-            test-flags: --no-compat --online --coverage
+            test-flags: --no-compat --online
           - name: tests (generic OS)
-            test-flags: --generic --online --coverage
+            test-flags: --generic --online
           - name: tests (Linux)
-            test-flags: --online --coverage
+            test-flags: --online
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -226,8 +226,6 @@ jobs:
           brew tests ${{ matrix.test-flags }}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192
 
   test-default-formula-linux:
     name: test default formula (Linux)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR removes code coverage checks on Linux in the tests workflow. The Linux tests are completed earlier and once there coverage is reported, they're almost always ❌ with a negative delta of ~5% (in the PRs I've seen). Once the macOS tests are done, this changes – to either ✅ or ❌ depending on the "actual" coverage impact.

I'm not too familiar with this but I'm assuming this is because fewer tests are run on Linux. We might as well stop reporting coverage on Linux since this is a recurring issue, and the macOS results are what we see/use in the end.