### PR TITLE
superenv: handle formulae with runtime CPU detection

### DIFF
--- a/Library/Homebrew/extend/ENV/super.rb
+++ b/Library/Homebrew/extend/ENV/super.rb
@@ -91,10 +91,11 @@ module Superenv
     # g - Enable "-stdlib=libc++" for clang.
     # h - Enable "-stdlib=libstdc++" for clang.
     # K - Don't strip -arch <arch>, -m32, or -m64
+    # d - Don't strip -march=<target>. Use only in formulae that
+    #     have runtime detection of CPU features.
     # w - Pass -no_weak_imports to the linker
     #
     # These flags will also be present:
-    # s - apply fix for sed's Unicode support
     # a - apply fix for apr-1-config path
   end
   alias generic_setup_build_environment setup_build_environment
@@ -312,6 +313,11 @@ module Superenv
   sig { void }
   def permit_arch_flags
     append_to_cccfg "K"
+  end
+
+  sig { void }
+  def runtime_cpu_detection
+    append_to_cccfg "d"
   end
 
   sig { void }

--- a/Library/Homebrew/shims/super/cc
+++ b/Library/Homebrew/shims/super/cc
@@ -173,10 +173,12 @@ class Cmd
 
     case arg
     when /^-g\d?$/, /^-gstabs\d+/, "-gstabs+", /^-ggdb\d?/,
-      /^-march=.+/, /^-mtune=.+/, /^-mcpu=.+/,
-      /^-O[0-9zs]?$/, "-fast", "-no-cpp-precomp",
-      "-pedantic", "-pedantic-errors", "-Wno-long-double",
+      /^-mtune=.+/, /^-mcpu=.+/, /^-O[0-9zs]?$/,
+      "-fast", "-no-cpp-precomp", "-pedantic",
+      "-pedantic-errors", "-Wno-long-double",
       "-Wno-unused-but-set-variable"
+    when /^-march=.+/
+      args << arg if runtime_cpu_detection?
     when "-fopenmp", "-lgomp", "-mno-fused-madd", "-fforce-addr", "-fno-defer-pop",
       "-mno-dynamic-no-pic", "-fearly-inlining", /^-f(?:no-)?inline-functions-called-once/,
       /^-finline-limit/, /^-f(?:no-)?check-new/, "-fno-delete-null-pointer-checks",
@@ -283,7 +285,7 @@ class Cmd
     args << "-pipe"
     args << "-w" unless configure?
     args << "-#{ENV["HOMEBREW_OPTIMIZATION_LEVEL"]}"
-    args.concat(optflags)
+    args.concat(optflags) unless runtime_cpu_detection?
     args.concat(archflags)
     args << "-std=#{@arg0}" if /c[89]9/.match?(@arg0)
     args
@@ -383,6 +385,10 @@ class Cmd
 
   def permit_arch_flags?
     config.include?("K")
+  end
+
+  def runtime_cpu_detection?
+    config.include?("d")
   end
 
   def no_weak_imports?


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [x] Have you successfully run `brew style` with your changes locally?
- [x] Have you successfully run `brew typecheck` with your changes locally?
- [x] Have you successfully run `brew tests` with your changes locally?

-----

Some formulae are able to detect the features of the runtime CPU, and
execute code accordingly. This typically entails 1) the detection of
features of the build-time CPU in order to determine the targets that
the compiler can generate code for, and 2) generating code for the
targets that the compiler can support.

Our filtering of optimization flags can cause misdetection of compiler
features, leading to failed builds [1], and miscompilation even when the
build does not fail [2].

Let's try to fix this by allowing formulae to declare
`ENV.runtime_cpu_detection` which skips the filtering of `-march` and
related flags.

I've also skipped the filtering of the optimisation
level, since it seems to me that if upstream maintainers have gone to
the lengths of writing code that detects runtime hardware, they probably
also know better about appropriate `-O` flags to use.

This is a partial list of formulae that should make use of this feature:
1. apache-arrow
2. fftw
3. gromacs
4. open-mpi
5. openblas

Partially resolves Homebrew/homebrew-core#76537.

[1] open-mpi/ompi#8306 and linked issues/PRs
[2] Homebrew/homebrew-core#76537