### PR TITLE
livecheck/strategy/sparkle: check minimumSystemVersion for compatibility

### DIFF
--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -117,12 +117,12 @@ module Homebrew
 
             if (minimum_system_version = item.elements["minimumSystemVersion"]&.text&.gsub(/\A\D+|\D+\z/, ""))
               macos_minimum_system_version = begin
-                MacOS::Version.new(minimum_system_version).strip_patch
+                OS::Mac::Version.new(minimum_system_version).strip_patch
               rescue MacOSVersionError
                 nil
               end
 
-              next if MacOS.version < macos_minimum_system_version
+              next if macos_minimum_system_version&.prerelease?
             end
 
             data = {

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -115,7 +115,7 @@ module Homebrew
 
             next if os && os != "osx"
 
-            if OS.mac? && (minimum_system_version = (item > "minimumSystemVersion").first&.text&.strip)
+            if (minimum_system_version = item.elements["minimumSystemVersion"]&.text&.gsub(/\A\D+|\D+\z/, ""))
               macos_minimum_system_version = begin
                 MacOS::Version.new(minimum_system_version).strip_patch
               rescue MacOSVersionError

--- a/Library/Homebrew/livecheck/strategy/sparkle.rb
+++ b/Library/Homebrew/livecheck/strategy/sparkle.rb
@@ -115,6 +115,16 @@ module Homebrew
 
             next if os && os != "osx"
 
+            if OS.mac? && (minimum_system_version = (item > "minimumSystemVersion").first&.text&.strip)
+              macos_minimum_system_version = begin
+                MacOS::Version.new(minimum_system_version).strip_patch
+              rescue MacOSVersionError
+                nil
+              end
+
+              next if MacOS.version < macos_minimum_system_version
+            end
+
             data = {
               title:          title,
               pub_date:       pub_date || Time.new(0),


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Helps close Homebrew/homebrew-cask#107112 

The issue in the above PR was that the `bartender` Cask Sparkle feed included a macOS Monterey-only (Beta) release, which shows up in `livecheck`. The only way to identify this variant would be to check the `sparkle:minimumSystemVersion` (or `livecheck` a different url/strategy):
```xml
<item>
  <title>Version 4.1.0</title>
  <sparkle:minimumSystemVersion>12.0.0</sparkle:minimumSystemVersion>
  <sparkle:releaseNotesLink>https://macbartender.com/B2/updates/4-1-00/rnotes.html</sparkle:releaseNotesLink>
  <pubDate>June 11, 2021 09:45:00 +0000</pubDate>
  <enclosure url="https://macbartender.com/B2/updates/4-1-00/Bartender%204.zip" sparkle:version="41000" sparkle:shortVersionString="4.1.0" length="10447378" type="application/octet-stream" sparkle:dsaSignature="MCwCFE6EG2iwK+LJpIADGYEn+9MueX4AAhR73iaPOonRsW9U5wa6GuKhIpZ0Xw==" />
</item>
```

---

A possible demerit from adding this would be that trying to update a Cask by checking `brew livecheck` on older macOS may no longer work.

On-the-other-hand, this also means `brew livecheck` output should align with `brew bump-cask-pr` in the case that there is an `if MacOS.version <= ` section.

---

Example on macOS Big Sur:
Before:
```console
❯ brew livecheck bartender
bartender : 4.0.48,40048 ==> 4.1.0,41000
```
After:
```console
❯ brew livecheck bartender
bartender : 4.0.48,40048 ==> 4.0.48,40048
```