### PR TITLE
OS::Mac: Move version methods into ::Version

### DIFF
--- a/Library/Homebrew/extend/os/mac/diagnostic.rb
+++ b/Library/Homebrew/extend/os/mac/diagnostic.rb
@@ -107,9 +107,9 @@ module Homebrew
         return if Homebrew::EnvConfig.developer?
 
         who = +"We"
-        what = if OS::Mac.prerelease?
+        what = if OS::Mac.version.prerelease?
           "pre-release version"
-        elsif OS::Mac.outdated_release?
+        elsif OS::Mac.version.outdated_release?
           who << " (and Apple)"
           "old version"
         end
@@ -139,7 +139,7 @@ module Homebrew
           #{MacOS::Xcode.update_instructions}
         EOS
 
-        if OS::Mac.prerelease?
+        if OS::Mac.version.prerelease?
           current_path = Utils.popen_read("/usr/bin/xcode-select", "-p")
           message += <<~EOS
             If #{MacOS::Xcode.latest_version} is installed, you may need to:
@@ -199,7 +199,7 @@ module Homebrew
 
       def check_ruby_version
         return if RUBY_VERSION == HOMEBREW_REQUIRED_RUBY_VERSION
-        return if Homebrew::EnvConfig.developer? && OS::Mac.prerelease?
+        return if Homebrew::EnvConfig.developer? && OS::Mac.version.prerelease?
 
         <<~EOS
           Ruby version #{RUBY_VERSION} is unsupported on #{MacOS.version}. Homebrew

--- a/Library/Homebrew/extend/os/mac/utils/bottles.rb
+++ b/Library/Homebrew/extend/os/mac/utils/bottles.rb
@@ -19,7 +19,9 @@ module Utils
       def find_matching_tag(tag, no_older_versions: false)
         # Used primarily by developers testing beta macOS releases.
         if no_older_versions ||
-           (OS::Mac.prerelease? && Homebrew::EnvConfig.developer? && Homebrew::EnvConfig.skip_or_later_bottles?)
+           (OS::Mac.version.prerelease? &&
+            Homebrew::EnvConfig.developer? &&
+            Homebrew::EnvConfig.skip_or_later_bottles?)
           generic_find_matching_tag(tag)
         else
           generic_find_matching_tag(tag) ||

--- a/Library/Homebrew/formula_installer.rb
+++ b/Library/Homebrew/formula_installer.rb
@@ -246,7 +246,7 @@ class FormulaInstaller
       # check fails)
       elsif !Homebrew::EnvConfig.developer? &&
             (!installed_as_dependency? || !formula.any_version_installed?) &&
-            (!OS.mac? || !OS::Mac.outdated_release?)
+            (!OS.mac? || !OS::Mac.version.outdated_release?)
         <<~EOS
           #{formula}: no bottle available!
         EOS

--- a/Library/Homebrew/os.rb
+++ b/Library/Homebrew/os.rb
@@ -43,8 +43,8 @@ module OS
   if OS.mac?
     require "os/mac"
     # Don't tell people to report issues on unsupported configurations.
-    if !OS::Mac.prerelease? &&
-       !OS::Mac.outdated_release? &&
+    if !OS::Mac.version.prerelease? &&
+       !OS::Mac.version.outdated_release? &&
        ARGV.none? { |v| v.start_with?("--cc=") } &&
        ENV["HOMEBREW_PREFIX"] == "/usr/local"
       ISSUES_URL = "https://docs.brew.sh/Troubleshooting"

--- a/Library/Homebrew/os/mac.rb
+++ b/Library/Homebrew/os/mac.rb
@@ -46,20 +46,6 @@ module OS
     end
     private :latest_sdk_version
 
-    def outdated_release?
-      # TODO: bump version when new macOS is released and also update
-      # references in docs/Installation.md and
-      # https://github.com/Homebrew/install/blob/HEAD/install.sh
-      version < "10.14"
-    end
-
-    def prerelease?
-      # TODO: bump version when new macOS is released or announced
-      # and also update references in docs/Installation.md and
-      # https://github.com/Homebrew/install/blob/HEAD/install.sh
-      version >= "12"
-    end
-
     sig { returns(String) }
     def preferred_perl_version
       if version >= :big_sur

--- a/Library/Homebrew/os/mac/version.rb
+++ b/Library/Homebrew/os/mac/version.rb
@@ -24,6 +24,18 @@ module OS
         yosemite:    "10.10",
       }.freeze
 
+      # TODO: bump version when new macOS is released or announced
+      # and also update references in docs/Installation.md and
+      # https://github.com/Homebrew/install/blob/HEAD/install.sh
+      MACOS_NEWEST_UNSUPPORTED = "12.0"
+      private_constant :MACOS_NEWEST_UNSUPPORTED
+
+      # TODO: bump version when new macOS is released and also update
+      # references in docs/Installation.md and
+      # https://github.com/Homebrew/install/blob/HEAD/install.sh
+      MACOS_OLDEST_SUPPORTED = "10.14"
+      private_constant :MACOS_OLDEST_SUPPORTED
+
       sig { params(version: Symbol).returns(T.attached_class) }
       def self.from_symbol(version)
         str = SYMBOLS.fetch(version) { raise MacOSVersionError, version }
@@ -71,6 +83,16 @@ module OS
       sig { returns(String) }
       def pretty_name
         @pretty_name ||= to_sym.to_s.split("_").map(&:capitalize).join(" ").freeze
+      end
+
+      sig { returns(T::Boolean) }
+      def outdated_release?
+        self < MACOS_OLDEST_SUPPORTED
+      end
+
+      sig { returns(T::Boolean) }
+      def prerelease?
+        self >= MACOS_NEWEST_UNSUPPORTED
       end
 
       # For {OS::Mac::Version} compatibility.

--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -32,7 +32,7 @@ module OS
         when "10.10" then "7.2.1"
         when "10.9"  then "6.2"
         else
-          raise "macOS '#{MacOS.version}' is invalid" unless OS::Mac.prerelease?
+          raise "macOS '#{MacOS.version}' is invalid" unless OS::Mac.version.prerelease?
 
           # Default to newest known version of Xcode for unreleased macOS versions.
           latest_stable
@@ -137,7 +137,7 @@ module OS
       end
 
       def installation_instructions
-        if OS::Mac.prerelease?
+        if OS::Mac.version.prerelease?
           <<~EOS
             Xcode can be installed from:
               #{Formatter.url("https://developer.apple.com/download/more/")}
@@ -151,7 +151,7 @@ module OS
 
       sig { returns(String) }
       def update_instructions
-        if OS::Mac.prerelease?
+        if OS::Mac.version.prerelease?
           <<~EOS
             Xcode can be updated from:
               #{Formatter.url("https://developer.apple.com/download/more/")}

--- a/Library/Homebrew/test/os/mac/diagnostic_spec.rb
+++ b/Library/Homebrew/test/os/mac/diagnostic_spec.rb
@@ -12,7 +12,8 @@ describe Homebrew::Diagnostic::Checks do
     macos_version = OS::Mac::Version.new("10.14")
     allow(OS::Mac).to receive(:version).and_return(macos_version)
     allow(OS::Mac).to receive(:full_version).and_return(macos_version)
-    allow(OS::Mac).to receive(:prerelease?).and_return(true)
+    allow(OS::Mac.version).to receive(:outdated_release?).and_return(false)
+    allow(OS::Mac.version).to receive(:prerelease?).and_return(true)
 
     expect(checks.check_for_unsupported_macos)
       .to match("We do not provide support for this pre-release version.")

--- a/Library/Homebrew/test/utils/bottles/collector_spec.rb
+++ b/Library/Homebrew/test/utils/bottles/collector_spec.rb
@@ -31,7 +31,7 @@ describe Utils::Bottles::Collector do
     it "does not use older tags when requested not to", :needs_macos do
       allow(Homebrew::EnvConfig).to receive(:developer?).and_return(true)
       allow(Homebrew::EnvConfig).to receive(:skip_or_later_bottles?).and_return(true)
-      allow(OS::Mac).to receive(:prerelease?).and_return(true)
+      allow(OS::Mac.version).to receive(:prerelease?).and_return(true)
       collector[:mojave] = "foo"
       expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:mojave))).to eq(:mojave)
       expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:catalina))).to be_nil
@@ -39,7 +39,7 @@ describe Utils::Bottles::Collector do
 
     it "ignores HOMEBREW_SKIP_OR_LATER_BOTTLES on release versions", :needs_macos do
       allow(Homebrew::EnvConfig).to receive(:skip_or_later_bottles?).and_return(true)
-      allow(OS::Mac).to receive(:prerelease?).and_return(false)
+      allow(OS::Mac.version).to receive(:prerelease?).and_return(false)
       collector[:mojave] = "foo"
       expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:mojave))).to eq(:mojave)
       expect(collector.send(:find_matching_tag, Utils::Bottles::Tag.from_symbol(:catalina))).to eq(:mojave)


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

#11557 needs to know if a Sparkle feed item's `minimumSystemVersion` (a macOS version like `12.0.0`) is a prerelease version. `OS::Mac` has a `#prerelease?` method but it can seemingly only be used to check the macOS version of the execution environment, like `OS::Mac.prerelease?`. We need to be able to do `OS::Mac::Version.new("12.0.0").prerelease?`, which isn't currently supported.

This PR moves the `#outdated_release?` and `#prerelease?` methods to `OS::Mac::Version` and simply calls the `::Version` methods in the related `OS::Mac` methods. This allows for both `OS::Mac.prerelease?` and `OS::Mac::Version.new("12.0.0").prerelease?`.

It would be nice to be able to remove these methods from `OS::Mac` while still being able to access them like `OS::Mac.prerelease?`. I couldn't get either `def_delegators` or `delegate` (from `ActiveSupport`) to work where `OS::Mac.prerelease?` calls `version.prerelease?`). Any suggestions on how to approach this or is the present code what we would expect?