### PR TITLE
typecheck: do not generate RBI file for did_you_mean

### DIFF
--- a/Library/Homebrew/dev-cmd/typecheck.rb
+++ b/Library/Homebrew/dev-cmd/typecheck.rb
@@ -55,8 +55,12 @@ module Homebrew
 
     HOMEBREW_LIBRARY_PATH.cd do
       if args.update?
+        excluded_gems = [
+          "did_you_mean", # RBI file is already provided by Sorbet
+        ]
+
         ohai "Updating Tapioca RBI files..."
-        system "bundle", "exec", "tapioca", "sync"
+        system "bundle", "exec", "tapioca", "sync", "--exclude", *excluded_gems
         system "bundle", "exec", "srb", "rbi", "hidden-definitions"
         system "bundle", "exec", "srb", "rbi", "todo"
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

Tapioca generated RBI file conflicts with RBI file provided by Sorbet. And since Sorbet covers `did_you_mean` I've disabled RBI generation for this gem.

See https://github.com/Homebrew/brew/pull/11589
