### PR TITLE
diagnostic: hide some warnings on Apple Silicon.

### DIFF
--- a/Library/Homebrew/diagnostic.rb
+++ b/Library/Homebrew/diagnostic.rb
@@ -487,7 +487,16 @@ module Homebrew
           #{HOMEBREW_PREFIX}/bin #{HOMEBREW_PREFIX}/sbin
           /Applications/Server.app/Contents/ServerRoot/usr/bin
           /Applications/Server.app/Contents/ServerRoot/usr/sbin
-        ].map(&:downcase)
+        ]
+        if OS.mac? && Hardware::CPU.physical_cpu_arm64?
+          allowlist += %W[
+            #{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/bin
+            #{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/sbin
+            #{HOMEBREW_DEFAULT_PREFIX}/bin
+            #{HOMEBREW_DEFAULT_PREFIX}/sbin
+          ]
+        end
+        allowlist.map!(&:downcase)
 
         paths.each do |p|
           next if allowlist.include?(p.downcase) || !File.directory?(p)

--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -316,10 +316,18 @@ module Homebrew
         end
 
         if gettext&.linked_keg&.directory?
-          homebrew_owned = @found.all? do |path|
-            Pathname.new(path).realpath.to_s.start_with? "#{HOMEBREW_CELLAR}/gettext"
+          allowlist = ["#{HOMEBREW_CELLAR}/gettext"]
+          if Hardware::CPU.physical_cpu_arm64?
+            allowlist += %W[
+              #{HOMEBREW_MACOS_ARM_DEFAULT_PREFIX}/Cellar/gettext
+              #{HOMEBREW_DEFAULT_PREFIX}/Cellar/gettext
+            ]
           end
-          return if homebrew_owned
+
+          return if @found.all? do |path|
+            realpath = Pathname.new(path).realpath.to_s
+            allowlist.any? { |rack| realpath.start_with?(rack) }
+          end
         end
 
         inject_file_list @found, <<~EOS


### PR DESCRIPTION
We don't want to complain about either Intel or ARM installations of Homebrew in `brew doctor` so check for/allow both.