### PR TITLE
test/utils/github_spec: fix artifact number

### DIFF
--- a/Library/Homebrew/test/utils/github_spec.rb
+++ b/Library/Homebrew/test/utils/github_spec.rb
@@ -86,7 +86,7 @@ describe GitHub do
       url = described_class.get_artifact_url(
         described_class.get_workflow_run("Homebrew", "homebrew-core", 79751, artifact_name: "bottles"),
       )
-      expect(url).to eq("https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/69422207/zip")
+      expect(url).to eq("https://api.github.com/repos/Homebrew/homebrew-core/actions/artifacts/70494047/zip")
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Fix issue mentioned in #11592 with newer artifact number from recent run.
Blocking some other PRs here.

---

Note that there are some `brew tests` that always fail for me, which I am ignoring in final checkbox:
- Testing on Rosetta causes issues for `Utils::Analytics::os_arch_prefix_ci`
- `HOMEBREW_GITHUB_API_TOKEN` being set causes failure in `brew tap-info`
