### PR TITLE
Exclude version audit on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
         run: brew style --display-cop-names homebrew/core
 
       - name: Run brew audit --skip-style on all taps
-        run: brew audit --skip-style --display-failures-only
+        run: brew audit --skip-style --except=version --display-failures-only
 
       - name: Set up all Homebrew taps
         run: |
@@ -112,7 +112,7 @@ jobs:
           HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
 
       - name: Run brew audit --skip-style on homebrew-core
-        run: brew audit --skip-style --tap=homebrew/core
+        run: brew audit --skip-style --except=version --tap=homebrew/core
         env:
           HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
 

--- a/Library/Homebrew/resource_auditor.rb
+++ b/Library/Homebrew/resource_auditor.rb
@@ -20,14 +20,23 @@ module Homebrew
       @spec_name = spec_name
       @online    = options[:online]
       @strict    = options[:strict]
+      @only      = options[:only]
+      @except    = options[:except]
       @problems  = []
     end
 
     def audit
-      audit_version
-      audit_download_strategy
-      audit_checksum
-      audit_urls
+      only_audits = @only
+      except_audits = @except
+
+      methods.map(&:to_s).grep(/^audit_/).each do |audit_method_name|
+        name = audit_method_name.delete_prefix("audit_")
+        next if only_audits&.exclude?(name)
+        next if except_audits&.include?(name)
+
+        send(audit_method_name)
+      end
+
       self
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This PR is intended to exclude `ResourceAuditor#audit_version` from being run as part of `brew audit` on CI, with the exception of new formulae. This audit will give a `version 1.2.3 is redundant with version scanned from URL` error when the version specified in a formula (e.g., `version "1.2.3"`) is the same as the `Version` detected from the `url`.

Under certain circumstances, the version audit can become a problem on Homebrew/brew and Homebrew/homebrew-core CI:

* Homebrew/brew CI will fail because of this audit if a PR modifies the `Version` parsing logic in a way that it fixes parsing for core formulae that previously needed to use `version` to specify the correct version. This scenario is a challenge because we can't remove `version` from these formulae until the `Version`-modifying PR is merged but we can't merge the `Version`-modifying PR because it fails CI due to the version audit error. This can be seen in #11491 and this PR is meant to unblock it (as well as any future PRs modifying `Version` parsing).
* Homebrew/homebrew-core CI will fail because of this audit if a PR preemptively adds `version` to a formula to account for a forthcoming change in `Version` parsing. In this scenario, we need to be able to merge this type of formula PR before any brew PR that modifies `Version` parsing, to prevent the version from becoming incorrect after the change. This can be seen in Homebrew/homebrew-core#78878, where `ammonite-repl`'s parsed version will change after #11491 is merged and we need to add `version` beforehand to maintain the correct version.

In both of these cases, it's necessary to exclude the version audit on CI for a PR to pass and allow us to merge it.

---

This PR makes this possible by modifying `ResourceAuditor` to add `only` and `except` options, like `FormulaAuditor`. I've borrowed the code that handles these options from `FormulaAuditor#audit` and the only difference in `ResourceAuditor#audit` is that it [necessarily] returns `self` at the end of the method. With this change, any `--only` and `--except` options provided to `brew audit` will also pass to `ResourceAuditor`, so `--except=version` becomes possible.

\[As noted in https://github.com/Homebrew/brew/pull/11491#issuecomment-860977367, an audit with the same name in `FormulaAuditor` and `ResourceAuditor` would both be affected by `--only` or `--except`. There aren't any overlapping names right now but, depending on the audit, this could be either desirable or undesirable behavior. It's best to continue avoiding any audit method name overlap between these two classes, so it doesn't become an issue.\]

After laying the groundwork, this PR modifies `brew audit` steps in `.github/workflows/tests.yml` to use `--except=version`. Please review this to ensure that I've modified the correct steps and let me know if it's not appropriate in either of the existing cases.

---

Past this, I will be opening a related PR in Homebrew/homebrew-test-bot momentarily to add `--except=version` to related `brew audit` calls. This is necessary for the version audit to be skipped on core CI.

Edit: The related test-bot PR can be found at Homebrew/homebrew-test-bot#617.