### PR TITLE
Tweak BuildPulse/`rspec-retry` logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -311,11 +311,24 @@ jobs:
           restore-keys: ${{ runner.os }}-parallel_runtime_rspec-
 
       - name: Run brew tests
-        run: brew tests --online --coverage
+        run: |
+          # Retry multiple times when using BuildPulse to detect and submit
+          # flakiness (because rspec-retry is disabled).
+          if [ -n "$HOMEBREW_BUILDPULSE_ACCESS_KEY_ID" ]; then
+            brew tests --online --coverage || \
+            brew tests --online --coverage || \
+            brew tests --online --coverage
+          else
+            brew tests --online --coverage
+          fi
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # These cannot be queried at the macOS level on GitHub Actions.
           HOMEBREW_LANGUAGES: en-GB
+          HOMEBREW_BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          HOMEBREW_BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          HOMEBREW_BUILDPULSE_ACCOUNT_ID: 1503512
+          HOMEBREW_BUILDPULSE_REPOSITORY_ID: 53238813
 
       - run: brew test-bot --only-formulae --test-default-formula
 

--- a/Library/Homebrew/dev-cmd/tests.rb
+++ b/Library/Homebrew/dev-cmd/tests.rb
@@ -36,6 +36,32 @@ module Homebrew
     end
   end
 
+  def use_buildpulse?
+    return @use_buildpulse if defined?(@use_buildpulse)
+
+    @use_buildpulse = ENV["HOMEBREW_BUILDPULSE_ACCESS_KEY_ID"].present? &&
+                      ENV["HOMEBREW_BUILDPULSE_SECRET_ACCESS_KEY"].present? &&
+                      ENV["HOMEBREW_BUILDPULSE_ACCOUNT_ID"].present? &&
+                      ENV["HOMEBREW_BUILDPULSE_REPOSITORY_ID"].present?
+  end
+
+  def run_buildpulse
+    require "formula"
+
+    unless Formula["buildpulse-test-reporter"].any_version_installed?
+      ohai "Installing `buildpulse-test-reporter` for reporting test flakiness..."
+      safe_system HOMEBREW_BREW_FILE, "install", "buildpulse-test-reporter"
+    end
+
+    ENV["BUILDPULSE_ACCESS_KEY_ID"] = ENV["HOMEBREW_BUILDPULSE_ACCESS_KEY_ID"]
+    ENV["BUILDPULSE_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_BUILDPULSE_SECRET_ACCESS_KEY"]
+
+    safe_system Formula["buildpulse-test-reporter"].opt_bin/"buildpulse-test-reporter",
+                "submit", "Library/Homebrew/test/junit",
+                "--account-id", ENV["HOMEBREW_BUILDPULSE_ACCOUNT_ID"],
+                "--repository-id", ENV["HOMEBREW_BUILDPULSE_REPOSITORY_ID"]
+  end
+
   def tests
     args = tests_args.parse
 
@@ -154,11 +180,17 @@ module Homebrew
       # Let `bundle` in PATH find its gem.
       ENV["GEM_PATH"] = "#{ENV["GEM_PATH"]}:#{gem_user_dir}"
 
+      # Submit test flakiness information using BuildPulse
+      # BUILDPULSE used in spec_helper.rb
+      ENV["BUILDPULSE"] = "1" if use_buildpulse?
+
       if parallel
         system "bundle", "exec", "parallel_rspec", *parallel_args, "--", *bundle_args, "--", *files
       else
         system "bundle", "exec", "rspec", *bundle_args, "--", *files
       end
+
+      run_buildpulse if use_buildpulse?
 
       return if $CHILD_STATUS.success?
 


### PR DESCRIPTION
BuildPulse is trying to find flaky tests for us but, given the previous model of using `rspec-retry`, it would rarely find them. Instead, let's try to always rerun `brew tests` multiple times, report to BuildPulse each time (by moving the reporting logic into `brew tests`) and disable `rspec-retry` when using BuildPulse.

While we're here, let's enable `rspec-retry` locally so we don't have flaky tests biting maintainers/contributors there.

CC @jasonrudolph for thoughts