### PR TITLE
Allow for homebrew/core to be untapped

### DIFF
--- a/Library/Homebrew/cask_dependent.rb
+++ b/Library/Homebrew/cask_dependent.rb
@@ -15,8 +15,8 @@ class CaskDependent
     @cask.full_name
   end
 
-  def runtime_dependencies
-    recursive_dependencies
+  def runtime_dependencies(ignore_missing: false)
+    recursive_dependencies ignore_missing: ignore_missing
   end
 
   def deps
@@ -43,8 +43,8 @@ class CaskDependent
     end
   end
 
-  def recursive_dependencies(&block)
-    Dependency.expand(self, &block)
+  def recursive_dependencies(ignore_missing: false, &block)
+    Dependency.expand(self, ignore_missing: ignore_missing, &block)
   end
 
   def recursive_requirements(&block)

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -25,7 +25,7 @@ module Homebrew
     args = untap_args.parse
 
     args.named.to_installed_taps.each do |tap|
-      odie "Untapping #{tap} is not allowed" if tap.core_tap?
+      odie "Untapping #{tap} is not allowed" if tap.core_tap? && !ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
 
       installed_tap_formulae = Formula.installed.select { |formula| formula.tap == tap }
       installed_tap_casks = Cask::Caskroom.casks.select { |cask| cask.tap == tap }

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -25,7 +25,7 @@ module Homebrew
     args = untap_args.parse
 
     args.named.to_installed_taps.each do |tap|
-      odie "Untapping #{tap} is not allowed" if tap.core_tap? && !ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
+      odie "Untapping #{tap} is not allowed" if tap.core_tap? && ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].blank?
 
       installed_tap_formulae = Formula.installed.select { |formula| formula.tap == tap }
       installed_tap_casks = Cask::Caskroom.casks.select { |cask| cask.tap == tap }

--- a/Library/Homebrew/cmd/untap.rb
+++ b/Library/Homebrew/cmd/untap.rb
@@ -25,7 +25,7 @@ module Homebrew
     args = untap_args.parse
 
     args.named.to_installed_taps.each do |tap|
-      odie "Untapping #{tap} is not allowed" if tap.core_tap? && ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].blank?
+      odie "Untapping #{tap} is not allowed" if tap.core_tap? && ENV["HOMEBREW_JSON_CORE"].blank?
 
       installed_tap_formulae = Formula.installed.select { |formula| formula.tap == tap }
       installed_tap_casks = Cask::Caskroom.casks.select { |cask| cask.tap == tap }

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -207,6 +207,7 @@ module Homebrew
 
   def install_core_tap_if_necessary
     return if ENV["HOMEBREW_UPDATE_TEST"]
+    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
 
     core_tap = CoreTap.instance
     return if core_tap.installed?

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -207,7 +207,7 @@ module Homebrew
 
   def install_core_tap_if_necessary
     return if ENV["HOMEBREW_UPDATE_TEST"]
-    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].present?
+    return if ENV["HOMEBREW_JSON_CORE"].present?
 
     core_tap = CoreTap.instance
     return if core_tap.installed?

--- a/Library/Homebrew/cmd/update-report.rb
+++ b/Library/Homebrew/cmd/update-report.rb
@@ -207,7 +207,7 @@ module Homebrew
 
   def install_core_tap_if_necessary
     return if ENV["HOMEBREW_UPDATE_TEST"]
-    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
+    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].present?
 
     core_tap = CoreTap.instance
     return if core_tap.installed?

--- a/Library/Homebrew/dependency.rb
+++ b/Library/Homebrew/dependency.rb
@@ -46,6 +46,15 @@ class Dependency
     formula
   end
 
+  def unavailable_core_formula?
+    to_formula
+    false
+  rescue CoreTapFormulaUnavailableError
+    true
+  rescue
+    false
+  end
+
   def installed?
     to_formula.latest_version_installed?
   end
@@ -130,6 +139,8 @@ class Dependency
 
     def action(dependent, dep, &block)
       catch(:action) do
+        prune if dep.unavailable_core_formula?
+
         if block
           yield dependent, dep
         elsif dep.optional? || dep.recommended?

--- a/Library/Homebrew/exceptions.rb
+++ b/Library/Homebrew/exceptions.rb
@@ -221,6 +221,13 @@ class TapFormulaUnavailableError < FormulaUnavailableError
   end
 end
 
+# Raised when a formula in a the core tap is unavailable.
+class CoreTapFormulaUnavailableError < TapFormulaUnavailableError
+  def initialize(name)
+    super CoreTap.instance, name
+  end
+end
+
 # Raised when a formula in a specific tap does not contain a formula class.
 class TapFormulaClassUnavailableError < TapFormulaUnavailableError
   include FormulaClassUnavailableErrorModule

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -361,6 +361,10 @@ module Formulary
     end
 
     def get_formula(*)
+      if !CoreTap.instance.installed? && ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
+        raise CoreTapFormulaUnavailableError, name
+      end
+
       raise FormulaUnavailableError, name
     end
   end

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -361,7 +361,7 @@ module Formulary
     end
 
     def get_formula(*)
-      if !CoreTap.instance.installed? && ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].present?
+      if !CoreTap.instance.installed? && ENV["HOMEBREW_JSON_CORE"].present?
         raise CoreTapFormulaUnavailableError, name
       end
 
@@ -399,7 +399,7 @@ module Formulary
   )
     raise ArgumentError, "Formulae must have a ref!" unless ref
 
-    if ENV["HOMEBREW_BOTTLE_JSON"].present? &&
+    if ENV["HOMEBREW_JSON_CORE"].present? &&
        @formula_name_local_bottle_path_map.present? &&
        @formula_name_local_bottle_path_map.key?(ref)
       ref = @formula_name_local_bottle_path_map[ref]
@@ -431,8 +431,8 @@ module Formulary
   # @param formula_name the formula name string to map.
   # @param local_bottle_path a path pointing to the target bottle archive.
   def self.map_formula_name_to_local_bottle_path(formula_name, local_bottle_path)
-    if ENV["HOMEBREW_BOTTLE_JSON"].blank?
-      raise UsageError, "HOMEBREW_BOTTLE_JSON not set but required for #{__method__}!"
+    if ENV["HOMEBREW_JSON_CORE"].blank?
+      raise UsageError, "HOMEBREW_JSON_CORE not set but required for #{__method__}!"
     end
 
     @formula_name_local_bottle_path_map ||= {}

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -361,7 +361,7 @@ module Formulary
     end
 
     def get_formula(*)
-      if !CoreTap.instance.installed? && ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
+      if !CoreTap.instance.installed? && ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].present?
         raise CoreTapFormulaUnavailableError, name
       end
 

--- a/Library/Homebrew/formulary.rb
+++ b/Library/Homebrew/formulary.rb
@@ -361,9 +361,7 @@ module Formulary
     end
 
     def get_formula(*)
-      if !CoreTap.instance.installed? && ENV["HOMEBREW_JSON_CORE"].present?
-        raise CoreTapFormulaUnavailableError, name
-      end
+      raise CoreTapFormulaUnavailableError, name if !CoreTap.instance.installed? && ENV["HOMEBREW_JSON_CORE"].present?
 
       raise FormulaUnavailableError, name
     end
@@ -431,9 +429,7 @@ module Formulary
   # @param formula_name the formula name string to map.
   # @param local_bottle_path a path pointing to the target bottle archive.
   def self.map_formula_name_to_local_bottle_path(formula_name, local_bottle_path)
-    if ENV["HOMEBREW_JSON_CORE"].blank?
-      raise UsageError, "HOMEBREW_JSON_CORE not set but required for #{__method__}!"
-    end
+    raise UsageError, "HOMEBREW_JSON_CORE not set but required for #{__method__}!" if ENV["HOMEBREW_JSON_CORE"].blank?
 
     @formula_name_local_bottle_path_map ||= {}
     @formula_name_local_bottle_path_map[formula_name] = Pathname(local_bottle_path).realpath

--- a/Library/Homebrew/installed_dependents.rb
+++ b/Library/Homebrew/installed_dependents.rb
@@ -50,7 +50,8 @@ module InstalledDependents
       when Formula
         dependent.missing_dependencies(hide: keg_names)
       when Cask::Cask
-        CaskDependent.new(dependent).runtime_dependencies.map(&:to_formula)
+        # When checking for cask dependents, we don't care about missing dependencies
+        CaskDependent.new(dependent).runtime_dependencies(ignore_missing: true).map(&:to_formula)
       end
 
       required_kegs = required.map do |f|

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -734,7 +734,7 @@ class CoreTap < Tap
 
   def self.ensure_installed!
     return if instance.installed?
-    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].present?
+    return if ENV["HOMEBREW_JSON_CORE"].present?
 
     safe_system HOMEBREW_BREW_FILE, "tap", instance.name
   end
@@ -751,7 +751,7 @@ class CoreTap < Tap
   # @private
   sig { params(manual: T::Boolean).void }
   def uninstall(manual: false)
-    raise "Tap#uninstall is not available for CoreTap" if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].blank?
+    raise "Tap#uninstall is not available for CoreTap" if ENV["HOMEBREW_JSON_CORE"].blank?
 
     super
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -734,7 +734,7 @@ class CoreTap < Tap
 
   def self.ensure_installed!
     return if instance.installed?
-    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
+    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].present?
 
     safe_system HOMEBREW_BREW_FILE, "tap", instance.name
   end
@@ -751,7 +751,7 @@ class CoreTap < Tap
   # @private
   sig { params(manual: T::Boolean).void }
   def uninstall(manual: false)
-    raise "Tap#uninstall is not available for CoreTap" unless ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
+    raise "Tap#uninstall is not available for CoreTap" if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"].blank?
 
     super
   end

--- a/Library/Homebrew/tap.rb
+++ b/Library/Homebrew/tap.rb
@@ -734,6 +734,7 @@ class CoreTap < Tap
 
   def self.ensure_installed!
     return if instance.installed?
+    return if ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
 
     safe_system HOMEBREW_BREW_FILE, "tap", instance.name
   end
@@ -748,9 +749,11 @@ class CoreTap < Tap
   end
 
   # @private
-  sig { void }
-  def uninstall
-    raise "Tap#uninstall is not available for CoreTap"
+  sig { params(manual: T::Boolean).void }
+  def uninstall(manual: false)
+    raise "Tap#uninstall is not available for CoreTap" unless ENV["HOMEBREW_UNTAP_HOMEBREW_CORE"]
+
+    super
   end
 
   # @private

--- a/Library/Homebrew/test/formulary_spec.rb
+++ b/Library/Homebrew/test/formulary_spec.rb
@@ -216,12 +216,12 @@ describe Formulary do
         described_class.factory("formula-to-map")
       }.to raise_error(FormulaUnavailableError)
 
-      ENV["HOMEBREW_BOTTLE_JSON"] = nil
+      ENV["HOMEBREW_JSON_CORE"] = nil
       expect {
         described_class.map_formula_name_to_local_bottle_path "formula-to-map", formula_path
-      }.to raise_error(UsageError, /HOMEBREW_BOTTLE_JSON not set/)
+      }.to raise_error(UsageError, /HOMEBREW_JSON_CORE not set/)
 
-      ENV["HOMEBREW_BOTTLE_JSON"] = "1"
+      ENV["HOMEBREW_JSON_CORE"] = "1"
       described_class.map_formula_name_to_local_bottle_path "formula-to-map", formula_path
 
       expect(described_class.factory("formula-to-map")).to be_kind_of(Formula)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This PR allows homebrew/core to be untapped if the `HOMEBREW_UNTAP_HOMEBREW_CORE` environment variable is set. We may want to consider merging this variable with `HOMEBREW_BOTTLE_JSON`. For now, I separated them because they are technically for different things (and I wasn't sure about a name). Happy to do whatever we think is best here.

Now, `Formulary` will throw a `CoreTapFormulaUnavailableError` when it can't find a formula under the conditions that homebrew/core is untapped and the environment variable is set.

`CoreTapFormulaUnavailableError` is a subclass of `TapFormulaUnavailableError` which is a subclass of `FormulaUnavailableError`. Therefore, anytime `CoreTapFormulaUnavailableError` is thrown it will still be caught by any `rescue FormulaUnavailableError` blocks. However, it will now also be caught by `resuce TapFormulaUnavailableError` blocks which means that more appropriate handling can be done. For example, we ignore missing `conflicts_with` formulae when a `TapFormulaUnavailableError` is raise but not when `FormulaUnavailableError` is raised. We want `CoreTapFormulaUnavailableError` to have the same logic as `TapFormulaUnavailableError` in this case, because the conflicts that are missing should be treated just as if they conflict with a different tap.

The other more major change is that `Dependency::expand` will now automatically prune all deps that raise `CoreTapFormulaUnavailableError` when calling `#to_formula`. This does mean that things like `brew deps` will not show any build/test dependencies that aren't installed locally, and may have other similar consequences.

I think this is okay, though, because the people who will have homebrew/core untapped likely won't need to worry about these things. Having homebrew/core untapped will definitely be bad for Homebrew developers, but I think that most of the weird side-effects that may appear won't matter for the general user. For example, a user who just wants to install a formula quickly won't care if running `brew deps --include-test --include-build` on that formula doesn't list all of the test/build deps that aren't installed already.

---

Here's how I tested:

```console
$ export HOMEBREW_BOTTLE_JSON=1

$ export HOMEBREW_UNTAP_HOMEBREW_CORE=1

$ brew untap homebrew/core
...
Untapping homebrew/core...
Untapped 2 commands and 5654 formulae (6,150 files, 435.5MB).

$ brew json rnv
==> Downloading https://ghcr.io/v2/homebrew/core/rnv/blobs/sha256:c262efcf45b880c131f5e466d1b672ce5120dff6302b9b7504f6c1e1ee87cb22
Already downloaded: /Users/rylanpolster/Library/Caches/Homebrew/downloads/22cd8e6434267f3561d6b0508f57ce5a83ac620b10b90b60f900abe2e4641b76--rnv--1.7.11.big_sur.bottle.tar.gz
==> Downloading https://ghcr.io/v2/homebrew/core/expat/blobs/sha256:18ebdde1356dd48de8c575eb2479dbb6556f7bef7a2b48a64c0f018dd79af1dc
Already downloaded: /Users/rylanpolster/Library/Caches/Homebrew/downloads/75221c8c9bb68848b82f46840d432a4b72bcf8318122376c3dce0b4ab1a081ec--expat--2.4.1.big_sur.bottle.tar.gz
==> Installing dependencies for rnv: expat
==> Installing rnv dependency: expat
==> Pouring expat--2.4.1.big_sur.bottle.tar.gz
🍺  /usr/local/Cellar/expat/2.4.1: 21 files, 568.7KB
==> Installing rnv
==> Pouring rnv--1.7.11.big_sur.bottle.tar.gz
🍺  /usr/local/Cellar/rnv/1.7.11: 10 files, 661.5KB

$ brew uninstall rnv expat
Uninstalling /usr/local/Cellar/rnv/1.7.11... (10 files, 661.5KB)
Uninstalling /usr/local/Cellar/expat/2.4.1... (21 files, 568.7KB)
```

Once the formula is installed, `Formulary::factory` will find it from the cellar without any issue, so things like `deps`, `uses --installed`, `info`, `desc`, `home`, `link`, `unlink`, `list`, `pin`, and `unpin` all work as expected (I tested all of those except the actual install logic with `pin` and `unpin`).

I haven't even bothered testing `brew upgrade` and `brew reinstall`, yet. Those will need some additional thought which will be one of the next steps.

Lastly, I did test installing a cask which seems to work fine. I haven't played with casks that depend on formulae at all yet. That will be something for much later.
