### PR TITLE
github_spec: Fix failed test due to expired artifacts

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -77,16 +77,16 @@ describe GitHub do
     it "fails to find artifacts that don't exist" do
       expect {
         described_class.get_artifact_url(
-          described_class.get_workflow_run("Homebrew", "homebrew-core", 51971, artifact_name: "false_bottles"),
+          described_class.get_workflow_run("Homebrew", "homebrew-core", 79751, artifact_name: "false_bottles"),
         )
       }.to raise_error(/No artifact .+ was found/)
     end
 
     it "gets an artifact link" do
       url = described_class.get_artifact_url(
-        described_class.get_workflow_run("Homebrew", "homebrew-core", 51971, artifact_name: "bottles"),
+        described_class.get_workflow_run("Homebrew", "homebrew-core", 79751, artifact_name: "bottles"),
       )
-      expect(url).to eq("https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/3557392/zip")
+      expect(url).to eq("https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/69422207/zip")
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Artifacts in PR https://github.com/Homebrew/homebrew-core/pull/51971 has expired which causes a couple of failed in `github_spec`. 
This PR updates the Pull Request id that we use in tests.
I think we'll need to come up with better solution.

```
Failures:

  1) GitHub::get_artifact_url gets an artifact link
     Failure/Error:
       url = described_class.get_artifact_url(
         described_class.get_workflow_run("Homebrew", "homebrew-core", 51971, artifact_name: "bottles"),
       )

     GitHub::API::Error:
       No matching workflow run found for these criteria!
         Commit SHA:   869200eb8281d8c399a978476ac868a30edf5e28
         Branch ref:   bibutils-6.9
         Pull request: 51971
         Workflow:     tests.yml
     # ./utils/github.rb:270:in `get_artifact_url'
     # ./test/utils/github_spec.rb:86:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:209:in `block (3 levels) in <top (required)>'
     # ./test/spec_helper.rb:208:in `block (2 levels) in <top (required)>'
     # ./test/spec_helper.rb:97:in `block (2 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
     # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'

  2) GitHub::get_artifact_url fails to find artifacts that don't exist
     Failure/Error:
       expect {
         described_class.get_artifact_url(
           described_class.get_workflow_run("Homebrew", "homebrew-core", 51971, artifact_name: "false_bottles"),
         )
       }.to raise_error(/No artifact .+ was found/)

       expected /No artifact .+ was found/, got #<GitHub::API::Error: No matching workflow run found for these criteria!
         Commit SHA:   869200eb8281d8c399a978476ac868a30edf5e28
         Branch ref:   bibutils-6.9
         Pull request: 51971
         Workflow:     tests.yml
       > with backtrace:
         # ./utils/github.rb:270:in `get_artifact_url'
         # ./test/utils/github_spec.rb:79:in `block (4 levels) in <top (required)>'
         # ./test/utils/github_spec.rb:78:in `block (3 levels) in <top (required)>'
         # ./test/spec_helper.rb:209:in `block (3 levels) in <top (required)>'
         # ./test/spec_helper.rb:208:in `block (2 levels) in <top (required)>'
         # ./test/spec_helper.rb:97:in `block (2 levels) in <top (required)>'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
         # ./vendor/bundle/ruby/2.6.0/gems/rspec-wait-0.0.9/lib/rspec/wait.rb:46:in `block (2 levels) in <top (required)>'
```