### PR TITLE
Cask::Audit: Handle livecheck skip conditions

### DIFF
--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -552,8 +552,10 @@ module Cask
 
     def check_livecheck_version
       return unless appcast?
-      return :skip if cask.livecheck.skip?
-      return :latest if cask.version.latest?
+
+      # Respect cask skip conditions (e.g. discontinued, latest, unversioned)
+      skip_info = Homebrew::Livecheck::SkipConditions.skip_information(cask)
+      return :skip if skip_info.present?
 
       latest_version = Homebrew::Livecheck.latest_version(cask)&.fetch(:latest)
       if cask.version.to_s == latest_version.to_s

--- a/Library/Homebrew/test/cask/audit_spec.rb
+++ b/Library/Homebrew/test/cask/audit_spec.rb
@@ -411,6 +411,35 @@ describe Cask::Audit, :cask do
       end
     end
 
+    describe "livecheck should be skipped" do
+      let(:online) { true }
+      let(:message) { /Version '[^']*' differs from '[^']*' retrieved by livecheck\./ }
+
+      context "when the Cask has a livecheck block using skip" do
+        let(:cask_token) { "livecheck/livecheck-skip" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+
+      context "when the Cask is discontinued" do
+        let(:cask_token) { "livecheck/discontinued" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+
+      context "when version is :latest" do
+        let(:cask_token) { "livecheck/version-latest" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+
+      context "when url is unversioned" do
+        let(:cask_token) { "livecheck/url-unversioned" }
+
+        it { is_expected.not_to fail_with(message) }
+      end
+    end
+
     describe "when the Cask stanza requires uninstall" do
       let(:message) { "installer and pkg stanzas require an uninstall stanza" }
 

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/discontinued.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/discontinued.rb
@@ -1,0 +1,18 @@
+cask "discontinued" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/discontinued-#{version}.dmg"
+  name "Discontinued"
+  desc "Cask for testing discontinued in livecheck"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/discontinued"
+
+  app "TestCask.app"
+
+  caveats do
+    discontinued
+  end
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/livecheck-skip.rb
@@ -1,0 +1,18 @@
+cask "livecheck-skip" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-skip-#{version}.dmg"
+  name "Skip"
+  desc "Cask for testing skip in a livecheck block"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/livecheck-skip"
+
+  livecheck do
+    skip "No version information available to check"
+  end
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/url-unversioned.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/url-unversioned.rb
@@ -1,0 +1,14 @@
+cask "url-unversioned" do
+  version "1.2.3"
+  sha256 "8c62a2b791cf5f0da6066a0a4b6e85f62949cd60975da062df44adf887f4370b"
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/url-unversioned.dmg"
+  name "Unversioned URL"
+  desc "Cask for testing an unversioned URL in livecheck"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/url-unversioned"
+
+  app "TestCask.app"
+end

--- a/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/version-latest.rb
+++ b/Library/Homebrew/test/support/fixtures/cask/Casks/livecheck/version-latest.rb
@@ -1,0 +1,14 @@
+cask "version-latest" do
+  version :latest
+  sha256 :no_check
+
+  # This cask is used in --online tests, so we use fake URLs to avoid impacting
+  # real servers. The URL paths are specific enough that they'll be
+  # understandable if they appear in local server logs.
+  url "http://localhost/homebrew/test/cask/audit/livecheck/version-latest.dmg"
+  name "Version Latest"
+  desc "Cask for testing a latest version in livecheck"
+  homepage "http://localhost/homebrew/test/cask/audit/livecheck/version-latest"
+
+  app "TestCask.app"
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

`brew audit --cask --online` is incorrectly failing for discontinued casks in Homebrew/homebrew-cask#107275 and Homebrew/homebrew-cask-versions#11181. This is because `Cask::Audit#check_livecheck_version` doesn't account for all of the skip conditions for casks (only `livecheck.skip?` and `version.latest?`, not `discontinued?` or `url.unversioned?`). As a result, `#check_livecheck_version` runs livecheck in some scenarios where it should be skipped and this predictably fails.

This PR modifies `#check_livecheck_version` to respect cask skip conditions by using `Livecheck::SkipConditions#skip_information`. This ensures the audit uses the same skip conditions as `brew livecheck`.

This also adds related tests, as this particular logic wasn't tested before. As expected, these tests fail with the previous `#check_livecheck_version` code and pass with the changes in this PR.

If additional skip conditions for casks are added to `SkipConditions` in the future, we shouldn't need to make changes to account for them in `#check_livecheck_version`. However, we'll need to expand the related tests to make sure that we're testing the new conditions as well.

---

I've labelled this as "critical" because it fixes a homebrew/cask CI issue and there are open PRs that need this fix to pass CI.