### PR TITLE
default_prefix: set macOS default prefix on Linux if simulating it

### DIFF
--- a/Library/Homebrew/default_prefix.rb
+++ b/Library/Homebrew/default_prefix.rb
@@ -4,7 +4,7 @@
 module Homebrew
   DEFAULT_PREFIX, DEFAULT_REPOSITORY = if OS.mac? && Hardware::CPU.arm?
     [HOMEBREW_MACOS_ARM_DEFAULT_PREFIX, HOMEBREW_MACOS_ARM_DEFAULT_REPOSITORY]
-  elsif OS.linux? && !EnvConfig.force_homebrew_on_linux?
+  elsif OS.linux? && !EnvConfig.simulate_macos_on_linux?
     [HOMEBREW_LINUX_DEFAULT_PREFIX, HOMEBREW_LINUX_DEFAULT_REPOSITORY]
   else
     [HOMEBREW_DEFAULT_PREFIX, HOMEBREW_DEFAULT_REPOSITORY]


### PR DESCRIPTION
- [ ] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This should fix the doctor complaining on Linux in `homebrew-core`:
```
Warning: Your Homebrew's prefix is not /usr/local.
Some of Homebrew's bottles (binary packages) can only be used with the default
prefix (/usr/local).
You will encounter build failures with some formulae.
Please create pull requests instead of asking for help on Homebrew's GitHub,
Twitter or any other official channels. You are responsible for resolving
any issues you experience while you are running this
unsupported configuration.
```

Above snippet taken from (somewhat companion) PR: https://github.com/Homebrew/homebrew-core/pull/80082

The `DEFAULT_PREFIX` should not be set to the macOS one when setting `HOMEBREW_FORCE_HOMEBREW_ON_LINUX`.
Since we have stricter env var (`HOMEBREW_SIMULATE_MACOS_ON_LINUX`), then use it rather than the former.

Also, doctor was right complaining about this issue of course, because now every bottle built for Linux in `homebrew-core` has the prefix set to the macOS one and I gotta rebuild those formulae after this PR is merged.
Example of latest Linux bottle JSON with wrong prefix:
```json
{
  "pkg-config": {
    "formula": {
      "name": "pkg-config",
      "pkg_version": "0.29.2_3",
      "path": "Library/Taps/homebrew/homebrew-core/Formula/pkg-config.rb",
      "tap_git_path": "Formula/pkg-config.rb",
      "tap_git_revision": "a7d01ae87028dd276476059772dd4a4db2aa6a63",
      "tap_git_remote": "https://github.com/Homebrew/homebrew-core",
      "desc": "Manage compile and link flags for libraries",
      "license": "GPL-2.0-or-later",
      "homepage": "https://freedesktop.org/wiki/Software/pkg-config/"
    },
    "bottle": {
      "root_url": "https://ghcr.io/v2/homebrew/core",
      "prefix": "/usr/local",
      "cellar": "any_skip_relocation",
      "rebuild": 0,
      "date": "2021-06-26",
      "tags": {
        "x86_64_linux": {
          "filename": "pkg-config-0.29.2_3.x86_64_linux.bottle.tar.gz",
          "local_filename": "pkg-config--0.29.2_3.x86_64_linux.bottle.tar.gz",
          "sha256": "3d9b8bf9b7b4bd08086be1104e3e18afb1c437dfaca03e6e7df8f2710b9c1c1a",
          "formulae_brew_sh_path": "formula",
          "tab": {
            "homebrew_version": "3.2.0-59-g196ec61",
            "changed_files": [
            ],
            "source_modified_time": 1490029698,
            "compiler": "gcc-5",
            "runtime_dependencies": [
            ],
            "arch": "x86_64",
            "built_on": {
              "os": "Linux",
              "os_version": "Ubuntu 16.04.7 LTS",
              "cpu_family": "broadwell",
              "glibc_version": "2.23",
              "oldest_cpu_family": "core2"
            }
          }
        }
      }
    }
  }
}
```

**Note** that we might need to swap those two env vars set in `homebrew-core` publishing workflow, but I'm not sure if the change in this PR will somehow negatively influence the publishing process. Talking about this line:
https://github.com/Homebrew/homebrew-core/blob/e80285c224946e333261436a9baa18a6faf26103/.github/workflows/publish-commit-bottles.yml#L14