### PR TITLE
depends_on_java to recommend openjdk formula

### DIFF
--- a/Library/Homebrew/cask/dsl/caveats.rb
+++ b/Library/Homebrew/cask/dsl/caveats.rb
@@ -112,17 +112,17 @@ module Cask
         if java_version == :any
           <<~EOS
             #{@cask} requires Java. You can install the latest version with:
-              brew install --cask adoptopenjdk
+              brew install --formula openjdk
           EOS
         elsif java_version.include?("+")
           <<~EOS
             #{@cask} requires Java #{java_version}. You can install the latest version with:
-              brew install --cask adoptopenjdk
+              brew install --formula openjdk
           EOS
         else
           <<~EOS
             #{@cask} requires Java #{java_version}. You can install it with:
-              brew install --cask homebrew/cask-versions/adoptopenjdk#{java_version}
+              brew install --formula openjdk@#{java_version}
           EOS
         end
       end


### PR DESCRIPTION
Since we package openjdk* formulas, let's set it as recommended Java provider for casks caveat.

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Offtopic: `brew typecheck/tests` bundle fails with message:
```
Could not find sorbet-static-0.5.6274-universal-darwin-14 in any of the sources
```