### PR TITLE
docs: fix cask doc urls to use docs.brew.sh

### DIFF
--- a/Library/.rubocop.yml
+++ b/Library/.rubocop.yml
@@ -39,11 +39,11 @@ Cask/NoDslVersion:
   Enabled: true
 
 Cask/StanzaGrouping:
-  Description: "Ensure that cask stanzas are grouped correctly. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order"
+  Description: "Ensure that cask stanzas are grouped correctly. More info at https://docs.brew.sh/Cask-Cookbook#stanza-order"
   Enabled: true
 
 Cask/StanzaOrder:
-  Description: "Ensure that cask stanzas are sorted correctly. More info at https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order"
+  Description: "Ensure that cask stanzas are sorted correctly. More info at https://docs.brew.sh/Cask-Cookbook#stanza-order"
   Enabled: true
 
 # enable all formulae audits

--- a/Library/Homebrew/cask/audit.rb
+++ b/Library/Homebrew/cask/audit.rb
@@ -305,7 +305,7 @@ module Cask
       add_error "Casks with `version :latest` should not use `auto_updates`."
     end
 
-    LIVECHECK_REFERENCE_URL = "https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/livecheck.md"
+    LIVECHECK_REFERENCE_URL = "https://docs.brew.sh/Cask-Cookbook#stanza-livecheck"
 
     def check_hosting_with_livecheck(livecheck_result:)
       return if block_url_offline? || cask.appcast || cask.livecheckable?
@@ -341,7 +341,7 @@ module Cask
       check_download_url_format
     end
 
-    SOURCEFORGE_OSDN_REFERENCE_URL = "https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/url.md#sourceforgeosdn-urls"
+    SOURCEFORGE_OSDN_REFERENCE_URL = "https://docs.brew.sh/Cask-Cookbook#sourceforgeosdn-urls"
 
     def check_download_url_format
       odebug "Auditing URL format"
@@ -426,7 +426,7 @@ module Cask
       cask.url.from_block?
     end
 
-    VERIFIED_URL_REFERENCE_URL = "https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/url.md#when-url-and-homepage-hostnames-differ-add-verified"
+    VERIFIED_URL_REFERENCE_URL = "https://docs.brew.sh/Cask-Cookbook#when-url-and-homepage-hostnames-differ-add-verified"
 
     def check_unnecessary_verified
       return if block_url_offline?

--- a/Library/Homebrew/rubocops/cask/stanza_grouping.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_grouping.rb
@@ -7,7 +7,7 @@ module RuboCop
   module Cop
     module Cask
       # This cop checks that a cask's stanzas are grouped correctly.
-      # @see https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order
+      # @see https://docs.brew.sh/Cask-Cookbook#stanza-order
       class StanzaGrouping < Base
         extend Forwardable
         extend AutoCorrector

--- a/Library/Homebrew/rubocops/cask/stanza_order.rb
+++ b/Library/Homebrew/rubocops/cask/stanza_order.rb
@@ -7,7 +7,7 @@ module RuboCop
   module Cop
     module Cask
       # This cop checks that a cask's stanzas are ordered correctly.
-      # @see https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/readme.md#stanza-order
+      # @see https://docs.brew.sh/Cask-Cookbook#stanza-order
       class StanzaOrder < Base
         extend Forwardable
         extend AutoCorrector

--- a/docs/Acceptable-Casks.md
+++ b/docs/Acceptable-Casks.md
@@ -36,7 +36,7 @@ When an App has a main stable version, alternative versions should be submitted 
 
 ### Regional and Localized
 
-When an App exists in more than one language or has different regional editions, [the `language` stanza should be used to switch between languages or regions](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/language.md).
+When an App exists in more than one language or has different regional editions, [the `language` stanza should be used to switch between languages or regions](https://docs.brew.sh/Cask-Cookbook#stanza-language).
 
 ### Trial and Freemium Versions
 
@@ -112,7 +112,7 @@ Common reasons to reject a Cask entirely:
 + The app is both open-source and CLI-only (i.e. it only uses the `binary` artifact). In that case, and [in the spirit of deduplication](https://github.com/Homebrew/homebrew-cask/issues/15603), submit it first to [Homebrew/core](https://github.com/Homebrew/homebrew-core) as a formula that builds from source. If it is rejected, you may then try again as a cask (link us to the issue so we can see the discussion and reasoning for rejection).
 + The app is open-source and has a GUI but no compiled versions (or only old ones) are provided. It’s better to have them in [Homebrew](https://github.com/Homebrew/homebrew) so users don’t get perpetually outdated versions. See [`gedit`](https://github.com/Homebrew/homebrew-cask/pull/23360) for example.
 + The app has been rejected before due to an issue we cannot fix, and the new submission doesn’t fix that. An example would be [the first submission of `soapui`](https://github.com/Homebrew/homebrew-cask/pull/4939), whose installation problems were not fixed in the two subsequent submissions ([#9969](https://github.com/Homebrew/homebrew-cask/pull/9969), [#10606](https://github.com/Homebrew/homebrew-cask/pull/10606)).
-+ The Cask is a duplicate. These submissions mostly occur when the [token reference](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/token_reference.md) was not followed.
++ The Cask is a duplicate. These submissions mostly occur when the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference) was not followed.
 + The download URL for the app is both behind a login/registration form and from a host that differs from the homepage, meaning users can’t easily verify its authenticity.
 + The Cask is for an unmaintained app (no releases in the last year, or [explicitly discontinued](https://github.com/Homebrew/homebrew-cask/pull/22699)).
 + The Cask is for an app that is too obscure. Examples:
@@ -121,7 +121,7 @@ Common reasons to reject a Cask entirely:
 + The Cask is for an app with no information on the homepage (example: a GitHub repository without a README).
 + The author has [specifically asked us not to include it](https://github.com/Homebrew/homebrew-cask/pull/5342).
 + The Cask requires [SIP to be disabled](https://github.com/Homebrew/homebrew-cask/pull/41890) to be installed and/or used.
-+ The Cask is a `pkg` that requires [`allow_untrusted: true`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/pkg.md#pkg-allow_untrusted).
++ The Cask is a `pkg` that requires [`allow_untrusted: true`](https://docs.brew.sh/Cask-Cookbook#pkg-allow_untrusted).
 
 Common reasons to reject a Cask from the main repo:
 

--- a/docs/Cask-Cookbook.md
+++ b/docs/Cask-Cookbook.md
@@ -281,7 +281,7 @@ The value of the `appcast` stanza is a string, holding the URL for an appcast wh
 
 Note: The [`livecheck` stanza](#stanza-livecheck) should be preferred in most cases, as it allows casks to be updated automatically.
 
-The main casks repo only accepts submissions for stable versions of software (and [documented exceptions](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/development/adding_a_cask.md#but-there-is-no-stable-version)), but it still gets pull requests for unstable versions. By checking the submitted `version` against the contents of an appcast, we can better detect these invalid cases.
+The main casks repo only accepts submissions for stable versions of software (and [documented exceptions](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version)), but it still gets pull requests for unstable versions. By checking the submitted `version` against the contents of an appcast, we can better detect these invalid cases.
 
 Example: [`atom.rb`](https://github.com/Homebrew/homebrew-cask/blob/645dbb8228ec2f1f217ed1431e188687aac13ca5/Casks/atom.rb#L7)
 
@@ -1115,7 +1115,7 @@ When the hostnames of `url` and `homepage` differ, the discrepancy should be doc
 
 This must be added so a user auditing the cask knows the URL was verified by the Homebrew Cask team as the one provided by the vendor, even though it may look unofficial. It is our responsibility as Homebrew Cask maintainers to verify both the `url` and `homepage` information when first added (or subsequently modified, apart from versioning).
 
-The parameter doesn’t mean you should trust the source blindly, but we only approve casks in which users can easily verify its authenticity with basic means, such as checking the official homepage or public repository. Occasionally, slightly more elaborate techniques may be used, such as inspecting an [`appcast`](#stanza-appcast) we established as official. Cases where such quick verifications aren’t possible (e.g. when the download URL is behind a registration wall) are [treated in a stricter manner](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/development/adding_a_cask.md#unofficial-vendorless-and-walled-builds).
+The parameter doesn’t mean you should trust the source blindly, but we only approve casks in which users can easily verify its authenticity with basic means, such as checking the official homepage or public repository. Occasionally, slightly more elaborate techniques may be used, such as inspecting an [`appcast`](#stanza-appcast) we established as official. Cases where such quick verifications aren’t possible (e.g. when the download URL is behind a registration wall) are [treated in a stricter manner](https://docs.brew.sh/Acceptable-Casks#unofficial-vendorless-and-walled-builds).
 
 #### Difficulty Finding a URL
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -233,7 +233,7 @@ There are a few ideas to fix this problem:
 
 So we let software be. Installing it with Homebrew Cask should make it behave the same as if you had installed it manually. But we also want to support software that does not auto-upgrade, so we add [`auto_updates true`](https://github.com/Homebrew/homebrew-cask/blob/62c0495b254845a481dacac6ea7c8005e27a3fb0/Casks/alfred.rb#L10) to casks of software that can do it, which excludes them from `brew upgrade`.
 
-Casks which use [`version :latest`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/doc/cask_language_reference/stanzas/version.md#version-latest) are also excluded, because we have no way to track the version they’re in. It helps to ask the developers of such software to provide versioned releases (i.e. have the version in the path of the download `url`).
+Casks which use [`version :latest`](https://docs.brew.sh/Cask-Cookbook#version-latest) are also excluded, because we have no way to track the version they’re in. It helps to ask the developers of such software to provide versioned releases (i.e. have the version in the path of the download `url`).
 
 If you still want to force software to be upgraded via Homebrew Cask, you can:
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Fixes Homebrew/homebrew-cask#107626

Some old URLs still remaining inside documentation, audit, etc.