### PR TITLE
Bottle: keep track of original filename

### DIFF
--- a/Library/Homebrew/dev-cmd/bottle.rb
+++ b/Library/Homebrew/dev-cmd/bottle.rb
@@ -273,7 +273,7 @@ module Homebrew
 
   def bottle_formula(f, name, args:)
     # If the file exists, this was called with a bottle path as
-    # the arugment instead of a formula name. The bottle path
+    # the argument instead of a formula name. The bottle path
     # specified might be different from the one we'd infer otherwise,
     # so prefer using the name that was specified.
     local_bottle_path = if File.exist?(name)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This fixes `brew bottle --json` when working with bottles using the older, pre-GitHub Packages filename format. The current version gets a bit confused because, although it's able to instantiate a formula and a produce a new destination filename for it, it still tries to perform file operations on the "new" file without having actually renamed it. Since the caller has access to the filename on disk, I've updated it to pass in both the filename and the formula so that the filename on disk can be used where necessary.