### PR TITLE
formula_installer: add fallback to use tap formula

### DIFF
--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -1056,9 +1056,11 @@ class FormulaInstaller
     # * Installing from a local bottle, or
     # * The formula doesn't exist in the tap (or the tap isn't installed), or
     # * The formula in the tap has a different pkg_version.
+    #
     # In all other cases, including if the formula from the keg is unreadable
-    # (third-party taps may `require` some of their own libraries), use the
-    # formula from the tap.
+    # (third-party taps may `require` some of their own libraries) or if there
+    # is no formula present in the keg (as is the case with old bottles), use
+    # the formula from the tap.
     formula_path = begin
       keg_formula_path = formula.opt_prefix/".brew/#{formula.name}.rb"
       tap_formula_path = formula.path
@@ -1073,7 +1075,7 @@ class FormulaInstaller
       else
         tap_formula_path
       end
-    rescue FormulaUnreadableError
+    rescue FormulaUnavailableError, FormulaUnreadableError
       tap_formula_path
     end
 


### PR DESCRIPTION
The keg formula isn't present in some old bottles. Use the tap
formula as a fallback when this is the case.

---

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

---

A few formulae in `linuxbrew-core` were bottled over 3-4 years ago, and their bottles do not seem to contain the `.brew` directory within the prefix. This PR adds a fallback to use the tap formula in such cases (rescuing from `FormulaUnavailableError` seems to do the trick). These formulae will be rebottled after the core merging, but it may still be a problem for external taps with old bottles.

CC @iMichka