### PR TITLE
Automatically detect and track flaky tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -322,7 +322,9 @@ jobs:
       - uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192
 
       - name: Upload test results to BuildPulse for flaky test detection
-        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        # Only run this step for PRs where where we have access to secrets.
+        # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: github.event.pull_request.head.repo.full_name == github.repository && !cancelled()
         env:
           BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -329,6 +329,5 @@ jobs:
           BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
         run: |
-          curl -fsSL https://github.com/buildpulse/test-reporter/releases/latest/download/test-reporter-darwin-amd64 > ./buildpulse-test-reporter
-          chmod +x ./buildpulse-test-reporter
-          ./buildpulse-test-reporter submit Library/Homebrew/test/junit --account-id 1503512 --repository-id 53238813
+          brew install buildpulse-test-reporter
+          buildpulse-test-reporter submit Library/Homebrew/test/junit --account-id 1503512 --repository-id 53238813

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -320,3 +320,13 @@ jobs:
       - run: brew test-bot --only-formulae --test-default-formula
 
       - uses: codecov/codecov-action@29386c70ef20e286228c72b668a06fd0e8399192
+
+      - name: Upload test results to BuildPulse for flaky test detection
+        if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        env:
+          BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+        run: |
+          curl -fsSL https://github.com/buildpulse/test-reporter/releases/latest/download/test-reporter-darwin-amd64 > ./buildpulse-test-reporter
+          chmod +x ./buildpulse-test-reporter
+          ./buildpulse-test-reporter submit Library/Homebrew/test/junit --account-id 1503512 --repository-id 53238813

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /Library/Homebrew/test/.gem
 /Library/Homebrew/test/.subversion
 /Library/Homebrew/test/coverage
+/Library/Homebrew/test/junit
 /Library/Homebrew/test/fs_leak_log
 /Library/Homebrew/vendor/portable-ruby
 /Library/Taps
@@ -133,6 +134,7 @@
 **/vendor/bundle/ruby/*/gems/rspec-*/
 **/vendor/bundle/ruby/*/gems/rspec-core-*/
 **/vendor/bundle/ruby/*/gems/rspec-expectations-*/
+**/vendor/bundle/ruby/*/gems/rspec_junit_formatter-*/
 **/vendor/bundle/ruby/*/gems/rspec-its-*/
 **/vendor/bundle/ruby/*/gems/rspec-mocks-*/
 **/vendor/bundle/ruby/*/gems/rspec-retry-*/

--- a/Library/Homebrew/.rspec_parallel
+++ b/Library/Homebrew/.rspec_parallel
@@ -1,0 +1,6 @@
+--format NoSeedProgressFormatter
+--format ParallelTests::RSpec::RuntimeLogger
+--out <%= ENV["PARALLEL_RSPEC_LOG_PATH"] %>
+--format RspecJunitFormatter
+--out test/junit/rspec<%= ENV["TEST_ENV_NUMBER"] %>.xml
+<%= "--format RSpec::Github::Formatter" if ENV["GITHUB_ACTIONS"] %>

--- a/Library/Homebrew/Gemfile
+++ b/Library/Homebrew/Gemfile
@@ -12,6 +12,7 @@ gem "ronn", require: false
 gem "rspec", require: false
 gem "rspec-github", require: false
 gem "rspec-its", require: false
+gem "rspec_junit_formatter", require: false
 gem "rspec-retry", require: false
 gem "rspec-wait", require: false
 gem "rubocop", require: false

--- a/Library/Homebrew/Gemfile.lock
+++ b/Library/Homebrew/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     rspec-support (3.10.2)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.17.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -194,6 +196,7 @@ DEPENDENCIES
   rspec-retry
   rspec-sorbet
   rspec-wait
+  rspec_junit_formatter
   rubocop
   rubocop-ast
   rubocop-performance

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -111,6 +111,7 @@ module Homebrew
       else
         "#{HOMEBREW_CACHE}/#{parallel_rspec_log_name}"
       end
+      ENV["PARALLEL_RSPEC_LOG_PATH"] = parallel_rspec_log_path
 
       parallel_args = if ENV["CI"]
         %W[
@@ -133,12 +134,7 @@ module Homebrew
         --seed #{seed}
         --color
         --require spec_helper
-        --format NoSeedProgressFormatter
-        --format ParallelTests::RSpec::RuntimeLogger
-        --out #{parallel_rspec_log_path}
       ]
-
-      bundle_args << "--format" << "RSpec::Github::Formatter" if ENV["GITHUB_ACTIONS"]
 
       unless OS.mac?
         bundle_args << "--tag" << "~needs_macos" << "--tag" << "~cask"


### PR DESCRIPTION
**tl;dr** This pull request proposes configuring tooling to automatically detect and track flaky tests. As I understand it, this has historically required manual effort for Homebrew maintainers. By automating the process, we hopefully reduce the time that maintainers have to spend on the thankless and laborious task of manually identifying flaky tests. 🤞

/cc @MikeMcQuaid for review

## Pull request template

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
     _No. I don't think this is applicable to this pull request, but if it is, please let me know._ :bow:
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

## How it works

At a high-level, setting things up works as follows:

1. Enhance the test suite to emit JUnit XML test reports.

    This is accomplished in e163eb8650cb38d03829cd8aa537a3f32af3682f. Please see the commit message for details.

2. Enhance the CI workflow to send those test reports to [buildpulse.io](https://buildpulse.io) for analysis.

    This is accomplished in 006299dcc148bf1cdebddac55c7b1d581009b528.

3. Maintainers can access an always-up-to-date list of flaky tests, along with stats on the disruptiveness of each test, how recently it has occurred, etc. Maintainers can also choose to receive daily digests in Slack and weekly digests via email, so that they don't have to remember to check yet another tool. 😅

## A few things to have in mind

- 🐣 To date, BuildPulse has been used primarily by teams working in private repositories. Homebrew/brew would be the first significant open source project using BuildPulse, so **we'll probably discover some speedbumps** due to the differences in workflows between open source projects versus private projects. I hope you'll bring those speedbumps to my attention (jason@buildpulse.io), because I'd love to find a good way to address them.

- 🍴 For GitHub Actions, workflows currently need to use GitHub Actions Secrets in order to authenticate when sending test results to BuildPulse. Since forks can't access secrets, this means that **forks can't yet send test results to BuildPulse** for analysis. Other tools ([like CodeCov](https://github.com/Homebrew/brew/blob/aa7d3280d40074a6b927e6e9554db2964f1fa53d/.github/workflows/tests.yml#L230)) have a solution for this kind of thing, and I hope to add support for forks in BuildPulse in the future as well.

- 🍎 This pull request enables flaky test detection **exclusively for the [macOS CI job](https://github.com/Homebrew/brew/blob/006299dcc148bf1cdebddac55c7b1d581009b528/.github/workflows/tests.yml#L247-L250)**.

    CI also runs tests in three other contexts: ["tests (no-compatibility mode)", "tests (generic OS)", "tests (Linux)"](https://github.com/Homebrew/brew/blob/006299dcc148bf1cdebddac55c7b1d581009b528/.github/workflows/tests.yml#L187-L195). Before enabling BuildPulse for the other contexts, BuildPulse will need to evolve to accept additional metadata to let you distinguish which context reported a given test result.

    Right now, the XML reports produced by `rspec_junit_reporter` don't distinguish one context's results from another context's results. For reliably detecting flaky tests, if we're sending BuildPulse results for multiple contexts, it will be important to distinguish which context the test is running in.

    For example, let's assume that a given test (*x*) runs in both the "tests (Linux)" context and the "test everything (macOS)" context. And let's say we're running the build multiple times at commit `0abcdef`. If test *x* always passes in the macOS job, and always fails in the Linux job, the test isn't flaky; it's just broken on Linux. :grimacing:

    But if we don't know the context associated with each test result, all we'd see is that test *x* sometimes passes and sometimes fails at commit `0abcdef`, and we'd wrongly conclude that the test is flaky. :see_no_evil:

    So, for now, we need to pick one context to use for sending test results to BuildPulse. @MikeMcQuaid recommended using the macOS job, since it runs the largest number of tests (e.g. the `brew cask` ones).

## Verifying these changes

Since this pull request makes changes to the macOS CI job, and since that job doesn't run in forks, we can't immediately see the effect of these changes. To work around that limitation (so that reviewers can see the effect of these changes), 1888739cf69963323dfcc179440c6b0f10ff1c3b temporarily updates the macOS job to run in my fork. We can see that the job succeeds (https://github.com/jasonrudolph/brew/runs/2877954175) and that test results were successfully sent to BuildPulse. [[screenshot](https://user-images.githubusercontent.com/2988/122814647-7e463f80-d2a2-11eb-8138-19f2b2d9c4d0.png)]
