### PR TITLE
formula_installer: restrict use of Formula from Keg

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1076,9 +1076,6 @@ class FormulaInstaller
       #{HOMEBREW_LIBRARY_PATH}/postinstall.rb
     ]
 
-    keg_formula_path = formula.opt_prefix/".brew/#{formula.name}.rb"
-    tap_formula_path = formula.path
-
     # Use the formula from the keg if:
     # * Installing from a local bottle, or
     # * The formula doesn't exist in the tap (or the tap isn't installed), or
@@ -1086,7 +1083,9 @@ class FormulaInstaller
     # In all other cases, including if the formula from the keg is unreadable
     # (third-party taps may `require` some of their own libraries), use the
     # formula from the tap.
-    args << begin
+    formula_path = begin
+      keg_formula_path = formula.opt_prefix/".brew/#{formula.name}.rb"
+      tap_formula_path = formula.path
       keg_formula = Formulary.factory(keg_formula_path)
       tap_formula = Formulary.factory(tap_formula_path) if tap_formula_path.exist?
       other_version_installed = (keg_formula.pkg_version != tap_formula&.pkg_version)
@@ -1101,6 +1100,8 @@ class FormulaInstaller
     rescue FormulaUnreadableError
       tap_formula_path
     end
+
+    args << formula_path
 
     Utils.safe_fork do
       if Sandbox.available?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Restrict usage of the formula file from the bottle. Should fix https://github.com/Homebrew/brew/pull/11468#issuecomment-860627703.

Formulae which require files from `lib` in the Tap could probably not get `post_install` to work if installing them without tapping the Tap.