### PR TITLE
formula: capture build logs more comprehensively

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1269,7 +1269,18 @@ class Formula
         staging.retain! if interactive || debug?
         raise
       ensure
-        cp Dir["config.log", "CMakeCache.txt"], logs
+        %w[
+          config.log
+          CMakeCache.txt
+          CMakeOutput.log
+          CMakeError.log
+        ].each do |logfile|
+          Dir["**/#{logfile}"].each do |logpath|
+            destdir = logs/File.dirname(logpath)
+            mkdir_p destdir
+            cp logpath, destdir
+          end
+        end
       end
     end
   ensure


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally? -- `reinstall` test execution expired

-----

Currently, we copy `config.log` and `CMakeCache.txt` from the root of
the source tree into the the logs generated by the build. This has three
shortcomings:

1. These files are not necessarily found where we look. This is often
   the case with a CMake build, but can occur with an Autotools build
   as well (e.g. GCC, or any other out-of-tree build).
2. There may be several of these files scattered throughout the build
   tree. This occurs, for example, when the build itself invokes
   `configure` or `cmake` as part of the build process.
3. We don't copy `CMakeOutput.log` or `CMakeError.log`, which are
   usually more informative about what happened during the CMake
   invocation. It is not sufficient to add them to the array of log
   files that we copy because these are never found at the source root,
   even when building in-tree.

Let's rectify this by copying all instances of these files that can be
found in the source tree. Since there will inevitably be duplicate file
names, we also store them in the log directory using the same relative
paths from the source root. [1] This has the added benefit of providing
context for these log files.

[1] For example, if `CMakeOutput.log` can be found in `build/CMakeFiles`
relative to the source root, then that will also be where it will be
stored in the log directory.