### PR TITLE
Formulary: map formula names to local bottle paths

### DIFF
--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -395,7 +395,7 @@ module Formulary
   )
     raise ArgumentError, "Formulae must have a ref!" unless ref
 
-    ref = @ref_mappings[ref] if @ref_mappings.present? && @ref_mappings.key?(ref)
+    ref = @name_mappings[ref] if @name_mappings.present? && @name_mappings.key?(ref)
 
     cache_key = "#{ref}-#{spec}-#{alias_path}-#{from}"
     if factory_cached? && cache[:formulary_factory] &&
@@ -413,17 +413,18 @@ module Formulary
     formula
   end
 
-  # Register a reference mapping. This mapping will be used by {Formulary::factory}
-  # to allow certain references to be substituted for another string before
-  # being retrived. For example, to map `foo` to the `bar` formula:
-  # <pre>Formulary.map "foo", to: "bar"
-  # Formulary.factory "bar" # returns the bar formula
+  # Map a formula name to a bottle archive. This mapping will be used by {Formulary::factory}
+  # to allow formulae to be loaded automatically from their bottle archive without
+  # needing to exist in a tap or be passed as a complete filepath. For example,
+  # to map `foo` to the `hello` formula from its bottle archive:
+  # <pre>Formulary.map_name_to_bottle "foo", HOMEBREW_CACHE/"hello--2.10"
+  # Formulary.factory "foo" # returns the hello formula from the bottle archive
   # </pre>
-  # @param ref the string to map.
-  # @param :to the target reference to which `ref` should be mapped.
-  def self.map(ref, to:)
-    @ref_mappings ||= {}
-    @ref_mappings[ref] = to
+  # @param name the string to map.
+  # @param bottle a path pointing to the target bottle archive.
+  def self.map_name_to_bottle(name, bottle)
+    @name_mappings ||= {}
+    @name_mappings[name] = bottle.realpath
   end
 
   # Return a {Formula} instance for the given rack.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -395,6 +395,8 @@ module Formulary
   )
     raise ArgumentError, "Formulae must have a ref!" unless ref
 
+    ref = @ref_mappings[ref] if @ref_mappings.present? && @ref_mappings.key?(ref)
+
     cache_key = "#{ref}-#{spec}-#{alias_path}-#{from}"
     if factory_cached? && cache[:formulary_factory] &&
        cache[:formulary_factory][cache_key]
@@ -409,6 +411,19 @@ module Formulary
       cache[:formulary_factory][cache_key] ||= formula
     end
     formula
+  end
+
+  # Register a reference mapping. This mapping will be used by {Formulary::factory}
+  # to allow certain references to be substituted for another string before
+  # being retrived. For example, to map `foo` to the `bar` formula:
+  # <pre>Formulary.map "foo", to: "bar"
+  # Formulary.factory "bar" # returns the bar formula
+  # </pre>
+  # @param ref the string to map.
+  # @param :to the target reference to which `ref` should be mapped.
+  def self.map(ref, to:)
+    @ref_mappings ||= {}
+    @ref_mappings[ref] = to
   end
 
   # Return a {Formula} instance for the given rack.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -395,7 +395,11 @@ module Formulary
   )
     raise ArgumentError, "Formulae must have a ref!" unless ref
 
-    ref = @name_mappings[ref] if @name_mappings.present? && @name_mappings.key?(ref)
+    if ENV["HOMEBREW_BOTTLE_JSON"].present? &&
+       @formula_name_local_bottle_path_map.present? &&
+       @formula_name_local_bottle_path_map.key?(ref)
+      ref = @formula_name_local_bottle_path_map[ref]
+    end
 
     cache_key = "#{ref}-#{spec}-#{alias_path}-#{from}"
     if factory_cached? && cache[:formulary_factory] &&
@@ -413,18 +417,22 @@ module Formulary
     formula
   end
 
-  # Map a formula name to a bottle archive. This mapping will be used by {Formulary::factory}
-  # to allow formulae to be loaded automatically from their bottle archive without
-  # needing to exist in a tap or be passed as a complete filepath. For example,
-  # to map `foo` to the `hello` formula from its bottle archive:
-  # <pre>Formulary.map_name_to_bottle "foo", HOMEBREW_CACHE/"hello--2.10"
-  # Formulary.factory "foo" # returns the hello formula from the bottle archive
+  # Map a formula name to a local/fetched bottle archive. This mapping will be used by {Formulary::factory}
+  # to allow formulae to be loaded automatically from their local bottle archive without
+  # needing to exist in a tap or be passed as a complete path. For example,
+  # to map `hello` from its bottle archive:
+  # <pre>Formulary.map_formula_name_to_local_bottle_path "hello", HOMEBREW_CACHE/"hello--2.10"
+  # Formulary.factory "hello" # returns the hello formula from the local bottle archive
   # </pre>
-  # @param name the string to map.
-  # @param bottle a path pointing to the target bottle archive.
-  def self.map_name_to_bottle(name, bottle)
-    @name_mappings ||= {}
-    @name_mappings[name] = Pathname(bottle).realpath
+  # @param formula_name the formula name string to map.
+  # @param local_bottle_path a path pointing to the target bottle archive.
+  def self.map_formula_name_to_local_bottle_path(formula_name, local_bottle_path)
+    if ENV["HOMEBREW_BOTTLE_JSON"].blank?
+      raise UsageError, "HOMEBREW_BOTTLE_JSON not set but required for #{__method__}!"
+    end
+
+    @formula_name_local_bottle_path_map ||= {}
+    @formula_name_local_bottle_path_map[formula_name] = Pathname(local_bottle_path).realpath
   end
 
   # Return a {Formula} instance for the given rack.

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -424,7 +424,7 @@ module Formulary
   # @param bottle a path pointing to the target bottle archive.
   def self.map_name_to_bottle(name, bottle)
     @name_mappings ||= {}
-    @name_mappings[name] = bottle.realpath
+    @name_mappings[name] = Pathname(bottle).realpath
   end
 
   # Return a {Formula} instance for the given rack.

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -205,7 +205,7 @@ describe Formulary do
     end
   end
 
-  describe "::map" do
+  describe "::map_name_to_bottle" do
     before do
       formula_path.dirname.mkpath
       formula_path.write formula_content
@@ -216,7 +216,7 @@ describe Formulary do
         described_class.factory("formula-to-map")
       }.to raise_error(FormulaUnavailableError)
 
-      described_class.map "formula-to-map", to: formula_name
+      described_class.map_name_to_bottle "formula-to-map", formula_path
 
       expect(described_class.factory("formula-to-map")).to be_kind_of(Formula)
     end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -213,12 +213,12 @@ describe Formulary do
 
     it "maps a reference to a new Formula" do
       expect {
-        described_class.factory("foo")
+        described_class.factory("formula-to-map")
       }.to raise_error(FormulaUnavailableError)
 
-      described_class.map "foo", to: formula_name
+      described_class.map "formula-to-map", to: formula_name
 
-      expect(described_class.factory("foo")).to be_kind_of(Formula)
+      expect(described_class.factory("formula-to-map")).to be_kind_of(Formula)
     end
   end
 

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -205,7 +205,7 @@ describe Formulary do
     end
   end
 
-  describe "::map_name_to_bottle" do
+  describe "::map_formula_name_to_local_bottle_path" do
     before do
       formula_path.dirname.mkpath
       formula_path.write formula_content
@@ -216,7 +216,13 @@ describe Formulary do
         described_class.factory("formula-to-map")
       }.to raise_error(FormulaUnavailableError)
 
-      described_class.map_name_to_bottle "formula-to-map", formula_path
+      ENV["HOMEBREW_BOTTLE_JSON"] = nil
+      expect {
+        described_class.map_formula_name_to_local_bottle_path "formula-to-map", formula_path
+      }.to raise_error(UsageError, /HOMEBREW_BOTTLE_JSON not set/)
+
+      ENV["HOMEBREW_BOTTLE_JSON"] = "1"
+      described_class.map_formula_name_to_local_bottle_path "formula-to-map", formula_path
 
       expect(described_class.factory("formula-to-map")).to be_kind_of(Formula)
     end

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -205,6 +205,23 @@ describe Formulary do
     end
   end
 
+  describe "::map" do
+    before do
+      formula_path.dirname.mkpath
+      formula_path.write formula_content
+    end
+
+    it "maps a reference to a new Formula" do
+      expect {
+        described_class.factory("foo")
+      }.to raise_error(FormulaUnavailableError)
+
+      described_class.map "foo", to: formula_name
+
+      expect(described_class.factory("foo")).to be_kind_of(Formula)
+    end
+  end
+
   specify "::from_contents" do
     expect(described_class.from_contents(formula_name, formula_path, formula_content)).to be_kind_of(Formula)
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR adds some new functionality to `Formulary` to allow for refs to be mapped to each other. This mapping is set up using `Formulary::map` and is then used to substitute the reference passed to `Formulary::factory`. For example:

```ruby
Formulary.factory "foo"        # error
Formulary.map "foo", to: "bar" # setup mapping
Formulary.factory "foo"        # returns the bar formula
```

At the moment, this is not used anywhere internally, but would be used in Homebrew/json if merged. Originally, I had opted to [monkey patch `Formulary` to look for cached bottles](https://github.com/Homebrew/homebrew-json/pull/6) and was a bit unwilling to add it to Homebrew/brew because it felt too specific to that tap. However, I rethought the process a bit over the weekend and am now planning on [monkey patching the changes from this PR (essentially)](https://github.com/Homebrew/homebrew-json/pull/7). Since these changes feel more general and don't need to be specific to Homebrew/json, I feel okay including them here.

If the consensus is that we don't want it to be added here unless we're using it internally, that's okay.
