### PR TITLE
utils/github.rb: fix dry-run message

### DIFF
--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -482,7 +482,7 @@ module GitHub
       changed_files += additional_files if additional_files.present?
 
       if args.dry_run? || (args.write? && !args.commit?)
-       remote_url = if args.no_fork?
+        remote_url = if args.no_fork?
           Utils.popen_read("git", "remote", "get-url", "--push", "origin").chomp
         else
           fork_message = "try to fork repository with GitHub API" \

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -482,10 +482,13 @@ module GitHub
       changed_files += additional_files if additional_files.present?
 
       if args.dry_run? || (args.write? && !args.commit?)
-        unless args.no_fork?
+        if args.no_fork?
+          remote_url = Utils.popen_read("git", "remote", "get-url", "--push", "origin").chomp
+        else
           fork_message = "try to fork repository with GitHub API" \
                          "#{" into `#{args.fork_org}` organization" if args.fork_org}"
           ohai fork_message
+          remote_url = "FORK_URL"
         end
         ohai "git fetch --unshallow origin" if shallow
         ohai "git add #{changed_files.join(" ")}"

--- a/Library/Homebrew/utils/github.rb
+++ b/Library/Homebrew/utils/github.rb
@@ -482,13 +482,13 @@ module GitHub
       changed_files += additional_files if additional_files.present?
 
       if args.dry_run? || (args.write? && !args.commit?)
-        if args.no_fork?
-          remote_url = Utils.popen_read("git", "remote", "get-url", "--push", "origin").chomp
+       remote_url = if args.no_fork?
+          Utils.popen_read("git", "remote", "get-url", "--push", "origin").chomp
         else
           fork_message = "try to fork repository with GitHub API" \
                          "#{" into `#{args.fork_org}` organization" if args.fork_org}"
           ohai fork_message
-          remote_url = "FORK_URL"
+          "FORK_URL"
         end
         ohai "git fetch --unshallow origin" if shallow
         ohai "git add #{changed_files.join(" ")}"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Address the issue reported in https://github.com/Homebrew/brew/pull/11556#issuecomment-864462191
I propose to obtain the remote url using `git remote get-url --push origin` in the dry-run mode when `no-fork` is specified, and set it to "FORK_URL" when `no-fork` is not used.

CC @cho-m 