### PR TITLE
release_notes: refactor/cleanup.

### DIFF
--- a/Library/Homebrew/dev-cmd/release.rb
+++ b/Library/Homebrew/dev-cmd/release.rb
@@ -71,7 +71,7 @@ module Homebrew
       latest_major_minor_version = "#{latest_version.major}.#{latest_version.minor.to_i}.0"
       ohai "Release notes since #{latest_major_minor_version} for #{new_version} blog post:"
       # release notes without username suffix or dependabot bumps
-      puts ReleaseNotes.generate_release_notes(latest_major_minor_version, "origin/HEAD", markdown: true)
+      puts ReleaseNotes.generate_release_notes(latest_major_minor_version, "origin/HEAD")
                        .lines
                        .reject { |l| l.include?(" (@Homebrew)") }
                        .map { |l| l.gsub(/ \(@[\w-]+\)$/, "") }
@@ -85,7 +85,7 @@ module Homebrew
     else
       ""
     end
-    release_notes += ReleaseNotes.generate_release_notes latest_version, "origin/HEAD", markdown: true
+    release_notes += ReleaseNotes.generate_release_notes latest_version, "origin/HEAD"
 
     begin
       release = GitHub.create_or_update_release "Homebrew", "brew", new_version, body: release_notes, draft: true

--- a/Library/Homebrew/test/release_notes_spec.rb
+++ b/Library/Homebrew/test/release_notes_spec.rb
@@ -18,19 +18,10 @@ describe ReleaseNotes do
   end
 
   describe ".generate_release_notes" do
-    it "generates release notes" do
-      expect(described_class.generate_release_notes("release-notes-testing", "HEAD")).to eq <<~NOTES
-        https://github.com/Homebrew/brew/pull/3 (@User) - Merge pull request #3 from User/another_change
-        https://github.com/Homebrew/brew/pull/2 (@User) - Do something else
-        https://github.com/Homebrew/brew/pull/1 (@Homebrew) - Do something
-      NOTES
-    end
-
     it "generates markdown release notes" do
-      expect(described_class.generate_release_notes("release-notes-testing", "HEAD", markdown: true)).to eq <<~NOTES
+      expect(described_class.generate_release_notes("release-notes-testing", "HEAD")).to eq <<~NOTES
         - [Merge pull request #3 from User/another_change](https://github.com/Homebrew/brew/pull/3) (@User)
         - [Do something else](https://github.com/Homebrew/brew/pull/2) (@User)
-        - [Do something](https://github.com/Homebrew/brew/pull/1) (@Homebrew)
       NOTES
     end
   end


### PR DESCRIPTION
This was failing for me locally so I've made some fixes:
- remove the `markdown` flag (as it's the only path now)
- refactor the generation to not use intermediate variables
- discard more weird cases rather than erroring
- exclude @Homebrew changes (e.g. from bots) because we don't care about  these in the release notes