### PR TITLE
cmd/pin: add warning recommending `brew extract`

### DIFF
--- a/Library/Homebrew/cmd/pin.rb
+++ b/Library/Homebrew/cmd/pin.rb
@@ -14,7 +14,8 @@ module Homebrew
     Homebrew::CLI::Parser.new do
       description <<~EOS
         Pin the specified <formula>, preventing them from being upgraded when
-        issuing the `brew upgrade` <formula> command. See also `unpin`.
+        issuing the `brew upgrade` <formula> command. See also `unpin`. Set
+        `HOMEBREW_NO_PIN_WARNING` to silence the warning about pinned formulae.
       EOS
 
       named_args :installed_formula, min: 1
@@ -22,6 +23,13 @@ module Homebrew
   end
 
   def pin
+    unless ENV["HOMEBREW_NO_PIN_WARNING"]
+      opoo <<~EOS
+        #{Tty.bold}`brew pin` is fragile and can break upgrades to other formulae!#{Tty.reset}
+        If you require a specific version of a formula, use `brew extract` instead.
+      EOS
+    end
+
     args = pin_args.parse
 
     args.named.to_resolved_formulae.each do |f|

--- a/docs/Manpage.md
+++ b/docs/Manpage.md
@@ -2004,6 +2004,9 @@ example, run `export HOMEBREW_NO_INSECURE_REDIRECT=1` rather than just
 - `HOMEBREW_NO_INSTALL_UPGRADE`
   <br>If set, `brew install` will not automatically upgrade installed but outdated formulae
 
+- `HOMEBREW_NO_PIN_WARNING`
+  <br>If set, `brew pin` will not display the warning about pinned formulae.
+
 - `HOMEBREW_PRY`
   <br>If set, use Pry for the `brew irb` command.
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? `reinstall` test failed with `execution expired`, and `--version` test failed because I edited the manpage while tests were running.

-----

As the warning message I've added states, `brew pin` is fragile, and
should be used with care. The warning message recommends that users use
`brew extract` instead.

Setting the environment variable `HOMEBREW_NO_PIN_WARNING` will silence
this warning.

Closes Homebrew/homebrew-core#79758.