### PR TITLE
Fix potential modifications to frozen string

### DIFF
--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -142,8 +142,8 @@ class Requirement
 
   def infer_name
     klass = self.class.name || self.class.to_s
-    klass.sub!(/(Dependency|Requirement)$/, "")
-    klass.sub!(/^(\w+::)*/, "")
+    klass = klass.sub(/(Dependency|Requirement)$/, "")
+    klass = klass.sub(/^(\w+::)*/, "")
     return klass.downcase if klass.present?
 
     return @cask if @cask.present?

--- a/Library/Homebrew/requirement.rb
+++ b/Library/Homebrew/requirement.rb
@@ -143,7 +143,7 @@ class Requirement
   def infer_name
     klass = self.class.name || self.class.to_s
     klass = klass.sub(/(Dependency|Requirement)$/, "")
-    klass = klass.sub(/^(\w+::)*/, "")
+                 .sub(/^(\w+::)*/, "")
     return klass.downcase if klass.present?
 
     return @cask if @cask.present?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Pardon me for the PR title since I can't write a better one.

I was experimenting with Homebrew to see if I can get it to run on Ruby 2.7 (I know this may sound stupid). Turns out most functions work, except for this:

```
$ brew info suspicious-package --debug
Error: Cask 'suspicious-package' definition is invalid: can't modify frozen String: "MacOSRequirement"
/usr/local/Homebrew/Library/Homebrew/cask/dsl.rb:241:in `rescue in depends_on'
/usr/local/Homebrew/Library/Homebrew/cask/dsl.rb:238:in `depends_on'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/suspicious-package.rb:19:in `block in load'
/usr/local/Homebrew/Library/Homebrew/cask/cask.rb:61:in `instance_eval'
/usr/local/Homebrew/Library/Homebrew/cask/cask.rb:61:in `config='
/usr/local/Homebrew/Library/Homebrew/cask/cask.rb:48:in `initialize'
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:43:in `new'
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:43:in `cask'
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:87:in `cask'
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:144:in `cask'
/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask/Casks/suspicious-package.rb:1:in `load'
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:72:in `instance_eval'
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:72:in `load'
/usr/local/Homebrew/Library/Homebrew/cask/cask_loader.rb:205:in `load'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:130:in `load_formula_or_cask'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:85:in `block in to_formulae_and_casks_and_unavailable'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:84:in `map'
/usr/local/Homebrew/Library/Homebrew/cli/named_args.rb:84:in `to_formulae_and_casks_and_unavailable'
/usr/local/Homebrew/Library/Homebrew/cmd/info.rb:147:in `print_info'
/usr/local/Homebrew/Library/Homebrew/cmd/info.rb:110:in `info'
/usr/local/Homebrew/Library/Homebrew/brew.rb:122:in `<main>'
```

So I fixed the offending code locally. But I also think it could be beneficial to the current Homebrew even though, well, it's not an issue as of Ruby 2.6.