### PR TITLE
Improve conflicts audit

### DIFF
--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -315,37 +315,37 @@ module Homebrew
 
     def audit_conflicts
       tap = formula.tap
-      formula.conflicts.each do |c|
-        conflicting_formula = Formulary.factory(c.name)
+      formula.conflicts.each do |conflict|
+        conflicting_formula = Formulary.factory(conflict.name)
         next if tap != conflicting_formula.tap
 
         problem "Formula should not conflict with itself" if formula == conflicting_formula
 
-        if tap.formula_renames.key?(c.name) || tap.aliases.include?(c.name)
+        if tap.formula_renames.key?(conflict.name) || tap.aliases.include?(conflict.name)
           problem "Formula conflict should be declared using " \
-                  "canonical name (#{conflicting_formula.name}) instead of #{c.name}"
+                  "canonical name (#{conflicting_formula.name}) instead of #{conflict.name}"
         end
 
-        rev_conflict_found = false
-        conflicting_formula.conflicts.each do |rc|
-          rc_formula = Formulary.factory(rc.name)
-          if tap.formula_renames.key?(rc.name) || tap.aliases.include?(rc.name)
+        reverse_conflict_found = false
+        conflicting_formula.conflicts.each do |reverse_conflict|
+          reverse_conflict_formula = Formulary.factory(reverse_conflict.name)
+          if tap.formula_renames.key?(reverse_conflict.name) || tap.aliases.include?(reverse_conflict.name)
             problem "Formula #{conflicting_formula.name} conflict should be declared using " \
-                    "canonical name (#{rc_formula.name}) instead of #{rc.name}"
+                    "canonical name (#{reverse_conflict_formula.name}) instead of #{reverse_conflict.name}"
           end
 
-          rev_conflict_found ||= rc_formula == formula
+          reverse_conflict_found ||= reverse_conflict_formula == formula
         end
-        unless rev_conflict_found
+        unless reverse_conflict_found
           problem "Formula #{conflicting_formula.name} should also have a conflict declared with #{formula.name}"
         end
       rescue TapFormulaUnavailableError
         # Don't complain about missing cross-tap conflicts.
         next
       rescue FormulaUnavailableError
-        problem "Can't find conflicting formula #{c.name.inspect}."
+        problem "Can't find conflicting formula #{conflict.name.inspect}."
       rescue TapFormulaAmbiguityError, TapFormulaWithOldnameAmbiguityError
-        problem "Ambiguous conflicting formula #{c.name.inspect}."
+        problem "Ambiguous conflicting formula #{conflict.name.inspect}."
       end
     end
 

--- a/Library/Homebrew/formula_auditor.rb
+++ b/Library/Homebrew/formula_auditor.rb
@@ -314,13 +314,14 @@ module Homebrew
     end
 
     def audit_conflicts
+      tap = formula.tap
       formula.conflicts.each do |c|
         conflicting_formula = Formulary.factory(c.name)
+        next if tap != conflicting_formula.tap
+
         problem "Formula should not conflict with itself" if formula == conflicting_formula
 
-        next unless @core_tap
-
-        if CoreTap.instance.formula_renames.key?(c.name) || Formula.aliases.include?(c.name)
+        if tap.formula_renames.key?(c.name) || tap.aliases.include?(c.name)
           problem "Formula conflict should be declared using " \
                   "canonical name (#{conflicting_formula.name}) instead of #{c.name}"
         end
@@ -328,7 +329,7 @@ module Homebrew
         rev_conflict_found = false
         conflicting_formula.conflicts.each do |rc|
           rc_formula = Formulary.factory(rc.name)
-          if CoreTap.instance.formula_renames.key?(rc.name) || Formula.aliases.include?(rc.name)
+          if tap.formula_renames.key?(rc.name) || tap.aliases.include?(rc.name)
             problem "Formula #{conflicting_formula.name} conflict should be declared using " \
                     "canonical name (#{rc_formula.name}) instead of #{rc.name}"
           end

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -58,20 +58,13 @@ module Homebrew
   end
 
   describe FormulaAuditor do
-    def formula_auditor(name_or_formula, text = nil, options = {})
-      formula = case name_or_formula
-      when String
-        path = Pathname.new "#{dir}/#{name_or_formula}.rb"
-        path.open("w") do |f|
-          f.write text
-        end
-
-        Formulary.factory(path)
-      when Formula
-        name_or_formula
+    def formula_auditor(name, text, options = {})
+      path = Pathname.new "#{dir}/#{name}.rb"
+      path.open("w") do |f|
+        f.write text
       end
 
-      described_class.new(formula, options)
+      described_class.new(Formulary.factory(path), options)
     end
 
     let(:dir) { mktmpdir }
@@ -1149,6 +1142,7 @@ module Homebrew
 
     describe "#audit_conflicts" do
       before do
+        # We don't really test FormulaTextAuditor here
         allow(File).to receive(:open).and_return("")
       end
 
@@ -1159,7 +1153,7 @@ module Homebrew
           conflicts_with "bar"
         end
 
-        fa = formula_auditor foo
+        fa = described_class.new foo
         fa.audit_conflicts
 
         expect(fa.problems.first[:message])
@@ -1174,7 +1168,7 @@ module Homebrew
         end
         stub_formula_loader foo
 
-        fa = formula_auditor foo
+        fa = described_class.new foo
         fa.audit_conflicts
 
         expect(fa.problems.first[:message])
@@ -1193,7 +1187,7 @@ module Homebrew
           conflicts_with "foo"
         end
 
-        fa = formula_auditor bar
+        fa = described_class.new bar
         fa.audit_conflicts
 
         expect(fa.problems.first[:message])

--- a/Library/Homebrew/test/dev-cmd/audit_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/audit_spec.rb
@@ -1142,7 +1142,7 @@ module Homebrew
 
     describe "#audit_conflicts" do
       specify "it warns when conflicting with non-existing formula" do
-        fa = formula_auditor "foo", <<~RUBY
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
 
@@ -1157,7 +1157,7 @@ module Homebrew
       end
 
       specify "it warns when conflicting with itself" do
-        fa = formula_auditor "foo", <<~RUBY
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
 
@@ -1172,13 +1172,13 @@ module Homebrew
       end
 
       specify "it warns when another formula does not have a symmetric conflict" do
-        formula_auditor "bar", <<~RUBY
+        formula_auditor "bar", <<~RUBY, core_tap: true
           class Bar < Formula
             url "https://brew.sh/foo-1.0.tgz"
           end
         RUBY
 
-        fa = formula_auditor "foo", <<~RUBY
+        fa = formula_auditor "foo", <<~RUBY, core_tap: true
           class Foo < Formula
             url "https://brew.sh/foo-1.0.tgz"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----
This PR adds a couple of more checks for conflict audit:
- a formula shouldn't conflict with itself
- if a formula conflicts with another one, the second formula should have a conflict with the first one

We have several formulae (23 when I've check it last time) with asymmetric `conflicts_with` statement. PR for them are coming

