### PR TITLE
Read multiple depends_on :arch as 'any of'

### DIFF
--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -14,7 +14,7 @@ class ArchRequirement < Requirement
   attr_reader :arch
 
   def initialize(tags)
-    @arch = Array.new
+    @arch = []
     tags.each do |tag|
       case tag
       when :x86_64, :arm64, :arm, :intel, :ppc

--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -14,7 +14,15 @@ class ArchRequirement < Requirement
   attr_reader :arch
 
   def initialize(tags)
-    @arch = tags.shift
+    @arch = Array.new
+    tags.each do |tag|
+      case tag
+      when :x86_64, :arm64, :arm, :intel, :ppc
+        @arch.append(tag)
+        tags.delete(tag)
+      end
+    end
+
     super(tags)
   end
 

--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -14,7 +14,7 @@ class ArchRequirement < Requirement
   attr_reader :arch
 
   def initialize(tags)
-    @arch = tags
+    @arch = tags.shift
     super(tags)
   end
 
@@ -29,6 +29,8 @@ class ArchRequirement < Requirement
       end
 
       next satisfied
+    elsif @arch.nil?
+      next true
     end
     satisfies_arch(@arch)
   end

--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -14,21 +14,37 @@ class ArchRequirement < Requirement
   attr_reader :arch
 
   def initialize(tags)
-    @arch = tags.shift
+    @arch = tags
     super(tags)
   end
 
   satisfy(build_env: false) do
-    case @arch
+    if @arch.is_a? Array
+      next true if @arch.empty?
+
+      satisfied = T.let(false, T::Boolean)
+      @arch.each do |arch|
+        satisfied = satisfies_arch(arch)
+        break if satisfied
+      end
+
+      next satisfied
+    end
+    satisfies_arch(@arch)
+  end
+
+  sig { params(arch: Symbol).returns(T::Boolean) }
+  def satisfies_arch(arch)
+    case arch
     when :x86_64 then Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
     when :arm64 then Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-    when :arm, :intel, :ppc then Hardware::CPU.type == @arch
+    when :arm, :intel, :ppc then Hardware::CPU.type == arch
     end
   end
 
   sig { returns(String) }
   def message
-    "The #{@arch} architecture is required for this software."
+    "One of #{@arch} architectures is required for this software."
   end
 
   def inspect

--- a/Library/Homebrew/requirements/arch_requirement.rb
+++ b/Library/Homebrew/requirements/arch_requirement.rb
@@ -16,8 +16,7 @@ class ArchRequirement < Requirement
   def initialize(tags)
     @arch = []
     tags.each do |tag|
-      case tag
-      when :x86_64, :arm64, :arm, :intel, :ppc
+      if Hardware::CPU::ALL_ARCHS.include? tag
         @arch.append(tag)
         tags.delete(tag)
       end

--- a/Library/Homebrew/test/requirements/arch_requirement_spec.rb
+++ b/Library/Homebrew/test/requirements/arch_requirement_spec.rb
@@ -4,11 +4,33 @@
 require "requirements/arch_requirement"
 
 describe ArchRequirement do
-  subject(:requirement) { described_class.new([Hardware::CPU.type]) }
+  subject(:requirement) {
+    described_class.new(arch)
+  }
 
   describe "#satisfied?" do
-    it "supports architecture symbols" do
-      expect(requirement).to be_satisfied
+    context "when given current architecture" do
+      let(:arch) { [Hardware::CPU.type] }
+
+      it "satisfies requirement" do
+        expect(requirement).to be_satisfied
+      end
+    end
+
+    context "when given all architectures" do
+      let(:arch) { [:x86_64, :arm64, :arm, :intel, :ppc] }
+
+      it "satisfies requirement" do
+        expect(requirement).to be_satisfied
+      end
+    end
+
+    context "when given empty array" do
+      let(:arch) { [] }
+
+      it "satisfies requirement" do
+        expect(requirement).to be_satisfied
+      end
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

This changes the behaviour of the `depends_on arch:` stanza, so that an array is evaluated as "OR", i.e. the following

```ruby
depends_on arch: [:x86_64, :aarch64]
```

means either `x86_64` OR `aarch64`.

Previous (AFAIK undocumented) behaviour was that only the first element of the array was evaluated.

See related discussion at https://github.com/Homebrew/discussions/discussions/1595

--- 

TODO: Figure out why sorbet keeps complaining about missing method.